### PR TITLE
DRAFT search: make all filters case insensitive

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -3,6 +3,8 @@
 package query
 
 import (
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/types"
 )
@@ -111,6 +113,7 @@ func parseAndCheck(conf *types.Config, input string) (*Query, error) {
 // "foo:yes foo:no foo:yes", then the last boolean value for the "foo" field is true ("yes"). The
 // default boolean value is false.
 func (q *Query) BoolValue(field string) bool {
+	field = strings.ToLower(field)
 	for _, v := range q.Fields[field] {
 		if v.Bool != nil {
 			return *v.Bool
@@ -127,6 +130,7 @@ func (q *Query) IsCaseSensitive() bool {
 
 // Values returns the values for the given field.
 func (q *Query) Values(field string) []*types.Value {
+	field = strings.ToLower(field)
 	if _, ok := q.conf.FieldTypes[field]; !ok {
 		panic("no such field: " + field)
 	}
@@ -136,6 +140,7 @@ func (q *Query) Values(field string) []*types.Value {
 // RegexpPatterns returns the regexp pattern source strings for the given field.
 // If the field is not recognized or it is not always regexp-typed, it panics.
 func (q *Query) RegexpPatterns(field string) (values, negatedValues []string) {
+	field = strings.ToLower(field)
 	fieldType, ok := q.conf.FieldTypes[field]
 	if !ok {
 		panic("no such field: " + field)
@@ -158,6 +163,7 @@ func (q *Query) RegexpPatterns(field string) (values, negatedValues []string) {
 // StringValues returns the string values for the given field. If the field is
 // not recognized or it is not always string-typed, it panics.
 func (q *Query) StringValues(field string) (values, negatedValues []string) {
+	field = strings.ToLower(field)
 	fieldType, ok := q.conf.FieldTypes[field]
 	if !ok {
 		panic("no such field: " + field)
@@ -179,6 +185,7 @@ func (q *Query) StringValues(field string) (values, negatedValues []string) {
 // StringValue returns the string value for the given field.
 // It panics if the field is not recognized, it is not always string-typed, or it is not singular.
 func (q *Query) StringValue(field string) (value, negatedValue string) {
+	field = strings.ToLower(field)
 	fieldType, ok := q.conf.FieldTypes[field]
 	if !ok {
 		panic("no such field: " + field)


### PR DESCRIPTION
Draft so @keegancsmith can comment 

early experiment on how to make all the search filters case insensitive, so filters camelCased like `repoHasFile` would work instead of only lower cased. 

From slack: 
> But I played around more in these files and couldn't get it to work:

https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/pkg/search/query/searchquery.go#L98-108
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/pkg/search/query/types/check.go#L42-58
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/pkg/search/query/types/check.go#L88-119

This code in the branch is most likely irrelevant. This is failing in because work needs to be done in the Check part (checkExpr specifically, I believe) of ParseAndCheck
