### PR TITLE
regression: add LOG option to log status messages 

### DIFF
--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -17,6 +17,7 @@ export interface Config {
     includeAdminOnboarding: boolean
     testUserPassword: string
     noCleanup: boolean
+    logStatusMessages: boolean
     logBrowserConsole: boolean
     slowMo: number
     headless: boolean
@@ -105,7 +106,7 @@ const configFields: ConfigFields = {
         envVar: 'NO_CLEANUP',
         parser: parseBool,
         description:
-            "If true, regression tests will not clean up users, external services, or other resources they create. Set this to true if running against a dev instance (as it'll make test runs faster). Set to false if running against production",
+            "If true, regression tests will not clean up users, external services, or other resources they create. Set this to true if running against a dev instance (as it'll make test runs faster). Set to false if running against production.",
     },
     keepBrowser: {
         envVar: 'KEEP_BROWSER',
@@ -116,8 +117,14 @@ const configFields: ConfigFields = {
     logBrowserConsole: {
         envVar: 'LOG_BROWSER_CONSOLE',
         parser: parseBool,
-        description: 'If true, log browser console to stdout',
+        description: 'If true, log browser console to stdout.',
         defaultValue: false,
+    },
+    logStatusMessages: {
+        envVar: 'LOG_STATUS_MESSAGES',
+        parser: parseBool,
+        description:
+            'If true, logs status messages to console. This does not log the browser console (use LOG_BROWSER_CONSOLE for that).',
     },
     slowMo: {
         envVar: 'SLOWMO',

--- a/web/src/regression/onboarding.test.ts
+++ b/web/src/regression/onboarding.test.ts
@@ -59,6 +59,7 @@ describe('Onboarding', () => {
         'headless',
         'slowMo',
         'logBrowserConsole',
+        'logStatusMessages',
         'keepBrowser'
     )
     const testExternalServiceConfig = {
@@ -165,9 +166,9 @@ describe('Onboarding', () => {
     test(
         'Non-admin user onboarding',
         async () => {
-            await ensureTestExternalService(gqlClient, testExternalServiceConfig)
+            await ensureTestExternalService(gqlClient, testExternalServiceConfig, config)
             const repoSlugs = testExternalServiceConfig.config.repos
-            await waitForRepos(gqlClient, ['github.com/' + repoSlugs[repoSlugs.length - 1]])
+            await waitForRepos(gqlClient, ['github.com/' + repoSlugs[repoSlugs.length - 1]], config)
 
             const testUser = await getUser(gqlClient, testUsername)
             if (!testUser) {

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -139,6 +139,7 @@ describe('Search regression test suite', () => {
         'sourcegraphBaseUrl',
         'noCleanup',
         'testUserPassword',
+        'logStatusMessages',
         'logBrowserConsole',
         'slowMo',
         'headless',
@@ -160,16 +161,20 @@ describe('Search regression test suite', () => {
                 resourceManager.add(
                     'External service',
                     testExternalServiceInfo.uniqueDisplayName,
-                    await ensureTestExternalService(gqlClient, {
-                        ...testExternalServiceInfo,
-                        config: {
-                            url: 'https://github.com',
-                            token: config.gitHubToken,
-                            repos: testRepoSlugs,
-                            repositoryQuery: ['none'],
+                    await ensureTestExternalService(
+                        gqlClient,
+                        {
+                            ...testExternalServiceInfo,
+                            config: {
+                                url: 'https://github.com',
+                                token: config.gitHubToken,
+                                repos: testRepoSlugs,
+                                repositoryQuery: ['none'],
+                            },
+                            waitForRepos: testRepoSlugs.map(slug => 'github.com/' + slug),
                         },
-                        waitForRepos: testRepoSlugs.map(slug => 'github.com/' + slug),
-                    })
+                        config
+                    )
                 )
             },
             // Cloning the repositories takes ~1 minute, so give initialization 2 minutes

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -10,11 +10,16 @@ import { zip, timer, concat, throwError, defer } from 'rxjs'
 import { CloneInProgressError, ECLONEINPROGESS } from '../../../../shared/src/backend/errors'
 import { isErrorLike } from '../../../../shared/src/util/errors'
 import { ResourceDestructor } from './TestResourceManager'
+import { Config } from '../../../../shared/src/e2e/config'
 
 /**
  * Wait until all repositories in the list exist.
  */
-export async function waitForRepos(gqlClient: GraphQLClient, ensureRepos: string[]): Promise<void> {
+export async function waitForRepos(
+    gqlClient: GraphQLClient,
+    ensureRepos: string[],
+    config?: Partial<Pick<Config, 'logStatusMessages'>>
+): Promise<void> {
     await zip(
         // List of Observables that complete after each repository is successfully fetched.
         ...ensureRepos.map(repoName =>
@@ -48,6 +53,9 @@ export async function waitForRepos(gqlClient: GraphQLClient, ensureRepos: string
                                 delayWhen(error => {
                                     if (isErrorLike(error) && error.code === ECLONEINPROGESS) {
                                         // Delay retry by 2s.
+                                        if (config && config.logStatusMessages) {
+                                            console.log(`Waiting for ${repoName} to finish cloning...`)
+                                        }
                                         return timer(2 * 1000)
                                     }
                                     // Throw all errors other than ECLONEINPROGRESS
@@ -147,7 +155,8 @@ export async function ensureTestExternalService(
         uniqueDisplayName: string
         config: Record<string, any>
         waitForRepos?: string[]
-    }
+    },
+    e2eConfig?: Partial<Pick<Config, 'logStatusMessages'>>
 ): Promise<ResourceDestructor> {
     if (!options.uniqueDisplayName.startsWith('[TEST]')) {
         throw new Error(
@@ -186,7 +195,7 @@ export async function ensureTestExternalService(
     )
 
     if (options.waitForRepos && options.waitForRepos.length > 0) {
-        await waitForRepos(gqlClient, options.waitForRepos)
+        await waitForRepos(gqlClient, options.waitForRepos, e2eConfig)
     }
 
     return destroy


### PR DESCRIPTION
add `LOG` option to log status messages in tests such as "waiting for repo to clone"

Initially cloning on first run can take awhile, and I often find myself wondering whether the test is hanging or is still doing useful work.