### PR TITLE
fix: only show literal search toast to users created before 3.9 release

### DIFF
--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -44,6 +44,7 @@ export function refreshAuthenticatedUser(): Observable<never> {
                     canSignOut
                 }
                 viewerCanAdminister
+                createdAt
             }
         }
     `).pipe(


### PR DESCRIPTION
Fixes the second part of https://github.com/sourcegraph/sourcegraph/issues/6028. We currently will show the new literal search toast for all users, but we really only want to show it to users who have been around since before 3.9. Those created on or after 3.9 would not know that the default used to be regexp.