### PR TITLE
a8n: Fix review state for GitHub changesets by only considering latest review per author

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -149,7 +149,7 @@ type ChangesetResolver interface {
 	Body() (string, error)
 	State() (a8n.ChangesetState, error)
 	ExternalURL() (*externallink.Resolver, error)
-	ReviewState() (a8n.ChangesetReviewState, error)
+	ReviewState(context.Context) (a8n.ChangesetReviewState, error)
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 	Campaigns(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (CampaignsConnectionResolver, error)
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -388,8 +388,11 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		changesetIDs[i] = c.ID
 	}
 
-	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: changesetIDs}
-	es, err := r.store.ListAllChangesetEvents(ctx, eventsOpts)
+	eventsOpts := ee.ListChangesetEventsOpts{
+		ChangesetIDs: changesetIDs,
+		Limit:        -1,
+	}
+	es, _, err := r.store.ListChangesetEvents(ctx, eventsOpts)
 	if err != nil {
 		return resolvers, err
 	}
@@ -642,8 +645,11 @@ func (r *changesetResolver) ReviewState(ctx context.Context) (a8n.ChangesetRevie
 		return r.Changeset.ReviewState()
 	}
 
-	opts := ee.ListChangesetEventsOpts{ChangesetIDs: []int64{r.Changeset.ID}}
-	es, err := r.store.ListAllChangesetEvents(ctx, opts)
+	opts := ee.ListChangesetEventsOpts{
+		ChangesetIDs: []int64{r.Changeset.ID},
+		Limit:        -1,
+	}
+	es, _, err := r.store.ListChangesetEvents(ctx, opts)
 	if err != nil {
 		return a8n.ChangesetReviewStatePending, err
 	}

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -387,28 +387,16 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	for i, c := range cs {
 		changesetIDs[i] = c.ID
 	}
-	var (
-		events     []ee.Event
-		eventsOpts = ee.ListChangesetEventsOpts{
-			ChangesetIDs: changesetIDs,
-			Limit:        1000,
-		}
-	)
 
-	for {
-		es, next, err := r.store.ListChangesetEvents(ctx, eventsOpts)
-		if err != nil {
-			return resolvers, err
-		}
+	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: changesetIDs}
+	es, err := r.store.ListAllChangesetEvents(ctx, eventsOpts)
+	if err != nil {
+		return resolvers, err
+	}
 
-		for _, e := range es {
-			events = append(events, e)
-		}
-
-		if next == 0 {
-			break
-		}
-		eventsOpts.Cursor = next
+	events := make([]ee.Event, len(es))
+	for i, e := range es {
+		events[i] = e
 	}
 
 	counts, err := ee.CalcCounts(start, end, cs, events...)
@@ -647,35 +635,22 @@ func (r *changesetResolver) ExternalURL() (*externallink.Resolver, error) {
 }
 
 func (r *changesetResolver) ReviewState(ctx context.Context) (a8n.ChangesetReviewState, error) {
+	// ChangesetEvents are currently only implemented for GitHub. For other
+	// codehosts we compute the ReviewState from the Metadata field of a
+	// Changeset.
 	if _, ok := r.Changeset.Metadata.(*github.PullRequest); !ok {
 		return r.Changeset.ReviewState()
 	}
 
-	// Load all events for this changeset with type "review"
-	// Sort events by their timestamp
-	// Calculate latest review state
-	var (
-		events     a8n.ChangesetEvents
-		eventsOpts = ee.ListChangesetEventsOpts{
-			ChangesetIDs: []int64{r.Changeset.ID},
-			Limit:        1000,
-		}
-	)
+	opts := ee.ListChangesetEventsOpts{ChangesetIDs: []int64{r.Changeset.ID}}
+	es, err := r.store.ListAllChangesetEvents(ctx, opts)
+	if err != nil {
+		return a8n.ChangesetReviewStatePending, err
+	}
 
-	for {
-		es, next, err := r.store.ListChangesetEvents(ctx, eventsOpts)
-		if err != nil {
-			return a8n.ChangesetReviewStatePending, err
-		}
-
-		for _, e := range es {
-			events = append(events, e)
-		}
-
-		if next == 0 {
-			break
-		}
-		eventsOpts.Cursor = next
+	events := make(a8n.ChangesetEvents, len(es))
+	for i, e := range es {
+		events[i] = e
 	}
 
 	sort.Sort(events)

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -348,7 +348,6 @@ LIMIT %s
 `
 
 const defaultListLimit = 50
-const defaultListAllBatchSize = 1000
 
 func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	if opts.Limit == 0 {
@@ -507,34 +506,6 @@ type ListChangesetEventsOpts struct {
 	ChangesetIDs []int64
 	Cursor       int64
 	Limit        int
-}
-
-// ListAllChangesetEvents lists all ChangesetEvents with the given filters, except for Limit.
-func (s *Store) ListAllChangesetEvents(ctx context.Context, opts ListChangesetEventsOpts) (cs []*a8n.ChangesetEvent, err error) {
-	opts.Limit = defaultListAllBatchSize
-
-	for {
-		var (
-			next  int64
-			batch = make([]*a8n.ChangesetEvent, opts.Limit)
-		)
-
-		batch, next, err = s.ListChangesetEvents(ctx, opts)
-		if err != nil {
-			return cs, err
-		}
-
-		for _, e := range batch {
-			cs = append(cs, e)
-		}
-
-		if next == 0 {
-			break
-		}
-		opts.Cursor = next
-	}
-
-	return cs, err
 }
 
 // ListChangesetEvents lists ChangesetEvents with the given filters.

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -571,7 +572,6 @@ SELECT
 FROM changeset_events
 WHERE %s
 ORDER BY id ASC
-LIMIT %s
 `
 
 func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
@@ -579,6 +579,11 @@ func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
 		opts.Limit = defaultListLimit
 	}
 	opts.Limit++
+
+	var limitClause string
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+	}
 
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
@@ -596,9 +601,8 @@ func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetEventsQueryFmtstr,
+		listChangesetEventsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
-		opts.Limit,
 	)
 }
 


### PR DESCRIPTION
This fixes #5987 by only looking at the latest review per author when computing the review state of a GitHub changeset.