### PR TITLE
a8n: Fix reading Bitbucket Server changesets from DB

### DIFF
--- a/enterprise/pkg/a8n/resolvers/graphql_test.go
+++ b/enterprise/pkg/a8n/resolvers/graphql_test.go
@@ -442,6 +442,14 @@ func TestCampaigns(t *testing.T) {
 			createdAt
 			updatedAt
 			campaigns { nodes { id } }
+			title
+			body
+			state
+			externalURL {
+				url
+				serviceType
+			}
+			reviewState
 		}
 
 		fragment c on Campaign {

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
 )
 
@@ -794,8 +795,10 @@ func scanChangeset(t *a8n.Changeset, s scanner) error {
 	switch t.ExternalServiceType {
 	case github.ServiceType:
 		t.Metadata = new(github.PullRequest)
+	case bitbucketserver.ServiceType:
+		t.Metadata = new(bitbucketserver.PullRequest)
 	default:
-		return nil
+		return errors.New("unknown external service type")
 	}
 
 	if err = json.Unmarshal(metadata, t.Metadata); err != nil {

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
 )
 
@@ -478,8 +479,8 @@ func TestStore(t *testing.T) {
 
 			now = now.Add(time.Second)
 			for _, c := range changesets {
-				c.Metadata = []byte(`{"updated": true}`)
-				c.ExternalServiceType = "gitlab"
+				c.Metadata = &bitbucketserver.PullRequest{ID: 1234}
+				c.ExternalServiceType = bitbucketserver.ServiceType
 
 				if c.RepoID != 0 {
 					c.RepoID++


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/5768

I forgot to extend this switch statement. And since we previously didn't
read back the created changeset from the database with the metadata
fields, it didn't cause a problem.

In this change I extended the test suite so that it fails when we read
an "unknown" changeset from the DB and extended the switch statement.