### PR TITLE
Update outdated link to newer GraphQL spec

### DIFF
--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -384,7 +384,7 @@ func IsRateLimitExceeded(err error) bool {
 }
 
 // graphqlErrors describes the errors in a GraphQL response. It contains at least 1 element when returned by
-// requestGraphQL. See https://facebook.github.io/graphql/#sec-Errors.
+// requestGraphQL. See https://graphql.github.io/graphql-spec/June2018/#sec-Errors.
 type graphqlErrors []struct {
 	Message   string        `json:"message"`
 	Type      string        `json:"type"`


### PR DESCRIPTION
The website of GraphQL has changed from https://facebook.github.io/graphql to https://graphql.github.io, updated the link accordingly.
