### PR TITLE
LSIF: switch to ID-based filenames

### DIFF
--- a/lsif/src/cpp.test.ts
+++ b/lsif/src/cpp.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
@@ -23,7 +24,7 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         const input = await getTestData('cpp/data/data.lsif.gz')
-        const tmp = 'tmp'
+        const tmp = path.join(storageRoot, 'tmp')
         const { packages, references } = await convertLsif(input, tmp)
         const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
         await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))

--- a/lsif/src/cpp.test.ts
+++ b/lsif/src/cpp.test.ts
@@ -26,7 +26,7 @@ describe('Database', () => {
         const tmp = 'tmp'
         const { packages, references } = await convertLsif(input, tmp)
         const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
-        await fs.rename(tmp, dbFilename(storageRoot, dumpID))
+        await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))
     })
 
     afterAll(async () => await rmfr(storageRoot))
@@ -44,7 +44,7 @@ describe('Database', () => {
             documentCache,
             resultChunkCache,
             dump.id,
-            dbFilename(storageRoot, dump.id)
+            dbFilename(storageRoot, dump.id, dump.repository, dump.commit)
         )
     }
 

--- a/lsif/src/cpp.test.ts
+++ b/lsif/src/cpp.test.ts
@@ -3,7 +3,7 @@ import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
 import { convertLsif } from './importer'
 import { createCommit, createLocation, getTestData, getCleanSqliteDatabase } from './test-utils'
-import { createDatabaseFilename } from './util'
+import { dbFilename } from './util'
 import { Database } from './database'
 import { entities } from './xrepo.models'
 import { XrepoDatabase } from './xrepo'
@@ -23,41 +23,47 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         const input = await getTestData('cpp/data/data.lsif.gz')
-        const database = createDatabaseFilename(storageRoot, repository, commit)
-        const { packages, references } = await convertLsif(input, database)
-        await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+        const tmp = 'tmp'
+        const { packages, references } = await convertLsif(input, tmp)
+        const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+        await fs.rename(tmp, dbFilename(storageRoot, dumpID))
     })
 
     afterAll(async () => await rmfr(storageRoot))
 
