### PR TITLE
Bext: don't resolve clientConfiguration

### DIFF
--- a/browser/src/browser/types.ts
+++ b/browser/src/browser/types.ts
@@ -57,7 +57,6 @@ export interface StorageItems {
      * Storage for feature flags.
      */
     featureFlags: Partial<FeatureFlags>
-    clientConfiguration: ClientConfigurationDetails
     /**
      * Overrides settings from Sourcegraph.
      */
@@ -65,13 +64,6 @@ export interface StorageItems {
     sideloadedExtensionURL: string | null
     dismissedHoverAlerts: {
         [alertType in ExtensionHoverAlertType]?: boolean
-    }
-}
-
-interface ClientConfigurationDetails {
-    contentScriptUrls: string[]
-    parentSourcegraph: {
-        url: string
     }
 }
 
@@ -85,12 +77,6 @@ export const defaultStorageItems: StorageItems = {
     sourcegraphAnonymousUid: '',
     disableExtension: false,
     featureFlags: featureFlagDefaults,
-    clientConfiguration: {
-        contentScriptUrls: [],
-        parentSourcegraph: {
-            url: DEFAULT_SOURCEGRAPH_URL,
-        },
-    },
     clientSettings: '',
     sideloadedExtensionURL: null,
     dismissedHoverAlerts: {},

--- a/browser/src/extension/scripts/background.tsx
+++ b/browser/src/extension/scripts/background.tsx
@@ -15,7 +15,6 @@ import { initializeOmniboxInterface } from '../../libs/cli'
 import { initSentry } from '../../libs/sentry'
 import { createBlobURLForBundle } from '../../platform/worker'
 import { getHeaders } from '../../shared/backend/headers'
-import { resolveClientConfiguration } from '../../shared/backend/server'
 import { fromBrowserEvent } from '../../shared/util/browser'
 import { DEFAULT_SOURCEGRAPH_URL, getPlatformName } from '../../shared/util/context'
 import { assertEnv } from '../envAssertion'
@@ -77,20 +76,6 @@ async function main(): Promise<void> {
         sourcegraphURL = DEFAULT_SOURCEGRAPH_URL
     }
 
-    async function syncClientConfiguration(): Promise<void> {
-        const config = await resolveClientConfiguration(requestGraphQL).toPromise()
-        // ClientConfiguration is the new storage option.
-        // Request permissions for the urls.
-        await storage.sync.set({
-            clientConfiguration: {
-                parentSourcegraph: {
-                    url: config.parentSourcegraph.url,
-                },
-                contentScriptUrls: config.contentScriptUrls,
-            },
-        })
-    }
-
     configureOmnibox(sourcegraphURL)
 
     // Sync managed enterprise URLs
@@ -115,7 +100,6 @@ async function main(): Promise<void> {
         }
 
         if (changes.sourcegraphURL && changes.sourcegraphURL.newValue) {
-            await syncClientConfiguration()
             configureOmnibox(changes.sourcegraphURL.newValue)
         }
     })

--- a/browser/src/shared/backend/server.ts
+++ b/browser/src/shared/backend/server.ts
@@ -4,29 +4,6 @@ import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 
-/**
- * @returns Observable that emits the client configuration details.
- *         Errors
- */
-export const resolveClientConfiguration = (
-    requestGraphQL: PlatformContext['requestGraphQL']
-): Observable<GQL.IClientConfigurationDetails> =>
-    requestGraphQL<GQL.IQuery>({
-        request: gql`query ClientConfiguration() {
-            clientConfiguration {
-                contentScriptUrls
-                parentSourcegraph {
-                    url
-                }
-            }
-        }`,
-        variables: {},
-        mightContainPrivateInfo: false,
-    }).pipe(
-        map(dataOrThrowErrors),
-        map(({ clientConfiguration }) => clientConfiguration, catchError((err, caught) => caught))
-    )
-
 export const fetchCurrentUser = (
     requestGraphQL: PlatformContext['requestGraphQL']
 ): Observable<GQL.IUser | undefined> =>


### PR DESCRIPTION
`clientConfiguration` was queried from the graphQL backend and saved in sync storage whenever the sourcegraph URL changed, but it was never actually read.
