### PR TITLE
fix: fix bug incorrectly preventing private instances from internally…

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -83,13 +83,16 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 	Source       string
 	Argument     *string
 }) (*EmptyResponse, error) {
-	if !conf.EventLoggingEnabled() || pubSubDotComEventsTopicID == "" {
+	if !conf.EventLoggingEnabled() {
 		return nil, nil
 	}
 	actor := actor.FromContext(ctx)
 
 	// On Sourcegraph.com, log events to BigQuery instead of the internal Postgres table.
 	if envvar.SourcegraphDotComMode() {
+		if pubSubDotComEventsTopicID == "" {
+			return nil, nil
+		}
 		var argument string
 		if args.Argument != nil {
 			argument = *args.Argument


### PR DESCRIPTION
… logging usage stats

This was a mistake in my commit that added logging to Sourcegraph.com — private instances have not been doing internal logging. This should be fixed for 3.9!

Related to https://github.com/sourcegraph/sourcegraph/issues/5542