### PR TITLE
Fix GH PR discussion snippets filename resolution

### DIFF
--- a/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/refined-github/code-view.html
+++ b/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/refined-github/code-view.html
@@ -1,209 +1,98 @@
-<div
-    class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
+<div class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
     <div class="file-header">
-        <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd"
-            class="text-mono text-small link-gray-dark wb-break-all mr-2"
-            title="web/src/regression/util/TestResourceManager.ts">
-            web/src/regression/util/TestResourceManager.ts
-        </a>
+          <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd" class="text-mono text-small link-gray-dark wb-break-all mr-2" title="web/src/regression/util/TestResourceManager.ts">
+        web/src/regression/util/TestResourceManager.ts
+      </a>
 
 
     </div>
 
 
-    <div class="blob-wrapper border-bottom rgh-linkified-code">
-        <table id="discussion-diff-329949662" class="diff-table rgh-showing-whitespace">
+  <div class="blob-wrapper border-bottom rgh-linkified-code">
+    <table id="discussion-diff-329949662" class="diff-table rgh-showing-whitespace">
 
 
 
-            <tbody>
-                <tr>
+      <tbody><tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R10" data-line-number="10"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R10" data-line-number="10" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>*</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>place</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>and</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>for</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>easy</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>resource</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>cleanup</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>at</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>the</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>end</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>of</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>tests</span><span><span>.</span></span><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>Also</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>prints</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>which</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>resources</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>are</span><span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span><span>created</span></span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>*<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>place<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>and<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>for<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>easy<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>resource<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>cleanup<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>at<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>the<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>end<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>of<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>tests.<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>Also<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>prints<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>which<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>resources<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>are<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>created</span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R11" data-line-number="11"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R11" data-line-number="11" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>*<span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>and<span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>destroyed<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>in<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>case<span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>tests<span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>are<span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>aborted<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>midway<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>through<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>and<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>manual<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>cleanup<span class="rgh-ws-char rgh-space-char"
-                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>is<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                    </span></span>required.</span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>*<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>and<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>destroyed<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>in<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>case<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>tests<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>are<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>aborted<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>midway<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>through<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>and<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>manual<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>cleanup<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>is<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>required.</span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R12" data-line-number="12"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R12" data-line-number="12" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span
-                                    class="pl-c"><span>*</span><span><span>/</span></span></span></span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span class="pl-c">*/</span></span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R13" data-line-number="13"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R13" data-line-number="13" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition annotated"><span
-                                class="pl-k"><span>export</span></span><span class="rgh-ws-char rgh-space-char"
-                                data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                </span></span><span class="pl-k"><span>class</span></span><span
-                                class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span
-                                class="pl-en"><span>TestResourceManager</span></span><span
-                                class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
-                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
-                                </span></span><span>{</span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition"><span class="pl-k">export</span><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span class="pl-k">class</span><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span class="pl-en">TestResourceManager</span><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>{</span>
 
-                    </td>
-                </tr>
+        </td>
+      </tr>
 
-            </tbody>
-        </table>
-    </div>
+    </tbody></table>
+  </div>
 
-    <div class="js-inline-comments-container">
-        <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
-            <div class="js-comments-holder">
+  <div class="js-inline-comments-container">
+    <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
+      <div class="js-comments-holder">
 
 
-                <div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links"
-                    id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
+  <div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links" id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
 
-                    <div class="minimized-comment position-relative d-none">
+      <div class="minimized-comment position-relative d-none">
 
 
 
 
-                        <details class="Details-element details-reset "
-                            data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
-                            <summary class="text-gray f6">
-                                <div class="d-flex flex-justify-between flex-items-center">
-                                    <h3 class="review-comment-contents bg-white f5 text-normal text-italic"
-                                        style="margin-left:38px">
-                                        <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-                                            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1"
-                                                width="14" height="16" aria-hidden="true">
-                                                <path fill-rule="evenodd"
-                                                    d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
-                                                </path>
-                                            </svg>
-                                        </div>
-                                        <div class="d-inline-block">
-                                            This comment has been minimized.
+    <details class="Details-element details-reset " data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
+      <summary class="text-gray f6">
+        <div class="d-flex flex-justify-between flex-items-center">
+          <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
+            <div class="discussion-item-icon discussion-item-icon-gray text-gray">
+              <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
+            </div>
+            <div class="d-inline-block">
+                  This comment has been minimized.
 
-                                        </div>
-                                    </h3>
-                                    <div class="Details-content--closed btn-link text-gray"><svg
-                                            class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1"
-                                            width="14" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z">
-                                            </path>
-                                        </svg>Show comment</div>
-                                    <div class="Details-content--open btn-link text-gray"><svg
-                                            class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1"
-                                            width="14" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
-                                            </path>
-                                        </svg>Hide comment</div>
-                                </div>
-                            </summary>
-                            <div class="py-2 pl-6 pr-0">
-                                <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-                                    <div class="edit-comment-hide">
-                                        <div class="timeline-comment-actions">
+            </div>
+          </h3>
+          <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
+          <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
+        </div>
+      </summary>
+      <div class="py-2 pl-6 pr-0">
+        <div class="previewable-edit  js-task-list-container reorderable-task-lists">
+          <div class="edit-comment-hide">
+            <div class="timeline-comment-actions">
 
 
 
@@ -222,142 +111,66 @@
 
 
 
-                                            <button type="button"
-                                                class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment"
-                                                role="menuitem" aria-label="Edit comment"><svg aria-hidden="true"
-                                                    class="octicon octicon-pencil" width="14" height="16">
-                                                    <path
-                                                        d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z">
-                                                    </path>
-                                                </svg></button>
-                                            <details
-                                                class="details-overlay details-reset position-relative d-inline-block ">
-                                                <summary class="btn-link timeline-comment-action link-gray"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg aria-label="Show options"
-                                                        class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16"
-                                                        version="1.1" width="13" height="16" role="img">
-                                                        <path fill-rule="evenodd"
-                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
-                                                        </path>
-                                                    </svg>
-                                                </summary>
-                                                <details-menu
-                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
-                                                    style="width:185px" role="menu">
-                                                    <clipboard-copy class="dropdown-item btn-link"
-                                                        for="discussion_r329949662-minimized-permalink" role="menuitem"
-                                                        tabindex="0">
-                                                        Copy link
-                                                    </clipboard-copy>
+  <button type="button" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block ">
+    <summary class="btn-link timeline-comment-action link-gray" aria-haspopup="menu" role="button">
+      <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
+    </summary>
+    <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
+          <clipboard-copy class="dropdown-item btn-link" for="discussion_r329949662-minimized-permalink" role="menuitem" tabindex="0">
+      Copy link
+    </clipboard-copy>
 
-                                                    <button type="button"
-                                                        class="dropdown-item btn-link d-none js-comment-quote-reply"
-                                                        role="menuitem">
-                                                        Quote reply
-                                                    </button>
+          <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
+      Quote reply
+    </button>
 
-                                                    <div class="dropdown-divider"></div><a
-                                                        href="/sourcegraph/sourcegraph/tree/HEAD@{2019-10-01T09:03:30Z}"
-                                                        class="dropdown-item btn-link" role="menuitem"
-                                                        title="Browse repository like it appeared on this day">View repo
-                                                        at this time</a>
-                                                    <div role="none" class="dropdown-divider"></div>
+          <div class="dropdown-divider"></div><a href="/sourcegraph/sourcegraph/tree/HEAD@{2019-10-01T09:03:30Z}" class="dropdown-item btn-link" role="menuitem" title="Browse repository like it appeared on this day">View repo at this time</a><div role="none" class="dropdown-divider"></div>
 
-                                                    <button type="button"
-                                                        class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment"
-                                                        role="menuitem" aria-label="Edit comment" hidden="">
-                                                        Edit
-                                                    </button>
+            <button type="button" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment" hidden="">
+        Edit
+      </button>
 
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form class="inline-form js-comment-unminimize width-full"
-                                                        action="/sourcegraph/sourcegraph/community/unminimize-comment"
-                                                        accept-charset="UTF-8" method="post"><input name="utf8"
-                                                            type="hidden" value="✓"><input type="hidden" name="_method"
-                                                            value="put"><input type="hidden" name="authenticity_token"
-                                                            value="o6+7W/gRAHhQ+Ox2niHDwY8321kWmlTvYdMg+vPI8jgL5UEGG8kCJwPNCrgQmn9C0Y6rUytD1NxTur/0j9BIdg==">
-                                                        <input type="hidden" name="comment_id"
-                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                        <button type="submit" class="dropdown-item btn-link"
-                                                            role="menuitem" aria-label="Unhide comment">
-                                                            Unhide
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form class="width-full inline-form js-comment-delete"
-                                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                                        accept-charset="UTF-8" method="post"><input name="utf8"
-                                                            type="hidden" value="✓"><input type="hidden" name="_method"
-                                                            value="delete"><input type="hidden"
-                                                            name="authenticity_token"
-                                                            value="NyWJMjs4MrzS/kiDz8/AVpvQEf+JYEg3hmy83GfM7KUO0PGMEHbEuu//BE6HYRv7mGkKUxuP9MzqM0WUVvrfIg==">
-                                                        <input type="hidden" name="input[id]"
-                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                        <button type="submit"
-                                                            class="dropdown-item menu-item-danger btn-link"
-                                                            aria-label="Delete comment" role="menuitem"
-                                                            data-confirm="Are you sure you want to delete this?">
-                                                            Delete
-                                                        </button>
-                                                    </form>
+              <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="t9CfMOqV+w74c0cnp54OZzep+uQU1EwQwc3usA3CYsYfmmVtCU35UatGoekpJbLkaRCK7ikNzCPzpHG+cdrYiA==">
+          <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+          <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
+            Unhide
+          </button>
+  </form>
+            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="VRzsb+bcCrIExfSdPOJ0/TbhEMSa8edwlWIg6JM49zNs6ZTRzZL8tDnEuFB0TK9QNVgLaAgeW4v5Pdmgog7EtA==">
+        <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+        <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
+          Delete
+        </button>
+  </form>
 
-                                                </details-menu>
-                                            </details>
+    </details-menu>
+  </details>
 
-                                        </div>
-                                        <a class="float-left mt-1" data-hovercard-type="user"
-                                            data-hovercard-url="/hovercards?user_id=1741180"
-                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                            href="/lguychard"><img class="avatar" height="28" width="28"
-                                                alt="@lguychard"
-                                                src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
-                                        <div class="review-comment-contents">
-                                            <h4 class="f5 text-normal d-inline text-gray-dark">
-                                                <strong class="text-gray">
+            </div>
+              <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard" src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+            <div class="review-comment-contents">
+              <h4 class="f5 text-normal d-inline text-gray-dark">
+                <strong class="text-gray">
 
 
-                                                    <a class="author link-gray-dark css-truncate-target rgh-fullname"
-                                                        show_full_name="false" data-hovercard-type="user"
-                                                        data-hovercard-url="/hovercards?user_id=1741180"
-                                                        data-octo-click="hovercard-link-click"
-                                                        data-octo-dimensions="link_type:self"
-                                                        href="/lguychard">lguychard</a>
+    <a class="author link-gray-dark css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard">lguychard</a>
 
 
-                                                </strong>
-                                                <span class="text-gray">
-                                                    <a href="#discussion_r329949662"
-                                                        id="discussion_r329949662-minimized-permalink"
-                                                        class="timestamp">
-                                                        <relative-time datetime="2019-10-01T09:03:30Z"
-                                                            title="Oct 1, 2019, 11:03 AM GMT+2">yesterday
-                                                        </relative-time>
-                                                    </a>
-                                                </span>
-                                            </h4>
+                </strong>
+                <span class="text-gray">
+                    <a href="#discussion_r329949662" id="discussion_r329949662-minimized-permalink" class="timestamp"><relative-time datetime="2019-10-01T09:03:30Z" title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time></a>
+                </span>
+              </h4>
 
-                                            <span
-                                                class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
-                                                aria-label="You are a member of the Sourcegraph organization.">
-                                                Member
-                                            </span>
+      <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="You are a member of the Sourcegraph organization.">
+        Member
+      </span>
 
 
-                                            <task-lists sortable="">
-                                                <div
-                                                    class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
-                                                    <p>Rather than introducing a new class/concept to the codebase, I
-                                                        would consider reusing <a
-                                                            href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
-                                                            rel="nofollow"><code>Disposable</code></a> (an
-                                                        <code>Unsubscribable</code> supporting async resource disposal)
-                                                        pattern from sourcegraph-typescript (<a href="">example
-                                                            usage</a>) :</p>
-                                                    <div class="highlight highlight-source-ts">
-                                                        <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+              <task-lists sortable="">
+                <div class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
+                    <p>Rather than introducing a new class/concept to the codebase, I would consider reusing <a href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts" rel="nofollow"><code>Disposable</code></a> (an <code>Unsubscribable</code> supporting async resource disposal) pattern from sourcegraph-typescript (<a href="">example usage</a>) :</p>
+  <div class="highlight highlight-source-ts"><pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
   <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
       <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
       <span class="pl-k">return</span> {
@@ -381,310 +194,124 @@
               <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
           )
       })
-  })</pre>
-                                                    </div>
-                                                    <p>Pros:</p>
-                                                    <ul>
-                                                        <li>Developers working in our codebase are already familiar with
-                                                            the subscription / subscription bag pattern (and, if they're
-                                                            not, it is <a
-                                                                href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
-                                                                rel="nofollow">documented</a>).</li>
-                                                        <li>The cleanup logic is encapsulated, and lives next to the
-                                                            resource creation logic. It is not duplicated if
-                                                            <code>ensureLoggedInOrCreateTestUser()</code> is called from
-                                                            multiple test suites. Callers need not look up how a given
-                                                            resource should be cleaned up, they simply need to handle
-                                                            the returned disposable / subscription.</li>
-                                                    </ul>
-                                                </div>
-                                            </task-lists>
-                                        </div>
-                                    </div>
+  })</pre></div>
+  <p>Pros:</p>
+  <ul>
+  <li>Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is <a href="https://docs.sourcegraph.com/dev/typescript/patterns#bag" rel="nofollow">documented</a>).</li>
+  <li>The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</li>
+  </ul>
+                </div>
+              </task-lists>
+            </div>
+          </div>
 
-                                    <!-- '"` -->
-                                    <!-- </textarea></xmp> -->
-                                    <form data-upload-policy-url="/upload/policies/assets"
-                                        data-upload-policy-authenticity-token="4qjbgh2HhBri5AwEg50UWOJCLC0Mrysh8TXgs5JIjnppi3C+y1uNMztQ5qRXGEJ4j1GQF+yUi+zW7YiU0rSQ4g=="
-                                        class="js-comment-update rgh-minimize-upload-bar" data-type="json"
-                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                            value="✓"><input type="hidden" name="_method" value="put"><input
-                                            type="hidden" name="authenticity_token"
-                                            value="YpXLo1R2y/UrS52WC2CcVV6joTPPgD9i0IWAmIOOjRbAN4UzkUVf4HCimGfSJP7hZ5kOEwNZhhpk1+RgqF0sEw==">
-                                        <div class="js-previewable-comment-form previewable-comment-form write-selected"
-                                            data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
-                                            data-preview-authenticity-token="orQePHMGB458bxDm7HtWUrZKs6TZxgtG7/w+RVUjGQdeS+/QH0ulte9EOMphijlkDOXW7HSbhPJmlsO/O/DvXg==">
+            <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="fn83MX6SBhXQ/EbP3+X9OD7th/9IU4ZdoUAIJsEp9NP1XJwNqE4PPAlIrG8LYKsYU/47xahoJpCGmGABgdXqSw==" class="js-comment-update rgh-minimize-upload-bar" data-type="json" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="NLO4yAHcTHQmn9C8omfaWHDjRbCT5kE5jFUaDkH48H6WEfZYxO/YYX121U17I7jsSdnqkF8/+EE4B372aitRew==">
+              <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="qTB642QTyPdiWR0FVp8ydyoWzXezbNLGrZBpoK2ukMVVz4sPCF5qzPFyNSnbbl1BkLmoPx4xXXIk+pRaw31mnA==">
 
-                                            <div class="comment-form-head tabnav ">
-                                                <nav class="tabnav-tabs" role="tablist">
-                                                    <button type="button"
-                                                        class="btn-link tabnav-tab write-tab js-write-tab selected"
-                                                        role="tab" aria-selected="true">Write</button>
-                                                    <button type="button"
-                                                        class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                                        role="tab">Preview</button>
-                                                </nav>
+  <div class="comment-form-head tabnav ">
+    <nav class="tabnav-tabs" role="tablist">
+      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+    </nav>
 
 
-                                                <markdown-toolbar for="discussion_r329949662-minimize-comment-body"
-                                                    class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+  <markdown-toolbar for="discussion_r329949662-minimize-comment-body" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
 
 
-                                                    <div class="flex-nowrap d-inline-block mr-3">
-                                                        <md-header tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add header text"
-                                                            data-ga-click="Markdown Toolbar, click, header"
-                                                            role="button">
-                                                            <svg class="octicon octicon-text-size" viewBox="0 0 18 16"
-                                                                version="1.1" width="18" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-header>
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
 
-                                                        <md-bold tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add bold text <cmd-b>"
-                                                            data-ga-click="Markdown Toolbar, click, bold" role="button"
-                                                            hotkey="b">
-                                                            <svg class="octicon octicon-bold" viewBox="0 0 10 16"
-                                                                version="1.1" width="10" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-bold>
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
 
-                                                        <md-italic tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add italic text <cmd-i>"
-                                                            data-ga-click="Markdown Toolbar, click, italic"
-                                                            role="button" hotkey="i">
-                                                            <svg class="octicon octicon-italic" viewBox="0 0 6 16"
-                                                                version="1.1" width="6" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-italic>
-                                                    </div>
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
 
-                                                    <div class="d-inline-block mr-3">
-                                                        <md-quote tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                            aria-label="Insert a quote"
-                                                            data-ga-click="Markdown Toolbar, click, quote"
-                                                            role="button">
-                                                            <svg class="octicon octicon-quote" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-quote>
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
 
-                                                        <md-code tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                            aria-label="Insert code"
-                                                            data-ga-click="Markdown Toolbar, click, code" role="button">
-                                                            <svg class="octicon octicon-code" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-code>
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
 
 
-                                                        <md-link tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                            aria-label="Add a link <cmd-k>"
-                                                            data-ga-click="Markdown Toolbar, click, link" role="button"
-                                                            hotkey="k">
-                                                            <svg class="octicon octicon-link" viewBox="0 0 16 16"
-                                                                version="1.1" width="16" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-link>
-                                                    </div>
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
 
-                                                    <div class="d-inline-block mr-3">
-                                                        <md-unordered-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a bulleted list"
-                                                            data-ga-click="Markdown Toolbar, click, unordered list"
-                                                            role="button">
-                                                            <svg class="octicon octicon-list-unordered"
-                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-unordered-list>
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
 
-                                                        <md-ordered-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a numbered list"
-                                                            data-ga-click="Markdown Toolbar, click, ordered list"
-                                                            role="button">
-                                                            <svg class="octicon octicon-list-ordered"
-                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-ordered-list>
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
 
-                                                        <md-task-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a task list"
-                                                            data-ga-click="Markdown Toolbar, click, task list"
-                                                            role="button" hotkey="L">
-                                                            <svg class="octicon octicon-tasklist" viewBox="0 0 16 16"
-                                                                version="1.1" width="16" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-task-list>
-                                                    </div>
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
 
-                                                    <div class="d-inline-block">
-                                                        <md-mention tabindex="-1"
-                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                            aria-label="Directly mention a user or team"
-                                                            data-ga-click="Markdown Toolbar, click, mention"
-                                                            role="button">
-                                                            <svg class="octicon octicon-mention" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-mention>
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
 
 
-                                                        <md-ref tabindex="-1"
-                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                            aria-label="Reference an issue or pull request"
-                                                            data-ga-click="Markdown Toolbar, click, reference"
-                                                            role="button">
-                                                            <svg class="octicon octicon-bookmark" viewBox="0 0 10 16"
-                                                                version="1.1" width="10" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-ref><button type="button"
-                                                            class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
-                                                            aria-label="Attach files"><svg aria-hidden="true"
-                                                                class="octicon octicon-cloud-upload" width="16"
-                                                                height="16">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
-                                                                </path>
-                                                            </svg></button><button type="button"
-                                                            class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
-                                                            aria-label="Add collapsible content"><svg aria-hidden="true"
-                                                                class="octicon octicon-fold-down" width="14"
-                                                                height="16">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
-                                                                </path>
-                                                            </svg></button>
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-upload-btn" aria-label="Attach files"><svg aria-hidden="true" class="octicon octicon-cloud-upload" width="16" height="16"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"></path></svg></button><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
 
-                                                        <details
-                                                            class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                            tabindex="-1">
-                                                            <summary tabindex="-1"
-                                                                class="text-center menu-target p-1 ml-1"
-                                                                aria-label="Insert a reply"
-                                                                data-ga-click="Markdown Toolbar, click, saved reply"
-                                                                aria-haspopup="menu" role="button">
-                                                                <svg class="octicon octicon-reply" viewBox="0 0 14 16"
-                                                                    version="1.1" width="14" height="16"
-                                                                    aria-hidden="true">
-                                                                    <path fill-rule="evenodd"
-                                                                        d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                                    </path>
-                                                                </svg>
-                                                                <span class="dropdown-caret "></span>
-                                                            </summary>
-                                                            <details-menu style="z-index: 99;"
-                                                                class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                                data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id"
-                                                                src="/settings/replies?context=none" preload=""
-                                                                role="menu">
-                                                                <div class="select-menu-header d-flex">
-                                                                    <span class="select-menu-title flex-auto">Select a
-                                                                        reply</span>
-                                                                    <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                                </div>
-                                                                <include-fragment role="menuitem"
-                                                                    class="select-menu-loading-overlay anim-pulse"
-                                                                    aria-label="Loading">
-                                                                    <svg class="octicon octicon-octoface"
-                                                                        viewBox="0 0 16 16" version="1.1" width="16"
-                                                                        height="16" aria-hidden="true">
-                                                                        <path fill-rule="evenodd"
-                                                                            d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                                        </path>
-                                                                    </svg>
-                                                                </include-fragment>
-                                                            </details-menu>
-                                                        </details>
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
 
-                                                    </div>
+    </div>
 
-                                                </markdown-toolbar>
+  </markdown-toolbar>
 
-                                            </div>
+  </div>
 
 
-                                            <div class="clearfix"></div>
+    <div class="clearfix"></div>
 
-                                            <p class="comment-form-error comment-show-stale">
-                                                <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
-                                                    </path>
-                                                </svg> The content you are editing has changed. Please try again.
-                                            </p>
+    <p class="comment-form-error comment-show-stale">
+      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
+    </p>
 
 
-                                            <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
-                                                data-upload-policy-url="/upload/policies/assets"
-                                                data-upload-policy-authenticity-token="V1gczXVu5qrqpYrpn0SH5FGeMLt7QBlfALKFtxWdef7ce7fxo7LvgzMRYElLwdHEPI2MgZt7uZInau2QVWFnZg=="
-                                                data-upload-repository-id="41288708">
-                                                <input type="hidden" name="context" value="discussion">
+  <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="TH6+96ATJxczmVklV9FAii9K0wT/iNKOnp1jNckb1BTHXRXLds8uPuots4WDVBaqQllvPh+zckO5RQsSiefKjA==" data-upload-repository-id="41288708">
+    <input type="hidden" name="context" value="discussion">
 
-                                                <input type="hidden" name="saved_reply_id"
-                                                    id="discussion_r329949662-minimize-comment-body_saved_reply_id"
-                                                    class="js-resettable-field" value="" data-reset-value="">
+      <input type="hidden" name="saved_reply_id" id="discussion_r329949662-minimize-comment-body_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
 
-                                                <input type="hidden" name="pull_request_review_comment[id]"
-                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                <input type="hidden" name="pull_request_review_comment[bodyVersion]"
-                                                    class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+    <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+    <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
 
-                                                <text-expander keys=": @ #"
-                                                    data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                                    data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                                    data-emoji-url="/autocomplete/emoji">
+    <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
 
-                                                    <textarea name="pull_request_review_comment[body]"
-                                                        id="discussion_r329949662-minimize-comment-body"
-                                                        placeholder="Leave a comment" aria-label="Comment body"
-                                                        class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field"
-                                                        title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+      <textarea name="pull_request_review_comment[body]" id="discussion_r329949662-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -717,396 +344,218 @@
   Pros:
   - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
-                                                </text-expander>
+    </text-expander>
 
 
-                                                <p
-                                                    class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                                    <input
-                                                        accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                                        type="file" multiple=""
-                                                        class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                                        aria-label="Attach files to your comment"
-                                                        id="fc-discussion_r329949662-minimize-comment-body">
-                                                    <span
-                                                        class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                                        style="pointer-events: none;"></span>
-                                                    <span class="position-relative pr-2" style="pointer-events: none;">
-                                                        <span class="default">
-                                                            Attach files by dragging &amp; dropping, selecting or
-                                                            pasting them.
-                                                        </span>
-                                                        <span class="loading">
-                                                            <img alt="" width="16" height="16"
-                                                                src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                            Uploading your files…
-                                                        </span>
-                                                        <span class="error bad-file">
-                                                            We don’t support that file type.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a
-                                                                GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                                or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error bad-permissions">
-                                                            Attaching documents requires write permission to this
-                                                            repository.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
-                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error repository-required">
-                                                            We don’t support that file type.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
-                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error too-big">
-                                                            Yowza, that’s a big file
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a file smaller than 10MB.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error empty">
-                                                            This file is empty.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a file that’s not empty.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error hidden-file">
-                                                            This file is hidden.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with another file.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error failed-request">
-                                                            Something went really wrong, and we can’t process that file.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again.</button>
-                                                            </span>
-                                                        </span>
-                                                    </span>
-                                                    <span class="tooltipped tooltipped-nw"
-                                                        aria-label="Styling with Markdown is supported">
-                                                        <a class="muted-link position-relative d-inline"
-                                                            href="https://guides.github.com/features/mastering-markdown/"
-                                                            target="_blank"
-                                                            data-ga-click="Markdown Toolbar, click, help"
-                                                            aria-label="Learn about styling with Markdown">
-                                                            <svg class="octicon octicon-markdown v-align-bottom"
-                                                                viewBox="0 0 16 16" version="1.1" width="16" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                                </path>
-                                                            </svg>
-                                                        </a>
-                                                    </span>
-                                                </p>
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-discussion_r329949662-minimize-comment-body">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
 
-                                            </div>
+  </div>
 
 
-                                            <div class="preview-content">
-                                                <div class="comment js-suggested-changes-container"
-                                                    data-thread-side="right">
-                                                    <div
-                                                        class="comment-body markdown-body js-preview-body rgh-linkified-code">
-                                                        <p>Nothing to preview</p>
-                                                    </div>
-                                                </div>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="right">
+    <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
 
-                                            </div>
+    </div>
 
-                                            <div class="clearfix">
+    <div class="clearfix">
 
-                                                <input type="hidden" name="original-line"
-                                                    value="+export class TestResourceManager {"
-                                                    class="js-original-line">
-                                                <input type="hidden" name="path"
-                                                    value="web/src/regression/util/TestResourceManager.ts"
-                                                    class="js-path">
-                                                <input type="hidden" name="line" value="13" class="js-line-number">
-                                                <div class="form-actions comment-form-actions">
-                                                    <button class="btn btn-primary" type="submit"
-                                                        data-disable-with="">Update comment</button>
-                                                    <button class="btn btn-danger js-comment-cancel-button"
-                                                        type="button"
-                                                        data-confirm-text="Are you sure you want to discard your unsaved changes?">
-                                                        Cancel
-                                                    </button>
-                                                </div>
-                                            </div>
+      <input type="hidden" name="original-line" value="+export class TestResourceManager {" class="js-original-line">
+      <input type="hidden" name="path" value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+      <input type="hidden" name="line" value="13" class="js-line-number">
+      <div class="form-actions comment-form-actions">
+        <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
+        <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
+          Cancel
+        </button>
+      </div>
+    </div>
 
-                                            <div class="comment-form-error mb-2 js-comment-update-error" hidden="">
-                                            </div>
-                                        </div>
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
 
-                                    </form>
-                                </div>
-                            </div>
-                        </details>
+  </form>      </div>
+      </div>
+    </details>
 
 
-                    </div>
+      </div>
 
-                    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists"
-                        data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
-                        <div class="edit-comment-hide">
-                            <div class="timeline-comment-actions">
+    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists" data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
+      <div class="edit-comment-hide">
+        <div class="timeline-comment-actions">
 
-                                <details
-                                    class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button"
-                                    data-channel="reaction:pull-request-review-comment:329949662"
-                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
-                                    <summary class="btn-link link-gray timeline-comment-action"
-                                        aria-label="Add your reaction" aria-haspopup="menu" role="button">
-                                        <svg class="octicon octicon-plus-small add-reaction-plus-icon"
-                                            viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
-                                        </svg>
-                                        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16"
-                                            height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
-                                            </path>
-                                        </svg>
-                                    </summary>
+    <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:329949662" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
+      <summary class="btn-link link-gray timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu" role="button">
+        <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
+        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
+      </summary>
 
-                                    <details-menu
-                                        class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1"
-                                        aria-label="Pick your reaction" style="width: 150px" role="menu">
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="put"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="cuUwNudrFpsgD6dOdGt2udr7CgqwfrrgwAkPymiHZHij9QN0x8J0WMsxIW5Has3yIISBRAJRNnXaVGY6tvw1ew==">
-                                            <p class="text-gray mx-2 my-1">
-                                                <span class="js-reaction-description">Pick your reaction</span>
-                                            </p>
+  <details-menu class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1" aria-label="Pick your reaction" style="width: 150px" role="menu">
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="yaP6F4vHtmPXSGOci9olDbsWNlbnqz9v5kr8W3AiVbEYs8lVq27UoDx25by4255GQWm9GFWEs/r8F5WrrlkEsg==">
+      <p class="text-gray mx-2 my-1">
+        <span class="js-reaction-description">Pick your reaction</span>
+      </p>
 
-                                            <div role="none" class="dropdown-divider"></div>
+      <div role="none" class="dropdown-divider"></div>
 
-                                            <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
-                                                <input type="hidden" name="input[subjectId]"
-                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="+1" name="input[content]"
-                                                    aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-                                                    <g-emoji alias="+1"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                        class="emoji">👍</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="-1" name="input[content]"
-                                                    aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-                                                    <g-emoji alias="-1"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
-                                                        class="emoji">👎</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Laugh" name="input[content]"
-                                                    aria-label="React with laugh emoji" value="LAUGH react">
-                                                    <g-emoji alias="smile"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
-                                                        class="emoji">😄</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Hooray" name="input[content]"
-                                                    aria-label="React with hooray emoji" value="HOORAY react">
-                                                    <g-emoji alias="tada"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
-                                                        class="emoji">🎉</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Confused" name="input[content]"
-                                                    aria-label="React with confused emoji" value="CONFUSED react">
-                                                    <g-emoji alias="thinking_face"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
-                                                        class="emoji">😕</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Heart" name="input[content]"
-                                                    aria-label="React with heart emoji" value="HEART react">
-                                                    <g-emoji alias="heart"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                        class="emoji">❤️</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Rocket" name="input[content]"
-                                                    aria-label="React with rocket emoji" value="ROCKET react">
-                                                    <g-emoji alias="rocket"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
-                                                        class="emoji">🚀</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Eyes" name="input[content]"
-                                                    aria-label="React with eyes emoji" value="EYES react">
-                                                    <g-emoji alias="eyes"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
-                                                        class="emoji">👀</g-emoji>
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </details-menu>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+            <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+            <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
+            <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
+            <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
+            <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
+            <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
+            <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
+            <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
+          </button>
+      </div>
+  </form></details-menu>
 
-                                </details>
+    </details>
 
-                                <button type="button" role="menuitem"
-                                    class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment"
-                                    aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil"
-                                        width="14" height="16">
-                                        <path
-                                            d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z">
-                                        </path>
-                                    </svg></button>
-                                <details class="details-overlay details-reset position-relative d-inline-block"
-                                    id="details-discussion_r329949662">
-                                    <summary class="btn-link timeline-comment-action" aria-label="Show more options"
-                                        aria-haspopup="menu" role="button">
-                                        <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1"
-                                            width="13" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
-                                            </path>
-                                        </svg>
-                                    </summary>
+          <button type="button" role="menuitem" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r329949662">
+            <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu" role="button">
+              <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
+            </summary>
 
-                                    <details-menu
-                                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
-                                        style="width:185px; z-index: 99;" role="menu">
+            <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
 
-                                        <clipboard-copy class="dropdown-item btn-link"
-                                            for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
-                                            Copy link
-                                        </clipboard-copy>
+              <clipboard-copy class="dropdown-item btn-link" for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
+                Copy link
+              </clipboard-copy>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link d-none js-comment-quote-reply">
-                                            Quote reply
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply">
+                Quote reply
+              </button>
 
 
-                                        <details
-                                            class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-                                            <summary class="dropdown-item" role="menuitem">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
+    <summary class="dropdown-item" role="menuitem">
 
-                                                Reference in new issue
-                                            </summary>
-                                            <details-dialog aria-label="Reference in new issue"
-                                                class="Box Box--overlay d-flex flex-column anim-fade-in fast "
-                                                role="dialog" aria-modal="true">
-                                                <div class="Box-header">
-                                                    <button class="Box-btn-octicon btn-octicon float-right"
-                                                        type="button" aria-label="Close dialog" data-close-dialog="">
-                                                        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1"
-                                                            width="12" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
-                                                            </path>
-                                                        </svg>
-                                                    </button>
-                                                    <h3 class="Box-title ">Reference in new issue</h3>
-                                                </div>
+      Reference in new issue
+    </summary>
+    <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog" aria-modal="true">
+      <div class="Box-header">
+        <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
+          <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+        </button>
+        <h3 class="Box-title ">Reference in new issue</h3>
+      </div>
 
-                                                <div class="Box-body scrollable-overlay">
+                  <div class="Box-body scrollable-overlay">
 
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form action="/comments/issues" accept-charset="UTF-8"
-                                                        method="post"><input name="utf8" type="hidden" value="✓"><input
-                                                            type="hidden" name="authenticity_token"
-                                                            value="/Jf4vYp0Op+AaHeg3uE/oWvp2uepBbcE8L++fZDXd3gB3eSn0ZxoFE0RrfRSVh0AFaq1jRzHoE4YFX8JjxzcDw==">
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label>
-                                                            </dt>
-                                                            <dd>
-                                                                <details
-                                                                    class="details-reset details-overlay select-menu">
-                                                                    <summary class="btn select-menu-button"
-                                                                        data-menu-button="" aria-haspopup="menu"
-                                                                        role="button">
-                                                                        <input type="hidden" name="issue[repository_id]"
-                                                                            value="41288708" checked="">
-                                                                        sourcegraph
-                                                                    </summary>
-                                                                    <details-menu
-                                                                        class="select-menu-modal position-absolute"
-                                                                        style="z-index: 99;"
-                                                                        src="/sourcegraph/sourcegraph/related_repositories"
-                                                                        preload="" role="menu">
-                                                                        <div class="select-menu-header">
-                                                                            <span
-                                                                                class="select-menu-title">Repositories</span>
-                                                                        </div>
-                                                                        <div class="select-menu-filters">
-                                                                            <div class="select-menu-text-filter">
-                                                                                <remote-input
-                                                                                    src="/sourcegraph/sourcegraph/related_repositories"
-                                                                                    aria-owns="related-repositories-menu">
-                                                                                    <input type="text"
-                                                                                        class="form-control"
-                                                                                        aria-label="Type to filter"
-                                                                                        placeholder="Find a repository"
-                                                                                        autofocus="" autocomplete="off"
-                                                                                        spellcheck="false">
-                                                                                </remote-input>
-                                                                            </div>
-                                                                        </div>
-                                                                        <include-fragment class="octocat-spinner my-6"
-                                                                            aria-label="Loading"></include-fragment>
-                                                                    </details-menu>
-                                                                </details>
-                                                            </dd>
-                                                        </dl>
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label>
-                                                            </dt>
-                                                            <dd><input
-                                                                    id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                                                                    class="form-control" type="text" name="issue[title]"
-                                                                    value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :"
-                                                                    aria-label="Issue title" autofocus="" required="">
-                                                            </dd>
-                                                        </dl>
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label>
-                                                            </dt>
-                                                            <dd><textarea
-                                                                    id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                                                                    name="issue[body]" class="form-control"
-                                                                    aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+  <!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="EbuJSF87nVfLLqfozgYkuQWS6dxdxlfHMRVh35qm8fzs8ZVSBNPP3AZXfbxCsQYYe9GGtugEQI3Zv6CrhW1aiw==">
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label></dt>
+      <dd>
+        <details class="details-reset details-overlay select-menu">
+          <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu" role="button">
+            <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
+            sourcegraph
+          </summary>
+          <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
+            <div class="select-menu-header">
+              <span class="select-menu-title">Repositories</span>
+            </div>
+            <div class="select-menu-filters">
+              <div class="select-menu-text-filter">
+                <remote-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
+                  <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
+                </remote-input>
+              </div>
+            </div>
+            <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
+          </details-menu>
+        </details>
+      </dd>
+    </dl>
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label></dt>
+      <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" class="form-control" type="text" name="issue[title]" value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :" aria-label="Issue title" autofocus="" required=""></dd>
+    </dl>
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label></dt>
+      <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" name="issue[body]" class="form-control" aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -1141,183 +590,157 @@
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.
 
   _Originally posted by @lguychard in https://github.com/sourcegraph/sourcegraph/pull/5746_</textarea></dd>
-                                                        </dl>
+    </dl>
 
-                                                        <div class="d-flex d-sm-block">
-                                                            <button type="submit" class="btn btn-primary"
-                                                                data-disable-with="Creating issue..."
-                                                                data-disable-invalid=""
-                                                                data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-                                                                Create issue
-                                                            </button>
-                                                        </div>
-                                                    </form>
-                                                </div>
+    <div class="d-flex d-sm-block">
+      <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
+        Create issue
+      </button>
+    </div>
+  </form>
+                  </div>
 
-                                            </details-dialog>
-                                        </details>
+    </details-dialog>
+  </details>
 
-                                        <div role="none" class="dropdown-divider"></div>
+                <div role="none" class="dropdown-divider"></div>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment"
-                                            aria-label="Edit comment" hidden="">
-                                            Edit
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment" hidden="">
+                Edit
+              </button>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link js-comment-hide-button"
-                                            aria-label="Hide comment">
-                                            Hide
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
+                Hide
+              </button>
 
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="width-full inline-form js-comment-delete"
-                                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="delete"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="6me1DA6PKRXiG3JKy13LDky934p/tayH2Zg5g8w7X6PTks2yJcHfE98aPoeD8xCjTwTEJu1aEHy1x8DL/Q1sJA==">
-                                            <input type="hidden" name="input[id]"
-                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                            <button type="submit" role="menuitem"
-                                                class="dropdown-item menu-item-danger btn-link"
-                                                aria-label="Delete comment"
-                                                data-confirm="Are you sure you want to delete this?">
-                                                Delete
-                                            </button>
-                                        </form>
+              <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="23YdWUgvnHz4CvyDK963xGLB/pCbkfPZIXBiGH20psjig2XnY2FqesULsE5jcGxpYXjlPAl+TyJNL5tQTIKVTw==">
+                <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
+                  Delete
+                </button>
+  </form>
 
 
-                                    </details-menu>
-                                </details>
-                            </div>
+            </details-menu>
+          </details>
+        </div>
 
-                            <span class="float-left mt-1">
-                                <a class="d-inline-block" data-hovercard-type="user"
-                                    data-hovercard-url="/hovercards?user_id=1741180"
-                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                    href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard"
-                                        src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
-                            </span>
+        <span class="float-left mt-1">
+          <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard" src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+        </span>
 
-                            <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-                                <h4 class="f5 text-normal d-inline">
-                                    <strong>
+        <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
+          <h4 class="f5 text-normal d-inline">
+            <strong>
 
 
-                                        <a class="author link-gray-dark css-truncate-target rgh-fullname"
-                                            show_full_name="false" data-hovercard-type="user"
-                                            data-hovercard-url="/hovercards?user_id=1741180"
-                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                            href="/lguychard">lguychard</a>
+    <a class="author link-gray-dark css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard">lguychard</a>
 
 
-                                    </strong>
-                                    <span class="text-gray">
+            </strong>
+            <span class="text-gray">
 
-                                        <a href="#discussion_r329949662" id="discussion_r329949662-permalink"
-                                            class="js-timestamp timestamp d-inline-block">
-                                            <relative-time datetime="2019-10-01T09:03:30Z"
-                                                title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
-                                        </a>
+                <a href="#discussion_r329949662" id="discussion_r329949662-permalink" class="js-timestamp timestamp d-inline-block">
+                  <relative-time datetime="2019-10-01T09:03:30Z" title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
+                </a>
 
 
-                                        <span class="d-inline-block text-gray-light">•</span>
+    <span class="d-inline-block text-gray-light">•</span>
 
-                                        <details class="details-overlay details-reset d-inline-block dropdown">
-                                            <summary class="btn-link no-underline text-gray js-notice"
-                                                aria-haspopup="menu" role="button">
-                                                <div class="position-relative">
-                                                    <span>
-                                                        edited
-                                                    </span>
-                                                    <svg height="11"
-                                                        class="octicon octicon-triangle-down v-align-middle"
-                                                        viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true">
-                                                        <path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path>
-                                                    </svg>
-                                                </div>
-                                            </summary>
-                                            <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0"
-                                                style="width:352px"
-                                                src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log"
-                                                preload="" role="menu">
-                                                <include-fragment class="octocat-spinner my-3" aria-label="Loading">
-                                                </include-fragment>
-                                            </details-menu>
-                                        </details>
-
-                                    </span>
-                                </h4>
+    <details class="details-overlay details-reset d-inline-block dropdown">
+      <summary class="btn-link no-underline text-gray js-notice" aria-haspopup="menu" role="button">
+        <div class="position-relative">
+          <span>
+              edited
+          </span>
+          <svg height="11" class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
+        </div>
+      </summary>
+      <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px" src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log" preload="" role="menu">
 
 
+  <div class="dropdown-header px-3 py-2 border-bottom">Edited 2 times</div>
+  <ul class="bg-gray-light" style="overflow-y:auto; max-height:250px">
+      <li class="border-bottom css-truncate">
+          <details class="details-reset details-overlay details-overlay-dark">
+            <summary class="dropdown-item p-2" role="menuitem">          <img src="https://avatars1.githubusercontent.com/u/1741180?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@lguychard">
+            <span class="css-truncate-target v-align-middle text-bold text-small">lguychard</span>
+          <span class="v-align-middle text-small">edited <relative-time datetime="2019-10-01T09:25:41Z" title="Oct 1, 2019, 11:25 AM GMT+2">yesterday</relative-time> (most recent)</span>
+  </summary>
+            <details-dialog src="/user_content_edits/MDE1OlVzZXJDb250ZW50RWRpdDI4NjA1MDA3Mg==" class="anim-fade-in fast Box Box-overlay--wide d-flex flex-column" role="dialog" aria-modal="true">
+              <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
+            </details-dialog>
+          </details>
+      </li>
+      <li class="border-bottom css-truncate">
+          <details class="details-reset details-overlay details-overlay-dark">
+            <summary class="dropdown-item p-2" role="menuitem">          <img src="https://avatars1.githubusercontent.com/u/1741180?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@lguychard">
+            <span class="css-truncate-target v-align-middle text-bold text-small">lguychard</span>
+          <span class="v-align-middle text-small">edited <relative-time datetime="2019-10-01T09:06:13Z" title="Oct 1, 2019, 11:06 AM GMT+2">yesterday</relative-time></span>
+  </summary>
+            <details-dialog src="/user_content_edits/MDE1OlVzZXJDb250ZW50RWRpdDI4NjAzODkxMA==" class="anim-fade-in fast Box Box-overlay--wide d-flex flex-column" role="dialog" aria-modal="true">
+              <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
+            </details-dialog>
+          </details>
+      </li>
+      <li class="border-bottom css-truncate">
+          <details class="details-reset details-overlay details-overlay-dark">
+            <summary class="dropdown-item p-2" role="menuitem">          <img src="https://avatars1.githubusercontent.com/u/1741180?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@lguychard">
+            <span class="css-truncate-target v-align-middle text-bold text-small">lguychard</span>
+          <span class="v-align-middle text-small">created <relative-time datetime="2019-10-01T09:03:30Z" title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time></span>
+  </summary>
+            <details-dialog src="/user_content_edits/MDE1OlVzZXJDb250ZW50RWRpdDI4NjAzODkwOQ==" class="anim-fade-in fast Box Box-overlay--wide d-flex flex-column" role="dialog" aria-modal="true">
+              <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
+            </details-dialog>
+          </details>
+      </li>
+  </ul>
 
-                                <span
-                                    class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
-                                    aria-label="You are a member of the Sourcegraph organization.">
-                                    Member
-                                </span>
+      </details-menu>
+    </details>
 
-
-                                <div class="js-minimize-comment d-none">
-
-
-                                    <div class="flash flash-warn my-2">
-                                        <button class="flash-close js-comment-hide-minimize-form" type="button"><svg
-                                                aria-label="Cancel hiding comment" class="octicon octicon-x"
-                                                viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img">
-                                                <path fill-rule="evenodd"
-                                                    d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
-                                                </path>
-                                            </svg></button>
-                                        <h3 class="f5">Choose a reason for hiding this comment</h3>
-                                        <p class="mb-3">The reason will be displayed to describe this comment to others.
-                                            <a
-                                                href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn
-                                                more</a>.</p>
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="js-comment-minimize"
-                                            action="/sourcegraph/sourcegraph/community/minimize-comment"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="put"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="yZEBpGPt78IJQ8rNM7x93IXCr9dO6H6ZxNNcE1no/cJOmYDHuNPVlO/z5MXxgrfiuXwF1SjrG4boCRK4uTpsDA==">
-                                            <input type="hidden" name="comment_id"
-                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                            <select name="classifier" class="form-select mr-2" aria-label="Reason"
-                                                required="">
-                                                <option value="">
-                                                    Choose a reason
-                                                </option>
-                                                <option value="SPAM">Spam</option>
-                                                <option value="ABUSE">Abuse</option>
-                                                <option value="OFF_TOPIC">Off Topic</option>
-                                                <option value="OUTDATED">Outdated</option>
-                                                <option value="RESOLVED">Resolved</option>
-                                            </select>
-                                            <button type="submit" class="btn">
-                                                Hide comment
-                                            </button>
-                                        </form>
-                                    </div>
-
-                                </div>
+            </span>
+          </h4>
 
 
 
-                                <task-lists sortable="">
-                                    <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
-                                        <p>Rather than introducing a new class/concept to the codebase, I would consider
-                                            reusing <a
-                                                href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
-                                                rel="nofollow"><code>Disposable</code></a> (an
-                                            <code>Unsubscribable</code> supporting async resource disposal) pattern from
-                                            sourcegraph-typescript (<a href="">example usage</a>) :</p>
-                                        <div class="highlight highlight-source-ts">
-                                            <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+      <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="You are a member of the Sourcegraph organization.">
+        Member
+      </span>
+
+
+            <div class="js-minimize-comment d-none">
+
+
+  <div class="flash flash-warn my-2">
+    <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+    <h3 class="f5">Choose a reason for hiding this comment</h3>
+    <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="a7sIJ8YcDZNjZR7G4TwMPC2sGTUOZTe4ABAuGDsgzQ/ss4lEHSI3xYXVMM4jAsYCERKzN2hmUqcsymCz2/JcwQ==">
+      <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
+        <option value="">
+        Choose a reason
+        </option>
+        <option value="SPAM">Spam</option>
+  <option value="ABUSE">Abuse</option>
+  <option value="OFF_TOPIC">Off Topic</option>
+  <option value="OUTDATED">Outdated</option>
+  <option value="RESOLVED">Resolved</option>
+      </select>
+      <button type="submit" class="btn">
+        Hide comment
+      </button>
+  </form></div>
+
+            </div>
+
+
+
+          <task-lists sortable="">
+            <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
+              <p>Rather than introducing a new class/concept to the codebase, I would consider reusing <a href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts" rel="nofollow"><code>Disposable</code></a> (an <code>Unsubscribable</code> supporting async resource disposal) pattern from sourcegraph-typescript (<a href="">example usage</a>) :</p>
+  <div class="highlight highlight-source-ts"><pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
   <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
       <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
       <span class="pl-k">return</span> {
@@ -1341,439 +764,189 @@
               <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
           )
       })
-  })</pre>
-                                        </div>
-                                        <p>Pros:</p>
-                                        <ul>
-                                            <li>Developers working in our codebase are already familiar with the
-                                                subscription / subscription bag pattern (and, if they're not, it is <a
-                                                    href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
-                                                    rel="nofollow">documented</a>).</li>
-                                            <li>The cleanup logic is encapsulated, and lives next to the resource
-                                                creation logic. It is not duplicated if
-                                                <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple
-                                                test suites. Callers need not look up how a given resource should be
-                                                cleaned up, they simply need to handle the returned disposable /
-                                                subscription.</li>
-                                        </ul>
-                                    </div>
-                                </task-lists>
+  })</pre></div>
+  <p>Pros:</p>
+  <ul>
+  <li>Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is <a href="https://docs.sourcegraph.com/dev/typescript/patterns#bag" rel="nofollow">documented</a>).</li>
+  <li>The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</li>
+  </ul>
+            </div>
+          </task-lists>
 
 
 
 
-                                <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content"
-                                    data-channel="reaction:pull-request-review-comment:329949662"
-                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
-                                    <!-- '"` -->
-                                    <!-- </textarea></xmp> -->
-                                    <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                            value="✓"><input type="hidden" name="_method" value="put"><input
-                                            type="hidden" name="authenticity_token"
-                                            value="41BpsrqL6gw4ybmub8M6nAhWCghx6NN3pxS4zsKL7RMyQFrwmiKIz9P3P45cwoHX8imBRsPHX+K9SdE+HPC8EA==">
-                                        <input type="hidden" name="input[subjectId]"
-                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+  <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:329949662" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="99xuhC5pk2ZcBV5XVIW6YwpedQw4LHe6Gb3pXOfqHA0mzF3GDsDxpbc72HdnhAEo8CH+QooD+y8D4ICsOZFNDg==">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                        <div class="comment-reactions-options rgh-reactions">
-                                            <button
-                                                class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline "
-                                                name="input[content]" type="submit" value="THUMBS_UP react"
-                                                aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
-                                                <g-emoji alias="+1"
-                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                    class="emoji mr-1">👍</g-emoji>
-                                                2
-                                                <a href="/felixfbecker"><img
-                                                        src="/felixfbecker.png?size=44.000000953674316"></a><a
-                                                    href="/unknwon"><img
-                                                        src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a>
-                                            </button>
-                                            <button
-                                                class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline "
-                                                name="input[content]" type="submit" value="HEART react"
-                                                aria-label="unknwon reacted with heart emoji">
-                                                <g-emoji alias="heart"
-                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                    class="emoji mr-1">❤️</g-emoji>
-                                                1
-                                                <a href="/unknwon"><img
-                                                        src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a>
-                                            </button>
-                                        </div>
-                                    </form>
-                                    <details
-                                        class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
-                                        <summary class="btn-link reaction-summary-item add-reaction-btn"
-                                            aria-label="Add your reaction" aria-haspopup="menu" role="button">
-                                            <svg class="octicon octicon-plus-small add-reaction-plus-icon"
-                                                viewBox="0 0 7 16" version="1.1" width="7" height="16"
-                                                aria-hidden="true">
-                                                <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
-                                            </svg>
-                                            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1"
-                                                width="16" height="16" aria-hidden="true">
-                                                <path fill-rule="evenodd"
-                                                    d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
-                                                </path>
-                                            </svg>
-                                        </summary>
+        <div class="comment-reactions-options rgh-reactions">
+            <button class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline " name="input[content]" type="submit" value="THUMBS_UP react" aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
+              <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji mr-1">👍</g-emoji>
+              2
+            <a href="/felixfbecker"><img src="/felixfbecker.png?size=44.000000953674316"></a><a href="/unknwon"><img src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a></button>
+            <button class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline " name="input[content]" type="submit" value="HEART react" aria-label="unknwon reacted with heart emoji">
+              <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji mr-1">❤️</g-emoji>
+              1
+            <a href="/unknwon"><img src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a></button>
+        </div>
+  </form>      <details class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
+          <summary class="btn-link reaction-summary-item add-reaction-btn" aria-label="Add your reaction" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
+            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
+          </summary>
 
-                                        <details-menu
-                                            class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0"
-                                            aria-label="Pick your reaction" style="width: 150px" role="menu">
-                                            <!-- '"` -->
-                                            <!-- </textarea></xmp> -->
-                                            <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                                accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                    value="✓"><input type="hidden" name="_method" value="put"><input
-                                                    type="hidden" name="authenticity_token"
-                                                    value="M0y2vm54Hpcv9TYHQorcD+M7O717kdsZNi3CBuTiIMPiXIX8TtF8VMTLsCdxi2dEGUSw88m+V4wscKv2OplxwA==">
-                                                <p class="text-gray mx-2 my-1">
-                                                    <span class="js-reaction-description">Pick your reaction</span>
-                                                </p>
+  <details-menu class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0" aria-label="Pick your reaction" style="width: 150px" role="menu">
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Kmzaow/u87SUwUE46JicILBPCNCdLLRewr0cu+oQOQv7fOnhL0eRd3//xxjbmSdrSjCDni8DOMvY4HVLNGtoCA==">
+      <p class="text-gray mx-2 my-1">
+        <span class="js-reaction-description">Pick your reaction</span>
+      </p>
 
-                                                <div role="none" class="dropdown-divider"></div>
+      <div role="none" class="dropdown-divider"></div>
 
-                                                <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
-                                                    <input type="hidden" name="input[subjectId]"
-                                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="+1" name="input[content]"
-                                                        aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-                                                        <g-emoji alias="+1"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                            class="emoji">👍</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="-1" name="input[content]"
-                                                        aria-label="React with thumbs down emoji"
-                                                        value="THUMBS_DOWN react">
-                                                        <g-emoji alias="-1"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
-                                                            class="emoji">👎</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Laugh" name="input[content]"
-                                                        aria-label="React with laugh emoji" value="LAUGH react">
-                                                        <g-emoji alias="smile"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
-                                                            class="emoji">😄</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Hooray" name="input[content]"
-                                                        aria-label="React with hooray emoji" value="HOORAY react">
-                                                        <g-emoji alias="tada"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
-                                                            class="emoji">🎉</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Confused" name="input[content]"
-                                                        aria-label="React with confused emoji" value="CONFUSED react">
-                                                        <g-emoji alias="thinking_face"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
-                                                            class="emoji">😕</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Heart" name="input[content]"
-                                                        aria-label="React with heart emoji" value="HEART react">
-                                                        <g-emoji alias="heart"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                            class="emoji">❤️</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Rocket" name="input[content]"
-                                                        aria-label="React with rocket emoji" value="ROCKET react">
-                                                        <g-emoji alias="rocket"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
-                                                            class="emoji">🚀</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Eyes" name="input[content]"
-                                                        aria-label="React with eyes emoji" value="EYES react">
-                                                        <g-emoji alias="eyes"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
-                                                            class="emoji">👀</g-emoji>
-                                                    </button>
-                                                </div>
-                                            </form>
-                                        </details-menu>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+            <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+            <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
+            <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
+            <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
+            <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
+            <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
+            <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
+            <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
+          </button>
+      </div>
+  </form></details-menu>
 
-                                    </details>
-                                </div>
+        </details>
+  </div>
 
-                            </div>
-                        </div>
+        </div>
+      </div>
 
-                        <!-- '"` -->
-                        <!-- </textarea></xmp> -->
-                        <form data-upload-policy-url="/upload/policies/assets"
-                            data-upload-policy-authenticity-token="MDWlZu6+B52FTLzW3KYRsk2FE4IsfIQprCf5lkKLvmm7Fg5aOGIOtFz4VnYII0eSIJavuMxHJOSL/5GxAneg8Q=="
-                            class="js-comment-update rgh-minimize-upload-bar" data-type="json"
-                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8"
-                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method"
-                                value="put"><input type="hidden" name="authenticity_token"
-                                value="rKwADXJfQ8UZx+LuFiUkh7p/R55I0fjbz7lw7pcsoNkODk6dt2zX0EIu5x/PYUYzg0XovoQIQaN76xQWvP8B3A==">
-                            <div class="js-previewable-comment-form previewable-comment-form write-selected"
-                                data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
-                                data-preview-authenticity-token="k9SaVVRXJblEe6bwqKDaHNtqUS9Yfd/Xv2o/daJhyIdvK2u5OBqHgtdQjtwlUbUqYcU0Z/UgUGM2AMKPzLI+3g==">
+        <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="hFyDF6/EN1Ou0ANklBGLxBley0Z42oB3w7x6+5qFbhMPfygreRg+endk6cRAlN3kdE13fJjhILrkZBLc2nlwiw==" class="js-comment-update rgh-minimize-upload-bar" data-type="json" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="3pVnpKzujUT2xe3RG/9ezjl5v2KSqJcWCmvQ7+MjuD18Nyk0ad0ZUa0s6CDCuzx6AEMQQl5xLm6+ObQXyPAZOA==">
+          <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="qcAiWGjG7aDKCF8VD2uzVm0QDVKaHpLx6XnkDG9ethpVP9O0BItPm1kjdzmCmtxg179oGjdDHUVgExn2AY1AQw==">
 
-                                <div class="comment-form-head tabnav ">
-                                    <nav class="tabnav-tabs" role="tablist">
-                                        <button type="button"
-                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
-                                            aria-selected="true">Write</button>
-                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                            role="tab">Preview</button>
-                                    </nav>
+  <div class="comment-form-head tabnav ">
+    <nav class="tabnav-tabs" role="tablist">
+      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+    </nav>
 
 
-                                    <markdown-toolbar for="discussion_r329949662-body"
-                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+  <markdown-toolbar for="discussion_r329949662-body" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
 
 
-                                        <div class="flex-nowrap d-inline-block mr-3">
-                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add header text"
-                                                data-ga-click="Markdown Toolbar, click, header" role="button">
-                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
-                                                    width="18" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-header>
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
 
-                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add bold text <cmd-b>"
-                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-bold>
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
 
-                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add italic text <cmd-i>"
-                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
-                                                hotkey="i">
-                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
-                                                    width="6" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                    </path>
-                                                </svg>
-                                            </md-italic>
-                                        </div>
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
 
-                                        <div class="d-inline-block mr-3">
-                                            <md-quote tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert a quote"
-                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
-                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-quote>
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
 
-                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
-                                                role="button">
-                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                    </path>
-                                                </svg>
-                                            </md-code>
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
 
 
-                                            <md-link tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                aria-label="Add a link <cmd-k>"
-                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                    </path>
-                                                </svg>
-                                            </md-link>
-                                        </div>
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
 
-                                        <div class="d-inline-block mr-3">
-                                            <md-unordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a bulleted list"
-                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-unordered-list>
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
 
-                                            <md-ordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a numbered list"
-                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ordered-list>
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
 
-                                            <md-task-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a task list"
-                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
-                                                hotkey="L">
-                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                    </path>
-                                                </svg>
-                                            </md-task-list>
-                                        </div>
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
 
-                                        <div class="d-inline-block">
-                                            <md-mention tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Directly mention a user or team"
-                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
-                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                    </path>
-                                                </svg>
-                                            </md-mention>
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
 
 
-                                            <md-ref tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Reference an issue or pull request"
-                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
-                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ref><button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
-                                                aria-label="Attach files"><svg aria-hidden="true"
-                                                    class="octicon octicon-cloud-upload" width="16" height="16">
-                                                    <path fill-rule="evenodd"
-                                                        d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
-                                                    </path>
-                                                </svg></button><button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
-                                                aria-label="Add collapsible content"><svg aria-hidden="true"
-                                                    class="octicon octicon-fold-down" width="14" height="16">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
-                                                    </path>
-                                                </svg></button>
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-upload-btn" aria-label="Attach files"><svg aria-hidden="true" class="octicon octicon-cloud-upload" width="16" height="16"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"></path></svg></button><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
 
-                                            <details
-                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                tabindex="-1">
-                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
-                                                    aria-label="Insert a reply"
-                                                    data-ga-click="Markdown Toolbar, click, saved reply"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
-                                                        width="14" height="16" aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                        </path>
-                                                    </svg>
-                                                    <span class="dropdown-caret "></span>
-                                                </summary>
-                                                <details-menu style="z-index: 99;"
-                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                    data-menu-input="discussion_r329949662-body_saved_reply_id"
-                                                    src="/settings/replies?context=none" preload="" role="menu">
-                                                    <div class="select-menu-header d-flex">
-                                                        <span class="select-menu-title flex-auto">Select a reply</span>
-                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                    </div>
-                                                    <include-fragment role="menuitem"
-                                                        class="select-menu-loading-overlay anim-pulse"
-                                                        aria-label="Loading">
-                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
-                                                            version="1.1" width="16" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                            </path>
-                                                        </svg>
-                                                    </include-fragment>
-                                                </details-menu>
-                                            </details>
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="discussion_r329949662-body_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
 
-                                        </div>
+    </div>
 
-                                    </markdown-toolbar>
+  </markdown-toolbar>
 
-                                </div>
+  </div>
 
 
-                                <div class="clearfix"></div>
+    <div class="clearfix"></div>
 
-                                <p class="comment-form-error comment-show-stale">
-                                    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16"
-                                        height="16" aria-hidden="true">
-                                        <path fill-rule="evenodd"
-                                            d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
-                                        </path>
-                                    </svg> The content you are editing has changed. Please try again.
-                                </p>
+    <p class="comment-form-error comment-show-stale">
+      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
+    </p>
 
 
-                                <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
-                                    data-upload-policy-url="/upload/policies/assets"
-                                    data-upload-policy-authenticity-token="x9bs+/oR+Pyjl7mz64BZRDh6fQ/fqWwCWH3jQI+GXZlM9UfHLM3x1XojUxM/BQ9kVWnBNT+SzM9/pYtnz3pDAQ=="
-                                    data-upload-repository-id="41288708">
-                                    <input type="hidden" name="context" value="discussion">
+  <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="nETk2px6mr/En1W1I47ZKMLnxlhw8ZPIj0O+23ekxM0XZ0/mSqaTlh0rvxX3C48Ir/R6YpDKMwWom9b8N1jaVQ==" data-upload-repository-id="41288708">
+    <input type="hidden" name="context" value="discussion">
 
-                                    <input type="hidden" name="saved_reply_id"
-                                        id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field"
-                                        value="" data-reset-value="">
+      <input type="hidden" name="saved_reply_id" id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
 
-                                    <input type="hidden" name="pull_request_review_comment[id]"
-                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                    <input type="hidden" name="pull_request_review_comment[bodyVersion]"
-                                        class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+    <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+    <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
 
-                                    <text-expander keys=": @ #"
-                                        data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                        data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                        data-emoji-url="/autocomplete/emoji">
+    <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
 
-                                        <textarea name="pull_request_review_comment[body]"
-                                            id="discussion_r329949662-body" placeholder="Leave a comment"
-                                            aria-label="Comment body"
-                                            class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field"
-                                            title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+      <textarea name="pull_request_review_comment[body]" id="discussion_r329949662-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -1806,567 +979,325 @@
   Pros:
   - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
-                                    </text-expander>
+    </text-expander>
 
 
-                                    <p
-                                        class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                        <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                            type="file" multiple=""
-                                            class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                            aria-label="Attach files to your comment"
-                                            id="fc-discussion_r329949662-body">
-                                        <span
-                                            class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                            style="pointer-events: none;"></span>
-                                        <span class="position-relative pr-2" style="pointer-events: none;">
-                                            <span class="default">
-                                                Attach files by dragging &amp; dropping, selecting or pasting them.
-                                            </span>
-                                            <span class="loading">
-                                                <img alt="" width="16" height="16"
-                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                Uploading your files…
-                                            </span>
-                                            <span class="error bad-file">
-                                                We don’t support that file type.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a
-                                                    GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error bad-permissions">
-                                                Attaching documents requires write permission to this repository.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
-                                                    PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error repository-required">
-                                                We don’t support that file type.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
-                                                    PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error too-big">
-                                                Yowza, that’s a big file
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a file smaller than 10MB.
-                                                </span>
-                                            </span>
-                                            <span class="error empty">
-                                                This file is empty.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a file that’s not empty.
-                                                </span>
-                                            </span>
-                                            <span class="error hidden-file">
-                                                This file is hidden.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with another file.
-                                                </span>
-                                            </span>
-                                            <span class="error failed-request">
-                                                Something went really wrong, and we can’t process that file.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again.</button>
-                                                </span>
-                                            </span>
-                                        </span>
-                                        <span class="tooltipped tooltipped-nw"
-                                            aria-label="Styling with Markdown is supported">
-                                            <a class="muted-link position-relative d-inline"
-                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                target="_blank" data-ga-click="Markdown Toolbar, click, help"
-                                                aria-label="Learn about styling with Markdown">
-                                                <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16"
-                                                    version="1.1" width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                    </path>
-                                                </svg>
-                                            </a>
-                                        </span>
-                                    </p>
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-discussion_r329949662-body">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
 
-                                </div>
+  </div>
 
 
-                                <div class="preview-content">
-                                    <div class="comment js-suggested-changes-container" data-thread-side="right">
-                                        <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-                                            <p>Nothing to preview</p>
-                                        </div>
-                                    </div>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="right">
+    <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
 
-                                </div>
-
-                                <div class="clearfix">
-
-                                    <input type="hidden" name="original-line"
-                                        value="+export class TestResourceManager {" class="js-original-line">
-                                    <input type="hidden" name="path"
-                                        value="web/src/regression/util/TestResourceManager.ts" class="js-path">
-                                    <input type="hidden" name="line" value="13" class="js-line-number">
-                                    <div class="form-actions comment-form-actions">
-                                        <button class="btn btn-primary" type="submit" data-disable-with="">Update
-                                            comment</button>
-                                        <button class="btn btn-danger js-comment-cancel-button" type="button"
-                                            data-confirm-text="Are you sure you want to discard your unsaved changes?">
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-                            </div>
-
-                        </form>
-                    </div>
-                </div>
-
-
-
-            </div>
-
-            <div class="review-thread-reply border-bottom">
-
-                <div class="inline-comment-form-container js-inline-comment-form-container">
-                    <div class="inline-comment-form-actions">
-                        <div class="d-table width-full">
-                            <div class="d-table-cell">
-                                <a class="d-inline-block" data-hovercard-type="user"
-                                    data-hovercard-url="/hovercards?user_id=1741180"
-                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                    href="/lguychard"><img class="avatar"
-                                        src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28"
-                                        height="28" alt="@lguychard"></a>
-                            </div>
-                            <div class="d-table-cell col-12">
-                                <button type="button"
-                                    class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
-                                    Reply…
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="inline-comment-form">
-                        <!-- '"` -->
-                        <!-- </textarea></xmp> -->
-                        <form class="js-inline-comment-form rgh-minimize-upload-bar"
-                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8"
-                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
-                                name="authenticity_token"
-                                value="y2OZnXxDobi9U9nCduUEXmZ3AGDdKgsm3RtZ8Sw+iMV/akGgymK7tO9u0LwUBuifEFJHfsVHcx6LUFkSZl2i2g==">
-                            <input type="hidden" name="comment_context" value="discussion">
-                            <input type="hidden" name="in_reply_to" value="329949662">
-
-
-                            <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
-                                data-preview-url="/preview?repository=41288708"
-                                data-preview-authenticity-token="/Rgu0cip5SPf5HQR16xNe7pcnreJ6P6Olc+BNCHEWwAB5989pORHGEzPXD1aXSJNAPP7/yS1cTocpXzOTxetWQ==">
-                                <div class="comment-form-head tabnav">
-
-                                    <markdown-toolbar
-                                        for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
-                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
-
-                                        <div class="d-inline-block mr-3">
-                                            <button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item "
-                                                aria-label="Insert a suggestion <cmd-g>"
-                                                data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CD9B:3B3A8:F08542:16C70BA:5D94713D&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
-                                                data-hydro-click-hmac="bea7f0b328064f34943b21954c8180de7fd1051ed68eda30066f2d71143aa42d"
-                                                data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                hotkey="g">
-                                                <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1"
-                                                    width="13" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z">
-                                                    </path>
-                                                </svg>
-                                            </button> </div>
-
-                                        <div class="flex-nowrap d-inline-block mr-3">
-                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add header text"
-                                                data-ga-click="Markdown Toolbar, click, header" role="button">
-                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
-                                                    width="18" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-header>
-
-                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add bold text <cmd-b>"
-                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-bold>
-
-                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add italic text <cmd-i>"
-                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
-                                                hotkey="i">
-                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
-                                                    width="6" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                    </path>
-                                                </svg>
-                                            </md-italic>
-                                        </div>
-
-                                        <div class="d-inline-block mr-3">
-                                            <md-quote tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert a quote"
-                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
-                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-quote>
-
-                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
-                                                role="button">
-                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                    </path>
-                                                </svg>
-                                            </md-code>
-
-
-                                            <md-link tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                aria-label="Add a link <cmd-k>"
-                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                    </path>
-                                                </svg>
-                                            </md-link>
-                                        </div>
-
-                                        <div class="d-inline-block mr-3">
-                                            <md-unordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a bulleted list"
-                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-unordered-list>
-
-                                            <md-ordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a numbered list"
-                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ordered-list>
-
-                                            <md-task-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a task list"
-                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
-                                                hotkey="L">
-                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                    </path>
-                                                </svg>
-                                            </md-task-list>
-                                        </div>
-
-                                        <div class="d-inline-block">
-                                            <md-mention tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Directly mention a user or team"
-                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
-                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                    </path>
-                                                </svg>
-                                            </md-mention>
-
-
-                                            <md-ref tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Reference an issue or pull request"
-                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
-                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ref><button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
-                                                aria-label="Attach files"><svg aria-hidden="true"
-                                                    class="octicon octicon-cloud-upload" width="16" height="16">
-                                                    <path fill-rule="evenodd"
-                                                        d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
-                                                    </path>
-                                                </svg></button><button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
-                                                aria-label="Add collapsible content"><svg aria-hidden="true"
-                                                    class="octicon octicon-fold-down" width="14" height="16">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
-                                                    </path>
-                                                </svg></button>
-
-                                            <details
-                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                tabindex="-1">
-                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
-                                                    aria-label="Insert a reply"
-                                                    data-ga-click="Markdown Toolbar, click, saved reply"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
-                                                        width="14" height="16" aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                        </path>
-                                                    </svg>
-                                                    <span class="dropdown-caret "></span>
-                                                </summary>
-                                                <details-menu style="z-index: 99;"
-                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                    data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
-                                                    src="/settings/replies?context=none" preload="" role="menu">
-                                                    <div class="select-menu-header d-flex">
-                                                        <span class="select-menu-title flex-auto">Select a reply</span>
-                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                    </div>
-                                                    <include-fragment role="menuitem"
-                                                        class="select-menu-loading-overlay anim-pulse"
-                                                        aria-label="Loading">
-                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
-                                                            version="1.1" width="16" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                            </path>
-                                                        </svg>
-                                                    </include-fragment>
-                                                </details-menu>
-                                            </details>
-
-                                        </div>
-
-                                    </markdown-toolbar>
-
-                                    <nav class="tabnav-tabs" role="tablist">
-                                        <button type="button"
-                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
-                                            aria-selected="true">Write</button>
-                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                            role="tab">Preview</button>
-                                    </nav>
-                                </div>
-
-                                <file-attachment class="js-upload-markdown-image is-default"
-                                    data-upload-repository-id="=&quot;41288708&quot;"
-                                    data-upload-policy-url="/upload/policies/assets"
-                                    data-upload-policy-authenticity-token="hbeyW1p3VqZIuddnNP58dYukPniSyhIsxm6VD4fahz0OlBlnjKtfj5ENPcfgeypV5reCQnLxsuHhtv0oxyaZpQ==">
-                                    <div class="write-content js-write-bucket upload-enabled">
-                                        <input type="hidden" name="saved_reply_id"
-                                            id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
-                                            class="js-resettable-field" value="" data-reset-value="">
-
-                                        <text-expander keys=": @ #"
-                                            data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                            data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                            data-emoji-url="/autocomplete/emoji">
-                                            <textarea name="comment[body]"
-                                                id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
-                                                placeholder="Leave a comment" aria-label="Comment body"
-                                                class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable"
-                                                title=""></textarea>
-                                        </text-expander>
-
-
-                                        <p
-                                            class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                            <input
-                                                accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                                type="file" multiple=""
-                                                class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                                aria-label="Attach files to your comment"
-                                                id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
-                                            <span
-                                                class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                                style="pointer-events: none;"></span>
-                                            <span class="position-relative pr-2" style="pointer-events: none;">
-                                                <span class="default">
-                                                    Attach files by dragging &amp; dropping, selecting or pasting them.
-                                                </span>
-                                                <span class="loading">
-                                                    <img alt="" width="16" height="16"
-                                                        src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                    Uploading your files…
-                                                </span>
-                                                <span class="error bad-file">
-                                                    We don’t support that file type.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a
-                                                        GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error bad-permissions">
-                                                    Attaching documents requires write permission to this repository.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                        or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error repository-required">
-                                                    We don’t support that file type.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                        or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error too-big">
-                                                    Yowza, that’s a big file
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a file smaller than 10MB.
-                                                    </span>
-                                                </span>
-                                                <span class="error empty">
-                                                    This file is empty.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a file that’s not empty.
-                                                    </span>
-                                                </span>
-                                                <span class="error hidden-file">
-                                                    This file is hidden.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with another file.
-                                                    </span>
-                                                </span>
-                                                <span class="error failed-request">
-                                                    Something went really wrong, and we can’t process that file.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try
-                                                            again.</button>
-                                                    </span>
-                                                </span>
-                                            </span>
-                                            <span class="tooltipped tooltipped-nw"
-                                                aria-label="Styling with Markdown is supported">
-                                                <a class="muted-link position-relative d-inline"
-                                                    href="https://guides.github.com/features/mastering-markdown/"
-                                                    target="_blank" data-ga-click="Markdown Toolbar, click, help"
-                                                    aria-label="Learn about styling with Markdown">
-                                                    <svg class="octicon octicon-markdown v-align-bottom"
-                                                        viewBox="0 0 16 16" version="1.1" width="16" height="16"
-                                                        aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                        </path>
-                                                    </svg>
-                                                </a>
-                                            </span>
-                                        </p>
-
-                                    </div>
-                                </file-attachment>
-                                <div class="preview-content">
-                                    <div class="comment js-suggested-changes-container" data-thread-side="">
-                                        <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-                                            <p>Nothing to preview</p>
-                                        </div>
-                                    </div>
-
-                                </div>
-
-                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-                            </div>
-
-
-                            <div class="form-actions">
-                                <div class="position-relative float-right ml-1">
-                                    <input type="hidden" name="single_comment" value="1">
-
-                                    <button name="single_comment" type="submit" value="1"
-                                        class="btn review-simple-reply-button btn-primary" data-disable-invalid=""
-                                        data-disable-with="">
-                                        Comment
-                                    </button>
-                                </div>
-
-                                <button class="btn js-hide-inline-comment-form" type="button"
-                                    data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-
-        <!-- '"` -->
-        <!-- </textarea></xmp> -->
-        <form class="js-resolvable-timeline-thread-form"
-            action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve"
-            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
-                name="_method" value="put"><input type="hidden" name="authenticity_token"
-                value="hMaOZWGUT0HwEPw0kZFpo80OpT7WbojlbC0VBAeONzHhCtYW6yGxsJzenoRTxwtm11n/r/uUs0m2DbGDYdX9BQ==">
-            <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…"
-                data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CD9B:3B3A8:F08542:16C70BA:5D94713D&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
-                data-hydro-click-hmac="c4f20eaa11b97b758ed9f8b07e7bfd04bdd29c92adf6bde8c1585916ce57527c">
-                Resolve conversation
-            </button></form>
     </div>
 
+    <div class="clearfix">
+
+      <input type="hidden" name="original-line" value="+export class TestResourceManager {" class="js-original-line">
+      <input type="hidden" name="path" value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+      <input type="hidden" name="line" value="13" class="js-line-number">
+      <div class="form-actions comment-form-actions">
+        <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
+        <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
+          Cancel
+        </button>
+      </div>
+    </div>
+
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
+
+  </form>  </div>
+  </div>
 
 
 
-</div>
+      </div>
+
+        <div class="review-thread-reply border-bottom">
+
+  <div class="inline-comment-form-container js-inline-comment-form-container">
+    <div class="inline-comment-form-actions">
+      <div class="d-table width-full">
+        <div class="d-table-cell">
+          <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28" height="28" alt="@lguychard"></a>
+        </div>
+        <div class="d-table-cell col-12">
+          <button type="button" class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
+            Reply…
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="inline-comment-form">
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-inline-comment-form rgh-minimize-upload-bar" action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="KX/jxZDcyBH+kwIn0RPp7ynHlwZyIq5uo31Dd7xPEd2ddjv4Jv3SHayuC1mz8AUuX+LQGGpP1lb1NkOU9iw7wg==">
+        <input type="hidden" name="comment_context" value="discussion">
+        <input type="hidden" name="in_reply_to" value="329949662">
+
+
+  <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected" data-preview-url="/preview?repository=41288708" data-preview-authenticity-token="PvK/NDbZmX/2jEkrxyhsINcaMp6IwSKEtLMoO0RfE93CDU7YWpQ7RGWnYQdK2QMWbbVX1iWcrTA92dXBKozlhA==">
+    <div class="comment-form-head tabnav">
+
+  <markdown-toolbar for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+      <div class="d-inline-block mr-3">
+        <button type="button" class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item " aria-label="Insert a suggestion <cmd-g>" data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;E697:427E1:A354E1:F5FCD5:5D949737&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="f999bb4eb45c9d5e77efded91fdeae0ffe288197bcef89f57fb029c9866ce4f4" data-ga-click="Markdown Toolbar, click, insert code suggestion" hotkey="g">
+            <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
+  </button>    </div>
+
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
+
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
+
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
+
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
+
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
+
+
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
+
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
+
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
+
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
+
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
+
+
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-upload-btn" aria-label="Attach files"><svg aria-hidden="true" class="octicon octicon-cloud-upload" width="16" height="16"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"></path></svg></button><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
+
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
+
+    </div>
+
+  </markdown-toolbar>
+
+      <nav class="tabnav-tabs" role="tablist">
+        <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+      </nav>
+    </div>
+
+    <file-attachment class="js-upload-markdown-image is-default" data-upload-repository-id="=&quot;41288708&quot;" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="2N8NKcgfMIznXTpGY1wBVG8p1dQPPwJxAtmaNvix3IRT/KYVHsM5pT7p0Oa32Vd0Ajpp7u8EorwlAfIRuE3CHA==">
+      <div class="write-content js-write-bucket upload-enabled">
+        <input type="hidden" name="saved_reply_id" id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
+
+        <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
+          <textarea name="comment[body]" id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable" title=""></textarea>
+        </text-expander>
+
+
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
+
+      </div>
+  </file-attachment>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="">
+    <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
+
+    </div>
+
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
+
+
+        <div class="form-actions">
+          <div class="position-relative float-right ml-1">
+            <input type="hidden" name="single_comment" value="1">
+
+            <button name="single_comment" type="submit" value="1" class="btn review-simple-reply-button btn-primary" data-disable-invalid="" data-disable-with="">
+              Comment
+            </button>
+          </div>
+
+          <button class="btn js-hide-inline-comment-form" type="button" data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
+        </div>
+  </form>  </div>
+  </div>
+
+        </div>
+    </div>
+
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-resolvable-timeline-thread-form" action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Cbb+/30CmzmtbBEfl8FADE3XwFL5PKecJujSBvzXj+dseqaM97dlyMGic69VlyLJV4Caw9TGnDD8yHaBmoxF0w==">
+        <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…" data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;E697:427E1:A354E1:F5FCD5:5D949737&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="e0966c7dafe422986f494b88db444a9b3f411095340c71ca42820e0a3c160d67">
+          Resolve conversation
+  </button></form>
+  </div>
+
+
+
+
+  </div>

--- a/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/refined-github/code-view.html
+++ b/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/refined-github/code-view.html
@@ -1,2707 +1,2370 @@
-<!-- https://github.com/sourcegraph/sourcegraph/pull/3221 -->
-<div class="file js-comment-container js-resolvable-timeline-thread-container has-inline-notes">
-  <div class="file-header">
-        <a href="/sourcegraph/sourcegraph/pull/3221/files/cb632145276dd3e17f03e44b272b611b8107f725#diff-5bd3e793932782601ddbd53a3d8dd073" class="file-info link-gray-dark" title="pkg/redispool/redispool.go">
-      pkg/redispool/redispool.go
-    </a>
-
-    <span title="Label: Outdated" class="Label Label--outline bg-yellow-light">Outdated</span>
-
-  </div>
-
-
-<div class="blob-wrapper border-bottom rgh-linkified-code">
-  <table id="discussion-diff-272416639" class="diff-table">
-
-
-
-    <tbody><tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R59" data-line-number="59" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	}</span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R60" data-line-number="60" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition"><br></span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R61" data-line-number="61" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	<span class="pl-k">var</span> <span class="pl-smi">host</span> <span class="pl-k">string</span></span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R62" data-line-number="62" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	<span class="pl-k">if</span> <span class="pl-c1">len</span>(parsedUrl.<span class="pl-smi">Opaque</span>) &gt; <span class="pl-c1">0</span> {</span>
-
-      </td>
-    </tr>
-
-  </tbody></table>
-</div>
-
-<div class="js-inline-comments-container">
-  <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
-    <div class="js-comments-holder">
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links" id="discussion_r272416639" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="d1773e368c1e4ab89003e7785857bb71">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<button type="button" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272416639-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div class="dropdown-divider"></div><a href="/sourcegraph/sourcegraph/tree/HEAD@{2019-04-05T00:58:40Z}" class="dropdown-item btn-link" role="menuitem" title="Browse repository like it appeared on this day">View repo at this time</a><div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment" hidden="">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="jlV0CxL4LTBnnSvHxbaEoeMURYBH8ew/mRtpBQMrjbaerEXZvqqSGqGTLASMMtb4TbYAx6piJ5/FvqzLTQIzFQ==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="yAWlu57/9A0+9P8Zu6e3r8om05yjMobUGrn6TOXruqPYNg/yd2lVrmED+b4qeircYir6yUw+4VTkQ8aDI4k76Q==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272416639&amp;report=beyang+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang"><img class="avatar" height="28" width="28" alt="@beyang" src="https://avatars0.githubusercontent.com/u/1646931?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang">beyang</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272416639" id="discussion_r272416639-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-05T00:58:40Z" title="5 Apr 2019, 02:58 CEST">27 days ago</relative-time></a>
-              </span>
-            </h4>
-
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the Sourcegraph organization.">
-      Member
-    </span>
-
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
-                  <p>Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="uRjB6R3OZnLZ9tuiBGDn1C9wkva046MjnYu4Mpb3upiLDo14UqOaOSz5jjEwtRCt4D2m4JBk71FdQg3950vPqA==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="sAh9q5kKKex0rkUEvblkn46BsplIK3sA/rkt6w8ftbCC0igZD3WwVoBWMz3JMRc6NLolLPWkUrDhBrGv5az9fA==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="2swCbmg4cp7txndzMeNkB+zDQsSI7lrtwDugEgRcZmga3F8W6xRIddLPYIadIyUUrtBFjzJQbm6yJ2W3KRGMRg==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272416639-minimize-comment-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="lLPK45zJDoRxwhkhab4qqeAwqvNWCV/CO9Y0zxKi/Z2mpYZy06Tyz4TNTLJda93QL32e5XKOE7D7H4EAYx6IrQ==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="d1773e368c1e4ab89003e7785857bb71">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272416639-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
+<div
+    class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
+    <div class="file-header">
+        <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd"
+            class="text-mono text-small link-gray-dark wb-break-all mr-2"
+            title="web/src/regression/util/TestResourceManager.ts">
+            web/src/regression/util/TestResourceManager.ts
+        </a>
 
 
     </div>
 
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="d1773e368c1e4ab89003e7785857bb71" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
 
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272416639" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
+    <div class="blob-wrapper border-bottom rgh-linkified-code">
+        <table id="discussion-diff-329949662" class="diff-table rgh-showing-whitespace">
 
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Qr4sGIK37iFW91Ax+UXHtLW/K22f35FjH+d3SIRaJ9lJGMtI6itYeWiOEHjxZ+28Y2YUvMeThc1PnQ04ap1xoQ==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
 
-    <div role="none" class="dropdown-divider"></div>
 
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
+            <tbody>
+                <tr>
 
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" title=":+1:">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji" title=":-1:">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji" title=":smile:">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji" title=":tada:">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji" title=":thinking_face:">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji" title=":heart:">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji" title=":rocket:">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji" title=":eyes:">👀</g-emoji>
-        </button>
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R10" data-line-number="10"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>*</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>place</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>and</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>for</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>easy</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>resource</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>cleanup</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>at</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>the</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>end</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>of</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>tests</span><span><span>.</span></span><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>Also</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>prints</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>which</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>resources</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>are</span><span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span><span>created</span></span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R11" data-line-number="11"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>*<span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>and<span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>destroyed<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>in<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>case<span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>tests<span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span>are<span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>aborted<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>midway<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>through<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>and<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>manual<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>cleanup<span class="rgh-ws-char rgh-space-char"
+                                    data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>is<span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                    </span></span>required.</span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R12" data-line-number="12"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                        class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span
+                                    class="pl-c"><span>*</span><span><span>/</span></span></span></span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R13" data-line-number="13"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition annotated"><span
+                                class="pl-k"><span>export</span></span><span class="rgh-ws-char rgh-space-char"
+                                data-rgh-spaces="·"><span class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                </span></span><span class="pl-k"><span>class</span></span><span
+                                class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"> </span></span><span
+                                class="pl-en"><span>TestResourceManager</span></span><span
+                                class="rgh-ws-char rgh-space-char" data-rgh-spaces="·"><span
+                                    class="rgh-ws-char rgh-space-char" data-rgh-spaces="·">
+                                </span></span><span>{</span></span>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
     </div>
-</form></details-menu>
 
-  </details>
-
-        <button type="button" role="menuitem" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272416639">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272416639-permalink" data-toggle-for="details-discussion_r272416639" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272416639">
-              Quote reply
-            </button>
+    <div class="js-inline-comments-container">
+        <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
+            <div class="js-comments-holder">
 
 
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
+                <div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links"
+                    id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
 
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
-    </div>
+                    <div class="minimized-comment position-relative d-none">
 
-                <div class="Box-body scrollable-overlay">
 
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="hExVlS/rqe6nz7kp/lJSyCTD+JkTejUdOONTi1HychUPmICRYwckpg5/u+CWFk4RqPYRilnU5QSbFGf8DEVfRQ==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" class="form-control" type="text" name="issue[title]" value="Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" name="issue[body]" class="form-control" aria-label="Issue body">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.
 
-_Originally posted by @beyang in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
 
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
+                        <details class="Details-element details-reset "
+                            data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
+                            <summary class="text-gray f6">
+                                <div class="d-flex flex-justify-between flex-items-center">
+                                    <h3 class="review-comment-contents bg-white f5 text-normal text-italic"
+                                        style="margin-left:38px">
+                                        <div class="discussion-item-icon discussion-item-icon-gray text-gray">
+                                            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1"
+                                                width="14" height="16" aria-hidden="true">
+                                                <path fill-rule="evenodd"
+                                                    d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
+                                                </path>
+                                            </svg>
+                                        </div>
+                                        <div class="d-inline-block">
+                                            This comment has been minimized.
+
+                                        </div>
+                                    </h3>
+                                    <div class="Details-content--closed btn-link text-gray"><svg
+                                            class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1"
+                                            width="14" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z">
+                                            </path>
+                                        </svg>Show comment</div>
+                                    <div class="Details-content--open btn-link text-gray"><svg
+                                            class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1"
+                                            width="14" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
+                                            </path>
+                                        </svg>Hide comment</div>
+                                </div>
+                            </summary>
+                            <div class="py-2 pl-6 pr-0">
+                                <div class="previewable-edit  js-task-list-container reorderable-task-lists">
+                                    <div class="edit-comment-hide">
+                                        <div class="timeline-comment-actions">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                            <button type="button"
+                                                class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment"
+                                                role="menuitem" aria-label="Edit comment"><svg aria-hidden="true"
+                                                    class="octicon octicon-pencil" width="14" height="16">
+                                                    <path
+                                                        d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z">
+                                                    </path>
+                                                </svg></button>
+                                            <details
+                                                class="details-overlay details-reset position-relative d-inline-block ">
+                                                <summary class="btn-link timeline-comment-action link-gray"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg aria-label="Show options"
+                                                        class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16"
+                                                        version="1.1" width="13" height="16" role="img">
+                                                        <path fill-rule="evenodd"
+                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
+                                                        </path>
+                                                    </svg>
+                                                </summary>
+                                                <details-menu
+                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
+                                                    style="width:185px" role="menu">
+                                                    <clipboard-copy class="dropdown-item btn-link"
+                                                        for="discussion_r329949662-minimized-permalink" role="menuitem"
+                                                        tabindex="0">
+                                                        Copy link
+                                                    </clipboard-copy>
+
+                                                    <button type="button"
+                                                        class="dropdown-item btn-link d-none js-comment-quote-reply"
+                                                        role="menuitem">
+                                                        Quote reply
+                                                    </button>
+
+                                                    <div class="dropdown-divider"></div><a
+                                                        href="/sourcegraph/sourcegraph/tree/HEAD@{2019-10-01T09:03:30Z}"
+                                                        class="dropdown-item btn-link" role="menuitem"
+                                                        title="Browse repository like it appeared on this day">View repo
+                                                        at this time</a>
+                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                    <button type="button"
+                                                        class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment"
+                                                        role="menuitem" aria-label="Edit comment" hidden="">
+                                                        Edit
+                                                    </button>
+
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form class="inline-form js-comment-unminimize width-full"
+                                                        action="/sourcegraph/sourcegraph/community/unminimize-comment"
+                                                        accept-charset="UTF-8" method="post"><input name="utf8"
+                                                            type="hidden" value="✓"><input type="hidden" name="_method"
+                                                            value="put"><input type="hidden" name="authenticity_token"
+                                                            value="o6+7W/gRAHhQ+Ox2niHDwY8321kWmlTvYdMg+vPI8jgL5UEGG8kCJwPNCrgQmn9C0Y6rUytD1NxTur/0j9BIdg==">
+                                                        <input type="hidden" name="comment_id"
+                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                        <button type="submit" class="dropdown-item btn-link"
+                                                            role="menuitem" aria-label="Unhide comment">
+                                                            Unhide
+                                                        </button>
+                                                    </form>
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form class="width-full inline-form js-comment-delete"
+                                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                                        accept-charset="UTF-8" method="post"><input name="utf8"
+                                                            type="hidden" value="✓"><input type="hidden" name="_method"
+                                                            value="delete"><input type="hidden"
+                                                            name="authenticity_token"
+                                                            value="NyWJMjs4MrzS/kiDz8/AVpvQEf+JYEg3hmy83GfM7KUO0PGMEHbEuu//BE6HYRv7mGkKUxuP9MzqM0WUVvrfIg==">
+                                                        <input type="hidden" name="input[id]"
+                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                        <button type="submit"
+                                                            class="dropdown-item menu-item-danger btn-link"
+                                                            aria-label="Delete comment" role="menuitem"
+                                                            data-confirm="Are you sure you want to delete this?">
+                                                            Delete
+                                                        </button>
+                                                    </form>
+
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+                                        <a class="float-left mt-1" data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=1741180"
+                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                            href="/lguychard"><img class="avatar" height="28" width="28"
+                                                alt="@lguychard"
+                                                src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+                                        <div class="review-comment-contents">
+                                            <h4 class="f5 text-normal d-inline text-gray-dark">
+                                                <strong class="text-gray">
+
+
+                                                    <a class="author link-gray-dark css-truncate-target rgh-fullname"
+                                                        show_full_name="false" data-hovercard-type="user"
+                                                        data-hovercard-url="/hovercards?user_id=1741180"
+                                                        data-octo-click="hovercard-link-click"
+                                                        data-octo-dimensions="link_type:self"
+                                                        href="/lguychard">lguychard</a>
+
+
+                                                </strong>
+                                                <span class="text-gray">
+                                                    <a href="#discussion_r329949662"
+                                                        id="discussion_r329949662-minimized-permalink"
+                                                        class="timestamp">
+                                                        <relative-time datetime="2019-10-01T09:03:30Z"
+                                                            title="Oct 1, 2019, 11:03 AM GMT+2">yesterday
+                                                        </relative-time>
+                                                    </a>
+                                                </span>
+                                            </h4>
+
+                                            <span
+                                                class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
+                                                aria-label="You are a member of the Sourcegraph organization.">
+                                                Member
+                                            </span>
+
+
+                                            <task-lists sortable="">
+                                                <div
+                                                    class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
+                                                    <p>Rather than introducing a new class/concept to the codebase, I
+                                                        would consider reusing <a
+                                                            href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
+                                                            rel="nofollow"><code>Disposable</code></a> (an
+                                                        <code>Unsubscribable</code> supporting async resource disposal)
+                                                        pattern from sourcegraph-typescript (<a href="">example
+                                                            usage</a>) :</p>
+                                                    <div class="highlight highlight-source-ts">
+                                                        <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+  <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
+      <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
+      <span class="pl-k">return</span> {
+          <span class="pl-en">dispose</span>: () <span class="pl-k">=&gt;</span> {
+              <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Destroying user ${<span class="pl-smi">name</span>}<span class="pl-pds">`</span></span>)
+              <span class="pl-k">return</span> <span class="pl-en">deleteUser</span>(<span class="pl-k">...</span>)
+          }
+      }
+  }
+
+
+  <span class="pl-en">describe</span>(<span class="pl-s"><span class="pl-pds">'</span>Search regression test suite<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+
+      <span class="pl-k"><span class="pl-k">const</span></span> disposables <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">Set</span>&lt;<span class="pl-en">Disposable</span> <span class="pl-k">|</span> <span class="pl-en">AsyncDisposable</span> <span class="pl-k">|</span> <span class="pl-en">Unsubscribable</span>&gt;()
+
+      <span class="pl-c"><span class="pl-c">//</span> Free resources created during testing. </span>
+      <span class="pl-en">afterAll</span>(() <span class="pl-k">=&gt;</span> <span class="pl-en">disposeAllAsync</span>(<span class="pl-smi">disposables</span>))
+
+      <span class="pl-en">test</span>(<span class="pl-s"><span class="pl-pds">'</span>something<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+          <span class="pl-smi">disposables</span>.<span class="pl-c1">add</span>(
+              <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
+          )
+      })
+  })</pre>
+                                                    </div>
+                                                    <p>Pros:</p>
+                                                    <ul>
+                                                        <li>Developers working in our codebase are already familiar with
+                                                            the subscription / subscription bag pattern (and, if they're
+                                                            not, it is <a
+                                                                href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
+                                                                rel="nofollow">documented</a>).</li>
+                                                        <li>The cleanup logic is encapsulated, and lives next to the
+                                                            resource creation logic. It is not duplicated if
+                                                            <code>ensureLoggedInOrCreateTestUser()</code> is called from
+                                                            multiple test suites. Callers need not look up how a given
+                                                            resource should be cleaned up, they simply need to handle
+                                                            the returned disposable / subscription.</li>
+                                                    </ul>
+                                                </div>
+                                            </task-lists>
+                                        </div>
+                                    </div>
+
+                                    <!-- '"` -->
+                                    <!-- </textarea></xmp> -->
+                                    <form data-upload-policy-url="/upload/policies/assets"
+                                        data-upload-policy-authenticity-token="4qjbgh2HhBri5AwEg50UWOJCLC0Mrysh8TXgs5JIjnppi3C+y1uNMztQ5qRXGEJ4j1GQF+yUi+zW7YiU0rSQ4g=="
+                                        class="js-comment-update rgh-minimize-upload-bar" data-type="json"
+                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                            value="✓"><input type="hidden" name="_method" value="put"><input
+                                            type="hidden" name="authenticity_token"
+                                            value="YpXLo1R2y/UrS52WC2CcVV6joTPPgD9i0IWAmIOOjRbAN4UzkUVf4HCimGfSJP7hZ5kOEwNZhhpk1+RgqF0sEw==">
+                                        <div class="js-previewable-comment-form previewable-comment-form write-selected"
+                                            data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
+                                            data-preview-authenticity-token="orQePHMGB458bxDm7HtWUrZKs6TZxgtG7/w+RVUjGQdeS+/QH0ulte9EOMphijlkDOXW7HSbhPJmlsO/O/DvXg==">
+
+                                            <div class="comment-form-head tabnav ">
+                                                <nav class="tabnav-tabs" role="tablist">
+                                                    <button type="button"
+                                                        class="btn-link tabnav-tab write-tab js-write-tab selected"
+                                                        role="tab" aria-selected="true">Write</button>
+                                                    <button type="button"
+                                                        class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                                        role="tab">Preview</button>
+                                                </nav>
+
+
+                                                <markdown-toolbar for="discussion_r329949662-minimize-comment-body"
+                                                    class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+
+                                                    <div class="flex-nowrap d-inline-block mr-3">
+                                                        <md-header tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add header text"
+                                                            data-ga-click="Markdown Toolbar, click, header"
+                                                            role="button">
+                                                            <svg class="octicon octicon-text-size" viewBox="0 0 18 16"
+                                                                version="1.1" width="18" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-header>
+
+                                                        <md-bold tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add bold text <cmd-b>"
+                                                            data-ga-click="Markdown Toolbar, click, bold" role="button"
+                                                            hotkey="b">
+                                                            <svg class="octicon octicon-bold" viewBox="0 0 10 16"
+                                                                version="1.1" width="10" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-bold>
+
+                                                        <md-italic tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add italic text <cmd-i>"
+                                                            data-ga-click="Markdown Toolbar, click, italic"
+                                                            role="button" hotkey="i">
+                                                            <svg class="octicon octicon-italic" viewBox="0 0 6 16"
+                                                                version="1.1" width="6" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-italic>
+                                                    </div>
+
+                                                    <div class="d-inline-block mr-3">
+                                                        <md-quote tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                            aria-label="Insert a quote"
+                                                            data-ga-click="Markdown Toolbar, click, quote"
+                                                            role="button">
+                                                            <svg class="octicon octicon-quote" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-quote>
+
+                                                        <md-code tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                            aria-label="Insert code"
+                                                            data-ga-click="Markdown Toolbar, click, code" role="button">
+                                                            <svg class="octicon octicon-code" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-code>
+
+
+                                                        <md-link tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                            aria-label="Add a link <cmd-k>"
+                                                            data-ga-click="Markdown Toolbar, click, link" role="button"
+                                                            hotkey="k">
+                                                            <svg class="octicon octicon-link" viewBox="0 0 16 16"
+                                                                version="1.1" width="16" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-link>
+                                                    </div>
+
+                                                    <div class="d-inline-block mr-3">
+                                                        <md-unordered-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a bulleted list"
+                                                            data-ga-click="Markdown Toolbar, click, unordered list"
+                                                            role="button">
+                                                            <svg class="octicon octicon-list-unordered"
+                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-unordered-list>
+
+                                                        <md-ordered-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a numbered list"
+                                                            data-ga-click="Markdown Toolbar, click, ordered list"
+                                                            role="button">
+                                                            <svg class="octicon octicon-list-ordered"
+                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-ordered-list>
+
+                                                        <md-task-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a task list"
+                                                            data-ga-click="Markdown Toolbar, click, task list"
+                                                            role="button" hotkey="L">
+                                                            <svg class="octicon octicon-tasklist" viewBox="0 0 16 16"
+                                                                version="1.1" width="16" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-task-list>
+                                                    </div>
+
+                                                    <div class="d-inline-block">
+                                                        <md-mention tabindex="-1"
+                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                            aria-label="Directly mention a user or team"
+                                                            data-ga-click="Markdown Toolbar, click, mention"
+                                                            role="button">
+                                                            <svg class="octicon octicon-mention" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-mention>
+
+
+                                                        <md-ref tabindex="-1"
+                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                            aria-label="Reference an issue or pull request"
+                                                            data-ga-click="Markdown Toolbar, click, reference"
+                                                            role="button">
+                                                            <svg class="octicon octicon-bookmark" viewBox="0 0 10 16"
+                                                                version="1.1" width="10" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-ref><button type="button"
+                                                            class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
+                                                            aria-label="Attach files"><svg aria-hidden="true"
+                                                                class="octicon octicon-cloud-upload" width="16"
+                                                                height="16">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
+                                                                </path>
+                                                            </svg></button><button type="button"
+                                                            class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
+                                                            aria-label="Add collapsible content"><svg aria-hidden="true"
+                                                                class="octicon octicon-fold-down" width="14"
+                                                                height="16">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
+                                                                </path>
+                                                            </svg></button>
+
+                                                        <details
+                                                            class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                            tabindex="-1">
+                                                            <summary tabindex="-1"
+                                                                class="text-center menu-target p-1 ml-1"
+                                                                aria-label="Insert a reply"
+                                                                data-ga-click="Markdown Toolbar, click, saved reply"
+                                                                aria-haspopup="menu" role="button">
+                                                                <svg class="octicon octicon-reply" viewBox="0 0 14 16"
+                                                                    version="1.1" width="14" height="16"
+                                                                    aria-hidden="true">
+                                                                    <path fill-rule="evenodd"
+                                                                        d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                                    </path>
+                                                                </svg>
+                                                                <span class="dropdown-caret "></span>
+                                                            </summary>
+                                                            <details-menu style="z-index: 99;"
+                                                                class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                                data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id"
+                                                                src="/settings/replies?context=none" preload=""
+                                                                role="menu">
+                                                                <div class="select-menu-header d-flex">
+                                                                    <span class="select-menu-title flex-auto">Select a
+                                                                        reply</span>
+                                                                    <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                                </div>
+                                                                <include-fragment role="menuitem"
+                                                                    class="select-menu-loading-overlay anim-pulse"
+                                                                    aria-label="Loading">
+                                                                    <svg class="octicon octicon-octoface"
+                                                                        viewBox="0 0 16 16" version="1.1" width="16"
+                                                                        height="16" aria-hidden="true">
+                                                                        <path fill-rule="evenodd"
+                                                                            d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                                        </path>
+                                                                    </svg>
+                                                                </include-fragment>
+                                                            </details-menu>
+                                                        </details>
+
+                                                    </div>
+
+                                                </markdown-toolbar>
+
+                                            </div>
+
+
+                                            <div class="clearfix"></div>
+
+                                            <p class="comment-form-error comment-show-stale">
+                                                <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
+                                                    </path>
+                                                </svg> The content you are editing has changed. Please try again.
+                                            </p>
+
+
+                                            <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
+                                                data-upload-policy-url="/upload/policies/assets"
+                                                data-upload-policy-authenticity-token="V1gczXVu5qrqpYrpn0SH5FGeMLt7QBlfALKFtxWdef7ce7fxo7LvgzMRYElLwdHEPI2MgZt7uZInau2QVWFnZg=="
+                                                data-upload-repository-id="41288708">
+                                                <input type="hidden" name="context" value="discussion">
+
+                                                <input type="hidden" name="saved_reply_id"
+                                                    id="discussion_r329949662-minimize-comment-body_saved_reply_id"
+                                                    class="js-resettable-field" value="" data-reset-value="">
+
+                                                <input type="hidden" name="pull_request_review_comment[id]"
+                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                <input type="hidden" name="pull_request_review_comment[bodyVersion]"
+                                                    class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+
+                                                <text-expander keys=": @ #"
+                                                    data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                                    data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                                    data-emoji-url="/autocomplete/emoji">
+
+                                                    <textarea name="pull_request_review_comment[body]"
+                                                        id="discussion_r329949662-minimize-comment-body"
+                                                        placeholder="Leave a comment" aria-label="Comment body"
+                                                        class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field"
+                                                        title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
+                                                </text-expander>
+
+
+                                                <p
+                                                    class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                                    <input
+                                                        accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                                        type="file" multiple=""
+                                                        class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                                        aria-label="Attach files to your comment"
+                                                        id="fc-discussion_r329949662-minimize-comment-body">
+                                                    <span
+                                                        class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                                        style="pointer-events: none;"></span>
+                                                    <span class="position-relative pr-2" style="pointer-events: none;">
+                                                        <span class="default">
+                                                            Attach files by dragging &amp; dropping, selecting or
+                                                            pasting them.
+                                                        </span>
+                                                        <span class="loading">
+                                                            <img alt="" width="16" height="16"
+                                                                src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                            Uploading your files…
+                                                        </span>
+                                                        <span class="error bad-file">
+                                                            We don’t support that file type.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a
+                                                                GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                                or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error bad-permissions">
+                                                            Attaching documents requires write permission to this
+                                                            repository.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
+                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error repository-required">
+                                                            We don’t support that file type.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
+                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error too-big">
+                                                            Yowza, that’s a big file
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a file smaller than 10MB.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error empty">
+                                                            This file is empty.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a file that’s not empty.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error hidden-file">
+                                                            This file is hidden.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with another file.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error failed-request">
+                                                            Something went really wrong, and we can’t process that file.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again.</button>
+                                                            </span>
+                                                        </span>
+                                                    </span>
+                                                    <span class="tooltipped tooltipped-nw"
+                                                        aria-label="Styling with Markdown is supported">
+                                                        <a class="muted-link position-relative d-inline"
+                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                            target="_blank"
+                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                            aria-label="Learn about styling with Markdown">
+                                                            <svg class="octicon octicon-markdown v-align-bottom"
+                                                                viewBox="0 0 16 16" version="1.1" width="16" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                                </path>
+                                                            </svg>
+                                                        </a>
+                                                    </span>
+                                                </p>
+
+                                            </div>
+
+
+                                            <div class="preview-content">
+                                                <div class="comment js-suggested-changes-container"
+                                                    data-thread-side="right">
+                                                    <div
+                                                        class="comment-body markdown-body js-preview-body rgh-linkified-code">
+                                                        <p>Nothing to preview</p>
+                                                    </div>
+                                                </div>
+
+                                            </div>
+
+                                            <div class="clearfix">
+
+                                                <input type="hidden" name="original-line"
+                                                    value="+export class TestResourceManager {"
+                                                    class="js-original-line">
+                                                <input type="hidden" name="path"
+                                                    value="web/src/regression/util/TestResourceManager.ts"
+                                                    class="js-path">
+                                                <input type="hidden" name="line" value="13" class="js-line-number">
+                                                <div class="form-actions comment-form-actions">
+                                                    <button class="btn btn-primary" type="submit"
+                                                        data-disable-with="">Update comment</button>
+                                                    <button class="btn btn-danger js-comment-cancel-button"
+                                                        type="button"
+                                                        data-confirm-text="Are you sure you want to discard your unsaved changes?">
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+
+                                            <div class="comment-form-error mb-2 js-comment-update-error" hidden="">
+                                            </div>
+                                        </div>
+
+                                    </form>
+                                </div>
+                            </div>
+                        </details>
+
+
+                    </div>
+
+                    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists"
+                        data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
+                        <div class="edit-comment-hide">
+                            <div class="timeline-comment-actions">
+
+                                <details
+                                    class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button"
+                                    data-channel="reaction:pull-request-review-comment:329949662"
+                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
+                                    <summary class="btn-link link-gray timeline-comment-action"
+                                        aria-label="Add your reaction" aria-haspopup="menu" role="button">
+                                        <svg class="octicon octicon-plus-small add-reaction-plus-icon"
+                                            viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
+                                        </svg>
+                                        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16"
+                                            height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
+                                            </path>
+                                        </svg>
+                                    </summary>
+
+                                    <details-menu
+                                        class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1"
+                                        aria-label="Pick your reaction" style="width: 150px" role="menu">
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="put"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="cuUwNudrFpsgD6dOdGt2udr7CgqwfrrgwAkPymiHZHij9QN0x8J0WMsxIW5Has3yIISBRAJRNnXaVGY6tvw1ew==">
+                                            <p class="text-gray mx-2 my-1">
+                                                <span class="js-reaction-description">Pick your reaction</span>
+                                            </p>
+
+                                            <div role="none" class="dropdown-divider"></div>
+
+                                            <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+                                                <input type="hidden" name="input[subjectId]"
+                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="+1" name="input[content]"
+                                                    aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+                                                    <g-emoji alias="+1"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                        class="emoji">👍</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="-1" name="input[content]"
+                                                    aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+                                                    <g-emoji alias="-1"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
+                                                        class="emoji">👎</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Laugh" name="input[content]"
+                                                    aria-label="React with laugh emoji" value="LAUGH react">
+                                                    <g-emoji alias="smile"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
+                                                        class="emoji">😄</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Hooray" name="input[content]"
+                                                    aria-label="React with hooray emoji" value="HOORAY react">
+                                                    <g-emoji alias="tada"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
+                                                        class="emoji">🎉</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Confused" name="input[content]"
+                                                    aria-label="React with confused emoji" value="CONFUSED react">
+                                                    <g-emoji alias="thinking_face"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
+                                                        class="emoji">😕</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Heart" name="input[content]"
+                                                    aria-label="React with heart emoji" value="HEART react">
+                                                    <g-emoji alias="heart"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                        class="emoji">❤️</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Rocket" name="input[content]"
+                                                    aria-label="React with rocket emoji" value="ROCKET react">
+                                                    <g-emoji alias="rocket"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
+                                                        class="emoji">🚀</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Eyes" name="input[content]"
+                                                    aria-label="React with eyes emoji" value="EYES react">
+                                                    <g-emoji alias="eyes"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
+                                                        class="emoji">👀</g-emoji>
+                                                </button>
+                                            </div>
+                                        </form>
+                                    </details-menu>
+
+                                </details>
+
+                                <button type="button" role="menuitem"
+                                    class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment"
+                                    aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil"
+                                        width="14" height="16">
+                                        <path
+                                            d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z">
+                                        </path>
+                                    </svg></button>
+                                <details class="details-overlay details-reset position-relative d-inline-block"
+                                    id="details-discussion_r329949662">
+                                    <summary class="btn-link timeline-comment-action" aria-label="Show more options"
+                                        aria-haspopup="menu" role="button">
+                                        <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1"
+                                            width="13" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
+                                            </path>
+                                        </svg>
+                                    </summary>
+
+                                    <details-menu
+                                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
+                                        style="width:185px; z-index: 99;" role="menu">
+
+                                        <clipboard-copy class="dropdown-item btn-link"
+                                            for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
+                                            Copy link
+                                        </clipboard-copy>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link d-none js-comment-quote-reply">
+                                            Quote reply
+                                        </button>
+
+
+                                        <details
+                                            class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
+                                            <summary class="dropdown-item" role="menuitem">
+
+                                                Reference in new issue
+                                            </summary>
+                                            <details-dialog aria-label="Reference in new issue"
+                                                class="Box Box--overlay d-flex flex-column anim-fade-in fast "
+                                                role="dialog" aria-modal="true">
+                                                <div class="Box-header">
+                                                    <button class="Box-btn-octicon btn-octicon float-right"
+                                                        type="button" aria-label="Close dialog" data-close-dialog="">
+                                                        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1"
+                                                            width="12" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
+                                                            </path>
+                                                        </svg>
+                                                    </button>
+                                                    <h3 class="Box-title ">Reference in new issue</h3>
+                                                </div>
+
+                                                <div class="Box-body scrollable-overlay">
+
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form action="/comments/issues" accept-charset="UTF-8"
+                                                        method="post"><input name="utf8" type="hidden" value="✓"><input
+                                                            type="hidden" name="authenticity_token"
+                                                            value="/Jf4vYp0Op+AaHeg3uE/oWvp2uepBbcE8L++fZDXd3gB3eSn0ZxoFE0RrfRSVh0AFaq1jRzHoE4YFX8JjxzcDw==">
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <details
+                                                                    class="details-reset details-overlay select-menu">
+                                                                    <summary class="btn select-menu-button"
+                                                                        data-menu-button="" aria-haspopup="menu"
+                                                                        role="button">
+                                                                        <input type="hidden" name="issue[repository_id]"
+                                                                            value="41288708" checked="">
+                                                                        sourcegraph
+                                                                    </summary>
+                                                                    <details-menu
+                                                                        class="select-menu-modal position-absolute"
+                                                                        style="z-index: 99;"
+                                                                        src="/sourcegraph/sourcegraph/related_repositories"
+                                                                        preload="" role="menu">
+                                                                        <div class="select-menu-header">
+                                                                            <span
+                                                                                class="select-menu-title">Repositories</span>
+                                                                        </div>
+                                                                        <div class="select-menu-filters">
+                                                                            <div class="select-menu-text-filter">
+                                                                                <remote-input
+                                                                                    src="/sourcegraph/sourcegraph/related_repositories"
+                                                                                    aria-owns="related-repositories-menu">
+                                                                                    <input type="text"
+                                                                                        class="form-control"
+                                                                                        aria-label="Type to filter"
+                                                                                        placeholder="Find a repository"
+                                                                                        autofocus="" autocomplete="off"
+                                                                                        spellcheck="false">
+                                                                                </remote-input>
+                                                                            </div>
+                                                                        </div>
+                                                                        <include-fragment class="octocat-spinner my-6"
+                                                                            aria-label="Loading"></include-fragment>
+                                                                    </details-menu>
+                                                                </details>
+                                                            </dd>
+                                                        </dl>
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label>
+                                                            </dt>
+                                                            <dd><input
+                                                                    id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                                                                    class="form-control" type="text" name="issue[title]"
+                                                                    value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :"
+                                                                    aria-label="Issue title" autofocus="" required="">
+                                                            </dd>
+                                                        </dl>
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label>
+                                                            </dt>
+                                                            <dd><textarea
+                                                                    id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                                                                    name="issue[body]" class="form-control"
+                                                                    aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.
+
+  _Originally posted by @lguychard in https://github.com/sourcegraph/sourcegraph/pull/5746_</textarea></dd>
+                                                        </dl>
+
+                                                        <div class="d-flex d-sm-block">
+                                                            <button type="submit" class="btn btn-primary"
+                                                                data-disable-with="Creating issue..."
+                                                                data-disable-invalid=""
+                                                                data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
+                                                                Create issue
+                                                            </button>
+                                                        </div>
+                                                    </form>
+                                                </div>
+
+                                            </details-dialog>
+                                        </details>
+
+                                        <div role="none" class="dropdown-divider"></div>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment"
+                                            aria-label="Edit comment" hidden="">
+                                            Edit
+                                        </button>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link js-comment-hide-button"
+                                            aria-label="Hide comment">
+                                            Hide
+                                        </button>
+
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="width-full inline-form js-comment-delete"
+                                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="delete"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="6me1DA6PKRXiG3JKy13LDky934p/tayH2Zg5g8w7X6PTks2yJcHfE98aPoeD8xCjTwTEJu1aEHy1x8DL/Q1sJA==">
+                                            <input type="hidden" name="input[id]"
+                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                            <button type="submit" role="menuitem"
+                                                class="dropdown-item menu-item-danger btn-link"
+                                                aria-label="Delete comment"
+                                                data-confirm="Are you sure you want to delete this?">
+                                                Delete
+                                            </button>
+                                        </form>
+
+
+                                    </details-menu>
+                                </details>
+                            </div>
+
+                            <span class="float-left mt-1">
+                                <a class="d-inline-block" data-hovercard-type="user"
+                                    data-hovercard-url="/hovercards?user_id=1741180"
+                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                    href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard"
+                                        src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+                            </span>
+
+                            <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
+                                <h4 class="f5 text-normal d-inline">
+                                    <strong>
+
+
+                                        <a class="author link-gray-dark css-truncate-target rgh-fullname"
+                                            show_full_name="false" data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=1741180"
+                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                            href="/lguychard">lguychard</a>
+
+
+                                    </strong>
+                                    <span class="text-gray">
+
+                                        <a href="#discussion_r329949662" id="discussion_r329949662-permalink"
+                                            class="js-timestamp timestamp d-inline-block">
+                                            <relative-time datetime="2019-10-01T09:03:30Z"
+                                                title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
+                                        </a>
+
+
+                                        <span class="d-inline-block text-gray-light">•</span>
+
+                                        <details class="details-overlay details-reset d-inline-block dropdown">
+                                            <summary class="btn-link no-underline text-gray js-notice"
+                                                aria-haspopup="menu" role="button">
+                                                <div class="position-relative">
+                                                    <span>
+                                                        edited
+                                                    </span>
+                                                    <svg height="11"
+                                                        class="octicon octicon-triangle-down v-align-middle"
+                                                        viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true">
+                                                        <path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path>
+                                                    </svg>
+                                                </div>
+                                            </summary>
+                                            <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0"
+                                                style="width:352px"
+                                                src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log"
+                                                preload="" role="menu">
+                                                <include-fragment class="octocat-spinner my-3" aria-label="Loading">
+                                                </include-fragment>
+                                            </details-menu>
+                                        </details>
+
+                                    </span>
+                                </h4>
+
+
+
+                                <span
+                                    class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
+                                    aria-label="You are a member of the Sourcegraph organization.">
+                                    Member
+                                </span>
+
+
+                                <div class="js-minimize-comment d-none">
+
+
+                                    <div class="flash flash-warn my-2">
+                                        <button class="flash-close js-comment-hide-minimize-form" type="button"><svg
+                                                aria-label="Cancel hiding comment" class="octicon octicon-x"
+                                                viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img">
+                                                <path fill-rule="evenodd"
+                                                    d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
+                                                </path>
+                                            </svg></button>
+                                        <h3 class="f5">Choose a reason for hiding this comment</h3>
+                                        <p class="mb-3">The reason will be displayed to describe this comment to others.
+                                            <a
+                                                href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn
+                                                more</a>.</p>
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="js-comment-minimize"
+                                            action="/sourcegraph/sourcegraph/community/minimize-comment"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="put"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="yZEBpGPt78IJQ8rNM7x93IXCr9dO6H6ZxNNcE1no/cJOmYDHuNPVlO/z5MXxgrfiuXwF1SjrG4boCRK4uTpsDA==">
+                                            <input type="hidden" name="comment_id"
+                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                            <select name="classifier" class="form-select mr-2" aria-label="Reason"
+                                                required="">
+                                                <option value="">
+                                                    Choose a reason
+                                                </option>
+                                                <option value="SPAM">Spam</option>
+                                                <option value="ABUSE">Abuse</option>
+                                                <option value="OFF_TOPIC">Off Topic</option>
+                                                <option value="OUTDATED">Outdated</option>
+                                                <option value="RESOLVED">Resolved</option>
+                                            </select>
+                                            <button type="submit" class="btn">
+                                                Hide comment
+                                            </button>
+                                        </form>
+                                    </div>
+
+                                </div>
+
+
+
+                                <task-lists sortable="">
+                                    <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
+                                        <p>Rather than introducing a new class/concept to the codebase, I would consider
+                                            reusing <a
+                                                href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
+                                                rel="nofollow"><code>Disposable</code></a> (an
+                                            <code>Unsubscribable</code> supporting async resource disposal) pattern from
+                                            sourcegraph-typescript (<a href="">example usage</a>) :</p>
+                                        <div class="highlight highlight-source-ts">
+                                            <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+  <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
+      <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
+      <span class="pl-k">return</span> {
+          <span class="pl-en">dispose</span>: () <span class="pl-k">=&gt;</span> {
+              <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Destroying user ${<span class="pl-smi">name</span>}<span class="pl-pds">`</span></span>)
+              <span class="pl-k">return</span> <span class="pl-en">deleteUser</span>(<span class="pl-k">...</span>)
+          }
+      }
+  }
+
+
+  <span class="pl-en">describe</span>(<span class="pl-s"><span class="pl-pds">'</span>Search regression test suite<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+
+      <span class="pl-k"><span class="pl-k">const</span></span> disposables <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">Set</span>&lt;<span class="pl-en">Disposable</span> <span class="pl-k">|</span> <span class="pl-en">AsyncDisposable</span> <span class="pl-k">|</span> <span class="pl-en">Unsubscribable</span>&gt;()
+
+      <span class="pl-c"><span class="pl-c">//</span> Free resources created during testing. </span>
+      <span class="pl-en">afterAll</span>(() <span class="pl-k">=&gt;</span> <span class="pl-en">disposeAllAsync</span>(<span class="pl-smi">disposables</span>))
+
+      <span class="pl-en">test</span>(<span class="pl-s"><span class="pl-pds">'</span>something<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+          <span class="pl-smi">disposables</span>.<span class="pl-c1">add</span>(
+              <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
+          )
+      })
+  })</pre>
+                                        </div>
+                                        <p>Pros:</p>
+                                        <ul>
+                                            <li>Developers working in our codebase are already familiar with the
+                                                subscription / subscription bag pattern (and, if they're not, it is <a
+                                                    href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
+                                                    rel="nofollow">documented</a>).</li>
+                                            <li>The cleanup logic is encapsulated, and lives next to the resource
+                                                creation logic. It is not duplicated if
+                                                <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple
+                                                test suites. Callers need not look up how a given resource should be
+                                                cleaned up, they simply need to handle the returned disposable /
+                                                subscription.</li>
+                                        </ul>
+                                    </div>
+                                </task-lists>
+
+
+
+
+                                <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content"
+                                    data-channel="reaction:pull-request-review-comment:329949662"
+                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
+                                    <!-- '"` -->
+                                    <!-- </textarea></xmp> -->
+                                    <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                            value="✓"><input type="hidden" name="_method" value="put"><input
+                                            type="hidden" name="authenticity_token"
+                                            value="41BpsrqL6gw4ybmub8M6nAhWCghx6NN3pxS4zsKL7RMyQFrwmiKIz9P3P45cwoHX8imBRsPHX+K9SdE+HPC8EA==">
+                                        <input type="hidden" name="input[subjectId]"
+                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                        <div class="comment-reactions-options rgh-reactions">
+                                            <button
+                                                class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline "
+                                                name="input[content]" type="submit" value="THUMBS_UP react"
+                                                aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
+                                                <g-emoji alias="+1"
+                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                    class="emoji mr-1">👍</g-emoji>
+                                                2
+                                                <a href="/felixfbecker"><img
+                                                        src="/felixfbecker.png?size=44.000000953674316"></a><a
+                                                    href="/unknwon"><img
+                                                        src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a>
+                                            </button>
+                                            <button
+                                                class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline "
+                                                name="input[content]" type="submit" value="HEART react"
+                                                aria-label="unknwon reacted with heart emoji">
+                                                <g-emoji alias="heart"
+                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                    class="emoji mr-1">❤️</g-emoji>
+                                                1
+                                                <a href="/unknwon"><img
+                                                        src="https://avatars1.githubusercontent.com/u/2946214?s=88&amp;v=4"></a>
+                                            </button>
+                                        </div>
+                                    </form>
+                                    <details
+                                        class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
+                                        <summary class="btn-link reaction-summary-item add-reaction-btn"
+                                            aria-label="Add your reaction" aria-haspopup="menu" role="button">
+                                            <svg class="octicon octicon-plus-small add-reaction-plus-icon"
+                                                viewBox="0 0 7 16" version="1.1" width="7" height="16"
+                                                aria-hidden="true">
+                                                <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
+                                            </svg>
+                                            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1"
+                                                width="16" height="16" aria-hidden="true">
+                                                <path fill-rule="evenodd"
+                                                    d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
+                                                </path>
+                                            </svg>
+                                        </summary>
+
+                                        <details-menu
+                                            class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0"
+                                            aria-label="Pick your reaction" style="width: 150px" role="menu">
+                                            <!-- '"` -->
+                                            <!-- </textarea></xmp> -->
+                                            <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                                accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                    value="✓"><input type="hidden" name="_method" value="put"><input
+                                                    type="hidden" name="authenticity_token"
+                                                    value="M0y2vm54Hpcv9TYHQorcD+M7O717kdsZNi3CBuTiIMPiXIX8TtF8VMTLsCdxi2dEGUSw88m+V4wscKv2OplxwA==">
+                                                <p class="text-gray mx-2 my-1">
+                                                    <span class="js-reaction-description">Pick your reaction</span>
+                                                </p>
+
+                                                <div role="none" class="dropdown-divider"></div>
+
+                                                <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+                                                    <input type="hidden" name="input[subjectId]"
+                                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="+1" name="input[content]"
+                                                        aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+                                                        <g-emoji alias="+1"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                            class="emoji">👍</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="-1" name="input[content]"
+                                                        aria-label="React with thumbs down emoji"
+                                                        value="THUMBS_DOWN react">
+                                                        <g-emoji alias="-1"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
+                                                            class="emoji">👎</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Laugh" name="input[content]"
+                                                        aria-label="React with laugh emoji" value="LAUGH react">
+                                                        <g-emoji alias="smile"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
+                                                            class="emoji">😄</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Hooray" name="input[content]"
+                                                        aria-label="React with hooray emoji" value="HOORAY react">
+                                                        <g-emoji alias="tada"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
+                                                            class="emoji">🎉</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Confused" name="input[content]"
+                                                        aria-label="React with confused emoji" value="CONFUSED react">
+                                                        <g-emoji alias="thinking_face"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
+                                                            class="emoji">😕</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Heart" name="input[content]"
+                                                        aria-label="React with heart emoji" value="HEART react">
+                                                        <g-emoji alias="heart"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                            class="emoji">❤️</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Rocket" name="input[content]"
+                                                        aria-label="React with rocket emoji" value="ROCKET react">
+                                                        <g-emoji alias="rocket"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
+                                                            class="emoji">🚀</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Eyes" name="input[content]"
+                                                        aria-label="React with eyes emoji" value="EYES react">
+                                                        <g-emoji alias="eyes"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
+                                                            class="emoji">👀</g-emoji>
+                                                    </button>
+                                                </div>
+                                            </form>
+                                        </details-menu>
+
+                                    </details>
+                                </div>
+
+                            </div>
+                        </div>
+
+                        <!-- '"` -->
+                        <!-- </textarea></xmp> -->
+                        <form data-upload-policy-url="/upload/policies/assets"
+                            data-upload-policy-authenticity-token="MDWlZu6+B52FTLzW3KYRsk2FE4IsfIQprCf5lkKLvmm7Fg5aOGIOtFz4VnYII0eSIJavuMxHJOSL/5GxAneg8Q=="
+                            class="js-comment-update rgh-minimize-upload-bar" data-type="json"
+                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8"
+                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method"
+                                value="put"><input type="hidden" name="authenticity_token"
+                                value="rKwADXJfQ8UZx+LuFiUkh7p/R55I0fjbz7lw7pcsoNkODk6dt2zX0EIu5x/PYUYzg0XovoQIQaN76xQWvP8B3A==">
+                            <div class="js-previewable-comment-form previewable-comment-form write-selected"
+                                data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
+                                data-preview-authenticity-token="k9SaVVRXJblEe6bwqKDaHNtqUS9Yfd/Xv2o/daJhyIdvK2u5OBqHgtdQjtwlUbUqYcU0Z/UgUGM2AMKPzLI+3g==">
+
+                                <div class="comment-form-head tabnav ">
+                                    <nav class="tabnav-tabs" role="tablist">
+                                        <button type="button"
+                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
+                                            aria-selected="true">Write</button>
+                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                            role="tab">Preview</button>
+                                    </nav>
+
+
+                                    <markdown-toolbar for="discussion_r329949662-body"
+                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+
+                                        <div class="flex-nowrap d-inline-block mr-3">
+                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add header text"
+                                                data-ga-click="Markdown Toolbar, click, header" role="button">
+                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
+                                                    width="18" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-header>
+
+                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add bold text <cmd-b>"
+                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-bold>
+
+                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add italic text <cmd-i>"
+                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
+                                                hotkey="i">
+                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
+                                                    width="6" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                    </path>
+                                                </svg>
+                                            </md-italic>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-quote tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert a quote"
+                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
+                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-quote>
+
+                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
+                                                role="button">
+                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                    </path>
+                                                </svg>
+                                            </md-code>
+
+
+                                            <md-link tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                aria-label="Add a link <cmd-k>"
+                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                    </path>
+                                                </svg>
+                                            </md-link>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-unordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a bulleted list"
+                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-unordered-list>
+
+                                            <md-ordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a numbered list"
+                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ordered-list>
+
+                                            <md-task-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a task list"
+                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
+                                                hotkey="L">
+                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                    </path>
+                                                </svg>
+                                            </md-task-list>
+                                        </div>
+
+                                        <div class="d-inline-block">
+                                            <md-mention tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Directly mention a user or team"
+                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
+                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                    </path>
+                                                </svg>
+                                            </md-mention>
+
+
+                                            <md-ref tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Reference an issue or pull request"
+                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
+                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ref><button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
+                                                aria-label="Attach files"><svg aria-hidden="true"
+                                                    class="octicon octicon-cloud-upload" width="16" height="16">
+                                                    <path fill-rule="evenodd"
+                                                        d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
+                                                    </path>
+                                                </svg></button><button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
+                                                aria-label="Add collapsible content"><svg aria-hidden="true"
+                                                    class="octicon octicon-fold-down" width="14" height="16">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
+                                                    </path>
+                                                </svg></button>
+
+                                            <details
+                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                tabindex="-1">
+                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
+                                                    aria-label="Insert a reply"
+                                                    data-ga-click="Markdown Toolbar, click, saved reply"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
+                                                        width="14" height="16" aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                        </path>
+                                                    </svg>
+                                                    <span class="dropdown-caret "></span>
+                                                </summary>
+                                                <details-menu style="z-index: 99;"
+                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                    data-menu-input="discussion_r329949662-body_saved_reply_id"
+                                                    src="/settings/replies?context=none" preload="" role="menu">
+                                                    <div class="select-menu-header d-flex">
+                                                        <span class="select-menu-title flex-auto">Select a reply</span>
+                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                    </div>
+                                                    <include-fragment role="menuitem"
+                                                        class="select-menu-loading-overlay anim-pulse"
+                                                        aria-label="Loading">
+                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
+                                                            version="1.1" width="16" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                            </path>
+                                                        </svg>
+                                                    </include-fragment>
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+
+                                    </markdown-toolbar>
+
+                                </div>
+
+
+                                <div class="clearfix"></div>
+
+                                <p class="comment-form-error comment-show-stale">
+                                    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16"
+                                        height="16" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
+                                        </path>
+                                    </svg> The content you are editing has changed. Please try again.
+                                </p>
+
+
+                                <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
+                                    data-upload-policy-url="/upload/policies/assets"
+                                    data-upload-policy-authenticity-token="x9bs+/oR+Pyjl7mz64BZRDh6fQ/fqWwCWH3jQI+GXZlM9UfHLM3x1XojUxM/BQ9kVWnBNT+SzM9/pYtnz3pDAQ=="
+                                    data-upload-repository-id="41288708">
+                                    <input type="hidden" name="context" value="discussion">
+
+                                    <input type="hidden" name="saved_reply_id"
+                                        id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field"
+                                        value="" data-reset-value="">
+
+                                    <input type="hidden" name="pull_request_review_comment[id]"
+                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                    <input type="hidden" name="pull_request_review_comment[bodyVersion]"
+                                        class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+
+                                    <text-expander keys=": @ #"
+                                        data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                        data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                        data-emoji-url="/autocomplete/emoji">
+
+                                        <textarea name="pull_request_review_comment[body]"
+                                            id="discussion_r329949662-body" placeholder="Leave a comment"
+                                            aria-label="Comment body"
+                                            class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field"
+                                            title="">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
+                                    </text-expander>
+
+
+                                    <p
+                                        class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                        <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                            type="file" multiple=""
+                                            class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                            aria-label="Attach files to your comment"
+                                            id="fc-discussion_r329949662-body">
+                                        <span
+                                            class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                            style="pointer-events: none;"></span>
+                                        <span class="position-relative pr-2" style="pointer-events: none;">
+                                            <span class="default">
+                                                Attach files by dragging &amp; dropping, selecting or pasting them.
+                                            </span>
+                                            <span class="loading">
+                                                <img alt="" width="16" height="16"
+                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                Uploading your files…
+                                            </span>
+                                            <span class="error bad-file">
+                                                We don’t support that file type.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a
+                                                    GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error bad-permissions">
+                                                Attaching documents requires write permission to this repository.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
+                                                    PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error repository-required">
+                                                We don’t support that file type.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
+                                                    PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error too-big">
+                                                Yowza, that’s a big file
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a file smaller than 10MB.
+                                                </span>
+                                            </span>
+                                            <span class="error empty">
+                                                This file is empty.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a file that’s not empty.
+                                                </span>
+                                            </span>
+                                            <span class="error hidden-file">
+                                                This file is hidden.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with another file.
+                                                </span>
+                                            </span>
+                                            <span class="error failed-request">
+                                                Something went really wrong, and we can’t process that file.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again.</button>
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="tooltipped tooltipped-nw"
+                                            aria-label="Styling with Markdown is supported">
+                                            <a class="muted-link position-relative d-inline"
+                                                href="https://guides.github.com/features/mastering-markdown/"
+                                                target="_blank" data-ga-click="Markdown Toolbar, click, help"
+                                                aria-label="Learn about styling with Markdown">
+                                                <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16"
+                                                    version="1.1" width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                    </path>
+                                                </svg>
+                                            </a>
+                                        </span>
+                                    </p>
+
+                                </div>
+
+
+                                <div class="preview-content">
+                                    <div class="comment js-suggested-changes-container" data-thread-side="right">
+                                        <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
+                                            <p>Nothing to preview</p>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                                <div class="clearfix">
+
+                                    <input type="hidden" name="original-line"
+                                        value="+export class TestResourceManager {" class="js-original-line">
+                                    <input type="hidden" name="path"
+                                        value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+                                    <input type="hidden" name="line" value="13" class="js-line-number">
+                                    <div class="form-actions comment-form-actions">
+                                        <button class="btn btn-primary" type="submit" data-disable-with="">Update
+                                            comment</button>
+                                        <button class="btn btn-danger js-comment-cancel-button" type="button"
+                                            data-confirm-text="Are you sure you want to discard your unsaved changes?">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+                            </div>
+
+                        </form>
+                    </div>
                 </div>
 
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment" hidden="">
-              Edit
-            </button>
 
 
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272416639&amp;report=beyang+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="OwkgJhmUcGfz2PbAn3Lt/6MjxG0Kqq5/pCp3x2AxSakrOopv8ALRxKwv8GcOr3CMCy/tOOWmyf9a0EsIplPI4w==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang"><img class="avatar" height="28" width="28" alt="@beyang" src="https://avatars0.githubusercontent.com/u/1646931?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang">beyang</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272416639" id="discussion_r272416639-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-05T00:58:40Z" title="5 Apr 2019, 02:58 CEST">27 days ago</relative-time>
-              </a>
-
-          </span>
-        </h4>
-
-
-
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the Sourcegraph organization.">
-      Member
-    </span>
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="7NoDnuBdRXJOER6BCcV9ROfic+8+Chb3xEJGSM4NT1/CLUV61c2GMtDN8R+TcpF+IjImmn5DwkVj24ZZ/z1T8w==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
-            <p>Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
             </div>
 
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272416639" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="JgxOmEuF9O03WWT3vESPYlgoGlJcILoDjDBYqADoIgkUGgIJBOgIpsJWMWSIkXgbl2UuRHin9nFM+e1ncVRXOQ==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="hswDn67hH34TyhqdZW15EbZqJZaNEEqcyFfLrNznj4K0FlYtOJ6GxOcybKQR5Qq0DFGyIzCfYyzX6FfoNlTHTg==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="JiURAlmHDALKB9xTsTSw1eAnXD+5cE0i51Tx/+jUIdXmNUx62qs26fUOy6Yd9PHGojRbdAPOeaGVSDRaxZnL+w==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272416639-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="EcYIl3UQoTJ7f+rwSGlZy4HOqrpeDsmW3WMZj5zWbGIj0EQGOn1deY5wv2N8vK6yToOerHqJheQdqqxA7WoZUg==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="d1773e368c1e4ab89003e7785857bb71">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272416639-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links" id="discussion_r272796448" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="cb2c551d0d9dac9546de9ea2988f9bdd">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<button type="button" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272796448-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div class="dropdown-divider"></div><a href="/sourcegraph/sourcegraph/tree/HEAD@{2019-04-06T13:53:50Z}" class="dropdown-item btn-link" role="menuitem" title="Browse repository like it appeared on this day">View repo at this time</a><div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment" hidden="">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="fcc+QM5c/4K4N9v7Zrd4MdDw9Pxgs56aBCCManJMAoxtPg+SYg5AqH453DgvMypoflKxu40gVTpYhUmkPGW8Lw==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="TU8uqa1ZmdiJ7aSE9VtcJmSzYepIIQ8cKlAJ3xOvEVFioumc3Aa0UTAH7/5u9HRGPiXofi/X7g4gOIU1eD7p6w==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272796448&amp;report=alexandnpu+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272796448" id="discussion_r272796448-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-06T13:53:50Z" title="6 Apr 2019, 15:53 CEST">25 days ago</relative-time></a>
-              </span>
-            </h4>
-
-
-            <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
-                  <p>Maybe <code>Opaque</code> is not a very straight forward word to understand. That part of code is handling urls whose pattern is <code>host:port</code>, such as "localhost:5000" or so.</p>
-<p>I do not like the way <code>Opaque</code> used here, but it is in the standard library net/url/url.go</p>
-<pre><code>// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-</code></pre>
-<p>any suggestions for making this part more elegant?</p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="MEz58dyShAa0U4Bqq/QUqB3fXO8S38yEfQAedQb9g30CWrVgk/94TUFc1fmfIePR0pJo+TZYgPa9yau6d0H2TQ==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Z2c1iOstVPx2X3ZhUyiuaTG6XBmNegnH+XYfeE+5oBguNjsl1pVJALPdHKW4suXj34rtm26AWfET8QHJPmvbhQ==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="cw8l7V4zVPGMvFPFlXF6/BvDf4HaZBdhGh6/rFcTDc+zH3iV3R9uGrO1RDA5sTvvWdB4ymDaI+JoAnoJel7n4Q==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272796448-minimize-comment-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="Wo4t/VHGvsJhWfnQ0zYekzh4PV7wL6gDbFrIF+v29FJomGFsHqtCiZRWrEPn4+nq9zUJSNSo5HGsk33YmkqBYg==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="cb2c551d0d9dac9546de9ea2988f9bdd">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272796448-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
-
-
-    </div>
-
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="cb2c551d0d9dac9546de9ea2988f9bdd" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
-
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272796448" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
-
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="skxP0V971SmU30t4ybP2eYpwkO04eG4vZW7A/MFND+m56qiBN+djcaqmCzHBkdxxXKmvPGA0eoE1FLqML4pZkQ==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
-
-    <div role="none" class="dropdown-divider"></div>
-
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" title=":+1:">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji" title=":-1:">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji" title=":smile:">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji" title=":tada:">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji" title=":thinking_face:">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji" title=":heart:">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji" title=":rocket:">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji" title=":eyes:">👀</g-emoji>
-        </button>
-    </div>
-</form></details-menu>
-
-  </details>
-
-        <button type="button" role="menuitem" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272796448">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272796448-permalink" data-toggle-for="details-discussion_r272796448" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272796448">
-              Quote reply
-            </button>
-
-
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
-
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
-    </div>
-
-                <div class="Box-body scrollable-overlay">
-
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="oMuHg9WiQrUySHoSwgnrAqgj4/TEQZIeoxuDR+eTIy8rH1KHmU7P/Zv4eNuqTffbJBYK547vQgcA7LcwuiQOfw==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" class="form-control" type="text" name="issue[title]" value="Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as &quot;localhost:5000&quot; or so." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" name="issue[body]" class="form-control" aria-label="Issue body">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?
-
-_Originally posted by @alexandnpu in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
-
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
+            <div class="review-thread-reply border-bottom">
+
+                <div class="inline-comment-form-container js-inline-comment-form-container">
+                    <div class="inline-comment-form-actions">
+                        <div class="d-table width-full">
+                            <div class="d-table-cell">
+                                <a class="d-inline-block" data-hovercard-type="user"
+                                    data-hovercard-url="/hovercards?user_id=1741180"
+                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                    href="/lguychard"><img class="avatar"
+                                        src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28"
+                                        height="28" alt="@lguychard"></a>
+                            </div>
+                            <div class="d-table-cell col-12">
+                                <button type="button"
+                                    class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
+                                    Reply…
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="inline-comment-form">
+                        <!-- '"` -->
+                        <!-- </textarea></xmp> -->
+                        <form class="js-inline-comment-form rgh-minimize-upload-bar"
+                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8"
+                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
+                                name="authenticity_token"
+                                value="y2OZnXxDobi9U9nCduUEXmZ3AGDdKgsm3RtZ8Sw+iMV/akGgymK7tO9u0LwUBuifEFJHfsVHcx6LUFkSZl2i2g==">
+                            <input type="hidden" name="comment_context" value="discussion">
+                            <input type="hidden" name="in_reply_to" value="329949662">
+
+
+                            <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                data-preview-url="/preview?repository=41288708"
+                                data-preview-authenticity-token="/Rgu0cip5SPf5HQR16xNe7pcnreJ6P6Olc+BNCHEWwAB5989pORHGEzPXD1aXSJNAPP7/yS1cTocpXzOTxetWQ==">
+                                <div class="comment-form-head tabnav">
+
+                                    <markdown-toolbar
+                                        for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
+                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+                                        <div class="d-inline-block mr-3">
+                                            <button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item "
+                                                aria-label="Insert a suggestion <cmd-g>"
+                                                data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CD9B:3B3A8:F08542:16C70BA:5D94713D&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
+                                                data-hydro-click-hmac="bea7f0b328064f34943b21954c8180de7fd1051ed68eda30066f2d71143aa42d"
+                                                data-ga-click="Markdown Toolbar, click, insert code suggestion"
+                                                hotkey="g">
+                                                <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1"
+                                                    width="13" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z">
+                                                    </path>
+                                                </svg>
+                                            </button> </div>
+
+                                        <div class="flex-nowrap d-inline-block mr-3">
+                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add header text"
+                                                data-ga-click="Markdown Toolbar, click, header" role="button">
+                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
+                                                    width="18" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-header>
+
+                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add bold text <cmd-b>"
+                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-bold>
+
+                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add italic text <cmd-i>"
+                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
+                                                hotkey="i">
+                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
+                                                    width="6" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                    </path>
+                                                </svg>
+                                            </md-italic>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-quote tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert a quote"
+                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
+                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-quote>
+
+                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
+                                                role="button">
+                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                    </path>
+                                                </svg>
+                                            </md-code>
+
+
+                                            <md-link tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                aria-label="Add a link <cmd-k>"
+                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                    </path>
+                                                </svg>
+                                            </md-link>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-unordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a bulleted list"
+                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-unordered-list>
+
+                                            <md-ordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a numbered list"
+                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ordered-list>
+
+                                            <md-task-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a task list"
+                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
+                                                hotkey="L">
+                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                    </path>
+                                                </svg>
+                                            </md-task-list>
+                                        </div>
+
+                                        <div class="d-inline-block">
+                                            <md-mention tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Directly mention a user or team"
+                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
+                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                    </path>
+                                                </svg>
+                                            </md-mention>
+
+
+                                            <md-ref tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Reference an issue or pull request"
+                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
+                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ref><button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n rgh-upload-btn"
+                                                aria-label="Attach files"><svg aria-hidden="true"
+                                                    class="octicon octicon-cloud-upload" width="16" height="16">
+                                                    <path fill-rule="evenodd"
+                                                        d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z">
+                                                    </path>
+                                                </svg></button><button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn"
+                                                aria-label="Add collapsible content"><svg aria-hidden="true"
+                                                    class="octicon octicon-fold-down" width="14" height="16">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z">
+                                                    </path>
+                                                </svg></button>
+
+                                            <details
+                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                tabindex="-1">
+                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
+                                                    aria-label="Insert a reply"
+                                                    data-ga-click="Markdown Toolbar, click, saved reply"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
+                                                        width="14" height="16" aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                        </path>
+                                                    </svg>
+                                                    <span class="dropdown-caret "></span>
+                                                </summary>
+                                                <details-menu style="z-index: 99;"
+                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                    data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
+                                                    src="/settings/replies?context=none" preload="" role="menu">
+                                                    <div class="select-menu-header d-flex">
+                                                        <span class="select-menu-title flex-auto">Select a reply</span>
+                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                    </div>
+                                                    <include-fragment role="menuitem"
+                                                        class="select-menu-loading-overlay anim-pulse"
+                                                        aria-label="Loading">
+                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
+                                                            version="1.1" width="16" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                            </path>
+                                                        </svg>
+                                                    </include-fragment>
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+
+                                    </markdown-toolbar>
+
+                                    <nav class="tabnav-tabs" role="tablist">
+                                        <button type="button"
+                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
+                                            aria-selected="true">Write</button>
+                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                            role="tab">Preview</button>
+                                    </nav>
+                                </div>
+
+                                <file-attachment class="js-upload-markdown-image is-default"
+                                    data-upload-repository-id="=&quot;41288708&quot;"
+                                    data-upload-policy-url="/upload/policies/assets"
+                                    data-upload-policy-authenticity-token="hbeyW1p3VqZIuddnNP58dYukPniSyhIsxm6VD4fahz0OlBlnjKtfj5ENPcfgeypV5reCQnLxsuHhtv0oxyaZpQ==">
+                                    <div class="write-content js-write-bucket upload-enabled">
+                                        <input type="hidden" name="saved_reply_id"
+                                            id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
+                                            class="js-resettable-field" value="" data-reset-value="">
+
+                                        <text-expander keys=": @ #"
+                                            data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                            data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                            data-emoji-url="/autocomplete/emoji">
+                                            <textarea name="comment[body]"
+                                                id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
+                                                placeholder="Leave a comment" aria-label="Comment body"
+                                                class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable"
+                                                title=""></textarea>
+                                        </text-expander>
+
+
+                                        <p
+                                            class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                            <input
+                                                accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                                type="file" multiple=""
+                                                class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                                aria-label="Attach files to your comment"
+                                                id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
+                                            <span
+                                                class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                                style="pointer-events: none;"></span>
+                                            <span class="position-relative pr-2" style="pointer-events: none;">
+                                                <span class="default">
+                                                    Attach files by dragging &amp; dropping, selecting or pasting them.
+                                                </span>
+                                                <span class="loading">
+                                                    <img alt="" width="16" height="16"
+                                                        src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                    Uploading your files…
+                                                </span>
+                                                <span class="error bad-file">
+                                                    We don’t support that file type.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a
+                                                        GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error bad-permissions">
+                                                    Attaching documents requires write permission to this repository.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                        or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error repository-required">
+                                                    We don’t support that file type.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                        or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error too-big">
+                                                    Yowza, that’s a big file
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a file smaller than 10MB.
+                                                    </span>
+                                                </span>
+                                                <span class="error empty">
+                                                    This file is empty.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a file that’s not empty.
+                                                    </span>
+                                                </span>
+                                                <span class="error hidden-file">
+                                                    This file is hidden.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with another file.
+                                                    </span>
+                                                </span>
+                                                <span class="error failed-request">
+                                                    Something went really wrong, and we can’t process that file.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try
+                                                            again.</button>
+                                                    </span>
+                                                </span>
+                                            </span>
+                                            <span class="tooltipped tooltipped-nw"
+                                                aria-label="Styling with Markdown is supported">
+                                                <a class="muted-link position-relative d-inline"
+                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                    target="_blank" data-ga-click="Markdown Toolbar, click, help"
+                                                    aria-label="Learn about styling with Markdown">
+                                                    <svg class="octicon octicon-markdown v-align-bottom"
+                                                        viewBox="0 0 16 16" version="1.1" width="16" height="16"
+                                                        aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                        </path>
+                                                    </svg>
+                                                </a>
+                                            </span>
+                                        </p>
+
+                                    </div>
+                                </file-attachment>
+                                <div class="preview-content">
+                                    <div class="comment js-suggested-changes-container" data-thread-side="">
+                                        <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
+                                            <p>Nothing to preview</p>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+                            </div>
+
+
+                            <div class="form-actions">
+                                <div class="position-relative float-right ml-1">
+                                    <input type="hidden" name="single_comment" value="1">
+
+                                    <button name="single_comment" type="submit" value="1"
+                                        class="btn review-simple-reply-button btn-primary" data-disable-invalid=""
+                                        data-disable-with="">
+                                        Comment
+                                    </button>
+                                </div>
+
+                                <button class="btn js-hide-inline-comment-form" type="button"
+                                    data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
 
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment" hidden="">
-              Edit
-            </button>
-
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272796448&amp;report=alexandnpu+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="sv4XP/hSFbhjmmmZmDqW7ISWK0x/6X0xhsh+d/RTSZidE9AKiQ04MdpwIuMDlb6M3gCi2BgfnCOMoPKdn8KxIg==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272796448" id="discussion_r272796448-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-06T13:53:50Z" title="6 Apr 2019, 15:53 CEST">25 days ago</relative-time>
-              </a>
-
-
-  <span class="d-inline-block text-gray-light">•</span>
-
-  <details class="details-overlay details-reset d-inline-block dropdown">
-    <summary class="btn-link no-underline text-gray js-notice" aria-haspopup="menu">
-      <div class="position-relative">
-        <span>
-            edited
-        </span>
-        <svg height="11" class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-      </div>
-    </summary>
-    <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px" src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/comment_edit_history_log" preload="" role="menu">
-      <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
-    </details-menu>
-  </details>
-
-          </span>
-        </h4>
-
-        <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="spVpkebEZ+bga1Cqf1Ae/8/Uap2BWQkLza2dHjVGZuucYi9101Skpn63vzTl5/LFCgQ/6MEQ3blqNF0PBHZ6Rw==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
-            <p>Maybe <code>Opaque</code> is not a very straight forward word to understand. That part of code is handling urls whose pattern is <code>host:port</code>, such as "localhost:5000" or so.</p>
-<p>I do not like the way <code>Opaque</code> used here, but it is in the standard library net/url/url.go</p>
-<pre><code>// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-</code></pre>
-<p>any suggestions for making this part more elegant?</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
             </div>
-
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272796448" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="GSW8v/iA82wk4ROgQSNLYs2sZ7uKrmo+vF6j/bmAz64rM/Aut+0PJ9HuRjN19rwbAuFTra4pJkx8lxYyyDy6ng==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="jLWmaLz8HChOv5y24izuH+MTpQrYC44FJ/F1lpMdlMvF5KjFgUQB1Is99nIJtqWVDSMUiDvx3jPNdmsn4s/vVg==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="7oedtJY1dJGIrDyDUBNgF2RUU+gIoJe2IWvdSuYvE6Mul8DMFRlOerelK3b80yEEJkdUo7IeozVTdxjvy2L5jQ==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272796448-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="+vQgByP5hthnWJ4FonocShpYKWf+5sPfII19k5MMXh7I4myWbJR6k5JXy5aWr+sz1RUdcdphj63gRMhc4rArLg==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="cb2c551d0d9dac9546de9ea2988f9bdd">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272796448-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment rgh-time-machine-links" id="discussion_r272957122" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="b844590cffa5a736fcb6fac819c0af65">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<button type="button" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272957122-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div class="dropdown-divider"></div><a href="/sourcegraph/sourcegraph/tree/HEAD@{2019-04-08T09:28:14Z}" class="dropdown-item btn-link" role="menuitem" title="Browse repository like it appeared on this day">View repo at this time</a><div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" role="menuitem" aria-label="Edit comment" hidden="">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="MJSNGHNbI3WaM5br8Dr1iUpB0L+ORty0gI16ksbZSZAgbbzK3wmcX1w9kSi5vqfQ5OOV+GPVFxTcKL9ciPD3Mw==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="sL22NGN1VIKajo2ARRrsIxMnGBqQaoLifx6x7YbGycnckDnplRkkM+hCMhyZCUXeDINGp6CpucRVrvYNb3JBiw==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272957122&amp;report=alexandnpu+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272957122" id="discussion_r272957122-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-08T09:28:14Z" title="8 Apr 2019, 11:28 CEST">24 days ago</relative-time></a>
-              </span>
-            </h4>
-
-
-            <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body rgh-linkified-code">
-                  <p>I've updated my way of parsing redis connection string and added some tests. Please have a review.</p>
-              </div>
-            </task-lists>
-          </div>
         </div>
 
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="n25NJuiUtJ1VOfTQlNrif8MJ/tEoizelQna+LH3li+SteAG3p/lI1qA2oUOgDxUGDETKxwwMe9eCvwvjDFn+1A==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="0Ny378I41IFFS8Z7tCy1C9WULcGeNkzd/QUl8lHFxdN1PyqS3tX0jpF5A1Egg3TsjRwbtHk2OY/IpGWeVFWcNQ==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="zj15OfsrOBxHDtCPTVoj1+6FXGMFn8L/HX3XWVxU8bwOLSRBeAcC93gHx3rhmmLErJZbKL8h9nxvYRL8cRkbkg==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272957122-minimize-comment-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="Zw80o0HnQyQBNtfvThAqBJaDHjMkQ33OSnf1lkQlEAhVGXgyDoq/b/Q5gnx6xd19Wc4qJQDEMbyKvkBZNZllOA==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="b844590cffa5a736fcb6fac819c0af65">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272957122-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">I've updated my way of parsing redis connection string and added some tests. Please have a review.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
+        <!-- '"` -->
+        <!-- </textarea></xmp> -->
+        <form class="js-resolvable-timeline-thread-form"
+            action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve"
+            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
+                name="_method" value="put"><input type="hidden" name="authenticity_token"
+                value="hMaOZWGUT0HwEPw0kZFpo80OpT7WbojlbC0VBAeONzHhCtYW6yGxsJzenoRTxwtm11n/r/uUs0m2DbGDYdX9BQ==">
+            <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…"
+                data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CD9B:3B3A8:F08542:16C70BA:5D94713D&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
+                data-hydro-click-hmac="c4f20eaa11b97b758ed9f8b07e7bfd04bdd29c92adf6bde8c1585916ce57527c">
+                Resolve conversation
+            </button></form>
     </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
-
-
-    </div>
-
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="b844590cffa5a736fcb6fac819c0af65" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
-
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272957122" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
-
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="5DFvY5z/fw1Yy4+yngEN8fkxsiiLnfmirWBr1mL9cezvl4gz9GPJVWayz/uWIyf5L+iN+dPR7Qz9GhGmjDonlA==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
-
-    <div role="none" class="dropdown-divider"></div>
-
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" title=":+1:">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji" title=":-1:">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji" title=":smile:">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji" title=":tada:">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji" title=":thinking_face:">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji" title=":heart:">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji" title=":rocket:">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji" title=":eyes:">👀</g-emoji>
-        </button>
-    </div>
-</form></details-menu>
-
-  </details>
-
-        <button type="button" role="menuitem" class="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment"><svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"></path></svg></button><details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272957122">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272957122-permalink" data-toggle-for="details-discussion_r272957122" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272957122">
-              Quote reply
-            </button>
-
-
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
-
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
-    </div>
-
-                <div class="Box-body scrollable-overlay">
-
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="wm2EYCkrA2fDz2M6OqOLrgJNb3OuQtWJvnFZ6rQhwVdJuVFkZceOL2p/YfNS55d3jniGYOTsBZAdhm2d6ZbsBw==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" class="form-control" type="text" name="issue[title]" value="I've updated my way of parsing redis connection string and added some tests. Please have a review." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" name="issue[body]" class="form-control" aria-label="Issue body">I've updated my way of parsing redis connection string and added some tests. Please have a review.
-
-_Originally posted by @alexandnpu in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
-
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
-                </div>
-
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button rgh-edit-comment" aria-label="Edit comment" hidden="">
-              Edit
-            </button>
-
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272957122&amp;report=alexandnpu+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="6l0mPX9nhYRmZk2VJrU7NQbOf608eq198QTTv+/EI/GGcKngiQv1NRSq8gn6ppLIGWohEAy5llvbtJRfBnCrsw==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target rgh-fullname" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272957122" id="discussion_r272957122-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-08T09:28:14Z" title="8 Apr 2019, 11:28 CEST">24 days ago</relative-time>
-              </a>
-
-          </span>
-        </h4>
-
-        <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="bDy2Fe552hOZ9grDKZNdov21rJ86+dPtbCrRYFlw90pCy/Dx2+kZUwcq5V2zJLGYOGX56nqwB1/LsxFxaEDr5g==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body js-comment-body rgh-linkified-code">
-            <p>I've updated my way of parsing redis connection string and added some tests. Please have a review.</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
-            </div>
-
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272957122" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="uBQx1/4kww3YXxw8J4YBZwCoUd4YSoi+Rh5X8HhlyVGKAn1GsUk/Ri1QSa8TU/Yez+VlyDzNxMyG1+I/Cdm8YQ==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="KIz8QeKj7K9Ah3RQdNlb1hdgkf8kuHJKtQMdVXeoXaaNb2E8/k7MoJS1sXrgdpoxT+inisO4BxiAol05cjgEQA==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="p1e+Hu5dgFgOH3Ffop23NZMBU6C2wZsnSgXWONNrIpZnR+NmbXG6szEWZqoOXfYm0RJU6wx/r6Q4GROd/ibIuA==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272957122-body" class="toolbar-commenting ">
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-error comment-show-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="ffek31GbaXZGsFoViGdlUE3gp286NZwPlTkHsDVC8hhP4ehOHvaVPbO/D4a8spIpgq2TeR6y0H1V8LJ/RP6HKA==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="b844590cffa5a736fcb6fac819c0af65">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272957122-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">I've updated my way of parsing redis connection string and added some tests. Please have a review.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-    </div>
-
-      <div class="review-thread-reply border-bottom">
-
-<div class="inline-comment-form-container js-inline-comment-form-container">
-  <div class="inline-comment-form-actions">
-    <div class="d-table width-full">
-      <div class="d-table-cell">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=10532611" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/felixfbecker"><img class="avatar" src="https://avatars2.githubusercontent.com/u/10532611?s=56&amp;v=4" width="28" height="28" alt="@felixfbecker"></a>
-      </div>
-      <div class="d-table-cell col-12">
-        <button type="button" class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
-          Reply…
-        </button>
-      </div>
-    </div>
-  </div>
-
-  <div class="inline-comment-form">
-    <!-- '"` --><!-- </textarea></xmp> --><form class="js-inline-comment-form" action="/sourcegraph/sourcegraph/pull/3221/review_comment/create" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="iWr3btSvF7umYrXKXTqYjg/SNI27a2Vq+QhSINOpVsXogRcgmHgoLcBsWj0pW/7sb8I747j3lxB8EjBkMpU3eA==">
-      <input type="hidden" name="comment_context" value="discussion">
-      <input type="hidden" name="in_reply_to" value="272416639">
-
-
-<div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected" data-preview-url="/preview?repository=41288708" data-preview-authenticity-token="1F4B0PZG52lbzFkSJQ3/vUDF0xdmhXr/vHTbY50pUTsUTlyodWrdgmTFTueJzb6uAtbUXNw7TnzOaB7GsGS7FQ==">
-  <div class="comment-form-head tabnav">
-
-<markdown-toolbar for="new_inline_comment_discussion_diff-5bd3e793932782601ddbd53a3d8dd073_272416639_21" class="toolbar-commenting ">
-    <div class="d-inline-block mr-3 ">
-      <button type="button" class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item" aria-label="Insert a suggestion <cmd-g>" data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:10532611,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MjY3NDM3NDQ3&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;2008835310.1548448452&quot;,&quot;originating_request_id&quot;:&quot;CBA4:EE01:3B09E7:5A0050:5CCA1DE8&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/3221&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="65c9425f42bc25b51cd389e9db2198ca00e3fc1c68adec8dda6d5f1ae0a89317" data-ga-click="Markdown Toolbar, click, insert code suggestion" hotkey="g">
-          <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
-</button>    </div>
-  <div class="d-inline-block mr-3 ">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="d-inline-block mr-3 ">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="d-inline-block">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref><button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content"><svg aria-hidden="true" class="octicon octicon-fold-down" width="14" height="16"><path fill-rule="evenodd" d="M4 11l3 3 3-3H8V5H6v6H4zm-4 0c0 .55.45 1 1 1h2.5l-1-1h-1l2-2H5V8H3.5l-2-2H5V5H1c-.55 0-1 .45-1 1l2.5 2.5L0 11zm10.5-2H9V8h1.5l2-2H9V5h4c.55 0 1 .45 1 1l-2.5 2.5L14 11c0 .55-.45 1-1 1h-2.5l1-1h1l-2-2z"></path></svg></button>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-    <nav class="tabnav-tabs" role="tablist">
-      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-    </nav>
-  </div>
-
-  <file-attachment class="js-upload-markdown-image is-default" data-upload-repository-id="=&quot;41288708&quot;" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="Il3Fi1TM86wU3bCtFYyuWD5P+ShMScTAWGNYvAqahn8QS4kaG6EP5+HS5T4hWVkh8QLNPmjOiLKYqu1zeybzTw==">
-    <div class="write-content js-write-bucket upload-enabled">
-      <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-      <textarea name="comment[body]" id="new_inline_comment_discussion_diff-5bd3e793932782601ddbd53a3d8dd073_272416639_21" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"></textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-    </div>
-</file-attachment>
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="">
-  <div class="comment-body markdown-body js-preview-body rgh-linkified-code">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-</div>
-
-
-      <div class="form-actions">
-        <div class="position-relative float-right ml-1">
-          <input type="hidden" name="single_comment" value="1">
-
-          <button name="single_comment" type="submit" value="1" class="btn review-simple-reply-button btn-primary" data-disable-invalid="" data-disable-with="">
-            Comment
-          </button>
-        </div>
-
-        <button class="btn js-hide-inline-comment-form" type="button" data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
-      </div>
-</form>  </div>
-</div>
-
-      </div>
-  </div>
-
-    <!-- '"` --><!-- </textarea></xmp> --><form class="js-resolvable-timeline-thread-form" action="/sourcegraph/sourcegraph/pull/3221/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMTY2NDA0MTMwOnYy/resolve" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="/g5oitDPmtilQ+yEmx9L0dChhgT/RwuYF49dj5Wt54MocW7dq3SKLW4r05Ie0b/CEoT8gmQU792hg7E5wshtFg==">
-      <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…" data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:166404130,&quot;user_id&quot;:10532611,&quot;client_id&quot;:&quot;2008835310.1548448452&quot;,&quot;originating_request_id&quot;:&quot;CBA4:EE01:3B09E7:5A0050:5CCA1DE8&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/3221&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="19bb6322a48a1a6febb86324733cd5c83ec5c64a4b5cafb87efa76993c129e25">
-        Resolve conversation
-</button></form>
-</div>
 
 
 

--- a/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/vanilla/code-view.html
+++ b/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/vanilla/code-view.html
@@ -1,2707 +1,2217 @@
-<!-- https://github.com/sourcegraph/sourcegraph/pull/3221 -->
-<div class="file js-comment-container js-resolvable-timeline-thread-container has-inline-notes">
-  <div class="file-header">
-        <a href="/sourcegraph/sourcegraph/pull/3221/files/cb632145276dd3e17f03e44b272b611b8107f725#diff-5bd3e793932782601ddbd53a3d8dd073" class="file-info link-gray-dark" title="pkg/redispool/redispool.go">
-      pkg/redispool/redispool.go
-    </a>
-
-    <span title="Label: Outdated" class="Label Label--outline bg-yellow-light">Outdated</span>
-
-  </div>
-
-
-<div class="blob-wrapper border-bottom">
-  <table id="discussion-diff-272416639" class="diff-table">
-
-
-
-    <tbody><tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R59" data-line-number="59" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	}</span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R60" data-line-number="60" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition"><br></span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R61" data-line-number="61" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	<span class="pl-k">var</span> <span class="pl-smi">host</span> <span class="pl-k">string</span></span>
-
-      </td>
-    </tr>
-    <tr>
-
-        <td class="blob-num blob-num-addition empty-cell"></td>
-
-        <td id="discussion-diff-272416639R62" data-line-number="62" class="blob-num blob-num-addition js-linkable-line-number"></td>
-
-      <td class="blob-code blob-code-addition">
-        <span class="blob-code-inner blob-code-marker-addition">	<span class="pl-k">if</span> <span class="pl-c1">len</span>(parsedUrl.<span class="pl-smi">Opaque</span>) &gt; <span class="pl-c1">0</span> {</span>
-
-      </td>
-    </tr>
-
-  </tbody></table>
-</div>
-
-<div class="js-inline-comments-container">
-  <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
-    <div class="js-comments-holder">
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment" id="discussion_r272416639" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="d1773e368c1e4ab89003e7785857bb71">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272416639-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button" role="menuitem" aria-label="Edit comment">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="O6V/rlDrNys5sFUeHTtZ882ORW3Q76zn3DIT7cRsjqErXE58/LmIAf++Ut1UvwuqYywAKj18Z0eAl9YjikUwAg==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="0vRDLCizKMElEe/YyLX9unpyK64Z+RZOEAo34jCBOQXCx+llwSWJYnrm6X9ZaGDJ0n4C+/b1cc7u8Ast9uO4Tw==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272416639&amp;report=beyang+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang"><img class="avatar" height="28" width="28" alt="@beyang" src="https://avatars0.githubusercontent.com/u/1646931?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang">beyang</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272416639" id="discussion_r272416639-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-05T00:58:40Z" title="5 Apr 2019, 02:58 CEST">27 days ago</relative-time></a>
-              </span>
-            </h4>
-
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the Sourcegraph organization.">
-      Member
-    </span>
-
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p>Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="DUkaxqECw7YfnFyWK6G7peUpEXWSGrGptXt3jlDWMlo/X1ZX7m8//eqTCQUfdEzcKmQlY7ad/dt1ssJBIWpHag==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="jgoD0FaaGcO7Gq+vAOmJE0NFWIg0Dn4bUQ1nbzK/u5m80FZiwOWAeU/i2ZZ0Yfq2+X7PPYmBV6tOsvsr2AzzVQ==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="IEUhh5Uf2rV/tqDcGv4lvA7lPd8K0C0WPdbttvBQdQ3gVXz/FjPgXkC/tym2PmSvTPY6lLBuGZVPyigT3R2fIw==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272416639-minimize-comment-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="idc8j2G7g3TS1M4MmBU2AttJvDtS+6jEwh31yqiilN+7wXAeLtZ/Pyfbm5+swMF7FASILXZ85LYC1EAF2R7h7w==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="d1773e368c1e4ab89003e7785857bb71">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272416639-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
+<div
+    class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
+    <div class="file-header">
+        <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd"
+            class="text-mono text-small link-gray-dark wb-break-all mr-2"
+            title="web/src/regression/util/TestResourceManager.ts">
+            web/src/regression/util/TestResourceManager.ts
+        </a>
 
 
     </div>
 
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="d1773e368c1e4ab89003e7785857bb71" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
 
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272416639" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
-
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="4ECYxiJTKrQOJ76HGh1JnLaPKRWphItUDv2kBmDR98nr5n+WSs+c7DBe/s4SP2OUYFYWxPHIn/peh952jhahsQ==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
-
-    <div role="none" class="dropdown-divider"></div>
-
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
-        </button>
-    </div>
-</form></details-menu>
-
-  </details>
-
-        <details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272416639">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272416639-permalink" data-toggle-for="details-discussion_r272416639" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272416639">
-              Quote reply
-            </button>
+    <div class="blob-wrapper border-bottom">
+        <table id="discussion-diff-329949662" class="diff-table">
 
 
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
 
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
+            <tbody>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R10" data-line-number="10"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> * place and for easy
+                                resource cleanup at the end of tests. Also prints which resources are
+                                created</span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R11" data-line-number="11"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> * and destroyed in
+                                case tests are aborted midway through and manual cleanup is required.</span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R12" data-line-number="12"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> <span
+                                    class="pl-c">*/</span></span></span>
+
+                    </td>
+                </tr>
+                <tr>
+
+                    <td class="blob-num blob-num-addition empty-cell"></td>
+
+                    <td id="discussion-diff-329949662R13" data-line-number="13"
+                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+
+                    <td class="blob-code blob-code-addition">
+                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-k">export</span> <span
+                                class="pl-k">class</span> <span class="pl-en">TestResourceManager</span> {</span>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
     </div>
 
-                <div class="Box-body scrollable-overlay">
+    <div class="js-inline-comments-container">
+        <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
+            <div class="js-comments-holder">
 
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="D6Yn8HKrJ0X1PFqkPaMQwquzu+OTczwF6TzPiIGwPDqEcvL0PkeqDVyMWG1V5wwbJ4ZS8Nnd7BxKy/v/3AcRag==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" class="form-control" type="text" name="issue[title]" value="Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==" name="issue[body]" class="form-control" aria-label="Issue body">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.
 
-_Originally posted by @beyang in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
+                <div class="review-comment js-minimizable-comment-group js-targetable-comment"
+                    id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
 
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
+                    <div class="minimized-comment position-relative d-none">
+
+
+
+
+                        <details class="Details-element details-reset "
+                            data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
+                            <summary class="text-gray f6">
+                                <div class="d-flex flex-justify-between flex-items-center">
+                                    <h3 class="review-comment-contents bg-white f5 text-normal text-italic"
+                                        style="margin-left:38px">
+                                        <div class="discussion-item-icon discussion-item-icon-gray text-gray">
+                                            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1"
+                                                width="14" height="16" aria-hidden="true">
+                                                <path fill-rule="evenodd"
+                                                    d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
+                                                </path>
+                                            </svg>
+                                        </div>
+                                        <div class="d-inline-block">
+                                            This comment has been minimized.
+
+                                        </div>
+                                    </h3>
+                                    <div class="Details-content--closed btn-link text-gray"><svg
+                                            class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1"
+                                            width="14" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z">
+                                            </path>
+                                        </svg>Show comment</div>
+                                    <div class="Details-content--open btn-link text-gray"><svg
+                                            class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1"
+                                            width="14" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
+                                            </path>
+                                        </svg>Hide comment</div>
+                                </div>
+                            </summary>
+                            <div class="py-2 pl-6 pr-0">
+                                <div class="previewable-edit  js-task-list-container reorderable-task-lists">
+                                    <div class="edit-comment-hide">
+                                        <div class="timeline-comment-actions">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                            <details
+                                                class="details-overlay details-reset position-relative d-inline-block ">
+                                                <summary class="btn-link timeline-comment-action link-gray"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg aria-label="Show options"
+                                                        class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16"
+                                                        version="1.1" width="13" height="16" role="img">
+                                                        <path fill-rule="evenodd"
+                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
+                                                        </path>
+                                                    </svg>
+                                                </summary>
+                                                <details-menu
+                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
+                                                    style="width:185px" role="menu">
+                                                    <clipboard-copy class="dropdown-item btn-link"
+                                                        for="discussion_r329949662-minimized-permalink" role="menuitem"
+                                                        tabindex="0">
+                                                        Copy link
+                                                    </clipboard-copy>
+
+                                                    <button type="button"
+                                                        class="dropdown-item btn-link d-none js-comment-quote-reply"
+                                                        role="menuitem">
+                                                        Quote reply
+                                                    </button>
+
+                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                    <button type="button"
+                                                        class="dropdown-item btn-link js-comment-edit-button"
+                                                        role="menuitem" aria-label="Edit comment">
+                                                        Edit
+                                                    </button>
+
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form class="inline-form js-comment-unminimize width-full"
+                                                        action="/sourcegraph/sourcegraph/community/unminimize-comment"
+                                                        accept-charset="UTF-8" method="post"><input name="utf8"
+                                                            type="hidden" value="✓"><input type="hidden" name="_method"
+                                                            value="put"><input type="hidden" name="authenticity_token"
+                                                            value="O7bfHn+7JNhZoYMfM01nOLRQcEtsrXrkZTUUkEohhWiT/CVDnGMmhwqUZdG99tu76ukAQVF0+tdXXIueNjk/Jg==">
+                                                        <input type="hidden" name="comment_id"
+                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                        <button type="submit" class="dropdown-item btn-link"
+                                                            role="menuitem" aria-label="Unhide comment">
+                                                            Unhide
+                                                        </button>
+                                                    </form>
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form class="width-full inline-form js-comment-delete"
+                                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                                        accept-charset="UTF-8" method="post"><input name="utf8"
+                                                            type="hidden" value="✓"><input type="hidden" name="_method"
+                                                            value="delete"><input type="hidden"
+                                                            name="authenticity_token"
+                                                            value="7YFuIenax6vP0yGJuVCV+ZyU3oFR5c2Nw+kEXM1PcTTUdBafwpQxrfLSbUTx/k5Uny3FLcMKcXavtv0U/HlCsw==">
+                                                        <input type="hidden" name="input[id]"
+                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                        <button type="submit"
+                                                            class="dropdown-item menu-item-danger btn-link"
+                                                            aria-label="Delete comment" role="menuitem"
+                                                            data-confirm="Are you sure you want to delete this?">
+                                                            Delete
+                                                        </button>
+                                                    </form>
+
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+                                        <a class="float-left mt-1" data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=1741180"
+                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                            href="/lguychard"><img class="avatar" height="28" width="28"
+                                                alt="@lguychard"
+                                                src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+                                        <div class="review-comment-contents">
+                                            <h4 class="f5 text-normal d-inline text-gray-dark">
+                                                <strong class="text-gray">
+
+
+                                                    <a class="author link-gray-dark css-truncate-target"
+                                                        show_full_name="false" data-hovercard-type="user"
+                                                        data-hovercard-url="/hovercards?user_id=1741180"
+                                                        data-octo-click="hovercard-link-click"
+                                                        data-octo-dimensions="link_type:self"
+                                                        href="/lguychard">lguychard</a>
+
+
+                                                </strong>
+                                                <span class="text-gray">
+                                                    <a href="#discussion_r329949662"
+                                                        id="discussion_r329949662-minimized-permalink"
+                                                        class="timestamp">
+                                                        <relative-time datetime="2019-10-01T09:03:30Z"
+                                                            title="Oct 1, 2019, 11:03 AM GMT+2">yesterday
+                                                        </relative-time>
+                                                    </a>
+                                                </span>
+                                            </h4>
+
+                                            <span
+                                                class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
+                                                aria-label="You are a member of the Sourcegraph organization.">
+                                                Member
+                                            </span>
+
+
+                                            <task-lists sortable="">
+                                                <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
+                                                    <p>Rather than introducing a new class/concept to the codebase, I
+                                                        would consider reusing <a
+                                                            href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
+                                                            rel="nofollow"><code>Disposable</code></a> (an
+                                                        <code>Unsubscribable</code> supporting async resource disposal)
+                                                        pattern from sourcegraph-typescript (<a href="">example
+                                                            usage</a>) :</p>
+                                                    <div class="highlight highlight-source-ts">
+                                                        <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+  <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
+      <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
+      <span class="pl-k">return</span> {
+          <span class="pl-en">dispose</span>: () <span class="pl-k">=&gt;</span> {
+              <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Destroying user ${<span class="pl-smi">name</span>}<span class="pl-pds">`</span></span>)
+              <span class="pl-k">return</span> <span class="pl-en">deleteUser</span>(<span class="pl-k">...</span>)
+          }
+      }
+  }
+
+
+  <span class="pl-en">describe</span>(<span class="pl-s"><span class="pl-pds">'</span>Search regression test suite<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+
+      <span class="pl-k"><span class="pl-k">const</span></span> disposables <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">Set</span>&lt;<span class="pl-en">Disposable</span> <span class="pl-k">|</span> <span class="pl-en">AsyncDisposable</span> <span class="pl-k">|</span> <span class="pl-en">Unsubscribable</span>&gt;()
+
+      <span class="pl-c"><span class="pl-c">//</span> Free resources created during testing. </span>
+      <span class="pl-en">afterAll</span>(() <span class="pl-k">=&gt;</span> <span class="pl-en">disposeAllAsync</span>(<span class="pl-smi">disposables</span>))
+
+      <span class="pl-en">test</span>(<span class="pl-s"><span class="pl-pds">'</span>something<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+          <span class="pl-smi">disposables</span>.<span class="pl-c1">add</span>(
+              <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
+          )
+      })
+  })</pre>
+                                                    </div>
+                                                    <p>Pros:</p>
+                                                    <ul>
+                                                        <li>Developers working in our codebase are already familiar with
+                                                            the subscription / subscription bag pattern (and, if they're
+                                                            not, it is <a
+                                                                href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
+                                                                rel="nofollow">documented</a>).</li>
+                                                        <li>The cleanup logic is encapsulated, and lives next to the
+                                                            resource creation logic. It is not duplicated if
+                                                            <code>ensureLoggedInOrCreateTestUser()</code> is called from
+                                                            multiple test suites. Callers need not look up how a given
+                                                            resource should be cleaned up, they simply need to handle
+                                                            the returned disposable / subscription.</li>
+                                                    </ul>
+                                                </div>
+                                            </task-lists>
+                                        </div>
+                                    </div>
+
+                                    <!-- '"` -->
+                                    <!-- </textarea></xmp> -->
+                                    <form data-upload-policy-url="/upload/policies/assets"
+                                        data-upload-policy-authenticity-token="PDStKbTbZM6Cd1fZmxSWE0sc4Fp3xS0pw2YKyVdppQ+3FwYVYgdt51vDvXlPkcAzJg9cYJf+jeTkvmLuF5W7lw=="
+                                        class="js-comment-update" data-type="json"
+                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                            value="✓"><input type="hidden" name="_method" value="put"><input
+                                            type="hidden" name="authenticity_token"
+                                            value="7mCDc3cRh+mg7ncaoEsZ0nXssBWRz53jk4xrfvLrFF5Mws3jsiIT/PsHcut5D3tmTNYfNV0WJJsn3g+G2Ti1Ww==">
+                                        <div class="js-previewable-comment-form previewable-comment-form write-selected"
+                                            data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
+                                            data-preview-authenticity-token="5rBjOALa8b6CSyOMiTusUZ0C1yYnv6zdgH6cEM26DBMaT5LUbpdThRFgC6AEysNnJ62yboriI2kJFGHqo2n6Sg==">
+
+                                            <div class="comment-form-head tabnav ">
+                                                <nav class="tabnav-tabs" role="tablist">
+                                                    <button type="button"
+                                                        class="btn-link tabnav-tab write-tab js-write-tab selected"
+                                                        role="tab" aria-selected="true">Write</button>
+                                                    <button type="button"
+                                                        class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                                        role="tab">Preview</button>
+                                                </nav>
+
+
+                                                <markdown-toolbar for="discussion_r329949662-minimize-comment-body"
+                                                    class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+
+                                                    <div class="flex-nowrap d-inline-block mr-3">
+                                                        <md-header tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add header text"
+                                                            data-ga-click="Markdown Toolbar, click, header"
+                                                            role="button">
+                                                            <svg class="octicon octicon-text-size" viewBox="0 0 18 16"
+                                                                version="1.1" width="18" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-header>
+
+                                                        <md-bold tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add bold text <cmd-b>"
+                                                            data-ga-click="Markdown Toolbar, click, bold" role="button"
+                                                            hotkey="b">
+                                                            <svg class="octicon octicon-bold" viewBox="0 0 10 16"
+                                                                version="1.1" width="10" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-bold>
+
+                                                        <md-italic tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add italic text <cmd-i>"
+                                                            data-ga-click="Markdown Toolbar, click, italic"
+                                                            role="button" hotkey="i">
+                                                            <svg class="octicon octicon-italic" viewBox="0 0 6 16"
+                                                                version="1.1" width="6" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-italic>
+                                                    </div>
+
+                                                    <div class="d-inline-block mr-3">
+                                                        <md-quote tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                            aria-label="Insert a quote"
+                                                            data-ga-click="Markdown Toolbar, click, quote"
+                                                            role="button">
+                                                            <svg class="octicon octicon-quote" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-quote>
+
+                                                        <md-code tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                            aria-label="Insert code"
+                                                            data-ga-click="Markdown Toolbar, click, code" role="button">
+                                                            <svg class="octicon octicon-code" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-code>
+
+
+                                                        <md-link tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                            aria-label="Add a link <cmd-k>"
+                                                            data-ga-click="Markdown Toolbar, click, link" role="button"
+                                                            hotkey="k">
+                                                            <svg class="octicon octicon-link" viewBox="0 0 16 16"
+                                                                version="1.1" width="16" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-link>
+                                                    </div>
+
+                                                    <div class="d-inline-block mr-3">
+                                                        <md-unordered-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a bulleted list"
+                                                            data-ga-click="Markdown Toolbar, click, unordered list"
+                                                            role="button">
+                                                            <svg class="octicon octicon-list-unordered"
+                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-unordered-list>
+
+                                                        <md-ordered-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a numbered list"
+                                                            data-ga-click="Markdown Toolbar, click, ordered list"
+                                                            role="button">
+                                                            <svg class="octicon octicon-list-ordered"
+                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-ordered-list>
+
+                                                        <md-task-list tabindex="-1"
+                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                            aria-label="Add a task list"
+                                                            data-ga-click="Markdown Toolbar, click, task list"
+                                                            role="button" hotkey="L">
+                                                            <svg class="octicon octicon-tasklist" viewBox="0 0 16 16"
+                                                                version="1.1" width="16" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-task-list>
+                                                    </div>
+
+                                                    <div class="d-inline-block">
+                                                        <md-mention tabindex="-1"
+                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                            aria-label="Directly mention a user or team"
+                                                            data-ga-click="Markdown Toolbar, click, mention"
+                                                            role="button">
+                                                            <svg class="octicon octicon-mention" viewBox="0 0 14 16"
+                                                                version="1.1" width="14" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-mention>
+
+
+                                                        <md-ref tabindex="-1"
+                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                            aria-label="Reference an issue or pull request"
+                                                            data-ga-click="Markdown Toolbar, click, reference"
+                                                            role="button">
+                                                            <svg class="octicon octicon-bookmark" viewBox="0 0 10 16"
+                                                                version="1.1" width="10" height="16" aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                                </path>
+                                                            </svg>
+                                                        </md-ref>
+
+                                                        <details
+                                                            class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                            tabindex="-1">
+                                                            <summary tabindex="-1"
+                                                                class="text-center menu-target p-1 ml-1"
+                                                                aria-label="Insert a reply"
+                                                                data-ga-click="Markdown Toolbar, click, saved reply"
+                                                                aria-haspopup="menu" role="button">
+                                                                <svg class="octicon octicon-reply" viewBox="0 0 14 16"
+                                                                    version="1.1" width="14" height="16"
+                                                                    aria-hidden="true">
+                                                                    <path fill-rule="evenodd"
+                                                                        d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                                    </path>
+                                                                </svg>
+                                                                <span class="dropdown-caret "></span>
+                                                            </summary>
+                                                            <details-menu style="z-index: 99;"
+                                                                class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                                data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id"
+                                                                src="/settings/replies?context=none" preload=""
+                                                                role="menu">
+                                                                <div class="select-menu-header d-flex">
+                                                                    <span class="select-menu-title flex-auto">Select a
+                                                                        reply</span>
+                                                                    <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                                </div>
+                                                                <include-fragment role="menuitem"
+                                                                    class="select-menu-loading-overlay anim-pulse"
+                                                                    aria-label="Loading">
+                                                                    <svg class="octicon octicon-octoface"
+                                                                        viewBox="0 0 16 16" version="1.1" width="16"
+                                                                        height="16" aria-hidden="true">
+                                                                        <path fill-rule="evenodd"
+                                                                            d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                                        </path>
+                                                                    </svg>
+                                                                </include-fragment>
+                                                            </details-menu>
+                                                        </details>
+
+                                                    </div>
+
+                                                </markdown-toolbar>
+
+                                            </div>
+
+
+                                            <div class="clearfix"></div>
+
+                                            <p class="comment-form-error comment-show-stale">
+                                                <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
+                                                    </path>
+                                                </svg> The content you are editing has changed. Please try again.
+                                            </p>
+
+
+                                            <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
+                                                data-upload-policy-url="/upload/policies/assets"
+                                                data-upload-policy-authenticity-token="c39sWiKSX746/j91+3OIu0lHem7/ZfQm38h6vJZzKT/4XMdm9E5Wl+NK1dUv9t6bJFTGVB9eVOv4EBKb1o83pw=="
+                                                data-upload-repository-id="41288708">
+                                                <input type="hidden" name="context" value="discussion">
+
+                                                <input type="hidden" name="saved_reply_id"
+                                                    id="discussion_r329949662-minimize-comment-body_saved_reply_id"
+                                                    class="js-resettable-field" value="" data-reset-value="">
+
+                                                <input type="hidden" name="pull_request_review_comment[id]"
+                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                                <input type="hidden" name="pull_request_review_comment[bodyVersion]"
+                                                    class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+
+                                                <text-expander keys=": @ #"
+                                                    data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                                    data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                                    data-emoji-url="/autocomplete/emoji">
+
+                                                    <textarea name="pull_request_review_comment[body]"
+                                                        id="discussion_r329949662-minimize-comment-body"
+                                                        placeholder="Leave a comment" aria-label="Comment body"
+                                                        class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
+                                                </text-expander>
+
+
+                                                <p
+                                                    class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                                    <input
+                                                        accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                                        type="file" multiple=""
+                                                        class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                                        aria-label="Attach files to your comment"
+                                                        id="fc-discussion_r329949662-minimize-comment-body">
+                                                    <span
+                                                        class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                                        style="pointer-events: none;"></span>
+                                                    <span class="position-relative pr-2" style="pointer-events: none;">
+                                                        <span class="default">
+                                                            Attach files by dragging &amp; dropping, selecting or
+                                                            pasting them.
+                                                        </span>
+                                                        <span class="loading">
+                                                            <img alt="" width="16" height="16"
+                                                                src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                            Uploading your files…
+                                                        </span>
+                                                        <span class="error bad-file">
+                                                            We don’t support that file type.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a
+                                                                GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                                or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error bad-permissions">
+                                                            Attaching documents requires write permission to this
+                                                            repository.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
+                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error repository-required">
+                                                            We don’t support that file type.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
+                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error too-big">
+                                                            Yowza, that’s a big file
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a file smaller than 10MB.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error empty">
+                                                            This file is empty.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with a file that’s not empty.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error hidden-file">
+                                                            This file is hidden.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again</button> with another file.
+                                                            </span>
+                                                        </span>
+                                                        <span class="error failed-request">
+                                                            Something went really wrong, and we can’t process that file.
+                                                            <span class="drag-and-drop-error-info">
+                                                                <button type="button"
+                                                                    class="btn-link manual-file-chooser-text">Try
+                                                                    again.</button>
+                                                            </span>
+                                                        </span>
+                                                    </span>
+                                                    <span class="tooltipped tooltipped-nw"
+                                                        aria-label="Styling with Markdown is supported">
+                                                        <a class="muted-link position-relative d-inline"
+                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                            target="_blank"
+                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                            aria-label="Learn about styling with Markdown">
+                                                            <svg class="octicon octicon-markdown v-align-bottom"
+                                                                viewBox="0 0 16 16" version="1.1" width="16" height="16"
+                                                                aria-hidden="true">
+                                                                <path fill-rule="evenodd"
+                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                                </path>
+                                                            </svg>
+                                                        </a>
+                                                    </span>
+                                                </p>
+
+                                            </div>
+
+
+                                            <div class="preview-content">
+                                                <div class="comment js-suggested-changes-container"
+                                                    data-thread-side="right">
+                                                    <div class="comment-body markdown-body js-preview-body">
+                                                        <p>Nothing to preview</p>
+                                                    </div>
+                                                </div>
+
+                                            </div>
+
+                                            <div class="clearfix">
+
+                                                <input type="hidden" name="original-line"
+                                                    value="+export class TestResourceManager {"
+                                                    class="js-original-line">
+                                                <input type="hidden" name="path"
+                                                    value="web/src/regression/util/TestResourceManager.ts"
+                                                    class="js-path">
+                                                <input type="hidden" name="line" value="13" class="js-line-number">
+                                                <div class="form-actions comment-form-actions">
+                                                    <button class="btn btn-primary" type="submit"
+                                                        data-disable-with="">Update comment</button>
+                                                    <button class="btn btn-danger js-comment-cancel-button"
+                                                        type="button"
+                                                        data-confirm-text="Are you sure you want to discard your unsaved changes?">
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+
+                                            <div class="comment-form-error mb-2 js-comment-update-error" hidden="">
+                                            </div>
+                                        </div>
+
+                                    </form>
+                                </div>
+                            </div>
+                        </details>
+
+
+                    </div>
+
+                    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists"
+                        data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
+                        <div class="edit-comment-hide">
+                            <div class="timeline-comment-actions">
+
+                                <details
+                                    class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button"
+                                    data-channel="reaction:pull-request-review-comment:329949662"
+                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
+                                    <summary class="btn-link link-gray timeline-comment-action"
+                                        aria-label="Add your reaction" aria-haspopup="menu" role="button">
+                                        <svg class="octicon octicon-plus-small add-reaction-plus-icon"
+                                            viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
+                                        </svg>
+                                        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16"
+                                            height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
+                                            </path>
+                                        </svg>
+                                    </summary>
+
+                                    <details-menu
+                                        class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1"
+                                        aria-label="Pick your reaction" style="width: 150px" role="menu">
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="put"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="LdsTl6NIOtEBd/ab1GoZdv1VrKS0yKpxHnBP53k2c5z8yyDVg+FYEupJcLvna6I9Byon6gbnJuQELSYXp00inw==">
+                                            <p class="text-gray mx-2 my-1">
+                                                <span class="js-reaction-description">Pick your reaction</span>
+                                            </p>
+
+                                            <div role="none" class="dropdown-divider"></div>
+
+                                            <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+                                                <input type="hidden" name="input[subjectId]"
+                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="+1" name="input[content]"
+                                                    aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+                                                    <g-emoji alias="+1"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                        class="emoji">👍</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="-1" name="input[content]"
+                                                    aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+                                                    <g-emoji alias="-1"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
+                                                        class="emoji">👎</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Laugh" name="input[content]"
+                                                    aria-label="React with laugh emoji" value="LAUGH react">
+                                                    <g-emoji alias="smile"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
+                                                        class="emoji">😄</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Hooray" name="input[content]"
+                                                    aria-label="React with hooray emoji" value="HOORAY react">
+                                                    <g-emoji alias="tada"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
+                                                        class="emoji">🎉</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Confused" name="input[content]"
+                                                    aria-label="React with confused emoji" value="CONFUSED react">
+                                                    <g-emoji alias="thinking_face"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
+                                                        class="emoji">😕</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Heart" name="input[content]"
+                                                    aria-label="React with heart emoji" value="HEART react">
+                                                    <g-emoji alias="heart"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                        class="emoji">❤️</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Rocket" name="input[content]"
+                                                    aria-label="React with rocket emoji" value="ROCKET react">
+                                                    <g-emoji alias="rocket"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
+                                                        class="emoji">🚀</g-emoji>
+                                                </button>
+                                                <button type="submit" role="menuitem"
+                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                    data-reaction-label="Eyes" name="input[content]"
+                                                    aria-label="React with eyes emoji" value="EYES react">
+                                                    <g-emoji alias="eyes"
+                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
+                                                        class="emoji">👀</g-emoji>
+                                                </button>
+                                            </div>
+                                        </form>
+                                    </details-menu>
+
+                                </details>
+
+                                <details class="details-overlay details-reset position-relative d-inline-block"
+                                    id="details-discussion_r329949662">
+                                    <summary class="btn-link timeline-comment-action" aria-label="Show more options"
+                                        aria-haspopup="menu" role="button">
+                                        <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1"
+                                            width="13" height="16" aria-hidden="true">
+                                            <path fill-rule="evenodd"
+                                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
+                                            </path>
+                                        </svg>
+                                    </summary>
+
+                                    <details-menu
+                                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
+                                        style="width:185px; z-index: 99;" role="menu">
+
+                                        <clipboard-copy class="dropdown-item btn-link"
+                                            for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
+                                            Copy link
+                                        </clipboard-copy>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link d-none js-comment-quote-reply">
+                                            Quote reply
+                                        </button>
+
+
+                                        <details
+                                            class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
+                                            <summary class="dropdown-item" role="menuitem">
+
+                                                Reference in new issue
+                                            </summary>
+                                            <details-dialog aria-label="Reference in new issue"
+                                                class="Box Box--overlay d-flex flex-column anim-fade-in fast "
+                                                role="dialog" aria-modal="true">
+                                                <div class="Box-header">
+                                                    <button class="Box-btn-octicon btn-octicon float-right"
+                                                        type="button" aria-label="Close dialog" data-close-dialog="">
+                                                        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1"
+                                                            width="12" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
+                                                            </path>
+                                                        </svg>
+                                                    </button>
+                                                    <h3 class="Box-title ">Reference in new issue</h3>
+                                                </div>
+
+                                                <div class="Box-body scrollable-overlay">
+
+                                                    <!-- '"` -->
+                                                    <!-- </textarea></xmp> -->
+                                                    <form action="/comments/issues" accept-charset="UTF-8"
+                                                        method="post"><input name="utf8" type="hidden" value="✓"><input
+                                                            type="hidden" name="authenticity_token"
+                                                            value="iz2CkSdB+3+JmIY54QjQgEqR67huXC0FIvTHS6c/LUN2d56LfKmp9EThXG1tv/IhNNKE0tueOk/KXgY/uPSGNA==">
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <details
+                                                                    class="details-reset details-overlay select-menu">
+                                                                    <summary class="btn select-menu-button"
+                                                                        data-menu-button="" aria-haspopup="menu"
+                                                                        role="button">
+                                                                        <input type="hidden" name="issue[repository_id]"
+                                                                            value="41288708" checked="">
+                                                                        sourcegraph
+                                                                    </summary>
+                                                                    <details-menu
+                                                                        class="select-menu-modal position-absolute"
+                                                                        style="z-index: 99;"
+                                                                        src="/sourcegraph/sourcegraph/related_repositories"
+                                                                        preload="" role="menu">
+                                                                        <div class="select-menu-header">
+                                                                            <span
+                                                                                class="select-menu-title">Repositories</span>
+                                                                        </div>
+                                                                        <div class="select-menu-filters">
+                                                                            <div class="select-menu-text-filter">
+                                                                                <remote-input
+                                                                                    src="/sourcegraph/sourcegraph/related_repositories"
+                                                                                    aria-owns="related-repositories-menu">
+                                                                                    <input type="text"
+                                                                                        class="form-control"
+                                                                                        aria-label="Type to filter"
+                                                                                        placeholder="Find a repository"
+                                                                                        autofocus="" autocomplete="off"
+                                                                                        spellcheck="false">
+                                                                                </remote-input>
+                                                                            </div>
+                                                                        </div>
+                                                                        <include-fragment class="octocat-spinner my-6"
+                                                                            aria-label="Loading"></include-fragment>
+                                                                    </details-menu>
+                                                                </details>
+                                                            </dd>
+                                                        </dl>
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label>
+                                                            </dt>
+                                                            <dd><input
+                                                                    id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                                                                    class="form-control" type="text" name="issue[title]"
+                                                                    value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :"
+                                                                    aria-label="Issue title" autofocus="" required="">
+                                                            </dd>
+                                                        </dl>
+                                                        <dl class="form-group">
+                                                            <dt><label
+                                                                    for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label>
+                                                            </dt>
+                                                            <dd><textarea
+                                                                    id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
+                                                                    name="issue[body]" class="form-control"
+                                                                    aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.
+
+  _Originally posted by @lguychard in https://github.com/sourcegraph/sourcegraph/pull/5746_</textarea></dd>
+                                                        </dl>
+
+                                                        <div class="d-flex d-sm-block">
+                                                            <button type="submit" class="btn btn-primary"
+                                                                data-disable-with="Creating issue..."
+                                                                data-disable-invalid=""
+                                                                data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
+                                                                Create issue
+                                                            </button>
+                                                        </div>
+                                                    </form>
+                                                </div>
+
+                                            </details-dialog>
+                                        </details>
+
+                                        <div role="none" class="dropdown-divider"></div>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link js-comment-edit-button"
+                                            aria-label="Edit comment">
+                                            Edit
+                                        </button>
+
+                                        <button type="button" role="menuitem"
+                                            class="dropdown-item btn-link js-comment-hide-button"
+                                            aria-label="Hide comment">
+                                            Hide
+                                        </button>
+
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="width-full inline-form js-comment-delete"
+                                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="delete"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="jDxvGtG7Cc0Zead/6ACEos1N034oJRLhZaWqeZGZ+4C1yRek+vX/yyR467Kgrl8PzvTI0rrKrhoJ+lMxoK/IBw==">
+                                            <input type="hidden" name="input[id]"
+                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                            <button type="submit" role="menuitem"
+                                                class="dropdown-item menu-item-danger btn-link"
+                                                aria-label="Delete comment"
+                                                data-confirm="Are you sure you want to delete this?">
+                                                Delete
+                                            </button>
+                                        </form>
+
+
+                                    </details-menu>
+                                </details>
+                            </div>
+
+                            <span class="float-left mt-1">
+                                <a class="d-inline-block" data-hovercard-type="user"
+                                    data-hovercard-url="/hovercards?user_id=1741180"
+                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                    href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard"
+                                        src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+                            </span>
+
+                            <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
+                                <h4 class="f5 text-normal d-inline">
+                                    <strong>
+
+
+                                        <a class="author link-gray-dark css-truncate-target" show_full_name="false"
+                                            data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180"
+                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                            href="/lguychard">lguychard</a>
+
+
+                                    </strong>
+                                    <span class="text-gray">
+
+                                        <a href="#discussion_r329949662" id="discussion_r329949662-permalink"
+                                            class="js-timestamp timestamp d-inline-block">
+                                            <relative-time datetime="2019-10-01T09:03:30Z"
+                                                title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
+                                        </a>
+
+
+                                        <span class="d-inline-block text-gray-light">•</span>
+
+                                        <details class="details-overlay details-reset d-inline-block dropdown">
+                                            <summary class="btn-link no-underline text-gray js-notice"
+                                                aria-haspopup="menu" role="button">
+                                                <div class="position-relative">
+                                                    <span>
+                                                        edited
+                                                    </span>
+                                                    <svg height="11"
+                                                        class="octicon octicon-triangle-down v-align-middle"
+                                                        viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true">
+                                                        <path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path>
+                                                    </svg>
+                                                </div>
+                                            </summary>
+                                            <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0"
+                                                style="width:352px"
+                                                src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log"
+                                                preload="" role="menu">
+                                                <include-fragment class="octocat-spinner my-3" aria-label="Loading">
+                                                </include-fragment>
+                                            </details-menu>
+                                        </details>
+
+                                    </span>
+                                </h4>
+
+
+
+                                <span
+                                    class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
+                                    aria-label="You are a member of the Sourcegraph organization.">
+                                    Member
+                                </span>
+
+
+                                <div class="js-minimize-comment d-none">
+
+
+                                    <div class="flash flash-warn my-2">
+                                        <button class="flash-close js-comment-hide-minimize-form" type="button"><svg
+                                                aria-label="Cancel hiding comment" class="octicon octicon-x"
+                                                viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img">
+                                                <path fill-rule="evenodd"
+                                                    d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
+                                                </path>
+                                            </svg></button>
+                                        <h3 class="f5">Choose a reason for hiding this comment</h3>
+                                        <p class="mb-3">The reason will be displayed to describe this comment to others.
+                                            <a
+                                                href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn
+                                                more</a>.</p>
+                                        <!-- '"` -->
+                                        <!-- </textarea></xmp> -->
+                                        <form class="js-comment-minimize"
+                                            action="/sourcegraph/sourcegraph/community/minimize-comment"
+                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                value="✓"><input type="hidden" name="_method" value="put"><input
+                                                type="hidden" name="authenticity_token"
+                                                value="bSeFf29CzKjsdk5Lg+Ha5++oCU34xuAvD8FHpAS1EK/qLwQctHz2/grGYENB3xDZ0xajT57FhTAjGwkP5GeBYQ==">
+                                            <input type="hidden" name="comment_id"
+                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                            <select name="classifier" class="form-select mr-2" aria-label="Reason"
+                                                required="">
+                                                <option value="">
+                                                    Choose a reason
+                                                </option>
+                                                <option value="SPAM">Spam</option>
+                                                <option value="ABUSE">Abuse</option>
+                                                <option value="OFF_TOPIC">Off Topic</option>
+                                                <option value="OUTDATED">Outdated</option>
+                                                <option value="RESOLVED">Resolved</option>
+                                            </select>
+                                            <button type="submit" class="btn">
+                                                Hide comment
+                                            </button>
+                                        </form>
+                                    </div>
+
+                                </div>
+
+
+
+                                <task-lists sortable="">
+                                    <div class="comment-body markdown-body  js-comment-body">
+                                        <p>Rather than introducing a new class/concept to the codebase, I would consider
+                                            reusing <a
+                                                href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
+                                                rel="nofollow"><code>Disposable</code></a> (an
+                                            <code>Unsubscribable</code> supporting async resource disposal) pattern from
+                                            sourcegraph-typescript (<a href="">example usage</a>) :</p>
+                                        <div class="highlight highlight-source-ts">
+                                            <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+  <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
+      <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
+      <span class="pl-k">return</span> {
+          <span class="pl-en">dispose</span>: () <span class="pl-k">=&gt;</span> {
+              <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Destroying user ${<span class="pl-smi">name</span>}<span class="pl-pds">`</span></span>)
+              <span class="pl-k">return</span> <span class="pl-en">deleteUser</span>(<span class="pl-k">...</span>)
+          }
+      }
+  }
+
+
+  <span class="pl-en">describe</span>(<span class="pl-s"><span class="pl-pds">'</span>Search regression test suite<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+
+      <span class="pl-k"><span class="pl-k">const</span></span> disposables <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">Set</span>&lt;<span class="pl-en">Disposable</span> <span class="pl-k">|</span> <span class="pl-en">AsyncDisposable</span> <span class="pl-k">|</span> <span class="pl-en">Unsubscribable</span>&gt;()
+
+      <span class="pl-c"><span class="pl-c">//</span> Free resources created during testing. </span>
+      <span class="pl-en">afterAll</span>(() <span class="pl-k">=&gt;</span> <span class="pl-en">disposeAllAsync</span>(<span class="pl-smi">disposables</span>))
+
+      <span class="pl-en">test</span>(<span class="pl-s"><span class="pl-pds">'</span>something<span class="pl-pds">'</span></span>, () <span class="pl-k">=&gt;</span> {
+          <span class="pl-smi">disposables</span>.<span class="pl-c1">add</span>(
+              <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
+          )
+      })
+  })</pre>
+                                        </div>
+                                        <p>Pros:</p>
+                                        <ul>
+                                            <li>Developers working in our codebase are already familiar with the
+                                                subscription / subscription bag pattern (and, if they're not, it is <a
+                                                    href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
+                                                    rel="nofollow">documented</a>).</li>
+                                            <li>The cleanup logic is encapsulated, and lives next to the resource
+                                                creation logic. It is not duplicated if
+                                                <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple
+                                                test suites. Callers need not look up how a given resource should be
+                                                cleaned up, they simply need to handle the returned disposable /
+                                                subscription.</li>
+                                        </ul>
+                                    </div>
+                                </task-lists>
+
+
+
+
+                                <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content"
+                                    data-channel="reaction:pull-request-review-comment:329949662"
+                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
+                                    <!-- '"` -->
+                                    <!-- </textarea></xmp> -->
+                                    <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                            value="✓"><input type="hidden" name="_method" value="put"><input
+                                            type="hidden" name="authenticity_token"
+                                            value="CUVRWocqAFJIQmYkZreCwFioAAZC/gRC7oNq6NjqpmTYVWIYp4NikaN84ARVtjmLoteLSPDRiNf03gMYBpH3Zw==">
+                                        <input type="hidden" name="input[subjectId]"
+                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                        <div class="comment-reactions-options">
+                                            <button
+                                                class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline "
+                                                name="input[content]" type="submit" value="THUMBS_UP react"
+                                                aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
+                                                <g-emoji alias="+1"
+                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                    class="emoji mr-1">👍</g-emoji>
+                                                2
+                                            </button>
+                                            <button
+                                                class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline "
+                                                name="input[content]" type="submit" value="HEART react"
+                                                aria-label="unknwon reacted with heart emoji">
+                                                <g-emoji alias="heart"
+                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                    class="emoji mr-1">❤️</g-emoji>
+                                                1
+                                            </button>
+                                        </div>
+                                    </form>
+                                    <details
+                                        class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
+                                        <summary class="btn-link reaction-summary-item add-reaction-btn"
+                                            aria-label="Add your reaction" aria-haspopup="menu" role="button">
+                                            <svg class="octicon octicon-plus-small add-reaction-plus-icon"
+                                                viewBox="0 0 7 16" version="1.1" width="7" height="16"
+                                                aria-hidden="true">
+                                                <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
+                                            </svg>
+                                            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1"
+                                                width="16" height="16" aria-hidden="true">
+                                                <path fill-rule="evenodd"
+                                                    d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
+                                                </path>
+                                            </svg>
+                                        </summary>
+
+                                        <details-menu
+                                            class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0"
+                                            aria-label="Pick your reaction" style="width: 150px" role="menu">
+                                            <!-- '"` -->
+                                            <!-- </textarea></xmp> -->
+                                            <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
+                                                accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
+                                                    value="✓"><input type="hidden" name="_method" value="put"><input
+                                                    type="hidden" name="authenticity_token"
+                                                    value="OK2OMjjZHKKfDf1Bd0I+seoboBLTu6672H5KK+lWOjfpvb1wGHB+YXQze2FEQ4X6EGQrXGGUIi7CIyPbNy1rNA==">
+                                                <p class="text-gray mx-2 my-1">
+                                                    <span class="js-reaction-description">Pick your reaction</span>
+                                                </p>
+
+                                                <div role="none" class="dropdown-divider"></div>
+
+                                                <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+                                                    <input type="hidden" name="input[subjectId]"
+                                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="+1" name="input[content]"
+                                                        aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+                                                        <g-emoji alias="+1"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
+                                                            class="emoji">👍</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="-1" name="input[content]"
+                                                        aria-label="React with thumbs down emoji"
+                                                        value="THUMBS_DOWN react">
+                                                        <g-emoji alias="-1"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
+                                                            class="emoji">👎</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Laugh" name="input[content]"
+                                                        aria-label="React with laugh emoji" value="LAUGH react">
+                                                        <g-emoji alias="smile"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
+                                                            class="emoji">😄</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Hooray" name="input[content]"
+                                                        aria-label="React with hooray emoji" value="HOORAY react">
+                                                        <g-emoji alias="tada"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
+                                                            class="emoji">🎉</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Confused" name="input[content]"
+                                                        aria-label="React with confused emoji" value="CONFUSED react">
+                                                        <g-emoji alias="thinking_face"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
+                                                            class="emoji">😕</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Heart" name="input[content]"
+                                                        aria-label="React with heart emoji" value="HEART react">
+                                                        <g-emoji alias="heart"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
+                                                            class="emoji">❤️</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Rocket" name="input[content]"
+                                                        aria-label="React with rocket emoji" value="ROCKET react">
+                                                        <g-emoji alias="rocket"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
+                                                            class="emoji">🚀</g-emoji>
+                                                    </button>
+                                                    <button type="submit" role="menuitem"
+                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
+                                                        data-reaction-label="Eyes" name="input[content]"
+                                                        aria-label="React with eyes emoji" value="EYES react">
+                                                        <g-emoji alias="eyes"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
+                                                            class="emoji">👀</g-emoji>
+                                                    </button>
+                                                </div>
+                                            </form>
+                                        </details-menu>
+
+                                    </details>
+                                </div>
+
+                            </div>
+                        </div>
+
+                        <!-- '"` -->
+                        <!-- </textarea></xmp> -->
+                        <form data-upload-policy-url="/upload/policies/assets"
+                            data-upload-policy-authenticity-token="dxb4uXAi57XbrnCGZm7+A6giq1BBMGpJCdmny4jJyV78NVOFpv7unAIamiay66gjxTEXaqELyoQuAc/syDXXxg=="
+                            class="js-comment-update" data-type="json"
+                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8"
+                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method"
+                                value="put"><input type="hidden" name="authenticity_token"
+                                value="4orOHiRkekLnBK8GqJaefBoqDlmaBIUoTmbp6quk8lhAKICO4VfuV7ztqvdx0vzIIxCheVbdPFD6NI0SgHdTXQ==">
+                            <div class="js-previewable-comment-form previewable-comment-form write-selected"
+                                data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
+                                data-preview-authenticity-token="agWuefVqqFretZzOMoXn2r/wUJnwPhNpbAhPH9nao8OW+l+VmScKYU2etOK/dIjsBV810V1jnN3lYrLltwlVmg==">
+
+                                <div class="comment-form-head tabnav ">
+                                    <nav class="tabnav-tabs" role="tablist">
+                                        <button type="button"
+                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
+                                            aria-selected="true">Write</button>
+                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                            role="tab">Preview</button>
+                                    </nav>
+
+
+                                    <markdown-toolbar for="discussion_r329949662-body"
+                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+
+                                        <div class="flex-nowrap d-inline-block mr-3">
+                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add header text"
+                                                data-ga-click="Markdown Toolbar, click, header" role="button">
+                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
+                                                    width="18" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-header>
+
+                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add bold text <cmd-b>"
+                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-bold>
+
+                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add italic text <cmd-i>"
+                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
+                                                hotkey="i">
+                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
+                                                    width="6" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                    </path>
+                                                </svg>
+                                            </md-italic>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-quote tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert a quote"
+                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
+                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-quote>
+
+                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
+                                                role="button">
+                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                    </path>
+                                                </svg>
+                                            </md-code>
+
+
+                                            <md-link tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                aria-label="Add a link <cmd-k>"
+                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                    </path>
+                                                </svg>
+                                            </md-link>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-unordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a bulleted list"
+                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-unordered-list>
+
+                                            <md-ordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a numbered list"
+                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ordered-list>
+
+                                            <md-task-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a task list"
+                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
+                                                hotkey="L">
+                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                    </path>
+                                                </svg>
+                                            </md-task-list>
+                                        </div>
+
+                                        <div class="d-inline-block">
+                                            <md-mention tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Directly mention a user or team"
+                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
+                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                    </path>
+                                                </svg>
+                                            </md-mention>
+
+
+                                            <md-ref tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Reference an issue or pull request"
+                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
+                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ref>
+
+                                            <details
+                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                tabindex="-1">
+                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
+                                                    aria-label="Insert a reply"
+                                                    data-ga-click="Markdown Toolbar, click, saved reply"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
+                                                        width="14" height="16" aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                        </path>
+                                                    </svg>
+                                                    <span class="dropdown-caret "></span>
+                                                </summary>
+                                                <details-menu style="z-index: 99;"
+                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                    data-menu-input="discussion_r329949662-body_saved_reply_id"
+                                                    src="/settings/replies?context=none" preload="" role="menu">
+                                                    <div class="select-menu-header d-flex">
+                                                        <span class="select-menu-title flex-auto">Select a reply</span>
+                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                    </div>
+                                                    <include-fragment role="menuitem"
+                                                        class="select-menu-loading-overlay anim-pulse"
+                                                        aria-label="Loading">
+                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
+                                                            version="1.1" width="16" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                            </path>
+                                                        </svg>
+                                                    </include-fragment>
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+
+                                    </markdown-toolbar>
+
+                                </div>
+
+
+                                <div class="clearfix"></div>
+
+                                <p class="comment-form-error comment-show-stale">
+                                    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16"
+                                        height="16" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
+                                        </path>
+                                    </svg> The content you are editing has changed. Please try again.
+                                </p>
+
+
+                                <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
+                                    data-upload-policy-url="/upload/policies/assets"
+                                    data-upload-policy-authenticity-token="QadU3Ls0/FkC2p0kRPo0MEnu8FQSdaJUwbqWjhVp14vKhP/gbej1cNtud4SQf2IQJP1MbvJOApnmYv6pVZXJEw=="
+                                    data-upload-repository-id="41288708">
+                                    <input type="hidden" name="context" value="discussion">
+
+                                    <input type="hidden" name="saved_reply_id"
+                                        id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field"
+                                        value="" data-reset-value="">
+
+                                    <input type="hidden" name="pull_request_review_comment[id]"
+                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                                    <input type="hidden" name="pull_request_review_comment[bodyVersion]"
+                                        class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+
+                                    <text-expander keys=": @ #"
+                                        data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                        data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                        data-emoji-url="/autocomplete/emoji">
+
+                                        <textarea name="pull_request_review_comment[body]"
+                                            id="discussion_r329949662-body" placeholder="Leave a comment"
+                                            aria-label="Comment body"
+                                            class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+
+  ```typescript
+  // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
+  export async function ensureLoggedInOrCreateTestUser(...): Promise&lt;AsyncDisposable&gt; {
+      console.log(`Creating test user "${name}"`)
+      return {
+          dispose: () =&gt; {
+              console.log(`Destroying user ${name}`)
+              return deleteUser(...)
+          }
+      }
+  }
+
+
+  describe('Search regression test suite', () =&gt; {
+
+      const disposables = new Set&lt;Disposable | AsyncDisposable | Unsubscribable&gt;()
+
+      // Free resources created during testing.
+      afterAll(() =&gt; disposeAllAsync(disposables))
+
+      test('something', () =&gt; {
+          disposables.add(
+              await ensureLoggedInOrCreateTestUser({...})
+          )
+      })
+  })
+  ```
+
+  Pros:
+  - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
+  - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
+                                    </text-expander>
+
+
+                                    <p
+                                        class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                        <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                            type="file" multiple=""
+                                            class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                            aria-label="Attach files to your comment"
+                                            id="fc-discussion_r329949662-body">
+                                        <span
+                                            class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                            style="pointer-events: none;"></span>
+                                        <span class="position-relative pr-2" style="pointer-events: none;">
+                                            <span class="default">
+                                                Attach files by dragging &amp; dropping, selecting or pasting them.
+                                            </span>
+                                            <span class="loading">
+                                                <img alt="" width="16" height="16"
+                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                Uploading your files…
+                                            </span>
+                                            <span class="error bad-file">
+                                                We don’t support that file type.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a
+                                                    GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error bad-permissions">
+                                                Attaching documents requires write permission to this repository.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
+                                                    PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error repository-required">
+                                                We don’t support that file type.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
+                                                    PPTX, TXT, XLSX or ZIP.
+                                                </span>
+                                            </span>
+                                            <span class="error too-big">
+                                                Yowza, that’s a big file
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a file smaller than 10MB.
+                                                </span>
+                                            </span>
+                                            <span class="error empty">
+                                                This file is empty.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with a file that’s not empty.
+                                                </span>
+                                            </span>
+                                            <span class="error hidden-file">
+                                                This file is hidden.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again</button> with another file.
+                                                </span>
+                                            </span>
+                                            <span class="error failed-request">
+                                                Something went really wrong, and we can’t process that file.
+                                                <span class="drag-and-drop-error-info">
+                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
+                                                        again.</button>
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="tooltipped tooltipped-nw"
+                                            aria-label="Styling with Markdown is supported">
+                                            <a class="muted-link position-relative d-inline"
+                                                href="https://guides.github.com/features/mastering-markdown/"
+                                                target="_blank" data-ga-click="Markdown Toolbar, click, help"
+                                                aria-label="Learn about styling with Markdown">
+                                                <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16"
+                                                    version="1.1" width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                    </path>
+                                                </svg>
+                                            </a>
+                                        </span>
+                                    </p>
+
+                                </div>
+
+
+                                <div class="preview-content">
+                                    <div class="comment js-suggested-changes-container" data-thread-side="right">
+                                        <div class="comment-body markdown-body js-preview-body">
+                                            <p>Nothing to preview</p>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                                <div class="clearfix">
+
+                                    <input type="hidden" name="original-line"
+                                        value="+export class TestResourceManager {" class="js-original-line">
+                                    <input type="hidden" name="path"
+                                        value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+                                    <input type="hidden" name="line" value="13" class="js-line-number">
+                                    <div class="form-actions comment-form-actions">
+                                        <button class="btn btn-primary" type="submit" data-disable-with="">Update
+                                            comment</button>
+                                        <button class="btn btn-danger js-comment-cancel-button" type="button"
+                                            data-confirm-text="Are you sure you want to discard your unsaved changes?">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+                            </div>
+
+                        </form>
+                    </div>
                 </div>
 
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button" aria-label="Edit comment">
-              Edit
-            </button>
 
 
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272416639&amp;report=beyang+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="VUaDmU/gIpBmGDqiYrS6MGSxkpz/HuV1MONJYujTmpJFdSnQpnaDMznvPAXzaSdDzL27yRASgvXOGXWtLrEb2A==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang"><img class="avatar" height="28" width="28" alt="@beyang" src="https://avatars0.githubusercontent.com/u/1646931?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1646931" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/beyang">beyang</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272416639" id="discussion_r272416639-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-05T00:58:40Z" title="5 Apr 2019, 02:58 CEST">27 days ago</relative-time>
-              </a>
-
-          </span>
-        </h4>
-
-
-
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the Sourcegraph organization.">
-      Member
-    </span>
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="cAlQY9uTbgnlP42QgZQ/mEhflTkvyReFgNlPNUMB5lFe/haH7gOtSXvjYg4bI9OijY/ATG+AwzcnQI8kcjH6/Q==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body  js-comment-body">
-            <p>Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
             </div>
 
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272416639" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="uMc3vsbiu7VTmKc7h8VG97cKqKBB0Cyz46VcRkgDj+uK0XsviY9H/qaX8qizELGOeEectmVXYMEjbOmJOb/62w==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272416639" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="N/3BHgi3+fWniFHSj8NYxEW0GTATZ+XlnWhyHrwy9akFJ5SsnshgT1NwJ+v7Syth/4+Oha7ozFWC1+5aVoG9ZQ==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="l+zs+rEbfcijs4nhj7hFpXjkibfShOkj6vXqxy+gaiBX/LGCMjdHI5y6nhQjeAS2OveO/Gg63aCY6S9iAu2ADg==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272416639-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="MBmzc3zQJVv2/cEn3oalL72nKsoH9iLkMiggIowEb+YCD//iM73ZEAPylLTqU1JWcuoe3CNxbpby4ZXt/bga1g==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3MjQxNjYzOQ==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="d1773e368c1e4ab89003e7785857bb71">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272416639-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Can you provide an example of a URL with an opaque component that would be used here? Haven't seen one used for connecting to Redis before, and adding that example to a unit test would be beneficial.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment" id="discussion_r272796448" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="cb2c551d0d9dac9546de9ea2988f9bdd">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272796448-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button" role="menuitem" aria-label="Edit comment">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="LZiyQuxLLcaxZDdmGrlzZ3iY1EK/ZECKozqGd0Ya58s9YYOQQBmS7HdqMKVTPSE+1jqRBVL3iyr/n0O5CDNZaA==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="Q2qWd0yt0Psbe9MP+JhgaPu60MpZo4qNkKLG8x4qkyVsh1FCPfL9cqKRmHVjN0gIoSxZXj5Va5+aykoZdbtrnw==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272796448&amp;report=alexandnpu+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272796448" id="discussion_r272796448-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-06T13:53:50Z" title="6 Apr 2019, 15:53 CEST">25 days ago</relative-time></a>
-              </span>
-            </h4>
-
-
-            <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p>Maybe <code>Opaque</code> is not a very straight forward word to understand. That part of code is handling urls whose pattern is <code>host:port</code>, such as "localhost:5000" or so.</p>
-<p>I do not like the way <code>Opaque</code> used here, but it is in the standard library net/url/url.go</p>
-<pre><code>// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-</code></pre>
-<p>any suggestions for making this part more elegant?</p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="bHKsbexwRvv2rQ4EexRfsypgD5F9qWKSFJJVQ8CoRmdeZOD8ox26sAOiW5dPwajK5S07h1kuLuDUW+CMsRQzVw==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="6BajjDlIIVRV/gy0xGN9CbmkJhtIOlCojit2w8E5lVChR60hBPA8qJB8ZnAv+TaDV5SXmavAAJ5krGhysOvuzQ==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="TVq+Qdy3t4Eh6INi2aLUUScPMItbXNxCbwX3PBCKkuSNSuM5X5uNah7hlJd1YpVCZRw3wOHi6MEdGTKZPcd4yg==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272796448-minimize-comment-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="QRa/7ZrL01h/EFJUUH8Ik6XN8KcoKANvlvlQOzu25iBzAPN81aYvE4ofB8dkqv/qaoDEsQyvTx1WMOX0SgqTEA==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="cb2c551d0d9dac9546de9ea2988f9bdd">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272796448-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
-
-
-    </div>
-
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="cb2c551d0d9dac9546de9ea2988f9bdd" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
-
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272796448" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
-
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="qr4K2CD9btbF53RvK61Cdi1YLv4AiPmyudtGoUfKSguhGO2ISGHYjvueNCYjj2h++4ERL1jE7RzpoTzRqQ0ccw==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
-
-    <div role="none" class="dropdown-divider"></div>
-
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
-        </button>
-    </div>
-</form></details-menu>
-
-  </details>
-
-        <details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272796448">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272796448-permalink" data-toggle-for="details-discussion_r272796448" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272796448">
-              Quote reply
-            </button>
-
-
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
-
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
-    </div>
-
-                <div class="Box-body scrollable-overlay">
-
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="cWAQ0Ymlk9ruiOFNUV9xPf/BUPvVUzazYpwwqrI6MkP6tMXVxUkekkc444Q5G23kc/S56J/95qrBawTd740fEw==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" class="form-control" type="text" name="issue[title]" value="Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as &quot;localhost:5000&quot; or so." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==" name="issue[body]" class="form-control" aria-label="Issue body">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?
-
-_Originally posted by @alexandnpu in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
-
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
+            <div class="review-thread-reply border-bottom">
+
+                <div class="inline-comment-form-container js-inline-comment-form-container">
+                    <div class="inline-comment-form-actions">
+                        <div class="d-table width-full">
+                            <div class="d-table-cell">
+                                <a class="d-inline-block" data-hovercard-type="user"
+                                    data-hovercard-url="/hovercards?user_id=1741180"
+                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
+                                    href="/lguychard"><img class="avatar"
+                                        src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28"
+                                        height="28" alt="@lguychard"></a>
+                            </div>
+                            <div class="d-table-cell col-12">
+                                <button type="button"
+                                    class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
+                                    Reply…
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="inline-comment-form">
+                        <!-- '"` -->
+                        <!-- </textarea></xmp> -->
+                        <form class="js-inline-comment-form"
+                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8"
+                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
+                                name="authenticity_token"
+                                value="RF3t3EyhTZgihg/kB1jReBYRTLLjP2+tBE6vZXjf1xXwVDXh+oBXlHC7Bppluz25YDQLrPtSF5VSBa+GMrz9Cg==">
+                            <input type="hidden" name="comment_context" value="discussion">
+                            <input type="hidden" name="in_reply_to" value="329949662">
+
+
+                            <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                data-preview-url="/preview?repository=41288708"
+                                data-preview-authenticity-token="GPGDHueDI8BLUCQVWWHzQzUDX8cL1PHxyAD3LMTnZ3zkDnLyi86B+9h7DDnUkJx1j6w6j6aJfkVBagrWqjSRJQ==">
+                                <div class="comment-form-head tabnav">
+
+                                    <markdown-toolbar
+                                        for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
+                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+                                        <div class="d-inline-block mr-3">
+                                            <button type="button"
+                                                class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item "
+                                                aria-label="Insert a suggestion <cmd-g>"
+                                                data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;D127:2C769:D2F197:1406DED:5D9471A2&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
+                                                data-hydro-click-hmac="0285edca4ce32a98afd66f44e5a90d3ce93c460aae7e4c6f95df0020e23391a3"
+                                                data-ga-click="Markdown Toolbar, click, insert code suggestion"
+                                                hotkey="g">
+                                                <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1"
+                                                    width="13" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z">
+                                                    </path>
+                                                </svg>
+                                            </button> </div>
+
+                                        <div class="flex-nowrap d-inline-block mr-3">
+                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add header text"
+                                                data-ga-click="Markdown Toolbar, click, header" role="button">
+                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
+                                                    width="18" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-header>
+
+                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add bold text <cmd-b>"
+                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-bold>
+
+                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add italic text <cmd-i>"
+                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
+                                                hotkey="i">
+                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
+                                                    width="6" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
+                                                    </path>
+                                                </svg>
+                                            </md-italic>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-quote tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert a quote"
+                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
+                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-quote>
+
+                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
+                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
+                                                role="button">
+                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
+                                                    </path>
+                                                </svg>
+                                            </md-code>
+
+
+                                            <md-link tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
+                                                aria-label="Add a link <cmd-k>"
+                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                                                    </path>
+                                                </svg>
+                                            </md-link>
+                                        </div>
+
+                                        <div class="d-inline-block mr-3">
+                                            <md-unordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a bulleted list"
+                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-unordered-list>
+
+                                            <md-ordered-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a numbered list"
+                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
+                                                    version="1.1" width="12" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ordered-list>
+
+                                            <md-task-list tabindex="-1"
+                                                class="toolbar-item tooltipped tooltipped-n mx-1"
+                                                aria-label="Add a task list"
+                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
+                                                hotkey="L">
+                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
+                                                    width="16" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
+                                                    </path>
+                                                </svg>
+                                            </md-task-list>
+                                        </div>
+
+                                        <div class="d-inline-block">
+                                            <md-mention tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Directly mention a user or team"
+                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
+                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
+                                                    width="14" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
+                                                    </path>
+                                                </svg>
+                                            </md-mention>
+
+
+                                            <md-ref tabindex="-1"
+                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
+                                                aria-label="Reference an issue or pull request"
+                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
+                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
+                                                    width="10" height="16" aria-hidden="true">
+                                                    <path fill-rule="evenodd"
+                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
+                                                    </path>
+                                                </svg>
+                                            </md-ref>
+
+                                            <details
+                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
+                                                tabindex="-1">
+                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
+                                                    aria-label="Insert a reply"
+                                                    data-ga-click="Markdown Toolbar, click, saved reply"
+                                                    aria-haspopup="menu" role="button">
+                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
+                                                        width="14" height="16" aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
+                                                        </path>
+                                                    </svg>
+                                                    <span class="dropdown-caret "></span>
+                                                </summary>
+                                                <details-menu style="z-index: 99;"
+                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
+                                                    data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
+                                                    src="/settings/replies?context=none" preload="" role="menu">
+                                                    <div class="select-menu-header d-flex">
+                                                        <span class="select-menu-title flex-auto">Select a reply</span>
+                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+                                                    </div>
+                                                    <include-fragment role="menuitem"
+                                                        class="select-menu-loading-overlay anim-pulse"
+                                                        aria-label="Loading">
+                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
+                                                            version="1.1" width="16" height="16" aria-hidden="true">
+                                                            <path fill-rule="evenodd"
+                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
+                                                            </path>
+                                                        </svg>
+                                                    </include-fragment>
+                                                </details-menu>
+                                            </details>
+
+                                        </div>
+
+                                    </markdown-toolbar>
+
+                                    <nav class="tabnav-tabs" role="tablist">
+                                        <button type="button"
+                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
+                                            aria-selected="true">Write</button>
+                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
+                                            role="tab">Preview</button>
+                                    </nav>
+                                </div>
+
+                                <file-attachment class="js-upload-markdown-image is-default"
+                                    data-upload-repository-id="=&quot;41288708&quot;"
+                                    data-upload-policy-url="/upload/policies/assets"
+                                    data-upload-policy-authenticity-token="Ir8RlCBZ0RbNu3TI3HWxqkrcQdtnjJa38Rw4peKLoe+pnLqo9oXYPxQPnmgI8OeKJ8/94Ye3NnrWxFCCone/dw==">
+                                    <div class="write-content js-write-bucket upload-enabled">
+                                        <input type="hidden" name="saved_reply_id"
+                                            id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
+                                            class="js-resettable-field" value="" data-reset-value="">
+
+                                        <text-expander keys=": @ #"
+                                            data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                            data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
+                                            data-emoji-url="/autocomplete/emoji">
+                                            <textarea name="comment[body]"
+                                                id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
+                                                placeholder="Leave a comment" aria-label="Comment body"
+                                                class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable"></textarea>
+                                        </text-expander>
+
+
+                                        <p
+                                            class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+                                            <input
+                                                accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
+                                                type="file" multiple=""
+                                                class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
+                                                aria-label="Attach files to your comment"
+                                                id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
+                                            <span
+                                                class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
+                                                style="pointer-events: none;"></span>
+                                            <span class="position-relative pr-2" style="pointer-events: none;">
+                                                <span class="default">
+                                                    Attach files by dragging &amp; dropping, selecting or pasting them.
+                                                </span>
+                                                <span class="loading">
+                                                    <img alt="" width="16" height="16"
+                                                        src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
+                                                    Uploading your files…
+                                                </span>
+                                                <span class="error bad-file">
+                                                    We don’t support that file type.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a
+                                                        GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error bad-permissions">
+                                                    Attaching documents requires write permission to this repository.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                        or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error repository-required">
+                                                    We don’t support that file type.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
+                                                        or ZIP.
+                                                    </span>
+                                                </span>
+                                                <span class="error too-big">
+                                                    Yowza, that’s a big file
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a file smaller than 10MB.
+                                                    </span>
+                                                </span>
+                                                <span class="error empty">
+                                                    This file is empty.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with a file that’s not empty.
+                                                    </span>
+                                                </span>
+                                                <span class="error hidden-file">
+                                                    This file is hidden.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try again</button>
+                                                        with another file.
+                                                    </span>
+                                                </span>
+                                                <span class="error failed-request">
+                                                    Something went really wrong, and we can’t process that file.
+                                                    <span class="drag-and-drop-error-info">
+                                                        <button type="button"
+                                                            class="btn-link manual-file-chooser-text">Try
+                                                            again.</button>
+                                                    </span>
+                                                </span>
+                                            </span>
+                                            <span class="tooltipped tooltipped-nw"
+                                                aria-label="Styling with Markdown is supported">
+                                                <a class="muted-link position-relative d-inline"
+                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                    target="_blank" data-ga-click="Markdown Toolbar, click, help"
+                                                    aria-label="Learn about styling with Markdown">
+                                                    <svg class="octicon octicon-markdown v-align-bottom"
+                                                        viewBox="0 0 16 16" version="1.1" width="16" height="16"
+                                                        aria-hidden="true">
+                                                        <path fill-rule="evenodd"
+                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
+                                                        </path>
+                                                    </svg>
+                                                </a>
+                                            </span>
+                                        </p>
+
+                                    </div>
+                                </file-attachment>
+                                <div class="preview-content">
+                                    <div class="comment js-suggested-changes-container" data-thread-side="">
+                                        <div class="comment-body markdown-body js-preview-body">
+                                            <p>Nothing to preview</p>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+                            </div>
+
+
+                            <div class="form-actions">
+                                <div class="position-relative float-right ml-1">
+                                    <input type="hidden" name="single_comment" value="1">
+
+                                    <button name="single_comment" type="submit" value="1"
+                                        class="btn review-simple-reply-button btn-primary" data-disable-invalid=""
+                                        data-disable-with="">
+                                        Comment
+                                    </button>
+                                </div>
+
+                                <button class="btn js-hide-inline-comment-form" type="button"
+                                    data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
 
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button" aria-label="Edit comment">
-              Edit
-            </button>
-
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272796448&amp;report=alexandnpu+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="7ilkVodGtSoFAQ/A4UfyhNoIES1Kd6b/EPj4dLUqVvLBxKNj9hmYo7zrRLp66NrkgJ6YuS2BR+0akHSe3ruuSA==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272796448" id="discussion_r272796448-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-06T13:53:50Z" title="6 Apr 2019, 15:53 CEST">25 days ago</relative-time>
-              </a>
-
-
-  <span class="d-inline-block text-gray-light">•</span>
-
-  <details class="details-overlay details-reset d-inline-block dropdown">
-    <summary class="btn-link no-underline text-gray js-notice" aria-haspopup="menu">
-      <div class="position-relative">
-        <span>
-            edited
-        </span>
-        <svg height="11" class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-      </div>
-    </summary>
-    <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px" src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/comment_edit_history_log" preload="" role="menu">
-      <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
-    </details-menu>
-  </details>
-
-          </span>
-        </h4>
-
-        <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="LKUzYkdoCz1C8vSAcCW9n4UAlmfFlRHGg8F81ii3SEwCUnWGcvjIfdwuGx7qklGlQNDDEoXcxXQkWLzHGYdU4A==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body  js-comment-body">
-            <p>Maybe <code>Opaque</code> is not a very straight forward word to understand. That part of code is handling urls whose pattern is <code>host:port</code>, such as "localhost:5000" or so.</p>
-<p>I do not like the way <code>Opaque</code> used here, but it is in the standard library net/url/url.go</p>
-<pre><code>// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-</code></pre>
-<p>any suggestions for making this part more elegant?</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
             </div>
-
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272796448" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="4patZX4HWpuvsy9G4Hglg82HLneH+In/7yf0gc0vnI/QgOH0MWqm0Fq8etXUrdL6AsoaYaN/xY0v7kFOvJPpvw==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272796448" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="K1dLXkeOVEt1o6+bsvXZEvX7MWIvFics+8yNPmZg9F1iBkXzejZJt7AhxV9Zb5KYG8uA4MzsdxoRS5OPF7KPwA==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="RB6rbIyiNRL962FppZRIKTppaXBoyrLnjyMho1RJyLGEDvYUD44P+cLidpwJVAk6eHpuO9J0hmT9P+QGeQQinw==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272796448-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="pIVyD42+HVQzbRb2Adxa4D+nXRFqnahnDHUS+2gAQYWWkz6ewtPhH8ZiQ2U1Ca2Z8OppB04a5BXMvKc0Gbw0tQ==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjc5NjQ0OA==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="cb2c551d0d9dac9546de9ea2988f9bdd">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272796448-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">Maybe `Opaque` is not a very straight forward word to understand. That part of code is handling urls whose pattern is `host:port`, such as "localhost:5000" or so.
-
-I do not like the way `Opaque` used here, but it is in the standard library net/url/url.go
-
-```
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, code must not use Path directly.
-// The Parse function sets both Path and RawPath in the URL it returns,
-// and URL's String method uses RawPath if it is a valid encoding of Path,
-// by calling the EscapedPath method.
-type URL struct {
-	Scheme     string
-	Opaque     string    // encoded opaque data
-	User       *Userinfo // username and password information
-	Host       string    // host or host:port
-	Path       string    // path (relative paths may omit leading slash)
-	RawPath    string    // encoded path hint (see EscapedPath method)
-	ForceQuery bool      // append a query ('?') even if RawQuery is empty
-	RawQuery   string    // encoded query values, without '?'
-	Fragment   string    // fragment for references, without '#'
-}
-```
-
-any suggestions for making this part more elegant?</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-<div class="review-comment js-minimizable-comment-group js-targetable-comment" id="discussion_r272957122" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/review_comment">
-
-    <div class="minimized-comment d-none">
-
-
-
-
-  <details class="Details-element details-reset " data-body-version="b844590cffa5a736fcb6fac819c0af65">
-    <summary class="text-gray f6">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
-          <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
-          </div>
-          <div class="discussion-item-copy d-inline-block">
-                This comment has been minimized.
-
-          </div>
-        </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<details class="details-overlay details-reset position-relative d-inline-block ">
-  <summary class="btn-link timeline-comment-action" aria-haspopup="menu">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
-        <clipboard-copy class="dropdown-item btn-link" for="discussion_r272957122-minimized-permalink" role="menuitem" tabindex="0">
-    Copy link
-  </clipboard-copy>
-
-        <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
-    Quote reply
-  </button>
-
-        <div role="none" class="dropdown-divider"></div>
-
-          <button type="button" class="dropdown-item btn-link js-comment-edit-button" role="menuitem" aria-label="Edit comment">
-      Edit
-    </button>
-
-            <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="zCpIUsNXiThb+c3TGIO9+eS1haf/SLqPHAtgQxLsyjXc03mAbwU2Ep33yhBRB++gShfA4BLbcS9ArqWNXMV0lg==">
-        <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-        <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
-          Unhide
-        </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="tLdRsyWj4YdR/gAPVnsrWkrPj42krvxcDFttycswyYLYmt5u08+RNiMyv5OKaIKnVWvRMJRtx3om6yopIoRBwA==">
-      <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-      <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
-        Delete
-      </button>
-</form>
-        <div role="none" class="dropdown-divider"></div>
-
-          <a aria-label="Report abusive content" role="menuitem" class="dropdown-item btn-link" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272957122&amp;report=alexandnpu+%28user%29">
-      Report abuse
-</a>
-
-  </details-menu>
-</details>
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r272957122" id="discussion_r272957122-minimized-permalink" class="timestamp"><relative-time datetime="2019-04-08T09:28:14Z" title="8 Apr 2019, 11:28 CEST">23 days ago</relative-time></a>
-              </span>
-            </h4>
-
-
-            <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-            <task-lists sortable="">
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p>I've updated my way of parsing redis connection string and added some tests. Please have a review.</p>
-              </div>
-            </task-lists>
-          </div>
         </div>
 
-          <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="VYKs9U2xwxK0SyiojlwC6jpKRSzx0HiM6rmd+bQ2zA1nlOBkAtw/WUFEfTu6ifWT9QdxOtVXNP4qcCg2xYq5PQ==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="mw1syr97idTOTMpWUwBlZnVAYthb2uCUQ7nkfynfkx4+7vG3o5ap2xp+D3zHr6SBLchUrbzalcZ2GKQTLE/K+A==">
-            <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="xOGJkqJrTb6Liu0Pv+YowySM2tP84T66SgtdKRVF614E8dTqIUd3VbSD+voTJmnQZp/dmEZfCjk4F5iMOAgBcA==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272957122-minimize-comment-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="OP9EE3SHXjRDFrgq2D2ZXNeqqPupoTkAl6wBKMb4/NMK6QiCO+qif7YZ7bns6G4lGOec7Y0mdXJXZbTnt0SJ4w==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="b844590cffa5a736fcb6fac819c0af65">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272957122-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">I've updated my way of parsing redis connection string and added some tests. Please have a review.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
+        <!-- '"` -->
+        <!-- </textarea></xmp> -->
+        <form class="js-resolvable-timeline-thread-form"
+            action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve"
+            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
+                name="_method" value="put"><input type="hidden" name="authenticity_token"
+                value="V5KHjL0m9LfuRCGluFgMeciL2Yh5QYbO8kWVFBxMCqoyXt//N5MKRoKKQxV6Dm680tyDGVS7vWIoZTGTehfAng==">
+            <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…"
+                data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;D127:2C769:D2F197:1406DED:5D9471A2&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
+                data-hydro-click-hmac="74758119ef02a3d8ee677364bea0ee630c1297aaeca94cf49e1a0861afe383ec">
+                Resolve conversation
+            </button></form>
     </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>      </div>
-    </div>
-  </details>
-
-
-    </div>
-
-  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment  reorderable-task-lists" data-body-version="b844590cffa5a736fcb6fac819c0af65" data-thread-side="right">
-    <div class="edit-comment-hide">
-      <div class="timeline-comment-actions">
-
-  <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:272957122" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/comment_header_reaction_button">
-    <summary class="btn-link timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu">
-      <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
-      <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
-    </summary>
-
-<details-menu class="dropdown-menu dropdown-menu-sw add-reaction-popover js-add-reaction-popover anim-scale-in" aria-label="Pick your reaction" role="menu">
-  <!-- '"` --><!-- </textarea></xmp> --><form class="reaction-popover-form js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="qV0vKrBEUSjOLLFW0094ymR39tFIz3NpKOh5SEKKUKui+8h62NjncPBV8R/bbVLCsq7JABCDZ8d4kgM4rE0G0w==">
-    <p class="text-gray mx-2 my-1">
-      <span class="js-reaction-description">Pick your reaction</span>
-      <img alt="" width="16" height="16" class="loading-spinner" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-    </p>
-
-    <div role="none" class="dropdown-divider"></div>
-
-    <div class="add-reactions-options mx-1 mb-1">
-      <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-          <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-          <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
-          <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
-          <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
-          <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
-          <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
-          <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
-        </button>
-        <button type="submit" role="menuitem" class="btn-link add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
-          <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
-        </button>
-    </div>
-</form></details-menu>
-
-  </details>
-
-        <details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r272957122">
-          <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu">
-            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-          </summary>
-
-          <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
-
-            <clipboard-copy class="dropdown-item btn-link" for="discussion_r272957122-permalink" data-toggle-for="details-discussion_r272957122" role="menuitem" tabindex="0">
-              Copy link
-            </clipboard-copy>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply" data-toggle-for="details-discussion_r272957122">
-              Quote reply
-            </button>
-
-
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-  <summary class="dropdown-item" aria-haspopup="dialog" role="menuitem">
-
-    Reference in new issue
-  </summary>
-  <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-      </button>
-      <h3 class="Box-title">Reference in new issue</h3>
-    </div>
-
-                <div class="Box-body scrollable-overlay">
-
-<!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="89uRIsACIYGaKjVscj+KsbGHBn7wIdLzyYNBnXupg5V4D0QmjO6syTOaN6Uae5ZoPbLvbbqPAupqdHXqJh6uxQ==">
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Repository</label></dt>
-    <dd>
-      <details class="details-reset details-overlay select-menu">
-        <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu">
-          <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
-          sourcegraph
-        </summary>
-        <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Repositories</span>
-          </div>
-          <div class="select-menu-filters">
-            <div class="select-menu-text-filter">
-              <filterable-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
-                <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
-              </filterable-input>
-            </div>
-          </div>
-          <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
-        </details-menu>
-      </details>
-    </dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Title</label></dt>
-    <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" class="form-control" type="text" name="issue[title]" value="I've updated my way of parsing redis connection string and added some tests. Please have a review." aria-label="Issue title" autofocus="" required=""></dd>
-  </dl>
-  <dl class="form-group">
-    <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">Body</label></dt>
-    <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==" name="issue[body]" class="form-control" aria-label="Issue body">I've updated my way of parsing redis connection string and added some tests. Please have a review.
-
-_Originally posted by @alexandnpu in https://github.com/sourcegraph/sourcegraph/pull/3221_</textarea></dd>
-  </dl>
-
-  <div class="d-flex d-sm-block">
-    <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-      Create issue
-    </button>
-  </div>
-</form>
-                </div>
-
-  </details-dialog>
-</details>
-
-              <div role="none" class="dropdown-divider"></div>
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button" aria-label="Edit comment">
-              Edit
-            </button>
-
-
-            <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
-              Hide
-            </button>
-
-            <a aria-label="Report content" class="dropdown-item btn-link" role="menuitem" data-ga-click="Report content, reported by OWNER" href="/contact/report-content?content_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3221%23discussion_r272957122&amp;report=alexandnpu+%28user%29">
-              Report
-</a>
-            <div role="none" class="dropdown-divider"></div>
-            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="CAM3gEQqoXmiKTVIjDFTBNij4yYByEJ9YdNChDWYu2RkLrhdskbRyNDlitRQIvr5xwe9mzELeVtLYwVk3CwzJg==">
-              <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-              <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
-                Delete
-              </button>
-</form>
-          </details-menu>
-        </details>
-      </div>
-
-      <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu"><img class="avatar" height="28" width="28" alt="@alexandnpu" src="https://avatars2.githubusercontent.com/u/1999503?s=60&amp;v=4"></a>
-      </span>
-
-      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-        <h4 class="f5 text-normal d-inline">
-          <strong>
-
-
-  <a class="author text-inherit css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1999503" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/alexandnpu">alexandnpu</a>
-
-
-          </strong>
-          <span class="text-gray">
-
-              <a href="#discussion_r272957122" id="discussion_r272957122-permalink" class="js-timestamp timestamp d-inline-block">
-                <relative-time datetime="2019-04-08T09:28:14Z" title="8 Apr 2019, 11:28 CEST">23 days ago</relative-time>
-              </a>
-
-          </span>
-        </h4>
-
-        <span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is the author of this pull request.">
-  Author
-</span>
-
-
-
-
-          <div class="js-minimize-comment d-none">
-
-
-<div class="flash flash-warn my-2">
-  <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  <h3 class="f5">Choose a reason for hiding this comment</h3>
-  <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
-  <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="PJ+mBx7ekSN5HfGK/hhFTFP9KlrnO0dDijoq0LqSeVYSaODjK05SY+fBHhRkr6l2li1/L6dyk/Eto+rBi6Jl+g==">
-    <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-    <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
-      <option value="">
-      Choose a reason
-      </option>
-      <option value="SPAM">Spam</option>
-<option value="ABUSE">Abuse</option>
-<option value="OFF_TOPIC">Off Topic</option>
-<option value="OUTDATED">Outdated</option>
-<option value="RESOLVED">Resolved</option>
-    </select>
-    <button type="submit" class="btn">
-      Hide comment
-    </button>
-</form></div>
-
-          </div>
-
-
-
-        <task-lists sortable="">
-          <div class="comment-body markdown-body  js-comment-body">
-            <p>I've updated my way of parsing redis connection string and added some tests. Please have a review.</p>
-          </div>
-        </task-lists>
-
-            <template class="js-suggested-changes-template" data-comment-pending="false" data-outdated-comment="true">
-              <div class="p-2 border-top d-flex flex-justify-end flex-items-center suggested-change-form-container js-suggested-change-form-container" data-comment-pending="false" data-outdated-comment="true" data-resolved-comment="false">
-                <button class="btn btn-sm js-suggestion-applied d-none" disabled="">
-                  <svg height="16" class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-                  Suggestion applied
-                </button>
-                <button class="btn btn-sm js-disabled-apply-suggestion-button d-none tooltipped tooltipped-multiline tooltipped-n" data-pull-is-open="false" aria-label="" disabled="">
-                  Commit suggestion
-                  <svg class="octicon octicon-triangle-down v-align-text-bottom" height="14" viewBox="0 0 12 16" version="1.1" width="10" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
-                </button>
-
-              </div>
-            </template>
-
-            <div class="form-group flex-auto warn m-0 text-orange js-error-message-placeholder" hidden="">
-              <div class="position-relative warning m-0" style="max-width: inherit;">
-                <span class="js-error-message"></span>
-                <span class="text-bold btn-link js-refresh-after-suggestion">Refresh and try again.</span>
-              </div>
-            </div>
-
-
-
-<div class="comment-reactions  js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:272957122" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==/comments/reactions">
-</div>
-
-      </div>
-    </div>
-
-      <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="tI36rdcHeSni4PbXTcUdL5/FnMtez9XKAnQMs+uPKneGm7Y8mGqFYhfvo0R5EOpWUIio3XpImbjCvbl8mjNfRw==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/3221/review_comment/272957122" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="oBJM0NuGt1doKiv88CKsylkS4sYECaRgViE7nxoNlGYF8dGtx2uXWLwY7tZkjW0tAZrUs+MJ0TJjgHvzH53NgA==">
-        <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="dsvFHiFsKN6htA0WxFgH26zdUotsm292DD2Oam80jSG225hmokASNZ69GuNomEbI7s5VwNYlW/V+IUvPQnlnDw==">
-
-<div class="comment-form-head tabnav ">
-  <nav class="tabnav-tabs" role="tablist">
-    <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-    <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-  </nav>
-
-
-<markdown-toolbar for="discussion_r272957122-body" class="toolbar-commenting ">
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-</div>
-
-
-  <p class="comment-form-stale">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
-  </p>
-
-
-<div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="n6loJT8RZhH/jJQhRTtROqdhAs9ww+3v13Gw3vttW5etvyS0cHyaWgqDwbJx7qZDaCw22VREoZ0XuAURitEupw==" data-upload-repository-id="41288708">
-  <input type="hidden" name="context" value="discussion">
-
-    <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-  <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI3Mjk1NzEyMg==">
-  <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="b844590cffa5a736fcb6fac819c0af65">
-  <textarea name="pull_request_review_comment[body]" id="discussion_r272957122-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph">I've updated my way of parsing redis connection string and added some tests. Please have a review.</textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-</div>
-
-
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="right">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="clearfix">
-
-    <input type="hidden" name="original-line" value="+	if len(parsedUrl.Opaque) > 0 {" class="js-original-line">
-    <input type="hidden" name="path" value="pkg/redispool/redispool.go" class="js-path">
-    <input type="hidden" name="line" value="62" class="js-line-number">
-    <div class="form-actions comment-form-actions">
-      <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
-      <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
-        Cancel
-      </button>
-    </div>
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-</form>  </div>
-</div>
-
-
-
-    </div>
-
-      <div class="review-thread-reply border-bottom">
-
-<div class="inline-comment-form-container js-inline-comment-form-container">
-  <div class="inline-comment-form-actions">
-    <div class="d-table width-full">
-      <div class="d-table-cell">
-        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=10532611" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/felixfbecker"><img class="avatar" src="https://avatars2.githubusercontent.com/u/10532611?s=56&amp;v=4" width="28" height="28" alt="@felixfbecker"></a>
-      </div>
-      <div class="d-table-cell col-12">
-        <button type="button" class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
-          Reply…
-        </button>
-      </div>
-    </div>
-  </div>
-
-  <div class="inline-comment-form">
-    <!-- '"` --><!-- </textarea></xmp> --><form class="js-inline-comment-form" action="/sourcegraph/sourcegraph/pull/3221/review_comment/create" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="5tgopkD0UcCrQQybOlfc0BU1ae0Mu4i/nleMTuq6UR6HM8joDCNuVs1P42xONrqydSVmgw8nesUbTe4KC4Ywow==">
-      <input type="hidden" name="comment_context" value="discussion">
-      <input type="hidden" name="in_reply_to" value="272416639">
-
-
-<div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected" data-preview-url="/preview?repository=41288708" data-preview-authenticity-token="ezam34GiAAPu/cgxhCogyKi5//+pEZnX+nf8lvmtSVq7JvunAo466NH038Qo6mHb6qr4tBOvrVSIazkz1OCjdA==">
-  <div class="comment-form-head tabnav">
-
-<markdown-toolbar for="new_inline_comment_discussion_diff-5bd3e793932782601ddbd53a3d8dd073_272416639_21" class="toolbar-commenting ">
-    <div class="toolbar-group">
-      <button type="button" class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item" aria-label="Insert a suggestion <cmd-g>" data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:10532611,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MjY3NDM3NDQ3&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;2008835310.1548448452&quot;,&quot;originating_request_id&quot;:&quot;EF65:110F6:19945F:269A8E:5CC9F5AF&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/3221&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="8a8d93810d691aa359e13f226c4974bdc6fa9b14e13c1003d8c4077da9f3c829" data-ga-click="Markdown Toolbar, click, insert code suggestion" hotkey="g">
-          <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
-</button>    </div>
-  <div class="toolbar-group">
-    <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
-      <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
-    </md-header>
-
-    <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-      <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
-    </md-bold>
-
-    <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
-      <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
-    </md-italic>
-  </div>
-
-  <div class="toolbar-group">
-    <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
-      <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
-    </md-quote>
-
-    <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    </md-code>
-
-    <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-      <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-    </md-link>
-  </div>
-
-  <div class="toolbar-group">
-    <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-      <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
-    </md-unordered-list>
-
-    <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-      <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
-    </md-ordered-list>
-
-    <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
-      <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
-    </md-task-list>
-  </div>
-
-  <div class="toolbar-group">
-    <md-mention tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
-      <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
-    </md-mention>
-
-    <md-ref tabindex="-1" class="toolbar-item tooltipped tooltipped-nw" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
-      <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
-    </md-ref>
-
-      <details class="details-reset details-overlay toolbar-item select-menu select-menu-modal-right js-saved-reply-container" tabindex="-1">
-        <summary class="menu-target" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu">
-          <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
-          <span class="dropdown-caret"></span>
-        </summary>
-        <details-menu class="select-menu-modal position-absolute right-0 js-saved-reply-menu" style="z-index: 99;" src="/settings/replies?context=none" preload="" role="menu">
-          <div class="select-menu-header d-flex">
-            <span class="select-menu-title flex-auto">Select a reply</span>
-            <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-          </div>
-          <include-fragment class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
-            <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-          </include-fragment>
-        </details-menu>
-      </details>
-  </div>
-</markdown-toolbar>
-
-    <nav class="tabnav-tabs" role="tablist">
-      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
-      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
-    </nav>
-  </div>
-
-  <file-attachment class="js-upload-markdown-image is-default" data-upload-repository-id="=&quot;41288708&quot;" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="DkU1RmXHfvpJ30e5dthEZijzkaz3QNVph18jCLZ2zMs8U3nXKqqCsbzQEipCDbMf576lutPHmRtHlpbHx8q5+w==">
-    <div class="write-content js-write-bucket upload-enabled">
-      <input type="hidden" name="saved_reply_id" class="js-saved-reply-id js-resettable-field" value="" data-reset-value="">
-
-      <textarea name="comment[body]" id="new_inline_comment_discussion_diff-5bd3e793932782601ddbd53a3d8dd073_272416639_21" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable" data-suggest-emoji="/autocomplete/emoji" data-suggest-issue="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-suggest-mention="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"></textarea>
-
-
-  <p class="drag-and-drop position-relative d-flex flex-justify-between">
-    <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="multiple" class="manual-file-chooser top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" style="opacity: 0.01; min-height: 0;" aria-label="Attach files to your comment">
-    <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
-    <span class="position-relative" style="pointer-events: none;">
-      <span class="default">
-          Attach files by dragging &amp; dropping, selecting or pasting them.
-      </span>
-      <span class="loading">
-        <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
-      </span>
-      <span class="error bad-file">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
-          GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error bad-permissions">
-        Attaching documents requires write permission to this repository.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error repository-required">
-        We don’t support that file type.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-        </span>
-      </span>
-      <span class="error too-big">
-        Yowza, that’s a big file
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
-        </span>
-      </span>
-      <span class="error empty">
-        This file is empty.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
-        </span>
-      </span>
-      <span class="error hidden-file">
-        This file is hidden.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
-        </span>
-      </span>
-      <span class="error failed-request">
-        Something went really wrong, and we can’t process that file.
-        <span class="drag-and-drop-error-info">
-          <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
-        </span>
-      </span>
-    </span>
-    <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
-      <a class="tabnav-extra position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
-        <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
-      </a>
-    </span>
-  </p>
-
-    </div>
-</file-attachment>
-  <div class="preview-content">
-    <div class="comment js-suggested-changes-container" data-thread-side="">
-  <div class="comment-body markdown-body js-preview-body">
-    <p>Nothing to preview</p>
-  </div>
-</div>
-
-  </div>
-
-  <div class="comment-form-error comment-form-bottom js-comment-update-error"></div>
-</div>
-
-
-      <div class="form-actions">
-        <div class="position-relative float-right ml-1">
-          <input type="hidden" name="single_comment" value="1">
-
-          <button name="single_comment" type="submit" value="1" class="btn review-simple-reply-button btn-primary" data-disable-invalid="" data-disable-with="">
-            Comment
-          </button>
-        </div>
-
-        <button class="btn js-hide-inline-comment-form" type="button" data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
-      </div>
-</form>  </div>
-</div>
-
-      </div>
-  </div>
-
-    <!-- '"` --><!-- </textarea></xmp> --><form class="js-resolvable-timeline-thread-form" action="/sourcegraph/sourcegraph/pull/3221/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMTY2NDA0MTMwOnYy/resolve" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="sdFwOAIazdlGNzO2cfCPA78YcGtIbqezL41drnouwaJnrnZveaHdLI1fDKD0PnsQfT0K7dM9Q/aZgbEYLUtLNw==">
-      <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…" data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:166404130,&quot;user_id&quot;:10532611,&quot;client_id&quot;:&quot;2008835310.1548448452&quot;,&quot;originating_request_id&quot;:&quot;EF65:110F6:19945F:269A8E:5CC9F5AF&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/3221&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="a5896be0fd8f6b37771bca04b03e00b846cdff8420e15b465524eec3f6dcc585">
-        Resolve conversation
-</button></form>
-</div>
 
 
 

--- a/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/vanilla/code-view.html
+++ b/browser/src/libs/github/__fixtures__/github.com/pull-request-discussion/vanilla/code-view.html
@@ -1,133 +1,98 @@
-<div
-    class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
+<div class="mt-0 bg-white file js-comment-container js-resolvable-timeline-thread-container has-inline-notes sg-mounted">
     <div class="file-header">
-        <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd"
-            class="text-mono text-small link-gray-dark wb-break-all mr-2"
-            title="web/src/regression/util/TestResourceManager.ts">
-            web/src/regression/util/TestResourceManager.ts
-        </a>
+          <a href="/sourcegraph/sourcegraph/pull/5746/files/bee9ea621dd605cceb0d6f23793c0d12fed22820#diff-c4ec1f2c733d38e620466bc2d80205dd" class="text-mono text-small link-gray-dark wb-break-all mr-2" title="web/src/regression/util/TestResourceManager.ts">
+        web/src/regression/util/TestResourceManager.ts
+      </a>
 
 
     </div>
 
 
-    <div class="blob-wrapper border-bottom">
-        <table id="discussion-diff-329949662" class="diff-table">
+  <div class="blob-wrapper border-bottom">
+    <table id="discussion-diff-329949662" class="diff-table">
 
 
 
-            <tbody>
-                <tr>
+      <tbody><tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R10" data-line-number="10"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R10" data-line-number="10" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> * place and for easy
-                                resource cleanup at the end of tests. Also prints which resources are
-                                created</span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span> </span><span><span>*</span></span><span> </span><span><span>place</span></span><span> </span><span><span>and</span></span><span> </span><span><span>for</span></span><span> </span><span><span>easy</span></span><span> </span><span><span>resource</span></span><span> </span><span><span>cleanup</span></span><span> </span><span><span>at</span></span><span> </span><span><span>the</span></span><span> </span><span><span>end</span></span><span> </span><span><span>of</span></span><span> </span><span><span>tests</span></span><span><span>.</span></span><span> </span><span><span>Also</span></span><span> </span><span><span>prints</span></span><span> </span><span><span>which</span></span><span> </span><span><span>resources</span></span><span> </span><span><span>are</span></span><span> </span><span><span>created</span></span></span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R11" data-line-number="11"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R11" data-line-number="11" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> * and destroyed in
-                                case tests are aborted midway through and manual cleanup is required.</span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span> </span><span><span>*</span></span><span> </span><span><span>and</span></span><span> </span><span><span>destroyed</span></span><span> </span><span><span>in</span></span><span> </span><span><span>case</span></span><span> </span><span><span>tests</span></span><span> </span><span><span>are</span></span><span> </span><span><span>aborted</span></span><span> </span><span><span>midway</span></span><span> </span><span><span>through</span></span><span> </span><span><span>and</span></span><span> </span><span><span>manual</span></span><span> </span><span><span>cleanup</span></span><span> </span><span><span>is</span></span><span> </span><span><span>required</span></span><span><span>.</span></span></span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R12" data-line-number="12"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R12" data-line-number="12" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-c"> <span
-                                    class="pl-c">*/</span></span></span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-c"><span> </span><span class="pl-c"><span>*</span><span><span>/</span></span></span></span></span>
 
-                    </td>
-                </tr>
-                <tr>
+        </td>
+      </tr>
+      <tr>
 
-                    <td class="blob-num blob-num-addition empty-cell"></td>
+          <td class="blob-num blob-num-addition empty-cell"></td>
 
-                    <td id="discussion-diff-329949662R13" data-line-number="13"
-                        class="blob-num blob-num-addition js-linkable-line-number"></td>
+          <td id="discussion-diff-329949662R13" data-line-number="13" class="blob-num blob-num-addition js-linkable-line-number"></td>
 
-                    <td class="blob-code blob-code-addition">
-                        <span class="blob-code-inner blob-code-marker-addition"><span class="pl-k">export</span> <span
-                                class="pl-k">class</span> <span class="pl-en">TestResourceManager</span> {</span>
+        <td class="blob-code blob-code-addition">
+          <span class="blob-code-inner blob-code-marker-addition annotated"><span class="pl-k"><span>export</span></span><span> </span><span class="pl-k"><span>class</span></span><span> </span><span class="pl-en"><span>TestResourceManager</span></span><span> </span><span><span>{</span></span></span>
 
-                    </td>
-                </tr>
+        </td>
+      </tr>
 
-            </tbody>
-        </table>
-    </div>
+    </tbody></table>
+  </div>
 
-    <div class="js-inline-comments-container">
-        <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
-            <div class="js-comments-holder">
+  <div class="js-inline-comments-container">
+    <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
+      <div class="js-comments-holder">
 
 
-                <div class="review-comment js-minimizable-comment-group js-targetable-comment"
-                    id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
+  <div class="review-comment js-minimizable-comment-group js-targetable-comment" id="discussion_r329949662" data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/review_comment">
 
-                    <div class="minimized-comment position-relative d-none">
+      <div class="minimized-comment position-relative d-none">
 
 
 
 
-                        <details class="Details-element details-reset "
-                            data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
-                            <summary class="text-gray f6">
-                                <div class="d-flex flex-justify-between flex-items-center">
-                                    <h3 class="review-comment-contents bg-white f5 text-normal text-italic"
-                                        style="margin-left:38px">
-                                        <div class="discussion-item-icon discussion-item-icon-gray text-gray">
-                                            <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1"
-                                                width="14" height="16" aria-hidden="true">
-                                                <path fill-rule="evenodd"
-                                                    d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
-                                                </path>
-                                            </svg>
-                                        </div>
-                                        <div class="d-inline-block">
-                                            This comment has been minimized.
+    <details class="Details-element details-reset " data-body-version="9458b92e7fc9c6c316cfa3edff2e9344">
+      <summary class="text-gray f6">
+        <div class="d-flex flex-justify-between flex-items-center">
+          <h3 class="review-comment-contents bg-white f5 text-normal text-italic" style="margin-left:38px">
+            <div class="discussion-item-icon discussion-item-icon-gray text-gray">
+              <svg class="octicon octicon-fold" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>
+            </div>
+            <div class="d-inline-block">
+                  This comment has been minimized.
 
-                                        </div>
-                                    </h3>
-                                    <div class="Details-content--closed btn-link text-gray"><svg
-                                            class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1"
-                                            width="14" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z">
-                                            </path>
-                                        </svg>Show comment</div>
-                                    <div class="Details-content--open btn-link text-gray"><svg
-                                            class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1"
-                                            width="14" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z">
-                                            </path>
-                                        </svg>Hide comment</div>
-                                </div>
-                            </summary>
-                            <div class="py-2 pl-6 pr-0">
-                                <div class="previewable-edit  js-task-list-container reorderable-task-lists">
-                                    <div class="edit-comment-hide">
-                                        <div class="timeline-comment-actions">
+            </div>
+          </h3>
+          <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"></path></svg>Show comment</div>
+          <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"></path></svg>Hide comment</div>
+        </div>
+      </summary>
+      <div class="py-2 pl-6 pr-0">
+        <div class="previewable-edit  js-task-list-container reorderable-task-lists">
+          <div class="edit-comment-hide">
+            <div class="timeline-comment-actions">
 
 
 
@@ -146,128 +111,66 @@
 
 
 
-                                            <details
-                                                class="details-overlay details-reset position-relative d-inline-block ">
-                                                <summary class="btn-link timeline-comment-action link-gray"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg aria-label="Show options"
-                                                        class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16"
-                                                        version="1.1" width="13" height="16" role="img">
-                                                        <path fill-rule="evenodd"
-                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
-                                                        </path>
-                                                    </svg>
-                                                </summary>
-                                                <details-menu
-                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
-                                                    style="width:185px" role="menu">
-                                                    <clipboard-copy class="dropdown-item btn-link"
-                                                        for="discussion_r329949662-minimized-permalink" role="menuitem"
-                                                        tabindex="0">
-                                                        Copy link
-                                                    </clipboard-copy>
+  <details class="details-overlay details-reset position-relative d-inline-block ">
+    <summary class="btn-link timeline-comment-action link-gray" aria-haspopup="menu" role="button">
+      <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
+    </summary>
+    <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px" role="menu">
+          <clipboard-copy class="dropdown-item btn-link" for="discussion_r329949662-minimized-permalink" role="menuitem" tabindex="0">
+      Copy link
+    </clipboard-copy>
 
-                                                    <button type="button"
-                                                        class="dropdown-item btn-link d-none js-comment-quote-reply"
-                                                        role="menuitem">
-                                                        Quote reply
-                                                    </button>
+          <button type="button" class="dropdown-item btn-link d-none js-comment-quote-reply" role="menuitem">
+      Quote reply
+    </button>
 
-                                                    <div role="none" class="dropdown-divider"></div>
+          <div role="none" class="dropdown-divider"></div>
 
-                                                    <button type="button"
-                                                        class="dropdown-item btn-link js-comment-edit-button"
-                                                        role="menuitem" aria-label="Edit comment">
-                                                        Edit
-                                                    </button>
+            <button type="button" class="dropdown-item btn-link js-comment-edit-button" role="menuitem" aria-label="Edit comment">
+        Edit
+      </button>
 
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form class="inline-form js-comment-unminimize width-full"
-                                                        action="/sourcegraph/sourcegraph/community/unminimize-comment"
-                                                        accept-charset="UTF-8" method="post"><input name="utf8"
-                                                            type="hidden" value="✓"><input type="hidden" name="_method"
-                                                            value="put"><input type="hidden" name="authenticity_token"
-                                                            value="O7bfHn+7JNhZoYMfM01nOLRQcEtsrXrkZTUUkEohhWiT/CVDnGMmhwqUZdG99tu76ukAQVF0+tdXXIueNjk/Jg==">
-                                                        <input type="hidden" name="comment_id"
-                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                        <button type="submit" class="dropdown-item btn-link"
-                                                            role="menuitem" aria-label="Unhide comment">
-                                                            Unhide
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form class="width-full inline-form js-comment-delete"
-                                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                                        accept-charset="UTF-8" method="post"><input name="utf8"
-                                                            type="hidden" value="✓"><input type="hidden" name="_method"
-                                                            value="delete"><input type="hidden"
-                                                            name="authenticity_token"
-                                                            value="7YFuIenax6vP0yGJuVCV+ZyU3oFR5c2Nw+kEXM1PcTTUdBafwpQxrfLSbUTx/k5Uny3FLcMKcXavtv0U/HlCsw==">
-                                                        <input type="hidden" name="input[id]"
-                                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                        <button type="submit"
-                                                            class="dropdown-item menu-item-danger btn-link"
-                                                            aria-label="Delete comment" role="menuitem"
-                                                            data-confirm="Are you sure you want to delete this?">
-                                                            Delete
-                                                        </button>
-                                                    </form>
+              <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-comment-unminimize width-full" action="/sourcegraph/sourcegraph/community/unminimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="0NZxBzd9HioCwfDVmHQg+RQsKAk/lrLJVwXzfRw3F8F4nIta1KUcdVH0FhsWz5x6SpVYAwJPMvplbGxzYC+tjw==">
+          <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+          <button type="submit" class="dropdown-item btn-link" role="menuitem" aria-label="Unhide comment">
+            Unhide
+          </button>
+  </form>
+            <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="TKtjGxVcxCpZBAOnSNfvObLvrJsQvo83y/uOuBtp9Wp1XhulPhIyLGQFT2oAeTSUsVa3N4JRM8ynpHfwKl/G7Q==">
+        <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+        <button type="submit" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" role="menuitem" data-confirm="Are you sure you want to delete this?">
+          Delete
+        </button>
+  </form>
 
-                                                </details-menu>
-                                            </details>
+    </details-menu>
+  </details>
 
-                                        </div>
-                                        <a class="float-left mt-1" data-hovercard-type="user"
-                                            data-hovercard-url="/hovercards?user_id=1741180"
-                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                            href="/lguychard"><img class="avatar" height="28" width="28"
-                                                alt="@lguychard"
-                                                src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
-                                        <div class="review-comment-contents">
-                                            <h4 class="f5 text-normal d-inline text-gray-dark">
-                                                <strong class="text-gray">
+            </div>
+              <a class="float-left mt-1" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard" src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+            <div class="review-comment-contents">
+              <h4 class="f5 text-normal d-inline text-gray-dark">
+                <strong class="text-gray">
 
 
-                                                    <a class="author link-gray-dark css-truncate-target"
-                                                        show_full_name="false" data-hovercard-type="user"
-                                                        data-hovercard-url="/hovercards?user_id=1741180"
-                                                        data-octo-click="hovercard-link-click"
-                                                        data-octo-dimensions="link_type:self"
-                                                        href="/lguychard">lguychard</a>
+    <a class="author link-gray-dark css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard">lguychard</a>
 
 
-                                                </strong>
-                                                <span class="text-gray">
-                                                    <a href="#discussion_r329949662"
-                                                        id="discussion_r329949662-minimized-permalink"
-                                                        class="timestamp">
-                                                        <relative-time datetime="2019-10-01T09:03:30Z"
-                                                            title="Oct 1, 2019, 11:03 AM GMT+2">yesterday
-                                                        </relative-time>
-                                                    </a>
-                                                </span>
-                                            </h4>
+                </strong>
+                <span class="text-gray">
+                    <a href="#discussion_r329949662" id="discussion_r329949662-minimized-permalink" class="timestamp"><relative-time datetime="2019-10-01T09:03:30Z" title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time></a>
+                </span>
+              </h4>
 
-                                            <span
-                                                class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
-                                                aria-label="You are a member of the Sourcegraph organization.">
-                                                Member
-                                            </span>
+      <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="You are a member of the Sourcegraph organization.">
+        Member
+      </span>
 
 
-                                            <task-lists sortable="">
-                                                <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                                                    <p>Rather than introducing a new class/concept to the codebase, I
-                                                        would consider reusing <a
-                                                            href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
-                                                            rel="nofollow"><code>Disposable</code></a> (an
-                                                        <code>Unsubscribable</code> supporting async resource disposal)
-                                                        pattern from sourcegraph-typescript (<a href="">example
-                                                            usage</a>) :</p>
-                                                    <div class="highlight highlight-source-ts">
-                                                        <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+              <task-lists sortable="">
+                <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
+                    <p>Rather than introducing a new class/concept to the codebase, I would consider reusing <a href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts" rel="nofollow"><code>Disposable</code></a> (an <code>Unsubscribable</code> supporting async resource disposal) pattern from sourcegraph-typescript (<a href="">example usage</a>) :</p>
+  <div class="highlight highlight-source-ts"><pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
   <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
       <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
       <span class="pl-k">return</span> {
@@ -291,293 +194,124 @@
               <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
           )
       })
-  })</pre>
-                                                    </div>
-                                                    <p>Pros:</p>
-                                                    <ul>
-                                                        <li>Developers working in our codebase are already familiar with
-                                                            the subscription / subscription bag pattern (and, if they're
-                                                            not, it is <a
-                                                                href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
-                                                                rel="nofollow">documented</a>).</li>
-                                                        <li>The cleanup logic is encapsulated, and lives next to the
-                                                            resource creation logic. It is not duplicated if
-                                                            <code>ensureLoggedInOrCreateTestUser()</code> is called from
-                                                            multiple test suites. Callers need not look up how a given
-                                                            resource should be cleaned up, they simply need to handle
-                                                            the returned disposable / subscription.</li>
-                                                    </ul>
-                                                </div>
-                                            </task-lists>
-                                        </div>
-                                    </div>
+  })</pre></div>
+  <p>Pros:</p>
+  <ul>
+  <li>Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is <a href="https://docs.sourcegraph.com/dev/typescript/patterns#bag" rel="nofollow">documented</a>).</li>
+  <li>The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</li>
+  </ul>
+                </div>
+              </task-lists>
+            </div>
+          </div>
 
-                                    <!-- '"` -->
-                                    <!-- </textarea></xmp> -->
-                                    <form data-upload-policy-url="/upload/policies/assets"
-                                        data-upload-policy-authenticity-token="PDStKbTbZM6Cd1fZmxSWE0sc4Fp3xS0pw2YKyVdppQ+3FwYVYgdt51vDvXlPkcAzJg9cYJf+jeTkvmLuF5W7lw=="
-                                        class="js-comment-update" data-type="json"
-                                        action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                            value="✓"><input type="hidden" name="_method" value="put"><input
-                                            type="hidden" name="authenticity_token"
-                                            value="7mCDc3cRh+mg7ncaoEsZ0nXssBWRz53jk4xrfvLrFF5Mws3jsiIT/PsHcut5D3tmTNYfNV0WJJsn3g+G2Ti1Ww==">
-                                        <div class="js-previewable-comment-form previewable-comment-form write-selected"
-                                            data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
-                                            data-preview-authenticity-token="5rBjOALa8b6CSyOMiTusUZ0C1yYnv6zdgH6cEM26DBMaT5LUbpdThRFgC6AEysNnJ62yboriI2kJFGHqo2n6Sg==">
+            <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="eJNzGpwM/V8J9i9X479oyXrWEaq5X90vhIgI0A4sFjDzsNgmStD0dtBCxfc3Oj7pF8WtkFlkfeKjUGD3TtAIqA==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="ZC7O0hzHfrTx0AdFMk5agXQzNbQ1Ksp+Ny9jvNKiNcTGjIBC2fTqoao5ArTrCjg1TQmalPnzcwaDfQdE+XGUwQ==">
+              <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="rLtILgZgDbpHWIewQN4hcqsUsbsSXsVlFAnf+0HKflpQRLnCai2vgdRzr5zNL05EEbvU878DStGdYyIBLxmIAw==">
 
-                                            <div class="comment-form-head tabnav ">
-                                                <nav class="tabnav-tabs" role="tablist">
-                                                    <button type="button"
-                                                        class="btn-link tabnav-tab write-tab js-write-tab selected"
-                                                        role="tab" aria-selected="true">Write</button>
-                                                    <button type="button"
-                                                        class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                                        role="tab">Preview</button>
-                                                </nav>
+  <div class="comment-form-head tabnav ">
+    <nav class="tabnav-tabs" role="tablist">
+      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+    </nav>
 
 
-                                                <markdown-toolbar for="discussion_r329949662-minimize-comment-body"
-                                                    class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+  <markdown-toolbar for="discussion_r329949662-minimize-comment-body" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
 
 
-                                                    <div class="flex-nowrap d-inline-block mr-3">
-                                                        <md-header tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add header text"
-                                                            data-ga-click="Markdown Toolbar, click, header"
-                                                            role="button">
-                                                            <svg class="octicon octicon-text-size" viewBox="0 0 18 16"
-                                                                version="1.1" width="18" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-header>
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
 
-                                                        <md-bold tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add bold text <cmd-b>"
-                                                            data-ga-click="Markdown Toolbar, click, bold" role="button"
-                                                            hotkey="b">
-                                                            <svg class="octicon octicon-bold" viewBox="0 0 10 16"
-                                                                version="1.1" width="10" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-bold>
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
 
-                                                        <md-italic tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add italic text <cmd-i>"
-                                                            data-ga-click="Markdown Toolbar, click, italic"
-                                                            role="button" hotkey="i">
-                                                            <svg class="octicon octicon-italic" viewBox="0 0 6 16"
-                                                                version="1.1" width="6" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-italic>
-                                                    </div>
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
 
-                                                    <div class="d-inline-block mr-3">
-                                                        <md-quote tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                            aria-label="Insert a quote"
-                                                            data-ga-click="Markdown Toolbar, click, quote"
-                                                            role="button">
-                                                            <svg class="octicon octicon-quote" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-quote>
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
 
-                                                        <md-code tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                            aria-label="Insert code"
-                                                            data-ga-click="Markdown Toolbar, click, code" role="button">
-                                                            <svg class="octicon octicon-code" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-code>
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
 
 
-                                                        <md-link tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                            aria-label="Add a link <cmd-k>"
-                                                            data-ga-click="Markdown Toolbar, click, link" role="button"
-                                                            hotkey="k">
-                                                            <svg class="octicon octicon-link" viewBox="0 0 16 16"
-                                                                version="1.1" width="16" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-link>
-                                                    </div>
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
 
-                                                    <div class="d-inline-block mr-3">
-                                                        <md-unordered-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a bulleted list"
-                                                            data-ga-click="Markdown Toolbar, click, unordered list"
-                                                            role="button">
-                                                            <svg class="octicon octicon-list-unordered"
-                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-unordered-list>
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
 
-                                                        <md-ordered-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a numbered list"
-                                                            data-ga-click="Markdown Toolbar, click, ordered list"
-                                                            role="button">
-                                                            <svg class="octicon octicon-list-ordered"
-                                                                viewBox="0 0 12 16" version="1.1" width="12" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-ordered-list>
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
 
-                                                        <md-task-list tabindex="-1"
-                                                            class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                            aria-label="Add a task list"
-                                                            data-ga-click="Markdown Toolbar, click, task list"
-                                                            role="button" hotkey="L">
-                                                            <svg class="octicon octicon-tasklist" viewBox="0 0 16 16"
-                                                                version="1.1" width="16" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-task-list>
-                                                    </div>
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
 
-                                                    <div class="d-inline-block">
-                                                        <md-mention tabindex="-1"
-                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                            aria-label="Directly mention a user or team"
-                                                            data-ga-click="Markdown Toolbar, click, mention"
-                                                            role="button">
-                                                            <svg class="octicon octicon-mention" viewBox="0 0 14 16"
-                                                                version="1.1" width="14" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-mention>
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
 
 
-                                                        <md-ref tabindex="-1"
-                                                            class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                            aria-label="Reference an issue or pull request"
-                                                            data-ga-click="Markdown Toolbar, click, reference"
-                                                            role="button">
-                                                            <svg class="octicon octicon-bookmark" viewBox="0 0 10 16"
-                                                                version="1.1" width="10" height="16" aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                                </path>
-                                                            </svg>
-                                                        </md-ref>
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref>
 
-                                                        <details
-                                                            class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                            tabindex="-1">
-                                                            <summary tabindex="-1"
-                                                                class="text-center menu-target p-1 ml-1"
-                                                                aria-label="Insert a reply"
-                                                                data-ga-click="Markdown Toolbar, click, saved reply"
-                                                                aria-haspopup="menu" role="button">
-                                                                <svg class="octicon octicon-reply" viewBox="0 0 14 16"
-                                                                    version="1.1" width="14" height="16"
-                                                                    aria-hidden="true">
-                                                                    <path fill-rule="evenodd"
-                                                                        d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                                    </path>
-                                                                </svg>
-                                                                <span class="dropdown-caret "></span>
-                                                            </summary>
-                                                            <details-menu style="z-index: 99;"
-                                                                class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                                data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id"
-                                                                src="/settings/replies?context=none" preload=""
-                                                                role="menu">
-                                                                <div class="select-menu-header d-flex">
-                                                                    <span class="select-menu-title flex-auto">Select a
-                                                                        reply</span>
-                                                                    <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                                </div>
-                                                                <include-fragment role="menuitem"
-                                                                    class="select-menu-loading-overlay anim-pulse"
-                                                                    aria-label="Loading">
-                                                                    <svg class="octicon octicon-octoface"
-                                                                        viewBox="0 0 16 16" version="1.1" width="16"
-                                                                        height="16" aria-hidden="true">
-                                                                        <path fill-rule="evenodd"
-                                                                            d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                                        </path>
-                                                                    </svg>
-                                                                </include-fragment>
-                                                            </details-menu>
-                                                        </details>
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="discussion_r329949662-minimize-comment-body_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
 
-                                                    </div>
+    </div>
 
-                                                </markdown-toolbar>
+  </markdown-toolbar>
 
-                                            </div>
+  </div>
 
 
-                                            <div class="clearfix"></div>
+    <div class="clearfix"></div>
 
-                                            <p class="comment-form-error comment-show-stale">
-                                                <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
-                                                    </path>
-                                                </svg> The content you are editing has changed. Please try again.
-                                            </p>
+    <p class="comment-form-error comment-show-stale">
+      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
+    </p>
 
 
-                                            <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
-                                                data-upload-policy-url="/upload/policies/assets"
-                                                data-upload-policy-authenticity-token="c39sWiKSX746/j91+3OIu0lHem7/ZfQm38h6vJZzKT/4XMdm9E5Wl+NK1dUv9t6bJFTGVB9eVOv4EBKb1o83pw=="
-                                                data-upload-repository-id="41288708">
-                                                <input type="hidden" name="context" value="discussion">
+  <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="9ftuMuX52FP02OSPJ9UvFzBjww0cUSmA7OI9okVrsQB+2MUOMyXRei1sDi/zUHk3XXB/N/xqiU3LOlWFBZevmA==" data-upload-repository-id="41288708">
+    <input type="hidden" name="context" value="discussion">
 
-                                                <input type="hidden" name="saved_reply_id"
-                                                    id="discussion_r329949662-minimize-comment-body_saved_reply_id"
-                                                    class="js-resettable-field" value="" data-reset-value="">
+      <input type="hidden" name="saved_reply_id" id="discussion_r329949662-minimize-comment-body_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
 
-                                                <input type="hidden" name="pull_request_review_comment[id]"
-                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                                <input type="hidden" name="pull_request_review_comment[bodyVersion]"
-                                                    class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+    <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+    <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
 
-                                                <text-expander keys=": @ #"
-                                                    data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                                    data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                                    data-emoji-url="/autocomplete/emoji">
+    <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
 
-                                                    <textarea name="pull_request_review_comment[body]"
-                                                        id="discussion_r329949662-minimize-comment-body"
-                                                        placeholder="Leave a comment" aria-label="Comment body"
-                                                        class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+      <textarea name="pull_request_review_comment[body]" id="discussion_r329949662-minimize-comment-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -610,387 +344,218 @@
   Pros:
   - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
-                                                </text-expander>
+    </text-expander>
 
 
-                                                <p
-                                                    class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                                    <input
-                                                        accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                                        type="file" multiple=""
-                                                        class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                                        aria-label="Attach files to your comment"
-                                                        id="fc-discussion_r329949662-minimize-comment-body">
-                                                    <span
-                                                        class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                                        style="pointer-events: none;"></span>
-                                                    <span class="position-relative pr-2" style="pointer-events: none;">
-                                                        <span class="default">
-                                                            Attach files by dragging &amp; dropping, selecting or
-                                                            pasting them.
-                                                        </span>
-                                                        <span class="loading">
-                                                            <img alt="" width="16" height="16"
-                                                                src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                            Uploading your files…
-                                                        </span>
-                                                        <span class="error bad-file">
-                                                            We don’t support that file type.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a
-                                                                GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                                or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error bad-permissions">
-                                                            Attaching documents requires write permission to this
-                                                            repository.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
-                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error repository-required">
-                                                            We don’t support that file type.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ,
-                                                                LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error too-big">
-                                                            Yowza, that’s a big file
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a file smaller than 10MB.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error empty">
-                                                            This file is empty.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with a file that’s not empty.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error hidden-file">
-                                                            This file is hidden.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again</button> with another file.
-                                                            </span>
-                                                        </span>
-                                                        <span class="error failed-request">
-                                                            Something went really wrong, and we can’t process that file.
-                                                            <span class="drag-and-drop-error-info">
-                                                                <button type="button"
-                                                                    class="btn-link manual-file-chooser-text">Try
-                                                                    again.</button>
-                                                            </span>
-                                                        </span>
-                                                    </span>
-                                                    <span class="tooltipped tooltipped-nw"
-                                                        aria-label="Styling with Markdown is supported">
-                                                        <a class="muted-link position-relative d-inline"
-                                                            href="https://guides.github.com/features/mastering-markdown/"
-                                                            target="_blank"
-                                                            data-ga-click="Markdown Toolbar, click, help"
-                                                            aria-label="Learn about styling with Markdown">
-                                                            <svg class="octicon octicon-markdown v-align-bottom"
-                                                                viewBox="0 0 16 16" version="1.1" width="16" height="16"
-                                                                aria-hidden="true">
-                                                                <path fill-rule="evenodd"
-                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                                </path>
-                                                            </svg>
-                                                        </a>
-                                                    </span>
-                                                </p>
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-discussion_r329949662-minimize-comment-body">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
 
-                                            </div>
+  </div>
 
 
-                                            <div class="preview-content">
-                                                <div class="comment js-suggested-changes-container"
-                                                    data-thread-side="right">
-                                                    <div class="comment-body markdown-body js-preview-body">
-                                                        <p>Nothing to preview</p>
-                                                    </div>
-                                                </div>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="right">
+    <div class="comment-body markdown-body js-preview-body">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
 
-                                            </div>
+    </div>
 
-                                            <div class="clearfix">
+    <div class="clearfix">
 
-                                                <input type="hidden" name="original-line"
-                                                    value="+export class TestResourceManager {"
-                                                    class="js-original-line">
-                                                <input type="hidden" name="path"
-                                                    value="web/src/regression/util/TestResourceManager.ts"
-                                                    class="js-path">
-                                                <input type="hidden" name="line" value="13" class="js-line-number">
-                                                <div class="form-actions comment-form-actions">
-                                                    <button class="btn btn-primary" type="submit"
-                                                        data-disable-with="">Update comment</button>
-                                                    <button class="btn btn-danger js-comment-cancel-button"
-                                                        type="button"
-                                                        data-confirm-text="Are you sure you want to discard your unsaved changes?">
-                                                        Cancel
-                                                    </button>
-                                                </div>
-                                            </div>
+      <input type="hidden" name="original-line" value="+export class TestResourceManager {" class="js-original-line">
+      <input type="hidden" name="path" value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+      <input type="hidden" name="line" value="13" class="js-line-number">
+      <div class="form-actions comment-form-actions">
+        <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
+        <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
+          Cancel
+        </button>
+      </div>
+    </div>
 
-                                            <div class="comment-form-error mb-2 js-comment-update-error" hidden="">
-                                            </div>
-                                        </div>
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
 
-                                    </form>
-                                </div>
-                            </div>
-                        </details>
+  </form>      </div>
+      </div>
+    </details>
 
 
-                    </div>
+      </div>
 
-                    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists"
-                        data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
-                        <div class="edit-comment-hide">
-                            <div class="timeline-comment-actions">
+    <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment current-user reorderable-task-lists" data-body-version="9458b92e7fc9c6c316cfa3edff2e9344" data-thread-side="right">
+      <div class="edit-comment-hide">
+        <div class="timeline-comment-actions">
 
-                                <details
-                                    class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button"
-                                    data-channel="reaction:pull-request-review-comment:329949662"
-                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
-                                    <summary class="btn-link link-gray timeline-comment-action"
-                                        aria-label="Add your reaction" aria-haspopup="menu" role="button">
-                                        <svg class="octicon octicon-plus-small add-reaction-plus-icon"
-                                            viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
-                                        </svg>
-                                        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16"
-                                            height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
-                                            </path>
-                                        </svg>
-                                    </summary>
+    <details class="details-overlay details-reset position-relative d-inline-block js-socket-channel js-updatable-content js-reaction-popover-container js-comment-header-reaction-button" data-channel="reaction:pull-request-review-comment:329949662" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_header_reaction_button">
+      <summary class="btn-link link-gray timeline-comment-action" aria-label="Add your reaction" aria-haspopup="menu" role="button">
+        <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
+        <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
+      </summary>
 
-                                    <details-menu
-                                        class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1"
-                                        aria-label="Pick your reaction" style="width: 150px" role="menu">
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="put"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="LdsTl6NIOtEBd/ab1GoZdv1VrKS0yKpxHnBP53k2c5z8yyDVg+FYEupJcLvna6I9Byon6gbnJuQELSYXp00inw==">
-                                            <p class="text-gray mx-2 my-1">
-                                                <span class="js-reaction-description">Pick your reaction</span>
-                                            </p>
+  <details-menu class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-sw mr-n1 mt-n1" aria-label="Pick your reaction" style="width: 150px" role="menu">
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="hhmoWZiGI2uiz7SNzftxhGanz3Y0A9xC3pIZ/VA73sFXCZsbuC9BqEnxMq3++srPnNhEOIYsUNfEz3ANjkCPwg==">
+      <p class="text-gray mx-2 my-1">
+        <span class="js-reaction-description">Pick your reaction</span>
+      </p>
 
-                                            <div role="none" class="dropdown-divider"></div>
+      <div role="none" class="dropdown-divider"></div>
 
-                                            <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
-                                                <input type="hidden" name="input[subjectId]"
-                                                    value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="+1" name="input[content]"
-                                                    aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-                                                    <g-emoji alias="+1"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                        class="emoji">👍</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="-1" name="input[content]"
-                                                    aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
-                                                    <g-emoji alias="-1"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
-                                                        class="emoji">👎</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Laugh" name="input[content]"
-                                                    aria-label="React with laugh emoji" value="LAUGH react">
-                                                    <g-emoji alias="smile"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
-                                                        class="emoji">😄</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Hooray" name="input[content]"
-                                                    aria-label="React with hooray emoji" value="HOORAY react">
-                                                    <g-emoji alias="tada"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
-                                                        class="emoji">🎉</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Confused" name="input[content]"
-                                                    aria-label="React with confused emoji" value="CONFUSED react">
-                                                    <g-emoji alias="thinking_face"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
-                                                        class="emoji">😕</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Heart" name="input[content]"
-                                                    aria-label="React with heart emoji" value="HEART react">
-                                                    <g-emoji alias="heart"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                        class="emoji">❤️</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Rocket" name="input[content]"
-                                                    aria-label="React with rocket emoji" value="ROCKET react">
-                                                    <g-emoji alias="rocket"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
-                                                        class="emoji">🚀</g-emoji>
-                                                </button>
-                                                <button type="submit" role="menuitem"
-                                                    class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                    data-reaction-label="Eyes" name="input[content]"
-                                                    aria-label="React with eyes emoji" value="EYES react">
-                                                    <g-emoji alias="eyes"
-                                                        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
-                                                        class="emoji">👀</g-emoji>
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </details-menu>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+            <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+            <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
+            <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
+            <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
+            <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
+            <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
+            <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
+            <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
+          </button>
+      </div>
+  </form></details-menu>
 
-                                </details>
+    </details>
 
-                                <details class="details-overlay details-reset position-relative d-inline-block"
-                                    id="details-discussion_r329949662">
-                                    <summary class="btn-link timeline-comment-action" aria-label="Show more options"
-                                        aria-haspopup="menu" role="button">
-                                        <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1"
-                                            width="13" height="16" aria-hidden="true">
-                                            <path fill-rule="evenodd"
-                                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z">
-                                            </path>
-                                        </svg>
-                                    </summary>
+          <details class="details-overlay details-reset position-relative d-inline-block" id="details-discussion_r329949662">
+            <summary class="btn-link timeline-comment-action" aria-label="Show more options" aria-haspopup="menu" role="button">
+              <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
+            </summary>
 
-                                    <details-menu
-                                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in"
-                                        style="width:185px; z-index: 99;" role="menu">
+            <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px; z-index: 99;" role="menu">
 
-                                        <clipboard-copy class="dropdown-item btn-link"
-                                            for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
-                                            Copy link
-                                        </clipboard-copy>
+              <clipboard-copy class="dropdown-item btn-link" for="discussion_r329949662-permalink" role="menuitem" tabindex="0">
+                Copy link
+              </clipboard-copy>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link d-none js-comment-quote-reply">
-                                            Quote reply
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link d-none js-comment-quote-reply">
+                Quote reply
+              </button>
 
 
-                                        <details
-                                            class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
-                                            <summary class="dropdown-item" role="menuitem">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark ">
+    <summary class="dropdown-item" role="menuitem">
 
-                                                Reference in new issue
-                                            </summary>
-                                            <details-dialog aria-label="Reference in new issue"
-                                                class="Box Box--overlay d-flex flex-column anim-fade-in fast "
-                                                role="dialog" aria-modal="true">
-                                                <div class="Box-header">
-                                                    <button class="Box-btn-octicon btn-octicon float-right"
-                                                        type="button" aria-label="Close dialog" data-close-dialog="">
-                                                        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1"
-                                                            width="12" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
-                                                            </path>
-                                                        </svg>
-                                                    </button>
-                                                    <h3 class="Box-title ">Reference in new issue</h3>
-                                                </div>
+      Reference in new issue
+    </summary>
+    <details-dialog aria-label="Reference in new issue" class="Box Box--overlay d-flex flex-column anim-fade-in fast " role="dialog" aria-modal="true">
+      <div class="Box-header">
+        <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog="">
+          <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+        </button>
+        <h3 class="Box-title ">Reference in new issue</h3>
+      </div>
 
-                                                <div class="Box-body scrollable-overlay">
+                  <div class="Box-body scrollable-overlay">
 
-                                                    <!-- '"` -->
-                                                    <!-- </textarea></xmp> -->
-                                                    <form action="/comments/issues" accept-charset="UTF-8"
-                                                        method="post"><input name="utf8" type="hidden" value="✓"><input
-                                                            type="hidden" name="authenticity_token"
-                                                            value="iz2CkSdB+3+JmIY54QjQgEqR67huXC0FIvTHS6c/LUN2d56LfKmp9EThXG1tv/IhNNKE0tueOk/KXgY/uPSGNA==">
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label>
-                                                            </dt>
-                                                            <dd>
-                                                                <details
-                                                                    class="details-reset details-overlay select-menu">
-                                                                    <summary class="btn select-menu-button"
-                                                                        data-menu-button="" aria-haspopup="menu"
-                                                                        role="button">
-                                                                        <input type="hidden" name="issue[repository_id]"
-                                                                            value="41288708" checked="">
-                                                                        sourcegraph
-                                                                    </summary>
-                                                                    <details-menu
-                                                                        class="select-menu-modal position-absolute"
-                                                                        style="z-index: 99;"
-                                                                        src="/sourcegraph/sourcegraph/related_repositories"
-                                                                        preload="" role="menu">
-                                                                        <div class="select-menu-header">
-                                                                            <span
-                                                                                class="select-menu-title">Repositories</span>
-                                                                        </div>
-                                                                        <div class="select-menu-filters">
-                                                                            <div class="select-menu-text-filter">
-                                                                                <remote-input
-                                                                                    src="/sourcegraph/sourcegraph/related_repositories"
-                                                                                    aria-owns="related-repositories-menu">
-                                                                                    <input type="text"
-                                                                                        class="form-control"
-                                                                                        aria-label="Type to filter"
-                                                                                        placeholder="Find a repository"
-                                                                                        autofocus="" autocomplete="off"
-                                                                                        spellcheck="false">
-                                                                                </remote-input>
-                                                                            </div>
-                                                                        </div>
-                                                                        <include-fragment class="octocat-spinner my-6"
-                                                                            aria-label="Loading"></include-fragment>
-                                                                    </details-menu>
-                                                                </details>
-                                                            </dd>
-                                                        </dl>
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label>
-                                                            </dt>
-                                                            <dd><input
-                                                                    id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                                                                    class="form-control" type="text" name="issue[title]"
-                                                                    value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :"
-                                                                    aria-label="Issue title" autofocus="" required="">
-                                                            </dd>
-                                                        </dl>
-                                                        <dl class="form-group">
-                                                            <dt><label
-                                                                    for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label>
-                                                            </dt>
-                                                            <dd><textarea
-                                                                    id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg=="
-                                                                    name="issue[body]" class="form-control"
-                                                                    aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+  <!-- '"` --><!-- </textarea></xmp> --><form action="/comments/issues" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="qEP/Wzbp0m2fpm8+mYli6gY5VuWfM85ICyB9lRypjWBVCeNBbQGA5lLftWoVPkBLeHo5jyrx2QLjirzhA2ImFw==">
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-repository-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Repository</label></dt>
+      <dd>
+        <details class="details-reset details-overlay select-menu">
+          <summary class="btn select-menu-button" data-menu-button="" aria-haspopup="menu" role="button">
+            <input type="hidden" name="issue[repository_id]" value="41288708" checked="">
+            sourcegraph
+          </summary>
+          <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/related_repositories" preload="" role="menu">
+            <div class="select-menu-header">
+              <span class="select-menu-title">Repositories</span>
+            </div>
+            <div class="select-menu-filters">
+              <div class="select-menu-text-filter">
+                <remote-input src="/sourcegraph/sourcegraph/related_repositories" aria-owns="related-repositories-menu">
+                  <input type="text" class="form-control" aria-label="Type to filter" placeholder="Find a repository" autofocus="" autocomplete="off" spellcheck="false">
+                </remote-input>
+              </div>
+            </div>
+            <include-fragment class="octocat-spinner my-6" aria-label="Loading"></include-fragment>
+          </details-menu>
+        </details>
+      </dd>
+    </dl>
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Title</label></dt>
+      <dd><input id="convert-to-issue-title-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" class="form-control" type="text" name="issue[title]" value="Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :" aria-label="Issue title" autofocus="" required=""></dd>
+    </dl>
+    <dl class="form-group">
+      <dt><label for="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">Body</label></dt>
+      <dd><textarea id="convert-to-issue-body-MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==" name="issue[body]" class="form-control" aria-label="Issue body">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -1025,182 +590,119 @@
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.
 
   _Originally posted by @lguychard in https://github.com/sourcegraph/sourcegraph/pull/5746_</textarea></dd>
-                                                        </dl>
+    </dl>
 
-                                                        <div class="d-flex d-sm-block">
-                                                            <button type="submit" class="btn btn-primary"
-                                                                data-disable-with="Creating issue..."
-                                                                data-disable-invalid=""
-                                                                data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
-                                                                Create issue
-                                                            </button>
-                                                        </div>
-                                                    </form>
-                                                </div>
+    <div class="d-flex d-sm-block">
+      <button type="submit" class="btn btn-primary" data-disable-with="Creating issue..." data-disable-invalid="" data-ga-click="Issues, create new issue, location:comment_menu logged_in:true">
+        Create issue
+      </button>
+    </div>
+  </form>
+                  </div>
 
-                                            </details-dialog>
-                                        </details>
+    </details-dialog>
+  </details>
 
-                                        <div role="none" class="dropdown-divider"></div>
+                <div role="none" class="dropdown-divider"></div>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link js-comment-edit-button"
-                                            aria-label="Edit comment">
-                                            Edit
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-edit-button" aria-label="Edit comment">
+                Edit
+              </button>
 
-                                        <button type="button" role="menuitem"
-                                            class="dropdown-item btn-link js-comment-hide-button"
-                                            aria-label="Hide comment">
-                                            Hide
-                                        </button>
+              <button type="button" role="menuitem" class="dropdown-item btn-link js-comment-hide-button" aria-label="Hide comment">
+                Hide
+              </button>
 
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="width-full inline-form js-comment-delete"
-                                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="delete"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="jDxvGtG7Cc0Zead/6ACEos1N034oJRLhZaWqeZGZ+4C1yRek+vX/yyR467Kgrl8PzvTI0rrKrhoJ+lMxoK/IBw==">
-                                            <input type="hidden" name="input[id]"
-                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                            <button type="submit" role="menuitem"
-                                                class="dropdown-item menu-item-danger btn-link"
-                                                aria-label="Delete comment"
-                                                data-confirm="Are you sure you want to delete this?">
-                                                Delete
-                                            </button>
-                                        </form>
+              <!-- '"` --><!-- </textarea></xmp> --><form class="width-full inline-form js-comment-delete" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="delete"><input type="hidden" name="authenticity_token" value="WrxdM8i0U7nlke4xhOdUanTbgFkPAzDbkXP3YhYUR2hjSSWN4/qlv9iQovzMSY/Hd2Kb9Z3sjCD9LA4qJyJ07w==">
+                <input type="hidden" name="input[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+                <button type="submit" role="menuitem" class="dropdown-item menu-item-danger btn-link" aria-label="Delete comment" data-confirm="Are you sure you want to delete this?">
+                  Delete
+                </button>
+  </form>
 
 
-                                    </details-menu>
-                                </details>
-                            </div>
+            </details-menu>
+          </details>
+        </div>
 
-                            <span class="float-left mt-1">
-                                <a class="d-inline-block" data-hovercard-type="user"
-                                    data-hovercard-url="/hovercards?user_id=1741180"
-                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                    href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard"
-                                        src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
-                            </span>
+        <span class="float-left mt-1">
+          <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" height="28" width="28" alt="@lguychard" src="https://avatars0.githubusercontent.com/u/1741180?s=60&amp;v=4"></a>
+        </span>
 
-                            <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
-                                <h4 class="f5 text-normal d-inline">
-                                    <strong>
+        <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
+          <h4 class="f5 text-normal d-inline">
+            <strong>
 
 
-                                        <a class="author link-gray-dark css-truncate-target" show_full_name="false"
-                                            data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180"
-                                            data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                            href="/lguychard">lguychard</a>
+    <a class="author link-gray-dark css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard">lguychard</a>
 
 
-                                    </strong>
-                                    <span class="text-gray">
+            </strong>
+            <span class="text-gray">
 
-                                        <a href="#discussion_r329949662" id="discussion_r329949662-permalink"
-                                            class="js-timestamp timestamp d-inline-block">
-                                            <relative-time datetime="2019-10-01T09:03:30Z"
-                                                title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
-                                        </a>
+                <a href="#discussion_r329949662" id="discussion_r329949662-permalink" class="js-timestamp timestamp d-inline-block">
+                  <relative-time datetime="2019-10-01T09:03:30Z" title="Oct 1, 2019, 11:03 AM GMT+2">yesterday</relative-time>
+                </a>
 
 
-                                        <span class="d-inline-block text-gray-light">•</span>
+    <span class="d-inline-block text-gray-light">•</span>
 
-                                        <details class="details-overlay details-reset d-inline-block dropdown">
-                                            <summary class="btn-link no-underline text-gray js-notice"
-                                                aria-haspopup="menu" role="button">
-                                                <div class="position-relative">
-                                                    <span>
-                                                        edited
-                                                    </span>
-                                                    <svg height="11"
-                                                        class="octicon octicon-triangle-down v-align-middle"
-                                                        viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true">
-                                                        <path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path>
-                                                    </svg>
-                                                </div>
-                                            </summary>
-                                            <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0"
-                                                style="width:352px"
-                                                src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log"
-                                                preload="" role="menu">
-                                                <include-fragment class="octocat-spinner my-3" aria-label="Loading">
-                                                </include-fragment>
-                                            </details-menu>
-                                        </details>
+    <details class="details-overlay details-reset d-inline-block dropdown">
+      <summary class="btn-link no-underline text-gray js-notice" aria-haspopup="menu" role="button">
+        <div class="position-relative">
+          <span>
+              edited
+          </span>
+          <svg height="11" class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"></path></svg>
+        </div>
+      </summary>
+      <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px" src="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/comment_edit_history_log" preload="" role="menu">
+        <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
+      </details-menu>
+    </details>
 
-                                    </span>
-                                </h4>
+            </span>
+          </h4>
 
 
 
-                                <span
-                                    class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s"
-                                    aria-label="You are a member of the Sourcegraph organization.">
-                                    Member
-                                </span>
+      <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="You are a member of the Sourcegraph organization.">
+        Member
+      </span>
 
 
-                                <div class="js-minimize-comment d-none">
+            <div class="js-minimize-comment d-none">
 
 
-                                    <div class="flash flash-warn my-2">
-                                        <button class="flash-close js-comment-hide-minimize-form" type="button"><svg
-                                                aria-label="Cancel hiding comment" class="octicon octicon-x"
-                                                viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img">
-                                                <path fill-rule="evenodd"
-                                                    d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z">
-                                                </path>
-                                            </svg></button>
-                                        <h3 class="f5">Choose a reason for hiding this comment</h3>
-                                        <p class="mb-3">The reason will be displayed to describe this comment to others.
-                                            <a
-                                                href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn
-                                                more</a>.</p>
-                                        <!-- '"` -->
-                                        <!-- </textarea></xmp> -->
-                                        <form class="js-comment-minimize"
-                                            action="/sourcegraph/sourcegraph/community/minimize-comment"
-                                            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                value="✓"><input type="hidden" name="_method" value="put"><input
-                                                type="hidden" name="authenticity_token"
-                                                value="bSeFf29CzKjsdk5Lg+Ha5++oCU34xuAvD8FHpAS1EK/qLwQctHz2/grGYENB3xDZ0xajT57FhTAjGwkP5GeBYQ==">
-                                            <input type="hidden" name="comment_id"
-                                                value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                            <select name="classifier" class="form-select mr-2" aria-label="Reason"
-                                                required="">
-                                                <option value="">
-                                                    Choose a reason
-                                                </option>
-                                                <option value="SPAM">Spam</option>
-                                                <option value="ABUSE">Abuse</option>
-                                                <option value="OFF_TOPIC">Off Topic</option>
-                                                <option value="OUTDATED">Outdated</option>
-                                                <option value="RESOLVED">Resolved</option>
-                                            </select>
-                                            <button type="submit" class="btn">
-                                                Hide comment
-                                            </button>
-                                        </form>
-                                    </div>
+  <div class="flash flash-warn my-2">
+    <button class="flash-close js-comment-hide-minimize-form" type="button"><svg aria-label="Cancel hiding comment" class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+    <h3 class="f5">Choose a reason for hiding this comment</h3>
+    <p class="mb-3">The reason will be displayed to describe this comment to others. <a href="https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment">Learn more</a>.</p>
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-comment-minimize" action="/sourcegraph/sourcegraph/community/minimize-comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="dqb3Msb4HsySOW0kuEairM1pwEYikBkRqRYxArvx6A/xrnZRHcYkmnSJQyx6eGiS8ddqRESTfA6FzH+pWyN5wQ==">
+      <input type="hidden" name="comment_id" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <select name="classifier" class="form-select mr-2" aria-label="Reason" required="">
+        <option value="">
+        Choose a reason
+        </option>
+        <option value="SPAM">Spam</option>
+  <option value="ABUSE">Abuse</option>
+  <option value="OFF_TOPIC">Off Topic</option>
+  <option value="OUTDATED">Outdated</option>
+  <option value="RESOLVED">Resolved</option>
+      </select>
+      <button type="submit" class="btn">
+        Hide comment
+      </button>
+  </form></div>
 
-                                </div>
+            </div>
 
 
 
-                                <task-lists sortable="">
-                                    <div class="comment-body markdown-body  js-comment-body">
-                                        <p>Rather than introducing a new class/concept to the codebase, I would consider
-                                            reusing <a
-                                                href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts"
-                                                rel="nofollow"><code>Disposable</code></a> (an
-                                            <code>Unsubscribable</code> supporting async resource disposal) pattern from
-                                            sourcegraph-typescript (<a href="">example usage</a>) :</p>
-                                        <div class="highlight highlight-source-ts">
-                                            <pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
+          <task-lists sortable="">
+            <div class="comment-body markdown-body  js-comment-body">
+              <p>Rather than introducing a new class/concept to the codebase, I would consider reusing <a href="https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts" rel="nofollow"><code>Disposable</code></a> (an <code>Unsubscribable</code> supporting async resource disposal) pattern from sourcegraph-typescript (<a href="">example usage</a>) :</p>
+  <div class="highlight highlight-source-ts"><pre><span class="pl-c"><span class="pl-c">//</span> Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.</span>
   <span class="pl-k">export</span> <span class="pl-k">async</span> <span class="pl-k">function</span> ensureLoggedInOrCreateTestUser(...)<span class="pl-k">:</span> <span class="pl-en">Promise</span>&lt;<span class="pl-en">AsyncDisposable</span>&gt; {
       <span class="pl-c1">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">`</span>Creating test user "${<span class="pl-smi">name</span>}"<span class="pl-pds">`</span></span>)
       <span class="pl-k">return</span> {
@@ -1224,418 +726,189 @@
               <span class="pl-k">await</span> <span class="pl-en">ensureLoggedInOrCreateTestUser</span>({<span class="pl-k">...</span>})
           )
       })
-  })</pre>
-                                        </div>
-                                        <p>Pros:</p>
-                                        <ul>
-                                            <li>Developers working in our codebase are already familiar with the
-                                                subscription / subscription bag pattern (and, if they're not, it is <a
-                                                    href="https://docs.sourcegraph.com/dev/typescript/patterns#bag"
-                                                    rel="nofollow">documented</a>).</li>
-                                            <li>The cleanup logic is encapsulated, and lives next to the resource
-                                                creation logic. It is not duplicated if
-                                                <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple
-                                                test suites. Callers need not look up how a given resource should be
-                                                cleaned up, they simply need to handle the returned disposable /
-                                                subscription.</li>
-                                        </ul>
-                                    </div>
-                                </task-lists>
+  })</pre></div>
+  <p>Pros:</p>
+  <ul>
+  <li>Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is <a href="https://docs.sourcegraph.com/dev/typescript/patterns#bag" rel="nofollow">documented</a>).</li>
+  <li>The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if <code>ensureLoggedInOrCreateTestUser()</code> is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</li>
+  </ul>
+            </div>
+          </task-lists>
 
 
 
 
-                                <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content"
-                                    data-channel="reaction:pull-request-review-comment:329949662"
-                                    data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
-                                    <!-- '"` -->
-                                    <!-- </textarea></xmp> -->
-                                    <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                        accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                            value="✓"><input type="hidden" name="_method" value="put"><input
-                                            type="hidden" name="authenticity_token"
-                                            value="CUVRWocqAFJIQmYkZreCwFioAAZC/gRC7oNq6NjqpmTYVWIYp4NikaN84ARVtjmLoteLSPDRiNf03gMYBpH3Zw==">
-                                        <input type="hidden" name="input[subjectId]"
-                                            value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+  <div class="comment-reactions has-reactions js-reactions-container js-socket-channel js-updatable-content" data-channel="reaction:pull-request-review-comment:329949662" data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==/comments/reactions">
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Wz2la597d0KRF2MC7Fcr0EL6vPu0EUx3R7Pzw1i++yuKLZYpv9IVgXop5SLfVpCbuIU3tQY+wOJd7pozhsWqKA==">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                        <div class="comment-reactions-options">
-                                            <button
-                                                class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline "
-                                                name="input[content]" type="submit" value="THUMBS_UP react"
-                                                aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
-                                                <g-emoji alias="+1"
-                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                    class="emoji mr-1">👍</g-emoji>
-                                                2
-                                            </button>
-                                            <button
-                                                class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline "
-                                                name="input[content]" type="submit" value="HEART react"
-                                                aria-label="unknwon reacted with heart emoji">
-                                                <g-emoji alias="heart"
-                                                    fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                    class="emoji mr-1">❤️</g-emoji>
-                                                1
-                                            </button>
-                                        </div>
-                                    </form>
-                                    <details
-                                        class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
-                                        <summary class="btn-link reaction-summary-item add-reaction-btn"
-                                            aria-label="Add your reaction" aria-haspopup="menu" role="button">
-                                            <svg class="octicon octicon-plus-small add-reaction-plus-icon"
-                                                viewBox="0 0 7 16" version="1.1" width="7" height="16"
-                                                aria-hidden="true">
-                                                <path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path>
-                                            </svg>
-                                            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1"
-                                                width="16" height="16" aria-hidden="true">
-                                                <path fill-rule="evenodd"
-                                                    d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z">
-                                                </path>
-                                            </svg>
-                                        </summary>
+        <div class="comment-reactions-options">
+            <button class="btn-link reaction-summary-item tooltipped tooltipped-se tooltipped-multiline " name="input[content]" type="submit" value="THUMBS_UP react" aria-label="felixfbecker and unknwon reacted with thumbs up emoji">
+              <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji mr-1">👍</g-emoji>
+              2
+            </button>
+            <button class="btn-link reaction-summary-item tooltipped tooltipped-s tooltipped-multiline " name="input[content]" type="submit" value="HEART react" aria-label="unknwon reacted with heart emoji">
+              <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji mr-1">❤️</g-emoji>
+              1
+            </button>
+        </div>
+  </form>      <details class="details-overlay details-reset position-relative float-left d-inline-block reaction-popover-container js-reaction-popover-container">
+          <summary class="btn-link reaction-summary-item add-reaction-btn" aria-label="Add your reaction" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-plus-small add-reaction-plus-icon" viewBox="0 0 7 16" version="1.1" width="7" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 4H3v3H0v1h3v3h1V8h3V7H4V4z"></path></svg>
+            <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"></path></svg>
+          </summary>
 
-                                        <details-menu
-                                            class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0"
-                                            aria-label="Pick your reaction" style="width: 150px" role="menu">
-                                            <!-- '"` -->
-                                            <!-- </textarea></xmp> -->
-                                            <form class="js-pick-reaction" action="/users/sourcegraph/reactions"
-                                                accept-charset="UTF-8" method="post"><input name="utf8" type="hidden"
-                                                    value="✓"><input type="hidden" name="_method" value="put"><input
-                                                    type="hidden" name="authenticity_token"
-                                                    value="OK2OMjjZHKKfDf1Bd0I+seoboBLTu6672H5KK+lWOjfpvb1wGHB+YXQze2FEQ4X6EGQrXGGUIi7CIyPbNy1rNA==">
-                                                <p class="text-gray mx-2 my-1">
-                                                    <span class="js-reaction-description">Pick your reaction</span>
-                                                </p>
+  <details-menu class="js-add-reaction-popover anim-scale-in dropdown-menu dropdown-menu-ne ml-2 mb-0" aria-label="Pick your reaction" style="width: 150px" role="menu">
+    <!-- '"` --><!-- </textarea></xmp> --><form class="js-pick-reaction" action="/users/sourcegraph/reactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="pZCU1gly1w0Bi9vtjv64HhvFmhXqlg2MXGs8/Mj6ijR0gKeUKdu1zuq1Xc29/wNV4boRW1i5gRlGNlUMFoHbNw==">
+      <p class="text-gray mx-2 my-1">
+        <span class="js-reaction-description">Pick your reaction</span>
+      </p>
 
-                                                <div role="none" class="dropdown-divider"></div>
+      <div role="none" class="dropdown-divider"></div>
 
-                                                <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
-                                                    <input type="hidden" name="input[subjectId]"
-                                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+      <div class="clearfix d-flex flex-wrap m-1 ml-2 mt-0">
+        <input type="hidden" name="input[subjectId]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
 
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="+1" name="input[content]"
-                                                        aria-label="React with thumbs up emoji" value="THUMBS_UP react">
-                                                        <g-emoji alias="+1"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png"
-                                                            class="emoji">👍</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="-1" name="input[content]"
-                                                        aria-label="React with thumbs down emoji"
-                                                        value="THUMBS_DOWN react">
-                                                        <g-emoji alias="-1"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png"
-                                                            class="emoji">👎</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Laugh" name="input[content]"
-                                                        aria-label="React with laugh emoji" value="LAUGH react">
-                                                        <g-emoji alias="smile"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png"
-                                                            class="emoji">😄</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Hooray" name="input[content]"
-                                                        aria-label="React with hooray emoji" value="HOORAY react">
-                                                        <g-emoji alias="tada"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"
-                                                            class="emoji">🎉</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Confused" name="input[content]"
-                                                        aria-label="React with confused emoji" value="CONFUSED react">
-                                                        <g-emoji alias="thinking_face"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png"
-                                                            class="emoji">😕</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Heart" name="input[content]"
-                                                        aria-label="React with heart emoji" value="HEART react">
-                                                        <g-emoji alias="heart"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"
-                                                            class="emoji">❤️</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Rocket" name="input[content]"
-                                                        aria-label="React with rocket emoji" value="ROCKET react">
-                                                        <g-emoji alias="rocket"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png"
-                                                            class="emoji">🚀</g-emoji>
-                                                    </button>
-                                                    <button type="submit" role="menuitem"
-                                                        class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item"
-                                                        data-reaction-label="Eyes" name="input[content]"
-                                                        aria-label="React with eyes emoji" value="EYES react">
-                                                        <g-emoji alias="eyes"
-                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png"
-                                                            class="emoji">👀</g-emoji>
-                                                    </button>
-                                                </div>
-                                            </form>
-                                        </details-menu>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="+1" name="input[content]" aria-label="React with thumbs up emoji" value="THUMBS_UP react">
+            <g-emoji alias="+1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji">👍</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="-1" name="input[content]" aria-label="React with thumbs down emoji" value="THUMBS_DOWN react">
+            <g-emoji alias="-1" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png" class="emoji">👎</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Laugh" name="input[content]" aria-label="React with laugh emoji" value="LAUGH react">
+            <g-emoji alias="smile" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" class="emoji">😄</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Hooray" name="input[content]" aria-label="React with hooray emoji" value="HOORAY react">
+            <g-emoji alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png" class="emoji">🎉</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Confused" name="input[content]" aria-label="React with confused emoji" value="CONFUSED react">
+            <g-emoji alias="thinking_face" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f615.png" class="emoji">😕</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Heart" name="input[content]" aria-label="React with heart emoji" value="HEART react">
+            <g-emoji alias="heart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png" class="emoji">❤️</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Rocket" name="input[content]" aria-label="React with rocket emoji" value="ROCKET react">
+            <g-emoji alias="rocket" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f680.png" class="emoji">🚀</g-emoji>
+          </button>
+          <button type="submit" role="menuitem" class="btn-link col-3 flex-content-center flex-items-center no-underline add-reactions-options-item js-reaction-option-item" data-reaction-label="Eyes" name="input[content]" aria-label="React with eyes emoji" value="EYES react">
+            <g-emoji alias="eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f440.png" class="emoji">👀</g-emoji>
+          </button>
+      </div>
+  </form></details-menu>
 
-                                    </details>
-                                </div>
+        </details>
+  </div>
 
-                            </div>
-                        </div>
+        </div>
+      </div>
 
-                        <!-- '"` -->
-                        <!-- </textarea></xmp> -->
-                        <form data-upload-policy-url="/upload/policies/assets"
-                            data-upload-policy-authenticity-token="dxb4uXAi57XbrnCGZm7+A6giq1BBMGpJCdmny4jJyV78NVOFpv7unAIamiay66gjxTEXaqELyoQuAc/syDXXxg=="
-                            class="js-comment-update" data-type="json"
-                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8"
-                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method"
-                                value="put"><input type="hidden" name="authenticity_token"
-                                value="4orOHiRkekLnBK8GqJaefBoqDlmaBIUoTmbp6quk8lhAKICO4VfuV7ztqvdx0vzIIxCheVbdPFD6NI0SgHdTXQ==">
-                            <div class="js-previewable-comment-form previewable-comment-form write-selected"
-                                data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708"
-                                data-preview-authenticity-token="agWuefVqqFretZzOMoXn2r/wUJnwPhNpbAhPH9nao8OW+l+VmScKYU2etOK/dIjsBV810V1jnN3lYrLltwlVmg==">
+        <!-- '"` --><!-- </textarea></xmp> --><form data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="q3oy+5KLqjmGVsELMqY7wSRneHNk0LfOv62/zOUEV00gWZnHRFejEF/iK6vmI23hSXTESYTrFwOYddfrpfhJ1Q==" class="js-comment-update" data-type="json" action="/sourcegraph/sourcegraph/pull/5746/review_comment/329949662" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="ICS0tpub0sWCCNJTO0vtdYHGj6i25f/xNvULv9JMHheChvomXqhG0Nnh16LiD4/BuPwgiHo8RomCp29H+Z+/Eg==">
+          <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708" data-preview-authenticity-token="EW/Xt0keiKP1WiYjHu938v1O+3sBf4L6zGvkTsgWWvftkCZbJVMqmGZxDg+THhjER+GeM6wiDU5FARm0psWsrg==">
 
-                                <div class="comment-form-head tabnav ">
-                                    <nav class="tabnav-tabs" role="tablist">
-                                        <button type="button"
-                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
-                                            aria-selected="true">Write</button>
-                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                            role="tab">Preview</button>
-                                    </nav>
+  <div class="comment-form-head tabnav ">
+    <nav class="tabnav-tabs" role="tablist">
+      <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+      <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+    </nav>
 
 
-                                    <markdown-toolbar for="discussion_r329949662-body"
-                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+  <markdown-toolbar for="discussion_r329949662-body" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
 
 
-                                        <div class="flex-nowrap d-inline-block mr-3">
-                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add header text"
-                                                data-ga-click="Markdown Toolbar, click, header" role="button">
-                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
-                                                    width="18" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-header>
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
 
-                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add bold text <cmd-b>"
-                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-bold>
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
 
-                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add italic text <cmd-i>"
-                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
-                                                hotkey="i">
-                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
-                                                    width="6" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                    </path>
-                                                </svg>
-                                            </md-italic>
-                                        </div>
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
 
-                                        <div class="d-inline-block mr-3">
-                                            <md-quote tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert a quote"
-                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
-                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-quote>
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
 
-                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
-                                                role="button">
-                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                    </path>
-                                                </svg>
-                                            </md-code>
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
 
 
-                                            <md-link tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                aria-label="Add a link <cmd-k>"
-                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                    </path>
-                                                </svg>
-                                            </md-link>
-                                        </div>
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
 
-                                        <div class="d-inline-block mr-3">
-                                            <md-unordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a bulleted list"
-                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-unordered-list>
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
 
-                                            <md-ordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a numbered list"
-                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ordered-list>
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
 
-                                            <md-task-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a task list"
-                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
-                                                hotkey="L">
-                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                    </path>
-                                                </svg>
-                                            </md-task-list>
-                                        </div>
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
 
-                                        <div class="d-inline-block">
-                                            <md-mention tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Directly mention a user or team"
-                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
-                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                    </path>
-                                                </svg>
-                                            </md-mention>
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
 
 
-                                            <md-ref tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Reference an issue or pull request"
-                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
-                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ref>
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref>
 
-                                            <details
-                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                tabindex="-1">
-                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
-                                                    aria-label="Insert a reply"
-                                                    data-ga-click="Markdown Toolbar, click, saved reply"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
-                                                        width="14" height="16" aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                        </path>
-                                                    </svg>
-                                                    <span class="dropdown-caret "></span>
-                                                </summary>
-                                                <details-menu style="z-index: 99;"
-                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                    data-menu-input="discussion_r329949662-body_saved_reply_id"
-                                                    src="/settings/replies?context=none" preload="" role="menu">
-                                                    <div class="select-menu-header d-flex">
-                                                        <span class="select-menu-title flex-auto">Select a reply</span>
-                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                    </div>
-                                                    <include-fragment role="menuitem"
-                                                        class="select-menu-loading-overlay anim-pulse"
-                                                        aria-label="Loading">
-                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
-                                                            version="1.1" width="16" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                            </path>
-                                                        </svg>
-                                                    </include-fragment>
-                                                </details-menu>
-                                            </details>
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="discussion_r329949662-body_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
 
-                                        </div>
+    </div>
 
-                                    </markdown-toolbar>
+  </markdown-toolbar>
 
-                                </div>
+  </div>
 
 
-                                <div class="clearfix"></div>
+    <div class="clearfix"></div>
 
-                                <p class="comment-form-error comment-show-stale">
-                                    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16"
-                                        height="16" aria-hidden="true">
-                                        <path fill-rule="evenodd"
-                                            d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z">
-                                        </path>
-                                    </svg> The content you are editing has changed. Please try again.
-                                </p>
+    <p class="comment-form-error comment-show-stale">
+      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg> The content you are editing has changed. Please try again.
+    </p>
 
 
-                                <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled"
-                                    data-upload-policy-url="/upload/policies/assets"
-                                    data-upload-policy-authenticity-token="QadU3Ls0/FkC2p0kRPo0MEnu8FQSdaJUwbqWjhVp14vKhP/gbej1cNtud4SQf2IQJP1MbvJOApnmYv6pVZXJEw=="
-                                    data-upload-repository-id="41288708">
-                                    <input type="hidden" name="context" value="discussion">
+  <div class="write-content js-write-bucket js-uploadable-container js-upload-markdown-image is-default upload-enabled" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="u72p7M1lZHQTrKb2qJGGRYWjs6YeNKX/NBUgFI1gw8QwngLQG7ltXcoYTFZ8FNBl6LAPnP4PBTITzUgzzZzdXA==" data-upload-repository-id="41288708">
+    <input type="hidden" name="context" value="discussion">
 
-                                    <input type="hidden" name="saved_reply_id"
-                                        id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field"
-                                        value="" data-reset-value="">
+      <input type="hidden" name="saved_reply_id" id="discussion_r329949662-body_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
 
-                                    <input type="hidden" name="pull_request_review_comment[id]"
-                                        value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
-                                    <input type="hidden" name="pull_request_review_comment[bodyVersion]"
-                                        class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
+    <input type="hidden" name="pull_request_review_comment[id]" value="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDMyOTk0OTY2Mg==">
+    <input type="hidden" name="pull_request_review_comment[bodyVersion]" class="js-body-version" value="9458b92e7fc9c6c316cfa3edff2e9344">
 
-                                    <text-expander keys=": @ #"
-                                        data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                        data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                        data-emoji-url="/autocomplete/emoji">
+    <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
 
-                                        <textarea name="pull_request_review_comment[body]"
-                                            id="discussion_r329949662-body" placeholder="Leave a comment"
-                                            aria-label="Comment body"
-                                            class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
+      <textarea name="pull_request_review_comment[body]" id="discussion_r329949662-body" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable js-saved-reply-shortcut-comment-field">Rather than introducing a new class/concept to the codebase, I would consider reusing [`Disposable`](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph-typescript@master/-/blob/server/src/disposable.ts) (an `Unsubscribable` supporting async resource disposal) pattern from sourcegraph-typescript ([example usage]()) :
 
   ```typescript
   // Return `Promise&lt;AsyncDisposable&gt;` instead of `Promise&lt;void&gt;`.
@@ -1668,552 +941,325 @@
   Pros:
   - Developers working in our codebase are already familiar with the subscription / subscription bag pattern (and, if they're not, it is [documented](https://docs.sourcegraph.com/dev/typescript/patterns#bag)).
   - The cleanup logic is encapsulated, and lives next to the resource creation logic. It is not duplicated if `ensureLoggedInOrCreateTestUser()` is called from multiple test suites. Callers need not look up how a given resource should be cleaned up, they simply need to handle the returned disposable / subscription.</textarea>
-                                    </text-expander>
+    </text-expander>
 
 
-                                    <p
-                                        class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                        <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                            type="file" multiple=""
-                                            class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                            aria-label="Attach files to your comment"
-                                            id="fc-discussion_r329949662-body">
-                                        <span
-                                            class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                            style="pointer-events: none;"></span>
-                                        <span class="position-relative pr-2" style="pointer-events: none;">
-                                            <span class="default">
-                                                Attach files by dragging &amp; dropping, selecting or pasting them.
-                                            </span>
-                                            <span class="loading">
-                                                <img alt="" width="16" height="16"
-                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                Uploading your files…
-                                            </span>
-                                            <span class="error bad-file">
-                                                We don’t support that file type.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a
-                                                    GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error bad-permissions">
-                                                Attaching documents requires write permission to this repository.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
-                                                    PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error repository-required">
-                                                We don’t support that file type.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,
-                                                    PPTX, TXT, XLSX or ZIP.
-                                                </span>
-                                            </span>
-                                            <span class="error too-big">
-                                                Yowza, that’s a big file
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a file smaller than 10MB.
-                                                </span>
-                                            </span>
-                                            <span class="error empty">
-                                                This file is empty.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with a file that’s not empty.
-                                                </span>
-                                            </span>
-                                            <span class="error hidden-file">
-                                                This file is hidden.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again</button> with another file.
-                                                </span>
-                                            </span>
-                                            <span class="error failed-request">
-                                                Something went really wrong, and we can’t process that file.
-                                                <span class="drag-and-drop-error-info">
-                                                    <button type="button" class="btn-link manual-file-chooser-text">Try
-                                                        again.</button>
-                                                </span>
-                                            </span>
-                                        </span>
-                                        <span class="tooltipped tooltipped-nw"
-                                            aria-label="Styling with Markdown is supported">
-                                            <a class="muted-link position-relative d-inline"
-                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                target="_blank" data-ga-click="Markdown Toolbar, click, help"
-                                                aria-label="Learn about styling with Markdown">
-                                                <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16"
-                                                    version="1.1" width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                    </path>
-                                                </svg>
-                                            </a>
-                                        </span>
-                                    </p>
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-discussion_r329949662-body">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
 
-                                </div>
+  </div>
 
 
-                                <div class="preview-content">
-                                    <div class="comment js-suggested-changes-container" data-thread-side="right">
-                                        <div class="comment-body markdown-body js-preview-body">
-                                            <p>Nothing to preview</p>
-                                        </div>
-                                    </div>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="right">
+    <div class="comment-body markdown-body js-preview-body">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
 
-                                </div>
-
-                                <div class="clearfix">
-
-                                    <input type="hidden" name="original-line"
-                                        value="+export class TestResourceManager {" class="js-original-line">
-                                    <input type="hidden" name="path"
-                                        value="web/src/regression/util/TestResourceManager.ts" class="js-path">
-                                    <input type="hidden" name="line" value="13" class="js-line-number">
-                                    <div class="form-actions comment-form-actions">
-                                        <button class="btn btn-primary" type="submit" data-disable-with="">Update
-                                            comment</button>
-                                        <button class="btn btn-danger js-comment-cancel-button" type="button"
-                                            data-confirm-text="Are you sure you want to discard your unsaved changes?">
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-                            </div>
-
-                        </form>
-                    </div>
-                </div>
-
-
-
-            </div>
-
-            <div class="review-thread-reply border-bottom">
-
-                <div class="inline-comment-form-container js-inline-comment-form-container">
-                    <div class="inline-comment-form-actions">
-                        <div class="d-table width-full">
-                            <div class="d-table-cell">
-                                <a class="d-inline-block" data-hovercard-type="user"
-                                    data-hovercard-url="/hovercards?user_id=1741180"
-                                    data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self"
-                                    href="/lguychard"><img class="avatar"
-                                        src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28"
-                                        height="28" alt="@lguychard"></a>
-                            </div>
-                            <div class="d-table-cell col-12">
-                                <button type="button"
-                                    class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
-                                    Reply…
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="inline-comment-form">
-                        <!-- '"` -->
-                        <!-- </textarea></xmp> -->
-                        <form class="js-inline-comment-form"
-                            action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8"
-                            method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
-                                name="authenticity_token"
-                                value="RF3t3EyhTZgihg/kB1jReBYRTLLjP2+tBE6vZXjf1xXwVDXh+oBXlHC7Bppluz25YDQLrPtSF5VSBa+GMrz9Cg==">
-                            <input type="hidden" name="comment_context" value="discussion">
-                            <input type="hidden" name="in_reply_to" value="329949662">
-
-
-                            <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
-                                data-preview-url="/preview?repository=41288708"
-                                data-preview-authenticity-token="GPGDHueDI8BLUCQVWWHzQzUDX8cL1PHxyAD3LMTnZ3zkDnLyi86B+9h7DDnUkJx1j6w6j6aJfkVBagrWqjSRJQ==">
-                                <div class="comment-form-head tabnav">
-
-                                    <markdown-toolbar
-                                        for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
-                                        class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
-
-                                        <div class="d-inline-block mr-3">
-                                            <button type="button"
-                                                class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item "
-                                                aria-label="Insert a suggestion <cmd-g>"
-                                                data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;D127:2C769:D2F197:1406DED:5D9471A2&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
-                                                data-hydro-click-hmac="0285edca4ce32a98afd66f44e5a90d3ce93c460aae7e4c6f95df0020e23391a3"
-                                                data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                hotkey="g">
-                                                <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1"
-                                                    width="13" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z">
-                                                    </path>
-                                                </svg>
-                                            </button> </div>
-
-                                        <div class="flex-nowrap d-inline-block mr-3">
-                                            <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add header text"
-                                                data-ga-click="Markdown Toolbar, click, header" role="button">
-                                                <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1"
-                                                    width="18" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-header>
-
-                                            <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add bold text <cmd-b>"
-                                                data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
-                                                <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-bold>
-
-                                            <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add italic text <cmd-i>"
-                                                data-ga-click="Markdown Toolbar, click, italic" role="button"
-                                                hotkey="i">
-                                                <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1"
-                                                    width="6" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z">
-                                                    </path>
-                                                </svg>
-                                            </md-italic>
-                                        </div>
-
-                                        <div class="d-inline-block mr-3">
-                                            <md-quote tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert a quote"
-                                                data-ga-click="Markdown Toolbar, click, quote" role="button">
-                                                <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-quote>
-
-                                            <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1"
-                                                aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code"
-                                                role="button">
-                                                <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z">
-                                                    </path>
-                                                </svg>
-                                            </md-code>
-
-
-                                            <md-link tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1"
-                                                aria-label="Add a link <cmd-k>"
-                                                data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
-                                                <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
-                                                    </path>
-                                                </svg>
-                                            </md-link>
-                                        </div>
-
-                                        <div class="d-inline-block mr-3">
-                                            <md-unordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a bulleted list"
-                                                data-ga-click="Markdown Toolbar, click, unordered list" role="button">
-                                                <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-unordered-list>
-
-                                            <md-ordered-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a numbered list"
-                                                data-ga-click="Markdown Toolbar, click, ordered list" role="button">
-                                                <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16"
-                                                    version="1.1" width="12" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ordered-list>
-
-                                            <md-task-list tabindex="-1"
-                                                class="toolbar-item tooltipped tooltipped-n mx-1"
-                                                aria-label="Add a task list"
-                                                data-ga-click="Markdown Toolbar, click, task list" role="button"
-                                                hotkey="L">
-                                                <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1"
-                                                    width="16" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z">
-                                                    </path>
-                                                </svg>
-                                            </md-task-list>
-                                        </div>
-
-                                        <div class="d-inline-block">
-                                            <md-mention tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Directly mention a user or team"
-                                                data-ga-click="Markdown Toolbar, click, mention" role="button">
-                                                <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1"
-                                                    width="14" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z">
-                                                    </path>
-                                                </svg>
-                                            </md-mention>
-
-
-                                            <md-ref tabindex="-1"
-                                                class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1"
-                                                aria-label="Reference an issue or pull request"
-                                                data-ga-click="Markdown Toolbar, click, reference" role="button">
-                                                <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1"
-                                                    width="10" height="16" aria-hidden="true">
-                                                    <path fill-rule="evenodd"
-                                                        d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z">
-                                                    </path>
-                                                </svg>
-                                            </md-ref>
-
-                                            <details
-                                                class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container "
-                                                tabindex="-1">
-                                                <summary tabindex="-1" class="text-center menu-target p-1 ml-1"
-                                                    aria-label="Insert a reply"
-                                                    data-ga-click="Markdown Toolbar, click, saved reply"
-                                                    aria-haspopup="menu" role="button">
-                                                    <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1"
-                                                        width="14" height="16" aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z">
-                                                        </path>
-                                                    </svg>
-                                                    <span class="dropdown-caret "></span>
-                                                </summary>
-                                                <details-menu style="z-index: 99;"
-                                                    class="select-menu-modal position-absolute right-0 js-saved-reply-menu "
-                                                    data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
-                                                    src="/settings/replies?context=none" preload="" role="menu">
-                                                    <div class="select-menu-header d-flex">
-                                                        <span class="select-menu-title flex-auto">Select a reply</span>
-                                                        <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
-                                                    </div>
-                                                    <include-fragment role="menuitem"
-                                                        class="select-menu-loading-overlay anim-pulse"
-                                                        aria-label="Loading">
-                                                        <svg class="octicon octicon-octoface" viewBox="0 0 16 16"
-                                                            version="1.1" width="16" height="16" aria-hidden="true">
-                                                            <path fill-rule="evenodd"
-                                                                d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z">
-                                                            </path>
-                                                        </svg>
-                                                    </include-fragment>
-                                                </details-menu>
-                                            </details>
-
-                                        </div>
-
-                                    </markdown-toolbar>
-
-                                    <nav class="tabnav-tabs" role="tablist">
-                                        <button type="button"
-                                            class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab"
-                                            aria-selected="true">Write</button>
-                                        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab"
-                                            role="tab">Preview</button>
-                                    </nav>
-                                </div>
-
-                                <file-attachment class="js-upload-markdown-image is-default"
-                                    data-upload-repository-id="=&quot;41288708&quot;"
-                                    data-upload-policy-url="/upload/policies/assets"
-                                    data-upload-policy-authenticity-token="Ir8RlCBZ0RbNu3TI3HWxqkrcQdtnjJa38Rw4peKLoe+pnLqo9oXYPxQPnmgI8OeKJ8/94Ye3NnrWxFCCone/dw==">
-                                    <div class="write-content js-write-bucket upload-enabled">
-                                        <input type="hidden" name="saved_reply_id"
-                                            id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id"
-                                            class="js-resettable-field" value="" data-reset-value="">
-
-                                        <text-expander keys=": @ #"
-                                            data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                            data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph"
-                                            data-emoji-url="/autocomplete/emoji">
-                                            <textarea name="comment[body]"
-                                                id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13"
-                                                placeholder="Leave a comment" aria-label="Comment body"
-                                                class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable"></textarea>
-                                        </text-expander>
-
-
-                                        <p
-                                            class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
-                                            <input
-                                                accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
-                                                type="file" multiple=""
-                                                class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control"
-                                                aria-label="Attach files to your comment"
-                                                id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
-                                            <span
-                                                class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1"
-                                                style="pointer-events: none;"></span>
-                                            <span class="position-relative pr-2" style="pointer-events: none;">
-                                                <span class="default">
-                                                    Attach files by dragging &amp; dropping, selecting or pasting them.
-                                                </span>
-                                                <span class="loading">
-                                                    <img alt="" width="16" height="16"
-                                                        src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">
-                                                    Uploading your files…
-                                                </span>
-                                                <span class="error bad-file">
-                                                    We don’t support that file type.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a
-                                                        GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error bad-permissions">
-                                                    Attaching documents requires write permission to this repository.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                        or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error repository-required">
-                                                    We don’t support that file type.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX
-                                                        or ZIP.
-                                                    </span>
-                                                </span>
-                                                <span class="error too-big">
-                                                    Yowza, that’s a big file
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a file smaller than 10MB.
-                                                    </span>
-                                                </span>
-                                                <span class="error empty">
-                                                    This file is empty.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with a file that’s not empty.
-                                                    </span>
-                                                </span>
-                                                <span class="error hidden-file">
-                                                    This file is hidden.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try again</button>
-                                                        with another file.
-                                                    </span>
-                                                </span>
-                                                <span class="error failed-request">
-                                                    Something went really wrong, and we can’t process that file.
-                                                    <span class="drag-and-drop-error-info">
-                                                        <button type="button"
-                                                            class="btn-link manual-file-chooser-text">Try
-                                                            again.</button>
-                                                    </span>
-                                                </span>
-                                            </span>
-                                            <span class="tooltipped tooltipped-nw"
-                                                aria-label="Styling with Markdown is supported">
-                                                <a class="muted-link position-relative d-inline"
-                                                    href="https://guides.github.com/features/mastering-markdown/"
-                                                    target="_blank" data-ga-click="Markdown Toolbar, click, help"
-                                                    aria-label="Learn about styling with Markdown">
-                                                    <svg class="octicon octicon-markdown v-align-bottom"
-                                                        viewBox="0 0 16 16" version="1.1" width="16" height="16"
-                                                        aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z">
-                                                        </path>
-                                                    </svg>
-                                                </a>
-                                            </span>
-                                        </p>
-
-                                    </div>
-                                </file-attachment>
-                                <div class="preview-content">
-                                    <div class="comment js-suggested-changes-container" data-thread-side="">
-                                        <div class="comment-body markdown-body js-preview-body">
-                                            <p>Nothing to preview</p>
-                                        </div>
-                                    </div>
-
-                                </div>
-
-                                <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
-                            </div>
-
-
-                            <div class="form-actions">
-                                <div class="position-relative float-right ml-1">
-                                    <input type="hidden" name="single_comment" value="1">
-
-                                    <button name="single_comment" type="submit" value="1"
-                                        class="btn review-simple-reply-button btn-primary" data-disable-invalid=""
-                                        data-disable-with="">
-                                        Comment
-                                    </button>
-                                </div>
-
-                                <button class="btn js-hide-inline-comment-form" type="button"
-                                    data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-
-        <!-- '"` -->
-        <!-- </textarea></xmp> -->
-        <form class="js-resolvable-timeline-thread-form"
-            action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve"
-            accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden"
-                name="_method" value="put"><input type="hidden" name="authenticity_token"
-                value="V5KHjL0m9LfuRCGluFgMeciL2Yh5QYbO8kWVFBxMCqoyXt//N5MKRoKKQxV6Dm680tyDGVS7vWIoZTGTehfAng==">
-            <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…"
-                data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;D127:2C769:D2F197:1406DED:5D9471A2&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}"
-                data-hydro-click-hmac="74758119ef02a3d8ee677364bea0ee630c1297aaeca94cf49e1a0861afe383ec">
-                Resolve conversation
-            </button></form>
     </div>
 
+    <div class="clearfix">
+
+      <input type="hidden" name="original-line" value="+export class TestResourceManager {" class="js-original-line">
+      <input type="hidden" name="path" value="web/src/regression/util/TestResourceManager.ts" class="js-path">
+      <input type="hidden" name="line" value="13" class="js-line-number">
+      <div class="form-actions comment-form-actions">
+        <button class="btn btn-primary" type="submit" data-disable-with="">Update comment</button>
+        <button class="btn btn-danger js-comment-cancel-button" type="button" data-confirm-text="Are you sure you want to discard your unsaved changes?">
+          Cancel
+        </button>
+      </div>
+    </div>
+
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
+
+  </form>  </div>
+  </div>
 
 
 
-</div>
+      </div>
+
+        <div class="review-thread-reply border-bottom">
+
+  <div class="inline-comment-form-container js-inline-comment-form-container">
+    <div class="inline-comment-form-actions">
+      <div class="d-table width-full">
+        <div class="d-table-cell">
+          <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1741180" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/lguychard"><img class="avatar" src="https://avatars2.githubusercontent.com/u/1741180?s=56&amp;v=4" width="28" height="28" alt="@lguychard"></a>
+        </div>
+        <div class="d-table-cell col-12">
+          <button type="button" class="review-thread-reply-button width-full text-gray text-left form-control js-toggle-inline-comment-form">
+            Reply…
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="inline-comment-form">
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-inline-comment-form" action="/sourcegraph/sourcegraph/pull/5746/review_comment/create" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="HwNKMnhl2Z8tR4Frrk1KPTysUEhEzT6mhfL7KHJSADKrCpIPzkTDk396iBXMrqb8SokXVlygRp7TufvLODEqLQ==">
+        <input type="hidden" name="comment_context" value="discussion">
+        <input type="hidden" name="in_reply_to" value="329949662">
+
+
+  <div class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected" data-preview-url="/preview?repository=41288708" data-preview-authenticity-token="NEeKnN7yfNkCymUGffvjEnHiKr39fUgOuDG6v2wOgWnIuHtwsr/e4pHhTSrwCowky01P9VAgx7oxW0dFAt13MA==">
+    <div class="comment-form-head tabnav">
+
+  <markdown-toolbar for="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13" class="js-details-container Details toolbar-commenting d-flex no-wrap flex-items-start flex-wrap ml-n3 mr-n3 px-3 ">
+
+      <div class="d-inline-block mr-3">
+        <button type="button" class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item " aria-label="Insert a suggestion <cmd-g>" data-hydro-click="{&quot;event_type&quot;:&quot;suggested_changes.target.click&quot;,&quot;payload&quot;:{&quot;user_id&quot;:1741180,&quot;target_type&quot;:&quot;insert_suggestion&quot;,&quot;pull_request_id&quot;:&quot;MDExOlB1bGxSZXF1ZXN0MzIxOTM0Mzc2&quot;,&quot;relationship_to_suggestion&quot;:&quot;reviewer&quot;,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;E539:18237:117CB5E:1A5E305:5D94968A&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="8b62f1cd86beb1341ba3b3409ec59925dfd194358f7e82177fb0abc0a1623aa2" data-ga-click="Markdown Toolbar, click, insert code suggestion" hotkey="g">
+            <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
+  </button>    </div>
+
+    <div class="flex-nowrap d-inline-block mr-3">
+      <md-header tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add header text" data-ga-click="Markdown Toolbar, click, header" role="button">
+        <svg class="octicon octicon-text-size" viewBox="0 0 18 16" version="1.1" width="18" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13.62 9.08L12.1 3.66h-.06l-1.5 5.42h3.08zM5.7 10.13S4.68 6.52 4.53 6.02h-.08l-1.13 4.11H5.7zM17.31 14h-2.25l-.95-3.25h-4.07L9.09 14H6.84l-.69-2.33H2.87L2.17 14H0l3.3-9.59h2.5l2.17 6.34L10.86 2h2.52l3.94 12h-.01z"></path></svg>
+      </md-header>
+
+      <md-bold tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add bold text <cmd-b>" data-ga-click="Markdown Toolbar, click, bold" role="button" hotkey="b">
+        <svg class="octicon octicon-bold" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2h3.83c2.48 0 4.3.75 4.3 2.95 0 1.14-.63 2.23-1.67 2.61v.06c1.33.3 2.3 1.23 2.3 2.86 0 2.39-1.97 3.52-4.61 3.52H1V2zm3.66 4.95c1.67 0 2.38-.66 2.38-1.69 0-1.17-.78-1.61-2.34-1.61H3.13v3.3h1.53zm.27 5.39c1.77 0 2.75-.64 2.75-1.98 0-1.27-.95-1.81-2.75-1.81h-1.8v3.8h1.8v-.01z"></path></svg>
+      </md-bold>
+
+      <md-italic tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add italic text <cmd-i>" data-ga-click="Markdown Toolbar, click, italic" role="button" hotkey="i">
+        <svg class="octicon octicon-italic" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2.81 5h1.98L3 14H1l1.81-9zm.36-2.7c0-.7.58-1.3 1.33-1.3.56 0 1.13.38 1.13 1.03 0 .75-.59 1.3-1.33 1.3-.58 0-1.13-.38-1.13-1.03z"></path></svg>
+      </md-italic>
+    </div>
+
+    <div class="d-inline-block mr-3">
+      <md-quote tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert a quote" data-ga-click="Markdown Toolbar, click, quote" role="button">
+        <svg class="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"></path></svg>
+      </md-quote>
+
+      <md-code tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 mx-1" aria-label="Insert code" data-ga-click="Markdown Toolbar, click, code" role="button">
+        <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      </md-code>
+
+
+      <md-link tabindex="-1" class="toolbar-item tooltipped tooltipped-n p-1 d-inline-block mx-1" aria-label="Add a link <cmd-k>" data-ga-click="Markdown Toolbar, click, link" role="button" hotkey="k">
+        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+      </md-link>
+    </div>
+
+    <div class="d-inline-block mr-3">
+      <md-unordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a bulleted list" data-ga-click="Markdown Toolbar, click, unordered list" role="button">
+        <svg class="octicon octicon-list-unordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"></path></svg>
+      </md-unordered-list>
+
+      <md-ordered-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a numbered list" data-ga-click="Markdown Toolbar, click, ordered list" role="button">
+        <svg class="octicon octicon-list-ordered" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12.01 13c0 .59 0 1-.59 1H4.6c-.59 0-.59-.41-.59-1 0-.59 0-1 .59-1h6.81c.59 0 .59.41.59 1h.01zM4.6 4h6.81C12 4 12 3.59 12 3c0-.59 0-1-.59-1H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1zm6.81 3H4.6c-.59 0-.59.41-.59 1 0 .59 0 1 .59 1h6.81C12 9 12 8.59 12 8c0-.59 0-1-.59-1zm-9.4-6h-.72c-.3.19-.58.25-1.03.34V2h.75v2.14H.17V5h2.84v-.86h-1V1zm.392 8.12c-.129 0-.592.04-.802.07.53-.56 1.14-1.25 1.14-1.89C2.72 6.52 2.18 6 1.38 6c-.59 0-.97.2-1.38.64l.58.58c.19-.19.38-.38.64-.38.28 0 .48.16.48.52 0 .53-.77 1.2-1.7 2.06V10h3v-.88h-.598zm-.222 3.79v-.03c.44-.19.64-.47.64-.86 0-.7-.56-1.11-1.44-1.11-.48 0-.89.19-1.28.52l.55.64c.25-.2.44-.31.69-.31.27 0 .42.13.42.36 0 .27-.2.44-.86.44v.75c.83 0 .98.17.98.47 0 .25-.23.38-.58.38-.28 0-.56-.14-.81-.38l-.48.66c.3.36.77.56 1.41.56.83 0 1.53-.41 1.53-1.16 0-.5-.31-.81-.77-.94v.01z"></path></svg>
+      </md-ordered-list>
+
+      <md-task-list tabindex="-1" class="toolbar-item tooltipped tooltipped-n mx-1" aria-label="Add a task list" data-ga-click="Markdown Toolbar, click, task list" role="button" hotkey="L">
+        <svg class="octicon octicon-tasklist" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.41 9H7.59C7 9 7 8.59 7 8c0-.59 0-1 .59-1h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM9.59 4C9 4 9 3.59 9 3c0-.59 0-1 .59-1h5.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H9.59zM0 3.91l1.41-1.3L3 4.2 7.09 0 8.5 1.41 3 6.91l-3-3zM7.59 12h7.81c.59 0 .59.41.59 1 0 .59 0 1-.59 1H7.59C7 14 7 13.59 7 13c0-.59 0-1 .59-1z"></path></svg>
+      </md-task-list>
+    </div>
+
+    <div class="d-inline-block">
+      <md-mention tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Directly mention a user or team" data-ga-click="Markdown Toolbar, click, mention" role="button">
+        <svg class="octicon octicon-mention" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.58 15c1.25 0 2.52-.31 3.56-.94l-.42-.94c-.84.52-1.89.83-3.03.83-3.23 0-5.64-2.08-5.64-5.72 0-4.37 3.23-7.18 6.58-7.18 3.45 0 5.22 2.19 5.22 5.2 0 2.39-1.34 3.86-2.5 3.86-1.05 0-1.36-.73-1.05-2.19l.73-3.75H8.98l-.11.72c-.41-.63-.94-.83-1.56-.83-2.19 0-3.66 2.39-3.66 4.38 0 1.67.94 2.61 2.3 2.61.84 0 1.67-.53 2.3-1.25.11.94.94 1.45 1.98 1.45 1.67 0 3.77-1.67 3.77-5C14 2.61 11.59 0 7.83 0 3.66 0 0 3.33 0 8.33 0 12.71 2.92 15 6.58 15zm-.31-5c-.73 0-1.36-.52-1.36-1.67 0-1.45.94-3.22 2.41-3.22.52 0 .84.2 1.25.83l-.52 3.02c-.63.73-1.25 1.05-1.78 1.05V10z"></path></svg>
+      </md-mention>
+
+
+      <md-ref tabindex="-1" class="flex-auto text-center toolbar-item tooltipped tooltipped-nw p-1 mx-1" aria-label="Reference an issue or pull request" data-ga-click="Markdown Toolbar, click, reference" role="button">
+        <svg class="octicon octicon-bookmark" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 0H1C.27 0 0 .27 0 1v15l5-3.09L10 16V1c0-.73-.27-1-1-1zm-.78 4.25L6.36 5.61l.72 2.16c.06.22-.02.28-.2.17L5 6.6 3.12 7.94c-.19.11-.25.05-.2-.17l.72-2.16-1.86-1.36c-.17-.16-.14-.23.09-.23l2.3-.03.7-2.16h.25l.7 2.16 2.3.03c.23 0 .27.08.09.23h.01z"></path></svg>
+      </md-ref>
+
+        <details class="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right js-saved-reply-container " tabindex="-1">
+          <summary tabindex="-1" class="text-center menu-target p-1 ml-1" aria-label="Insert a reply" data-ga-click="Markdown Toolbar, click, saved reply" aria-haspopup="menu" role="button">
+            <svg class="octicon octicon-reply" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path></svg>
+            <span class="dropdown-caret "></span>
+          </summary>
+          <details-menu style="z-index: 99;" class="select-menu-modal position-absolute right-0 js-saved-reply-menu " data-menu-input="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id" src="/settings/replies?context=none" preload="" role="menu">
+            <div class="select-menu-header d-flex">
+              <span class="select-menu-title flex-auto">Select a reply</span>
+              <code><span class="border rounded-1 p-1 mr-2">ctrl .</span></code>
+            </div>
+            <include-fragment role="menuitem" class="select-menu-loading-overlay anim-pulse" aria-label="Loading">
+              <svg class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+            </include-fragment>
+          </details-menu>
+        </details>
+
+    </div>
+
+  </markdown-toolbar>
+
+      <nav class="tabnav-tabs" role="tablist">
+        <button type="button" class="btn-link tabnav-tab write-tab js-write-tab selected" role="tab" aria-selected="true">Write</button>
+        <button type="button" class="btn-link tabnav-tab preview-tab js-preview-tab" role="tab">Preview</button>
+      </nav>
+    </div>
+
+    <file-attachment class="js-upload-markdown-image is-default" data-upload-repository-id="=&quot;41288708&quot;" data-upload-policy-url="/upload/policies/assets" data-upload-policy-authenticity-token="4ar+3mw3vSKj2OXCD/uY+i50ZCk+sG7e7Z6jKNbLa8xqiVXiuuu0C3psD2Lbfs7aQ2fYE96LzhPKRssPljd1VA==">
+      <div class="write-content js-write-bucket upload-enabled">
+        <input type="hidden" name="saved_reply_id" id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13_saved_reply_id" class="js-resettable-field" value="" data-reset-value="">
+
+        <text-expander keys=": @ #" data-issue-url="/suggestions?issue_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-mention-url="/suggestions?mention_suggester=1&amp;repository=sourcegraph&amp;user_id=sourcegraph" data-emoji-url="/autocomplete/emoji">
+          <textarea name="comment[body]" id="new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13" placeholder="Leave a comment" aria-label="Comment body" class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-size-to-fit js-session-resumable"></textarea>
+        </text-expander>
+
+
+    <p class="drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between">
+      <input accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 js-manual-file-chooser form-control" aria-label="Attach files to your comment" id="fc-new_inline_comment_discussion_diff-c4ec1f2c733d38e620466bc2d80205dd_329949662_13">
+      <span class="bg-gray-light position-absolute top-0 left-0 width-full height-full rounded-1" style="pointer-events: none;"></span>
+      <span class="position-relative pr-2" style="pointer-events: none;">
+        <span class="default">
+            Attach files by dragging &amp; dropping, selecting or pasting them.
+        </span>
+        <span class="loading">
+          <img alt="" width="16" height="16" src="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif"> Uploading your files…
+        </span>
+        <span class="error bad-file">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a
+            GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error bad-permissions">
+          Attaching documents requires write permission to this repository.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error repository-required">
+          We don’t support that file type.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP.
+          </span>
+        </span>
+        <span class="error too-big">
+          Yowza, that’s a big file
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file smaller than 10MB.
+          </span>
+        </span>
+        <span class="error empty">
+          This file is empty.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with a file that’s not empty.
+          </span>
+        </span>
+        <span class="error hidden-file">
+          This file is hidden.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again</button> with another file.
+          </span>
+        </span>
+        <span class="error failed-request">
+          Something went really wrong, and we can’t process that file.
+          <span class="drag-and-drop-error-info">
+            <button type="button" class="btn-link manual-file-chooser-text">Try again.</button>
+          </span>
+        </span>
+      </span>
+      <span class="tooltipped tooltipped-nw" aria-label="Styling with Markdown is supported">
+        <a class="muted-link position-relative d-inline" href="https://guides.github.com/features/mastering-markdown/" target="_blank" data-ga-click="Markdown Toolbar, click, help" aria-label="Learn about styling with Markdown">
+          <svg class="octicon octicon-markdown v-align-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"></path></svg>
+        </a>
+      </span>
+    </p>
+
+      </div>
+  </file-attachment>
+    <div class="preview-content">
+      <div class="comment js-suggested-changes-container" data-thread-side="">
+    <div class="comment-body markdown-body js-preview-body">
+      <p>Nothing to preview</p>
+    </div>
+  </div>
+
+    </div>
+
+    <div class="comment-form-error mb-2 js-comment-update-error" hidden=""></div>
+  </div>
+
+
+        <div class="form-actions">
+          <div class="position-relative float-right ml-1">
+            <input type="hidden" name="single_comment" value="1">
+
+            <button name="single_comment" type="submit" value="1" class="btn review-simple-reply-button btn-primary" data-disable-invalid="" data-disable-with="">
+              Comment
+            </button>
+          </div>
+
+          <button class="btn js-hide-inline-comment-form" type="button" data-confirm-cancel-text="Are you sure you want to discard your unsaved changes?">Cancel</button>
+        </div>
+  </form>  </div>
+  </div>
+
+        </div>
+    </div>
+
+      <!-- '"` --><!-- </textarea></xmp> --><form class="js-resolvable-timeline-thread-form" action="/sourcegraph/sourcegraph/pull/5746/threads/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjAzMDA3MzM0OnYy/resolve" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="put"><input type="hidden" name="authenticity_token" value="Uc4lTFvyGl9gp56VbGm3M9DOY7lFJhcs5COdUSVFn240An0/0Ufkrgxp/CWuP9X2ypk5KGjcLIA+AznWQx5VWg==">
+        <button name="button" type="submit" class="btn m-3" data-disable-with="Resolving conversation…" data-hydro-click="{&quot;event_type&quot;:&quot;resolvable_threads.resolve&quot;,&quot;payload&quot;:{&quot;thread_id&quot;:203007334,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;E539:18237:117CB5E:1A5E305:5D94968A&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/pull/5746&quot;,&quot;referrer&quot;:null}}" data-hydro-click-hmac="af409de088c64d1e2419a44595d51b3ce7a5bea4cab3f62a316ab71460ed790d">
+          Resolve conversation
+  </button></form>
+  </div>
+
+
+
+
+  </div>

--- a/browser/src/libs/github/__snapshots__/dom_functions.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/dom_functions.test.ts.snap
@@ -476,30 +476,34 @@ Object {
 }
 `;
 
-exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 62 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
+exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 13 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
 Object {
-  "content": "if len(parsedUrl.Opaque) > 0 {",
-  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition",
+  "content": "export
+                                class TestResourceManager
+                                {",
+  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition.annotated",
 }
 `;
 
-exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 62 in head diff part getLineElementFromLineNumber() should return the right line element given the line number 1`] = `
+exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 13 in head diff part getLineElementFromLineNumber() should return the right line element given the line number 1`] = `
 Object {
-  "content": "if len(parsedUrl.Opaque) > 0 {",
+  "content": "export
+                                class TestResourceManager
+                                {",
   "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition",
 }
 `;
 
-exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Vanilla line number 62 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
+exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Vanilla line number 13 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
 Object {
-  "content": "if len(parsedUrl.Opaque) > 0 {",
+  "content": "export class TestResourceManager {",
   "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition",
 }
 `;
 
-exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Vanilla line number 62 in head diff part getLineElementFromLineNumber() should return the right line element given the line number 1`] = `
+exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Vanilla line number 13 in head diff part getLineElementFromLineNumber() should return the right line element given the line number 1`] = `
 Object {
-  "content": "if len(parsedUrl.Opaque) > 0 {",
+  "content": "export class TestResourceManager {",
   "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition",
 }
 `;

--- a/browser/src/libs/github/__snapshots__/dom_functions.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/dom_functions.test.ts.snap
@@ -478,18 +478,14 @@ Object {
 
 exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 13 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
 Object {
-  "content": "export
-                                class TestResourceManager
-                                {",
-  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition.annotated",
+  "content": "export class TestResourceManager {",
+  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition",
 }
 `;
 
 exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Refined Github line number 13 in head diff part getLineElementFromLineNumber() should return the right line element given the line number 1`] = `
 Object {
-  "content": "export
-                                class TestResourceManager
-                                {",
+  "content": "export class TestResourceManager {",
   "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition",
 }
 `;
@@ -497,7 +493,7 @@ Object {
 exports[`GitHub DOM functions diffDomFunctions github.com Pull Request Discussion page Vanilla line number 13 in head diff part getCodeElementFromLineNumber() should return the right code element given the line number 1`] = `
 Object {
   "content": "export class TestResourceManager {",
-  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition",
+  "selector": "TR:nth-child(4) > TD.blob-code.blob-code-addition > SPAN.blob-code-inner.blob-code-marker-addition.annotated",
 }
 `;
 

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -213,7 +213,8 @@ const genericCodeViewResolver: ViewResolver<CodeView> = {
             return { element: elem, ...singleFileCodeView }
         }
 
-        if (elem.closest('.discussion-item-body')) {
+        if (elem.closest('.discussion-item-body') || elem.classList.contains('js-comment-container')) {
+            // This code view is embedded on a PR conversation page.
             return { element: elem, ...diffConversationCodeView }
         }
 

--- a/browser/src/libs/github/dom_functions.test.ts
+++ b/browser/src/libs/github/dom_functions.test.ts
@@ -55,7 +55,7 @@ describe('GitHub DOM functions', () => {
                 'pull-request-discussion': {
                     url: 'https://github.com/sourcegraph/sourcegraph/pull/3221',
                     lineCases: [
-                        { diffPart: 'head', lineNumber: 62 }, // added
+                        { diffPart: 'head', lineNumber: 13 }, // added
                     ],
                 },
             },

--- a/browser/src/libs/github/file_info.ts
+++ b/browser/src/libs/github/file_info.ts
@@ -1,11 +1,11 @@
 import { Observable, of, throwError } from 'rxjs'
 import { FileInfo } from '../code_intelligence'
 import { getCommitIDFromPermalink } from './scrape'
-import { getDeltaFileName, getDiffResolvedRev, getFilePath, parseURL } from './util'
+import { getDiffFileName, getDiffResolvedRev, getFilePath, parseURL } from './util'
 
 export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo> => {
     const { rawRepoName } = parseURL()
-    const { headFilePath, baseFilePath } = getDeltaFileName(codeView)
+    const { headFilePath, baseFilePath } = getDiffFileName(codeView)
     if (!headFilePath) {
         throw new Error('cannot determine file path')
     }

--- a/browser/src/libs/github/util.test.ts
+++ b/browser/src/libs/github/util.test.ts
@@ -1,3 +1,4 @@
+import { startCase } from 'lodash'
 import { parseURL, getDiffFileName } from './util'
 import { getFixtureBody } from '../code_intelligence/code_intelligence_test_utils'
 
@@ -99,11 +100,11 @@ describe('getDiffFileName()', () => {
         })
     }
     for (const gitHubVersion of ['github.com', 'ghe-2.14.11'] as const) {
-        describe(`${gitHubVersion}`, () => {
+        describe(gitHubVersion, () => {
             for (const [gitHubDiffPage, expectedFilePath] of Object.entries(tests[gitHubVersion])) {
-                describe(`${gitHubDiffPage}`, () => {
+                describe(`${startCase(gitHubDiffPage)} page`, () => {
                     for (const gitHubFlavor of ['vanilla', 'refined-github']) {
-                        describe(`${gitHubFlavor}`, () => {
+                        describe(startCase(gitHubFlavor), () => {
                             if (gitHubDiffPage === 'pull-request-discussion') {
                                 testGetDeltaFilename({
                                     expectedFilePath,

--- a/browser/src/libs/github/util.test.ts
+++ b/browser/src/libs/github/util.test.ts
@@ -1,4 +1,5 @@
-import { parseURL } from './util'
+import { parseURL, getDeltaFileName } from './util'
+import { getFixtureBody } from '../code_intelligence/code_intelligence_test_utils'
 
 describe('util', () => {
     describe('parseURL()', () => {
@@ -59,4 +60,69 @@ describe('util', () => {
             })
         }
     })
+})
+
+type GithubVersion = 'github.com' | 'ghe-2.14.11'
+type GithubDiffPage = 'commit' | 'pull-request' | 'pull-request-discussion'
+
+describe('getDeltaFileName()', () => {
+    const tests: Record<GithubVersion, Record<GithubDiffPage, string>> = {
+        'github.com': {
+            commit: 'doc/dev/incidents.md',
+            'pull-request-discussion': 'web/src/regression/util/TestResourceManager.ts',
+            'pull-request': 'packages/sourcegraph-extension-api/src/sourcegraph.d.ts',
+        },
+        'ghe-2.14.11': {
+            commit: 'mux.go',
+            'pull-request': 'mux.go',
+            'pull-request-discussion': 'mux.go',
+        },
+    }
+    const testGetDeltaFilename = ({
+        expectedFilePath,
+        htmlFixturePath,
+    }: {
+        expectedFilePath: string
+        htmlFixturePath: string
+    }) => {
+        test('extracts the filename', async () => {
+            const container = await getFixtureBody({
+                htmlFixturePath,
+                isFullDocument: false,
+            })
+            // TODO add examples with renamed files and check that getDeltaFilename() doesn't return
+            // identical headFilePath & baseFilePath
+            expect(getDeltaFileName(container)).toStrictEqual({
+                baseFilePath: expectedFilePath,
+                headFilePath: expectedFilePath,
+            })
+        })
+    }
+    for (const gitHubVersion of ['github.com', 'ghe-2.14.11'] as const) {
+        describe(`${gitHubVersion}`, () => {
+            for (const [gitHubDiffPage, expectedFilePath] of Object.entries(tests[gitHubVersion])) {
+                describe(`${gitHubDiffPage}`, () => {
+                    for (const gitHubFlavor of ['vanilla', 'refined-github']) {
+                        describe(`${gitHubFlavor}`, () => {
+                            if (gitHubDiffPage === 'pull-request-discussion') {
+                                testGetDeltaFilename({
+                                    expectedFilePath,
+                                    htmlFixturePath: `${__dirname}/__fixtures__/${gitHubVersion}/${gitHubDiffPage}/${gitHubFlavor}/code-view.html`,
+                                })
+                            } else {
+                                for (const view of ['split', 'unified']) {
+                                    describe(`${view}`, () => {
+                                        testGetDeltaFilename({
+                                            expectedFilePath,
+                                            htmlFixturePath: `${__dirname}/__fixtures__/${gitHubVersion}/${gitHubDiffPage}/${gitHubFlavor}/${view}/code-view.html`,
+                                        })
+                                    })
+                                }
+                            }
+                        })
+                    }
+                })
+            }
+        })
+    }
 })

--- a/browser/src/libs/github/util.test.ts
+++ b/browser/src/libs/github/util.test.ts
@@ -1,4 +1,4 @@
-import { parseURL, getDeltaFileName } from './util'
+import { parseURL, getDiffFileName } from './util'
 import { getFixtureBody } from '../code_intelligence/code_intelligence_test_utils'
 
 describe('util', () => {
@@ -65,7 +65,7 @@ describe('util', () => {
 type GithubVersion = 'github.com' | 'ghe-2.14.11'
 type GithubDiffPage = 'commit' | 'pull-request' | 'pull-request-discussion'
 
-describe('getDeltaFileName()', () => {
+describe('getDiffFileName()', () => {
     const tests: Record<GithubVersion, Record<GithubDiffPage, string>> = {
         'github.com': {
             commit: 'doc/dev/incidents.md',
@@ -92,7 +92,7 @@ describe('getDeltaFileName()', () => {
             })
             // TODO add examples with renamed files and check that getDeltaFilename() doesn't return
             // identical headFilePath & baseFilePath
-            expect(getDeltaFileName(container)).toStrictEqual({
+            expect(getDiffFileName(container)).toStrictEqual({
                 baseFilePath: expectedFilePath,
                 headFilePath: expectedFilePath,
             })

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -18,15 +18,28 @@ export function getFileContainers(): HTMLCollectionOf<HTMLElement> {
  * getDeltaFileName returns the path of the file container. It assumes
  * the file container is for a diff (i.e. a commit or pull request view).
  */
-export function getDeltaFileName(container: HTMLElement): { headFilePath: string; baseFilePath: string | undefined } {
-    const info = container.querySelector('.file-info') as HTMLElement
-
-    if (info.title) {
-        // for PR conversation snippets
-        return getPathNamesFromElement(info)
+export function getDeltaFileName(container: HTMLElement): { headFilePath: string; baseFilePath?: string } {
+    const fileInfoElement = container.querySelector<HTMLElement>('.file-info')
+    if (fileInfoElement) {
+        if (fileInfoElement.tagName === 'A') {
+            // for PR conversation snippets on GHE, where the .file-info element
+            // is the link containing the file paths.
+            return getPathNamesFromElement(fileInfoElement)
+        }
+        // On commit code views, or code views on a PR's files tab,
+        // find the link contained in the .file-info element.
+        const link = fileInfoElement.querySelector<HTMLElement>('a')
+        if (link) {
+            return getPathNamesFromElement(link)
+        }
     }
-    const link = info.querySelector('a') as HTMLElement
-    return getPathNamesFromElement(link)
+    // If no file info element is present, the code view is probably a PR conversation snippet
+    // on github.com, where a link containing the file path can be found in the .file-header element.
+    const fileHeaderLink = container.querySelector<HTMLLinkElement>('.file-header a')
+    if (fileHeaderLink) {
+        return getPathNamesFromElement(fileHeaderLink)
+    }
+    throw new Error('Could not determine delta file name')
 }
 
 function getPathNamesFromElement(element: HTMLElement): { headFilePath: string; baseFilePath: string | undefined } {

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -15,10 +15,10 @@ export function getFileContainers(): HTMLCollectionOf<HTMLElement> {
 }
 
 /**
- * getDeltaFileName returns the path of the file container. It assumes
+ * Returns the path of the file container. It assumes
  * the file container is for a diff (i.e. a commit or pull request view).
  */
-export function getDeltaFileName(container: HTMLElement): { headFilePath: string; baseFilePath?: string } {
+export function getDiffFileName(container: HTMLElement): { headFilePath: string; baseFilePath?: string } {
     const fileInfoElement = container.querySelector<HTMLElement>('.file-info')
     if (fileInfoElement) {
         if (fileInfoElement.tagName === 'A') {
@@ -39,7 +39,7 @@ export function getDeltaFileName(container: HTMLElement): { headFilePath: string
     if (fileHeaderLink) {
         return getPathNamesFromElement(fileHeaderLink)
     }
-    throw new Error('Could not determine delta file name')
+    throw new Error('Could not determine diff file name')
 }
 
 function getPathNamesFromElement(element: HTMLElement): { headFilePath: string; baseFilePath: string | undefined } {


### PR DESCRIPTION
Fixes #5728

Fixes filename resolution (and thus code intelligence) for commented snippets on the GitHub.com PR discussion page: these snippets no longer include a `.file-info` element.

Updates the code-view.html fixtures for github.com to reflect the new DOM, and adds unit tests for `getDeltaFilename()`ensuring that filenames are still correctly resolved for all other types of code views.

Also makes sure to return `diffConversationCodeView` for embedded snippets, so that we don't attempt to mount the code view toolbar.