### PR TITLE
a8n: Fix GitHub PR ReviewState by ignoring pending/commented reviews

### DIFF
--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -280,14 +280,11 @@ func (ce ChangesetEvents) ReviewState() (ChangesetReviewState, error) {
 	for _, e := range ce {
 		switch e.Type() {
 		case ChangesetEventKindGitHubReviewed:
-			s, ok := e.ReviewState()
-			if !ok {
-				continue
+			switch s, _ := e.ReviewState(); s {
+			case ChangesetReviewStateApproved,
+				ChangesetReviewStateChangesRequested:
+				reviewsByActor[e.Actor()] = s
 			}
-
-			actor := e.Actor()
-
-			reviewsByActor[actor] = s
 		}
 	}
 

--- a/internal/a8n/types_test.go
+++ b/internal/a8n/types_test.go
@@ -104,6 +104,34 @@ func TestChangesetEventsReviewState(t *testing.T) {
 		},
 		{
 			events: ChangesetEvents{
+				ghReview(daysAgo(1), "user1", "APPROVED"),
+				ghReview(daysAgo(0), "user1", "COMMENTED"),
+			},
+			want: ChangesetReviewStateApproved,
+		},
+		{
+			events: ChangesetEvents{
+				ghReview(daysAgo(1), "user1", "CHANGES_REQUESTED"),
+				ghReview(daysAgo(0), "user1", "COMMENTED"),
+			},
+			want: ChangesetReviewStateChangesRequested,
+		},
+		{
+			events: ChangesetEvents{
+				ghReview(daysAgo(1), "user1", "APPROVED"),
+				ghReview(daysAgo(0), "user1", "PENDING"),
+			},
+			want: ChangesetReviewStateApproved,
+		},
+		{
+			events: ChangesetEvents{
+				ghReview(daysAgo(1), "user1", "CHANGES_REQUESTED"),
+				ghReview(daysAgo(0), "user1", "PENDING"),
+			},
+			want: ChangesetReviewStateChangesRequested,
+		},
+		{
+			events: ChangesetEvents{
 				ghReview(daysAgo(2), "user1", "APPROVED"),
 				ghReview(daysAgo(1), "user1", "CHANGES_REQUESTED"),
 			},


### PR DESCRIPTION
This fixes a bug I discovered locally where we reported the review state
of PR https://github.com/sourcegraph/sourcegraph/pull/5895 to be
"Pending".

The reason why we did that is because we didn't ignore Pending/Commented
reviews, which we do in the burndown chart calculations.