### PR TITLE
endpoint: Introduce Static and GetMany function

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -271,7 +271,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Repos:        makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev"),
 		Query:        q,
 		Zoekt:        zoekt,
-		SearcherURLs: endpoint.New("test"),
+		SearcherURLs: endpoint.Static("test"),
 	}
 	results, common, err := searchFilesInRepos(context.Background(), args)
 	if err != nil {
@@ -301,7 +301,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Repos:        makeRepositoryRevisions("foo/no-rev@dev"),
 		Query:        q,
 		Zoekt:        zoekt,
-		SearcherURLs: endpoint.New("test"),
+		SearcherURLs: endpoint.Static("test"),
 	}
 	_, _, err = searchFilesInRepos(context.Background(), args)
 	if !gitserver.IsRevisionNotFound(errors.Cause(err)) {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -130,8 +130,11 @@ func (m *Map) Get(key string, exclude map[string]bool) (string, error) {
 	return urls.get(key, exclude), nil
 }
 
-// GetMany is the same as calling Get on each item of keys. However, it is
-// optimized to be faster.
+// GetMany is the same as calling Get on each item of keys. It will only
+// acquire the underlying endpoint map once, so is preferred to calling Get
+// for each key which will acquire the endpoint map for each call. The benefit
+// is it is faster (O(1) mutex acquires vs O(n)) and consistent (endpoint map
+// is immutable vs may change between Get calls).
 func (m *Map) GetMany(keys ...string) ([]string, error) {
 	urls, err := m.getUrls()
 	if err != nil {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -90,6 +90,19 @@ func New(urlspec string) *Map {
 	return m
 }
 
+// Static returns an Endpoint map which consistently hashes over endpoints.
+//
+// There are no requirements on endpoints, it can be any arbitrary
+// string. Unlike static endpoints created via New.
+//
+// Static Maps are guaranteed to never return an error.
+func Static(endpoints ...string) *Map {
+	return &Map{
+		urlspec: fmt.Sprintf("%v", endpoints),
+		urls:    newConsistentHashMap(endpoints),
+	}
+}
+
 // Empty returns an Endpoint map which always fails with err.
 func Empty(err error) *Map {
 	return &Map{
@@ -115,6 +128,21 @@ func (m *Map) Get(key string, exclude map[string]bool) (string, error) {
 	}
 
 	return urls.get(key, exclude), nil
+}
+
+// GetMany is the same as calling Get on each item of keys. However, it is
+// optimized to be faster.
+func (m *Map) GetMany(keys ...string) ([]string, error) {
+	urls, err := m.getUrls()
+	if err != nil {
+		return nil, err
+	}
+
+	vals := make([]string, len(keys))
+	for i := range keys {
+		vals[i] = urls.get(keys[i], nil)
+	}
+	return vals, nil
 }
 
 // Endpoints returns a set of all addresses. Do not modify the returned value.


### PR DESCRIPTION
`Static` is the same behaviour as calling `endpoint.New` with space separated arguments, but instead the type is lifted from parsing a string into a go slice.

`GetMany` will be used by our horizontal sharding to more efficiently map the set of repositories to shards.

Both changes are useful for the changes in zoekt horizontal sharding.

Test plan: go test

Part of #5725