### PR TITLE
graphqlbackend: Only sort branches if less than 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed an issue that rendered the search filter `repohascommitafter` unusable in the presence of an empty repository. [#5149](https://github.com/sourcegraph/sourcegraph/issues/5149)
 - An issue where `externalURL` not being configured in the management console could go unnoticed. [#3899](https://github.com/sourcegraph/sourcegraph/issues/3899)
+- Listing branches and refs now falls back to a fast path if there are a large number of branches. Previously we would time out. [#4581](https://github.com/sourcegraph/sourcegraph/issues/4581)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -49,6 +49,20 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 			return nil, err
 		}
 
+		// Filter before calls to GetCommit. This hopefully reduces the
+		// working set enough that we can sort interactively.
+		if args.Query != nil {
+			query := strings.ToLower(*args.Query)
+
+			filtered := branches[:0]
+			for _, branch := range branches {
+				if strings.Contains(strings.ToLower(branch.Name), query) {
+					filtered = append(filtered, branch)
+				}
+			}
+			branches = filtered
+		}
+
 		if args.Interactive && len(branches) > 1000 {
 			// Do not sort
 		} else if args.OrderBy != nil && *args.OrderBy == gitRefOrderAuthoredOrCommittedAt {

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -11,39 +11,26 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
 )
 
-func (r *RepositoryResolver) Branches(ctx context.Context, args *struct {
-	graphqlutil.ConnectionArgs
-	Query   *string
-	OrderBy *string
-}) (*gitRefConnectionResolver, error) {
-	gitRefTypeBranch := gitRefTypeBranch
-	return r.GitRefs(ctx, &struct {
-		graphqlutil.ConnectionArgs
-		Query   *string
-		Type    *string
-		OrderBy *string
-	}{ConnectionArgs: args.ConnectionArgs, Query: args.Query, Type: &gitRefTypeBranch, OrderBy: args.OrderBy})
-}
-
-func (r *RepositoryResolver) Tags(ctx context.Context, args *struct {
-	graphqlutil.ConnectionArgs
-	Query *string
-}) (*gitRefConnectionResolver, error) {
-	gitRefTypeTag := gitRefTypeTag
-	return r.GitRefs(ctx, &struct {
-		graphqlutil.ConnectionArgs
-		Query   *string
-		Type    *string
-		OrderBy *string
-	}{ConnectionArgs: args.ConnectionArgs, Query: args.Query, Type: &gitRefTypeTag})
-}
-
-func (r *RepositoryResolver) GitRefs(ctx context.Context, args *struct {
+type refsArgs struct {
 	graphqlutil.ConnectionArgs
 	Query   *string
 	Type    *string
 	OrderBy *string
-}) (*gitRefConnectionResolver, error) {
+}
+
+func (r *RepositoryResolver) Branches(ctx context.Context, args *refsArgs) (*gitRefConnectionResolver, error) {
+	t := gitRefTypeBranch
+	args.Type = &t
+	return r.GitRefs(ctx, args)
+}
+
+func (r *RepositoryResolver) Tags(ctx context.Context, args *refsArgs) (*gitRefConnectionResolver, error) {
+	t := gitRefTypeTag
+	args.Type = &t
+	return r.GitRefs(ctx, args)
+}
+
+func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitRefConnectionResolver, error) {
 	var branches []*git.Branch
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		cachedRepo, err := backend.CachedGitRepo(ctx, r.repo)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1418,6 +1418,10 @@ type Repository implements Node & GenericSearchResultInterface {
         type: GitRefType
         # Ordering for Git refs in the list.
         orderBy: GitRefOrder
+        # Ordering is an expensive operation that doesn't scale for lots of
+        # references. If this is true we fallback on not ordering. This should
+        # never be false in interactive API requests.
+        interactive: Boolean = true
     ): GitRefConnection!
     # The repository's Git branches.
     branches(
@@ -1427,6 +1431,10 @@ type Repository implements Node & GenericSearchResultInterface {
         query: String
         # Ordering for Git branches in the list.
         orderBy: GitRefOrder
+        # Ordering is an expensive operation that doesn't scale for lots of
+        # references. If this is true we fallback on not ordering. This should
+        # never be false in interactive API requests.
+        interactive: Boolean = true
     ): GitRefConnection!
     # The repository's Git tags.
     tags(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1425,6 +1425,10 @@ type Repository implements Node & GenericSearchResultInterface {
         type: GitRefType
         # Ordering for Git refs in the list.
         orderBy: GitRefOrder
+        # Ordering is an expensive operation that doesn't scale for lots of
+        # references. If this is true we fallback on not ordering. This should
+        # never be false in interactive API requests.
+        interactive: Boolean = true
     ): GitRefConnection!
     # The repository's Git branches.
     branches(
@@ -1434,6 +1438,10 @@ type Repository implements Node & GenericSearchResultInterface {
         query: String
         # Ordering for Git branches in the list.
         orderBy: GitRefOrder
+        # Ordering is an expensive operation that doesn't scale for lots of
+        # references. If this is true we fallback on not ordering. This should
+        # never be false in interactive API requests.
+        interactive: Boolean = true
     ): GitRefConnection!
     # The repository's Git tags.
     tags(


### PR DESCRIPTION
To sort branches we need to fetch each branch's commit individually. This is a
slow operation. So we introduce a new field to the GraphQL calls
"interactive". It defaults to true, and will skip on the expensive operation
if we have too many commits to get. 1000 is a thumb-sucked number.

Test plan: Visit a repository locally and confirm we still have sorted branches. Adjust 1000 down to 1 and see if branches still show up.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4581