### PR TITLE
schemadoc: docker pull if image missing

### DIFF
--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -46,6 +46,16 @@ func generate(log *log.Logger) (string, error) {
 		defer runIgnoreError("dropdb", dbname)
 	} else {
 		log.Printf("Running PostgreSQL 9.6 in docker since local version is %s", strings.TrimSpace(string(out)))
+		if err := exec.Command("docker", "image", "inspect", "postgres:9.6").Run(); err != nil {
+			log.Println("docker pull postgres9.6")
+			pull := exec.Command("docker", "pull", "postgres:9.6")
+			pull.Stdout = log.Writer()
+			pull.Stderr = log.Writer()
+			if err := pull.Run(); err != nil {
+				return "", fmt.Errorf("docker pull postgres9.6 failed: %w", err)
+			}
+			log.Println("docker pull complete")
+		}
 		runIgnoreError("docker", "rm", "--force", dbname)
 		server := exec.Command("docker", "run", "--rm", "--name", dbname, "-p", "5433:5432", "postgres:9.6")
 		if err := server.Start(); err != nil {

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -30,12 +30,6 @@ explicit transaction blocks added to the migration script template.
 # Enter statements here
 ```
 
-If you're not running PostgreSQL 9.6 locally, pull the Docker image first:
-
-```
-docker pull postgres:9.6
-```
-
 After adding SQL statements to those files, embed them into the Go code and update the schema doc:
 
 ```


### PR DESCRIPTION
This is to avoid the 30s timeout we use for run.

Test Plan: Checked that the script worked with and without the image being presents:

```shell
docker pull postgres:9.6
go generate ./cmd/frontend/db
docker image rm postgres:9.6
go generate ./cmd/frontend/db
```
