### PR TITLE
LSIF: Add machinery for repeated/scheduled jobs.

### DIFF
--- a/lsif/src/queue.ts
+++ b/lsif/src/queue.ts
@@ -1,4 +1,4 @@
-import Bull, { Queue, Job } from 'bull'
+import Bull, { Queue, Job, JobOptions } from 'bull'
 import { Span, Tracer, FORMAT_TEXT_MAP } from 'opentracing'
 import { Logger } from 'winston'
 
@@ -15,7 +15,6 @@ export function createQueue(name: string, endpoint: string, logger: Logger): Que
     const redis = {
         host,
         port: parseInt(port, 10),
-        namespace: `lsif_${name}`,
     }
 
     const queue = new Bull(name, { redis })
@@ -29,15 +28,60 @@ export function createQueue(name: string, endpoint: string, logger: Logger): Que
  * Enqueue a job to be run by a worker.
  *
  * @param queue The job queue.
+ * @param name The name of the job class.
  * @param args The job arguments.
+ * @param opts The job options.
  * @param tracer The tracer instance.
  * @param span The parent span.
  */
-export const enqueue = (queue: Queue, args: object, tracer?: Tracer, span?: Span): Promise<Job> => {
+export const enqueue = (
+    queue: Queue,
+    name: string,
+    args: object,
+    opts: JobOptions,
+    tracer?: Tracer,
+    span?: Span
+): Promise<Job> => {
     const tracing = {}
     if (tracer && span) {
         tracer.inject(span, FORMAT_TEXT_MAP, tracing)
     }
 
-    return queue.add({ args, tracing })
+    return queue.add(name, { args, tracing }, opts)
+}
+
+/**
+ * Schedule a job to be invoked on an interval. If this job was previously
+ * scheduled with a different interval, the old instance is first unscheduled.
+ *
+ * @param queue The job queue.
+ * @param name The name of the job class.
+ * @param args The job arguments.
+ * @param intervalMs How frequently to run the job.
+ */
+export const scheduleRepeatedJob = async (
+    queue: Queue,
+    name: string,
+    args: object,
+    intervalMs: number
+): Promise<void> => {
+    const keys = []
+    for (const job of await queue.getRepeatableJobs()) {
+        if (job.name === name) {
+            // Job already scheduled with correct interval
+            if (job.every === intervalMs * 1000) {
+                return
+            }
+
+            keys.push(job.key)
+        }
+    }
+
+    for (const key of keys) {
+        // Remove old scheduled jobs with different intervals
+        await queue.removeRepeatableByKey(key)
+    }
+
+    // Schedule job with correct interval
+    await enqueue(queue, name, args, { repeat: { every: intervalMs * 1000 } })
 }

--- a/lsif/src/queue.ts
+++ b/lsif/src/queue.ts
@@ -59,7 +59,7 @@ export const enqueue = (
  * @param args The job arguments.
  * @param intervalMs How frequently to run the job.
  */
-export const scheduleRepeatedJob = async (
+export const ensureOnlyRepeatableJob = async (
     queue: Queue,
     name: string,
     args: object,

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -121,7 +121,7 @@ async function main(logger: Logger): Promise<void> {
     await ensureDirectory(path.join(STORAGE_ROOT, 'uploads'))
 
     // Create queue to publish convert
-    const queue = createQueue('convert', REDIS_ENDPOINT, logger)
+    const queue = createQueue('lsif', REDIS_ENDPOINT, logger)
 
     // Update queue size metric on a timer
     setInterval(async () => queueSizeGauge.set(await queue.count()), 1000)
@@ -286,7 +286,8 @@ async function lsifEndpoints(
 
                 // Enqueue convert job
                 logger.debug('enqueueing convert job', { repository, commit, root })
-                await enqueue(queue, { repository, commit, root: root || '', filename }, tracer, ctx.span)
+                const args = { repository, commit, root: root || '', filename }
+                await enqueue(queue, 'convert', args, {}, tracer, ctx.span)
                 res.send('Upload successful, queued for processing.\n')
             }
         )

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -158,10 +158,10 @@ async function main(logger: Logger): Promise<void> {
     )
 
     // Create queue to poll for jobs
-    const queue = createQueue('convert', REDIS_ENDPOINT, logger)
+    const queue = createQueue('lsif', REDIS_ENDPOINT, logger)
 
     // Start processing work
-    queue.process(convertJobProcessor).catch(() => {})
+    queue.process('convert', convertJobProcessor).catch(() => {})
 }
 
 /**


### PR DESCRIPTION
This PR adds logic to add repeatable jobs to the queue. This will be useful for asking gitserver for branch tips on a schedule in [RFC 43](https://docs.google.com/document/d/18I15BKFSdJOh7BZsrQpx4Tegdwxp5VkUcoFYYgDfggI/edit).

This method will be used in upcoming PRs.