### PR TITLE
confdefaults: put externalURL in comments

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -37,7 +37,7 @@ var DockerContainer = conftypes.RawUnified{
 	Critical: `{
 	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
 	// This is required to be configured for Sourcegraph to work correctly.
-	"externalURL": "https://sourcegraph.example.com",
+	// "externalURL": "https://sourcegraph.example.com",
 
 	"auth.providers": [
 		{
@@ -58,7 +58,7 @@ var Cluster = conftypes.RawUnified{
 	Critical: `{
 	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
 	// This is required to be configured for Sourcegraph to work correctly.
-	"externalURL": "https://sourcegraph.example.com",
+	// "externalURL": "https://sourcegraph.example.com",
 
 	// The authentication provider to use for identifying and signing in users.
 	// Only one entry is supported.


### PR DESCRIPTION
Because the dummy URL is causing admin not be able to sign up with "invalid CSRF token" (i.e. `sourcegraph/sourcegraph:insiders`). This issue is currently a show-stopper for anyone who wants to run fresh Sourcegraph Docker container against `master` branch.

Put them in comment in first few lines of config is at least visible to admins.

Thanks @ryan-blunden who found this!
