### PR TITLE
src-expose: Enable src-expose via special repo name

### DIFF
--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -46,7 +46,7 @@ func NewOtherSource(svc *ExternalService, cf *httpcli.Factory) (*OtherSource, er
 // ListRepos returns all Other repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s OtherSource) ListRepos(ctx context.Context, results chan SourceResult) {
-	if s.conn.ExperimentalSrcExpose {
+	if len(s.conn.Repos) == 1 && s.conn.Repos[0] == "src-expose" {
 		repos, err := s.srcExpose(ctx)
 		if err != nil {
 			results <- SourceResult{Source: s, Err: err}

--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -188,8 +188,7 @@ Paste the following configuration as an Other External Service in Sourcegraph:
 
   {
     "url": "http://%s", // Use http://%s if Sourcegraph is running in Docker
-    "repos": ["hack-ignore-me"],
-    "experimental.srcExpose": true
+    "repos": ["src-expose"], // This may change in versions later than 3.9
   }
 
 `, *globalSnapshotDir, strings.Join(args[1:], "\n- "), *serveAddr, *serveAddr, dockerAddr(*serveAddr))

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -34,11 +34,6 @@
       "type": "string",
       "default": "{base}/{repo}",
       "examples": ["pretty-host-name/{repo}"]
-    },
-    "experimental.srcExpose": {
-      "description": "EXPERIMENTAL: If true, the base url is used as a src-expose API endpoint. repositoryPathPattern and repos is ignored. This will be lifted to its own service type.",
-      "type": "boolean",
-      "default": false
     }
   }
 }

--- a/schema/other_external_service_stringdata.go
+++ b/schema/other_external_service_stringdata.go
@@ -39,11 +39,6 @@ const OtherExternalServiceSchemaJSON = `{
       "type": "string",
       "default": "{base}/{repo}",
       "examples": ["pretty-host-name/{repo}"]
-    },
-    "experimental.srcExpose": {
-      "description": "EXPERIMENTAL: If true, the base url is used as a src-expose API endpoint. repositoryPathPattern and repos is ignored. This will be lifted to its own service type.",
-      "type": "boolean",
-      "default": false
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -411,7 +411,6 @@ type OpenIDConnectAuthProvider struct {
 
 // OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
 type OtherExternalServiceConnection struct {
-	ExperimentalSrcExpose bool     `json:"experimental.srcExpose,omitempty"`
 	Repos                 []string `json:"repos"`
 	RepositoryPathPattern string   `json:"repositoryPathPattern,omitempty"`
 	Url                   string   `json:"url,omitempty"`


### PR DESCRIPTION
@ryan-blunden suggested as a way to make src-expose more hidden, as well as a nice
way to remove the ugly "hack-me" required in the repo field since we ensure it
is non-empty. I quite like the idea, and think this is nice for our initial
release of src-expose.