### PR TITLE
build: Set -trimpath for go build

### DIFF
--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -18,7 +18,7 @@ export CGO_ENABLED=0
 
 echo "--- go build"
 for pkg in github.com/sourcegraph/sourcegraph/cmd/frontend; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 echo "--- docker build $IMAGE"

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/github-proxy; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/gitserver; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/loadtest; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/management-console/build.sh
+++ b/cmd/management-console/build.sh
@@ -18,7 +18,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in $path_to_package; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/query-runner; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/replacer/build.sh
+++ b/cmd/replacer/build.sh
@@ -113,7 +113,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/replacer; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/replacer/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -18,7 +18,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in $path_to_package; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/cmd/searcher; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT \

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -40,6 +40,7 @@ for pkg in $server_pkg \
     github.com/google/zoekt/cmd/zoekt-webserver $additional_images; do
 
     go build \
+      -trimpath \
       -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION"  \
       -buildmode exe \
       -installsuffix netgo \

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend; do
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
+    go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
 docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT \


### PR DESCRIPTION
This helps make builds more deterministic as well as easier to link pprof to
local source files. Added in go1.13. Description of trimpath below:

  remove all file system paths from the resulting executable. Instead of
  absolute file system paths, the recorded file names will begin with either
  "go" (for the standard library), or a module path@version (when using
  modules), or a plain import path (when using GOPATH).

Test plan: CI