### PR TITLE
a8n: Implement skeleton API and CRUD layer for running campaigns

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -108,13 +108,6 @@ func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCa
 	return r.a8nResolver.PreviewCampaignPlan(ctx, args)
 }
 
-func (r *schemaResolver) CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error) {
-	if r.a8nResolver == nil {
-		return nil, onlyInEnterprise
-	}
-	return r.a8nResolver.CampaignPlanByID(ctx, id)
-}
-
 func (r *schemaResolver) CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error) {
 	if r.a8nResolver == nil {
 		return nil, onlyInEnterprise

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -24,6 +24,7 @@ type CreateCampaignArgs struct {
 		Namespace   graphql.ID
 		Name        string
 		Description string
+		Plan        *graphql.ID
 	}
 }
 
@@ -35,7 +36,23 @@ type UpdateCampaignArgs struct {
 	}
 }
 
+type PreviewCampaignPlanArgs struct {
+	Specification struct {
+		Type      string
+		Arguments JSONCString
+	}
+	Wait bool
+}
+
+type CancelCampaignPlanArgs struct {
+	Plan graphql.ID
+}
+
 type DeleteCampaignArgs struct {
+	Campaign graphql.ID
+}
+
+type RetryCampaignArgs struct {
 	Campaign graphql.ID
 }
 
@@ -46,18 +63,30 @@ type CreateChangesetsArgs struct {
 	}
 }
 
+type RepoSearcher interface {
+	SearchRepos(ctx context.Context, query string) ([]*RepositoryResolver, error)
+}
+
 type A8NResolver interface {
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
 	UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error)
 	Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error)
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
+	RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error)
 
-	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ChangesetResolver, error)
-	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
-	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetsConnectionResolver, error)
+	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error)
+	ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error)
+	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ExternalChangesetsConnectionResolver, error)
 
 	AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error)
+
+	PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error)
+	CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error)
+	CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error)
+
+	HasRepoSearcher() bool
+	SetRepoSearcher(RepoSearcher)
 }
 
 var onlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
@@ -67,6 +96,30 @@ func (r *schemaResolver) AddChangesetsToCampaign(ctx context.Context, args *AddC
 		return nil, onlyInEnterprise
 	}
 	return r.a8nResolver.AddChangesetsToCampaign(ctx, args)
