### PR TITLE
Browser extension GSuite deployment fixes

### DIFF
--- a/browser/src/browser/ExtensionStorageSubject.ts
+++ b/browser/src/browser/ExtensionStorageSubject.ts
@@ -1,13 +1,13 @@
 import { BehaviorSubject, NextObserver, Observable } from 'rxjs'
 import { observeStorageKey, storage } from './storage'
-import { StorageItems } from './types'
+import { LocalStorageItems } from './types'
 
 /**
  * An RxJS subject that is backed by an extension storage item.
  */
-export class ExtensionStorageSubject<T extends keyof StorageItems> extends Observable<StorageItems[T]>
-    implements NextObserver<StorageItems[T]>, Pick<BehaviorSubject<StorageItems[T]>, 'value'> {
-    constructor(private key: T, defaultValue: StorageItems[T]) {
+export class ExtensionStorageSubject<T extends keyof LocalStorageItems> extends Observable<LocalStorageItems[T]>
+    implements NextObserver<LocalStorageItems[T]>, Pick<BehaviorSubject<LocalStorageItems[T]>, 'value'> {
+    constructor(private key: T, defaultValue: LocalStorageItems[T]) {
         super(subscriber => {
             subscriber.next(this.value)
             return observeStorageKey('local', this.key).subscribe((item = defaultValue) => {
@@ -18,9 +18,9 @@ export class ExtensionStorageSubject<T extends keyof StorageItems> extends Obser
         this.value = defaultValue
     }
 
-    public async next(value: StorageItems[T]): Promise<void> {
+    public async next(value: LocalStorageItems[T]): Promise<void> {
         await storage.local.set({ [this.key]: value })
     }
 
-    public value: StorageItems[T]
+    public value: LocalStorageItems[T]
 }

--- a/browser/src/browser/storage.ts
+++ b/browser/src/browser/storage.ts
@@ -1,4 +1,4 @@
-import { concat, from, Observable } from 'rxjs'
+import { concat, from, Observable, of } from 'rxjs'
 import { filter, map } from 'rxjs/operators'
 import { fromBrowserEvent } from '../shared/util/browser'
 import { getPlatformName } from '../shared/util/context'

--- a/browser/src/browser/storage.ts
+++ b/browser/src/browser/storage.ts
@@ -1,33 +1,52 @@
 import { concat, from, Observable } from 'rxjs'
 import { filter, map } from 'rxjs/operators'
 import { fromBrowserEvent } from '../shared/util/browser'
-import { StorageItems } from './types'
+import { getPlatformName } from '../shared/util/context'
+import { LocalStorageItems, SyncStorageItems, ManagedStorageItems } from './types'
+
+interface ExtensionStorageItems {
+    local: LocalStorageItems
+    sync: SyncStorageItems
+    managed: ManagedStorageItems
+}
 
 /**
  * Type-safe access to browser extension storage.
  *
  * `undefined` in non-browser context (in-page integration). Make sure to check `isInPage`/`isExtension` first.
  */
-export const storage: Record<browser.storage.AreaName, browser.storage.StorageArea<StorageItems>> & {
+export const storage: {
+    [K in browser.storage.AreaName]: browser.storage.StorageArea<ExtensionStorageItems[K]>
+} & {
     onChanged: browser.CallbackEventEmitter<
-        (changes: browser.storage.ChangeDict<StorageItems>, areaName: browser.storage.AreaName) => void
+        (
+            changes: browser.storage.ChangeDict<ExtensionStorageItems[typeof areaName]>,
+            areaName: browser.storage.AreaName
+        ) => void
     >
 } = globalThis.browser && browser.storage
 
-export const observeStorageKey = <K extends keyof StorageItems>(
-    areaName: browser.storage.AreaName,
+export const observeStorageKey = <A extends browser.storage.AreaName, K extends keyof ExtensionStorageItems[A]>(
+    areaName: A,
     key: K
-): Observable<StorageItems[K] | undefined> =>
-    concat(
+): Observable<ExtensionStorageItems[A][K] | undefined> => {
+    if (getPlatformName() !== 'chrome-extension' && areaName === 'managed') {
+        // Accessing managed storage throws an error on Firefox.
+        return of(undefined)
+    }
+    return concat(
         // Start with current value of the item
-        from(storage[areaName].get(key)).pipe(map(items => items[key])),
+        from((storage[areaName] as browser.storage.StorageArea<ExtensionStorageItems[A]>).get(key)).pipe(
+            map(items => (items as ExtensionStorageItems[A])[key])
+        ),
         // Emit every new value from change events that affect that item
         fromBrowserEvent(storage.onChanged).pipe(
             filter(([, name]) => areaName === name),
             map(([changes]) => changes),
-            filter((changes): changes is { [k in K]: browser.storage.StorageChange<StorageItems[k]> } =>
-                Object.prototype.hasOwnProperty.call(changes, key)
-            ),
+            filter((changes): changes is {
+                [k in K]: browser.storage.StorageChange<ExtensionStorageItems[A][K]>
+            } => Object.prototype.hasOwnProperty.call(changes, key)),
             map(changes => changes[key].newValue)
         )
     )
+}

--- a/browser/src/browser/types.ts
+++ b/browser/src/browser/types.ts
@@ -1,7 +1,6 @@
 import { GraphQLResult } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { ExtensionHoverAlertType } from '../libs/code_intelligence/hover_alerts'
-import { DEFAULT_SOURCEGRAPH_URL } from '../shared/util/context'
 
 export interface PhabricatorMapping {
     callsign: string
@@ -37,11 +36,11 @@ export const featureFlagDefaults: FeatureFlags = {
     experimentalTextFieldCompletion: false,
 }
 
-export interface StorageItems {
+interface SourcegraphURL {
     sourcegraphURL: string
+}
 
-    identity: string
-    phabricatorMappings: PhabricatorMapping[]
+export interface SyncStorageItems extends SourcegraphURL {
     sourcegraphAnonymousUid: string
     /**
      * Temporarily disable the browser extension features.
@@ -55,23 +54,17 @@ export interface StorageItems {
      * Overrides settings from Sourcegraph.
      */
     clientSettings: string
-    sideloadedExtensionURL: string | null
     dismissedHoverAlerts: {
         [alertType in ExtensionHoverAlertType]?: boolean
     }
 }
 
-export const defaultStorageItems: StorageItems = {
-    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
+export interface LocalStorageItems {
+    sideloadedExtensionURL: string | null
+}
 
-    identity: '',
-    phabricatorMappings: [],
-    sourcegraphAnonymousUid: '',
-    disableExtension: false,
-    featureFlags: featureFlagDefaults,
-    clientSettings: '',
-    sideloadedExtensionURL: null,
-    dismissedHoverAlerts: {},
+export interface ManagedStorageItems extends SourcegraphURL {
+    phabricatorMappings: PhabricatorMapping[]
 }
 
 /**

--- a/browser/src/browser/types.ts
+++ b/browser/src/browser/types.ts
@@ -3,10 +3,6 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { ExtensionHoverAlertType } from '../libs/code_intelligence/hover_alerts'
 import { DEFAULT_SOURCEGRAPH_URL } from '../shared/util/context'
 
-interface RepoLocations {
-    [key: string]: string
-}
-
 export interface PhabricatorMapping {
     callsign: string
     path: string
@@ -45,8 +41,6 @@ export interface StorageItems {
     sourcegraphURL: string
 
     identity: string
-    enterpriseUrls: string[]
-    repoLocations: RepoLocations
     phabricatorMappings: PhabricatorMapping[]
     sourcegraphAnonymousUid: string
     /**
@@ -71,8 +65,6 @@ export const defaultStorageItems: StorageItems = {
     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
 
     identity: '',
-    enterpriseUrls: [],
-    repoLocations: {},
     phabricatorMappings: [],
     sourcegraphAnonymousUid: '',
     disableExtension: false,

--- a/browser/src/extension/schema.json
+++ b/browser/src/extension/schema.json
@@ -12,6 +12,11 @@
           "children": { "$ref": "ListOfCallsignMappings" }
         }
       }
+    },
+    "sourcegraphURL": {
+      "type": "string",
+      "title": "Sourcegraph URL",
+      "description": "The URL of your self-hosted Sourcegraph instance."
     }
   }
 }

--- a/browser/src/extension/schema.json
+++ b/browser/src/extension/schema.json
@@ -1,12 +1,6 @@
 {
   "type": "object",
   "properties": {
-    "enterpriseUrls": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "phabricatorMappings": {
       "type": "array",
       "id": "ListOfCallsignMappings",

--- a/browser/src/extension/scripts/background.tsx
+++ b/browser/src/extension/scripts/background.tsx
@@ -9,8 +9,7 @@ import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 import { createExtensionHostWorker } from '../../../../shared/src/api/extension/worker'
 import { GraphQLResult, requestGraphQL as requestGraphQLCommon } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
-import { storage } from '../../browser/storage'
-import { BackgroundMessageHandlers, defaultStorageItems } from '../../browser/types'
+import { BackgroundMessageHandlers } from '../../browser/types'
 import { initializeOmniboxInterface } from '../../libs/cli'
 import { initSentry } from '../../libs/sentry'
 import { createBlobURLForBundle } from '../../platform/worker'
@@ -160,25 +159,9 @@ async function main(): Promise<void> {
 
     await browser.runtime.setUninstallURL('https://about.sourcegraph.com/uninstall/')
 
-    browser.runtime.onInstalled.addListener(async () => {
-        setDefaultBrowserAction()
-        const items = await storage.sync.get()
-        // Enterprise deployments of Sourcegraph are passed a configuration file.
-        const managedItems = await storage.managed.get()
-        await storage.sync.set({
-            ...defaultStorageItems,
-            ...items,
-            ...managedItems,
-        })
-    })
-
-    function setDefaultBrowserAction(): void {
-        browser.browserAction.setBadgeText({ text: '' })
-        browser.browserAction.setPopup({ popup: 'options.html?popup=true' })
-    }
-
     browser.browserAction.onClicked.addListener(noop)
-    setDefaultBrowserAction()
+    browser.browserAction.setBadgeText({ text: '' })
+    browser.browserAction.setPopup({ popup: 'options.html?popup=true' })
 
     // Add "Enable Sourcegraph on this domain" context menu item
     addDomainPermissionToggle()

--- a/browser/src/extension/scripts/options.tsx
+++ b/browser/src/extension/scripts/options.tsx
@@ -8,17 +8,20 @@ import { GraphQLResult } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { background } from '../../browser/runtime'
 import { observeStorageKey, storage } from '../../browser/storage'
-import { defaultStorageItems, featureFlagDefaults, FeatureFlags } from '../../browser/types'
+import { featureFlagDefaults, FeatureFlags } from '../../browser/types'
 import { OptionsContainer, OptionsContainerProps } from '../../libs/options/OptionsContainer'
 import { OptionsMenuProps } from '../../libs/options/OptionsMenu'
 import { initSentry } from '../../libs/sentry'
 import { fetchSite } from '../../shared/backend/server'
 import { featureFlags } from '../../shared/util/featureFlags'
 import { assertEnv } from '../envAssertion'
+import { observeSourcegraphURL } from '../../shared/util/context'
 
 assertEnv('OPTIONS')
 
 initSentry('options')
+
+const IS_EXTENSION = true
 
 type State = Pick<
     FeatureFlags,
@@ -90,11 +93,9 @@ class Options extends React.Component<{}, State> {
         )
 
         this.subscriptions.add(
-            observeStorageKey('sync', 'sourcegraphURL').subscribe(
-                (sourcegraphURL = defaultStorageItems.sourcegraphURL) => {
-                    this.setState({ sourcegraphURL })
-                }
-            )
+            observeSourcegraphURL(IS_EXTENSION).subscribe(sourcegraphURL => {
+                this.setState({ sourcegraphURL })
+            })
         )
 
         this.subscriptions.add(

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -3,7 +3,7 @@ import { catchError, map, startWith, switchMap } from 'rxjs/operators'
 import { HoverAlert } from '../../../../shared/src/hover/HoverOverlay'
 import { combineLatestOrDefault } from '../../../../shared/src/util/rxjs/combineLatestOrDefault'
 import { observeStorageKey, storage } from '../../browser/storage'
-import { StorageItems } from '../../browser/types'
+import { SyncStorageItems } from '../../browser/types'
 import { isInPage } from '../../context'
 
 export type ExtensionHoverAlertType = 'nativeTooltips'
@@ -36,7 +36,7 @@ export function getActiveHoverAlerts(
  */
 export async function onHoverAlertDismissed(alertType: ExtensionHoverAlertType): Promise<void> {
     try {
-        const partialStorageItems: Pick<StorageItems, 'dismissedHoverAlerts'> = {
+        const partialStorageItems: Pick<SyncStorageItems, 'dismissedHoverAlerts'> = {
             dismissedHoverAlerts: {},
             ...(await storage.sync.get('dismissedHoverAlerts')),
         }

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -322,7 +322,7 @@ export function getRepoDetailsFromRevisionID(
 
 async function convertConduitRepoToRepoDetails(repo: ConduitRepo): Promise<PhabricatorRepoDetails | null> {
     if (isExtension) {
-        const items = await storage.sync.get()
+        const items = await storage.managed.get()
         if (items.phabricatorMappings) {
             for (const mapping of items.phabricatorMappings) {
                 if (mapping.callsign === repo.fields.callsign) {

--- a/browser/src/libs/sentry/index.ts
+++ b/browser/src/libs/sentry/index.ts
@@ -3,7 +3,9 @@ import { once } from 'lodash'
 import { observeStorageKey } from '../../browser/storage'
 import { featureFlagDefaults } from '../../browser/types'
 import { isInPage } from '../../context'
-import { DEFAULT_SOURCEGRAPH_URL, getExtensionVersion } from '../../shared/util/context'
+import { DEFAULT_SOURCEGRAPH_URL, getExtensionVersion, observeSourcegraphURL } from '../../shared/util/context'
+
+const IS_EXTENSION = true
 
 const isExtensionStackTrace = (stacktrace: Sentry.Stacktrace, extensionID: string): boolean =>
     !!(stacktrace.frames && stacktrace.frames.some(({ filename }) => !!(filename && filename.includes(extensionID))))
@@ -56,7 +58,7 @@ export function initSentry(script: 'content' | 'options' | 'background', codeHos
         })
     })
 
-    observeStorageKey('sync', 'sourcegraphURL').subscribe(url => {
+    observeSourcegraphURL(IS_EXTENSION).subscribe(url => {
         Sentry.configureScope(scope => {
             scope.setTag('using_dot_com', url === DEFAULT_SOURCEGRAPH_URL ? 'true' : 'false')
         })

--- a/browser/src/platform/context.ts
+++ b/browser/src/platform/context.ts
@@ -10,7 +10,6 @@ import { LocalStorageSubject } from '../../../shared/src/util/LocalStorageSubjec
 import { toPrettyBlobURL } from '../../../shared/src/util/url'
 import { ExtensionStorageSubject } from '../browser/ExtensionStorageSubject'
 import { background } from '../browser/runtime'
-import { observeStorageKey } from '../browser/storage'
 import { isInPage } from '../context'
 import { CodeHost } from '../libs/code_intelligence'
 import { DEFAULT_SOURCEGRAPH_URL, observeSourcegraphURL } from '../shared/util/context'
@@ -85,14 +84,7 @@ export function createPlatformContext(
          *   the UX).
          */
         settings: combineLatest([
-            merge(
-                isInPage
-                    ? fetchViewerSettings(requestGraphQL)
-                    : observeStorageKey('sync', 'sourcegraphURL').pipe(
-                          switchMap(() => fetchViewerSettings(requestGraphQL))
-                      ),
-                updatedViewerSettings
-            ).pipe(
+            merge(fetchViewerSettings(requestGraphQL), updatedViewerSettings).pipe(
                 publishReplay(1),
                 refCount()
             ),


### PR DESCRIPTION
Rel #5604
Closes #3604

Removes unused storage items, adds the ability to set the Sourcegraph URL through managed storage, and cleans up storage access.

- Remove unused storage items `repoLocations` (never read) and `enterpriseUrls`. The only consequence of having `enterpriseURLs` present in storage was to set the browser action to open the options page instead of the popup. In the options page, nothing specific is done when enterpriseURLs were present. They were otherwise unused in the browser extension.
- Handle reading the `sourcegraphURL` from managed storage.
- Split StorageItems by storage area: there are now different storage item types for local, sync and managed storage items. The typings of `observeStorageKey` and `storage` reflect this. Rather than copying all items from managed storage to sync storage upon installation, relevant storage items (for instance `phabricatorMappings`) are directly observed from managed storage.