### PR TITLE
[WIP] lsif: use proper sourcegraph/alpine base image

### DIFF
--- a/lsif/Dockerfile
+++ b/lsif/Dockerfile
@@ -19,7 +19,8 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache supervisor=3.3.5-r0 nodejs-current=12.4.0-r0
+RUN apk add --no-cache supervisor=3.3.4-r1 nodejs-current=11.3.0-r0
+
 
 COPY --from=builder /lsif /lsif
 COPY supervisord.conf /etc/supervisord.conf

--- a/lsif/Dockerfile
+++ b/lsif/Dockerfile
@@ -7,7 +7,7 @@ COPY . /lsif/
 RUN yarn --cwd /lsif
 RUN yarn --cwd /lsif run build
 
-FROM alpine:3.9@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache tini supervisor=3.3.5-r0 nodejs-current=12.4.0-r0
+RUN apk add --no-cache supervisor=3.3.5-r0 nodejs-current=12.4.0-r0
 
 COPY --from=builder /lsif /lsif
 COPY supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
Prior to this change, lsif-server was not using our `sourcegraph/alpine` base
image. Using this base image and not standard `alpine` is very important for
three reasons:

1. It installs [a critical package](https://github.com/sourcegraph/sourcegraph/blob/10e81ba9fa9f055cae8e755682dc74ef4413204c/docker-images/alpine/Dockerfile#L17-L25) without which DNS lookups fail in certain deployment contexts.
2. It [creates a standard `sourcegraph` user](https://github.com/sourcegraph/sourcegraph/blob/10e81ba9fa9f055cae8e755682dc74ef4413204c/docker-images/alpine/Dockerfile#L10-L15) with a static UID/GID, which is important for `deploy-sourcegraph-docker` deployment contexts where file permissions must sometimes be set manually on the host.
3. It unifies the base image of alpine and packages we install across all services, e.g. `tini`.

Additionally, because lsif-server had no user before, it was being ran as `root` and all of its files are owned by `root` in Kubernetes deployments. I will send a pair change with this one to automatically update the permissions in such clusters.
