### PR TITLE
fix: broken suggestions due to empty language suggestions

### DIFF
--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -22,6 +22,7 @@ import { createSuggestion, Suggestion, SuggestionItem } from './Suggestion'
 import RegexpToggle from './RegexpToggle'
 import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { PatternTypeProps } from '..'
+import { isDefined } from '../../../../shared/src/util/types'
 
 /**
  * The query input field is clobbered and updated to contain this subject's values, as

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -136,7 +136,7 @@ export class QueryInput extends React.Component<Props, State> {
                             map(createSuggestion),
                             filter((suggestion): suggestion is Suggestion => !!suggestion),
                             toArray(),
-                            map((suggestions: Suggestion[]) => ({
+                            map(suggestions => ({
                                 suggestions,
                                 selectedSuggestion: -1,
                                 hideSuggestions: false,

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -18,7 +18,7 @@ import { Key } from 'ts-key-enum'
 import { eventLogger } from '../../tracking/eventLogger'
 import { scrollIntoView } from '../../util'
 import { fetchSuggestions } from '../backend'
-import { createSuggestion, Suggestion, SuggestionItem, LangSuggestion } from './Suggestion'
+import { createSuggestion, Suggestion, SuggestionItem } from './Suggestion'
 import RegexpToggle from './RegexpToggle'
 import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { PatternTypeProps } from '..'
@@ -134,9 +134,9 @@ export class QueryInput extends React.Component<Props, State> {
                             .join(' ')
                         return fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
-                            filter((suggestion): suggestion is Exclude<Suggestion, LangSuggestion> => !!suggestion),
+                            filter((suggestion): suggestion is Suggestion => !!suggestion),
                             toArray(),
-                            map((suggestions: Exclude<Suggestion, LangSuggestion>[]) => ({
+                            map((suggestions: Suggestion[]) => ({
                                 suggestions,
                                 selectedSuggestion: -1,
                                 hideSuggestions: false,

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -134,7 +134,7 @@ export class QueryInput extends React.Component<Props, State> {
                             .join(' ')
                         return fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
-                            filter((suggestion): suggestion is Suggestion => !!suggestion),
+                            filter(isDefined),
                             toArray(),
                             map(suggestions => ({
                                 suggestions,

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -134,6 +134,7 @@ export class QueryInput extends React.Component<Props, State> {
                             .join(' ')
                         return fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
+                            filter(suggestion => suggestion.type !== 'lang'),
                             toArray(),
                             map((suggestions: Suggestion[]) => ({
                                 suggestions,

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -18,7 +18,7 @@ import { Key } from 'ts-key-enum'
 import { eventLogger } from '../../tracking/eventLogger'
 import { scrollIntoView } from '../../util'
 import { fetchSuggestions } from '../backend'
-import { createSuggestion, Suggestion, SuggestionItem } from './Suggestion'
+import { createSuggestion, Suggestion, SuggestionItem, LangSuggestion } from './Suggestion'
 import RegexpToggle from './RegexpToggle'
 import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { PatternTypeProps } from '..'
@@ -134,9 +134,9 @@ export class QueryInput extends React.Component<Props, State> {
                             .join(' ')
                         return fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
-                            filter(suggestion => suggestion.type !== 'lang'),
+                            filter((suggestion): suggestion is Exclude<Suggestion, LangSuggestion> => !!suggestion),
                             toArray(),
-                            map((suggestions: Suggestion[]) => ({
+                            map((suggestions: Exclude<Suggestion, LangSuggestion>[]) => ({
                                 suggestions,
                                 selectedSuggestion: -1,
                                 hideSuggestions: false,

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -39,13 +39,13 @@ interface DirSuggestion extends BaseSuggestion {
     type: 'dir'
 }
 
-interface LangSuggestion extends BaseSuggestion {
+export interface LangSuggestion extends BaseSuggestion {
     type: 'lang'
 }
 
 export type Suggestion = SymbolSuggestion | RepoSuggestion | FileSuggestion | DirSuggestion | LangSuggestion
 
-export function createSuggestion(item: GQL.SearchSuggestion): Suggestion {
+export function createSuggestion(item: GQL.SearchSuggestion): Exclude<Suggestion, LangSuggestion> | undefined {
     switch (item.__typename) {
         case 'Repository': {
             return {
@@ -91,19 +91,13 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion {
                 urlLabel: 'go to definition',
             }
         }
-        case 'Language': {
-            return {
-                type: 'lang',
-                title: item.name,
-                url: '', // TODO:
-                urlLabel: '', // TODO:
-            }
-        }
+        default:
+            return undefined
     }
 }
 
 interface SuggestionIconProps {
-    suggestion: Suggestion
+    suggestion: Exclude<Suggestion, LangSuggestion>
     className?: string
 }
 
@@ -117,8 +111,6 @@ const SuggestionIcon: React.FunctionComponent<SuggestionIconProps> = ({ suggesti
             return <SymbolIcon kind={GQL.SymbolKind.FILE} {...passThru} />
         case 'symbol':
             return <SymbolIcon kind={suggestion.kind} {...passThru} />
-        case 'lang':
-            return null // TODO: handle lang suggestions in RFC 14 frontend PR.
     }
 }
 

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -88,6 +88,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             }
         }
         default:
+            // TODO: Handle language suggestions
             return undefined
     }
 }

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -39,13 +39,9 @@ interface DirSuggestion extends BaseSuggestion {
     type: 'dir'
 }
 
-export interface LangSuggestion extends BaseSuggestion {
-    type: 'lang'
-}
+export type Suggestion = SymbolSuggestion | RepoSuggestion | FileSuggestion | DirSuggestion
 
-export type Suggestion = SymbolSuggestion | RepoSuggestion | FileSuggestion | DirSuggestion | LangSuggestion
-
-export function createSuggestion(item: GQL.SearchSuggestion): Exclude<Suggestion, LangSuggestion> | undefined {
+export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undefined {
     switch (item.__typename) {
         case 'Repository': {
             return {
@@ -97,7 +93,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Exclude<Suggestion
 }
 
 interface SuggestionIconProps {
-    suggestion: Exclude<Suggestion, LangSuggestion>
+    suggestion: Suggestion
     className?: string
 }
 
@@ -131,19 +127,13 @@ export const SuggestionItem: React.FunctionComponent<SuggestionProps> = ({
     isSelected,
     onClick,
     liRef,
-}) => {
-    if (suggestion.type === 'lang') {
-        // TODO: handle lang suggestions in RFC 14 frontend PR.
-        return null
-    }
-    return (
-        <li className={'suggestion' + (isSelected ? ' suggestion--selected' : '')} onMouseDown={onClick} ref={liRef}>
-            <SuggestionIcon className="icon-inline suggestion__icon" suggestion={suggestion} />
-            <div className="suggestion__title">{suggestion.title}</div>
-            <div className="suggestion__description">{suggestion.description}</div>
-            <div className="suggestion__action" hidden={!isSelected}>
-                <kbd>enter</kbd> {suggestion.urlLabel}
-            </div>
-        </li>
-    )
-}
+}) => (
+    <li className={'suggestion' + (isSelected ? ' suggestion--selected' : '')} onMouseDown={onClick} ref={liRef}>
+        <SuggestionIcon className="icon-inline suggestion__icon" suggestion={suggestion} />
+        <div className="suggestion__title">{suggestion.title}</div>
+        <div className="suggestion__description">{suggestion.description}</div>
+        <div className="suggestion__action" hidden={!isSelected}>
+            <kbd>enter</kbd> {suggestion.urlLabel}
+        </div>
+    </li>
+)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6126.

I was/still am not able to get a completely reliable repro on the issue, but when it did occur, I found that we were returning empty `lang` suggestions, added in https://github.com/sourcegraph/sourcegraph/pull/5859. When we got these lang suggestions on the frontend, we handled them by returning `null` instead of a search row, causing there to be a bunch of empty, but selectable, entries in the DOM.
