### PR TITLE
csrf middleware: let grafana requests through

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -38,6 +38,8 @@ func addDebugHandlers(r *mux.Router) {
 				grafanaURLFromEnv, err)
 			addNoGrafanaHandler(r)
 		} else {
+			// 🚨 SECURITY: see cmd/frontend/internal/pkg/handlerutil/middleware.go: CSRFMiddleware if you intend to make
+			// changes to the path under which this reverse proxy is run
 			addReverseProxyForService(debugserver.Service{
 				Name:        "grafana",
 				Host:        grafanaURL.Host,

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -38,7 +38,8 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// 🚨 SECURITY: this is to let POST and PUT requests through that are intended for the grafana instance
 		// running behind a reverse proxy (see cmd/frontend/internal/app/debug.go).
-		// this is ok because it is contained to grafana and grafana itself uses cookies with SameSite=lax attribute
+		// this is ok because it is contained to grafana and grafana itself uses CSRF cookies
+		// with SameSite=lax attribute
 		if strings.HasPrefix(r.URL.Path, "/-/debug/grafana") {
 			next.ServeHTTP(w, r)
 			return

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -36,6 +36,9 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 	v.Store(newHandler(isSecure()))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 🚨 SECURITY: this is to let POST and PUT requests through that are intended for the grafana instance
+		// running behind a reverse proxy (see cmd/frontend/internal/app/debug.go).
+		// this is ok because it is contained to grafana and grafana itself uses cookies with SameSite=lax attribute
 		if strings.HasPrefix(r.URL.Path, "/-/debug/grafana") {
 			next.ServeHTTP(w, r)
 			return

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -36,7 +36,7 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 	v.Store(newHandler(isSecure()))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if i := strings.Index(r.URL.Path, "/-/debug/grafana"); i >= 0 {
+		if strings.HasPrefix(r.URL.Path, "/-/debug/grafana") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -2,6 +2,7 @@ package handlerutil
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -35,6 +36,10 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 	v.Store(newHandler(isSecure()))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if i := strings.Index(r.URL.Path, "/-/debug/grafana"); i >= 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
 		h, secure := v.Load().(handler), isSecure()
 		if secure != h.secure {
 			mu.Lock()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6075

CSRF protection kicks in for unsafe HTTP commands like PUT and POST.

this wasn't a problem for our reverse proxy at 
https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/internal/app/debug.go
before because all the instrumentation http traffic (varz, metrics etc) for gitserver and the others were pure GET requests.

now that we're running grafana behind the same scheme it does POST and PUT requests too and the csrf token is invalid.

grafana itself is csrf protected so i think it's ok to bypass the middleware for requests to grafana.