### PR TITLE
Change log level for spurious "error" from the resque scheduler.

### DIFF
--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -124,8 +124,8 @@ function connect(connectionOptions: PostgresConnectionCredentialsOptions, logger
     return pRetry(connect, {
         factor: 1,
         retries: MAX_CONNECTION_RETRIES,
-        minTimeout: CONNECTION_RETRY_INTERVAL,
-        maxTimeout: CONNECTION_RETRY_INTERVAL,
+        minTimeout: CONNECTION_RETRY_INTERVAL * 1000,
+        maxTimeout: CONNECTION_RETRY_INTERVAL * 1000,
     })
 }
 
@@ -150,8 +150,8 @@ function waitForMigrations(connection: Connection, database: string, logger: Log
     return pRetry(check, {
         factor: 1,
         retries: MAX_SCHEMA_POLL_RETRIES,
-        minTimeout: SCHEMA_POLL_INTERVAL,
-        maxTimeout: SCHEMA_POLL_INTERVAL,
+        minTimeout: SCHEMA_POLL_INTERVAL * 1000,
+        maxTimeout: SCHEMA_POLL_INTERVAL * 1000,
     })
 }
 

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -163,7 +163,7 @@ async function main(logger: Logger): Promise<void> {
  * https://github.com/sourcegraph/sourcegraph/issues/5917 for more context.
  */
 function isSpuriousSchedulerError(error: Error): boolean {
-    return error.message.includes('force-cleaning worker') && error.message.includes('but cannot find queues')
+    return /force-cleaning worker .* but cannot find queues/.test(error.message)
 }
 
 /**

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -158,6 +158,15 @@ async function main(logger: Logger): Promise<void> {
 }
 
 /**
+ * Used to filter out this noisy and quite alarm message. This is really just
+ * a warning from node resque that comes on a somehwat misnamed event. See
+ * https://github.com/sourcegraph/sourcegraph/issues/5917 for more context.
+ */
+function isSpuriousSchedulerError(error: Error): boolean {
+    return error.message.includes('force-cleaning worker') && error.message.includes('but cannot find queues')
+}
+
+/**
  * Connect and start an active connection to the worker queue. We also run a
  * node-resque scheduler on each server instance, as these are guaranteed to
  * always be up with a responsive system. The schedulers will do their own
@@ -189,7 +198,13 @@ async function setupQueue(logger: Logger): Promise<Queue> {
     scheduler.on('master', () => logger.debug('scheduler became master'))
     scheduler.on('cleanStuckWorker', worker => logger.debug('scheduler cleaning stuck worker', { worker }))
     scheduler.on('transferredJob', (_, job) => logger.debug('scheduler transferring job', { job }))
-    scheduler.on('error', error => logger.error('scheduler error', { error }))
+    scheduler.on('error', error => {
+        if (isSpuriousSchedulerError(error)) {
+            logger.debug('scheduler warning', { error })
+        } else {
+            logger.error('scheduler error', { error })
+        }
+    })
 
     await scheduler.connect()
     exitHook(() => scheduler.end())


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/5917.