### PR TITLE
fix watch dirs (pkg->internal)

### DIFF
--- a/dev/watchdirs.sh
+++ b/dev/watchdirs.sh
@@ -2,4 +2,4 @@
 #
 # Prints the list of directories to watch in development
 
-echo cmd dev pkg schema
+echo cmd dev internal schema


### PR DESCRIPTION
85fba22315ea0be5740d4cc331457b5609cf09a4 (#5898) renamed pkg->internal but this watch script was not updated. This caused the watch task to fail (at least when using inotify).

