### PR TITLE
fix: don't suggest quoted queries in literal mode

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -36,6 +36,12 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	if len(a.proposedQueries) == 0 {
 		return nil
 	}
+	// TODO: we need to append patternType:regexp to all proposed queries to avoid
+	// invalid suggestions. There are many where places we assume the original query is regexp,
+	// so more work is required to create a nice solution for this.
+	for _, proposedQuery := range a.proposedQueries {
+		proposedQuery.query = proposedQuery.query + " patternType:regexp"
+	}
 	return &a.proposedQueries
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6008. 

When queries fail due to "too many repos" or "no repos matching" errors, we would suggest alternative queries which append a repo to the query. However, in literal mode, the match string  is wrapped in quotes in regexp-land ensure an exact match, so the suggested queries would return the match string as wrapped in quotes. This fixes it by simply appending `patternType:regexp` to existing suggestions. 

This isn't the ideal solution but there are a lot of places we assume our search is regexp-only, so will need more time to improve this.