### PR TITLE
dev: Automate release ping step from captain duties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ libsqlite3-pcre.so
 
 # Direnv
 .envrc
+
+dev/comment.txt

--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ libsqlite3-pcre.so
 # Direnv
 .envrc
 
-dev/comment.txt
+comment.txt

--- a/dev/release-ping.sh
+++ b/dev/release-ping.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This script automates sending a comment to all open issues and PRs in
+# a milestone.
+
+set -euo pipefail
+
+cat > comment.txt <<EOF
+Dear all,
+
+This is your release captain speaking. 🚂🚂🚂
+
+Branch cut for the **$1 release is scheduled for tomorrow**.
+
+Is this issue / PR going to make it in time? Please change the milestone accordingly.
+When in doubt, reach out!
+
+Thank you
+EOF
+
+issues=$(hub issue --include-pulls -M "$1" -F "%I%n")
+
+for i in $issues; do
+  hub api --flat -XPOST "/repos/sourcegraph/sourcegraph/issues/$i/comments" -F "body=@comment.txt"
+done

--- a/dev/release-ping.sh
+++ b/dev/release-ping.sh
@@ -18,7 +18,7 @@ When in doubt, reach out!
 Thank you
 EOF
 
-issues=$(hub issue --include-pulls -M "$1" -F "%I%n")
+issues=$(hub issue --include-pulls -M "$1" -f "%I%n")
 
 for i in $issues; do
   hub api --flat -XPOST "/repos/sourcegraph/sourcegraph/issues/$i/comments" -F "body=@comment.txt"

--- a/dev/release-ping.sh
+++ b/dev/release-ping.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+trap "rm -f comment.txt" EXIT
+
 cat > comment.txt <<EOF
 Dear all,
 

--- a/doc/dev/release_issue_template.md
+++ b/doc/dev/release_issue_template.md
@@ -26,7 +26,7 @@ Run a find replace on:
 
 ## 5 working days before release (YYYY-MM-DD)
 
-- [ ] Private message each teammate who has open issues in the milestone and ask them to remove any issues that won't be done by the time that the release branch is scheduled to be created.
+- [ ] Use `./dev/release-ping.sh` to message teammates who have open issues / PRs in the milestone and ask them to remove those that won't be done by the time that the release branch is scheduled to be created.
 - [ ] Verify that there is a draft of the blog post and that it will be ready to be merged on time.
 - [ ] Ping each team, and ask them to identify which of the optional rows that they own on the release testing grid should be tested this iteration.
 - [ ] Ping the @distribution team to determine which environments each row on the release testing grid should be tested in.


### PR DESCRIPTION
This PR introduces a script that automates sending a comment to all open PRs and
issues in a given milestone, meant to be done by the release captain one
day before branch cut is scheduled.

See https://github.com/sourcegraph/sourcegraph/issues/5845
