### PR TITLE
LSIF: Ensure process exits are not swallowed

### DIFF
--- a/lsif/Dockerfile
+++ b/lsif/Dockerfile
@@ -3,7 +3,9 @@ FROM alpine:3.10@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529
 RUN apk add --no-cache nodejs-current=12.4.0-r0 nodejs-npm=10.16.3-r0
 RUN npm install -g yarn@1.17.3
 
-COPY . /lsif/
+COPY package.json tsconfig.json yarn.lock /lsif/
+COPY src /lsif/src
+
 RUN yarn --cwd /lsif
 RUN yarn --cwd /lsif run build
 
@@ -25,7 +27,8 @@ ENV PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg
 RUN apk add --no-cache tini supervisor=3.3.5-r0 nodejs-current=12.4.0-r0
 
 COPY --from=builder /lsif /lsif
-COPY supervisord.conf /etc/supervisord.conf
+COPY supervisord.conf /supervisord.conf
+COPY kill_supervisor.sh /kill_supervisor.sh
 
 EXPOSE 3186 3187
-CMD ["/sbin/tini", "--", "/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
+CMD ["/sbin/tini", "--", "/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/lsif/kill_supervisor.sh
+++ b/lsif/kill_supervisor.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This is a script that is registered as an eventlistener
+# in the supervisord process running in the Docker contianer.
+# We use a supervisor here so that we can run two processes in
+# a sane way (not just backgrounding one process on startup).
+# However, we want to allow the outer orchestration method
+# (either k8s or docker/compose) to be able to handle process
+# restarts. When any process exits, the supervisor is sent
+# SIGQUIT.
+#
+# See http://supervisord.org/events.html
+
+# Transition from ACKNOWLEDGED to READY
+echo "READY"
+
+# Wait for an event
+read line
+
+# Log on stderr (stdout is for events)
+>&2 echo "child process exited: $line"
+>&2 echo "terminating supervisor"
+
+# Kill the supervisor
+kill -3 $(cat /supervisord.pid)

--- a/lsif/kill_supervisor.sh
+++ b/lsif/kill_supervisor.sh
@@ -22,4 +22,4 @@ read line
 >&2 echo "terminating supervisor"
 
 # Kill the supervisor
-kill -3 $(cat /supervisord.pid)
+kill -s SIGQUIT $(cat /supervisord.pid)

--- a/lsif/src/commits.ts
+++ b/lsif/src/commits.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto'
 import { TracingContext, logAndTraceCall } from './tracing'
 
 /**
- * THe number of commits to ask gitserver for when updating commit data for
+ * The number of commits to ask gitserver for when updating commit data for
  * a particular repository.
  */
 const MAX_COMMITS_PER_UPDATE = 5000

--- a/lsif/supervisord.conf
+++ b/lsif/supervisord.conf
@@ -1,6 +1,11 @@
 [supervisord]
+user=root
 nodaemon=true
 loglevel=debug
+
+[eventlistener:onexit]
+command=/kill_supervisor.sh
+events=PROCESS_STATE_EXITED
 
 [program:server]
 command=node /lsif/out/server.js


### PR DESCRIPTION
This adds an event watcher for the supervisor process in the lsif-server container. This will send SIGQUIT to the supervisor if either process exits. Either process should exit when there is churn and the process should be restarted by the outer orchestration layer (k8s or docker). 