### PR TITLE
graphqlbackend: Call new Node.To* methods to remove non-determinism in coverage

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -61,6 +61,15 @@ func TestNodeResolverTo(t *testing.T) {
 		if _, b := r.ToAccessToken(); b {
 			continue
 		}
+		if _, b := r.ToCampaign(); b {
+			continue
+		}
+		if _, b := r.ToChangeset(); b {
+			continue
+		}
+		if _, b := r.ToChangesetEvent(); b {
+			continue
+		}
 		if _, b := r.ToDiscussionComment(); b {
 			continue
 		}


### PR DESCRIPTION
We do this for a bunch of other functions. Noticed codecov reporting these functions on unrelated PRs.