### PR TITLE
warn users if they may be accidently searching literally for quotes

### DIFF
--- a/web/src/search/results/SearchResultsInfoBar.scss
+++ b/web/src/search/results/SearchResultsInfoBar.scss
@@ -33,5 +33,8 @@
         display: flex;
         align-items: center;
         margin-right: 1rem;
+        &--no-results {
+            padding: 0.375rem 0.75rem 0 0.375rem;
+        }
     }
 }

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -7,6 +7,7 @@ import CloudDownloadIcon from 'mdi-react/CloudDownloadIcon'
 import DownloadIcon from 'mdi-react/DownloadIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
+import FormatQuoteOpenIcon from 'mdi-react/FormatQuoteOpenIcon'
 import * as React from 'react'
 import { ContributableMenu } from '../../../../shared/src/api/protocol'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
@@ -17,15 +18,18 @@ import { pluralize } from '../../../../shared/src/util/strings'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { ServerBanner, ServerBannerNoRepo } from '../../marketing/ServerBanner'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
+import { PatternTypeProps } from '..'
 
 interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip'>,
-        TelemetryProps {
+        TelemetryProps,
+        PatternTypeProps {
     /** The currently authenticated user or null */
     authenticatedUser: GQL.IUser | null
 
     /** The loaded search results and metadata */
+    query?: string
     results: GQL.ISearchResults
     onShowMoreResultsClick: () => void
 
@@ -117,6 +121,25 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                                 <CloudDownloadIcon className="icon-inline" /> {props.results.cloning.length}{' '}
                                 {pluralize('repository', props.results.cloning.length, 'repositories')} cloning (reload
                                 to try again)
+                            </span>
+                        </div>
+                    )}
+                    {/*
+                        If the user is searching literally and has quotes in their query,
+                        it is possible that they think their query `"foobar"` will be
+                        searching literally for `foobar` (without quotes). Inform them
+                        that this may be the case to avoid confusion.
+                    */}
+                    {console.log(props.patternType)}
+                    {console.log(props.query)}
+                    {props.patternType == 'literal' && props.query && props.query.includes('"') && (
+                        <div
+                            className="search-results-info-bar__notice"
+                            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
+                        >
+                            <span>
+                                <FormatQuoteOpenIcon className="icon-inline" />
+                                Searching literally <strong>(including quotes)</strong>
                             </span>
                         </div>
                     )}

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -130,9 +130,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         searching literally for `foobar` (without quotes). Inform them
                         that this may be the case to avoid confusion.
                     */}
-                    {console.log(props.patternType)}
-                    {console.log(props.query)}
-                    {props.patternType === 'literal' && props.query && props.query.includes('"') && (
+                    {props.patternType === GQL.SearchPatternType.literal && props.query && props.query.includes('"') && (
                         <div
                             className="search-results-info-bar__notice"
                             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -132,7 +132,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     */}
                     {console.log(props.patternType)}
                     {console.log(props.query)}
-                    {props.patternType == 'literal' && props.query && props.query.includes('"') && (
+                    {props.patternType === 'literal' && props.query && props.query.includes('"') && (
                         <div
                             className="search-results-info-bar__notice"
                             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -52,11 +52,44 @@ interface SearchResultsInfoBarProps
 }
 
 /**
+ * A notice for when the user is searching literally and has quotes in thier
+ * query, in which case it is possible that they think their query `"foobar"`
+ * will be searching literally for `foobar` (without quotes). This notice
+ * informs them that this may be the case to avoid confusion.
+ */
+const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInfoBarProps> = props =>
+    props.patternType === GQL.SearchPatternType.literal && props.query && props.query.includes('"') ? (
+        <div
+            className={`search-results-info-bar__notice${
+                props.results.results.length === 0 ? ' search-results-info-bar__notice--no-results' : ''
+            }`}
+            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
+        >
+            <span>
+                <FormatQuoteOpenIcon className="icon-inline" />
+                Searching literally <strong>(including quotes)</strong>
+            </span>
+        </div>
+    ) : null
+
+/**
  * The info bar shown over the search results list that displays metadata
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
     <div className="search-results-info-bar" data-testid="results-info-bar">
+        {/*
+            If there were no results, still show the "quotes are interpreted literally"
+            notice as this is the most common case where a user will make this mistake.
+        */}
+        {props.results.results.length === 0 && (
+            <small className="search-results-info-bar__row">
+                <div className="search-results-info-bar__row-left">
+                    <QuotesInterpretedLiterallyNotice {...props} />
+                </div>
+                <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end"></ul>
+            </small>
+        )}
         {(props.results.timedout.length > 0 ||
             props.results.cloning.length > 0 ||
             props.results.results.length > 0 ||
@@ -124,23 +157,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             </span>
                         </div>
                     )}
-                    {/*
-                        If the user is searching literally and has quotes in their query,
-                        it is possible that they think their query `"foobar"` will be
-                        searching literally for `foobar` (without quotes). Inform them
-                        that this may be the case to avoid confusion.
-                    */}
-                    {props.patternType === GQL.SearchPatternType.literal && props.query && props.query.includes('"') && (
-                        <div
-                            className="search-results-info-bar__notice"
-                            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
-                        >
-                            <span>
-                                <FormatQuoteOpenIcon className="icon-inline" />
-                                Searching literally <strong>(including quotes)</strong>
-                            </span>
-                        </div>
-                    )}
+                    <QuotesInterpretedLiterallyNotice {...props} />
                 </div>
                 <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
                     <ActionsNavItems

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -345,6 +345,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                     {/* Info Bar */}
                                     <SearchResultsInfoBar
                                         {...this.props}
+                                        query={parsedQuery}
                                         results={results}
                                         showDotComMarketing={this.props.isSourcegraphDotCom}
                                         displayPerformanceWarning={this.state.displayPerformanceWarning}


### PR DESCRIPTION
This is an issue that is hindering my personal workflow and happens to me
multiple times a day even though I "know" it is the new behavior it still
trips me up constantly. I fear our users will experience the same pain, and
a fix was simple enough so I went ahead and implemented this.

If you have performed a search literally and it contains quotes, we now
display a note that the quotes are also being interpreted literally to
help users like myself who are used to "quoting" everything for literal
search:

![image](https://user-images.githubusercontent.com/3173176/67041871-77355a00-f0db-11e9-8115-6c5f69602cf7.png)

And the more common case, how it looks when there are no results at all:

![image](https://user-images.githubusercontent.com/3173176/67046491-29bdea80-f0e5-11e9-9ea4-25a6709b6400.png)

Fixes #6016

Test plan: Manual + existing e2e tests
