### PR TITLE
repo-updater: Remove Enabled field from configuredRepo2

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -109,10 +109,9 @@ type updateScheduler struct {
 // a configuration source, such as information retrieved from GitHub for a
 // given GitHubConnection.
 type configuredRepo2 struct {
-	URL     string
-	ID      uint32
-	Name    api.RepoName
-	Enabled bool
+	URL  string
+	ID   uint32
+	Name api.RepoName
 }
 
 // sourceRepoMap is the set of repositories associated with a specific configuration source.
@@ -291,9 +290,8 @@ func (s *updateScheduler) remove(r *Repo) {
 
 func configuredRepo2FromRepo(r *Repo) *configuredRepo2 {
 	repo := configuredRepo2{
-		ID:      r.ID,
-		Name:    api.RepoName(r.Name),
-		Enabled: r.Enabled,
+		ID:   r.ID,
+		Name: api.RepoName(r.Name),
 	}
 
 	if urls := r.CloneURLs(); len(urls) > 0 {
@@ -316,7 +314,7 @@ func (s *updateScheduler) updateSource(source string, newList sourceRepoMap) {
 	// Remove repos that don't exist in the new list or are disabled in the new list.
 	oldList := s.sourceRepos[source]
 	for key, repo := range oldList {
-		if updatedRepo, ok := newList[key]; !ok || !updatedRepo.Enabled {
+		if _, ok := newList[key]; !ok {
 			s.schedule.remove(repo)
 			updating := false // don't immediately remove repos that are already updating; they will automatically get removed when the update finishes
 			s.updateQueue.remove(repo, updating)
@@ -325,10 +323,8 @@ func (s *updateScheduler) updateSource(source string, newList sourceRepoMap) {
 
 	// Schedule enabled repos.
 	for _, updatedRepo := range newList {
-		if updatedRepo.Enabled {
-			s.schedule.upsert(updatedRepo)
-			s.updateQueue.enqueue(updatedRepo, priorityLow)
-		}
+		s.schedule.upsert(updatedRepo)
+		s.updateQueue.enqueue(updatedRepo, priorityLow)
 	}
 
 	s.sourceRepos[source] = newList

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -1334,119 +1334,44 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 		expectedNotifications func(s *updateScheduler) []chan struct{}
 	}{
 		{
-			name:               "add disabled repo",
-			initialSourceRepos: map[string]sourceRepoMap{},
-			updateSourceCalls: []*updateSourceCall{
-				{
-					source: "a",
-					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
-					},
-				},
-			},
-			finalSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
-				},
-			},
-		},
-		{
 			name:               "add enabled repo",
 			initialSourceRepos: map[string]sourceRepoMap{},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Seq: 1, Updating: false},
 			},
 			timeAfterFuncDelays: []time.Duration{minDelay},
 			expectedNotifications: func(s *updateScheduler) []chan struct{} {
 				return []chan struct{}{s.schedule.wakeup, s.updateQueue.notifyEnqueue}
-			},
-		},
-		{
-			name: "update disabled repo",
-			initialSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
-				},
-			},
-			updateSourceCalls: []*updateSourceCall{
-				{
-					source: "a",
-					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
-					},
-				},
-			},
-			finalSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
-				},
-			},
-			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
-			},
-			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
-			},
-			timeAfterFuncDelays: []time.Duration{minDelay},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
-				return []chan struct{}{s.schedule.wakeup, s.updateQueue.notifyEnqueue}
-			},
-		},
-		{
-			name: "disabled repo removed from schedule and queue",
-			initialSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
-				},
-			},
-			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
-			},
-			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false}, Updating: false},
-			},
-			updateSourceCalls: []*updateSourceCall{
-				{
-					source: "a",
-					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-					},
-				},
-			},
-			finalSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-				},
 			},
 		},
 		{
 			name: "missing repo removed from schedule and queue",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true /* enabled state doesn't get updated once in the queue because concurrency nightmare */}, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Updating: false},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
@@ -1456,50 +1381,20 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {},
-			},
-		},
-		{
-			name: "disabled repo not removed from queue when updating",
-			initialSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
-				},
-			},
-			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
-			},
-			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Updating: true},
-			},
-			updateSourceCalls: []*updateSourceCall{
-				{
-					source: "a",
-					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-					},
-				},
-			},
-			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
-			},
-			finalSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-				},
 			},
 		},
 		{
 			name: "missing repo not removed from queue when updating",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Updating: true},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
@@ -1508,97 +1403,76 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 				},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Seq: 1, Updating: true},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {},
 			},
 		},
 		{
-			name: "enabled repo updated",
+			name: "repo updated",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Seq: 1, Updating: false},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"}, Seq: 1, Updating: false},
 			},
 		},
 		{
-			name: "disabled repo updated",
+			name: "update repo while updating",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
-				},
-			},
-			updateSourceCalls: []*updateSourceCall{
-				{
-					source: "a",
-					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-					},
-				},
-			},
-			finalSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
-				},
-			},
-		},
-		{
-			name: "update enabled repo while updating",
-			initialSourceRepos: map[string]sourceRepoMap{
-				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com"},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Seq: 1, Updating: true},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com"}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}, Seq: 1, Updating: true},
 			},
 		},
 	}
@@ -1627,5 +1501,3 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 		})
 	}
 }
-
-// TODO: update enabled state and url once in the queue?


### PR DESCRIPTION
It is always true. So we remove the field, and remove tests targetted at
disabled repos. This is some minor work towards removing the enabled field.

Part of https://github.com/sourcegraph/sourcegraph/issues/3971