### PR TITLE
Use gon.gitlab_url instead of location.hostname

### DIFF
--- a/browser/src/globals.d.ts
+++ b/browser/src/globals.d.ts
@@ -1,20 +1,43 @@
-interface Window {
-    SOURCEGRAPH_URL?: string
-    SOURCEGRAPH_ASSETS_URL?: string
-    PHABRICATOR_CALLSIGN_MAPPINGS:
-        | {
-              callsign: string
-              path: string
-          }[]
-        | undefined
-    SOURCEGRAPH_PHABRICATOR_EXTENSION?: boolean
-    SOURCEGRAPH_INTEGRATION?: 'phabricator-integration' | 'bitbucket-integration'
-    SG_ENV: 'EXTENSION' | 'PAGE'
-    EXTENSION_ENV: 'CONTENT' | 'BACKGROUND' | 'OPTIONS' | null
-    SOURCEGRAPH_BUNDLE_URL: string | undefined // Bundle Sourcegraph URL is set from the Phabricator extension.
-    // Bitbucket has a global require function on the DOM that we rely on to get the current Bitbucket state.
-    require: any
+/** Set by the browser extension page and extension entry scripts. */
+declare var SG_ENV: 'EXTENSION' | 'PAGE' | undefined
+
+/** Set by the browser extension content, background and option page entry scripts. */
+declare var EXTENSION_ENV: 'CONTENT' | 'BACKGROUND' | 'OPTIONS' | null | undefined
+
+/** Set by native integrations. */
+declare var SOURCEGRAPH_URL: string | undefined
+
+/** Set by native integrations. */
+declare var SOURCEGRAPH_INTEGRATION:
+    | 'phabricator-integration'
+    | 'bitbucket-integration'
+    | 'gitlab-integration'
+    | undefined
+
+/**
+ * Set by Gitlab native integration to load the assets from the Gitlab instance
+ * instead of the Sourcegraph instance.
+ */
+declare var SOURCEGRAPH_ASSETS_URL: string | undefined
+
+/** Global object with metadata available on Gitlab pages. */
+declare var gon: {
+    gitlab_url: string
 }
+
+/** Set from the Phabricator native integration. **/
+declare var PHABRICATOR_CALLSIGN_MAPPINGS:
+    | {
+          callsign: string
+          path: string
+      }[]
+    | undefined
+
+/** Set from the Phabricator native integration. **/
+declare var SOURCEGRAPH_PHABRICATOR_EXTENSION: boolean | undefined
+
+/** Set from the Phabricator native integration. **/
+declare var SOURCEGRAPH_BUNDLE_URL: string | undefined
 
 /**
  * Set by shared/dev/jest-environment.js

--- a/browser/src/libs/gitlab/scrape.ts
+++ b/browser/src/libs/gitlab/scrape.ts
@@ -29,8 +29,6 @@ interface GitLabFileInfo extends RawRepoSpec, FileSpec, RevSpec {}
  * Gets information about the page.
  */
 export function getPageInfo(): GitLabInfo {
-    const host = window.location.hostname
-
     const projectLink = document.querySelector<HTMLAnchorElement>('.context-header a')
     if (!projectLink) {
         throw new Error('Unable to determine project name')
@@ -55,7 +53,7 @@ export function getPageInfo(): GitLabInfo {
     return {
         owner,
         projectName,
-        rawRepoName: [host, owner, projectName].join('/'),
+        rawRepoName: [gon.gitlab_url, owner, projectName].join('/'),
         pageKind,
     }
 }

--- a/browser/src/shared/util/context.tsx
+++ b/browser/src/shared/util/context.tsx
@@ -32,7 +32,7 @@ export function isSourcegraphDotCom(url: string): boolean {
     return url === DEFAULT_SOURCEGRAPH_URL
 }
 
-type PlatformName = 'phabricator-integration' | 'bitbucket-integration' | 'firefox-extension' | 'chrome-extension'
+type PlatformName = typeof globalThis.SOURCEGRAPH_INTEGRATION | 'firefox-extension' | 'chrome-extension'
 
 export function getPlatformName(): PlatformName {
     if (window.SOURCEGRAPH_PHABRICATOR_EXTENSION) {


### PR DESCRIPTION
This is the last blocker for https://gitlab.com/gitlab-org/gitlab/merge_requests/16556.

`gon.gitlab_url` is the canonical URL that that Sourcegraph would be accessing Gitlab under, not `location.hostname`.

Refactored globals.d.ts a bit to declare all the globals as actual globals instead of only on `Window` (they are still on `Window` with this change).