### PR TITLE
LSIF: Cache entry TTLs

### DIFF
--- a/lsif/src/cache.ts
+++ b/lsif/src/cache.ts
@@ -75,13 +75,6 @@ interface CacheMetrics {
 }
 
 /**
- * Return the current timestamp in milliseconds.
- */
-function defaultNowMs(): number {
-    return new Date().getTime()
-}
-
-/**
  * A generic LRU cache. We use this instead of the `lru-cache` package
  * available in NPM so that we can handle async payloads in a more
  * first-class way as well as shedding some of the cruft around evictions.
@@ -124,7 +117,7 @@ export class GenericCache<K, V> {
         private disposeFunction: (value: V) => Promise<void> | void,
         private validityInterval: number,
         private metrics: CacheMetrics,
-        private nowMs: () => number = defaultNowMs
+        private nowMs: () => number = () => new Date().getTime()
     ) {}
 
     /**

--- a/lsif/src/cpp.test.ts
+++ b/lsif/src/cpp.test.ts
@@ -16,9 +16,9 @@ describe('Database', () => {
     const repository = 'five'
     const commit = createCommit('five')
 
-    const connectionCache = new ConnectionCache(10)
-    const documentCache = new DocumentCache(10)
-    const resultChunkCache = new ResultChunkCache(10)
+    const connectionCache = new ConnectionCache(10, 1000)
+    const documentCache = new DocumentCache(10, 1000)
+    const resultChunkCache = new ResultChunkCache(10, 1000)
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -73,6 +73,21 @@ const DOCUMENT_CACHE_CAPACITY = readEnvInt('DOCUMENT_CACHE_CAPACITY', 1024 * 102
 const RESULT_CHUNK_CACHE_CAPACITY = readEnvInt('RESULT_CHUNK_CACHE_CAPACITY', 1024 * 1024 * 1024)
 
 /**
+ * The maximum time (in milliseconds) a stale connection can be cached.
+ */
+const CONNECTION_CACHE_TTL = readEnvInt('CONNECTION_CACHE_TTL', 5 * 60 * 1000)
+
+/**
+ * The maximum time (in milliseconds) a stale document can be cached.
+ */
+const DOCUMENT_CACHE_TTL = readEnvInt('DOCUMENT_CACHE_TTL', 5 * 60 * 1000)
+
+/**
+ * The maximum time (in milliseconds) a stale result chunk can be cached.
+ */
+const RESULT_CHUNK_CACHE_TTL = readEnvInt('RESULT_CHUNK_CACHE_TTL', 5 * 60 * 1000)
+
+/**
  * Where on the file system to store LSIF files.
  */
 const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
@@ -328,9 +343,9 @@ async function lsifEndpoints(
     const router = express.Router()
 
     // Create cross-repo database
-    const connectionCache = new ConnectionCache(CONNECTION_CACHE_CAPACITY)
-    const documentCache = new DocumentCache(DOCUMENT_CACHE_CAPACITY)
-    const resultChunkCache = new ResultChunkCache(RESULT_CHUNK_CACHE_CAPACITY)
+    const connectionCache = new ConnectionCache(CONNECTION_CACHE_CAPACITY, CONNECTION_CACHE_TTL)
+    const documentCache = new DocumentCache(DOCUMENT_CACHE_CAPACITY, DOCUMENT_CACHE_TTL)
+    const resultChunkCache = new ResultChunkCache(RESULT_CHUNK_CACHE_CAPACITY, RESULT_CHUNK_CACHE_TTL)
 
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)

--- a/lsif/src/typescript-linked-reference-results.test.ts
+++ b/lsif/src/typescript-linked-reference-results.test.ts
@@ -16,9 +16,9 @@ describe('Database', () => {
     const repository = 'test'
     const commit = createCommit('test')
 
-    const connectionCache = new ConnectionCache(10)
-    const documentCache = new DocumentCache(10)
-    const resultChunkCache = new ResultChunkCache(10)
+    const connectionCache = new ConnectionCache(10, 1000)
+    const documentCache = new DocumentCache(10, 1000)
+    const resultChunkCache = new ResultChunkCache(10, 1000)
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())

--- a/lsif/src/typescript-xrepo.test.ts
+++ b/lsif/src/typescript-xrepo.test.ts
@@ -18,10 +18,9 @@ describe('Database', () => {
     let cleanup!: () => Promise<void>
     let storageRoot!: string
     let xrepoDatabase!: XrepoDatabase
-
-    const connectionCache = new ConnectionCache(10)
-    const documentCache = new DocumentCache(10)
-    const resultChunkCache = new ResultChunkCache(10)
+    const connectionCache = new ConnectionCache(10, 1000)
+    const documentCache = new DocumentCache(10, 1000)
+    const resultChunkCache = new ResultChunkCache(10, 1000)
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())


### PR DESCRIPTION
This PR puts a maximum lifetime for entries in the LSIF caches. 

This updates the cache class. Now the `getEntry` function will run a validation function on the cache value if it hasn't been checked within its expiry. There are two types of validation here:

- sqlite connections are validated by comparing the db file's mtime against the last time the validation function was run, and
- decoded results from the sqlite database are removed from the cache unconditionally after the TTL. This is because we don't currently track which db the results came from.

This adds no new concurrent behavior.