### PR TITLE
LSIF: fix quadratic SQL query

### DIFF
--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -13,7 +13,8 @@ import { discoverAndUpdateCommit } from './commits'
 import { TracingContext } from './tracing'
 
 /**
- * The maximum traversal distance when finding the closest commit.
+ * The maximum number of commits to visit breadth-first style when when finding
+ * the closest commit.
  */
 export const MAX_TRAVERSAL_LIMIT = 100
 
@@ -115,30 +116,28 @@ export class XrepoDatabase {
 
         return this.withConnection(async connection => {
             const query = `
-                with recursive lineage(repository, "commit", parent_commit, has_lsif_data, distance, direction) as (
+                with recursive lineage(repository, "commit", parent_commit, has_lsif_data, direction) as (
                     -- seed result set with the target repository and commit marked
                     -- with both ancestor and descendant directions
                     select l.* from (
-                        select c.*, 0, 'A' from lsif_commits_with_lsif_data c union
-                        select c.*, 0, 'D' from lsif_commits_with_lsif_data c
+                        select c.*, 'A' from lsif_commits_with_lsif_data c union
+                        select c.*, 'D' from lsif_commits_with_lsif_data c
                     ) l
                     where l.repository = $1 and l."commit" = $2
 
                     union
 
                     -- get the next commit in the ancestor or descendant direction
-                    select c.*, l.distance + 1, l.direction from lineage l
+                    select c.*, l.direction from lineage l
                     join lsif_commits_with_lsif_data c on (
                         (l.direction = 'A' and c.repository = l.repository and c."commit" = l.parent_commit) or
                         (l.direction = 'D' and c.repository = l.repository and c.parent_commit = l."commit")
                     )
-                    -- limit traversal distance
-                    where l.distance < $3
                 )
 
                 -- lineage is ordered by distance to the target commit by
                 -- construction; get the nearest commit that has LSIF data
-                select l."commit" from lineage l where l.has_lsif_data limit 1
+                select l."commit" from (select * from lineage limit $3) l where l.has_lsif_data limit 1
             `
 
             const results = (await connection.query(query, [repository, commit, MAX_TRAVERSAL_LIMIT])) as {


### PR DESCRIPTION
**Prior to this change**

The nearest-commit CTE was very slow on repos with lots of merge commits. That was because the `distance` column is different for the same commit on different paths through the commit graph, so the union didn't filter them out of the working table. That means the working table kept increasing in size, resulting in roughly quadratic performance. There was a limit on the `distance`, but no limit on the total number of commits visited. The behavior of CTEs is described in https://www.postgresql.org/docs/9.1/queries-with.html

This was causing lsif-server to take upwards of 75s to run the nearest-commit query (I have since temporarily disabled LSIF on Sourcegraph.com).

**After this change**

The nearest-commit CTE is linear in the number of visited commits, and there's a limit on it.

**Performance analysis**

Here's a scatter plot of the query time by the distance from the target commit on moby/moby, starting from the tip of master and walking back in history. At each commit, both the old and new queries are run and the response times are recorded.

Script and data: [chart.tar.gz](https://github.com/sourcegraph/sourcegraph/files/3720630/chart.tar.gz)

Legend:

- 🔵 old query (left y-axis)
- 🔴 new query (left y-axis)
- 🔶 ratio of old query ms / new query ms (right y-axis)

![image](https://user-images.githubusercontent.com/1387653/66701304-380ca080-ecb8-11e9-89a1-3e3cc097695d.png)

> The sudden drops occur when the walk reaches a merge-base where the other branch has a much shorter distance to the target commit.

See how the ratio of old/new **increases** as the distance from the target commit increases? That indicates the old query's response time increases more than a constant factor faster than the new query (I'm guessing the old query is roughly quadratic in the distance from the target commit).

Previous perf issue about this query: https://github.com/sourcegraph/sourcegraph/issues/5939