### PR TITLE
Fix spurious typeorm error.

### DIFF
--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -471,9 +471,17 @@ export class Database {
             }
         }
 
-        return await this.documentCache.withValue(`${this.databasePath}::${path}`, factory, document =>
-            Promise.resolve(document.data)
-        )
+        try {
+            return await this.documentCache.withValue(`${this.databasePath}::${path}`, factory, document =>
+                Promise.resolve(document.data)
+            )
+        } catch (error) {
+            if (error.name === 'EntityNotFound') {
+                return undefined
+            }
+
+            throw error
+        }
     }
 
     /**


### PR DESCRIPTION
We want to return undefined when the database cannot be loaded (due to not checking the exists endpoint first). The current behavior results in an uncaught error.