### PR TITLE
Fix adding external service for search regression test

### DIFF
--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -167,8 +167,8 @@ describe('Search regression test suite', () => {
                             token: config.gitHubToken,
                             repos: testRepoSlugs,
                             repositoryQuery: ['none'],
-                            waitForRepos: testRepoSlugs.map(slug => 'github.com/' + slug),
                         },
+                        waitForRepos: testRepoSlugs.map(slug => 'github.com/' + slug),
                     })
                 )
             },


### PR DESCRIPTION
@beyang I think you accidentally placed `waitForRepos` in the wrong object. 

The current placement invalidates the external service config since it doesn't support the field `waitForRepos` so the external service is unable to be added. This makes the rest of the search regression tests fail since there are no repositories.