### PR TITLE
Add stubs for core functionality regression tests (section 2 of the release test grid)

### DIFF
--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -15,6 +15,7 @@ export interface Config {
     logBrowserConsole: boolean
     slowMo: number
     headless: boolean
+    keepBrowser: boolean
 }
 
 interface Field<T = string> {
@@ -78,6 +79,12 @@ const configFields: ConfigFields = {
         parser: parseBool,
         description:
             "If true, regression tests will not clean up users, external services, or other resources they create. Set this to true if running against a dev instance (as it'll make test runs faster). Set to false if running against production",
+    },
+    keepBrowser: {
+        envVar: 'KEEP_BROWSER',
+        parser: parseBool,
+        description: 'If true, browser window will remain open after tests run',
+        defaultValue: false,
     },
     logBrowserConsole: {
         envVar: 'LOG_BROWSER_CONSOLE',

--- a/web/src/regression/core.test.ts
+++ b/web/src/regression/core.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ */
+
+import { TestResourceManager } from './util/TestResourceManager'
+import { GraphQLClient } from './util/GraphQLClient'
+import { Driver } from '../../../shared/src/e2e/driver'
+import { getConfig } from '../../../shared/src/e2e/config'
+import { getTestFixtures } from './util/init'
+import { ensureLoggedInOrCreateTestUser } from './util/helpers'
+import { deleteUser } from './util/api'
+
+describe('Core functionality regression test suite', () => {
+    const testUsername = 'test-core'
+    const config = getConfig(
+        'sudoToken',
+        'sudoUsername',
+        'gitHubToken',
+        'sourcegraphBaseUrl',
+        'noCleanup',
+        'testUserPassword',
+        'logBrowserConsole',
+        'slowMo',
+        'headless',
+        'keepBrowser'
+    )
+
+    let driver: Driver
+    let gqlClient: GraphQLClient
+    let resourceManager: TestResourceManager
+    beforeAll(async () => {
+        ;({ driver, gqlClient, resourceManager } = await getTestFixtures(config))
+        await resourceManager.create({
+            type: 'User',
+            name: testUsername,
+            create: () =>
+                ensureLoggedInOrCreateTestUser(driver, gqlClient, {
+                    username: testUsername,
+                    deleteIfExists: true,
+                    ...config,
+                }),
+            destroy: () => deleteUser(gqlClient, testUsername, false),
+        })
+    })
+
+    afterAll(async () => {
+        if (!config.noCleanup) {
+            await resourceManager.destroyAll()
+        }
+        if (driver) {
+            await driver.close()
+        }
+    })
+
+    test('User settings are saved and applied', async () => {
+        const getSettings = async () => {
+            await driver.page.waitForSelector('.view-line')
+            return await driver.page.evaluate(() => {
+                const editor = document.querySelector('.monaco-editor') as HTMLElement
+                return editor ? editor.innerText : null
+            })
+        }
+
+        await driver.page.goto(config.sourcegraphBaseUrl + `/users/${testUsername}/settings`)
+        const previousSettings = await getSettings()
+        if (!previousSettings) {
+            throw new Error('Previous settings were null')
+        }
+        const newSettings = '{\xa0/*\xa0These\xa0are\xa0new\xa0settings\xa0*/}'
+        await driver.replaceText({
+            selector: '.monaco-editor',
+            newText: newSettings,
+            selectMethod: 'keyboard',
+            enterTextMethod: 'paste',
+        })
+        await driver.page.reload()
+
+        const currentSettings = await getSettings()
+        if (currentSettings !== previousSettings) {
+            throw new Error(
+                `Settings ${JSON.stringify(currentSettings)} did not match (old) saved settings ${JSON.stringify(
+                    previousSettings
+                )}`
+            )
+        }
+
+        await driver.replaceText({
+            selector: '.monaco-editor',
+            newText: newSettings,
+            selectMethod: 'keyboard',
+            enterTextMethod: 'type',
+        })
+        await driver.clickElementWithText('Save changes')
+        await driver.page.waitForFunction(
+            () => document.evaluate("//*[text() = ' Saving...']", document).iterateNext() === null
+        )
+        await driver.page.reload()
+
+        const currentSettings2 = await getSettings()
+        if (JSON.stringify(currentSettings2) !== JSON.stringify(newSettings)) {
+            throw new Error(
+                `Settings ${JSON.stringify(currentSettings2)} did not match (new) saved settings ${JSON.stringify(
+                    newSettings
+                )}`
+            )
+        }
+
+        // Restore old settings
+        await driver.replaceText({
+            selector: '.monaco-editor',
+            newText: previousSettings,
+            selectMethod: 'keyboard',
+            enterTextMethod: 'paste',
+        })
+        await driver.clickElementWithText('Save changes')
+        await driver.page.waitForFunction(
+            () => document.evaluate("//*[text() = ' Saving...']", document).iterateNext() === null
+        )
+        const previousSettings2 = await getSettings()
+        await driver.page.reload()
+
+        const currentSettings3 = await getSettings()
+        if (currentSettings3 !== previousSettings2) {
+            throw new Error(
+                `Settings ${JSON.stringify(currentSettings3)} did not match (old) saved settings ${JSON.stringify(
+                    previousSettings2
+                )}`
+            )
+        }
+    })
+
+    test('User profile page', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('User emails page', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('Access tokens work', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('Organizations (admin user)', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('Organizations (non-admin user)', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('Explore page', async () => {
+        // TODO(@sourcegraph/web)
+    })
+    test('Quicklinks', async () => {
+        // TODO(@sourcegraph/web)
+    })
+})

--- a/web/src/regression/onboarding.test.ts
+++ b/web/src/regression/onboarding.test.ts
@@ -5,7 +5,7 @@
 import * as GQL from '../../../shared/src/graphql/schema'
 import { Driver } from '../../../shared/src/e2e/driver'
 import { GraphQLClient } from './util/GraphQLClient'
-import { setTestDefaults, createAndInitializeDriver } from './util/init'
+import { getTestFixtures } from './util/init'
 import { getConfig } from '../../../shared/src/e2e/config'
 import { ensureLoggedInOrCreateTestUser } from './util/helpers'
 import {
@@ -59,7 +59,8 @@ describe('Onboarding', () => {
         'testUserPassword',
         'headless',
         'slowMo',
-        'logBrowserConsole'
+        'logBrowserConsole',
+        'keepBrowser'
     )
     const testExternalServiceConfig = {
         kind: GQL.ExternalServiceKind.GITHUB,
@@ -71,21 +72,15 @@ describe('Onboarding', () => {
             repositoryQuery: ['none'],
         },
     }
+    const testUsername = 'test-onboarding-regression-test-user'
+
     let driver: Driver
     let gqlClient: GraphQLClient
+    let resourceManager: TestResourceManager
     let screenshots: ScreenshotVerifier
-    const testUsername = 'test-onboarding-regression-test-user'
-    const resourceManager = new TestResourceManager()
-
     beforeAll(
         async () => {
-            driver = await createAndInitializeDriver(config)
-            gqlClient = GraphQLClient.newForPuppeteerTest({
-                baseURL: config.sourcegraphBaseUrl,
-                sudoToken: config.sudoToken,
-                username: config.sudoUsername,
-            })
-            await setTestDefaults(driver, gqlClient)
+            ;({ driver, gqlClient, resourceManager } = await getTestFixtures(config))
             screenshots = new ScreenshotVerifier(driver)
 
             await resourceManager.create({

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -4,89 +4,13 @@
 
 import { Driver } from '../../../shared/src/e2e/driver'
 import { getConfig } from '../../../shared/src/e2e/config'
-import { setTestDefaults, createAndInitializeDriver } from './util/init'
+import { getTestFixtures } from './util/init'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { GraphQLClient } from './util/GraphQLClient'
 import { ensureTestExternalService, waitForRepos, deleteUser, ensureNoTestExternalServices } from './util/api'
 import { ensureLoggedInOrCreateTestUser } from './util/helpers'
 import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { TestResourceManager } from './util/TestResourceManager'
-
-const testRepoSlugs = [
-    'auth0/go-jwt-middleware',
-    'kyoshidajp/ghkw',
-    'PalmStoneGames/kube-cert-manager',
-    'adjust/go-wrk',
-    'P3GLEG/Whaler',
-    'sajari/docconv',
-    'marianogappa/chart',
-    'divan/gobenchui',
-    'tuna/tunasync',
-    'mthbernardes/GTRS',
-    'antonmedv/expr',
-    'kshvakov/clickhouse',
-    'xwb1989/sqlparser',
-    'henrylee2cn/pholcus_lib',
-    'itcloudy/ERP',
-    'iovisor/kubectl-trace',
-    'minio/highwayhash',
-    'matryer/moq',
-    'vkuznecovas/mouthful',
-    'DirectXMan12/k8s-prometheus-adapter',
-    'stephens2424/php',
-    'ericchiang/k8s',
-    'jonmorehouse/terraform-provisioner-ansible',
-    'solo-io/supergloo',
-    'intel-go/bytebuf',
-    'xtaci/smux',
-    'MatchbookLab/local-persist',
-    'ossrs/go-oryx',
-    'yep/eth-tweet',
-    'deckarep/gosx-notifier',
-    'zentures/sequence',
-    'nishanths/license',
-    'beego/mux',
-    'status-im/status-go',
-    'antonmedv/countdown',
-    'lonng/nanoserver',
-    'vbauerster/mpb',
-    'evilsocket/sg1',
-    'zhenghaoz/gorse',
-    'nsf/godit',
-    '3xxx/engineercms',
-    'howtowhale/dvm',
-    'gosuri/uitable',
-    'github/vulcanizer',
-    'metaparticle-io/package',
-    'bwmarrin/snowflake',
-    'wyh267/FalconEngine',
-    'moul/sshportal',
-    'fogleman/fauxgl',
-    'DataDog/datadog-agent',
-    'line/line-bot-sdk-go',
-    'pinterest/bender',
-    'esimov/diagram',
-    'nytimes/openapi2proto',
-    'iris-contrib/examples',
-    'munnerz/kube-plex',
-    'inbucket/inbucket',
-    'golangci/awesome-go-linters',
-    'htcat/htcat',
-    'tidwall/pinhole',
-    'gocraft/health',
-    'ivpusic/grpool',
-    'Antonito/gfile',
-    'yinqiwen/gscan',
-    'facebookarchive/httpcontrol',
-    'josharian/impl',
-    'salihciftci/liman',
-    'kelseyhightower/konfd',
-    'mohanson/daze',
-    'google/ko',
-    'freedomofdevelopers/fod',
-    'sgtest/mux',
-    'facebook/react',
-]
 
 /**
  * Reads the number of results from the text at the top of the results page
@@ -125,37 +49,109 @@ function hasNoResultsOrError(): boolean {
 }
 
 describe('Search regression test suite', () => {
-    let driver: Driver
-    let gqlClient: GraphQLClient
+    /**
+     * Test data
+     */
     const testUsername = 'test-search'
     const testExternalServiceInfo = {
         kind: GQL.ExternalServiceKind.GITHUB,
         uniqueDisplayName: '[TEST] GitHub (search.test.ts)',
     }
+    const testRepoSlugs = [
+        'auth0/go-jwt-middleware',
+        'kyoshidajp/ghkw',
+        'PalmStoneGames/kube-cert-manager',
+        'adjust/go-wrk',
+        'P3GLEG/Whaler',
+        'sajari/docconv',
+        'marianogappa/chart',
+        'divan/gobenchui',
+        'tuna/tunasync',
+        'mthbernardes/GTRS',
+        'antonmedv/expr',
+        'kshvakov/clickhouse',
+        'xwb1989/sqlparser',
+        'henrylee2cn/pholcus_lib',
+        'itcloudy/ERP',
+        'iovisor/kubectl-trace',
+        'minio/highwayhash',
+        'matryer/moq',
+        'vkuznecovas/mouthful',
+        'DirectXMan12/k8s-prometheus-adapter',
+        'stephens2424/php',
+        'ericchiang/k8s',
+        'jonmorehouse/terraform-provisioner-ansible',
+        'solo-io/supergloo',
+        'intel-go/bytebuf',
+        'xtaci/smux',
+        'MatchbookLab/local-persist',
+        'ossrs/go-oryx',
+        'yep/eth-tweet',
+        'deckarep/gosx-notifier',
+        'zentures/sequence',
+        'nishanths/license',
+        'beego/mux',
+        'status-im/status-go',
+        'antonmedv/countdown',
+        'lonng/nanoserver',
+        'vbauerster/mpb',
+        'evilsocket/sg1',
+        'zhenghaoz/gorse',
+        'nsf/godit',
+        '3xxx/engineercms',
+        'howtowhale/dvm',
+        'gosuri/uitable',
+        'github/vulcanizer',
+        'metaparticle-io/package',
+        'bwmarrin/snowflake',
+        'wyh267/FalconEngine',
+        'moul/sshportal',
+        'fogleman/fauxgl',
+        'DataDog/datadog-agent',
+        'line/line-bot-sdk-go',
+        'pinterest/bender',
+        'esimov/diagram',
+        'nytimes/openapi2proto',
+        'iris-contrib/examples',
+        'munnerz/kube-plex',
+        'inbucket/inbucket',
+        'golangci/awesome-go-linters',
+        'htcat/htcat',
+        'tidwall/pinhole',
+        'gocraft/health',
+        'ivpusic/grpool',
+        'Antonito/gfile',
+        'yinqiwen/gscan',
+        'facebookarchive/httpcontrol',
+        'josharian/impl',
+        'salihciftci/liman',
+        'kelseyhightower/konfd',
+        'mohanson/daze',
+        'google/ko',
+        'freedomofdevelopers/fod',
+        'sgtest/mux',
+        'facebook/react',
+    ]
+    const config = getConfig(
+        'sudoToken',
+        'sudoUsername',
+        'gitHubToken',
+        'sourcegraphBaseUrl',
+        'noCleanup',
+        'testUserPassword',
+        'logBrowserConsole',
+        'slowMo',
+        'headless',
+        'keepBrowser'
+    )
 
     describe('Search over a dozen repositories', () => {
-        const resourceManager = new TestResourceManager()
-        const config = getConfig(
-            'sudoToken',
-            'sudoUsername',
-            'gitHubToken',
-            'sourcegraphBaseUrl',
-            'noCleanup',
-            'testUserPassword',
-            'logBrowserConsole',
-            'slowMo',
-            'headless'
-        )
+        let driver: Driver
+        let gqlClient: GraphQLClient
+        let resourceManager: TestResourceManager
         beforeAll(
             async () => {
-                driver = await createAndInitializeDriver(config)
-                gqlClient = GraphQLClient.newForPuppeteerTest({
-                    baseURL: config.sourcegraphBaseUrl,
-                    sudoToken: config.sudoToken,
-                    username: config.sudoUsername,
-                })
-                await setTestDefaults(driver, gqlClient)
-
+                ;({ driver, gqlClient, resourceManager } = await getTestFixtures(config))
                 await resourceManager.create({
                     type: 'User',
                     name: testUsername,


### PR DESCRIPTION
Probably easiest to view the 2 commits that comprise this PR separate. The first is mostly a refactor (though it adds the `KEEP_BROWSER` env var for keeping the browser open after the tests run). The second adds the file `core.test.ts`, which contains the new test and test stubs.