### PR TITLE
Update migration docs for non-9.6 PostgreSQL

### DIFF
--- a/dev/update-schema-and-bindata.sh
+++ b/dev/update-schema-and-bindata.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-go generate github.com/sourcegraph/sourcegraph/migrations github.com/sourcegraph/sourcegraph/cmd/frontend/db

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -2,7 +2,7 @@ This directory contains database migrations for the frontend Postgres DB.
 
 ## Usage
 
-Migrations are handled by the [migrate](https://github.com/golang-migrate/migrate/tree/master/cli#installation) tool. Migrations get applied automatically at application startup. The CLI tool can also be used to manually test migrations.
+Migrations are handled by the [migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#installation) tool. Migrations get applied automatically at application startup. The CLI tool can also be used to manually test migrations.
 
 ### Add a new migration
 
@@ -32,16 +32,8 @@ explicit transaction blocks added to the migration script template.
 
 After adding SQL statements to those files, embed them into the Go code and update the schema doc:
 
-- If you're running Postgres 9.6:
-
 ```
 ./dev/generate.sh
-```
-
-- If you're not running Postgres 9.6:
-
-```
-./dev/update-schema-and-bindata.sh
 ```
 
 or, to only run the DB generate scripts (subset of the command above):

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -30,6 +30,12 @@ explicit transaction blocks added to the migration script template.
 # Enter statements here
 ```
 
+If you're not running PostgreSQL 9.6 locally, pull the Docker image first:
+
+```
+docker pull postgres:9.6
+```
+
 After adding SQL statements to those files, embed them into the Go code and update the schema doc:
 
 ```


### PR DESCRIPTION
- The current version of the script `dev/update-schema-and-bindata.sh` is basically doing the exact same commands in the docs. So no need to keep it IMO.
- Ask user to pull the postgres:9.6 Docker image before generate schema.md because we do not that automatically.

Test plan: CI
