### PR TITLE
Search: convert structural search patterns to zoekt queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -77,9 +77,12 @@ func (r *schemaResolver) Search(args *searchArgs) (searchIntf, error) {
 	}
 
 	var queryString string
-	if searchType == "literal" {
+	switch searchType {
+	case "literal":
 		queryString = query.ConvertToLiteral(args.Query)
-	} else {
+	case "structural":
+		fmt.Println("Structural search")
+	default:
 		queryString = args.Query
 	}
 
@@ -125,7 +128,7 @@ func detectSearchType(version string, patternType *string, input string) (string
 	var searchType string
 	if patternType != nil {
 		switch *patternType {
-		case "regexp", "literal":
+		case "regexp", "literal", "structural":
 			searchType = *patternType
 		default:
 			return "", fmt.Errorf("unrecognized patternType: %v", patternType)
@@ -158,6 +161,8 @@ func detectSearchType(version string, patternType *string, input string) (string
 			searchType = "regexp"
 		case "literal":
 			searchType = "literal"
+		case "structural":
+			searchType = "structural"
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -77,10 +77,9 @@ func (r *schemaResolver) Search(args *searchArgs) (searchIntf, error) {
 	}
 
 	var queryString string
-	switch searchType {
-	case "literal":
+	if searchType == "literal" {
 		queryString = query.ConvertToLiteral(args.Query)
-	default:
+	} else {
 		queryString = args.Query
 	}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -80,8 +80,6 @@ func (r *schemaResolver) Search(args *searchArgs) (searchIntf, error) {
 	switch searchType {
 	case "literal":
 		queryString = query.ConvertToLiteral(args.Query)
-	case "structural":
-		fmt.Println("Structural search")
 	default:
 		queryString = args.Query
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -639,13 +639,19 @@ type getPatternInfoOptions struct {
 	// forceFileSearch, when true, specifies that the search query should be
 	// treated as if every default term had `file:` before it. This can be used
 	// to allow users to jump to files by just typing their name.
-	forceFileSearch bool
+	forceFileSearch         bool
+	performStructuralSearch bool
 }
 
 // getPatternInfo gets the search pattern info for the query in the resolver.
 func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.PatternInfo, error) {
 	var patternsToCombine []string
-	if opts == nil || !opts.forceFileSearch {
+	isRegExp := false
+	isStructuralPat := false
+	if opts != nil && opts.performStructuralSearch {
+		isStructuralPat = true
+	} else if opts == nil || !opts.forceFileSearch {
+		isRegExp = true
 		for _, v := range r.query.Values(query.FieldDefault) {
 			// Treat quoted strings as literal strings to match, not regexps.
 			var pattern string
@@ -666,6 +672,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 		// when not using indexed search. I am unsure what the right solution
 		// is here. Would this code path go away when we switch fully to
 		// indexed search @keegan? This workaround is OK for now though.
+		isRegExp = true
 		patternsToCombine = append(patternsToCombine, ".")
 	}
 
@@ -688,7 +695,8 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 	excludePatterns = append(excludePatterns, langExcludePatterns...)
 
 	patternInfo := &search.PatternInfo{
-		IsRegExp:                     true,
+		IsRegExp:                     isRegExp,
+		IsStructuralPat:              isStructuralPat,
 		IsCaseSensitive:              r.query.IsCaseSensitive(),
 		FileMatchLimit:               r.maxResults(),
 		Pattern:                      regexpPatternMatchingExprsInOrder(patternsToCombine),
@@ -806,7 +814,12 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return alertResult, nil
 	}
 
-	p, err := r.getPatternInfo(nil)
+	patternInfo := &getPatternInfoOptions{}
+	if r.patternType == "structural" {
+		patternInfo = &getPatternInfoOptions{performStructuralSearch: true}
+	}
+	p, err := r.getPatternInfo(patternInfo)
+
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -814,11 +814,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return alertResult, nil
 	}
 
-	patternInfo := &getPatternInfoOptions{}
+	options := &getPatternInfoOptions{}
 	if r.patternType == "structural" {
-		patternInfo = &getPatternInfoOptions{performStructuralSearch: true}
+		options = &getPatternInfoOptions{performStructuralSearch: true}
 	}
-	p, err := r.getPatternInfo(patternInfo)
+	p, err := r.getPatternInfo(options)
 
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -122,12 +122,12 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 		{
 			Name:    "Just a hole",
 			Pattern: ":[1]",
-			Want:    `case_file_substr:""`,
+			Want:    `TRUE`,
 		},
 		{
 			Name:    "Adjacent holes",
 			Pattern: ":[1]:[2]:[3]",
-			Want:    `case_file_substr:""`,
+			Want:    `TRUE`,
 		},
 		{
 			Name:    "Substring between holes",
@@ -143,6 +143,14 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 			Name:    "Substrings covering all hole kinds.",
 			Pattern: `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
 			Want:    `(and case_file_substr:"1. " case_file_substr:" 2. " case_file_substr:" 3. " case_file_substr:" 4. " case_file_substr:" 5. " case_file_substr:" 6. " case_file_substr:" done.")`,
+		},
+		{
+			Name: "Substrings across multiple lines.",
+			Pattern: `:[1] spans
+multiple
+lines
+ :[2]`,
+			Want: `(and case_file_substr:" spans\nmultiple\nlines\n ")`,
 		},
 	}
 	for _, tt := range cases {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -113,6 +113,48 @@ func TestQueryToZoektQuery(t *testing.T) {
 	}
 }
 
+func TestStructuralPatToZoektQuery(t *testing.T) {
+	cases := []struct {
+		Name    string
+		Pattern string
+		Want    string
+	}{
+		{
+			Name:    "Just a hole",
+			Pattern: ":[1]",
+			Want:    `case_file_substr:""`,
+		},
+		{
+			Name:    "Adjacent holes",
+			Pattern: ":[1]:[2]:[3]",
+			Want:    `case_file_substr:""`,
+		},
+		{
+			Name:    "Substring between holes",
+			Pattern: ":[1] substring :[2]",
+			Want:    `(and case_file_substr:" substring ")`,
+		},
+		{
+			Name:    "Substring before and after different hole kinds",
+			Pattern: "prefix :[[1]] :[2.] suffix",
+			Want:    `(and case_file_substr:"prefix " case_file_substr:" " case_file_substr:" suffix")`,
+		},
+		{
+			Name:    "Substrings covering all hole kinds.",
+			Pattern: `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
+			Want:    `(and case_file_substr:"1. " case_file_substr:" 2. " case_file_substr:" 3. " case_file_substr:" 4. " case_file_substr:" 5. " case_file_substr:" 6. " case_file_substr:" done.")`,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			got := StructuralPatToQuery(tt.Pattern)
+			if got.String() != tt.Want {
+				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), tt.Want)
+			}
+		})
+	}
+}
+
 func queryEqual(a zoektquery.Q, b zoektquery.Q) bool {
 	sortChildren := func(q zoektquery.Q) zoektquery.Q {
 		switch s := q.(type) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"regexp/syntax"
 	"strings"
 	"time"
@@ -370,6 +371,44 @@ func fileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 	return parseRe(pattern, true, queryIsCaseSensitive)
 }
 
+func splitOnHoles(pattern string) []string {
+	word := `\w`
+	whitespaceAndOptionalWord := `[ ]+(\w+)?`
+	holeAnything := `:\[` + word + `\]`
+	holeAlphanum := `:\[\[` + word + `\]\]`
+	holeWithPunctuation := `:\[` + word + `\.\]`
+	holeWithNewline := `:\[` + word + `\\n\]`
+	holeWhitespace := `:\[` + whitespaceAndOptionalWord + `\]`
+	hole := strings.Join([]string{
+		holeAnything,
+		holeAlphanum,
+		holeWithPunctuation,
+		holeWithNewline,
+		holeWhitespace,
+	}, "|")
+	return regexp.MustCompile(hole).Split(pattern, -1)
+}
+
+// Parses comby a structural syntax by stripping holes and returns a Zoekt
+// query. The Zoekt query is (only) a a conjunction of constant substrings.
+// Examples:
+//
+// "foo(:[args])"   -> "foo(" AND ")"
+// ":[fn](:[[1]], :[[2]])" -> "(" AND ", " AND ")"
+// ":[1\n] :[ whitespace]"     -> " "
+func structuralPatToQuery(pattern string) (zoektquery.Q, error) {
+	var children []zoektquery.Q
+	substrings := splitOnHoles(pattern)
+	for _, s := range substrings {
+		children = append(children, &zoektquery.Substring{
+			Pattern:       s,
+			CaseSensitive: true,
+			FileName:      true,
+		})
+	}
+	return &zoektquery.And{Children: children}, nil
+}
+
 func queryToZoektQuery(query *search.PatternInfo, isSymbol bool) (zoektquery.Q, error) {
 	var and []zoektquery.Q
 
@@ -377,6 +416,12 @@ func queryToZoektQuery(query *search.PatternInfo, isSymbol bool) (zoektquery.Q, 
 	if query.IsRegExp {
 		var err error
 		q, err = parseRe(query.Pattern, false, query.IsCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+	} else if query.IsStructuralPat {
+		var err error
+		q, err = structuralPatToQuery(query.Pattern)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -371,6 +371,25 @@ func fileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 	return parseRe(pattern, true, queryIsCaseSensitive)
 }
 
+func splitOnHolesPattern() string {
+	word := `\w`
+	whitespaceAndOptionalWord := `[ ]+(\w+)?`
+	holeAnything := `:\[` + word + `\]`
+	holeAlphanum := `:\[\[` + word + `\]\]`
+	holeWithPunctuation := `:\[` + word + `\.\]`
+	holeWithNewline := `:\[` + word + `\\n\]`
+	holeWhitespace := `:\[` + whitespaceAndOptionalWord + `\]`
+	return strings.Join([]string{
+		holeAnything,
+		holeAlphanum,
+		holeWithPunctuation,
+		holeWithNewline,
+		holeWhitespace,
+	}, "|")
+}
+
+var matchHoleRegexp = regexp.MustCompile(splitOnHolesPattern())
+
 // Parses comby a structural syntax by stripping holes and returns a Zoekt
 // query. The Zoekt query is (only) a a conjunction of constant substrings.
 // Examples:
@@ -380,42 +399,21 @@ func fileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 // ":[1\n] :[ whitespace]" -> " "
 func StructuralPatToQuery(pattern string) zoektquery.Q {
 	var children []zoektquery.Q
-	substrings := splitOnHoles(pattern)
+	substrings := matchHoleRegexp.Split(pattern, -1)
 	for _, s := range substrings {
 		if s != "" {
 			children = append(children, &zoektquery.Substring{
 				Pattern:       s,
 				CaseSensitive: true,
 				FileName:      true,
+				Content:       true,
 			})
 		}
 	}
 	if len(children) == 0 {
-		return &zoektquery.Substring{
-			Pattern:       "",
-			CaseSensitive: true,
-			FileName:      true,
-		}
+		return &zoektquery.Const{Value: true}
 	}
 	return &zoektquery.And{Children: children}
-}
-
-func splitOnHoles(pattern string) []string {
-	word := `\w`
-	whitespaceAndOptionalWord := `[ ]+(\w+)?`
-	holeAnything := `:\[` + word + `\]`
-	holeAlphanum := `:\[\[` + word + `\]\]`
-	holeWithPunctuation := `:\[` + word + `\.\]`
-	holeWithNewline := `:\[` + word + `\\n\]`
-	holeWhitespace := `:\[` + whitespaceAndOptionalWord + `\]`
-	hole := strings.Join([]string{
-		holeAnything,
-		holeAlphanum,
-		holeWithPunctuation,
-		holeWithNewline,
-		holeWhitespace,
-	}, "|")
-	return regexp.MustCompile(hole).Split(pattern, -1)
 }
 
 func queryToZoektQuery(query *search.PatternInfo, isSymbol bool) (zoektquery.Q, error) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -375,9 +375,9 @@ func fileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 // query. The Zoekt query is (only) a a conjunction of constant substrings.
 // Examples:
 //
-// "foo(:[args])"   -> "foo(" AND ")"
+// "foo(:[args])"          -> "foo(" AND ")"
 // ":[fn](:[[1]], :[[2]])" -> "(" AND ", " AND ")"
-// ":[1\n] :[ whitespace]"     -> " "
+// ":[1\n] :[ whitespace]" -> " "
 func StructuralPatToQuery(pattern string) zoektquery.Q {
 	var children []zoektquery.Q
 	substrings := splitOnHoles(pattern)

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -14,6 +14,7 @@ import (
 type PatternInfo struct {
 	Pattern         string
 	IsRegExp        bool
+	IsStructuralPat bool
 	IsWordMatch     bool
 	IsCaseSensitive bool
 	FileMatchLimit  int32

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -57,6 +57,9 @@ type PatternInfo struct {
 	// IsRegExp if true will treat the Pattern as a regular expression.
 	IsRegExp bool
 
+	// IsStructuralPat if true will treat the pattern as a Comby structural search pattern.
+	IsStructuralPat bool
+
 	// IsWordMatch if true will only match the pattern at word boundaries.
 	IsWordMatch bool
 


### PR DESCRIPTION
This PR:

- Adds scaffolding for the structural search code path. The `patterntype:structural` option will case out (a) the code path for converting structural search patterns to Zoekt patterns for indexed search and (b) the code path for searcher to run structural search.

- Adds the functionality for (a) above, and converts structural (comby) patterns to Zoekt queries for indexed search. The resulting Zoekt queries are (only) a conjunction of substrings. The intent is for Zoekt to return only the files that satisfy this pattern. The results are not used yet.

Test plan: Added tests for converting structural queries to Zoekt patterns. No end-to-end yet, because the other end isn't done yet.
