### PR TITLE
Create Renovate PRs for nightly TypeScript builds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,15 @@
   "semanticCommits": false,
   "packageRules": [
     {
+      "packageNames": ["typescript"],
+      "ignoreUnstable": false,
+      "followTag": "next",
+      "schedule": null,
+      "reviewers": [],
+      "automerge": false,
+      "labels": ["bot", "npm", "nightly"]
+    },
+    {
       "paths": ["lsif/**"],
       "reviewers": ["team:code-intel"]
     }


### PR DESCRIPTION
This will allow us to notice compiler bugs and breaking type system changes before the stable/beta releases (but only merge the stable updates).

@rarkins is there a way to configure it so that we get separate PRs for the nightly versions and the stable versions, similar to how major and minor updates are separated?