### PR TITLE
Add GitLab integration to corsOrigin config description

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -72,9 +72,9 @@
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
+      "description": "Only required when using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator, GitLab, or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com\"",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -72,7 +72,7 @@
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator, GitLab, or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com\"",
+      "description": "Only required when using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
       "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -77,9 +77,9 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
+      "description": "Only required when using the Phabricator integration, GitLab integration, or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },


### PR DESCRIPTION
I have two commits here, the first adding GitLab to the description, and the second removing the extra sentence about this setting being used for the browser extension. I think it's been long enough now that it's no longer needed, and it makes the description more clear. 

How do I generate the `site_stringdata.go`? Or does that happen automatically?

This should only merge after the [GitLab MR](https://gitlab.com/gitlab-org/gitlab/merge_requests/16556) is merged.