### PR TITLE
a8n: Fix listing all ChangesetEvents resulting in empty results

### DIFF
--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -522,7 +522,7 @@ func (s *Store) ListChangesetEvents(ctx context.Context, opts ListChangesetEvent
 		return int64(c.ID), 1, err
 	})
 
-	if len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.Limit {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -776,6 +776,23 @@ func testStore(db *sql.DB) func(*testing.T) {
 						cursor = next
 					}
 				})
+
+				t.Run("EmptyResultListingAll", func(t *testing.T) {
+					opts := ListChangesetEventsOpts{ChangesetIDs: []int64{99999}, Limit: -1}
+
+					ts, next, err := s.ListChangesetEvents(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have, want := next, int64(0); have != want {
+						t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+					}
+
+					if len(ts) != 0 {
+						t.Fatalf("listed %d events, want: %d", len(ts), 0)
+					}
+				})
 			})
 		})
 	}


### PR DESCRIPTION
This fixes #6011.

The panic in the bug report was caused by `len(cs)` being `0` and
trying to access `cs[:-1]`, leading to an index-out-of-range panic.

This happens only when `Limit` has been set to `-1` before (it's
incremented to `0` in the function that constructs the query) to list
all changeset events and the query resulting in an empty result set.