### PR TITLE
Make LiteralSearchToast properly themed

### DIFF
--- a/web/src/marketing/LiteralSearchToast.tsx
+++ b/web/src/marketing/LiteralSearchToast.tsx
@@ -37,6 +37,7 @@ export default class LiteralSearchToast extends React.Component<Props, State> {
                     title="New regular expression toggle!"
                     subtitle="Search queries are no longer interpreted as regular expressions by default. Click the .* icon in the search bar to toggle regular expression search."
                     onDismiss={this.onDismiss}
+                    useDarkTheme={true}
                     cta={
                         <Link
                             to={`${docsURLPrefix}/user/search/queries`}

--- a/web/src/marketing/LiteralSearchToast.tsx
+++ b/web/src/marketing/LiteralSearchToast.tsx
@@ -37,7 +37,6 @@ export default class LiteralSearchToast extends React.Component<Props, State> {
                     title="New regular expression toggle!"
                     subtitle="Search queries are no longer interpreted as regular expressions by default. Click the .* icon in the search bar to toggle regular expression search."
                     onDismiss={this.onDismiss}
-                    useDarkTheme={true}
                     cta={
                         <Link
                             to={`${docsURLPrefix}/user/search/queries`}

--- a/web/src/marketing/Toast.scss
+++ b/web/src/marketing/Toast.scss
@@ -7,8 +7,9 @@
     display: flex;
     align-items: flex-start;
     border-radius: 0.25rem;
-    background-color: $color-light-bg-2;
-    color: $color-light-text-1;
+    background-color: $color-bg-2;
+    color: $color-text-2;
+    border: 1px solid $color-border;
 
     &__logo {
         flex: 0 0 auto;
@@ -65,6 +66,8 @@
 .theme-light {
     .toast {
         border: 1px solid $color-light-border;
+        background-color: $color-light-bg-2;
+        color: $color-light-text-1;
 
         &__close-button {
             &:hover {

--- a/web/src/marketing/Toast.scss
+++ b/web/src/marketing/Toast.scss
@@ -1,4 +1,3 @@
-@import './LiteralSearchToast.scss';
 .toast {
     position: fixed;
     right: 2rem;

--- a/web/src/marketing/Toast.scss
+++ b/web/src/marketing/Toast.scss
@@ -1,3 +1,4 @@
+@import './LiteralSearchToast.scss';
 .toast {
     position: fixed;
     right: 2rem;
@@ -7,10 +8,14 @@
     display: flex;
     align-items: flex-start;
     border-radius: 0.25rem;
-    background-color: $color-bg-2;
-    color: $color-text-2;
-    border: 1px solid $color-border;
+    background-color: $color-light-bg-2;
+    color: $color-light-text-1;
 
+    &--dark {
+        background-color: $color-bg-2;
+        color: $color-text-2;
+        border: 1px solid $color-border;
+    }
     &__logo {
         flex: 0 0 auto;
         width: 2rem;
@@ -66,8 +71,6 @@
 .theme-light {
     .toast {
         border: 1px solid $color-light-border;
-        background-color: $color-light-bg-2;
-        color: $color-light-text-1;
 
         &__close-button {
             &:hover {

--- a/web/src/marketing/Toast.scss
+++ b/web/src/marketing/Toast.scss
@@ -7,14 +7,10 @@
     display: flex;
     align-items: flex-start;
     border-radius: 0.25rem;
-    background-color: $color-light-bg-2;
-    color: $color-light-text-1;
+    background-color: $color-bg-2;
+    color: $color-text-2;
+    border: 1px solid $color-border;
 
-    &--dark {
-        background-color: $color-bg-2;
-        color: $color-text-2;
-        border: 1px solid $color-border;
-    }
     &__logo {
         flex: 0 0 auto;
         width: 2rem;
@@ -70,6 +66,8 @@
 .theme-light {
     .toast {
         border: 1px solid $color-light-border;
+        background-color: $color-light-bg-2;
+        color: $color-light-text-1;
 
         &__close-button {
             &:hover {

--- a/web/src/marketing/Toast.tsx
+++ b/web/src/marketing/Toast.tsx
@@ -6,11 +6,13 @@ interface Props {
     title: string
     subtitle?: string
     cta?: JSX.Element
+    // Whether you want this toast to be properly themed in dark mode. Toast are always light-themed by default.
+    useDarkTheme?: boolean
     onDismiss: () => void
 }
 
 export const Toast: React.FunctionComponent<Props> = props => (
-    <div className="toast light">
+    <div className={`toast ${props.useDarkTheme ? 'toast--dark' : ''}`}>
         <div className="toast__contents">
             <div className="d-flex">
                 <span className="toast__logo icon-inline">{props.icon}</span>

--- a/web/src/marketing/Toast.tsx
+++ b/web/src/marketing/Toast.tsx
@@ -6,13 +6,11 @@ interface Props {
     title: string
     subtitle?: string
     cta?: JSX.Element
-    // Whether you want this toast to be properly themed in dark mode. Toast are always light-themed by default.
-    useDarkTheme?: boolean
     onDismiss: () => void
 }
 
 export const Toast: React.FunctionComponent<Props> = props => (
-    <div className={`toast ${props.useDarkTheme ? 'toast--dark' : ''}`}>
+    <div className="toast">
         <div className="toast__contents">
             <div className="d-flex">
                 <span className="toast__logo icon-inline">{props.icon}</span>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6051. This updates the `LiteralSearchToast`  component follow the dark theme. Adds a `useDarkTheme` prop to the `Toast` component, which makes toasts fit the dark theme when true.
