### PR TITLE
search pagination: add extensive tests for slicing + fix critical issues

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -393,7 +393,7 @@ type slicedSearchResults struct {
 func sliceSearchResults(results []searchResultResolver, common *searchResultsCommon, offset, limit int) (final slicedSearchResults) {
 	// First we handle the case of having few enough results that we do not
 	// need to slice anything.
-	if len(results[offset:]) < limit {
+	if len(results[offset:]) <= limit {
 		results = results[offset:]
 		final.results = results
 		final.common = common

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -427,22 +427,21 @@ func sliceSearchResults(results []searchResultResolver, common *searchResultsCom
 	// request should use a Cursor.ResultOffset == 2 to indicate we should
 	// resume fetching results starting at b3.
 	lastResultRepo, _ := results[len(results)-1].searchResultURIs()
-	resultsInRepoConsumed := int32(0)
-	for i, r := range results[:limit] {
+	for _, r := range results[:limit] {
 		repo, _ := r.searchResultURIs()
-		if i == limit-1 && repo == lastResultRepo {
-			// resultsInRepoConsumed is the last result we consumed, so add one
-			// so the next query starts on a new result.
-			final.resultOffset = resultsInRepoConsumed + 1
-			break
-		}
 		if repo != lastResultRepo {
-			resultsInRepoConsumed = 1
+			final.resultOffset = 0
 			final.lastRepoConsumed = reposByName[repo]
 		} else {
-			resultsInRepoConsumed++
+			final.resultOffset++
 		}
 		lastResultRepo = repo
+	}
+	nextRepo, _ := results[limit].searchResultURIs()
+	if nextRepo != lastResultRepo {
+		final.resultOffset = 0
+	} else {
+		final.resultOffset++
 	}
 
 	// Construct the new searchResultsCommon structure for just the results

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -372,7 +372,8 @@ type slicedSearchResults struct {
 	resultOffset int32
 
 	// lastRepoConsumed indicates the last repo whose results were consumed
-	// within the input result set.
+	// within the input result set, or nil if there were no results after
+	// slicing.
 	lastRepoConsumed *types.Repo
 
 	// limitHit indicates if the limit was hit and results were truncated.
@@ -386,12 +387,15 @@ func sliceSearchResults(results []searchResultResolver, common *searchResultsCom
 	// First we handle the case of having few enough results that we do not
 	// need to slice anything.
 	if len(results[offset:]) < limit {
-		final.results = results[offset:]
+		results = results[offset:]
+		final.results = results
 		final.common = common
-		lastRepoConsumedName, _ := results[len(results)-1].searchResultURIs()
-		for _, repo := range common.repos {
-			if string(repo.Name) == lastRepoConsumedName {
-				final.lastRepoConsumed = repo
+		if len(results) > 0 {
+			lastRepoConsumedName, _ := results[len(results)-1].searchResultURIs()
+			for _, repo := range common.repos {
+				if string(repo.Name) == lastRepoConsumedName {
+					final.lastRepoConsumed = repo
+				}
 			}
 		}
 		return

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -460,8 +460,15 @@ func sliceSearchResults(results []searchResultResolver, common *searchResultsCom
 			}
 		}
 	}
-	for _, r := range common.repos {
-		repo := reposByName[string(r.Name)]
+	seenRepos := map[string]struct{}{}
+	for _, r := range results[:limit] {
+		repoName, _ := r.searchResultURIs()
+		if _, ok := seenRepos[repoName]; ok {
+			continue
+		}
+		seenRepos[repoName] = struct{}{}
+
+		repo := reposByName[repoName]
 		results := resultsByRepo[repo]
 
 		// Include the results and copy over metadata from the common structure.

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -60,6 +60,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		} else {
 			fmt.Fprintf(&b, "lastRepoConsumed: %s\n", r.lastRepoConsumed.Name)
 		}
+		fmt.Fprintf(&b, "lastRepoConsumedPartially: %v\n", r.lastRepoConsumedPartially)
 		fmt.Fprintf(&b, "limitHit: %v\n", r.limitHit)
 		return b.String()
 	}
@@ -102,9 +103,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       nil,
 					partial:     nil,
 				},
-				resultOffset:     0,
-				lastRepoConsumed: nil,
-				limitHit:         false,
+				resultOffset:              0,
+				lastRepoConsumed:          nil,
+				lastRepoConsumedPartially: false,
+				limitHit:                  false,
 			},
 		},
 		{
@@ -124,9 +126,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     0,
-				lastRepoConsumed: repo("org/repo1"),
-				limitHit:         true,
+				resultOffset:              0,
+				lastRepoConsumed:          repo("org/repo1"),
+				lastRepoConsumedPartially: false,
+				limitHit:                  true,
 			},
 		},
 		{
@@ -145,9 +148,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     2,
-				lastRepoConsumed: repo("org/repo1"),
-				limitHit:         true,
+				resultOffset:              2,
+				lastRepoConsumed:          repo("org/repo1"),
+				lastRepoConsumedPartially: true,
+				limitHit:                  true,
 			},
 		},
 		{
@@ -167,9 +171,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       []*types.Repo{repo("org/repo2"), repo("org/repo3")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     0,
-				lastRepoConsumed: repo("org/repo3"),
-				limitHit:         true,
+				resultOffset:              0,
+				lastRepoConsumed:          repo("org/repo3"),
+				lastRepoConsumedPartially: false,
+				limitHit:                  true,
 			},
 		},
 		{
@@ -189,9 +194,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     0,
-				lastRepoConsumed: repo("org/repo2"),
-				limitHit:         true,
+				resultOffset:              0,
+				lastRepoConsumed:          repo("org/repo2"),
+				lastRepoConsumedPartially: false,
+				limitHit:                  true,
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -121,9 +121,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					// BUG: repo2 and repo3 should not be included
-					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
-					partial: make(map[api.RepoName]struct{}),
+					repos:       []*types.Repo{repo("org/repo1")},
+					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset:     0,
 				lastRepoConsumed: repo("org/repo1"),
@@ -143,9 +142,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 2,
-					// BUG: repo2 and repo3 should not be included
-					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
-					partial: make(map[api.RepoName]struct{}),
+					repos:       []*types.Repo{repo("org/repo1")},
+					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset:     2,
 				lastRepoConsumed: repo("org/repo1"),
@@ -166,9 +164,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					// BUG: repo1 should not be included
-					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
-					partial: make(map[api.RepoName]struct{}),
+					repos:       []*types.Repo{repo("org/repo2"), repo("org/repo3")},
+					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset:     0,
 				lastRepoConsumed: repo("org/repo3"),
@@ -189,9 +186,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					// BUG: repo3 should not be included
-					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2")},
-					partial: make(map[api.RepoName]struct{}),
+					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset:     0,
 				lastRepoConsumed: repo("org/repo2"),

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -200,6 +200,38 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				limitHit:                  true,
 			},
 		},
+		{
+			name: "offset repo boundary fully consumed",
+			results: []searchResultResolver{
+				result(repo("org/repo1"), "a.go"),
+				result(repo("org/repo1"), "b.go"),
+				result(repo("org/repo1"), "c.go"),
+				result(repo("org/repo2"), "a.go"),
+				result(repo("org/repo2"), "b.go"),
+				result(repo("org/repo2"), "c.go"),
+			},
+			common: &searchResultsCommon{
+				repos: []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+			},
+			offset: 3,
+			limit:  3,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo2"), "a.go"),
+					result(repo("org/repo2"), "b.go"),
+					result(repo("org/repo2"), "c.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 3,
+					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+					partial:     make(map[api.RepoName]struct{}),
+				},
+				resultOffset:              0,
+				lastRepoConsumed:          repo("org/repo2"),
+				lastRepoConsumedPartially: false,
+				limitHit:                  false,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -211,7 +211,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				result(repo("org/repo2"), "c.go"),
 			},
 			common: &searchResultsCommon{
-				repos: []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+				repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+				resultCount: 3,
 			},
 			offset: 3,
 			limit:  3,
@@ -224,7 +225,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 3,
 					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     nil,
 				},
 				resultOffset:              0,
 				lastRepoConsumed:          repo("org/repo2"),

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -166,7 +166,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					// BUG: repo2 and repo3 should not be included
+					// BUG: repo1 should not be included
 					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
 					partial: make(map[api.RepoName]struct{}),
 				},
@@ -189,8 +189,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					// BUG: repo2 and repo3 should not be included
-					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+					// BUG: repo3 should not be included
+					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2")},
 					partial: make(map[api.RepoName]struct{}),
 				},
 				resultOffset:     0,

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -125,7 +125,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
 					partial: make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     3, // BUG: repo1 only has 3 results so this should be 0
