### PR TITLE
Dev: add script to update schema

### DIFF
--- a/dev/update-schema-and-bindata.sh
+++ b/dev/update-schema-and-bindata.sh
@@ -11,7 +11,7 @@ done
 go generate github.com/sourcegraph/sourcegraph/migrations
 env \
   PATH="/usr/local/opt/postgresql@9.6/bin:$PATH" \
-  LOG_MIGRATE=true \
+  LOG_MIGRATE_TO_STDOUT=true \
   PGPORT=5433 \
   PGDATABASE=postgres \
   PGUSER=postgres \

--- a/dev/update-schema-and-bindata.sh
+++ b/dev/update-schema-and-bindata.sh
@@ -11,6 +11,7 @@ done
 go generate github.com/sourcegraph/sourcegraph/migrations
 env \
   PATH="/usr/local/opt/postgresql@9.6/bin:$PATH" \
+  LOG_MIGRATE=true \
   PGPORT=5433 \
   PGDATABASE=postgres \
   PGUSER=postgres \

--- a/dev/update-schema-and-bindata.sh
+++ b/dev/update-schema-and-bindata.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+container="$(docker run -d --name some-postgres -p 5433:5432 postgres:9.6)"
+trap "docker rm -f $container" EXIT
+
+while ! env PGPORT=5433 pg_isready; do
+    echo "Sleeping 1s to wait for the postgres Docker container to start..."
+    sleep 1
+done
+
+go generate github.com/sourcegraph/sourcegraph/migrations
+env \
+  PATH="/usr/local/opt/postgresql@9.6/bin:$PATH" \
+  PGPORT=5433 \
+  PGDATABASE=postgres \
+  PGUSER=postgres \
+  GO111MODULE=on \
+  go generate github.com/sourcegraph/sourcegraph/cmd/frontend/db

--- a/internal/db/dbconn/dbconn.go
+++ b/internal/db/dbconn/dbconn.go
@@ -236,7 +236,7 @@ func NewMigrate(db *sql.DB, dataSource string) *migrate.Migrate {
 	// In case another process was faster and runs migrations, we will wait
 	// this long
 	m.LockTimeout = 5 * time.Minute
-	if os.Getenv("LOG_MIGRATE") != "" {
+	if os.Getenv("LOG_MIGRATE_TO_STDOUT") != "" {
 		m.Log = stdoutLogger{}
 	}
 

--- a/internal/db/dbconn/dbconn.go
+++ b/internal/db/dbconn/dbconn.go
@@ -236,7 +236,9 @@ func NewMigrate(db *sql.DB, dataSource string) *migrate.Migrate {
 	// In case another process was faster and runs migrations, we will wait
 	// this long
 	m.LockTimeout = 5 * time.Minute
-	m.Log = stdoutLogger{}
+	if os.Getenv("LOG_MIGRATE") != "" {
+		m.Log = stdoutLogger{}
+	}
 
 	return m
 }

--- a/internal/db/dbconn/dbconn.go
+++ b/internal/db/dbconn/dbconn.go
@@ -209,6 +209,15 @@ func configureConnectionPool(db *sql.DB) {
 	db.SetConnMaxLifetime(time.Minute)
 }
 
+type stdoutLogger struct{}
+
+func (logger stdoutLogger) Printf(format string, v ...interface{}) {
+	fmt.Printf(format, v...)
+}
+func (logger stdoutLogger) Verbose() bool {
+	return true
+}
+
 func NewMigrate(db *sql.DB, dataSource string) *migrate.Migrate {
 	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	if err != nil {
@@ -227,6 +236,7 @@ func NewMigrate(db *sql.DB, dataSource string) *migrate.Migrate {
 	// In case another process was faster and runs migrations, we will wait
 	// this long
 	m.LockTimeout = 5 * time.Minute
+	m.Log = stdoutLogger{}
 
 	return m
 }

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -32,8 +32,16 @@ explicit transaction blocks added to the migration script template.
 
 After adding SQL statements to those files, embed them into the Go code and update the schema doc:
 
+- If you're running Postgres 9.6:
+
 ```
 ./dev/generate.sh
+```
+
+- If you're not running Postgres 9.6:
+
+```
+./dev/update-schema-and-bindata.sh
 ```
 
 or, to only run the DB generate scripts (subset of the command above):
@@ -47,12 +55,6 @@ Verify that the migration is backward-compatible:
 
 ```
 dev/ci/ci-db-backcompat.sh  # NOTE: this checks out a different git revision, so make sure the work tree is clean before running
-```
-
-Update the schema and bindata:
-
-```
-./dev/update-schema-and-bindata.sh
 ```
 
 ### Migrating up/down

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -49,6 +49,12 @@ Verify that the migration is backward-compatible:
 dev/ci/ci-db-backcompat.sh  # NOTE: this checks out a different git revision, so make sure the work tree is clean before running
 ```
 
+Update the schema and bindata:
+
+```
+./dev/update-schema-and-bindata.sh
+```
+
 ### Migrating up/down
 
 Up migrations happen automatically on server start-up after running the


### PR DESCRIPTION
Until https://github.com/sourcegraph/sourcegraph/pull/5752 is implemented, this is a convenient way to update `schema.md` and `bindata.go`:

```
$ ./dev/update-schema-and-bindata.sh
localhost:5433 - no response
Sleeping 1s to wait for the postgres Docker container to start...
localhost:5433 - no response
Sleeping 1s to wait for the postgres Docker container to start...
localhost:5433 - accepting connections
Start buffering 1528395582/u squashed_migrations
...
Start buffering 1528395593/u allows_trailing_hyphen_in_usernames
Read and execute 1528395582/u squashed_migrations
Finished 1528395582/u squashed_migrations (read 11.768334ms, ran 323.917385ms)
...
Finished 1528395603/u add_patterntype_to_saved_searches (read 318.975088ms, ran 16.152499ms)
757f3dc89c42e65e9d6f2152509569494783bd242c6b2a718ccb2f476a200847
```

This is homebrew macOS only because I don't know where the bin directory will be for Linux or other installations.

Original formulation of this: https://github.com/sourcegraph/sourcegraph/pull/5734#issuecomment-541229084

Hard to get the same output as CI: https://sourcegraph.slack.com/archives/C07KZF47K/p1570664138024100