### PR TITLE
dev-config: Enable automation by default for devs

### DIFF
--- a/dev/config.json
+++ b/dev/config.json
@@ -2,7 +2,8 @@
 {
   "externalURL": "http://localhost:3080",
   "experimentalFeatures": {
-    "discussions": "enabled"
+    "discussions": "enabled",
+    "automation": "enabled"
   },
   "disablePublicRepoRedirects": true,
   "repoListUpdateInterval": 1,


### PR DESCRIPTION
I don't like having to add this every time I want to test something :)