### PR TITLE
Bump deadlock timeout on server initialization to 60s

### DIFF
--- a/internal/conf/store.go
+++ b/internal/conf/store.go
@@ -127,7 +127,7 @@ func (s *Store) WaitUntilInitialized() {
 	if mode == modeServer {
 		deadlockTimeout := 5 * time.Minute
 		if IsDev(DeployType()) {
-			deadlockTimeout = 30 * time.Second
+			deadlockTimeout = 60 * time.Second
 			disable, _ := strconv.ParseBool(os.Getenv("DISABLE_CONF_DEADLOCK_DETECTOR"))
 			if disable {
 				deadlockTimeout = 24 * 365 * time.Hour
@@ -144,7 +144,7 @@ func (s *Store) WaitUntilInitialized() {
 			// deadlock, so ask Go to dump all goroutine stack traces.
 			debug.SetTraceback("all")
 			if IsDev(DeployType()) {
-				panic("potential deadlock detected: the frontend's configuration server hasn't started after 30s indicating a deadlock may be happening. A common cause of this is calling conf.Get or conf.Watch before the frontend has started fully (e.g. inside an init function) and if that is the case you may need to invoke those functions in a separate goroutine.")
+				panic("potential deadlock detected: the frontend's configuration server hasn't started after 60s indicating a deadlock may be happening. A common cause of this is calling conf.Get or conf.Watch before the frontend has started fully (e.g. inside an init function) and if that is the case you may need to invoke those functions in a separate goroutine.")
 			}
 			panic(fmt.Sprintf("(bug) frontend configuration server failed to start after %v, this may indicate the DB is inaccessible", deadlockTimeout))
 		}


### PR DESCRIPTION
We're seeing CI flakiness due to Postgres DB migrations taking more than 30s, which triggers the deadlock detector.

It takes 12s to initialize a sourcegraph/server instance on my macOS, and with variabilities in runtime in CI it's perhaps not surprising that we exceed the 30s from time to time.

This bumps the timeout from 30s to 60s.

Alternatives:

- Investigate further, profile migrations, see if they can be sped up
- Exclude the period of time during which migrations are being run from the deadlock detector timeout

More context: https://github.com/sourcegraph/sourcegraph/issues/5721#issuecomment-540855232