### PR TITLE
Don't swallow errors in updateSettings

### DIFF
--- a/browser/src/platform/context.ts
+++ b/browser/src/platform/context.ts
@@ -123,6 +123,8 @@ export function createPlatformContext(
                     // try once more.
                     updatedViewerSettings.next(await fetchViewerSettings(requestGraphQL).toPromise())
                     await updateSettings(context, subject, edit, mutateSettings)
+                } else {
+                    throw error
                 }
             }
             updatedViewerSettings.next(await fetchViewerSettings(requestGraphQL).toPromise())

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -49,6 +49,8 @@ export function createPlatformContext(): PlatformContext {
                     // try once more.
                     updatedSettings.next(await fetchViewerSettings().toPromise())
                     await updateSettings(context, subject, edit, mutateSettings)
+                } else {
+                    throw error
                 }
             }
             updatedSettings.next(await fetchViewerSettings().toPromise())


### PR DESCRIPTION
Fixes #5887

https://github.com/sourcegraph/sourcegraph/pull/2189 had added logic to retry updating the settings when a "version mismatch" error" was thrown. Unfortunately, other errors (like "Invalid JSON") were caught, but never rethrown.
