### PR TITLE
search: fix repohascommitafter

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -587,19 +587,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 			var specifiers []search.RevisionSpecifier
 			for _, rev := range revs.Revs {
 				ok, err := git.HasCommitAfter(ctx, revs.GitserverRepo(), after, rev.RevSpec)
-				if err != nil {
-					if gitserver.IsRevisionNotFound(err) {
-						continue
-					}
-
-					if ctx.Err() != nil {
-						err = errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)")
-					}
-
-					run.Error(err)
-					continue
-				}
-				if ok {
+				if ok && err != nil {
 					specifiers = append(specifiers, rev)
 				}
 			}


### PR DESCRIPTION
This PR ignores relaying extraneous errors (missing revisions/repository/etc) from `repohascommitafter`. Instead, we avoid searching these revisions.