### PR TITLE
add guide on how to add a separate website maintained by Sourcegraph

### DIFF
--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -42,7 +42,7 @@ We use terraform to manage our DNS records.
 
 💡 If you don't have terraform installed and install via ```brew install terraform```. Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.  
 
-To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
+To update DNS, follow the [DNS guide](https://github.com/sourcegraph/infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
 
 💡 Important:
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -15,7 +15,7 @@ the sole providers, we publish this information on an independent website.
 
 First step is to request @beyang get a domain and add the site to Sourcegraph's Cloudflare account. 
     
-💡 Make sure `www` redirects to `https`.
+> 💡 Make sure `www` redirects to `https`.
 
 ### Create the website content
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -1,0 +1,54 @@
+# How to setup a separate website maintained by Sourcegraph
+
+    💡 Use this template to describe the steps engineers should follow to setup a separate website maintained by Sourcegraph. 
+
+# 1. When do we need a separate website?
+
+For projects like [langserver.org](http://langserver.org) or [lsif.dev](http://lsif.dev), we prefer to create separate websites from 
+[Sourcegraph.com](http://sourcegraph.com). In these two examples, we provide a list of LSPs or LSIF indexers offered by us or other parties 
+that can be used for Sourcegraph or other static analysis applications. Since the usage isn't strictly tide to Sourcegraph and we are not 
+the sole providers, we publish this information on an independent website.
+
+# 2. Setup domain and create content
+
+### Secure the domain
+
+    💡 First step is to get a domain at Namecheap and add the site to our Cloudflare account (Beyang or Quinn would do this). Make sure `www` is redirecting to `https`.
+
+### Create the website content
+
+- Once the domain is secured, we need to setup the Github page, where the static page will be hosted as: `[projectname].github.io`.
+- We clone the repo locally, create a branch from master (make sure master is up-to-date!) and add the following files:
+    - CNAME
+    Containing:
+
+        [project url]
+
+    - README.md
+    - index.html
+    - style-addition.css
+- Once all content is created, we `push` our branch, create a **PR** and ask for reviews and merge to master.
+
+Examples: [Langserver](http://github.com/langserver), [LSIF](http://github.com/lsif)
+
+# 3. Update the DNS to point to the server
+
+We use terraform to manage our DNS records. To update DNS, follow this guide, but push to `branch` not `master` and get it reviewed before merging. 
+
+If you don't have terraform installed and install via ```brew install terraform```:
+
+    💡 Ensure that your local `terrraform` version is the same as the `CI` version to **avoid file locks**.
+
+[DNS guide](https://github.com/sourcegraph/infrastructure/blob/master/dns/README.md)
+
+    💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
+
+    💡 Check that all of the domain's `A records` are also referenced in the terraform file.
+
+Inside your branch:
+
+    $ terraform apply
+    $ git commit -m 'dns: Updated terraform.tfstate' terraform.tfstate
+    $ git push origin branch
+
+Get the branch reviewed and merge to `master`.

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -2,14 +2,14 @@
 
   > 💡 Use this template to describe the steps engineers should follow to setup a separate website maintained by Sourcegraph. 
 
-# 1. When do we need a separate website?
+## 1. When do we need a separate website?
 
 For projects like [langserver.org](http://langserver.org) or [lsif.dev](http://lsif.dev), we prefer to create separate websites from 
 [Sourcegraph.com](http://sourcegraph.com). In these two examples, we provide a list of LSPs or LSIF indexers offered by us or other parties 
 that can be used for Sourcegraph or other static analysis applications. Since the usage isn't strictly tied to Sourcegraph and we are not 
 the sole providers, we publish this information on an independent website.
 
-# 2. Set up domain and create content
+## 2. Set up domain and create content
 
 ### Secure the domain
 
@@ -36,7 +36,7 @@ When all the content is created, we `push` our branch, create a **PR** and ask f
 
 Examples: [Langserver](https://github.com/langserver/langserver.github.io), [LSIF](https://github.com/lsif/lsif.github.io)
 
-# 3. Update the DNS to point to the server
+## 3. Update the DNS to point to the server
 
 We use terraform to manage our DNS records. 
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -54,3 +54,10 @@ Inside your branch:
     $ git push origin branch
 
 Get the branch reviewed and merge to `master`.
+
+
+Other Sourcegraph docs:
+
+- [Contributing to Sourcegraph documentation](index.md#contributing-to-docs)
+- [Documentation directory structure](index.md#documentation-directory-structure)
+- [Documentation style guidelines](style_guide.md)

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -39,7 +39,7 @@ If you don't have terraform installed and install via ```brew install terraform`
 
     💡 Ensure that your local `terrraform` version is the same as the `CI` version to **avoid file locks**.
 
-[DNS guide](../../../../../infrastructure/blob/master/dns/README.md)
+[DNS guide](../../../../../../infrastructure/blob/master/dns/README.md)
 
     💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -6,22 +6,22 @@
 
 For projects like [langserver.org](http://langserver.org) or [lsif.dev](http://lsif.dev), we prefer to create separate websites from 
 [Sourcegraph.com](http://sourcegraph.com). In these two examples, we provide a list of LSPs or LSIF indexers offered by us or other parties 
-that can be used for Sourcegraph or other static analysis applications. Since the usage isn't strictly tide to Sourcegraph and we are not 
+that can be used for Sourcegraph or other static analysis applications. Since the usage isn't strictly tied to Sourcegraph and we are not 
 the sole providers, we publish this information on an independent website.
 
-# 2. Setup domain and create content
+# 2. Set up domain and create content
 
 ### Secure the domain
 
-First step is to request @beyang or @sqs get a domain and add the site to Sourcegraph's Cloudflare account. 
+First step is to request @beyang get a domain and add the site to Sourcegraph's Cloudflare account. 
     
-    💡 Make sure `www` is redirecting to `https`.
+    💡 Make sure `www` redirects to `https`.
 
 ### Create the website content
 
 Once the domain is secured, we need to setup the GitHub page, where the static page will be hosted as: `[projectname].github.io`.
 
-We clone the repo locally, create a branch from master (make sure master is up-to-date!) and add the following files:
+We clone the repository locally, create a branch from master (make sure master is up-to-date!) and add the following files:
     - CNAME
     Containing:
 
@@ -37,17 +37,17 @@ Examples: [Langserver](http://github.com/langserver), [LSIF](http://github.com/l
 
 # 3. Update the DNS to point to the server
 
-We use terraform to manage our DNS records. To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to `branch` not `master` and get it reviewed before merging.
+We use terraform to manage our DNS records. To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
 
 If you don't have terraform installed and install via ```brew install terraform```:
 
-    💡 Ensure that your local `terrraform` version is the same as the `CI` version to **avoid file locks**.
+    💡 Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.
 
     💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
 
     💡 Check that all of the domain's `A records` are also referenced in the terraform file.
 
-Inside your branch:
+From the `infrastructure` repository, with your branch checked out:
 
     $ terraform apply
     $ git commit -m 'dns: Updated terraform.tfstate' terraform.tfstate

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -39,7 +39,7 @@ If you don't have terraform installed and install via ```brew install terraform`
 
     💡 Ensure that your local `terrraform` version is the same as the `CI` version to **avoid file locks**.
 
-[DNS guide](https://github.com/sourcegraph/infrastructure/blob/master/dns/README.md)
+[DNS guide](../../../../../infrastructure/blob/master/dns/README.md)
 
     💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -13,12 +13,15 @@ the sole providers, we publish this information on an independent website.
 
 ### Secure the domain
 
-    💡 First step is to get a domain at Namecheap and add the site to our Cloudflare account (Beyang or Quinn would do this). Make sure `www` is redirecting to `https`.
+First step is to request @beyang or @sqs get a domain and add the site to Sourcegraph's Cloudflare account. 
+    
+    💡 Make sure `www` is redirecting to `https`.
 
 ### Create the website content
 
-- Once the domain is secured, we need to setup the Github page, where the static page will be hosted as: `[projectname].github.io`.
-- We clone the repo locally, create a branch from master (make sure master is up-to-date!) and add the following files:
+Once the domain is secured, we need to setup the GitHub page, where the static page will be hosted as: `[projectname].github.io`.
+
+We clone the repo locally, create a branch from master (make sure master is up-to-date!) and add the following files:
     - CNAME
     Containing:
 
@@ -27,19 +30,18 @@ the sole providers, we publish this information on an independent website.
     - README.md
     - index.html
     - style-addition.css
-- Once all content is created, we `push` our branch, create a **PR** and ask for reviews and merge to master.
+
+When all the content is created, we `push` our branch, create a **PR** and ask for reviews and merge to master.
 
 Examples: [Langserver](http://github.com/langserver), [LSIF](http://github.com/lsif)
 
 # 3. Update the DNS to point to the server
 
-We use terraform to manage our DNS records. To update DNS, follow this guide, but push to `branch` not `master` and get it reviewed before merging. 
+We use terraform to manage our DNS records. To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to `branch` not `master` and get it reviewed before merging.
 
 If you don't have terraform installed and install via ```brew install terraform```:
 
     💡 Ensure that your local `terrraform` version is the same as the `CI` version to **avoid file locks**.
-
-[DNS guide](../../../../../../infrastructure/blob/master/dns/README.md)
 
     💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -1,6 +1,6 @@
 # How to setup a separate website maintained by Sourcegraph
 
-    💡 Use this template to describe the steps engineers should follow to setup a separate website maintained by Sourcegraph. 
+  > 💡 Use this template to describe the steps engineers should follow to setup a separate website maintained by Sourcegraph. 
 
 # 1. When do we need a separate website?
 
@@ -40,14 +40,14 @@ Examples: [Langserver](https://github.com/langserver/langserver.github.io), [LSI
 
 We use terraform to manage our DNS records. 
 
-💡 If you don't have terraform installed and install via ```brew install terraform```. Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.  
+> 💡 If you don't have terraform installed and install via ```brew install terraform```. Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.  
 
 To update DNS, follow the [DNS guide](https://github.com/sourcegraph/infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
 
-💡 Important:
-
-  - Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
-  - Check that all of the domain's `A records` are also referenced in the terraform file.
+> 💡 Important:
+> - Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
+> - Check that all of the domain's `A records` are also referenced in the terraform file.
+>
 
 From the `infrastructure` repository, with your branch checked out:
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -13,7 +13,7 @@ the sole providers, we publish this information on an independent website.
 
 ### Secure the domain
 
-First step is to request @beyang get a domain and add the site to Sourcegraph's Cloudflare account. 
+First step is to request [@beyang](https://github.com/beyang) get a domain and add the site to Sourcegraph's Cloudflare account. 
     
 > 💡 Make sure `www` redirects to `https`.
 

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -15,13 +15,14 @@ the sole providers, we publish this information on an independent website.
 
 First step is to request @beyang get a domain and add the site to Sourcegraph's Cloudflare account. 
     
-    💡 Make sure `www` redirects to `https`.
+💡 Make sure `www` redirects to `https`.
 
 ### Create the website content
 
 Once the domain is secured, we need to setup the GitHub page, where the static page will be hosted as: `[projectname].github.io`.
 
 We clone the repository locally, create a branch from master (make sure master is up-to-date!) and add the following files:
+
     - CNAME
     Containing:
 
@@ -33,19 +34,20 @@ We clone the repository locally, create a branch from master (make sure master i
 
 When all the content is created, we `push` our branch, create a **PR** and ask for reviews and merge to master.
 
-Examples: [Langserver](http://github.com/langserver), [LSIF](http://github.com/lsif)
+Examples: [Langserver](https://github.com/langserver/langserver.github.io), [LSIF](https://github.com/lsif/lsif.github.io)
 
 # 3. Update the DNS to point to the server
 
-We use terraform to manage our DNS records. To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
+We use terraform to manage our DNS records. 
 
-If you don't have terraform installed and install via ```brew install terraform```:
+💡 If you don't have terraform installed and install via ```brew install terraform```. Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.  
 
-    💡 Ensure that your local `terraform` version is the same as the `CI` version to **avoid file locks**.
+To update DNS, follow the [DNS guide](../../../../../../infrastructure/blob/master/dns/README.md), but push to a non-`master` branch and get it reviewed before merging.
 
-    💡 Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
+💡 Important:
 
-    💡 Check that all of the domain's `A records` are also referenced in the terraform file.
+  - Make sure to pull the **latest version** of the infrastructure `master` before creating your branch.
+  - Check that all of the domain's `A records` are also referenced in the terraform file.
 
 From the `infrastructure` repository, with your branch checked out:
 
@@ -54,10 +56,3 @@ From the `infrastructure` repository, with your branch checked out:
     $ git push origin branch
 
 Get the branch reviewed and merge to `master`.
-
-
-Other Sourcegraph docs:
-
-- [Contributing to Sourcegraph documentation](index.md#contributing-to-docs)
-- [Documentation directory structure](index.md#documentation-directory-structure)
-- [Documentation style guidelines](style_guide.md)

--- a/doc/dev/documentation/structure.md
+++ b/doc/dev/documentation/structure.md
@@ -10,6 +10,7 @@ Before getting started, read through the following docs:
 - [Contributing to Sourcegraph documentation](index.md#contributing-to-docs)
 - [Documentation directory structure](index.md#documentation-directory-structure)
 - [Documentation style guidelines](style_guide.md)
+- Example Documentation: [How to setup a separate website maintained by Sourcegraph](separate_website.md)
 
 ## Documentation blurb
 

--- a/doc/dev/documentation/style_guide.md
+++ b/doc/dev/documentation/style_guide.md
@@ -90,8 +90,7 @@ breaks are shown as a full line Sourcegraph markdown 80-100. <!-- TODO(ryan): Li
   you can use `[Text][identifier]` and at the bottom of the section or the
   document add: `[identifier]: https://example.com`, in which case, we do
   encourage you to also add an alternative text: `[identifier]: https://example.com "Alternative text"` that appears when hovering your mouse on a link.
-- To link to internal documentation, use relative links, not full URLs. Use `../` to
-  navigate to higher-level directories, and always add the file name `file.md` at the
+- To link to internal documentation within the same repository, use relative links, not full URLs. Use `../` to navigate to higher-level directories, and always add the file name `file.md` at the
   end of the link with the `.md` extension, not `.html`.
   Example: instead of `[text](../../merge_requests/)`, use
   `[text](../../merge_requests/index.md)` or, `[text](../../ci/README.md)`, or,


### PR DESCRIPTION
Documentation on how to create a separate website maintained by Sourcegraph, e.g. [LSIF.dev](https://lsif.dev) or [langserver.org](https://langserver.org).
