### PR TITLE
Enforce free user limit on enterprise builds

### DIFF
--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -74,5 +74,5 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	return *NoLicenseWarningUserCount < int32(userCount), nil
+	return *NoLicenseWarningUserCount <= int32(userCount), nil
 }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement.go
@@ -39,9 +39,9 @@ func NewPreCreateUserHook(s UsersStore) func(context.Context) error {
 			} else {
 				message := "Unable to create user account: "
 				if info == nil {
-					message = fmt.Sprintf("a Sourcegraph subscription is required to exceed %d users, and new users can not be created above %d (this instance now has %d users). A site admin must purchase a subscription at https://sourcegraph.com/user/settings/subscriptions/new. Enter the license key in the Sourcegraph management console.", NoLicenseWarningUserCount, NoLicenseMaximumAllowedUserCount, userCount)
+					message = fmt.Sprintf("a Sourcegraph subscription is required to exceed %d users (this instance now has %d users). Contact Sourcegraph to learn more at https://about.sourcegraph.com/contact/sales.", NoLicenseMaximumAllowedUserCount, userCount)
 				} else {
-					message += "the Sourcegraph subscription's maximum user count has been reached. A site admin must upgrade the Sourcegraph subscription to allow for more users. Enter the license key in the Sourcegraph management console (https://docs.sourcegraph.com/admin/management_console)."
+					message += "the Sourcegraph subscription's maximum user count has been reached. A site admin must upgrade the Sourcegraph subscription to allow for more users. Contact Sourcegraph at https://about.sourcegraph.com/contact/sales."
 				}
 				return errcode.NewPresentationError(message)
 			}

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -157,8 +157,8 @@ func StartMaxUserCount(s UsersStore) {
 // NoLicenseMaximumAllowedUserCount is the maximum number of user accounts that may exist on Sourcegraph Core
 // (i.e., when running without a license). Exceeding this number of user accounts requires a
 // license.
-const NoLicenseMaximumAllowedUserCount int32 = 50
+const NoLicenseMaximumAllowedUserCount int32 = 20
 
-// NoLicenseWarningUserCount is the number of user accounts that may exist on Sourcegraph Core
-// (i.e., when running without a license) before all users are shown a warning.
+// NoLicenseWarningUserCount is the number of user accounts when all users are shown a warning (when running
+// without a license).
 const NoLicenseWarningUserCount int32 = 20

--- a/web/src/site/FreeUsersExceededAlert.tsx
+++ b/web/src/site/FreeUsersExceededAlert.tsx
@@ -10,7 +10,7 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
 }> = ({ noLicenseWarningUserCount, className = '' }) => (
     <div className={`alert alert-danger alert-animated-bg ${className}`}>
         <WarningIcon className="icon-inline mr-2" />
-        This Sourcegraph instance has exceeded{' '}
+        This Sourcegraph instance has reached{' '}
         {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users, and an admin must{' '}
         <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">
             <span className="underline">purchase a license</span>
@@ -18,6 +18,7 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
         or{' '}
         <a className="site-alert__link" href="https://about.sourcegraph.com/contact/sales">
             <span className="underline">contact Sourcegraph for a free trial</span>
-        </a>
+        </a>{' '}
+        to add more
     </div>
 )


### PR DESCRIPTION
Enforces our 20 free user limit on official docker builds. In the past, we just showed a warning banner from 20-50 users — this change no longer allows that.

In-app notification that appears for all users:
![image](https://user-images.githubusercontent.com/5589410/66449127-cf4bcc80-ea08-11e9-8f11-8657159a74cf.png)

Notification when a 21st user tries to sign up:
![image](https://user-images.githubusercontent.com/5589410/66449175-f7d3c680-ea08-11e9-9e93-d57da1a94ef5.png)
