### PR TITLE
ci: Set coverpkg to record dependency code coverage

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -102,7 +102,7 @@ func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go:",
 		bk.Cmd("./cmd/symbols/build.sh buildLibsqlite3Pcre"), // for symbols tests
 		bk.Cmd("./cmd/replacer/build.sh installComby"),       // for replacer tests
-		bk.Cmd("go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./..."),
+		bk.Cmd("go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -coverpkg github.com/sourcegraph/sourcegraph/... -race ./..."),
 		bk.ArtifactPaths("coverage.txt"))
 }
 


### PR DESCRIPTION
We will now record coverage in all sourcegraph packages. Previously we only
recorded the coverage per package test, so missed things like our DB tests
covering the migrations bindata.

We used to set this flag, but I think we lost it during our OSS
process. Additionally it had a bug that was introduced and then fixed again in
go1.13.

Retry of https://github.com/sourcegraph/sourcegraph/pull/4375

Fixes https://github.com/sourcegraph/sourcegraph/issues/4376
