### PR TITLE
update to reflect new syntect_server version; improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Sourcegraph cluster deployments now run a more stable syntax highlighting server which can self-recover from rarer failure cases such as getting stuck at high CPU usage when highlighting some specific files. This will be ported to single-container deployments [at a later date](https://github.com/sourcegraph/sourcegraph/issues/5841).
+- Sourcegraph cluster deployments now run a more stable syntax highlighting server which can self-recover from rarer failure cases such as getting stuck at high CPU usage when highlighting some specific files. [#5406](https://github.com/sourcegraph/sourcegraph/issues/5406) This will be ported to single-container deployments [at a later date](https://github.com/sourcegraph/sourcegraph/issues/5841).
 
 ## 3.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+## 3.8.2
+
+### Fixed
+
+- Sourcegraph cluster deployments now run a more stable syntax highlighting server which can self-recover from rarer failure cases such as getting stuck at high CPU usage when highlighting some specific files. This will be ported to single-container deployments [at a later date](https://github.com/sourcegraph/sourcegraph/issues/5841).
+
 ## 3.8.1
 
 ### Added

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -52,7 +52,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.7.0@sha256:7e4995f7c294f447d0b06e3854a829126b210da9a64cbe32154fbe4468659e20 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:5e1efbb@sha256:6ec136246b302a6c8fc113f087a66d5f9a89a9f5b851e9abb917c8b5e1d8c4b1 /syntect_server /usr/local/bin/
+COPY --from=sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88 /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/lsif-server:ci /lsif /lsif
@@ -64,9 +64,9 @@ COPY --from=sourcegraph/prometheus:10.0.0@sha256:aca8cf12d41cbf5d8885ed675fa017b
 
 # hadolint ignore=DL3018
 RUN set -ex && \
- addgroup -S grafana && \
- adduser -S -G grafana grafana && \
- apk add --no-cache libc6-compat=1.1.23-r3 ca-certificates su-exec
+    addgroup -S grafana && \
+    adduser -S -G grafana grafana && \
+    apk add --no-cache libc6-compat=1.1.23-r3 ca-certificates su-exec
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/grafana:10.0.0@sha256:f84e4260dce4e36f5d5e9c6deb393ac1e9c930ffae622c432fa86640a1f2699f /usr/share/grafana /usr/share/grafana

--- a/dev/syntect_server
+++ b/dev/syntect_server
@@ -21,4 +21,4 @@ addr=''
 if [[ "${INSECURE_DEV:-}" == '1' ]]; then
     addr='-e ROCKET_ADDRESS=0.0.0.0'
 fi
-exec docker run --name=syntect_server --rm -p9238:9238 ${addr} sourcegraph/syntect_server:5e1efbb
+exec docker run --name=syntect_server --rm -p9238:9238 ${addr} sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/sourcegraph/go-jsonschema v0.0.0-20190205151546-7939fa138765
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
-	github.com/sourcegraph/gosyntect v0.0.0-20190512033712-1205f5e776e1
+	github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb
 	github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect
 	github.com/spf13/afero v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -732,6 +732,8 @@ github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab h1:tXj2rcIvqVG
 github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab/go.mod h1:ZqB/uu1WtCDmlwK8c+TO8+QSfDkJsWx9LYjQBgGxxtk=
 github.com/sourcegraph/gosyntect v0.0.0-20190512033712-1205f5e776e1 h1:EWPtdGam5rnA29pHkF1fawhZHpRL8LE/XyUCgRDiwGU=
 github.com/sourcegraph/gosyntect v0.0.0-20190512033712-1205f5e776e1/go.mod h1:GJtLTMyfNp97Mi5/diAtNsgiYQBtLpUZmJenqheEUYU=
+github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb h1:bbs7cDhEjewPB6aicTDJ15tseQAsl8bSGDVsnIuG0c0=
+github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
 github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c h1:MXlcJZ1VL5nNGkCj6ZTT71P4pImPkeG2lvzcJYzGvU4=
 github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c/go.mod h1:ovHiFoMDwf4nf7ynAc7lIhD4w0nc/6tO27DtVzqYrTQ=
 github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bCneDoK/c+ZbPGqOP5Hme5ulatc8smbQ=

--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -169,15 +169,15 @@ func Code(ctx context.Context, p Params) (h template.HTML, aborted bool, err err
 		table, err2 := generatePlainTable(code)
 		return table, true, err2
 	} else if err != nil {
+		log15.Error(
+			"syntax highlighting failed (this is a bug, please report it)",
+			"filepath", p.Filepath,
+			"repo_name", p.Metadata.RepoName,
+			"revision", p.Metadata.Revision,
+			"snippet", fmt.Sprintf("%q…", firstCharacters(code, 80)),
+			"error", err,
+		)
 		if cause := errors.Cause(err); cause == gosyntect.ErrRequestTooLarge || cause == gosyntect.ErrPanic {
-			log15.Error(
-				"syntax highlighting failed (this is a bug, please report it)",
-				"filepath", p.Filepath,
-				"repo_name", p.Metadata.RepoName,
-				"revision", p.Metadata.Revision,
-				"snippet", fmt.Sprintf("%q…", firstCharacters(code, 80)),
-				"error", err,
-			)
 			if cause == gosyntect.ErrPanic {
 				tr.LogFields(otlog.Bool("panic", true))
 				prometheusStatus = "panic"


### PR DESCRIPTION
- Update to reflect new HA syntect_server version.
- Log highlighting failures regardless of cause for better debugging.

Test plan: Manual testing, currently.

Helps https://github.com/sourcegraph/sourcegraph/issues/5406