### PR TITLE
Update FilteredConnection to support forward direction cursor-paging

### DIFF
--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -493,7 +493,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         // connection, if appendResults is set, the previous page is not
                         // stale, and neither the connection nor the current page are an
                         // error-like value.
-                        const combineResults = (newC: C | ErrorLike | undefined): C | ErrorLike | undefined => {
+                        const appendResultsToPage = (newC: C | ErrorLike | undefined): typeof newC => {
                             if (this.props.appendResults && !this.state.stalePreviousPage) {
                                 const oldC = this.state.connectionOrError
                                 if (newC && !isErrorLike(newC) && oldC && !isErrorLike(oldC)) {
@@ -515,7 +515,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 catchError(error => [asError(error)]),
                                 map(
                                     (c): PartialStateUpdate => ({
-                                        connectionOrError: combineResults(c),
+                                        connectionOrError: appendResultsToPage(c),
                                         connectionQuery: query,
                                         loading: false,
                                     })

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -508,6 +508,9 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                     switchMap(({ query, filter, shouldRefresh, queryCount }) => {
                         const result = this.props
                             .queryConnection({
+                                // If this is our first query and we were supplied a value for `visible`,
+                                // load that many results. If we weren't given such a value or this is a
+                                // subsequent request, only ask for one page of results.
                                 first: (queryCount === 1 && this.state.visible) || this.state.first,
                                 after: shouldRefresh ? undefined : this.state.after,
                                 query,
@@ -538,7 +541,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                     }),
                     scan<PartialStateUpdate & { shouldRefresh: boolean }, PartialStateUpdate & { previousPage: N[] }>(
                         ({ previousPage }, { shouldRefresh, connectionOrError, ...rest }) => {
-                            let nodes: N[] = []
+                            let nodes: N[] = previousPage
                             let after: string | undefined
 
                             if (this.props.cursorPaging && connectionOrError && !isErrorLike(connectionOrError)) {

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -417,7 +417,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             first: parseQueryInt(q, 'first') || this.props.defaultFirst!,
 
             // Note: Do not set after from the URL, as this doesn't track the number
-            // of results on the previous page. This makes teh count look broken when
+            // of results on the previous page. This makes the count look broken when
             // coming to a page in the middle of a set of results.
             //
             // For example:

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -529,7 +529,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                     previousPagesCount: this.state.queried
                                         ? shouldRefresh
                                             ? 0
-                                            : this.state.previousPage.length 
+                                            : this.state.previousPage.length
                                         : this.state.previousPagesCount,
                                 }),
                                 hash: this.props.location.hash,
@@ -552,7 +552,6 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                             })
                             .pipe(
                                 catchError(error => [asError(error)]),
-                                tap(() => this.setState({ queried: true })),
                                 mergeMap(
                                     async (c: C | ErrorLike): Promise<PartialStateUpdate> => {
                                         // If we're paging with cursors and we have a new set of results,
@@ -566,6 +565,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                                             ? c.nodes
                                                             : state.previousPage.concat(c.nodes),
                                                         after: (c.pageInfo && c.pageInfo.endCursor) || undefined,
+                                                        queried: true,
                                                     }),
                                                     () => {
                                                         // Update the connection's nodes to the concatenated set of results.

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -587,7 +587,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             this.showMoreClicks
                 .pipe(
                     map(() =>
-                        // If after is set, then it's the endCursor from the previous request.
+                        // If `after` is set, then it's the endCursor from the previous request.
                         // Use this and do not change the first (page size) parameter. Otherwise,
                         // we'll fallback to our legacy 'request-more' paging technique and not
                         // supply a cursor to the subsequent request.

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -123,7 +123,7 @@ interface ConnectionStateCommon {
 
     /**
      * The number of results that were visible from previous requests. The initial request of
-     * a result set will load `visible items, then will request `first` items on each subsequent
+     * a result set will load `visible` items, then will request `first` items on each subsequent
      * request. This has the effect of loading the correct number of visible results when a URL
      * is copied during pagination. This value is only useful with cursor-based paging.
      */

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -569,6 +569,11 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                             connectionOrError: c,
                                             connectionQuery: query,
                                             loading: false,
+                                            // If our response has a page info object, try to pull the end cursor out of
+                                            // it so we can pass it to the subsequent request.
+                                            ...(c && !isErrorLike(c) && c.pageInfo
+                                                ? { after: c.pageInfo.endCursor || undefined }
+                                                : {}),
                                         }
                                     }
                                 ),
@@ -595,23 +600,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         }
                     })
                 )
-                .subscribe(
-                    stateUpdate => {
-                        // If our response has a page info object, try to pull the end cursor out of
-                        // it so we can pass it to the subsequent request.
-                        let additionalUpdates = {}
-                        const c = stateUpdate.connectionOrError
-                        if (c && !isErrorLike(c) && c.pageInfo) {
-                            additionalUpdates = { after: c.pageInfo.endCursor || undefined }
-                        }
-
-                        this.setState({
-                            ...stateUpdate,
-                            ...additionalUpdates,
-                        })
-                    },
-                    err => console.error(err)
-                )
+                .subscribe(stateUpdate => this.setState(stateUpdate), err => console.error(err))
         )
 
         this.subscriptions.add(

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -119,7 +119,7 @@ interface ConnectionStateCommon {
 
     connectionQuery?: string
 
-    /** The `endCursor` value from the previous request. */
+    /** The `PageInfo.endCursor` value from the previous request. */
     after?: string
 
     /**

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -416,7 +416,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             activeFilter: getFilterFromURL(q, this.props.filters),
             first: parseQueryInt(q, 'first') || this.props.defaultFirst!,
 
-            // Note: Do not set after from the URL, as this doesn't track the number
+            // Note: Do not set `after` from the URL, as this doesn't track the number
             // of results on the previous page. This makes the count look broken when
             // coming to a page in the middle of a set of results.
             //

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -81,7 +81,7 @@ interface ConnectionDisplayProps {
     /** The component displayed when the list of nodes is empty. */
     emptyElement?: JSX.Element
 
-    /** Append new results onto existing list when paging with cursors. */
+    /** Append new results onto existing list. This should always be true when paging with cursors. */
     appendResults?: boolean
 }
 
@@ -467,7 +467,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         // The number of additional results we want to load on the first query. This is used instead of encoding
         // the `after` parameter so that we load the entire visible result set again when a user has loaded multiple
         // pages of results and copied the URL.
-        let previousPagesCount = parseQueryInt(q, 'previousPagesCount') || 0
+        const previousPagesCount = parseQueryInt(q, 'previousPagesCount') || 0
 
         // Whether or not a query has been made. We track this so that we only change the `first` parameter of
         // the very first request of this component (see `previousPagesCount` defined above).
@@ -535,11 +535,11 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 query,
                                 ...(filter ? filter.args : {}),
                             })
-                            .tap(() => {
-                                // Do not modify the first parameter for subsequent requests
-                                queried = true
-                            })
                             .pipe(
+                                tap(() => {
+                                    // Do not modify the first parameter for subsequent requests
+                                    queried = true
+                                }),
                                 catchError(error => [asError(error)]),
                                 map(
                                     (c): PartialStateUpdate => ({
@@ -659,7 +659,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             q.set('filter', arg.filter.id)
         }
         if (arg.previousPagesCount !== 0) {
-            q.set('visipreviousPagesCountble', String(arg.previousPagesCount))
+            q.set('previousPagesCount', String(arg.previousPagesCount))
         }
         return q.toString()
     }


### PR DESCRIPTION
This introduces additional functionality into `FilteredConnection` to support forward-only cursor paging. This functionality will be necessary for [RFC 46](https://docs.google.com/document/d/1v1Sojj4B07ZTX3bI3pu6uVCRGkYhujkQXmIi6A3Nbc4) and possibly [RFC 23](https://docs.google.com/document/d/1VZB0Y4tWKeOUN1JvdDgo4LHwQn875MPOI9xztzqoSRc).

The *legacy* pagination supported by `FilteredConnection` simply doubles the `first` parameter on each subsequent request, which acts as an increasing limit. This increases the time required in the backend to fetch increasingly large result sets.

This change detects if an `endCursor` is present in the `PageInfo` of the GraphQL response. If so, the subsequent request is given this value as its `after` argument, as described in the [docs](https://graphql.org/learn/pagination/).

If cursor-based pagination is used, subsequent results are (optionally) *appended* to the current set of results to produce an infinite-scroll pagination. This is the smallest change that supports cursor-based pagination without requiring additional UX work to ensure that the item counts are not problematic (`X total, showing first Y`).

In the future, we'll want a more in-depth discussion in order to support forward and backward cursor-based paging that has a more accurate item count description, and updated URL parameters that allow you to jump directly to a result page (the `after` parameter is explicitly omitted from the URL in this effort, as we don't have an easy way to determine how many items we've skipped when given an opaque after ID).