### PR TITLE
./dev/add_migration.sh: catch bad migrate call

### DIFF
--- a/dev/add_migration.sh
+++ b/dev/add_migration.sh
@@ -12,6 +12,14 @@ fi
 ABSOLUTE_PATH=$(pwd)
 migrate create -ext sql -dir $ABSOLUTE_PATH -digits 10 -seq "$1"
 
+if [ -z "$(git status --porcelain -- . | grep "^??")" ]; then
+    echo "It looks like your migrate command failed to create new .sql files. Try upgrading:"
+    echo ""
+    echo "    go get -tags 'postgres' -u github.com/golang-migrate/migrate/v4/cmd/migrate/"
+    echo ""
+    exit 1
+fi
+
 files=$(ls -1 | grep '^[0-9]'.*\.sql | sort -n | tail -n2)
 
 for f in $files; do


### PR DESCRIPTION
This helps prevent an incompatible migrate command from overwriting files in the `migrations/` directory.

Resolves https://github.com/sourcegraph/sourcegraph/issues/5944