### PR TITLE
server: Upgrade libc6 from 1.1.23-r3 to 1.1.24-r0

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=sourcegraph/prometheus:10.0.1@sha256:ba6dd9e33621801d553651191b4d4c6
 RUN set -ex && \
     addgroup -S grafana && \
     adduser -S -G grafana grafana && \
-    apk add --no-cache libc6-compat=1.1.23-r3 ca-certificates su-exec
+    apk add --no-cache libc6-compat=1.1.24-r0 ca-certificates su-exec
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/grafana:10.0.2@sha256:ac3f89039007be1359a2308a0cd2f8aebdd85ee933a9ab1728fd7077ed103b67 /usr/share/grafana /usr/share/grafana


### PR DESCRIPTION
Builds were failing because 1.1.23-r3 could not be resolved anymore:

    https://buildkite.com/sourcegraph/sourcegraph/builds/45273#39822b26-f8e8-456d-b18d-c205c07393dc
    https://buildkite.com/sourcegraph/sourcegraph/builds/45272#b555f82f-c48b-4153-b869-1e005461d4f8

It looks like the upgrade to 1.1.24 affects every version of Alpine:

    https://git.alpinelinux.org/aports/commit/?id=ba05f40c20ddc515f748f205f01befbba3a88feb
