### PR TITLE
gitserver: Reclone repositories with gic gc warnings

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -29,7 +29,13 @@ func init() {
 	prometheus.MustRegister(reposRecloned)
 }
 
-const repoTTL = time.Hour * 24 * 45
+const (
+	// repoTTL is how often we should reclone a repository
+	repoTTL = time.Hour * 24 * 45
+	// repoTTLGC is how often we should reclone a repository once it is
+	// reporting git gc issues.
+	repoTTLGC = time.Hour * 24
+)
 
 var reposRemoved = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: "src",

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -61,19 +61,13 @@ func TestCleanupExpired(t *testing.T) {
 	defer os.RemoveAll(root)
 
 	repoNew := path.Join(root, "repo-new", ".git")
-	cmd := exec.Command("git", "--bare", "init", repoNew)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
 	repoOld := path.Join(root, "repo-old", ".git")
-	cmd = exec.Command("git", "--bare", "init", repoOld)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
 	remote := path.Join(root, "remote", ".git")
-	cmd = exec.Command("git", "--bare", "init", remote)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+	for _, path := range []string{repoNew, repoOld, remote} {
+		cmd := exec.Command("git", "--bare", "init", path)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	origRepoRemoteURL := repoRemoteURL
@@ -87,7 +81,7 @@ func TestCleanupExpired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", strconv.FormatInt(time.Now().Add(-(2*repoTTL)).Unix(), 10))
+	cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", strconv.FormatInt(time.Now().Add(-(2*repoTTL)).Unix(), 10))
 	cmd.Dir = repoOld
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -390,13 +390,15 @@ func mkFiles(t *testing.T, root string, paths ...string) {
 		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(p)), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
-		fd, err := os.OpenFile(filepath.Join(root, p), os.O_RDONLY|os.O_CREATE, 0666)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := fd.Close(); err != nil {
-			t.Fatal(err)
-		}
+		writeFile(t, filepath.Join(root, p), nil)
+	}
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	err := ioutil.WriteFile(path, content, 0666)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -90,10 +90,13 @@ func TestCleanupExpired(t *testing.T) {
 	for path, delta := range map[string]time.Duration{
 		repoOld: 2 * repoTTL,
 	} {
-		ts := strconv.FormatInt(time.Now().Add(-delta).Unix(), 10)
-		cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", ts)
+		ts := time.Now().Add(-delta)
+		cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", strconv.FormatInt(ts.Unix(), 10))
 		cmd.Dir = path
 		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(filepath.Join(path, "HEAD"), ts, ts); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -81,10 +81,15 @@ func TestCleanupExpired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", strconv.FormatInt(time.Now().Add(-(2*repoTTL)).Unix(), 10))
-	cmd.Dir = repoOld
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+	for path, delta := range map[string]time.Duration{
+		repoOld: 2 * repoTTL,
+	} {
+		ts := strconv.FormatInt(time.Now().Add(-delta).Unix(), 10)
+		cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", ts)
+		cmd.Dir = path
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	s := &Server{ReposDir: root}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 type Test struct {
@@ -448,4 +450,12 @@ func TestRemoveBadRefs(t *testing.T) {
 			t.Fatalf("git ref %s failed to be removed: %s", name, got)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
45 days is too long to wait for large repositories such as kubernetes. Git
will add a warning log file called `gc.log` when it detects a clone is
needed. Our reclone job now takes this signal into account when deciding to
reclone. If the file is present and it has been at least a day since our last
clone, the repository will get recloned.

Test Plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/5522