### PR TITLE
Set prometheus container to use 1 CPU.

### DIFF
--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -38,7 +38,7 @@ fi
 docker inspect $CONTAINER > /dev/null 2>&1 && docker rm -f $CONTAINER
 docker run --rm ${NET_ARG} --cidfile ${CID_FILE} \
     --name=prometheus \
-    --cpus=4 \
+    --cpus=1 \
     --memory=4g \
     --user=$UID \
     -p 0.0.0.0:9090:9090 \


### PR DESCRIPTION
Prometheus is currently set to use 4 CPUs. The container will not start if the host hardware doesn't have 4 CPUs (from `prometheus.log`):

```
docker: Error response from daemon: Range of CPUs is from 0.01 to 2.00, as there are only 2 CPUs available.
See 'docker run --help'.
```

Setting it to `1`, as per @slimsag recommendation. Would be nice to have this fail loudly (took some time to discover the logs) but unsure where catch the faulty part to print a message that says 'Check the logs'.