+				resultOffset:     0,
 				lastRepoConsumed: repo("org/repo1"),
 				limitHit:         true,
 			},
@@ -193,7 +193,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
 					partial: make(map[api.RepoName]struct{}),
 				},
-				resultOffset:     2, // BUG: repo2 only has 2 results, so this should be 0
+				resultOffset:     0,
 				lastRepoConsumed: repo("org/repo2"),
 				limitHit:         true,
 			},

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -1,8 +1,15 @@
 package graphqlbackend
 
 import (
+	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 func TestSearchPagination_unmarshalSearchCursor(t *testing.T) {
@@ -25,5 +32,190 @@ func TestSearchPagination_unmarshalSearchCursor(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatal("expected got == want")
+	}
+}
+
+func TestSearchPagination_sliceSearchResults(t *testing.T) {
+	repo := func(name string) *types.Repo {
+		return &types.Repo{Name: api.RepoName(name)}
+	}
+	result := func(repo *types.Repo, path string) *fileMatchResolver {
+		return &fileMatchResolver{JPath: path, repo: repo}
+	}
+	format := func(r slicedSearchResults) string {
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "results:\n")
+		for i, result := range r.results {
+			fm, _ := result.ToFileMatch()
+			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.repo.Name, fm.JPath)
+		}
+		fmt.Fprintf(&b, "common.repos:\n")
+		for i, r := range r.common.repos {
+			fmt.Fprintf(&b, "	[%d] %s\n", i, r.Name)
+		}
+		fmt.Fprintf(&b, "common.resultCount: %v\n", r.common.resultCount)
+		fmt.Fprintf(&b, "resultOffset: %d\n", r.resultOffset)
+		if r.lastRepoConsumed == nil {
+			fmt.Fprintf(&b, "lastRepoConsumed: nil\n")
+		} else {
+			fmt.Fprintf(&b, "lastRepoConsumed: %s\n", r.lastRepoConsumed.Name)
+		}
+		fmt.Fprintf(&b, "limitHit: %v\n", r.limitHit)
+		return b.String()
+	}
+	sharedResult := []searchResultResolver{
+		result(repo("org/repo1"), "a.go"),
+		result(repo("org/repo1"), "b.go"),
+		result(repo("org/repo1"), "c.go"),
+		result(repo("org/repo2"), "a.go"),
+		result(repo("org/repo2"), "b.go"),
+		result(repo("org/repo3"), "a.go"),
+		result(repo("org/repo4"), "a.go"),
+		result(repo("org/repo4"), "b.go"),
+		result(repo("org/repo4"), "c.go"),
+		result(repo("org/repo5"), "a.go"),
+		result(repo("org/repo5"), "b.go"),
+		result(repo("org/repo5"), "c.go"),
+		result(repo("org/repo5"), "d.go"),
+		result(repo("org/repo5"), "e.go"),
+	}
+	sharedCommon := &searchResultsCommon{
+		repos: []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+	}
+	tests := []struct {
+		name          string
+		results       []searchResultResolver
+		common        *searchResultsCommon
+		offset, limit int
+		want          slicedSearchResults
+	}{
+		{
+			name:    "empty result set",
+			results: []searchResultResolver{},
+			common:  &searchResultsCommon{},
+			offset:  0,
+			limit:   3,
+			want: slicedSearchResults{
+				results: []searchResultResolver{},
+				common: &searchResultsCommon{
+					resultCount: 0,
+					repos:       nil,
+					partial:     nil,
+				},
+				resultOffset:     0,
+				lastRepoConsumed: nil,
+				limitHit:         false,
+			},
+		},
+		{
+			name:    "limit repo boundary",
+			results: sharedResult,
+			common:  sharedCommon,
+			offset:  0,
+			limit:   3,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo1"), "a.go"),
+					result(repo("org/repo1"), "b.go"),
+					result(repo("org/repo1"), "c.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 3,
+					// BUG: repo2 and repo3 should not be included
+					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+					partial: make(map[api.RepoName]struct{}),
+				},
+				resultOffset:     3, // BUG: repo1 only has 3 results so this should be 0
+				lastRepoConsumed: repo("org/repo1"),
+				limitHit:         true,
+			},
+		},
+		{
+			name:    "limit non repo boundary",
+			results: sharedResult,
+			common:  sharedCommon,
+			offset:  0,
+			limit:   2,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo1"), "a.go"),
+					result(repo("org/repo1"), "b.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 2,
+					// BUG: repo2 and repo3 should not be included
+					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+					partial: make(map[api.RepoName]struct{}),
+				},
+				resultOffset:     2,
+				lastRepoConsumed: repo("org/repo1"),
+				limitHit:         true,
+			},
+		},
+		{
+			name:    "offset repo boundary",
+			results: sharedResult,
+			common:  sharedCommon,
+			offset:  3,
+			limit:   3,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo2"), "a.go"),
+					result(repo("org/repo2"), "b.go"),
+					result(repo("org/repo3"), "a.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 3,
+					// BUG: repo2 and repo3 should not be included
+					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+					partial: make(map[api.RepoName]struct{}),
+				},
+				resultOffset:     0,
+				lastRepoConsumed: repo("org/repo3"),
+				limitHit:         true,
+			},
+		},
+		{
+			name:    "offset non-repo boundary",
+			results: sharedResult,
+			common:  sharedCommon,
+			offset:  2,
+			limit:   3,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo1"), "c.go"),
+					result(repo("org/repo2"), "a.go"),
+					result(repo("org/repo2"), "b.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 3,
+					// BUG: repo2 and repo3 should not be included
+					repos:   []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+					partial: make(map[api.RepoName]struct{}),
+				},
+				resultOffset:     2, // BUG: repo2 only has 2 results, so this should be 0
+				lastRepoConsumed: repo("org/repo2"),
+				limitHit:         true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := sliceSearchResults(test.results, test.common, test.offset, test.limit)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Logf("got != want")
+				gotFormatted := format(got)
+				wantFormatted := format(test.want)
+				t.Logf("got:\n%s\n", gotFormatted)
+				t.Logf("want:\n%s\n", wantFormatted)
+				dmp := diffmatchpatch.New()
+				t.Error("diff(got, want):\n", dmp.DiffPrettyText(dmp.DiffMain(wantFormatted, gotFormatted, true)))
+
+				if wantFormatted == gotFormatted {
+					dmp = diffmatchpatch.New()
+					t.Error("diff(got, want):\n", dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(test.want), spew.Sdump(got), true)))
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR fixes two critical issues with the search pagination API:

Fixes #6022
Fixes #6020

Additionally, I used TDD and added extensive tests for `sliceSearchResults` which was the source of all the bugs I fixed here.

Test plan: see new tests added