### PR TITLE
Define statuses for RFCs

### DIFF
--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -8,14 +8,14 @@ _All RFCs are in a [public Google Drive folder](https://drive.google.com/drive/f
 
 ## Status
 
-Each RFC has a status that is in the title of the RFC (e.g. "RFC 1: WIP Title").
+Each RFC has a status that is in the title of the RFC (e.g. "RFC 1: WIP Title"). The author is responsible for keeping the status updated.
 
 | Status | Description |
 |-------|-------------|
 | WIP | The author is still drafting the RFC and it is not ready for review. |
-| REVIEW | The RFC is ready to be reviewed. The RFC explicitly lists who the expected reviewers are and a desired timeline for review comments. |
-| APPROVED | All comment threads are resolved and the content of the RFC has been approved by the necessary reviewers (i.e. they added their names to the approvers list).|
-| ABANDONED | There are no plans to move forward with this RFC. For example, the RFC may have failed to get the the necessary approvals, it may have been superseded by another RFC, or we may not have resources to work on this RFC in the forseeable future. |
+| REVIEW | The RFC is ready to be reviewed. The RFC explicitly lists whose approvals are required and a requested timeline for those approvals. |
+| APPROVED | All comment threads are resolved and the RFC has been approved by all required approvers. Just because an RFC is approved doesn't mean it will definitely be implemented (e.g. priorities may change, or new information might be discovered during implementation or code review that causes a change in plan). It is in the author's best interest to avoid suprises at code review time by ensuring the RFC has a sufficient level of detail and has approval from all relevant stakeholders. |
+| ABANDONED | There are no plans to move forward with this RFC. The particular reason is communicated in the metadata section of the RFC. For example, the RFC may have failed to get the necessary approvals, it may be been superseded by another RFC, priorities may have changed, or we may not have resources to work on this RFC in the forseeable future. |
 | IMPLEMENTED | This RFC has been implemented. |
 
 A prose description of the status appears in the [metadata](#RFC-structure) of an RFC.
@@ -78,8 +78,8 @@ Effective RFCs contain the following information:
     - "We aren't going to pursue this RFC for the following reasons..."
     - "The web team is going to implement this RFC in 3.8."
     - "This RFC has been implemented."
-  - Reviewers: The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Reviewers: Alice and Bob can you please review by 10am PT 10/21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message).
-  - Approvers: RFC readers add their name to this list if they understand what the RFC is proposing and agree with the proposal. Anyone can express approval for an RFC, even if they are not in the "Reviewers" list; however a RFC is not APPROVED until the RFC author receives approval from the people on the "Approvers" list.
+  - Required approvers: The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Required approvers: Alice and Bob can you please review by 10am PT 10/21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message).
+  - Approvals: A list of people who approve of this RFC. Anyone can express approval for an RFC, even if they are not in the "Required approvers" list; however, a RFC is not APPROVED until the RFC author receives approval from the people on the "Required approvers" list.
   - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
 - Background/Situation: A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
 - Problem/Goals/Complication/Constraints: A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -6,15 +6,19 @@ This document describes how we operationalize written planning through our RFC p
 
 _All RFCs are in a [public Google Drive folder](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR)._
 
-## Lifecycle
+## Status
 
-The general lifecycle of an RFC is:
+Each RFC has a status that is in the title of the RFC (e.g. "RFC 1: WIP Title").
 
