### PR TITLE
Fix incorrect changelog entries from recent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,13 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
-- Sourcegraph now receives [pings](https://docs.sourcegraph.com/admin/pings) on which extensions are activated from Sourcegraph.com.
 
 ### Fixed
 
 ### Removed
 
 - The `statusIndicator` feature flag has been removed from the site configuration's `experimentalFeatures` section. The status indicator has been enabled by default since 3.6.0 and you can now safely remove the feature flag from your configuration.
+- Public usage is now only available on Sourcegraph.com. Because many core features rely on persisted user settings, anonymous usage leads to a degraded experience for most users. As a result, for self-hosted private instances it is preferable for all users to have accounts. But on sourcegraph.com, users will continue to have to opt-in to accounts, despite the degraded UX.
 
 ## 3.7.2
 
@@ -262,7 +262,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Fields related to Repository enablement have been deprecated. Mutations are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutations will be removed in 3.6. Mutations: `setRepositoryEnabled`, `setAllRepositoriesEnabled`, `updateAllMirrorRepositories`, `deleteRepository`. Query parameters: `repositories.enabled`, `repositories.disabled`. Field: `Repository.enabled`.
 - Global saved searches are now deprecated. Any existing global saved searches have been assigned to the Sourcegraph instance's first site admin's user account.
 - The `search.savedQueries` configuration option is now deprecated. Existing entries remain in user and org settings for backward compatibility, but are unused as saved searches are now stored in the database.
-- Public usage is now only available on Sourcegraph.com. Because many core features rely on persisted user settings, anonymous usage leads to a degraded experience for most users. As a result, for self-hosted private instances it is preferable for all users to have accounts. But on sourcegraph.com, users will continue to have to opt-in to accounts, despite the degraded UX.
 
 ### Fixed
 


### PR DESCRIPTION
1) Regarding the "Public usage" change:

In https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/46595d6b756fcfeccd90b1dffe26fe758f6de62f, this changelog entry somehow got put into 3.4 (?) — something got mixed up during a rebase, I assume.

2) Regarding the "pings" change:

In https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/302e48ddf9b4e2e7e3ad93d12367854503d5b076, incorrect wording was used in the changelog for an event logging update. What was originally under consideration to be added to pings, was actually only added on Sourcegraph.com logging (which is typically left out of changelogs). I updated this on our pings docs page a few weeks ago in https://github.com/sourcegraph/sourcegraph/pull/5560, but forgot to update it on the changelog until now.