### PR TITLE
fix: strip quotes suggestion appearing on any literal search with no results

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -108,11 +108,12 @@ func (r *schemaResolver) Search(args *struct {
 	}
 
 	return &searchResolver{
-		query:        q,
-		pagination:   pagination,
-		patternType:  finalPatternType,
-		zoekt:        search.Indexed(),
-		searcherURLs: search.SearcherURLs(),
+		query:         q,
+		originalQuery: args.Query,
+		pagination:    pagination,
+		patternType:   finalPatternType,
+		zoekt:         search.Indexed(),
+		searcherURLs:  search.SearcherURLs(),
 	}, nil
 }
 
@@ -155,9 +156,10 @@ func asString(v *searchquerytypes.Value) string {
 
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	query       *query.Query          // the parsed search query
-	pagination  *searchPaginationInfo // pagination information, or nil if the request is not paginated.
-	patternType string
+	query         *query.Query          // the parsed search query
+	originalQuery string                // the raw string of the original search query
+	pagination    *searchPaginationInfo // pagination information, or nil if the request is not paginated.
+	patternType   string
 
 	// Cached resolveRepositories results.
 	reposMu                   sync.Mutex

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1065,7 +1065,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		alert = r.alertForMissingRepoRevs(missingRepoRevs)
 	}
 
-	if len(results) == 0 && strings.Contains(r.query.String(), `"`) && r.patternType == "literal" {
+	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == "literal" {
 		alert, err = r.alertForQuotesInQueryInLiteralMode(ctx)
 	}
 


### PR DESCRIPTION
Fixes an issue with a previous release blocker's fix https://github.com/sourcegraph/sourcegraph/commit/d4e24b9fe2ccd8f444d9a2339ef42fbd1e0860be. The suggested query would appear on all searches, rather than just those that contain a quote, because we were scanning for a `"` character in the query that was already processed into a `Query` object.

Test plan: Manual testing
