### PR TITLE
Gitlab: don't use gon in the browser extension

### DIFF
--- a/browser/src/libs/gitlab/scrape.ts
+++ b/browser/src/libs/gitlab/scrape.ts
@@ -3,6 +3,7 @@ import { last, take } from 'lodash'
 import { FileSpec, RawRepoSpec, RevSpec } from '../../../../shared/src/util/url'
 import { commitIDFromPermalink } from '../../shared/util/dom'
 import { FileInfo } from '../code_intelligence'
+import { isExtension } from '../../context'
 
 export enum GitLabPageKind {
     File,
@@ -50,10 +51,12 @@ export function getPageInfo(): GitLabInfo {
         pageKind = GitLabPageKind.File
     }
 
+    const hostname = isExtension ? window.location.hostname : new URL(gon.gitlab_url).hostname
+
     return {
         owner,
         projectName,
-        rawRepoName: [new URL(gon.gitlab_url).hostname, owner, projectName].join('/'),
+        rawRepoName: [hostname, owner, projectName].join('/'),
         pageKind,
     }
 }


### PR DESCRIPTION
Browser extension content scripts cannot access global variables from page scripts. Accessing `gon.gitlab_url` in the browser extension caused a ReferenceError.