+}
+
+func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	if !r.a8nResolver.HasRepoSearcher() {
+		r.a8nResolver.SetRepoSearcher(r)
+	}
+	return r.a8nResolver.PreviewCampaignPlan(ctx, args)
+}
+
+func (r *schemaResolver) CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	return r.a8nResolver.CampaignPlanByID(ctx, id)
+}
+
+func (r *schemaResolver) CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	return r.a8nResolver.CancelCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error) {
@@ -90,6 +143,13 @@ func (r *schemaResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaig
 	return r.a8nResolver.DeleteCampaign(ctx, args)
 }
 
+func (r *schemaResolver) RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	return r.a8nResolver.RetryCampaign(ctx, args)
+}
+
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {
 	if r.a8nResolver == nil {
 		return nil, onlyInEnterprise
@@ -97,14 +157,14 @@ func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.Connec
 	return r.a8nResolver.Campaigns(ctx, args)
 }
 
-func (r *schemaResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ChangesetResolver, error) {
+func (r *schemaResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error) {
 	if r.a8nResolver == nil {
 		return nil, onlyInEnterprise
 	}
 	return r.a8nResolver.CreateChangesets(ctx, args)
 }
 
-func (r *schemaResolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetsConnectionResolver, error) {
+func (r *schemaResolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ExternalChangesetsConnectionResolver, error) {
 	if r.a8nResolver == nil {
 		return nil, onlyInEnterprise
 	}
@@ -125,8 +185,11 @@ type CampaignResolver interface {
 	Namespace(ctx context.Context) (n NamespaceResolver, err error)
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
-	Changesets(ctx context.Context, args struct{ graphqlutil.ConnectionArgs }) ChangesetsConnectionResolver
+	Changesets(ctx context.Context, args struct{ graphqlutil.ConnectionArgs }) ExternalChangesetsConnectionResolver
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
+	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (RepositoryComparisonConnectionResolver, error)
+	Plan(ctx context.Context) (CampaignPlanResolver, error)
+	ChangesetCreationStatus() BackgroundProcessStatus
 }
 
 type CampaignsConnectionResolver interface {
@@ -135,13 +198,20 @@ type CampaignsConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type ChangesetsConnectionResolver interface {
-	Nodes(ctx context.Context) ([]ChangesetResolver, error)
+type ChangesetResolver interface {
+	Title() (string, error)
+	Body() (string, error)
+	Repository(ctx context.Context) (*RepositoryResolver, error)
+	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
+}
+
+type ExternalChangesetsConnectionResolver interface {
+	Nodes(ctx context.Context) ([]ExternalChangesetResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type ChangesetResolver interface {
+type ExternalChangesetResolver interface {
 	ID() graphql.ID
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
@@ -153,6 +223,23 @@ type ChangesetResolver interface {
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 	Campaigns(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (CampaignsConnectionResolver, error)
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
+	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
+	ToChangesetPlan() (ChangesetPlanResolver, bool)
+	ToExternalChangeset() (ExternalChangesetResolver, bool)
+}
+
+type ChangesetPlansConnectionResolver interface {
+	Nodes(ctx context.Context) ([]ChangesetPlanResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type ChangesetPlanResolver interface {
+	Title() (string, error)
+	Body() (string, error)
+	Repository(ctx context.Context) (*RepositoryResolver, error)
+	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
+	ToExternalChangeset() (ExternalChangesetResolver, bool)
 }
 
 type ChangesetEventsConnectionResolver interface {
@@ -163,7 +250,7 @@ type ChangesetEventsConnectionResolver interface {
 
 type ChangesetEventResolver interface {
 	ID() graphql.ID
-	Changeset(ctx context.Context) (ChangesetResolver, error)
+	Changeset(ctx context.Context) (ExternalChangesetResolver, error)
 	CreatedAt() DateTime
 }
 
@@ -176,4 +263,36 @@ type ChangesetCountsResolver interface {
 	OpenApproved() int32
 	OpenChangesRequested() int32
 	OpenPending() int32
+}
+
+type CampaignPlanArgResolver interface {
+	Name() string
+	Value() string
+}
+
+type CampaignPlanSpecification interface {
+	Type() string
+	Arguments() string
+}
+
+type BackgroundProcessStatus interface {
+	CompletedCount() int32
+	PendingCount() int32
+
+	State() a8n.BackgroundProcessState
+
+	Errors() []string
+}
+
+type CampaignPlanResolver interface {
+	ID() graphql.ID
+
+	Type() string
+	Arguments() (JSONCString, error)
+
+	Status() BackgroundProcessStatus
+
+	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
+
+	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewRepositoryDiffConnectionResolver, error)
 }

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -473,7 +473,7 @@ func (r *discussionThreadTargetRepoResolver) RelativePath(ctx context.Context, a
 		return nil, err
 	}
 	currentPath := *r.t.Path
-	fileDiffs, err := comparison.FileDiffs(&struct{ First *int32 }{}).Nodes(ctx)
+	fileDiffs, err := comparison.FileDiffs(&graphqlutil.ConnectionArgs{}).Nodes(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -80,8 +80,18 @@ func (r *NodeResolver) ToCampaign() (CampaignResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToCampaignPlan() (CampaignPlanResolver, bool) {
+	n, ok := r.Node.(CampaignPlanResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToChangeset() (ChangesetResolver, bool) {
 	n, ok := r.Node.(ChangesetResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToExternalChangeset() (ExternalChangesetResolver, bool) {
+	n, ok := r.Node.(ExternalChangesetResolver)
 	return n, ok
 }
 
@@ -196,6 +206,11 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 			return nil, onlyInEnterprise
 		}
 		return r.a8nResolver.CampaignByID(ctx, id)
+	case "CampaignPlan":
+		if r.a8nResolver == nil {
+			return nil, onlyInEnterprise
+		}
+		return r.a8nResolver.CampaignPlanByID(ctx, id)
 	case "Changeset":
 		if r.a8nResolver == nil {
 			return nil, onlyInEnterprise

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -211,7 +211,7 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 			return nil, onlyInEnterprise
 		}
 		return r.a8nResolver.CampaignPlanByID(ctx, id)
-	case "Changeset":
+	case "ExternalChangeset":
 		if r.a8nResolver == nil {
 			return nil, onlyInEnterprise
 		}

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -64,6 +64,9 @@ func TestNodeResolverTo(t *testing.T) {
 		if _, b := r.ToCampaign(); b {
 			continue
 		}
+		if _, b := r.ToCampaignPlan(); b {
+			continue
+		}
 		if _, b := r.ToChangeset(); b {
 			continue
 		}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -35,13 +35,39 @@ type Mutation {
     # exists, it's returned instead of a new entry being added to the database.
     createChangesets(input: [CreateChangesetInput!]!): [Changeset!]!
     # Adds a list of Changesets to a Campaign.
+    # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
     # Create a campaign in a namespace. The newly created campaign is returned.
     createCampaign(input: CreateCampaignInput!): Campaign!
+    # Preview the plan for a campaign, including its diff.
+    # The returned CampaignPlan can be referred to when creating the campaign.
+    # It is cached with a short TTL.
+    # The campaign plan is computed asynchronously.
+    # Check its status property and query it by its id to see its latest state.
+    previewCampaignPlan(
+        specification: CampaignPlanSpecification!
+        # Whether to wait to finish computing the plan before returning.
+        # If false, callers must poll the CampaignPlan using its node ID to track progress and get results.
+        # If the plan is not ready within an interval that would result in request timeouts,
+        # the query will return anyway, so the caller must check the result's CampaignPlan.status.
+        wait: Boolean = false
+    ): CampaignPlan!
+    # Cancel a campaign plan that is being generated.
+    # Cancellation expresses a desinterest in the campaign plan and is best-effort.
+    # It may not be relied upon.
+    # The return of this mutation does not mean the plan was fully cancelled yet,
+    # only that the desinterest in the campaign plan was acknowledged.
+    # This mutation is idempotent and a noop if called for a completed campaign plan.
+    # There is no requirement to call this mutation, it is a performance optimization.
+    cancelCampaignPlan(plan: ID!): EmptyResponse
     # Updates a campaign.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
+    # Retries creating changesets of the campaign plan that could not be successfully created on the code host.
+    # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.
+    retryCampaign(campaign: ID!): Campaign!
     # Deletes a campaign.
     deleteCampaign(campaign: ID!): EmptyResponse
+
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.
@@ -371,6 +397,19 @@ type Mutation {
     deleteSavedSearch(id: ID!): EmptyResponse
 }
 
+# The specification of what changesets Sourcegraph will open when the campaign is created.
+input CampaignPlanSpecification {
+    # A known campaign type.
+    # Currently only "comby" is supported.
+    type: String!
+
+    # JSONC string that configures the changes that Sourcegraph will open changesets for when the campaign is created.
+    #
+    # Schema for comby:
+    # { scopeQuery: string, matchTemplate: string, rewriteTemplate: string }
+    arguments: JSONCString!
+}
+
 # Input arguments for creating a campaign.
 input CreateCampaignInput {
     # The ID of the namespace where this campaign is defined.
@@ -381,6 +420,15 @@ input CreateCampaignInput {
 
     # The description of the campaign as Markdown.
     description: String!
+
+    # An optional reference to a completed campaign plan that was previewed before this mutation.
+    # If null, existing changesets can be added manually.
+    # If set, no changesets can be added manually, they will be created by Sourcegraph
+    # after creating the campaign according to the precomputed campaign plan.
+    # Will error if the plan has been purged already and needs to be recomputed by another call to previewCampaignPlan.
+    # Will error if the plan is not completed yet.
+    # Using a campaign plan for a campaign will retain it for the lifetime of the campaign and prevents it from being purged.
+    plan: ID
 }
 
 # Input arguments for updating a campaign.
@@ -395,10 +443,88 @@ input UpdateCampaignInput {
     description: String
 }
 
-# A collection of threads.
+# A preview of changes that will be applied by a campaign.
+# It is chached and addressable by its ID for a limited amount of time.
+type CampaignPlan implements Node {
+    # The unique ID of this campaign plan.
+    id: ID!
+
+    # The campaign type.
+    type: String!
+
+    # The JSONC string that configures how Sourcegraph generates the diff and changesets.
+    arguments: JSONCString!
+
+    # The progress status of generating changesets.
+    status: BackgroundProcessStatus!
+
+    # The changesets that will be created by the campaign.
+    changesets(first: Int): ChangesetPlanConnection!
+
+    # The combined diff of all changesets that will be created by the campaign.
+    repositoryDiffs(first: Int): PreviewRepositoryDiffConnection!
+}
+
+# A paginated list of repository diff previews.
+type PreviewRepositoryDiffConnection {
+    # A list of repository diffs.
+    nodes: [PreviewRepositoryDiff!]!
+
+    # The total number of repository diffs in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A paginated list of repository diffs committed to git.
+type RepositoryComparisonConnection {
+    # A list of repository diffs committed to git.
+    nodes: [RepositoryComparison!]!
+
+    # The total number of repository diffs in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# The state a background process can be in.
+enum BackgroundProcessState {
+    # The background process is processing items.
+    PROCESSING
+    # The background process attempted processing all items, but some failed.
+    ERRORED
+    # The background process completed processing all items successfully.
+    COMPLETED
+}
+
+# Reusable type to report progress of a background process.
+type BackgroundProcessStatus {
+    # How many items were successfully completed.
+    completedCount: Int!
+
+    # How many items are not done yet (including items that errored).
+    pendingCount: Int!
+
+    # The state the background process is currently in.
+    state: BackgroundProcessState!
+
+    # Messages of errors that occurred since the current run of this process was started.
+    errors: [String!]!
+}
+
+# A collection of changesets.
 type Campaign implements Node {
     # The unique ID for the campaign.
     id: ID!
+
+    # The campaign plan that was used to create this campaign.
+    # If null, changesets are added to the campaign manually.
+    plan: CampaignPlan
+
+    # The current status of creating the campaigns changesets on the code host.
+    changesetCreationStatus: BackgroundProcessStatus!
 
     # The namespace where this campaign is defined.
     namespace: Namespace!
@@ -421,8 +547,11 @@ type Campaign implements Node {
     # The date and time when the campaign was updated.
     updatedAt: DateTime!
 
-    # The changesets in this campaign.
-    changesets(first: Int): ChangesetConnection!
+    # The combined diff of all changesets across all repositories, already created on the code host.
+    repositoryDiffs(first: Int): RepositoryComparisonConnection!
+
+    # The changesets in this campaign, already created on the code host.
+    changesets(first: Int): ExternalChangesetConnection!
 
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(
@@ -490,12 +619,42 @@ input CreateChangesetInput {
     externalID: String!
 }
 
+# Basic fields of a changeset.
+interface Changeset {
+    # The repository changed by the changeset.
+    repository: Repository!
+
+    # The title of the changeset.
+    title: String!
+
+    # The body of the changeset.
+    body: String!
+
+    # The diff of the changeset.
+    diff: RepositoryDiff!
+}
+
+# Preview of a changeset planned to be created.
+type ChangesetPlan implements Changeset {
+    # The repository changed by the changeset.
+    repository: Repository!
+
+    # The title of the changeset.
+    title: String!
+
+    # The body of the changeset.
+    body: String!
+
+    # The diff of the changeset.
+    diff: RepositoryDiff!
+}
+
 # A changeset in a code host (e.g. a PR on Github)
-type Changeset implements Node {
+type ExternalChangeset implements Changeset & Node {
     # The unique ID for the changeset.
     id: ID!
 
-    # The repository where this changeset is defined.
+    # The repository changed by this changeset.
     repository: Repository!
 
     # The campaigns that have this changeset in them.
@@ -519,19 +678,34 @@ type Changeset implements Node {
     # The state of the changeset
     state: ChangesetState!
 
-    # The external URL of the changeset on the code host
+    # The external URL of the changeset on the code host.
     externalURL: ExternalLink!
 
     # The review state of this changeset.
     reviewState: ChangesetReviewState!
+
+    # The diff of this changeset.
+    diff: RepositoryDiff!
 }
 
 # A list of changesets.
-type ChangesetConnection {
+type ExternalChangesetConnection {
     # A list of changesets.
-    nodes: [Changeset!]!
+    nodes: [ExternalChangeset!]!
 
-    # The total number of campaigns in the connection.
+    # The total number of changesets in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A list of changesets plans.
+type ChangesetPlanConnection {
+    # A list of changeset plans.
+    nodes: [ChangesetPlan!]!
+
+    # The total number of changeset plans in the connection.
     totalCount: Int!
 
     # Pagination information.
@@ -544,7 +718,7 @@ type ChangesetEvent implements Node {
     id: ID!
 
     # The changeset this event belongs to.
-    changeset: Changeset!
+    changeset: ExternalChangeset!
 
     # The date and time when the changeset was created.
     createdAt: DateTime!
@@ -1713,8 +1887,26 @@ type GitRefConnection {
     pageInfo: PageInfo!
 }
 
-# The differences between two Git commits in a repository.
-type RepositoryComparison {
+# A not-yet-committed preview of a diff on a repository.
+type PreviewRepositoryDiff implements RepositoryDiff {
+    # The repository that this diff is targeting.
+    baseRepository: Repository!
+
+    # The file diffs for each changed file.
+    fileDiffs(first: Int): FileDiffConnection!
+}
+
+# Any diff on a concrete repository.
+interface RepositoryDiff {
+    # The repository that this diff is targeting.
+    baseRepository: Repository!
+
+    # The file diffs for each changed file.
+    fileDiffs(first: Int): FileDiffConnection!
+}
+
+# The differences between two concrete Git commits in a repository.
+type RepositoryComparison implements RepositoryDiff {
     # The repository that is the base (left-hand side) of this comparison.
     baseRepository: Repository!
 
@@ -2300,13 +2492,6 @@ interface File2 {
     externalURLs: [ExternalLink!]!
     # Highlight the file.
     highlight(disableTimeout: Boolean!, isLightTheme: Boolean!): HighlightedFile!
-    # Symbols defined in this file.
-    symbols(
-        # Returns the first n symbols from the list.
-        first: Int
-        # Return symbols matching the query.
-        query: String
-    ): SymbolConnection!
 }
 
 # File is temporarily preserved for backcompat with browser extension search API client code.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -33,7 +33,7 @@ type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
     # exists, it's returned instead of a new entry being added to the database.
-    createChangesets(input: [CreateChangesetInput!]!): [Changeset!]!
+    createChangesets(input: [CreateChangesetInput!]!): [ExternalChangeset!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -524,7 +524,7 @@ type Campaign implements Node {
     plan: CampaignPlan
 
     # The current status of creating the campaigns changesets on the code host.
-    changesetCreationStatus: BackgroundProcessStatus!
+    changesetCreationStatus: BackgroundProcessStatus
 
     # The namespace where this campaign is defined.
     namespace: Namespace!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -531,7 +531,7 @@ type Campaign implements Node {
     plan: CampaignPlan
 
     # The current status of creating the campaigns changesets on the code host.
-    changesetCreationStatus: BackgroundProcessStatus!
+    changesetCreationStatus: BackgroundProcessStatus
 
     # The namespace where this campaign is defined.
     namespace: Namespace!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -35,7 +35,7 @@ type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
     # exists, it's returned instead of a new entry being added to the database.
-    createChangesets(input: [CreateChangesetInput!]!): [Changeset!]!
+    createChangesets(input: [CreateChangesetInput!]!): [ExternalChangeset!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -37,13 +37,39 @@ type Mutation {
     # exists, it's returned instead of a new entry being added to the database.
     createChangesets(input: [CreateChangesetInput!]!): [Changeset!]!
     # Adds a list of Changesets to a Campaign.
+    # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
     # Create a campaign in a namespace. The newly created campaign is returned.
     createCampaign(input: CreateCampaignInput!): Campaign!
+    # Preview the plan for a campaign, including its diff.
+    # The returned CampaignPlan can be referred to when creating the campaign.
+    # It is cached with a short TTL.
+    # The campaign plan is computed asynchronously.
+    # Check its status property and query it by its id to see its latest state.
+    previewCampaignPlan(
+        specification: CampaignPlanSpecification!
+        # Whether to wait to finish computing the plan before returning.
+        # If false, callers must poll the CampaignPlan using its node ID to track progress and get results.
+        # If the plan is not ready within an interval that would result in request timeouts,
+        # the query will return anyway, so the caller must check the result's CampaignPlan.status.
+        wait: Boolean = false
+    ): CampaignPlan!
+    # Cancel a campaign plan that is being generated.
+    # Cancellation expresses a desinterest in the campaign plan and is best-effort.
+    # It may not be relied upon.
+    # The return of this mutation does not mean the plan was fully cancelled yet,
+    # only that the desinterest in the campaign plan was acknowledged.
+    # This mutation is idempotent and a noop if called for a completed campaign plan.
+    # There is no requirement to call this mutation, it is a performance optimization.
+    cancelCampaignPlan(plan: ID!): EmptyResponse
     # Updates a campaign.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
+    # Retries creating changesets of the campaign plan that could not be successfully created on the code host.
+    # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.
+    retryCampaign(campaign: ID!): Campaign!
     # Deletes a campaign.
     deleteCampaign(campaign: ID!): EmptyResponse
+
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.
@@ -378,6 +404,19 @@ type Mutation {
     deleteSavedSearch(id: ID!): EmptyResponse
 }
 
+# The specification of what changesets Sourcegraph will open when the campaign is created.
+input CampaignPlanSpecification {
+    # A known campaign type.
+    # Currently only "comby" is supported.
+    type: String!
+
+    # JSONC string that configures the changes that Sourcegraph will open changesets for when the campaign is created.
+    #
+    # Schema for comby:
+    # { scopeQuery: string, matchTemplate: string, rewriteTemplate: string }
+    arguments: JSONCString!
+}
+
 # Input arguments for creating a campaign.
 input CreateCampaignInput {
     # The ID of the namespace where this campaign is defined.
@@ -388,6 +427,15 @@ input CreateCampaignInput {
 
     # The description of the campaign as Markdown.
     description: String!
+
+    # An optional reference to a completed campaign plan that was previewed before this mutation.
+    # If null, existing changesets can be added manually.
+    # If set, no changesets can be added manually, they will be created by Sourcegraph
+    # after creating the campaign according to the precomputed campaign plan.
+    # Will error if the plan has been purged already and needs to be recomputed by another call to previewCampaignPlan.
+    # Will error if the plan is not completed yet.
+    # Using a campaign plan for a campaign will retain it for the lifetime of the campaign and prevents it from being purged.
+    plan: ID
 }
 
 # Input arguments for updating a campaign.
@@ -402,10 +450,88 @@ input UpdateCampaignInput {
     description: String
 }
 
-# A collection of threads.
+# A preview of changes that will be applied by a campaign.
+# It is chached and addressable by its ID for a limited amount of time.
+type CampaignPlan implements Node {
+    # The unique ID of this campaign plan.
+    id: ID!
+
+    # The campaign type.
+    type: String!
+
+    # The JSONC string that configures how Sourcegraph generates the diff and changesets.
+    arguments: JSONCString!
+
+    # The progress status of generating changesets.
+    status: BackgroundProcessStatus!
+
+    # The changesets that will be created by the campaign.
+    changesets(first: Int): ChangesetPlanConnection!
+
+    # The combined diff of all changesets that will be created by the campaign.
+    repositoryDiffs(first: Int): PreviewRepositoryDiffConnection!
+}
+
+# A paginated list of repository diff previews.
+type PreviewRepositoryDiffConnection {
+    # A list of repository diffs.
+    nodes: [PreviewRepositoryDiff!]!
+
+    # The total number of repository diffs in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A paginated list of repository diffs committed to git.
+type RepositoryComparisonConnection {
+    # A list of repository diffs committed to git.
+    nodes: [RepositoryComparison!]!
+
+    # The total number of repository diffs in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# The state a background process can be in.
+enum BackgroundProcessState {
+    # The background process is processing items.
+    PROCESSING
+    # The background process attempted processing all items, but some failed.
+    ERRORED
+    # The background process completed processing all items successfully.
+    COMPLETED
+}
+
+# Reusable type to report progress of a background process.
+type BackgroundProcessStatus {
+    # How many items were successfully completed.
+    completedCount: Int!
+
+    # How many items are not done yet (including items that errored).
+    pendingCount: Int!
+
+    # The state the background process is currently in.
+    state: BackgroundProcessState!
+
+    # Messages of errors that occurred since the current run of this process was started.
+    errors: [String!]!
+}
+
+# A collection of changesets.
 type Campaign implements Node {
     # The unique ID for the campaign.
     id: ID!
+
+    # The campaign plan that was used to create this campaign.
+    # If null, changesets are added to the campaign manually.
+    plan: CampaignPlan
+
+    # The current status of creating the campaigns changesets on the code host.
+    changesetCreationStatus: BackgroundProcessStatus!
 
     # The namespace where this campaign is defined.
     namespace: Namespace!
@@ -428,8 +554,11 @@ type Campaign implements Node {
     # The date and time when the campaign was updated.
     updatedAt: DateTime!
 
-    # The changesets in this campaign.
-    changesets(first: Int): ChangesetConnection!
+    # The combined diff of all changesets across all repositories, already created on the code host.
+    repositoryDiffs(first: Int): RepositoryComparisonConnection!
+
+    # The changesets in this campaign, already created on the code host.
+    changesets(first: Int): ExternalChangesetConnection!
 
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(
@@ -497,12 +626,42 @@ input CreateChangesetInput {
     externalID: String!
 }
 
+# Basic fields of a changeset.
+interface Changeset {
+    # The repository changed by the changeset.
+    repository: Repository!
+
+    # The title of the changeset.
+    title: String!
+
+    # The body of the changeset.
+    body: String!
+
+    # The diff of the changeset.
+    diff: RepositoryDiff!
+}
+
+# Preview of a changeset planned to be created.
+type ChangesetPlan implements Changeset {
+    # The repository changed by the changeset.
+    repository: Repository!
+
+    # The title of the changeset.
+    title: String!
+
+    # The body of the changeset.
+    body: String!
+
+    # The diff of the changeset.
+    diff: RepositoryDiff!
+}
+
 # A changeset in a code host (e.g. a PR on Github)
-type Changeset implements Node {
+type ExternalChangeset implements Changeset & Node {
     # The unique ID for the changeset.
     id: ID!
 
-    # The repository where this changeset is defined.
+    # The repository changed by this changeset.
     repository: Repository!
 
     # The campaigns that have this changeset in them.
@@ -526,19 +685,34 @@ type Changeset implements Node {
     # The state of the changeset
     state: ChangesetState!
 
-    # The external URL of the changeset on the code host
+    # The external URL of the changeset on the code host.
     externalURL: ExternalLink!
 
     # The review state of this changeset.
     reviewState: ChangesetReviewState!
+
+    # The diff of this changeset.
+    diff: RepositoryDiff!
 }
 
 # A list of changesets.
-type ChangesetConnection {
+type ExternalChangesetConnection {
     # A list of changesets.
-    nodes: [Changeset!]!
+    nodes: [ExternalChangeset!]!
 
-    # The total number of campaigns in the connection.
+    # The total number of changesets in the connection.
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A list of changesets plans.
+type ChangesetPlanConnection {
+    # A list of changeset plans.
+    nodes: [ChangesetPlan!]!
+
+    # The total number of changeset plans in the connection.
     totalCount: Int!
 
     # Pagination information.
@@ -551,7 +725,7 @@ type ChangesetEvent implements Node {
     id: ID!
 
     # The changeset this event belongs to.
-    changeset: Changeset!
+    changeset: ExternalChangeset!
 
     # The date and time when the changeset was created.
     createdAt: DateTime!
@@ -1720,8 +1894,26 @@ type GitRefConnection {
     pageInfo: PageInfo!
 }
 
-# The differences between two Git commits in a repository.
-type RepositoryComparison {
+# A not-yet-committed preview of a diff on a repository.
+type PreviewRepositoryDiff implements RepositoryDiff {
+    # The repository that this diff is targeting.
+    baseRepository: Repository!
+
+    # The file diffs for each changed file.
+    fileDiffs(first: Int): FileDiffConnection!
+}
+
+# Any diff on a concrete repository.
+interface RepositoryDiff {
+    # The repository that this diff is targeting.
+    baseRepository: Repository!
+
+    # The file diffs for each changed file.
+    fileDiffs(first: Int): FileDiffConnection!
+}
+
+# The differences between two concrete Git commits in a repository.
+type RepositoryComparison implements RepositoryDiff {
     # The repository that is the base (left-hand side) of this comparison.
     baseRepository: Repository!
 
@@ -2307,13 +2499,6 @@ interface File2 {
     externalURLs: [ExternalLink!]!
     # Highlight the file.
     highlight(disableTimeout: Boolean!, isLightTheme: Boolean!): HighlightedFile!
-    # Symbols defined in this file.
-    symbols(
-        # Returns the first n symbols from the list.
-        first: Int
-        # Return symbols matching the query.
-        query: String
-    ): SymbolConnection!
 }
 
 # File is temporarily preserved for backcompat with browser extension search API client code.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -775,6 +775,33 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	return suggestions, nil
 }
 
+// SearchRepos searches for the provided query but only the the unique list of
+// repositories belonging to the search results.
+// It's used by a8n to search.
+func (r *schemaResolver) SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver, error) {
+	queryString := query.ConvertToLiteral(plainQuery)
+
+	q, err := query.ParseAndCheck(queryString)
+	if err != nil {
+		return nil, err
+	}
+
+	sr := &searchResolver{
+		query:         q,
+		originalQuery: plainQuery,
+		pagination:    nil,
+		patternType:   SearchTypeLiteral,
+		zoekt:         search.Indexed(),
+		searcherURLs:  search.SearcherURLs(),
+	}
+
+	results, err := sr.Results(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return results.Repositories(), nil
+}
+
 func unionRegExps(patterns []string) string {
 	if len(patterns) == 0 {
 		return ""

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -1,0 +1,89 @@
+package resolvers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/a8n"
+)
+
+const campaignPlanIDKind = "CampaignPlan"
+
+func marshalCampaignPlanID(id int64) graphql.ID {
+	return relay.MarshalID(campaignPlanIDKind, id)
+}
+
+func unmarshalCampaignPlanID(id graphql.ID) (campaignPlanID int64, err error) {
+	err = relay.UnmarshalSpec(id, &campaignPlanID)
+	return
+}
+
+type campaignPlanResolver struct {
+	store        *ee.Store
+	campaignPlan *a8n.CampaignPlan
+}
+
+func (r *campaignPlanResolver) ID() graphql.ID {
+	return marshalCampaignPlanID(r.campaignPlan.ID)
+}
+
+func (r *campaignPlanResolver) Type() string { return r.campaignPlan.CampaignType }
+func (r *campaignPlanResolver) Arguments() (graphqlbackend.JSONCString, error) {
+	b, err := json.Marshal(r.campaignPlan.Arguments)
+	if err != nil {
+		return graphqlbackend.JSONCString(""), err
+	}
+
+	return graphqlbackend.JSONCString(string(b)), nil
+}
+
+func (r *campaignPlanResolver) Status() graphqlbackend.BackgroundProcessStatus {
+	// TODO(a8n): Implement this
+	return a8n.BackgroundProcessStatus{
+		Completed:     0,
+		Pending:       99,
+		ProcessState:  a8n.BackgroundProcessStateErrored,
+		ProcessErrors: []string{"this is just a skeleton api"},
+	}
+}
+
+func (r *campaignPlanResolver) Changesets(
+	ctx context.Context,
+	args *graphqlutil.ConnectionArgs,
+) graphqlbackend.ChangesetPlansConnectionResolver {
+	// TODO(a8n): Implement this. We need to fetch the CampaignJobs and their
+	// diffs/errors and return them as a `campaignJobConnectionResolver` that
+	// implements the `ChangesetsConnectionResolver` interface.
+	return &changesetPlansConnectionResolver{store: r.store, campaignPlan: r.campaignPlan}
+}
+
+func (r *campaignPlanResolver) RepositoryDiffs(
+	ctx context.Context,
+	args *graphqlutil.ConnectionArgs,
+) (graphqlbackend.PreviewRepositoryDiffConnectionResolver, error) {
+	// TODO(a8n): Implement this. We need to fetch the CampaignJobs diffs
+	// and return them as a `PreviewRepositoryDiffConnectionResolver`
+	return nil, nil
+}
+
+type changesetPlansConnectionResolver struct {
+	store        *ee.Store
+	campaignPlan *a8n.CampaignPlan
+}
+
+func (r *changesetPlansConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetPlanResolver, error) {
+	return []graphqlbackend.ChangesetPlanResolver{}, nil
+}
+
+func (r *changesetPlansConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	return 0, nil
+}
+
+func (r *changesetPlansConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}

--- a/enterprise/pkg/a8n/resolvers/campaigns.go
+++ b/enterprise/pkg/a8n/resolvers/campaigns.go
@@ -120,7 +120,7 @@ func (r *campaignResolver) UpdatedAt() graphqlbackend.DateTime {
 
 func (r *campaignResolver) Changesets(ctx context.Context, args struct {
 	graphqlutil.ConnectionArgs
-}) graphqlbackend.ChangesetsConnectionResolver {
+}) graphqlbackend.ExternalChangesetsConnectionResolver {
 	return &changesetsConnectionResolver{
 		store: r.store,
 		opts: ee.ListChangesetsOpts{
@@ -186,4 +186,35 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	}
 
 	return resolvers, nil
+}
+
+func (r *campaignResolver) Plan(ctx context.Context) (graphqlbackend.CampaignPlanResolver, error) {
+	if r.Campaign.CampaignPlanID == 0 {
+		return nil, nil
+	}
+
+	plan, err := r.store.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: r.Campaign.CampaignPlanID})
+	if err != nil {
+		return nil, err
+	}
+
+	return &campaignPlanResolver{store: r.store, campaignPlan: plan}, nil
+}
+
+func (r *campaignResolver) RepositoryDiffs(
+	ctx context.Context,
+	args *graphqlutil.ConnectionArgs,
+) (graphqlbackend.RepositoryComparisonConnectionResolver, error) {
+	// TODO(a8n): implement this
+	return nil, nil
+}
+
+func (r *campaignResolver) ChangesetCreationStatus() graphqlbackend.BackgroundProcessStatus {
+	// TODO(a8n): Implement this
+	return a8n.BackgroundProcessStatus{
+		Completed:     0,
+		Pending:       99,
+		ProcessState:  a8n.BackgroundProcessStateErrored,
+		ProcessErrors: []string{"something went wrong we don't know what"},
+	}
 }

--- a/enterprise/pkg/a8n/resolvers/changeset_events.go
+++ b/enterprise/pkg/a8n/resolvers/changeset_events.go
@@ -78,7 +78,7 @@ func (r *changesetEventResolver) CreatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: r.ChangesetEvent.CreatedAt}
 }
 
-func (r *changesetEventResolver) Changeset(ctx context.Context) (graphqlbackend.ChangesetResolver, error) {
+func (r *changesetEventResolver) Changeset(ctx context.Context) (graphqlbackend.ExternalChangesetResolver, error) {
 	return &changesetResolver{store: r.store, Changeset: r.changeset}, nil
 }
 

--- a/enterprise/pkg/a8n/resolvers/changesets.go
+++ b/enterprise/pkg/a8n/resolvers/changesets.go
@@ -29,12 +29,12 @@ type changesetsConnectionResolver struct {
 	err        error
 }
 
-func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetResolver, error) {
+func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ExternalChangesetResolver, error) {
 	changesets, _, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resolvers := make([]graphqlbackend.ChangesetResolver, 0, len(changesets))
+	resolvers := make([]graphqlbackend.ExternalChangesetResolver, 0, len(changesets))
 	for _, c := range changesets {
 		resolvers = append(resolvers, &changesetResolver{store: r.store, Changeset: c})
 	}
@@ -77,6 +77,14 @@ func marshalChangesetID(id int64) graphql.ID {
 func unmarshalChangesetID(id graphql.ID) (cid int64, err error) {
 	err = relay.UnmarshalSpec(id, &cid)
 	return
+}
+
+func (r *changesetResolver) ToChangesetPlan() (graphqlbackend.ChangesetPlanResolver, bool) {
+	return r, true
+}
+
+func (r *changesetResolver) ToExternalChangeset() (graphqlbackend.ExternalChangesetResolver, bool) {
+	return r, true
 }
 
 func (r *changesetResolver) ID() graphql.ID {
@@ -178,4 +186,9 @@ func (r *changesetResolver) Events(ctx context.Context, args *struct {
 			Limit:        int(args.ConnectionArgs.GetFirst()),
 		},
 	}, nil
+}
+
+func (r *changesetResolver) Diff(ctx context.Context) (*graphqlbackend.RepositoryComparisonResolver, error) {
+	// TODO(a8n): implement this (see: https://github.com/sourcegraph/sourcegraph/pull/6206/files)
+	return nil, nil
 }

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -352,7 +352,7 @@ func TestCampaigns(t *testing.T) {
 	)
 
 	mustExec(ctx, t, s, nil, &result, fmt.Sprintf(`
-		fragment cs on Changeset {
+		fragment cs on ExternalChangeset {
 			id
 			repository { id }
 			createdAt
@@ -474,7 +474,7 @@ func TestCampaigns(t *testing.T) {
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
 
-		fragment cs on Changeset {
+		fragment cs on ExternalChangeset {
 			id
 			repository { id }
 			createdAt

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -28,6 +28,8 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 		ctx := context.Background()
 
+		deferConstraint(t, tx, "campaign_jobs_repo_id_fkey")
+
 		t.Run("Campaigns", func(t *testing.T) {
 			campaigns := make([]*a8n.Campaign, 0, 3)
 
@@ -849,5 +851,395 @@ func testStore(db *sql.DB) func(*testing.T) {
 				})
 			})
 		})
+
+		t.Run("CampaignPlans", func(t *testing.T) {
+			campaignPlans := make([]*a8n.CampaignPlan, 0, 3)
+
+			t.Run("Create", func(t *testing.T) {
+				for i := 0; i < cap(campaignPlans); i++ {
+					c := &a8n.CampaignPlan{
+						CampaignType: "COMBY",
+						Arguments:    map[string]string{"pattern": "foobar"},
+					}
+
+					want := c.Clone()
+					have := c
+
+					err := s.CreateCampaignPlan(ctx, have)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have.ID == 0 {
+						t.Fatal("ID should not be zero")
+					}
+
+					want.ID = have.ID
+					want.CreatedAt = now
+					want.UpdatedAt = now
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+
+					campaignPlans = append(campaignPlans, c)
+				}
+			})
+
+			t.Run("Count", func(t *testing.T) {
+				count, err := s.CountCampaignPlans(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := count, int64(len(campaignPlans)); have != want {
+					t.Fatalf("have count: %d, want: %d", have, want)
+				}
+			})
+
+			t.Run("List", func(t *testing.T) {
+				opts := ListCampaignPlansOpts{}
+
+				ts, next, err := s.ListCampaignPlans(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := next, int64(0); have != want {
+					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+				}
+
+				have, want := ts, campaignPlans
+				if len(have) != len(want) {
+					t.Fatalf("listed %d campaignPlans, want: %d", len(have), len(want))
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+
+				for i := 1; i <= len(campaignPlans); i++ {
+					cs, next, err := s.ListCampaignPlans(ctx, ListCampaignPlansOpts{Limit: i})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					{
+						have, want := next, int64(0)
+						if i < len(campaignPlans) {
+							want = campaignPlans[i].ID
+						}
+
+						if have != want {
+							t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+						}
+					}
+
+					{
+						have, want := cs, campaignPlans[:i]
+						if len(have) != len(want) {
+							t.Fatalf("listed %d campaignPlans, want: %d", len(have), len(want))
+						}
+
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatal(diff)
+						}
+					}
+				}
+
+				{
+					var cursor int64
+					for i := 1; i <= len(campaignPlans); i++ {
+						opts := ListCampaignPlansOpts{Cursor: cursor, Limit: 1}
+						have, next, err := s.ListCampaignPlans(ctx, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						want := campaignPlans[i-1 : i]
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatalf("opts: %+v, diff: %s", opts, diff)
+						}
+
+						cursor = next
+					}
+				}
+			})
+
+			t.Run("Update", func(t *testing.T) {
+				for _, c := range campaignPlans {
+					c.CampaignType += "-updated"
+					c.Arguments["anotherArg"] = "anotherValue"
+
+					now = now.Add(time.Second)
+					want := c
+					want.UpdatedAt = now
+
+					have := c.Clone()
+					if err := s.UpdateCampaignPlan(ctx, have); err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				}
+			})
+
+			t.Run("Get", func(t *testing.T) {
+				t.Run("ByID", func(t *testing.T) {
+					if len(campaignPlans) == 0 {
+						t.Fatalf("campaignPlans is empty")
+					}
+					want := campaignPlans[0]
+					opts := GetCampaignPlanOpts{ID: want.ID}
+
+					have, err := s.GetCampaignPlan(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
+				t.Run("NoResults", func(t *testing.T) {
+					opts := GetCampaignPlanOpts{ID: 0xdeadbeef}
+
+					_, have := s.GetCampaignPlan(ctx, opts)
+					want := ErrNoResults
+
+					if have != want {
+						t.Fatalf("have err %v, want %v", have, want)
+					}
+				})
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				for i := range campaignPlans {
+					err := s.DeleteCampaignPlan(ctx, campaignPlans[i].ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					count, err := s.CountCampaignPlans(ctx)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have, want := count, int64(len(campaignPlans)-(i+1)); have != want {
+						t.Fatalf("have count: %d, want: %d", have, want)
+					}
+				}
+			})
+		})
+
+		t.Run("CampaignJobs", func(t *testing.T) {
+			campaignJobs := make([]*a8n.CampaignJob, 0, 3)
+
+			t.Run("Create", func(t *testing.T) {
+				for i := 0; i < cap(campaignJobs); i++ {
+					c := &a8n.CampaignJob{
+						CampaignPlanID: int64(i + 1),
+						RepoID:         1,
+						Diff:           "+ foobar - barfoo",
+						Error:          "only set on error",
+					}
+
+					want := c.Clone()
+					have := c
+
+					err := s.CreateCampaignJob(ctx, have)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have.ID == 0 {
+						t.Fatal("ID should not be zero")
+					}
+
+					want.ID = have.ID
+					want.CreatedAt = now
+					want.UpdatedAt = now
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+
+					campaignJobs = append(campaignJobs, c)
+				}
+			})
+
+			t.Run("Count", func(t *testing.T) {
+				count, err := s.CountCampaignJobs(ctx, CountCampaignJobsOpts{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := count, int64(len(campaignJobs)); have != want {
+					t.Fatalf("have count: %d, want: %d", have, want)
+				}
+
+				count, err = s.CountCampaignJobs(ctx, CountCampaignJobsOpts{CampaignPlanID: 1})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := count, int64(1); have != want {
+					t.Fatalf("have count: %d, want: %d", have, want)
+				}
+			})
+
+			t.Run("List", func(t *testing.T) {
+				for i := 1; i <= len(campaignJobs); i++ {
+					opts := ListCampaignJobsOpts{CampaignPlanID: int64(i)}
+
+					ts, next, err := s.ListCampaignJobs(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have, want := next, int64(0); have != want {
+						t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+					}
+
+					have, want := ts, campaignJobs[i-1:i]
+					if len(have) != len(want) {
+						t.Fatalf("listed %d campaignJobs, want: %d", len(have), len(want))
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatalf("opts: %+v, diff: %s", opts, diff)
+					}
+				}
+
+				for i := 1; i <= len(campaignJobs); i++ {
+					cs, next, err := s.ListCampaignJobs(ctx, ListCampaignJobsOpts{Limit: i})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					{
+						have, want := next, int64(0)
+						if i < len(campaignJobs) {
+							want = campaignJobs[i].ID
+						}
+
+						if have != want {
+							t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+						}
+					}
+
+					{
+						have, want := cs, campaignJobs[:i]
+						if len(have) != len(want) {
+							t.Fatalf("listed %d campaignJobs, want: %d", len(have), len(want))
+						}
+
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatal(diff)
+						}
+					}
+				}
+
+				{
+					var cursor int64
+					for i := 1; i <= len(campaignJobs); i++ {
+						opts := ListCampaignJobsOpts{Cursor: cursor, Limit: 1}
+						have, next, err := s.ListCampaignJobs(ctx, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						want := campaignJobs[i-1 : i]
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatalf("opts: %+v, diff: %s", opts, diff)
+						}
+
+						cursor = next
+					}
+				}
+			})
+
+			t.Run("Update", func(t *testing.T) {
+				for _, c := range campaignJobs {
+					now = now.Add(time.Second)
+					c.StartedAt = now
+					c.FinishedAt = now
+					c.Diff += "-updated"
+					c.Error += "-updated"
+
+					want := c
+					want.UpdatedAt = now
+
+					have := c.Clone()
+					if err := s.UpdateCampaignJob(ctx, have); err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				}
+			})
+
+			t.Run("Get", func(t *testing.T) {
+				t.Run("ByID", func(t *testing.T) {
+					if len(campaignJobs) == 0 {
+						t.Fatal("campaignJobs is empty")
+					}
+					want := campaignJobs[0]
+					opts := GetCampaignJobOpts{ID: want.ID}
+
+					have, err := s.GetCampaignJob(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
+				t.Run("NoResults", func(t *testing.T) {
+					opts := GetCampaignJobOpts{ID: 0xdeadbeef}
+
+					_, have := s.GetCampaignJob(ctx, opts)
+					want := ErrNoResults
+
+					if have != want {
+						t.Fatalf("have err %v, want %v", have, want)
+					}
+				})
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				for i := range campaignJobs {
+					err := s.DeleteCampaignJob(ctx, campaignJobs[i].ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					count, err := s.CountCampaignJobs(ctx, CountCampaignJobsOpts{})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have, want := count, int64(len(campaignJobs)-(i+1)); have != want {
+						t.Fatalf("have count: %d, want: %d", have, want)
+					}
+				}
+			})
+		})
+	}
+}
+
+func deferConstraint(t *testing.T, tx *sql.Tx, constraint string) {
+	t.Helper()
+
+	_, err := tx.Exec("SET CONSTRAINTS " + constraint + " DEFERRED")
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -28,8 +28,6 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 		ctx := context.Background()
 
-		deferConstraint(t, tx, "campaign_jobs_repo_id_fkey")
-
 		t.Run("Campaigns", func(t *testing.T) {
 			campaigns := make([]*a8n.Campaign, 0, 3)
 
@@ -1232,14 +1230,5 @@ func testStore(db *sql.DB) func(*testing.T) {
 				}
 			})
 		})
-	}
-}
-
-func deferConstraint(t *testing.T, tx *sql.Tx, constraint string) {
-	t.Helper()
-
-	_, err := tx.Exec("SET CONSTRAINTS " + constraint + " DEFERRED")
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/migrations/1528395608_create_campaign_plans_table.down.sql
+++ b/migrations/1528395608_create_campaign_plans_table.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE campaigns DROP COLUMN IF EXISTS campaign_plan_id;
+
+DROP TABLE IF EXISTS campaign_plans;
+
+COMMIT;

--- a/migrations/1528395608_create_campaign_plans_table.up.sql
+++ b/migrations/1528395608_create_campaign_plans_table.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE campaign_plans (
+  id bigserial PRIMARY KEY,
+  campaign_type text NOT NULL CHECK (campaign_type != ''),
+  arguments jsonb NOT NULL DEFAULT '{}'
+    CHECK (jsonb_typeof(arguments) = 'object'),
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE campaigns
+ADD COLUMN campaign_plan_id integer REFERENCES campaign_plans(id)
+DEFERRABLE INITIALLY IMMEDIATE;
+
+COMMIT;
+

--- a/migrations/1528395609_create_campaign_jobs_table.down.sql
+++ b/migrations/1528395609_create_campaign_jobs_table.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE IF EXISTS campaign_jobs;
+
+COMMIT;
+

--- a/migrations/1528395609_create_campaign_jobs_table.up.sql
+++ b/migrations/1528395609_create_campaign_jobs_table.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE campaign_jobs (
+  id bigserial PRIMARY KEY,
+  campaign_plan_id bigint NOT NULL REFERENCES campaign_plans(id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+
+  repo_id bigint NOT NULL REFERENCES repo(id)
+    DEFERRABLE INITIALLY IMMEDIATE,
+
+  rev text NOT NULL,
+
+  diff text NOT NULL,
+  error text NOT NULL,
+
+  started_at timestamp with time zone,
+  finished_at timestamp with time zone,
+
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -52,6 +52,10 @@
 // 1528395606_lsif_add_visible_at_tip_flag.up.sql (273B)
 // 1528395607_lsif_add_dump_uploaded_at.down.sql (158B)
 // 1528395607_lsif_add_dump_uploaded_at.up.sql (339B)
+// 1528395608_create_campaign_plans_table.down.sql (117B)
+// 1528395608_create_campaign_plans_table.up.sql (470B)
+// 1528395609_create_campaign_jobs_table.down.sql (54B)
+// 1528395609_create_campaign_jobs_table.up.sql (551B)
 
 package migrations
 
@@ -1160,6 +1164,86 @@ func _1528395607_lsif_add_dump_uploaded_atUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395608_create_campaign_plans_tableDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x86\xcb\xc7\x17\xe4\x24\xe6\xc5\x67\xa6\x58\x73\x71\x81\x15\x42\x74\xe3\x50\x57\x6c\xcd\xc5\xe5\xec\xef\xeb\xeb\x19\x62\xcd\x05\x08\x00\x00\xff\xff\xf8\xfc\xff\xb1\x75\x00\x00\x00")
+
+func _1528395608_create_campaign_plans_tableDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395608_create_campaign_plans_tableDownSql,
+		"1528395608_create_campaign_plans_table.down.sql",
+	)
+}
+
+func _1528395608_create_campaign_plans_tableDownSql() (*asset, error) {
+	bytes, err := _1528395608_create_campaign_plans_tableDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395608_create_campaign_plans_table.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x26, 0x41, 0x3, 0x82, 0x3, 0x15, 0xa, 0x5a, 0xcd, 0xce, 0xb9, 0xd8, 0x67, 0x15, 0x7, 0x85, 0x66, 0x9f, 0xd1, 0x14, 0x31, 0x87, 0x8, 0xd6, 0x48, 0x96, 0xd2, 0x2f, 0x46, 0xe6, 0xbd, 0x91}}
+	return a, nil
+}
+
+var __1528395608_create_campaign_plans_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x91\xcd\x6e\xea\x30\x14\x84\xf7\x7e\x8a\xb9\xab\x24\xd2\x7d\x03\xc4\xc2\x24\x87\xd6\xc2\x09\x95\x6b\x16\xac\x90\x21\x6e\x6a\x44\x9c\x28\x36\xa2\x3f\xea\xbb\x57\xa4\x6a\x11\x74\xd7\xa5\xe5\xf9\xbe\x23\xcd\xcc\xe8\x4e\x54\x13\xc6\x72\x45\x5c\x13\x34\x9f\x49\xc2\xce\xb4\xbd\x71\x8d\xdf\xf4\x07\xe3\x03\x52\x06\xb8\x1a\x5b\xd7\x04\x3b\x38\x73\xc0\x83\x12\x25\x57\x6b\x2c\x68\xfd\x9f\xe1\x12\x8f\xaf\xbd\x45\xb4\x2f\x11\xd5\x52\xa3\x5a\x49\x89\xfc\x9e\xf2\x05\xd2\xeb\xc8\xbf\x29\x92\x24\x3b\xa3\x66\x68\x8e\xad\xf5\x31\x60\x1f\x3a\xbf\xbd\x70\x05\xcd\xf9\x4a\x6a\x24\xef\x1f\x09\x03\xf0\x2d\x1a\x63\xa3\xa5\x7b\x4a\x7f\xe8\x0c\x53\x24\xdd\x76\x6f\x77\xf1\xcb\xbb\x1b\xac\x89\xb6\xde\x98\x88\xe8\x5a\x1b\xa2\x69\x7b\x9c\x5c\x7c\x1e\x9f\x78\xeb\xbc\xfd\x7d\xcb\x77\xa7\x74\xa4\x8f\x7d\xfd\x47\x9a\x65\x13\xc6\xb8\xd4\xa4\x6e\xaa\x0c\x8c\x17\x05\xf2\xa5\x5c\x95\xd5\x75\xbf\x1b\x57\xc3\xf9\x68\x1b\x3b\x40\xd1\x9c\x14\x55\x39\x3d\xde\x6c\x90\xba\x3a\x63\xc5\xf9\x57\x8d\x5a\x51\x09\x2d\xb8\x94\x6b\x88\xb2\xa4\x42\x70\x4d\xe7\x11\x97\x65\x29\xf4\x84\xb1\xcf\x00\x00\x00\xff\xff\xdc\xc2\x4d\x18\xd6\x01\x00\x00")
+
+func _1528395608_create_campaign_plans_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395608_create_campaign_plans_tableUpSql,
+		"1528395608_create_campaign_plans_table.up.sql",
+	)
+}
+
+func _1528395608_create_campaign_plans_tableUpSql() (*asset, error) {
+	bytes, err := _1528395608_create_campaign_plans_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395608_create_campaign_plans_table.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc3, 0xf8, 0x88, 0xdb, 0x67, 0xc0, 0xa0, 0x54, 0x29, 0xcf, 0x9d, 0x85, 0xf3, 0x77, 0x43, 0x9a, 0xfb, 0x92, 0x46, 0x88, 0x74, 0x21, 0x55, 0xb6, 0x4e, 0x8f, 0x7, 0x18, 0xf1, 0xc1, 0x8e, 0xfd}}
+	return a, nil
+}
+
+var __1528395609_create_campaign_jobs_tableDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x8b\xcf\xca\x4f\x2a\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\xe2\x02\x04\x00\x00\xff\xff\xcf\xc2\x2c\x9d\x36\x00\x00\x00")
+
+func _1528395609_create_campaign_jobs_tableDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395609_create_campaign_jobs_tableDownSql,
+		"1528395609_create_campaign_jobs_table.down.sql",
+	)
+}
+
+func _1528395609_create_campaign_jobs_tableDownSql() (*asset, error) {
+	bytes, err := _1528395609_create_campaign_jobs_tableDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395609_create_campaign_jobs_table.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x11, 0x0, 0x9f, 0x94, 0x36, 0x71, 0x2f, 0xdf, 0x5d, 0x86, 0xd6, 0xb0, 0x7f, 0x5c, 0xbb, 0x3d, 0x47, 0x10, 0x5e, 0x74, 0xa6, 0x42, 0x18, 0x38, 0xe6, 0x58, 0xf5, 0xef, 0x1f, 0x1c, 0x43, 0xfc}}
+	return a, nil
+}
+
+var __1528395609_create_campaign_jobs_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x92\xc1\x6a\x32\x31\x14\x85\xf7\x79\x8a\xb3\x54\xf0\x0d\x5c\xc5\x99\xeb\x4f\xf8\x33\xb1\xc4\xb8\x70\x25\xb1\x13\x35\x45\x33\x43\x92\xd6\xd2\xa7\x2f\x99\x42\x87\x96\xc2\x94\x2e\x73\xf8\xce\x39\xb9\x97\xbb\xa2\x7f\x42\x2d\x19\xab\x34\x71\x43\x30\x7c\x25\x09\x8f\xf6\xd6\x5b\x7f\x0e\x87\xa7\xee\x98\x30\x63\x80\x6f\x71\xf4\xe7\xe4\xa2\xb7\x57\x3c\x68\xd1\x70\xbd\xc7\x7f\xda\x2f\x18\x46\xba\xbf\xda\x70\xf8\x20\x7d\xc8\x50\x1b\x03\xb5\x93\x12\x9a\xd6\xa4\x49\x55\xb4\xfd\xca\xa6\x99\x6f\xe7\x0c\x00\x36\x0a\x35\x49\x32\x84\x8a\x6f\x2b\x5e\x13\xea\xe2\xd1\xc3\x6f\x84\x12\x46\x70\x29\xf7\x10\x4d\x43\xb5\xe0\x86\x16\x8c\x01\xd1\xf5\xdd\x44\x5d\x41\x3e\x4b\x7e\x15\xf9\x82\xec\x5e\xc7\xb0\x41\x6d\xfd\xe9\xf4\x5d\x06\x5c\x8c\x5d\xfc\x81\x4e\xd9\xc6\xec\xda\x83\xcd\xc8\xfe\xe6\x52\xb6\xb7\x1e\x77\x9f\x2f\xc3\x13\x6f\x5d\x70\xc5\x7e\xf2\xc1\xa7\xcb\x14\x57\xd6\x1b\x9d\x9d\xc8\x1b\x67\xaf\x69\xcd\x77\xd2\x20\x74\xf7\xd9\xbc\xd4\x3c\xf7\xed\x1f\xdd\x6c\x5e\xce\x62\xd3\x34\xc2\x2c\xd9\x7b\x00\x00\x00\xff\xff\x82\xb5\x9c\x6f\x27\x02\x00\x00")
+
+func _1528395609_create_campaign_jobs_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395609_create_campaign_jobs_tableUpSql,
+		"1528395609_create_campaign_jobs_table.up.sql",
+	)
+}
+
+func _1528395609_create_campaign_jobs_tableUpSql() (*asset, error) {
+	bytes, err := _1528395609_create_campaign_jobs_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395609_create_campaign_jobs_table.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd3, 0x7f, 0x74, 0x7, 0xdb, 0xf3, 0xa9, 0x9, 0x5f, 0xf8, 0x30, 0xee, 0xba, 0xba, 0xa0, 0x96, 0xe, 0x4f, 0x48, 0xf1, 0xe8, 0x68, 0xcd, 0x33, 0x1a, 0xfd, 0x68, 0x9e, 0x90, 0xcd, 0xba, 0xba}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1303,6 +1387,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395606_lsif_add_visible_at_tip_flag.up.sql":                           _1528395606_lsif_add_visible_at_tip_flagUpSql,
 	"1528395607_lsif_add_dump_uploaded_at.down.sql":                            _1528395607_lsif_add_dump_uploaded_atDownSql,
 	"1528395607_lsif_add_dump_uploaded_at.up.sql":                              _1528395607_lsif_add_dump_uploaded_atUpSql,
+	"1528395608_create_campaign_plans_table.down.sql":                          _1528395608_create_campaign_plans_tableDownSql,
+	"1528395608_create_campaign_plans_table.up.sql":                            _1528395608_create_campaign_plans_tableUpSql,
+	"1528395609_create_campaign_jobs_table.down.sql":                           _1528395609_create_campaign_jobs_tableDownSql,
+	"1528395609_create_campaign_jobs_table.up.sql":                             _1528395609_create_campaign_jobs_tableUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1398,6 +1486,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395606_lsif_add_visible_at_tip_flag.up.sql":                           {_1528395606_lsif_add_visible_at_tip_flagUpSql, map[string]*bintree{}},
 	"1528395607_lsif_add_dump_uploaded_at.down.sql":                            {_1528395607_lsif_add_dump_uploaded_atDownSql, map[string]*bintree{}},
 	"1528395607_lsif_add_dump_uploaded_at.up.sql":                              {_1528395607_lsif_add_dump_uploaded_atUpSql, map[string]*bintree{}},
+	"1528395608_create_campaign_plans_table.down.sql":                          {_1528395608_create_campaign_plans_tableDownSql, map[string]*bintree{}},
+	"1528395608_create_campaign_plans_table.up.sql":                            {_1528395608_create_campaign_plans_tableUpSql, map[string]*bintree{}},
+	"1528395609_create_campaign_jobs_table.down.sql":                           {_1528395609_create_campaign_jobs_tableDownSql, map[string]*bintree{}},
+	"1528395609_create_campaign_jobs_table.up.sql":                             {_1528395609_create_campaign_jobs_tableUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -7,7 +7,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { UserAvatar } from '../../../user/UserAvatar'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { CampaignsIcon } from '../icons'
-import { ChangesetNode } from './changesets/ChangesetNode'
+import { ExternalChangesetNode } from './changesets/ExternalChangesetNode'
 import { noop, upperFirst } from 'lodash'
 import { Form } from '../../../components/Form'
 import { fetchCampaignById, updateCampaign, deleteCampaign, createCampaign, queryChangesets } from './backend'
@@ -277,10 +277,10 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
 
                     <AddChangesetForm campaignID={campaign.id} onAdd={nextChangesetUpdate} />
 
-                    <FilteredConnection<GQL.IChangeset>
+                    <FilteredConnection<GQL.IExternalChangeset>
                         className="mt-2"
                         updates={changesetUpdates}
-                        nodeComponent={ChangesetNode}
+                        nodeComponent={ExternalChangesetNode}
                         queryConnection={queryChangesetsConnection}
                         hideSearch={true}
                         defaultFirst={15}

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -7,7 +7,7 @@ import {
     ICampaign,
     IUpdateCampaignInput,
     ICreateCampaignInput,
-    IChangesetConnection,
+    IExternalChangesetConnection,
     IChangesetsOnCampaignArguments,
 } from '../../../../../shared/src/graphql/schema'
 
@@ -116,7 +116,7 @@ export const fetchCampaignById = (campaign: ID): Observable<ICampaign | null> =>
 export const queryChangesets = (
     campaign: ID,
     { first }: IChangesetsOnCampaignArguments
-): Observable<IChangesetConnection> =>
+): Observable<IExternalChangesetConnection> =>
     queryGraphQL(
         gql`
             query CampaignChangesets($campaign: ID!, $first: Int) {

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
@@ -34,9 +34,13 @@ export const ChangesetNode: React.FunctionComponent<Props> = ({ node }) => {
                     <Link to={node.repository.url} className="text-muted">
                         {node.repository.name}
                     </Link>{' '}
-                    <Link to={node.externalURL.url} target="_blank" rel="noopener noreferrer">
-                        {node.title}
-                    </Link>
+                    {node.externalURL ? (
+                        <Link to={node.externalURL.url} target="_blank" rel="noopener noreferrer">
+                            {node.title}
+                        </Link>
+                    ) : (
+                        node.title
+                    )}
                 </h4>
                 <div className="text-truncate w-100">{node.body}</div>
             </div>

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -1,4 +1,4 @@
-import { IChangeset } from '../../../../../../shared/src/graphql/schema'
+import { IExternalChangeset } from '../../../../../../shared/src/graphql/schema'
 import React from 'react'
 import SourcePullIcon from 'mdi-react/SourcePullIcon'
 import {
@@ -10,10 +10,10 @@ import {
 import { Link } from '../../../../../../shared/src/components/Link'
 
 interface Props {
-    node: IChangeset
+    node: IExternalChangeset
 }
 
-export const ChangesetNode: React.FunctionComponent<Props> = ({ node }) => {
+export const ExternalChangesetNode: React.FunctionComponent<Props> = ({ node }) => {
     const ReviewStateIcon = changesetReviewStateIcons[node.reviewState]
     return (
         <li className="list-group-item d-flex pl-1 align-items-center">

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -34,13 +34,9 @@ export const ExternalChangesetNode: React.FunctionComponent<Props> = ({ node }) 
                     <Link to={node.repository.url} className="text-muted">
                         {node.repository.name}
                     </Link>{' '}
-                    {node.externalURL ? (
-                        <Link to={node.externalURL.url} target="_blank" rel="noopener noreferrer">
-                            {node.title}
-                        </Link>
-                    ) : (
-                        node.title
-                    )}
+                    <Link to={node.externalURL.url} target="_blank" rel="noopener noreferrer">
+                        {node.title}
+                    </Link>
                 </h4>
                 <div className="text-truncate w-100">{node.body}</div>
             </div>


### PR DESCRIPTION
This implements the skeleton of the API described in https://github.com/sourcegraph/sourcegraph/pull/6135/files

Differences: 
- https://github.com/sourcegraph/sourcegraph/pull/6135/files#r339048480
- Didn't implement all changes from `String` to `JSONCString` (see #6135)

It also adds a database CRUD layer for two new entities — `CampaignPlan` and `CampaignJob` — and uses those CRUD methods where easy to do so.

Most importantly: it adds a lot of placeholders and `TODO(a8n)` that then need to be filled out. 

**It doesn't do anything yet**, but having this skeleton GraphQL layer and database layer in place helps us parallelize and makes future PRs easier to review.

Requires: https://github.com/sourcegraph/sourcegraph/pull/6135/files

Run `previewCampaignPlan` locally: [click here](http://localhost:3080/api/console#%7B%22query%22%3A%22mutation%20PreviewCombyCampaign(%24spec%3A%20CampaignPlanSpecification!)%20%7B%5Cn%20%20previewCampaignPlan(specification%3A%20%24spec)%20%7B%5Cn%20%20%20%20__typename%5Cn%20%20%20%20...%20on%20CampaignPlan%20%7B%5Cn%20%20%20%20%20%20...CampaignPlanFields%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cnfragment%20CampaignPlanFields%20on%20CampaignPlan%20%7B%5Cn%20%20id%5Cn%20%20type%5Cn%20%20arguments%5Cn%20%20status%20%7B%5Cn%20%20%20%20completedCount%5Cn%20%20%20%20pendingCount%5Cn%20%20%20%20state%5Cn%20%20%20%20errors%5Cn%20%20%7D%5Cn%20%20changesets%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%5Cn%20%20%20%20%20%20title%5Cn%20%20%20%20%20%20body%5Cn%20%20%20%20%20%20diff%20%7B%5Cn%20%20%20%20%20%20%20%20fileDiffs%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20hunks%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20body%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20repository%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%20%20url%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D)

```graphql
mutation PreviewCombyCampaign($spec: CampaignPlanSpecification!) {
  previewCampaignPlan(specification: $spec) {
    __typename
    ... on CampaignPlan {
      ...CampaignPlanFields
    }
  }
}

fragment CampaignPlanFields on CampaignPlan {
  id
  type
  arguments
  status {
    completedCount
    pendingCount
    state
    errors
  }
  changesets {
    nodes {
      
      title
      body
      diff {
        fileDiffs {
          nodes {
            hunks {
              body
            }
          }
        }
      }
      repository {
        name
        url
      }
    }
  }
}

```