### PR TITLE
site_alerts: add runtime validation for critical.externalURL

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -61,8 +61,6 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 	return alerts, nil
 }
 
-// doRuntimeValidation performs additional validations at runtime which otherwise will
-// prevent server from starting via conf.ContributeValidator.
 // getConfigWarnings identifies problems with the configuration that a site
 // admin should address, but do not prevent Sourcegraph from running.
 func getConfigWarnings() (problems conf.Problems, err error) {

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -63,7 +63,9 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 
 // doRuntimeValidation performs additional validations at runtime which otherwise will
 // prevent server from starting via conf.ContributeValidator.
-func doRuntimeValidation() (problems conf.Problems, err error) {
+// getConfigWarnings identifies problems with the configuration that a site
+// admin should address, but do not prevent Sourcegraph from running.
+func getConfigWarnings() (problems conf.Problems, err error) {
 	var c conf.Unified
 	if err := jsonc.Unmarshal(globals.ConfigurationServerFrontendOnly.Raw().Critical, &c.Critical); err != nil {
 		return nil, err
@@ -94,7 +96,7 @@ func init() {
 			}
 		}
 
-		runtimeProblems, err := doRuntimeValidation()
+		configWarnings, err := getConfigWarnings()
 		if err != nil {
 			return []*Alert{
 				{
@@ -103,7 +105,7 @@ func init() {
 				},
 			}
 		}
-		problems = append(problems, runtimeProblems...)
+		problems = append(problems, configWarnings...)
 
 		if len(problems) == 0 {
 			return nil

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
 // Alert implements the GraphQL type Alert.
@@ -60,6 +61,19 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 	return alerts, nil
 }
 
+// doRuntimeValidation performs additional validations at runtime which otherwise will
+// prevent server from starting via conf.ContributeValidator.
+func doRuntimeValidation() (problems conf.Problems, err error) {
+	var c conf.Unified
+	if err := jsonc.Unmarshal(globals.ConfigurationServerFrontendOnly.Raw().Critical, &c.Critical); err != nil {
+		return nil, err
+	}
+	if c.Critical.ExternalURL == "" {
+		problems = append(problems, conf.NewCriticalProblem("`externalURL` was empty and it is required to be configured for Sourcegraph to work correctly."))
+	}
+	return problems, nil
+}
+
 func init() {
 	// Warn about invalid site configuration.
 	AlertFuncs = append(AlertFuncs, func(args AlertFuncArgs) []*Alert {
@@ -79,6 +93,18 @@ func init() {
 				},
 			}
 		}
+
+		runtimeProblems, err := doRuntimeValidation()
+		if err != nil {
+			return []*Alert{
+				{
+					TypeValue:    AlertTypeError,
+					MessageValue: `Update [**critical configuration**](/help/admin/management_console) to resolve problems: ` + err.Error(),
+				},
+			}
+		}
+		problems = append(problems, runtimeProblems...)
+
 		if len(problems) == 0 {
 			return nil
 		}
@@ -89,7 +115,7 @@ func init() {
 		if len(criticalProblems) > 0 {
 			alerts = append(alerts, &Alert{
 				TypeValue: AlertTypeWarning,
-				MessageValue: `[**Update critical configuration**](/help/admin/management_console) to resolve problems.` +
+				MessageValue: `[**Update critical configuration**](/help/admin/management_console) to resolve problems:` +
 					"\n* " + strings.Join(criticalProblems.Messages(), "\n* "),
 			})
 		}
@@ -98,7 +124,7 @@ func init() {
 		if len(siteProblems) > 0 {
 			alerts = append(alerts, &Alert{
 				TypeValue: AlertTypeWarning,
-				MessageValue: `[**Update site configuration**](/site-admin/configuration) to resolve problems.` +
+				MessageValue: `[**Update site configuration**](/site-admin/configuration) to resolve problems:` +
 					"\n* " + strings.Join(siteProblems.Messages(), "\n* "),
 			})
 		}

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -123,9 +123,9 @@ describe('e2e test suite', () => {
             await driver.page.click('.e2e-settings-file .e2e-save-toolbar-save')
             await driver.page.waitForSelector('.e2e-global-alert .global-alerts__alert', { visible: true })
             await driver.page.evaluate(message => {
-                const elem = document.querySelector('.e2e-global-alert .global-alerts__alert')
+                const elem = document.querySelector('.e2e-global-alert .notices .global-alerts__alert')
                 if (!elem) {
-                    throw new Error('No .e2e-global-alert .global-alerts__alert element found')
+                    throw new Error('No .e2e-global-alert .notices .global-alerts__alert element found')
                 }
                 if (!(elem as HTMLElement).innerText.includes(message)) {
                     throw new Error('Expected "' + message + '" message, but didn\'t find it')

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -121,7 +121,7 @@ describe('e2e test suite', () => {
                 selectMethod: 'keyboard',
             })
             await driver.page.click('.e2e-settings-file .e2e-save-toolbar-save')
-            await driver.page.waitForSelector('.e2e-global-alert .global-alerts__alert', { visible: true })
+            await driver.page.waitForSelector('.e2e-global-alert .notices .global-alerts__alert', { visible: true })
             await driver.page.evaluate(message => {
                 const elem = document.querySelector('.e2e-global-alert .notices .global-alerts__alert')
                 if (!elem) {


### PR DESCRIPTION
This PR adds runtime validation for configuration apart from using `conf.ContributeValidator` because latter will prevent server from starting. Only `externalURL` is validated at this point.

This fixes the original problem reported in https://github.com/sourcegraph/sourcegraph/issues/3899.

**Test plan**: Comment out `externalURL` in `dev-private` and see if the site alert shows up. And disappear after set a non-empty value via management console.

**UI preview**:
![image](https://user-images.githubusercontent.com/2946214/66615138-5ec7bb80-eb80-11e9-8887-1677378df644.png)
