### PR TITLE
dev: fix syntect_server startup if already running

### DIFF
--- a/dev/syntect_server
+++ b/dev/syntect_server
@@ -21,4 +21,6 @@ addr=''
 if [[ "${INSECURE_DEV:-}" == '1' ]]; then
     addr='-e ROCKET_ADDRESS=0.0.0.0'
 fi
+
+docker inspect syntect_server > /dev/null 2>&1 && docker rm -f syntect_server
 exec docker run --name=syntect_server --rm -p9238:9238 ${addr} sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88


### PR DESCRIPTION
@rvantonder ran into this because `syntect_server` had already been running