### PR TITLE
Search query fixup: Rename syntax.Query to syntax.ParseTree [1/3]

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/syntax/parser.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parser.go
@@ -23,7 +23,7 @@ type context struct {
 	field string // name of the field currently in scope (or "")
 }
 
-// Parse parses the query and returns its parse tree. Returned errors are of
+// Parse parses the input string and returns its parse tree. Returned errors are of
 // type *ParseError, which includes the error position and message.
 //
 // BNF-ish query syntax:
@@ -33,7 +33,7 @@ type context struct {
 //   expr      := fieldExpr | lit | quoted | pattern
 //   fieldExpr := lit ":" value
 //   value     := lit | quoted
-func Parse(input string) (*Query, error) {
+func Parse(input string) (*ParseTree, error) {
 	tokens := Scan(input)
 	p := parser{tokens: tokens}
 	ctx := context{field: ""}
@@ -41,12 +41,12 @@ func Parse(input string) (*Query, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Query{Expr: exprs, Input: input}, nil
+	return &ParseTree{Expr: exprs, Input: input}, nil
 }
 
 // ParseAllowingErrors works like Parse except that any errors are
-// returned as TokenError within the Expr slice of the returned Query.
-func ParseAllowingErrors(input string) *Query {
+// returned as TokenError within the Expr slice of the returned parse tree.
+func ParseAllowingErrors(input string) *ParseTree {
 	tokens := Scan(input)
 	p := parser{tokens: tokens, allowErrors: true}
 	ctx := context{field: ""}
@@ -54,7 +54,7 @@ func ParseAllowingErrors(input string) *Query {
 	if err != nil {
 		panic(fmt.Sprintf("(bug) error returned by parseExprList despite allowErrors=true (this should never happen): %v", err))
 	}
-	return &Query{Expr: exprs, Input: input}
+	return &ParseTree{Expr: exprs, Input: input}
 }
 
 // peek returns the next token without consuming it. Peeking beyond the end of

--- a/cmd/frontend/internal/pkg/search/query/syntax/parser_test.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parser_test.go
@@ -119,17 +119,17 @@ func TestParseAllowingErrors(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *Query
+		want *ParseTree
 	}{
 		{
 			name: "empty",
 			args: args{input: ""},
-			want: &Query{Expr: nil},
+			want: &ParseTree{Expr: nil},
 		},
 		{
 			name: "a",
 			args: args{input: "a"},
-			want: &Query{
+			want: &ParseTree{
 				Input: "a",
 				Expr: []*Expr{
 					{
@@ -142,7 +142,7 @@ func TestParseAllowingErrors(t *testing.T) {
 		{
 			name: ":=",
 			args: args{input: ":="},
-			want: &Query{
+			want: &ParseTree{
 				Input: ":=",
 				Expr: []*Expr{
 					{

--- a/cmd/frontend/internal/pkg/search/query/syntax/query.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/query.go
@@ -7,29 +7,29 @@ import (
 	"strings"
 )
 
-// A Query contains the parse tree of a query.
-type Query struct {
-	Input string  // the original input query string
-	Expr  []*Expr // expressions in this query
+// The parse tree for search input.
+type ParseTree struct {
+	Input string  // the original input search string
+	Expr  []*Expr // expressions in this tree
 }
 
-func (q *Query) String() string {
-	return ExprString(q.Expr)
+func (p *ParseTree) String() string {
+	return ExprString(p.Expr)
 }
 
-// WithErrorsQuoted converts a query like `f:foo b(ar` to `f:foo "b(ar"`.
-func (q *Query) WithErrorsQuoted() *Query {
-	q2 := &Query{}
-	for _, e := range q.Expr {
+// WithErrorsQuoted converts a search input like `f:foo b(ar` to `f:foo "b(ar"`.
+func (p *ParseTree) WithErrorsQuoted() *ParseTree {
+	p2 := &ParseTree{}
+	for _, e := range p.Expr {
 		e2 := e.WithErrorsQuoted()
-		q2.Expr = append(q2.Expr, &e2)
+		p2.Expr = append(p2.Expr, &e2)
 	}
-	return q2
+	return p2
 }
 
-// An Expr describes an expression in a query.
+// An Expr describes an expression in the parse tree.
 type Expr struct {
-	Pos       int       // the starting character position of the query expression
+	Pos       int       // the starting character position of the expression
 	Not       bool      // the expression is negated (e.g., -term or -field:term)
 	Field     string    // the field that this expression applies to
 	Value     string    // the raw field value
@@ -78,7 +78,7 @@ func (e Expr) WithErrorsQuoted() Expr {
 	return e2
 }
 
-// ExprString returns the query string that parses to expr.
+// ExprString returns the string that parses to expr.
 func ExprString(expr []*Expr) string {
 	s := make([]string, len(expr))
 	for i, e := range expr {

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -39,12 +39,12 @@ type FieldType struct {
 }
 
 // Check typechecks the input query for field and type validity.
-func (c *Config) Check(query *syntax.Query) (*Query, error) {
+func (c *Config) Check(parseTree *syntax.ParseTree) (*Query, error) {
 	checkedQuery := Query{
-		Syntax: query,
+		Syntax: parseTree,
 		Fields: map[string][]*Value{},
 	}
-	for _, expr := range query.Expr {
+	for _, expr := range parseTree.Expr {
 		field, fieldType, value, err := c.checkExpr(expr)
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/internal/pkg/search/query/types/query.go
+++ b/cmd/frontend/internal/pkg/search/query/types/query.go
@@ -11,7 +11,7 @@ import (
 
 // A Query is the typechecked representation of a search query.
 type Query struct {
-	Syntax *syntax.Query       // the query syntax
+	Syntax *syntax.ParseTree   // the query parse tree
 	Fields map[string][]*Value // map of field name -> values
 }
 


### PR DESCRIPTION
This is the base diff of #6115 and #6116.

**This is a semantics preserving change.**

**Summary**

`Query` is overladed in the codebase. There are these two references, and also Zoekt queries:
1. There's the parse tree, which is typed as `syntax.Query` in `query.go` [with comment](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/pkg/search/query/syntax/query.go#L10) 
```
// A Query contains the parse tree of a query. 
```
2. Then the validated `Query` in `searchquery.go` [with comment](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@312e0edc4c7d323604594bda718dbf902e5abb29/-/blob/cmd/frontend/internal/pkg/search/query/searchquery.go#L89)
```
// A Query is the parsed representation of a search query
```

The comments above do not refer to the same Query. The former is the parse tree, the latter a validated parse tree (we can call _that_ the query). This PR is the first of three changes to migrate the first reference to a `ParseTree` type, which simplifies everything down the line. Follow-up diffs #6115 and #6116 branch off of this one to simplify things further and they should be easy to review.

I'm pushing for these changes because I need them to implement RFC 48 while avoiding more spaghetti code <3

Test plan: This is a refactor, tests are updated.
