### PR TITLE
Search: pull out search interface

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -40,7 +40,6 @@ import (
 
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
-//
 
 func maxReposToSearch() int {
 	switch max := conf.Get().MaxReposToSearch; {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -41,9 +41,6 @@ import (
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
 //
-// NOTE: This file and most supporting code will be deleted when search2.go is
-// rolled out. However, right now to understand search and fix bugs in it you
-// should start here.
 
 func maxReposToSearch() int {
 	switch max := conf.Get().MaxReposToSearch; {
@@ -55,19 +52,23 @@ func maxReposToSearch() int {
 	}
 }
 
-// Search provides search results and suggestions.
-func (r *schemaResolver) Search(args *struct {
+type searchArgs struct {
 	Version     string
 	PatternType *string
 	Query       string
 	After       *graphql.ID
 	First       *int32
-}) (interface {
+}
+
+type searchIntf interface {
 	Results(context.Context) (*searchResultsResolver, error)
 	Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	Stats(context.Context) (*searchResultsStats, error)
-}, error) {
+}
+
+// Search provides search results and suggestions.
+func (r *schemaResolver) Search(args *searchArgs) (searchIntf, error) {
 	tr, _ := trace.New(context.Background(), "graphql.schemaResolver", "Search")
 	defer tr.Finish()
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/zoekt"
 	zoektrpc "github.com/google/zoekt/rpc"
-	"github.com/graph-gophers/graphql-go"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
@@ -29,13 +28,7 @@ func TestSearchResults(t *testing.T) {
 	limitOffset := &db.LimitOffset{Limit: maxReposToSearch() + 1}
 
 	getResults := func(t *testing.T, query, version string) []string {
-		r, err := (&schemaResolver{}).Search(&struct {
-			Version     string
-			PatternType *string
-			Query       string
-			After       *graphql.ID
-			First       *int32
-		}{Query: query, Version: version})
+		r, err := (&schemaResolver{}).Search(&searchArgs{Query: query, Version: version})
 		if err != nil {
 			t.Fatal("Search:", err)
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"testing"
 
-	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
@@ -21,13 +20,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 	getSuggestions := func(t *testing.T, query, version string) []string {
 		t.Helper()
-		r, err := (&schemaResolver{}).Search(&struct {
-			Version     string
-			PatternType *string
-			Query       string
-			After       *graphql.ID
-			First       *int32
-		}{Query: query, Version: version})
+		r, err := (&schemaResolver{}).Search(&searchArgs{Query: query, Version: version})
 		if err != nil {
 			t.Fatal("Search:", err)
 		}
@@ -122,13 +115,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 	// This test is only valid for Regexp searches. Literal searches won't return suggestions for an invalid regexp.
 	t.Run("single term invalid regex", func(t *testing.T) {
-		sr, err := (&schemaResolver{}).Search(&struct {
-			Version     string
-			PatternType *string
-			Query       string
-			After       *graphql.ID
-			First       *int32
-		}{Query: "[foo", PatternType: nil, Version: "V1"})
+		sr, err := (&schemaResolver{}).Search(&searchArgs{Query: "[foo", PatternType: nil, Version: "V1"})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Use dedicated types to improve readability. Also deleted a comment about `search2.go`

Test plan: Tests pass.