-   1. Write a draft.
-   2. Solicit feedback from relevant teammates.
-   3. Update draft and go to step 2.
-   4. Make a decision.
-   5. If appropriate, file tracking issues on GitHub and add them to appropriate milestones.
+| Status | Description |
+|-------|-------------|
+| WIP | The author is still drafting the RFC and it is not ready for review. |
+| REVIEW | The RFC is ready to be reviewed. The RFC explicitly lists who the expected reviewers are and a desired timeline for review comments. |
+| APPROVED | All comment threads are resolved and the content of the RFC has been approved by the necessary reviewers (i.e. they added their names to the approvers list).|
+| ABANDONED | There are no plans to move forward with this RFC. The RFC may have failed to get the the necessary approvals, or we may not have resources to work on this RFC in the forseeable future. |
+| IMPLEMENTED | This RFC has been implemented. |
+
+A prose description of the status appears in the [metadata](#RFC-structure) of an RFC.
 
 ## RFCs are sequentially numbered
 
@@ -74,7 +78,8 @@ Effective RFCs contain the following information:
     - "We aren't going to pursue this RFC for the following reasons..."
     - "The web team is going to implement this RFC in 3.8."
     - "This RFC has been implemented."
-  - LGTM: RFC readers add their name to this list if they understand what the RFC is proposing and agree with the proposal. "Looks Good To Me".
+  - Reviewers: The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Reviewers: Alice and Bob can you please review by 10am PT 10/21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message).
+  - Approvers: RFC readers add their name to this list if they understand what the RFC is proposing and agree with the proposal. Anyone can express approval for an RFC, even if they are not in the "Reviewers" list; however a RFC is not APPROVED until the RFC author receives approval from the people on the "Approvers" list.
   - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
 - Background/Situation: A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
 - Problem/Goals/Complication/Constraints: A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -78,7 +78,7 @@ Effective RFCs contain the following information:
     - "We aren't going to pursue this RFC for the following reasons..."
     - "The web team is going to implement this RFC in 3.8."
     - "This RFC has been implemented."
-  - Required approvers: The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Required approvers: Alice and Bob can you please review by 10am PT 10/21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message).
+  - Required approvers: The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Required approvers: Alice and Bob can you please review by 10am PT 10/21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message or tagging them in a comment on the Google Doc).
   - Approvals: A list of people who approve of this RFC. Anyone can express approval for an RFC, even if they are not in the "Required approvers" list; however, a RFC is not APPROVED until the RFC author receives approval from the people on the "Required approvers" list.
   - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
 - Background/Situation: A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -8,7 +8,7 @@ _All RFCs are in a [public Google Drive folder](https://drive.google.com/drive/f
 
 ## Status
 
-Each RFC has a status that is in the title of the RFC (e.g. "RFC 1: WIP Title"). The author is responsible for keeping the status updated.
+Each RFC has a status that is in the title of the RFC (e.g. "RFC 1 WIP: Title"). The author is responsible for keeping the status updated.
 
 | Status | Description |
 |-------|-------------|

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -15,7 +15,7 @@ Each RFC has a status that is in the title of the RFC (e.g. "RFC 1: WIP Title").
 | WIP | The author is still drafting the RFC and it is not ready for review. |
 | REVIEW | The RFC is ready to be reviewed. The RFC explicitly lists who the expected reviewers are and a desired timeline for review comments. |
 | APPROVED | All comment threads are resolved and the content of the RFC has been approved by the necessary reviewers (i.e. they added their names to the approvers list).|
-| ABANDONED | There are no plans to move forward with this RFC. The RFC may have failed to get the the necessary approvals, or we may not have resources to work on this RFC in the forseeable future. |
+| ABANDONED | There are no plans to move forward with this RFC. For example, the RFC may have failed to get the the necessary approvals, it may have been superseded by another RFC, or we may not have resources to work on this RFC in the forseeable future. |
 | IMPLEMENTED | This RFC has been implemented. |
 
 A prose description of the status appears in the [metadata](#RFC-structure) of an RFC.


### PR DESCRIPTION
I have received feedback from multiple people that our RFC process lacks clarity on when RFCs are "done" or "approved". 

This PR proposes standardized on a small number of statuses and adds more formality to the approval process.

If approved, I will update the titles of existing RFCs to use these terms.

@slimsag @efritz @unknwon IIRC you all had questions for me about this recently. Would these proposed changes address your concerns?