### PR TITLE
revert 976402d7

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -38,8 +38,6 @@ func addDebugHandlers(r *mux.Router) {
 				grafanaURLFromEnv, err)
 			addNoGrafanaHandler(r)
 		} else {
-			// 🚨 SECURITY: see cmd/frontend/internal/pkg/handlerutil/middleware.go: CSRFMiddleware if you intend to make
-			// changes to the path under which this reverse proxy is run
 			addReverseProxyForService(debugserver.Service{
 				Name:        "grafana",
 				Host:        grafanaURL.Host,

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -2,7 +2,6 @@ package handlerutil
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -36,14 +35,6 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 	v.Store(newHandler(isSecure()))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 🚨 SECURITY: this is to let POST and PUT requests through that are intended for the grafana instance
-		// running behind a reverse proxy (see cmd/frontend/internal/app/debug.go).
-		// this is ok because it is contained to grafana and grafana itself uses CSRF cookies
-		// with SameSite=lax attribute
-		if strings.HasPrefix(r.URL.Path, "/-/debug/grafana") {
-			next.ServeHTTP(w, r)
-			return
-		}
 		h, secure := v.Load().(handler), isSecure()
 		if secure != h.secure {
 			mu.Lock()


### PR DESCRIPTION
commit to be reverted makes an exemption in the csrf middleware for /-/debug/grafana

this is a security hole and we're reverting https://github.com/sourcegraph/sourcegraph/pull/6094. we will come up with a different approach to fix https://github.com/sourcegraph/sourcegraph/issues/6075