### PR TITLE
search: Make search query fields case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Allow single trailing hyphen in usernames and org names [#5680](https://github.com/sourcegraph/sourcegraph/pull/5680)
 - Indexed search won't spam the logs on startup if the frontend API is not yet available. [zoekt#30](https://github.com/sourcegraph/zoekt/pull/30), [#5866](https://github.com/sourcegraph/sourcegraph/pull/5866)
 - Sourcegraph now creates a secondary database within the configured PostgreSQL instance. This database has a name of the form `{PGDATABASE}_lsif`, where `{PGDATABASE}` is the name of the primary database. This is done automatically, but please ensure the configured PostgreSQL user has permission to perform `CREATE DATABASE` if using an external database before upgrading.
+- Search query fields are now case insensitive. For example `repoHasFile:` will now be recognized, not just `repohasfile:`. [#5168](https://github.com/sourcegraph/sourcegraph/issues/5168)
 
 ### Fixed
 

--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -3,6 +3,8 @@
 package query
 
 import (
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/types"
 )
@@ -100,6 +102,12 @@ func parseAndCheck(conf *types.Config, input string) (*Query, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// We want to make query fields case insensitive
+	for _, expr := range syntaxQuery.Expr {
+		expr.Field = strings.ToLower(expr.Field)
+	}
+
 	checkedQuery, err := conf.Check(syntaxQuery)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/internal/pkg/search/query/searchquery_test.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery_test.go
@@ -131,6 +131,22 @@ func TestQuery_StringValues(t *testing.T) {
 	})
 }
 
+func TestQuery_CaseInsensitiveFields(t *testing.T) {
+	query, err := ParseAndCheck("repoHasFile:foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values, _ := query.RegexpPatterns(FieldRepoHasFile)
+	if len(values) != 1 || values[0] != "foo" {
+		t.Errorf("unexpected values: want {\"foo\"}, got %v", values)
+	}
+
+	if got, want := query.Query.String(), `repohasfile~"foo"`; got != want {
+		t.Errorf("unexpected parsed query:\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
 func checkPanic(t *testing.T, msg string, f func()) {
 	t.Helper()
 	defer func() {

--- a/cmd/frontend/internal/pkg/search/query/syntax/scanner.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/scanner.go
@@ -126,7 +126,7 @@ func scanDefault(s *scanner) stateFn {
 
 func scanText(s *scanner) stateFn {
 	// Characters that may come before a ':' (TokenColon) in a TokenLiteral.
-	preColonChars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	preColonChars := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 	for {
 		if s.eof() {

--- a/cmd/frontend/internal/pkg/search/query/types/query.go
+++ b/cmd/frontend/internal/pkg/search/query/types/query.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
 )
@@ -10,6 +13,26 @@ import (
 type Query struct {
 	Syntax *syntax.Query       // the query syntax
 	Fields map[string][]*Value // map of field name -> values
+}
+
+func (q *Query) String() string {
+	fields := []string{}
+	for key, values := range q.Fields {
+		for _, v := range values {
+			switch s := v.Value().(type) {
+			case string:
+				fields = append(fields, fmt.Sprintf("%s:%q", key, s))
+			case *regexp.Regexp:
+				fields = append(fields, fmt.Sprintf("%s~%q", key, s))
+			case bool:
+				fields = append(fields, fmt.Sprintf("%s:%v", key, s))
+			default:
+				fields = append(fields, fmt.Sprintf("(UNKNOWN TYPE %s:%v)", key, s))
+			}
+		}
+	}
+	sort.Strings(fields)
+	return strings.Join(fields, " ")
 }
 
 // ValueType is the set of types of values in queries.


### PR DESCRIPTION
This required modifying the syntax parser, since it explicitly only allowed
lowercase letters (and digits) before the colon. Additionally we add a String
method to Query which returns a normalized string. This is used in the test
added, but can be used to simplify parsing tests going forward.

Fixes https://github.com/sourcegraph/sourcegraph/issues/5168