### PR TITLE
Search query fixup: simplify ParseTree type [3/3]

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -355,8 +355,8 @@ func omitQueryFields(r *searchResolver, field string) string {
 }
 
 func omitQueryExprWithField(query *query.Query, field string) syntax.ParseTree {
-	expr2 := make(syntax.ParseTree, 0, len(*query.ParseTree))
-	for _, e := range *query.ParseTree {
+	expr2 := make(syntax.ParseTree, 0, len(query.ParseTree))
+	for _, e := range query.ParseTree {
 		if e.Field == field {
 			continue
 		}
@@ -366,8 +366,8 @@ func omitQueryExprWithField(query *query.Query, field string) syntax.ParseTree {
 }
 
 func omitQuotes(query *query.Query) syntax.ParseTree {
-	result := make(syntax.ParseTree, 0, len(*query.ParseTree))
-	for _, e := range *query.ParseTree {
+	result := make(syntax.ParseTree, 0, len(query.ParseTree))
+	for _, e := range query.ParseTree {
 		cpy := *e
 		e = &cpy
 		if e.Field == "" && strings.HasPrefix(e.Value, `"\"`) && strings.HasSuffix(e.Value, `\""`) {
@@ -409,8 +409,8 @@ func pathParentsByFrequency(paths []string) []string {
 // guaranteed to always return the simplest query.
 func addQueryRegexpField(query *query.Query, field, pattern string) syntax.ParseTree {
 	// Copy query expressions.
-	expr := make(syntax.ParseTree, len(*query.ParseTree))
-	for i, e := range *query.ParseTree {
+	expr := make(syntax.ParseTree, len(query.ParseTree))
+	for i, e := range query.ParseTree {
 		tmp := *e
 		expr[i] = &tmp
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -354,9 +354,9 @@ func omitQueryFields(r *searchResolver, field string) string {
 	return syntax.ExprString(omitQueryExprWithField(r.query, field))
 }
 
-func omitQueryExprWithField(query *query.Query, field string) []*syntax.Expr {
-	expr2 := make([]*syntax.Expr, 0, len(query.ParseTree.Expr))
-	for _, e := range query.ParseTree.Expr {
+func omitQueryExprWithField(query *query.Query, field string) syntax.ParseTree {
+	expr2 := make(syntax.ParseTree, 0, len(*query.ParseTree))
+	for _, e := range *query.ParseTree {
 		if e.Field == field {
 			continue
 		}
@@ -365,9 +365,9 @@ func omitQueryExprWithField(query *query.Query, field string) []*syntax.Expr {
 	return expr2
 }
 
-func omitQuotes(query *query.Query) []*syntax.Expr {
-	result := make([]*syntax.Expr, 0, len(query.ParseTree.Expr))
-	for _, e := range query.ParseTree.Expr {
+func omitQuotes(query *query.Query) syntax.ParseTree {
+	result := make(syntax.ParseTree, 0, len(*query.ParseTree))
+	for _, e := range *query.ParseTree {
 		cpy := *e
 		e = &cpy
 		if e.Field == "" && strings.HasPrefix(e.Value, `"\"`) && strings.HasSuffix(e.Value, `\""`) {
@@ -407,10 +407,10 @@ func pathParentsByFrequency(paths []string) []string {
 // a query like "x:foo", if given a field "x" with pattern "foobar" to add,
 // it will return a query "x:foobar" instead of "x:foo x:foobar". It is not
 // guaranteed to always return the simplest query.
-func addQueryRegexpField(query *query.Query, field, pattern string) []*syntax.Expr {
+func addQueryRegexpField(query *query.Query, field, pattern string) syntax.ParseTree {
 	// Copy query expressions.
-	expr := make([]*syntax.Expr, len(query.ParseTree.Expr))
-	for i, e := range query.ParseTree.Expr {
+	expr := make(syntax.ParseTree, len(*query.ParseTree))
+	for i, e := range *query.ParseTree {
 		tmp := *e
 		expr[i] = &tmp
 	}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -46,7 +46,7 @@ var (
 func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
 	args.applyDefaultsAndConstraints()
 
-	if len(r.query.ParseTree.Expr) == 0 {
+	if len(*r.query.ParseTree) == 0 {
 		return nil, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -46,7 +46,7 @@ var (
 func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
 	args.applyDefaultsAndConstraints()
 
-	if len(*r.query.ParseTree) == 0 {
+	if len(r.query.ParseTree) == 0 {
 		return nil, nil
 	}
 

--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -100,17 +100,17 @@ func ParseAndCheck(input string) (*Query, error) {
 }
 
 func parseAndCheck(conf *types.Config, input string) (*Query, error) {
-	syntaxQuery, err := syntax.Parse(input)
+	parseTree, err := syntax.Parse(input)
 	if err != nil {
 		return nil, err
 	}
 
 	// We want to make query fields case insensitive
-	for _, expr := range syntaxQuery.Expr {
+	for _, expr := range parseTree {
 		expr.Field = strings.ToLower(expr.Field)
 	}
 
-	checkedQuery, err := conf.Check(syntaxQuery)
+	checkedQuery, err := conf.Check(parseTree)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/pkg/search/query/syntax/parse_tree.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parse_tree.go
@@ -7,21 +7,19 @@ import (
 	"strings"
 )
 
-// The parse tree for search input.
-type ParseTree struct {
-	Expr []*Expr // expressions in this tree
-}
+// The parse tree for search input. It is a list of expressions.
+type ParseTree []*Expr
 
-func (p *ParseTree) String() string {
-	return ExprString(p.Expr)
+func (p ParseTree) String() string {
+	return ExprString(p)
 }
 
 // WithErrorsQuoted converts a search input like `f:foo b(ar` to `f:foo "b(ar"`.
-func (p *ParseTree) WithErrorsQuoted() *ParseTree {
-	p2 := &ParseTree{}
-	for _, e := range p.Expr {
+func (p ParseTree) WithErrorsQuoted() ParseTree {
+	p2 := []*Expr{}
+	for _, e := range p {
 		e2 := e.WithErrorsQuoted()
-		p2.Expr = append(p2.Expr, &e2)
+		p2 = append(p2, &e2)
 	}
 	return p2
 }

--- a/cmd/frontend/internal/pkg/search/query/syntax/parser.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parser.go
@@ -33,7 +33,7 @@ type context struct {
 //   expr      := fieldExpr | lit | quoted | pattern
 //   fieldExpr := lit ":" value
 //   value     := lit | quoted
-func Parse(input string) (*ParseTree, error) {
+func Parse(input string) (ParseTree, error) {
 	tokens := Scan(input)
 	p := parser{tokens: tokens}
 	ctx := context{field: ""}
@@ -41,12 +41,12 @@ func Parse(input string) (*ParseTree, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ParseTree{Expr: exprs}, nil
+	return exprs, nil
 }
 
 // ParseAllowingErrors works like Parse except that any errors are
 // returned as TokenError within the Expr slice of the returned parse tree.
-func ParseAllowingErrors(input string) *ParseTree {
+func ParseAllowingErrors(input string) ParseTree {
 	tokens := Scan(input)
 	p := parser{tokens: tokens, allowErrors: true}
 	ctx := context{field: ""}
@@ -54,7 +54,7 @@ func ParseAllowingErrors(input string) *ParseTree {
 	if err != nil {
 		panic(fmt.Sprintf("(bug) error returned by parseExprList despite allowErrors=true (this should never happen): %v", err))
 	}
-	return &ParseTree{Expr: exprs}
+	return exprs
 }
 
 // peek returns the next token without consuming it. Peeking beyond the end of

--- a/cmd/frontend/internal/pkg/search/query/syntax/parser_test.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parser_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestParser(t *testing.T) {
 	tests := map[string]struct {
-		wantExpr   []*Expr
+		wantExpr   ParseTree
 		wantString string
 		wantErr    *ParseError
 	}{
@@ -93,19 +93,19 @@ func TestParser(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if len(query.Expr) == 0 {
-				query.Expr = []*Expr{}
+			if len(query) == 0 {
+				query = []*Expr{}
 			}
-			for _, expr := range query.Expr {
+			for _, expr := range query {
 				expr.Pos = 0
 			}
-			if !reflect.DeepEqual(query.Expr, test.wantExpr) {
-				t.Errorf("expr: %s\ngot  %v\nwant %v", input, query.Expr, test.wantExpr)
+			if !reflect.DeepEqual(query, test.wantExpr) {
+				t.Errorf("expr: %s\ngot  %v\nwant %v", input, query, test.wantExpr)
 			}
-			if test.wantString == "" && len(query.Expr) > 0 {
+			if test.wantString == "" && len(query) > 0 {
 				test.wantString = input
 			}
-			if exprString := ExprString(query.Expr); exprString != test.wantString {
+			if exprString := ExprString(query); exprString != test.wantString {
 				t.Errorf("expr string: %s\ngot  %s\nwant %s", input, exprString, test.wantString)
 			}
 		})
@@ -119,34 +119,30 @@ func TestParseAllowingErrors(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *ParseTree
+		want ParseTree
 	}{
 		{
 			name: "empty",
 			args: args{input: ""},
-			want: &ParseTree{Expr: nil},
+			want: nil,
 		},
 		{
 			name: "a",
 			args: args{input: "a"},
-			want: &ParseTree{
-				Expr: []*Expr{
-					{
-						Value:     "a",
-						ValueType: TokenLiteral,
-					},
+			want: []*Expr{
+				{
+					Value:     "a",
+					ValueType: TokenLiteral,
 				},
 			},
 		},
 		{
 			name: ":=",
 			args: args{input: ":="},
-			want: &ParseTree{
-				Expr: []*Expr{
-					{
-						Value:     ":=",
-						ValueType: TokenError,
-					},
+			want: []*Expr{
+				{
+					Value:     ":=",
+					ValueType: TokenError,
 				},
 			},
 		},

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -39,12 +39,12 @@ type FieldType struct {
 }
 
 // Check typechecks the input query for field and type validity.
-func (c *Config) Check(parseTree *syntax.ParseTree) (*Query, error) {
+func (c *Config) Check(parseTree syntax.ParseTree) (*Query, error) {
 	checkedQuery := Query{
-		ParseTree: parseTree,
+		ParseTree: &parseTree,
 		Fields:    map[string][]*Value{},
 	}
-	for _, expr := range parseTree.Expr {
+	for _, expr := range parseTree {
 		field, fieldType, value, err := c.checkExpr(expr)
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -41,7 +41,7 @@ type FieldType struct {
 // Check typechecks the input query for field and type validity.
 func (c *Config) Check(parseTree syntax.ParseTree) (*Query, error) {
 	checkedQuery := Query{
-		ParseTree: &parseTree,
+		ParseTree: parseTree,
 		Fields:    map[string][]*Value{},
 	}
 	for _, expr := range parseTree {

--- a/cmd/frontend/internal/pkg/search/query/types/query.go
+++ b/cmd/frontend/internal/pkg/search/query/types/query.go
@@ -11,7 +11,7 @@ import (
 
 // A Query is the typechecked representation of a search query.
 type Query struct {
-	ParseTree *syntax.ParseTree   // the query parse tree
+	ParseTree syntax.ParseTree    // the query parse tree
 	Fields    map[string][]*Value // map of field name -> values
 }
 


### PR DESCRIPTION
This stacked diff depends on #6115.

**This is a semantics preserving change.**

**Summary**

- Aliases ParseTree type to expression list and get rid of the struct and propagate the type.
- Simplifies tests, and it's now much clearer when doing `make(syntax.ParseTree...` instead of `make([]*syntax.Expr...)`

Test plan: This is a refactor, tests are updated.

![so-fresh-so-clean](https://user-images.githubusercontent.com/888624/67136922-9d91ed00-f1e2-11e9-8618-2fe7bb77859f.png)