### PR TITLE
Web app: fix paths with special characters

### DIFF
--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -98,6 +98,15 @@ describe('parseRepoURI', () => {
             },
         })
     })
+
+    test('should parse a file with special characters', () => {
+        const parsed = parseRepoURI('git://github.com/gorilla/mux?branch#space%20here.go')
+        assertDeepStrictEqual(parsed, {
+            repoName: 'github.com/gorilla/mux',
+            rev: 'branch',
+            filePath: 'space here.go',
+        })
+    })
 })
 
 describe('makeRepoURI', () => {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -151,7 +151,7 @@ export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
     const fragmentSplit = parsed.hash
         .substr('#'.length)
         .split(':')
-        .map(piece => decodeURIComponent(piece))
+        .map(decodeURIComponent)
     let filePath: string | undefined
     let position: Position | undefined
     let range: Range | undefined

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -153,7 +153,7 @@ export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
     let position: Position | undefined
     let range: Range | undefined
     if (fragmentSplit.length === 1) {
-        filePath = fragmentSplit[0]
+        filePath = decodeURIComponent(fragmentSplit[0])
     }
     if (fragmentSplit.length === 2) {
         filePath = fragmentSplit[0]

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -148,12 +148,15 @@ export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
     if (rev && rev.match(/[0-9a-fA-f]{40}/)) {
         commitID = rev
     }
-    const fragmentSplit = parsed.hash.substr('#'.length).split(':')
+    const fragmentSplit = parsed.hash
+        .substr('#'.length)
+        .split(':')
+        .map(piece => decodeURIComponent(piece))
     let filePath: string | undefined
     let position: Position | undefined
     let range: Range | undefined
     if (fragmentSplit.length === 1) {
-        filePath = decodeURIComponent(fragmentSplit[0])
+        filePath = fragmentSplit[0]
     }
     if (fragmentSplit.length === 2) {
         filePath = fragmentSplit[0]


### PR DESCRIPTION
The webapp wasn't decoding the path from the URL fragment (the part after the `#`), resulting in errors in the references panel.

Fixes https://github.com/sourcegraph/sourcegraph/issues/6049

More context: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1571178999056900?thread_ts=1571085736.041800&cid=CHXHX7XAS

This goes way back: https://github.com/sourcegraph/enterprise/commit/b1dab9d239fa3cc52f60daa55f438b100b470c9a#diff-aaf2fa7a0b42f7e114770b804b61e7faR57

Test plan: added a unit test
