### PR TITLE
remove redundant sentence from LiteralSearchToast

### DIFF
--- a/web/src/marketing/LiteralSearchToast.tsx
+++ b/web/src/marketing/LiteralSearchToast.tsx
@@ -35,7 +35,7 @@ export default class LiteralSearchToast extends React.Component<Props, State> {
                 <Toast
                     icon={<RegexIcon size={32} />}
                     title="New regular expression toggle!"
-                    subtitle="Search queries are no longer interpreted as regular expressions by default. Click the .* icon in the search bar to toggle regular expression search. Learn more about this update in the docs."
+                    subtitle="Search queries are no longer interpreted as regular expressions by default. Click the .* icon in the search bar to toggle regular expression search."
                     onDismiss={this.onDismiss}
                     cta={
                         <Link


### PR DESCRIPTION
The removed sentence was confusing because it was not linked and it referred to the button right below. This sentence is in fact not needed.