### PR TITLE
confdefault: revert cluster default `externalURL`

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -58,7 +58,7 @@ var Cluster = conftypes.RawUnified{
 	Critical: `{
 	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
 	// This is required to be configured for Sourcegraph to work correctly.
-	// "externalURL": "https://sourcegraph.example.com",
+	"externalURL": "http://localhost:3080",
 
 	// The authentication provider to use for identifying and signing in users.
 	// Only one entry is supported.


### PR DESCRIPTION
Revert default value of `externalURL` for Cluster back to `http://localhost:3080`. As @dadlerj mentioned in https://github.com/sourcegraph/sourcegraph/pull/5938#discussion_r333298380.
