### PR TITLE
gitserver: Remove bad ref HEAD after clone and fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue that rendered the search filter `repohascommitafter` unusable in the presence of an empty repository. [#5149](https://github.com/sourcegraph/sourcegraph/issues/5149)
 - An issue where `externalURL` not being configured in the management console could go unnoticed. [#3899](https://github.com/sourcegraph/sourcegraph/issues/3899)
 - Listing branches and refs now falls back to a fast path if there are a large number of branches. Previously we would time out. [#4581](https://github.com/sourcegraph/sourcegraph/issues/4581)
+- Sourcegraph will now ignore the ambiguous ref HEAD if a repository contains it. [#5291](https://github.com/sourcegraph/sourcegraph/issues/5291)
 
 ### Removed
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -811,6 +811,8 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 			return errors.Wrapf(err, "clone failed. Output: %s", string(output))
 		}
 
+		removeBadRefs(ctx, tmpPath)
+
 		// Update the last-changed stamp.
 		if err := setLastChanged(tmpPath); err != nil {
 			return errors.Wrapf(err, "failed to update last changed time")
@@ -1068,6 +1070,24 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, url string
 	}
 }
 
+// removeBadRefs removes bad refs and tags from the git repo at dir. This
+// should be run after a clone or fetch. If your repository contains a ref or
+// tag called HEAD (case insensitive), most commands will output a warning
+// from git:
+//
+//  warning: refname 'HEAD' is ambiguous.
+//
+// Instead we just remove this ref.
+func removeBadRefs(ctx context.Context, dir string) {
+	cmd := exec.CommandContext(ctx, "git", "branch", "-D", "HEAD")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	cmd = exec.CommandContext(ctx, "git", "tag", "-d", "HEAD")
+	cmd.Dir = dir
+	_ = cmd.Run()
+}
+
 // setLastChanged discerns an approximate last-changed timestamp for a
 // repository. This can be approximate; it's used to determine how often we
 // should run `git fetch`, but is not relied on strongly. The basic plan
@@ -1258,6 +1278,8 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 		log15.Error("Failed to update", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to update")
 	}
+
+	removeBadRefs(ctx, dir)
 
 	// Update the last-changed stamp.
 	if err := setLastChanged(dir); err != nil {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -317,7 +317,7 @@ func TestCloneRepo(t *testing.T) {
 			"GIT_AUTHOR_NAME=a",
 			"GIT_AUTHOR_EMAIL=a@a.com",
 		}
-		b, err := c.Output()
+		b, err := c.CombinedOutput()
 		if err != nil {
 			t.Fatalf("%s %s failed: %s", name, strings.Join(arg, " "), err)
 		}
@@ -330,6 +330,8 @@ func TestCloneRepo(t *testing.T) {
 	cmd("git", "add", "hello.txt")
 	cmd("git", "commit", "-m", "hello")
 	wantCommit := cmd("git", "rev-parse", "HEAD")
+	// Add a bad tag
+	cmd("git", "tag", "HEAD")
 
 	reposDir, cleanup2 := tmpDir(t)
 	defer cleanup2()
@@ -361,7 +363,7 @@ func TestCloneRepo(t *testing.T) {
 	repo = dst
 	gotCommit := cmd("git", "rev-parse", "HEAD")
 	if wantCommit != gotCommit {
-		t.Fatal("failed to clone")
+		t.Fatal("failed to clone:", gotCommit)
 	}
 
 	// Test blocking with a failure (already exists since we didn't specify overwrite)
@@ -385,6 +387,73 @@ func TestCloneRepo(t *testing.T) {
 	repo = dst
 	gotCommit = cmd("git", "rev-parse", "HEAD")
 	if wantCommit != gotCommit {
-		t.Fatal("failed to clone")
+		t.Fatal("failed to clone:", gotCommit)
+	}
+}
+
+func TestRemoveBadRefs(t *testing.T) {
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
+
+	cmd := func(name string, arg ...string) string {
+		t.Helper()
+		c := exec.Command(name, arg...)
+		c.Dir = dir
+		c.Env = []string{
+			"GIT_COMMITTER_NAME=a",
+			"GIT_COMMITTER_EMAIL=a@a.com",
+			"GIT_AUTHOR_NAME=a",
+			"GIT_AUTHOR_EMAIL=a@a.com",
+		}
+		b, err := c.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %s failed: %s", name, strings.Join(arg, " "), err)
+		}
+		return string(b)
+	}
+
+	// Setup a repo with a commit so we can add bad refs
+	cmd("git", "init", ".")
+	cmd("sh", "-c", "echo hello world > hello.txt")
+	cmd("git", "add", "hello.txt")
+	cmd("git", "commit", "-m", "hello")
+	want := cmd("git", "rev-parse", "HEAD")
+
+	for _, name := range []string{"HEAD", "head", "Head", "HeAd"} {
+		// Tag
+		cmd("git", "tag", name)
+
+		if dontWant := cmd("git", "rev-parse", "HEAD"); dontWant == want {
+			t.Fatalf("git tag %s failed to produce ambiguous output: %s", name, dontWant)
+		}
+
+		removeBadRefs(context.Background(), dir)
+
+		if got := cmd("git", "rev-parse", "HEAD"); got != want {
+			t.Fatalf("git tag %s failed to be removed: %s", name, got)
+		}
+
+		if got := cmd("git", "rev-parse", name); got != want {
+			t.Fatalf("git tag %s failed to be removed: %s", name, got)
+		}
+
+		// Ref
+		if err := ioutil.WriteFile(filepath.Join(dir, ".git", "refs", "heads", name), []byte(want), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if dontWant := cmd("git", "rev-parse", "HEAD"); dontWant == want {
+			t.Fatalf("git ref %s failed to produce ambiguous output: %s", name, dontWant)
+		}
+
+		removeBadRefs(context.Background(), dir)
+
+		if got := cmd("git", "rev-parse", "HEAD"); got != want {
+			t.Fatalf("git ref %s failed to be removed: %s", name, got)
+		}
+
+		if got := cmd("git", "rev-parse", name); got != want {
+			t.Fatalf("git ref %s failed to be removed: %s", name, got)
+		}
 	}
 }

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -433,10 +433,6 @@ func TestRemoveBadRefs(t *testing.T) {
 			t.Fatalf("git tag %s failed to be removed: %s", name, got)
 		}
 
-		if got := cmd("git", "rev-parse", name); got != want {
-			t.Fatalf("git tag %s failed to be removed: %s", name, got)
-		}
-
 		// Ref
 		if err := ioutil.WriteFile(filepath.Join(dir, ".git", "refs", "heads", name), []byte(want), 0600); err != nil {
 			t.Fatal(err)
@@ -449,10 +445,6 @@ func TestRemoveBadRefs(t *testing.T) {
 		removeBadRefs(context.Background(), dir)
 
 		if got := cmd("git", "rev-parse", "HEAD"); got != want {
-			t.Fatalf("git ref %s failed to be removed: %s", name, got)
-		}
-
-		if got := cmd("git", "rev-parse", name); got != want {
 			t.Fatalf("git ref %s failed to be removed: %s", name, got)
 		}
 	}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -424,7 +424,7 @@ func TestRemoveBadRefs(t *testing.T) {
 		cmd("git", "tag", name)
 
 		if dontWant := cmd("git", "rev-parse", "HEAD"); dontWant == want {
-			t.Fatalf("git tag %s failed to produce ambiguous output: %s", name, dontWant)
+			t.Logf("WARNING: git tag %s failed to produce ambiguous output: %s", name, dontWant)
 		}
 
 		removeBadRefs(context.Background(), dir)
@@ -443,7 +443,7 @@ func TestRemoveBadRefs(t *testing.T) {
 		}
 
 		if dontWant := cmd("git", "rev-parse", "HEAD"); dontWant == want {
-			t.Fatalf("git ref %s failed to produce ambiguous output: %s", name, dontWant)
+			t.Logf("WARNING: git ref %s failed to produce ambiguous output: %s", name, dontWant)
 		}
 
 		removeBadRefs(context.Background(), dir)


### PR DESCRIPTION
Git produces warning output when a repository contains a reference or tag
HEAD. Repositories shouldn't contain these tags or refs, but bad repositories
exist leading to our tooling breaking due to unexpected output. To avoid this
problem we remove the problematic refs on fetch/clone.

Test plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/5291
