### PR TITLE
internalapi: Allow ping to wait on other services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Allow single trailing hyphen in usernames and org names [#5680](https://github.com/sourcegraph/sourcegraph/pull/5680)
-- Indexed search won't spam the logs on startup if the frontend API is not yet available. [zoekt#30](https://github.com/sourcegraph/zoekt/pull/30)
+- Indexed search won't spam the logs on startup if the frontend API is not yet available. [zoekt#30](https://github.com/sourcegraph/zoekt/pull/30) [#5866](https://github.com/sourcegraph/sourcegraph/pull/5866)
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20191001080155-fb5ac48a08e1
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20191004083501-73044befd78b
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -585,7 +585,6 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opentracing-contrib/go-stdlib v0.0.0-20190510164024-2b2d2700a3b7/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9 h1:QsgXACQhd9QJhEmRumbsMQQvBtmdS0mafoVEBplWXEg=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -730,8 +729,6 @@ github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d h1:FxF0pen6r
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d/go.mod h1:8HCyYaC38XwX0AOu0+fuY02Y5Z7CkITW0oVJavbna4Q=
 github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab h1:tXj2rcIvqVGM6SOt6DkGVxcjVE8c03hEethti8D77O8=
 github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab/go.mod h1:ZqB/uu1WtCDmlwK8c+TO8+QSfDkJsWx9LYjQBgGxxtk=
-github.com/sourcegraph/gosyntect v0.0.0-20190512033712-1205f5e776e1 h1:EWPtdGam5rnA29pHkF1fawhZHpRL8LE/XyUCgRDiwGU=
-github.com/sourcegraph/gosyntect v0.0.0-20190512033712-1205f5e776e1/go.mod h1:GJtLTMyfNp97Mi5/diAtNsgiYQBtLpUZmJenqheEUYU=
 github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb h1:bbs7cDhEjewPB6aicTDJ15tseQAsl8bSGDVsnIuG0c0=
 github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
 github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c h1:MXlcJZ1VL5nNGkCj6ZTT71P4pImPkeG2lvzcJYzGvU4=
@@ -740,8 +737,8 @@ github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bC
 github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/sourcegraph/zoekt v0.0.0-20191001080155-fb5ac48a08e1 h1:7JfTbtQeEW9b0nBtIRTEkfGTp7TFGYh+IkPaJPGrAng=
-github.com/sourcegraph/zoekt v0.0.0-20191001080155-fb5ac48a08e1/go.mod h1:H8z9wvHGyu+MiKyVKkJza8B+SWZispxX23A692cJAno=
+github.com/sourcegraph/zoekt v0.0.0-20191004083501-73044befd78b h1:wIS5dS/VhYu9jWzCReBgAPI1t9iEiPwuTEnGh4IhSIk=
+github.com/sourcegraph/zoekt v0.0.0-20191004083501-73044befd78b/go.mod h1:H8z9wvHGyu+MiKyVKkJza8B+SWZispxX23A692cJAno=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
We want zoekt-indexserver to only start once gitserver is up. It doesn't know
how to communicate with gitserver directly, so we need to add a way for it to
detect gitserver being available. It already pings the frontend, it can now
additionally specify gitserver as a ping.

Alternatively I considered adding a new internal endpoint, but this seemed
like overkill and ping already fits this purpose.

Note: indexserver already correctly handles gitserver not being up, but it
leads to a lot of logspam. EG when you start up server you will often see a
lot of "resolve-rev 500" logs from the frontend. This is because indexserver
is operating before gitserver is ready.