-    const loadDatabase = (repository: string, commit: string): Database =>
-        new Database(
+    const loadDatabase = async (repository: string, commit: string): Promise<Database> => {
+        const dump = await xrepoDatabase.getDump(repository, commit)
+        if (!dump) {
+            throw new Error(`Unknown repository@commit ${repository}@${commit}`)
+        }
+
+        return new Database(
             storageRoot,
             xrepoDatabase,
             connectionCache,
             documentCache,
             resultChunkCache,
-            repository,
-            commit,
-            createDatabaseFilename(storageRoot, repository, commit)
+            dump.id,
+            dbFilename(storageRoot, dump.id)
         )
+    }
 
     it('should find all defs of `four` from main.cpp', async () => {
-        const db = loadDatabase(repository, commit)
+        const db = await loadDatabase(repository, commit)
         const definitions = await db.definitions('main.cpp', { line: 12, character: 3 })
         // TODO - (FIXME) currently the dxr indexer returns zero-width ranges
         expect(definitions).toEqual([createLocation('main.cpp', 6, 4, 6, 4)])
     })
 
     it('should find all defs of `five` from main.cpp', async () => {
-        const db = loadDatabase(repository, commit)
+        const db = await loadDatabase(repository, commit)
         const definitions = await db.definitions('main.cpp', { line: 11, character: 3 })
         // TODO - (FIXME) currently the dxr indexer returns zero-width ranges
         expect(definitions).toEqual([createLocation('five.cpp', 2, 4, 2, 4)])
     })
 
     it('should find all refs of `five` from main.cpp', async () => {
-        const db = loadDatabase(repository, commit)
+        const db = await loadDatabase(repository, commit)
         const references = await db.references('main.cpp', { line: 11, character: 3 })
 
         // TODO - should the definition be in this result set?

--- a/lsif/src/database.test.ts
+++ b/lsif/src/database.test.ts
@@ -124,6 +124,7 @@ describe('createRemoteUri', () => {
                 repository: 'github.com/sourcegraph/codeintellify',
                 commit: 'deadbeef',
             },
+            dump_id: 0,
         }
 
         const uri = createRemoteUri(pkg, 'src/position.ts')

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -1,14 +1,14 @@
 import * as lsp from 'vscode-languageserver-protocol'
 import { Connection } from 'typeorm'
 import { ConnectionCache, DocumentCache, EncodedJsonCacheValue, ResultChunkCache } from './cache'
-import { createDatabaseFilename, hashKey, mustGet, hasErrorCode } from './util'
+import { dbFilename, hashKey, mustGet, hasErrorCode } from './util'
 import { instrument } from './metrics'
 import { databaseQueryDurationHistogram, databaseQueryErrorsCounter } from './database.metrics'
 import { DefaultMap } from './default-map'
 import { gunzipJSON } from './encoding'
 import * as fs from 'mz/fs'
 import { isEqual, uniqWith } from 'lodash'
-import { PackageModel } from './xrepo.models'
+import { PackageModel, DumpID } from './xrepo.models'
 import { XrepoDatabase } from './xrepo'
 import {
     DefinitionModel,
@@ -46,8 +46,7 @@ export class Database {
      * @param connectionCache The cache of SQLite connections.
      * @param documentCache The cache of loaded documents.
      * @param resultChunkCache The cache of loaded result chunks.
-     * @param repository The repository for which this database answers queries.
-     * @param commit The commit for which this database answers queries.
+     * @param dumpID The ID of the dump for which this database answers queries.
      * @param databasePath The path to the database file.
      */
     constructor(
@@ -56,8 +55,7 @@ export class Database {
         private connectionCache: ConnectionCache,
         private documentCache: DocumentCache,
         private resultChunkCache: ResultChunkCache,
-        private repository: string,
-        private commit: string,
+        private dumpID: DumpID,
         private databasePath: string
     ) {}
 
@@ -380,11 +378,7 @@ export class Database {
             packageCommit: packageEntity.dump.commit,
         })
 
-        const db = this.createNewDatabase(
-            packageEntity.dump.repository,
-            packageEntity.dump.commit,
-            createDatabaseFilename(this.storageRoot, packageEntity.dump.repository, packageEntity.dump.commit)
-        )
+        const db = this.createNewDatabase(packageEntity.dump.id, dbFilename(this.storageRoot, packageEntity.dump.id))
 
         const pathTransformer = (path: string): string => createRemoteUri(packageEntity, path)
         return await db.monikerResults(model, moniker, pathTransformer, ctx)
@@ -436,15 +430,11 @@ export class Database {
         for (const reference of references) {
             // Skip the remote reference that show up for ourselves - we've already gathered
             // these in the previous step of the references query.
-            if (reference.dump.repository === this.repository && reference.dump.commit === this.commit) {
+            if (reference.dump.id === this.dumpID) {
                 continue
             }
 
-            const db = this.createNewDatabase(
-                reference.dump.repository,
-                reference.dump.commit,
-                createDatabaseFilename(this.storageRoot, reference.dump.repository, reference.dump.commit)
-            )
+            const db = this.createNewDatabase(reference.dump.id, dbFilename(this.storageRoot, reference.dump.id))
 
             const pathTransformer = (path: string): string => createRemoteUri(reference, path)
             const references = await db.monikerResults(ReferenceModel, moniker, pathTransformer, ctx)
@@ -570,19 +560,17 @@ export class Database {
      * Create a new database with the same configuration but a different repository,
      * commit, and databasePath.
      *
-     * @param repository The repository for which this database answers queries.
-     * @param commit The commit for which this database answers queries.
+     * @param dumpID The ID of the dump for which this database answers queries.
      * @param databasePath The path to the database file.
      */
-    private createNewDatabase(repository: string, commit: string, databasePath: string): Database {
+    private createNewDatabase(dumpID: DumpID, databasePath: string): Database {
         return new Database(
             this.storageRoot,
             this.xrepoDatabase,
             this.connectionCache,
             this.documentCache,
             this.resultChunkCache,
-            repository,
-            commit,
+            dumpID,
             databasePath
         )
     }
@@ -607,7 +595,7 @@ export class Database {
      * @param pairs The values to log.
      */
     private logSpan(ctx: TracingContext, event: string, pairs: { [K: string]: any }): void {
-        logSpan(ctx, event, { ...pairs, dbRepository: this.repository, dbCommit: this.commit })
+        logSpan(ctx, event, { ...pairs, dbID: this.dumpID })
     }
 }
 
@@ -742,8 +730,7 @@ export function mapRangesToLocations(ranges: Map<RangeId, RangeData>, uri: strin
  * @param connectionCache The cache of SQLite connections.
  * @param documentCache The cache of loaded documents.
  * @param resultChunkCache The cache of loaded result chunks.
- * @param repository The repository for which this database answers queries.
- * @param commit The commit for which this database answers queries.
+ * @param dumpID The ID of the dump for which this database answers queries.
  * @param databasePath The path to the database file.
  */
 export async function tryCreateDatabase(
@@ -752,8 +739,7 @@ export async function tryCreateDatabase(
     connectionCache: ConnectionCache,
     documentCache: DocumentCache,
     resultChunkCache: ResultChunkCache,
-    repository: string,
-    commit: string,
+    dumpID: DumpID,
     databasePath: string
 ): Promise<Database | undefined> {
     try {
@@ -772,8 +758,7 @@ export async function tryCreateDatabase(
         connectionCache,
         documentCache,
         resultChunkCache,
-        repository,
-        commit,
+        dumpID,
         databasePath
     )
 }

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -378,7 +378,15 @@ export class Database {
             packageCommit: packageEntity.dump.commit,
         })
 
-        const db = this.createNewDatabase(packageEntity.dump.id, dbFilename(this.storageRoot, packageEntity.dump.id))
+        const db = this.createNewDatabase(
+            packageEntity.dump.id,
+            dbFilename(
+                this.storageRoot,
+                packageEntity.dump.id,
+                packageEntity.dump.repository,
+                packageEntity.dump.commit
+            )
+        )
 
         const pathTransformer = (path: string): string => createRemoteUri(packageEntity, path)
         return await db.monikerResults(model, moniker, pathTransformer, ctx)
@@ -434,7 +442,10 @@ export class Database {
                 continue
             }
 
-            const db = this.createNewDatabase(reference.dump.id, dbFilename(this.storageRoot, reference.dump.id))
+            const db = this.createNewDatabase(
+                reference.dump.id,
+                dbFilename(this.storageRoot, reference.dump.id, reference.dump.repository, reference.dump.commit)
+            )
 
             const pathTransformer = (path: string): string => createRemoteUri(reference, path)
             const references = await db.monikerResults(ReferenceModel, moniker, pathTransformer, ctx)

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -174,7 +174,7 @@ async function main(logger: Logger): Promise<void> {
  */
 async function ensureFilenamesAreIDs(db: Connection): Promise<void> {
     const doneFile = path.join(STORAGE_ROOT, 'id-based-filenames')
-    if (fs.existsSync(doneFile)) {
+    if (await fs.exists(doneFile)) {
         // Already migrated.
         return
     }
@@ -182,14 +182,14 @@ async function ensureFilenamesAreIDs(db: Connection): Promise<void> {
     for (const dump of await db.getRepository(LsifDump).find()) {
         const oldFile = dbFilenameOld(STORAGE_ROOT, dump.repository, dump.commit)
         const newFile = dbFilename(STORAGE_ROOT, dump.id, dump.repository, dump.commit)
-        if (!fs.existsSync(oldFile)) {
+        if (!(await fs.exists(oldFile))) {
             continue
         }
-        fs.renameSync(oldFile, newFile)
+        await fs.rename(oldFile, newFile)
     }
 
     // Create an empty done file to record that all files have been renamed.
-    fs.closeSync(fs.openSync(doneFile, 'w'))
+    await fs.close(await fs.open(doneFile, 'w'))
 }
 
 /**

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -181,7 +181,7 @@ async function ensureFilenamesAreIDs(db: Connection): Promise<void> {
 
     for (const dump of await db.getRepository(LsifDump).find()) {
         const oldFile = dbFilenameOld(STORAGE_ROOT, dump.repository, dump.commit)
-        const newFile = dbFilename(STORAGE_ROOT, dump.id)
+        const newFile = dbFilename(STORAGE_ROOT, dump.id, dump.repository, dump.commit)
         if (!fs.existsSync(oldFile)) {
             continue
         }
@@ -363,7 +363,7 @@ async function lsifEndpoints(
             documentCache,
             resultChunkCache,
             dump.id,
-            dbFilename(STORAGE_ROOT, dump.id)
+            dbFilename(STORAGE_ROOT, dump.id, dump.repository, dump.commit)
         )
         if (database) {
             return { database, ctx: { logger, span } }
@@ -394,7 +394,7 @@ async function lsifEndpoints(
             documentCache,
             resultChunkCache,
             dumpWithData.id,
-            dbFilename(STORAGE_ROOT, dumpWithData.id)
+            dbFilename(STORAGE_ROOT, dumpWithData.id, dumpWithData.repository, dumpWithData.commit)
         )
 
         return { database: approximateDatabase, ctx: addTags({ logger, span }, { closestCommit: commitWithData }) }

--- a/lsif/src/typescript-linked-reference-results.test.ts
+++ b/lsif/src/typescript-linked-reference-results.test.ts
@@ -3,7 +3,7 @@ import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
 import { convertLsif } from './importer'
 import { createCommit, createLocation, getTestData, getCleanSqliteDatabase } from './test-utils'
-import { createDatabaseFilename } from './util'
+import { dbFilename } from './util'
 import { Database } from './database'
 import { entities } from './xrepo.models'
 import { XrepoDatabase } from './xrepo'
@@ -23,27 +23,33 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         const input = await getTestData('typescript/linked-reference-results/data/data.lsif.gz')
-        const database = createDatabaseFilename(storageRoot, repository, commit)
-        const { packages, references } = await convertLsif(input, database, {})
-        await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+        const tmp = 'tmp'
+        const { packages, references } = await convertLsif(input, tmp, {})
+        const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+        await fs.rename(tmp, dbFilename(storageRoot, dumpID))
     })
 
     afterAll(async () => await rmfr(storageRoot))
 
-    const loadDatabase = (repository: string, commit: string): Database =>
-        new Database(
+    const loadDatabase = async (repository: string, commit: string): Promise<Database> => {
+        const dump = await xrepoDatabase.getDump(repository, commit)
+        if (!dump) {
+            throw new Error(`Unknown repository@commit ${repository}@${commit}`)
+        }
+
+        return new Database(
             storageRoot,
             xrepoDatabase,
             connectionCache,
             documentCache,
             resultChunkCache,
-            repository,
-            commit,
-            createDatabaseFilename(storageRoot, repository, commit)
+            dump.id,
+            dbFilename(storageRoot, dump.id)
         )
+    }
 
     it('should find all refs of `foo`', async () => {
-        const db = loadDatabase(repository, commit)
+        const db = await loadDatabase(repository, commit)
 
         const positions = [
             { line: 1, character: 5 },

--- a/lsif/src/typescript-linked-reference-results.test.ts
+++ b/lsif/src/typescript-linked-reference-results.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
@@ -23,7 +24,7 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         const input = await getTestData('typescript/linked-reference-results/data/data.lsif.gz')
-        const tmp = 'tmp'
+        const tmp = path.join(storageRoot, 'tmp')
         const { packages, references } = await convertLsif(input, tmp, {})
         const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
         await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))

--- a/lsif/src/typescript-linked-reference-results.test.ts
+++ b/lsif/src/typescript-linked-reference-results.test.ts
@@ -26,7 +26,7 @@ describe('Database', () => {
         const tmp = 'tmp'
         const { packages, references } = await convertLsif(input, tmp, {})
         const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
-        await fs.rename(tmp, dbFilename(storageRoot, dumpID))
+        await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))
     })
 
     afterAll(async () => await rmfr(storageRoot))
@@ -44,7 +44,7 @@ describe('Database', () => {
             documentCache,
             resultChunkCache,
             dump.id,
-            dbFilename(storageRoot, dump.id)
+            dbFilename(storageRoot, dump.id, dump.repository, dump.commit)
         )
     }
 

--- a/lsif/src/typescript-xrepo.test.ts
+++ b/lsif/src/typescript-xrepo.test.ts
@@ -24,7 +24,7 @@ describe('Database', () => {
             const tmp = 'tmp'
             const { packages, references } = await convertLsif(input, tmp)
             const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
-            await fs.rename(tmp, dbFilename(storageRoot, dumpID))
+            await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))
         }
     })
 
@@ -43,7 +43,7 @@ describe('Database', () => {
             documentCache,
             resultChunkCache,
             dump.id,
-            dbFilename(storageRoot, dump.id)
+            dbFilename(storageRoot, dump.id, dump.repository, dump.commit)
         )
     }
 

--- a/lsif/src/typescript-xrepo.test.ts
+++ b/lsif/src/typescript-xrepo.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
@@ -21,7 +22,7 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         for (const { input, repository, commit } of await createTestInputs()) {
-            const tmp = 'tmp'
+            const tmp = path.join(storageRoot, 'tmp')
             const { packages, references } = await convertLsif(input, tmp)
             const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
             await fs.rename(tmp, dbFilename(storageRoot, dumpID, repository, commit))

--- a/lsif/src/typescript-xrepo.test.ts
+++ b/lsif/src/typescript-xrepo.test.ts
@@ -3,7 +3,7 @@ import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
 import { convertLsif } from './importer'
 import { createCommit, createLocation, createRemoteLocation, getTestData, getCleanSqliteDatabase } from './test-utils'
-import { createDatabaseFilename } from './util'
+import { dbFilename } from './util'
 import { Database } from './database'
 import { entities } from './xrepo.models'
 import { Readable } from 'stream'
@@ -21,49 +21,55 @@ describe('Database', () => {
         xrepoDatabase = new XrepoDatabase(await getCleanSqliteDatabase(storageRoot, entities))
 
         for (const { input, repository, commit } of await createTestInputs()) {
-            const database = createDatabaseFilename(storageRoot, repository, commit)
-            const { packages, references } = await convertLsif(input, database)
-            await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+            const tmp = 'tmp'
+            const { packages, references } = await convertLsif(input, tmp)
+            const dumpID = await xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
+            await fs.rename(tmp, dbFilename(storageRoot, dumpID))
         }
     })
 
     afterAll(async () => await rmfr(storageRoot))
 
-    const loadDatabase = (repository: string, commit: string): Database =>
-        new Database(
+    const loadDatabase = async (repository: string, commit: string): Promise<Database> => {
+        const dump = await xrepoDatabase.getDump(repository, commit)
+        if (!dump) {
+            throw new Error(`Unknown repository@commit ${repository}@${commit}`)
+        }
+
+        return new Database(
             storageRoot,
             xrepoDatabase,
             connectionCache,
             documentCache,
             resultChunkCache,
-            repository,
-            commit,
-            createDatabaseFilename(storageRoot, repository, commit)
+            dump.id,
+            dbFilename(storageRoot, dump.id)
         )
+    }
 
     it('should find all defs of `add` from repo a', async () => {
-        const db = loadDatabase('a', createCommit('a'))
+        const db = await loadDatabase('a', createCommit('a'))
         const definitions = await db.definitions('src/index.ts', { line: 11, character: 18 })
         expect(definitions).toContainEqual(createLocation('src/index.ts', 0, 16, 0, 19))
         expect(definitions && definitions.length).toEqual(1)
     })
 
     it('should find all defs of `add` from repo b1', async () => {
-        const db = loadDatabase('b1', createCommit('b1'))
+        const db = await loadDatabase('b1', createCommit('b1'))
         const definitions = await db.definitions('src/index.ts', { line: 3, character: 12 })
         expect(definitions).toContainEqual(createRemoteLocation('a', 'src/index.ts', 0, 16, 0, 19))
         expect(definitions && definitions.length).toEqual(1)
     })
 
     it('should find all defs of `mul` from repo b1', async () => {
-        const db = loadDatabase('b1', createCommit('b1'))
+        const db = await loadDatabase('b1', createCommit('b1'))
         const definitions = await db.definitions('src/index.ts', { line: 3, character: 16 })
         expect(definitions).toContainEqual(createRemoteLocation('a', 'src/index.ts', 4, 16, 4, 19))
         expect(definitions && definitions.length).toEqual(1)
     })
 
     it('should find all refs of `mul` from repo a', async () => {
-        const db = loadDatabase('a', createCommit('a'))
+        const db = await loadDatabase('a', createCommit('a'))
         // TODO - (FIXME) why are these garbage results in the index
         const references = (await db.references('src/index.ts', { line: 4, character: 19 }))!.filter(
             l => !l.uri.includes('node_modules')
@@ -86,7 +92,7 @@ describe('Database', () => {
     })
 
     it('should find all refs of `mul` from repo b1', async () => {
-        const db = loadDatabase('b1', createCommit('b1'))
+        const db = await loadDatabase('b1', createCommit('b1'))
         // TODO - (FIXME) why are these garbage results in the index
         const references = (await db.references('src/index.ts', { line: 3, character: 16 }))!.filter(
             l => !l.uri.includes('node_modules')
@@ -109,7 +115,7 @@ describe('Database', () => {
     })
 
     it('should find all refs of `add` from repo a', async () => {
-        const db = loadDatabase('a', createCommit('a'))
+        const db = await loadDatabase('a', createCommit('a'))
         // TODO - (FIXME) why are these garbage results in the index
         const references = (await db.references('src/index.ts', { line: 0, character: 17 }))!.filter(
             l => !l.uri.includes('node_modules')
@@ -142,7 +148,7 @@ describe('Database', () => {
     })
 
     it('should find all refs of `add` from repo c1', async () => {
-        const db = loadDatabase('c1', createCommit('c1'))
+        const db = await loadDatabase('c1', createCommit('c1'))
         // TODO - (FIXME) why are these garbage results in the index
         const references = (await db.references('src/index.ts', { line: 3, character: 16 }))!.filter(
             l => !l.uri.includes('node_modules')

--- a/lsif/src/util.ts
+++ b/lsif/src/util.ts
@@ -107,8 +107,18 @@ export function hashKey(id: DefinitionReferenceResultId, maxIndex: number): numb
  * @param repository The repository name.
  * @param commit The repository commit.
  */
-export function createDatabaseFilename(storageRoot: string, repository: string, commit: string): string {
+export function dbFilenameOld(storageRoot: string, repository: string, commit: string): string {
     return path.join(storageRoot, `${encodeURIComponent(repository)}@${commit}.lsif.db`)
+}
+
+/**
+ * Construct the path of the SQLite database file for the given dump.
+ *
+ * @param storageRoot The path where SQLite databases are stored.
+ * @param id The ID of the dump.
+ */
+export function dbFilename(storageRoot: string, id: number): string {
+    return path.join(storageRoot, `${id}.lsif.db`)
 }
 
 /**

--- a/lsif/src/util.ts
+++ b/lsif/src/util.ts
@@ -117,8 +117,8 @@ export function dbFilenameOld(storageRoot: string, repository: string, commit: s
  * @param storageRoot The path where SQLite databases are stored.
  * @param id The ID of the dump.
  */
-export function dbFilename(storageRoot: string, id: number): string {
-    return path.join(storageRoot, `${id}.lsif.db`)
+export function dbFilename(storageRoot: string, id: number, repository: string, commit: string): string {
+    return path.join(storageRoot, `${id}-${encodeURIComponent(repository)}@${commit}.lsif.db`)
 }
 
 /**

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -5,7 +5,7 @@ import express from 'express'
 import promClient from 'prom-client'
 import uuid from 'uuid'
 import { convertLsif } from './importer'
-import { createDatabaseFilename, ensureDirectory, readEnvInt } from './util'
+import { dbFilename, ensureDirectory, readEnvInt } from './util'
 import { createLogger } from './logging'
 import { createPostgresConnection } from './connection'
 import { JobsHash, Worker } from 'node-resque'
@@ -124,13 +124,13 @@ const createConvertJob = (xrepoDatabase: XrepoDatabase, fetchConfiguration: Conf
             // Create database in a temp path
             const { packages, references } = await convertLsif(input, tempFile, ctx)
 
-            // Move the temp file where it can be found by the server
-            await fs.rename(tempFile, createDatabaseFilename(STORAGE_ROOT, repository, commit))
-
-            // Add the new database to the xrepo db
-            await logAndTraceCall(ctx, 'populating cross-repo database', () =>
+            // Add packages and references to the xrepo db
+            const dumpID = await logAndTraceCall(ctx, 'populating cross-repo database', () =>
                 xrepoDatabase.addPackagesAndReferences(repository, commit, packages, references)
             )
+
+            // Move the temp file where it can be found by the server
+            await fs.rename(tempFile, dbFilename(STORAGE_ROOT, dumpID))
         } catch (e) {
             // Don't leave busted artifacts
             await fs.unlink(tempFile)

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -130,7 +130,7 @@ const createConvertJob = (xrepoDatabase: XrepoDatabase, fetchConfiguration: Conf
             )
 
             // Move the temp file where it can be found by the server
-            await fs.rename(tempFile, dbFilename(STORAGE_ROOT, dumpID))
+            await fs.rename(tempFile, dbFilename(STORAGE_ROOT, dumpID, repository, commit))
         } catch (e) {
             // Don't leave busted artifacts
             await fs.unlink(tempFile)

--- a/lsif/src/xrepo.models.ts
+++ b/lsif/src/xrepo.models.ts
@@ -41,6 +41,11 @@ export class Commit {
 }
 
 /**
+ * The primary key of the `lsif_dumps` table.
+ */
+export type DumpID = number
+
+/**
  * An entity within the cross-repo database. A row with a repository and commit
  * indicates that there exists LSIF data for that pair.
  */
@@ -50,7 +55,7 @@ export class LsifDump {
      * A unique ID required by typeorm entities.
      */
     @PrimaryGeneratedColumn('increment', { type: 'int' })
-    public id!: number
+    public id!: DumpID
 
     /**
      * The name of the source repository.

--- a/lsif/src/xrepo.models.ts
+++ b/lsif/src/xrepo.models.ts
@@ -104,9 +104,19 @@ class Package {
     @Column('text', { nullable: true })
     public version!: string | null
 
+    /**
+     * The corresponding dump, `LsifDump` when querying and `DumpID` when
+     * inserting.
+     */
     @OneToOne(type => LsifDump, { eager: true })
     @JoinColumn({ name: 'dump_id' })
     public dump!: LsifDump
+
+    /**
+     * The foreign key to the dump.
+     */
+    @Column('integer')
+    public dump_id!: DumpID
 }
 
 /**

--- a/lsif/src/xrepo.test.ts
+++ b/lsif/src/xrepo.test.ts
@@ -38,9 +38,9 @@ describe('XrepoDatabase', () => {
         ])
 
         // Add relations
-        await xrepoDatabase.addPackagesAndReferences('foo', 'a', [], [])
-        await xrepoDatabase.addPackagesAndReferences('foo', 'c', [], [])
-        await xrepoDatabase.addPackagesAndReferences('foo', 'g', [], [])
+        await xrepoDatabase.insertDump('foo', 'a')
+        await xrepoDatabase.insertDump('foo', 'c')
+        await xrepoDatabase.insertDump('foo', 'g')
 
         // Test closest commit
         expect(await xrepoDatabase.findClosestCommitWithData('foo', 'a')).toEqual('a')
@@ -78,7 +78,7 @@ describe('XrepoDatabase', () => {
         ])
 
         // Add markers
-        await xrepoDatabase.addPackagesAndReferences('foo', 'b', [], [])
+        await xrepoDatabase.insertDump('foo', 'b')
 
         // Test closest commit
         expect(await xrepoDatabase.findClosestCommitWithData('foo', 'a')).toEqual('b')
@@ -103,7 +103,7 @@ describe('XrepoDatabase', () => {
         await xrepoDatabase.updateCommits('foo', commits)
 
         // Add markers
-        await xrepoDatabase.addPackagesAndReferences('foo', '0', [], [])
+        await xrepoDatabase.insertDump('foo', '0')
 
         // Test closest commit
         expect(await xrepoDatabase.findClosestCommitWithData('foo', '0')).toEqual('0')
@@ -123,7 +123,7 @@ describe('XrepoDatabase', () => {
         expect(await xrepoDatabase.findClosestCommitWithData('foo', '50')).toBeUndefined()
 
         // Mark commit 1
-        await xrepoDatabase.addPackagesAndReferences('foo', '1', [], [])
+        await xrepoDatabase.insertDump('foo', '1')
 
         // Now commit 1 should be found
         expect(await xrepoDatabase.findClosestCommitWithData('foo', '50')).toEqual('1')

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -356,7 +356,7 @@ export class XrepoDatabase {
      *
      * @param callback The function invoke with the entity manager.
      */
-    public withTransactionalEntityManager<T>(callback: (connection: EntityManager) => Promise<T>): Promise<T> {
+    private withTransactionalEntityManager<T>(callback: (connection: EntityManager) => Promise<T>): Promise<T> {
         return this.withConnection(connection => connection.transaction(callback))
     }
 }

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -206,13 +206,13 @@ export class XrepoDatabase {
      * @param packages The list of packages that this repository defines (scheme, name, and version).
      * @param references The list of packages that this repository depends on (scheme, name, and version) and the symbols that the package references.
      */
-    public async addPackagesAndReferences(
+    public addPackagesAndReferences(
         repository: string,
         commit: string,
         packages: Package[],
         references: SymbolReferences[]
     ): Promise<DumpID> {
-        return await this.withTransactionalEntityManager(async entityManager => {
+        return this.withTransactionalEntityManager(async entityManager => {
             const dumpID = await this.insertDump(repository, commit, entityManager)
 
             const packageInserter = new TableInserter<PackageModel, new () => PackageModel>(

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -215,7 +215,7 @@ export class XrepoDatabase {
         return await this.withTransactionalEntityManager(async entityManager => {
             const dumpID = await this.insertDump(repository, commit, entityManager)
 
-            const packageInserter = new TableInserter(
+            const packageInserter = new TableInserter<PackageModel, new () => PackageModel>(
                 entityManager,
                 PackageModel,
                 PackageModel.BatchSize,
@@ -223,7 +223,7 @@ export class XrepoDatabase {
                 true // Do nothing on conflict
             )
 
-            const referenceInserter = new TableInserter(
+            const referenceInserter = new TableInserter<ReferenceModel, new () => ReferenceModel>(
                 entityManager,
                 ReferenceModel,
                 ReferenceModel.BatchSize,
@@ -231,12 +231,12 @@ export class XrepoDatabase {
             )
 
             for (const pkg of packages) {
-                await packageInserter.insert({ dump: dumpID, ...pkg })
+                await packageInserter.insert({ dump_id: dumpID, ...pkg })
             }
 
             for (const reference of references) {
                 await referenceInserter.insert({
-                    dump: dumpID,
+                    dump_id: dumpID,
                     filter: await createFilter(reference.identifiers),
                     ...reference.package,
                 })

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -293,12 +293,10 @@ export class XrepoDatabase {
      * @param commit The commit.
      * @param entityManager The EntityManager for the connection to the xrepo database.
      */
-    public async getDump(
-        repository: string,
-        commit: string,
-        entityManager: EntityManager = this.connection.createEntityManager()
-    ): Promise<LsifDump | undefined> {
-        return await this.connection.getRepository(LsifDump).findOne({ where: { repository, commit } })
+    public async getDump(repository: string, commit: string): Promise<LsifDump | undefined> {
+        return await this.withConnection(connection =>
+            connection.getRepository(LsifDump).findOne({ where: { repository, commit } })
+        )
     }
 
     /**


### PR DESCRIPTION
This is one more piece necessary for multi-lang/project support where we'll need to store **multiple** dumps per repo@commit.

Prior to this change, each individual SQLite DB was named based on the repo@commit. It would be rather awkward to keep shoving metadata into the filenames to ensure they're unique and don't conflict with each other.

After this change, each individual SQLite DB will be named based on the associated primary key in the `lsif_dumps` table. That lets us add metadata in Postgres without changing the filenames.

Test plan: manually checked that files get renamed

[RFC 24: LSIF for multi-project repositories](https://docs.google.com/a/sourcegraph.com/document/d/1ocoxE_Jnee70_RjQEFSz58jxRE3VZuNg9OGHvu68O6o/edit?disco=AAAADd4IacA)

Depends on https://github.com/sourcegraph/sourcegraph/pull/5947