### PR TITLE
Search: use named search type selector.

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -305,26 +305,29 @@ func Test_defaultRepositories(t *testing.T) {
 	}
 }
 
-func Test_defaultToRegexp(t *testing.T) {
+func Test_detectSearchType(t *testing.T) {
 	typeRegexp := "regexp"
 	typeLiteral := "literal"
 	testCases := []struct {
 		name        string
 		version     string
 		patternType *string
-		want        bool
+		input       string
+		want        string
 	}{
-		{"V1, no pattern type", "V1", nil, true},
-		{"V2, no pattern type", "V2", nil, false},
-		{"V1, regexp pattern type", "V1", &typeRegexp, true},
-		{"V2, regexp pattern type", "V2", &typeRegexp, true},
-		{"V1, literal pattern type", "V1", &typeLiteral, false},
-		{"V2, regexp pattern type", "V2", &typeLiteral, false},
+		{"V1, no pattern type", "V1", nil, "", "regexp"},
+		{"V2, no pattern type", "V2", nil, "", "literal"},
+		{"V1, regexp pattern type", "V1", &typeRegexp, "", "regexp"},
+		{"V2, regexp pattern type", "V2", &typeRegexp, "", "regexp"},
+		{"V1, literal pattern type", "V1", &typeLiteral, "", "literal"},
+		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", "regexp"},
+		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", "regexp"},
+		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", "literal"},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(*testing.T) {
-			got, err := defaultToRegexp(test.version, test.patternType)
+			got, err := detectSearchType(test.version, test.patternType, test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -8,59 +8,37 @@ import (
 
 var fieldRx = regexp.MustCompile(`^-?[a-zA-Z]+:`)
 
-// HandlePatternType returns a modified version of the input query where it has
-// been either quoted because it has patternType:literal, not quoted because it
-// has patternType:regex, or been possibly quoted in the default case according
-// to the defaultToRegexp parameter.
-func HandlePatternType(input string, defaultToRegexp bool) (string, bool) {
+// ConvertToLiteral quotes the input query for literal search.
+func ConvertToLiteral(input string) string {
 	tokens := tokenize(input)
-	isRegex := defaultToRegexp
-	var tokens2 []string
+	// Sort the tokens into fields and non-fields.
+	var fields, nonFields []string
 	for _, t := range tokens {
-		switch strings.ToLower(t) {
-		case "patterntype:regex":
-			isRegex = true
-		case "patterntype:regexp":
-			isRegex = true
-		case "patterntype:literal":
-			isRegex = false
-		default:
-			tokens2 = append(tokens2, t)
+		if fieldRx.MatchString(t) {
+			fields = append(fields, t)
+		} else {
+			nonFields = append(nonFields, t)
 		}
 	}
-	if isRegex {
-		// Rebuild the input from the remaining tokens.
-		input = strings.TrimSpace(strings.Join(tokens2, ""))
-	} else {
-		// Sort the tokens into fields and non-fields.
-		var fields, nonFields []string
-		for _, t := range tokens2 {
-			if fieldRx.MatchString(t) {
-				fields = append(fields, t)
-			} else {
-				nonFields = append(nonFields, t)
-			}
-		}
 
-		// Rebuild the input as fields followed by non-fields quoted together.
-		var pieces []string
-		if len(fields) > 0 {
-			pieces = append(pieces, strings.Join(fields, " "))
-		}
-		if len(nonFields) > 0 {
-			// Count up the number of non-whitespace tokens in the nonFields slice.
-			q := strings.Join(nonFields, "")
-			q = strings.TrimSpace(q)
-			q = strings.ReplaceAll(q, `\`, `\\`)
-			q = strings.ReplaceAll(q, `"`, `\"`)
-			q = fmt.Sprintf(`"%s"`, q)
-			if q != `""` {
-				pieces = append(pieces, q)
-			}
-		}
-		input = strings.Join(pieces, " ")
+	// Rebuild the input as fields followed by non-fields quoted together.
+	var pieces []string
+	if len(fields) > 0 {
+		pieces = append(pieces, strings.Join(fields, " "))
 	}
-	return input, isRegex
+	if len(nonFields) > 0 {
+		// Count up the number of non-whitespace tokens in the nonFields slice.
+		q := strings.Join(nonFields, "")
+		q = strings.TrimSpace(q)
+		q = strings.ReplaceAll(q, `\`, `\\`)
+		q = strings.ReplaceAll(q, `"`, `\"`)
+		q = fmt.Sprintf(`"%s"`, q)
+		if q != `""` {
+			pieces = append(pieces, q)
+		}
+	}
+	input = strings.Join(pieces, " ")
+	return input
 }
 
 var tokenRx = regexp.MustCompile(`("([^"\\]|[\\].)*"|\s+|\S+)`)

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestHandlePatternType_Literal(t *testing.T) {
+func TestConvertToLiteral(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -49,7 +49,7 @@ func TestHandlePatternType_Literal(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			out := ConvertToLiteral(test.input)
 			if out != test.want {
-				t.Errorf("handlePatternType (%q) = %q, want %q", test.input, out, test.want)
+				t.Errorf("ConverToLiteral (%q) = %q, want %q", test.input, out, test.want)
 			}
 		})
 	}

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -49,7 +49,7 @@ func TestConvertToLiteral(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			out := ConvertToLiteral(test.input)
 			if out != test.want {
-				t.Errorf("ConverToLiteral (%q) = %q, want %q", test.input, out, test.want)
+				t.Errorf("ConvertToLiteral (%q) = %q, want %q", test.input, out, test.want)
 			}
 		})
 	}

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -7,74 +7,49 @@ import (
 
 func TestHandlePatternType_Literal(t *testing.T) {
 	tests := []struct {
-		input           string
-		defaultToRegexp bool
-		want            string
+		input string
+		want  string
 	}{
-		{"", false, ""},
-		{" ", false, ""},
-		{"  ", false, ""},
-		{`a`, false, `"a"`},
-		{` a`, false, `"a"`},
-		{`a `, false, `"a"`},
-		{` a `, false, `"a"`},
-		{` a b`, false, `"a b"`},
-		{`a  b`, false, `"a  b"`},
-		{"a\tb", false, "\"a\tb\""},
-		{`:`, false, `":"`},
-		{`:=`, false, `":="`},
-		{`:= range`, false, `":= range"`},
-		{"`", false, "\"`\""},
-		{`'`, false, `"'"`},
-		{`:`, false, `":"`},
-		{"f:a", false, "f:a"},
-		{`"f:a"`, false, `"\"f:a\""`},
-		{"r:b r:c", false, "r:b r:c"},
-		{"r:b -r:c", false, "r:b -r:c"},
-		{"patterntype:regex", false, ""},
-		{"patterntype:regexp", false, ""},
-		{"patterntype:literal", false, ""},
-		{"patterntype:literal", true, ""},
-		{"patterntype:regexp patterntype:literal .*", false, `".*"`},
-		{"patterntype:regexp patterntype:literal .*", false, `".*"`},
-		{"patterntype:regexp patterntype:literal .*", true, `".*"`},
-		{`patterntype:regexp "patterntype:literal"`, false, `"patterntype:literal"`},
-		{`patterntype:regexp "patterntype:regexp"`, false, `"patterntype:regexp"`},
-		{`patterntype:literal "patterntype:regexp"`, false, `"\"patterntype:regexp\""`},
-		{"patterntype:regexp .*", false, ".*"},
-		{"patterntype:regexp .* ", false, ".*"},
-		{"patterntype:regexp .* .*", false, ".* .*"},
-		{"patterntype:regexp .*  .*", false, ".*  .*"},
-		{"patterntype:regexp .*\t.*", false, ".*\t.*"},
-		{".* patterntype:regexp .*", false, ".*  .*"},
-		{".* patterntype:regexp", false, ".*"},
-		{"patterntype:regexp .*", false, ".*"},
-		{"patterntype:regexp .* ", false, ".*"},
-		{"patterntype:regexp .* .*", false, ".* .*"},
-		{"patterntype:regexp .*  .*", false, ".*  .*"},
-		{"patterntype:regexp .*\t.*", false, ".*\t.*"},
-		{".* patterntype:regexp .*", false, ".*  .*"},
-		{".* patterntype:regexp", false, ".*"},
-		{"patterntype:literal .*", false, `".*"`},
-		{"patterntype:literal .*", true, `".*"`},
-		{`lang:go func main`, false, `lang:go "func main"`},
-		{`lang:go func  main`, false, `lang:go "func  main"`},
-		{`func main lang:go`, false, `lang:go "func main"`},
-		{`func  main lang:go`, false, `lang:go "func  main"`},
-		{`func lang:go main`, false, `lang:go "func  main"`},
+		{"", ""},
+		{" ", ""},
+		{"  ", ""},
+		{`a`, `"a"`},
+		{` a`, `"a"`},
+		{`a `, `"a"`},
+		{` a `, `"a"`},
+		{` a b`, `"a b"`},
+		{`a  b`, `"a  b"`},
+		{"a\tb", "\"a\tb\""},
+		{`:`, `":"`},
+		{`:=`, `":="`},
+		{`:= range`, `":= range"`},
+		{"`", "\"`\""},
+		{`'`, `"'"`},
+		{`:`, `":"`},
+		{"f:a", "f:a"},
+		{`"f:a"`, `"\"f:a\""`},
+		{"r:b r:c", "r:b r:c"},
+		{"r:b -r:c", "r:b -r:c"},
+		{".*", `".*"`},
+		{`a:b "patterntype:regexp"`, `a:b "\"patterntype:regexp\""`},
+		{`lang:go func main`, `lang:go "func main"`},
+		{`lang:go func  main`, `lang:go "func  main"`},
+		{`func main lang:go`, `lang:go "func main"`},
+		{`func  main lang:go`, `lang:go "func  main"`},
+		{`func lang:go main`, `lang:go "func  main"`},
 		// Searching for \n in literal mode brings back literal matches for backslash followed by n.
-		{`\n`, false, `"\\n"`},
-		{`\t`, false, `"\\t"`},
-		{`\`, false, `"\\"`},
-		{`foo\d "bar*"`, false, `"foo\\d \"bar*\""`},
-		{`\d`, false, `"\\d"`},
+		{`\n`, `"\\n"`},
+		{`\t`, `"\\t"`},
+		{`\`, `"\\"`},
+		{`foo\d "bar*"`, `"foo\\d \"bar*\""`},
+		{`\d`, `"\\d"`},
 	}
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			out, _ := HandlePatternType(test.input, test.defaultToRegexp)
+			out := ConvertToLiteral(test.input)
 			if out != test.want {
-				t.Errorf("handlePatternType (%q), with defaultToRegexp %t = %q, want %q", test.input, test.defaultToRegexp, out, test.want)
+				t.Errorf("handlePatternType (%q) = %q, want %q", test.input, out, test.want)
 			}
 		})
 	}

--- a/cmd/frontend/internal/pkg/search/query/syntax/parse_tree.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/parse_tree.go
@@ -14,6 +14,17 @@ func (p ParseTree) String() string {
 	return ExprString(p)
 }
 
+// Values returns the raw string values associated with a field.
+func (p ParseTree) Values(field string) []string {
+	var v []string
+	for _, expr := range p {
+		if expr.Field == field {
+			v = append(v, expr.Value)
+		}
+	}
+	return v
+}
+
 // WithErrorsQuoted converts a search input like `f:foo b(ar` to `f:foo "b(ar"`.
 func (p ParseTree) WithErrorsQuoted() ParseTree {
 	p2 := []*Expr{}


### PR DESCRIPTION
We should use a string type instead of a boolean flag to indicate the search kind (whether regex, literal, or soon, structural). This PR:

- converts the `isRegexp` flag to `searchType`
- extracts the logic in `pattern_type.go` that overrides the searchType based on the `patterntype` field to the the new function `detectSearchType`. This function uses the query parser, not regex patterns, to get the field values of `patterntype`.

- Side effect: separates the `ParseAndCheck` function, because we need `Parse` to be separately exposed for checking `patterntype`.

Test plan: 

- Updates tests and removes tests for `pattern_type.go` that don't make sense with the new structure (checking, e.g., `patterntype`).