### PR TITLE
GitHub auth: only request user email scope for sourcegraph.com

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider.go
@@ -57,7 +57,7 @@ func parseProvider(p *schema.GitHubAuthProvider, sourceCfg schema.AuthProviders)
 
 func requestedScopes() []string {
 	if envvar.SourcegraphDotComMode() {
-		return []string{"public_repo", "user:email"}
+		return []string{"user:email"}
 	}
 	return []string{"repo", "user:email"}
 }


### PR DESCRIPTION
Fix https://github.com/sourcegraph/sourcegraph/issues/6063