### PR TITLE
fix: copy for literal search toast to make it applicable to new users

### DIFF
--- a/web/src/marketing/LiteralSearchToast.tsx
+++ b/web/src/marketing/LiteralSearchToast.tsx
@@ -34,8 +34,8 @@ export default class LiteralSearchToast extends React.Component<Props, State> {
             <div className="e2e-literal-search-toast">
                 <Toast
                     icon={<RegexIcon size={32} />}
-                    title="New regular expression toggle!"
-                    subtitle="Search queries are no longer interpreted as regular expressions by default. Click the .* icon in the search bar to toggle regular expression search."
+                    title="Regular expression toggle"
+                    subtitle="Sourcegraph interprets search queries literally by default. You can use the .* regular expression toggle to switch between literal and regular expression search."
                     onDismiss={this.onDismiss}
                     cta={
                         <Link


### PR DESCRIPTION
It is difficult to only show the new literal search popup notification for "old" users who have been using sourcegraph while the default was regexp search, since we can't currently detect upgrades.

Instead of showing the popup only to new users, @slimsag and I discussed that it might be best to update the copy of the popup, to make it similar to a guided onboarding modal. Now, the toast simply describes the regexp toggle, not mentioning "new". It is useful for new users to know they can do regexp search anyways, so we wouldn't have to remove this in a future release either.

Addresses the second part of https://github.com/sourcegraph/sourcegraph/issues/6028