### PR TITLE
server: escape hatch to not shutdown when failing to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- `sourcegraph/server` Docker deployments now support the environment variable `IGNORE_PROCESS_DEATH`. If set to true the container will keep running, even if a subprocess has died. This is useful when manually fixing problems in the container which the container refuses to start. For example a bad databse migration.
+
 ### Changed
 
 ### Fixed

--- a/cmd/server/internal/goreman/goreman.go
+++ b/cmd/server/internal/goreman/goreman.go
@@ -54,14 +54,21 @@ func readProcfile(content []byte) error {
 	return nil
 }
 
+type Options struct {
+	// RPCAddr is the address to listen for Goreman RPCs.
+	RPCAddr string
+}
+
 // Start starts up the Procfile.
-func Start(rpcAddr string, contents []byte) error {
+func Start(contents []byte, opts Options) error {
 	err := readProcfile(contents)
 	if err != nil {
 		return err
 	}
-	if err := startServer(rpcAddr); err != nil {
-		return err
+	if opts.RPCAddr != "" {
+		if err := startServer(opts.RPCAddr); err != nil {
+			return err
+		}
 	}
 	startProcs()
 	return waitProcs()

--- a/cmd/server/internal/goreman/goreman.go
+++ b/cmd/server/internal/goreman/goreman.go
@@ -3,6 +3,7 @@ package goreman
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -57,7 +58,7 @@ func readProcfile(content []byte) error {
 
 // ProcDiedAction specifies the behaviour Goreman takes if a process exits
 // with a non-zero exit code.
-type ProcDiedAction int
+type ProcDiedAction uint
 
 const (
 	// Shutdown will shutdown Goreman if any process shuts down with a
@@ -86,6 +87,9 @@ func Start(contents []byte, opts Options) error {
 	err := readProcfile(contents)
 	if err != nil {
 		return err
+	}
+	if opts.ProcDiedAction > Ignore {
+		return fmt.Errorf("invalid ProcDiedAction %v", opts.ProcDiedAction)
 	}
 	procDiedAction = opts.ProcDiedAction
 	if opts.RPCAddr != "" {

--- a/cmd/server/internal/goreman/goreman.go
+++ b/cmd/server/internal/goreman/goreman.go
@@ -55,9 +55,30 @@ func readProcfile(content []byte) error {
 	return nil
 }
 
+// ProcDiedAction specifies the behaviour Goreman takes if a process exits
+// with a non-zero exit code.
+type ProcDiedAction int
+
+const (
+	// Shutdown will shutdown Goreman if any process shuts down with a
+	// non-zero exit code.
+	Shutdown ProcDiedAction = iota
+
+	// Ignore will continue running Goreman and will leave not restart the
+	// dead process.
+	Ignore
+)
+
+// procDiedAction is the ProcDiedAction to take. Goreman still is globals
+// everywhere \o/
+var procDiedAction ProcDiedAction
+
 type Options struct {
 	// RPCAddr is the address to listen for Goreman RPCs.
 	RPCAddr string
+
+	// ProcDiedAction specifies the behaviour to take when a process dies.
+	ProcDiedAction ProcDiedAction
 }
 
 // Start starts up the Procfile.
@@ -66,6 +87,7 @@ func Start(contents []byte, opts Options) error {
 	if err != nil {
 		return err
 	}
+	procDiedAction = opts.ProcDiedAction
 	if opts.RPCAddr != "" {
 		if err := os.Setenv("GOREMAN_RPC_ADDR", opts.RPCAddr); err != nil {
 			return err

--- a/cmd/server/internal/goreman/goreman.go
+++ b/cmd/server/internal/goreman/goreman.go
@@ -3,6 +3,7 @@ package goreman
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -66,6 +67,9 @@ func Start(contents []byte, opts Options) error {
 		return err
 	}
 	if opts.RPCAddr != "" {
+		if err := os.Setenv("GOREMAN_RPC_ADDR", opts.RPCAddr); err != nil {
+			return err
+		}
 		if err := startServer(opts.RPCAddr); err != nil {
 			return err
 		}

--- a/cmd/server/internal/goreman/proc.go
+++ b/cmd/server/internal/goreman/proc.go
@@ -66,8 +66,15 @@ func startProc(proc string) error {
 		wg.Done()
 		p.mu.Unlock()
 		if !stopped {
-			log.Printf("%s died. Shutting down...", proc)
-			signals <- syscall.SIGINT
+			switch procDiedAction {
+			case Shutdown:
+				log.Printf("%s died. Shutting down...", proc)
+				signals <- syscall.SIGINT
+			case Ignore:
+				log.Printf("%s died.", proc)
+			default:
+				log.Fatalf("%s died. Unknown ProcDiedAction %v", proc, procDiedAction)
+			}
 		}
 	}()
 	return nil

--- a/cmd/server/internal/goremancmd/main.go
+++ b/cmd/server/internal/goremancmd/main.go
@@ -21,13 +21,8 @@ func do() error {
 		return err
 	}
 
-	const goremanAddr = "127.0.0.1:5005"
-	if err := os.Setenv("GOREMAN_RPC_ADDR", goremanAddr); err != nil {
-		return err
-	}
-
 	return goreman.Start(procfile, goreman.Options{
-		RPCAddr: goremanAddr,
+		RPCAddr: "127.0.0.1:5005",
 	})
 }
 

--- a/cmd/server/internal/goremancmd/main.go
+++ b/cmd/server/internal/goremancmd/main.go
@@ -26,7 +26,9 @@ func do() error {
 		return err
 	}
 
-	return goreman.Start(goremanAddr, procfile)
+	return goreman.Start(procfile, goreman.Options{
+		RPCAddr: goremanAddr,
+	})
 }
 
 func main() {

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -166,8 +167,19 @@ func Main() {
 
 	procfile = append(procfile, maybeZoektProcFile()...)
 
+	// Shutdown if any process dies
+	procDiedAction := goreman.Shutdown
+	if ignore, _ := strconv.ParseBool(os.Getenv("IGNORE_PROCESS_DEATH")); ignore {
+		// IGNORE_PROCESS_DEATH is an escape hatch so that sourcegraph/server
+		// keeps running in the case of a subprocess dieing on startup. An
+		// example use case is connecting to postgres even though frontend is
+		// dieing due to a bad migration.
+		procDiedAction = goreman.Ignore
+	}
+
 	err = goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
-		RPCAddr: "127.0.0.1:5005",
+		RPCAddr:        "127.0.0.1:5005",
+		ProcDiedAction: procDiedAction,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -166,13 +166,8 @@ func Main() {
 
 	procfile = append(procfile, maybeZoektProcFile()...)
 
-	const goremanAddr = "127.0.0.1:5005"
-	if err := os.Setenv("GOREMAN_RPC_ADDR", goremanAddr); err != nil {
-		log.Fatal(err)
-	}
-
 	err = goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
-		RPCAddr: goremanAddr,
+		RPCAddr: "127.0.0.1:5005",
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -171,7 +171,9 @@ func Main() {
 		log.Fatal(err)
 	}
 
-	err = goreman.Start(goremanAddr, []byte(strings.Join(procfile, "\n")))
+	err = goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
+		RPCAddr: goremanAddr,
+	})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR introduces `IGNORE_PROCESS_DEATH` environment variable. If set to true sourcegraph/server will no longer shutdown if a subprocess has a non-zero exit code.

In particular this is targetting the situation where there is a dirty migration that requires cleaning up. You don't have any time to clean it up in the default case since frontend will die due to the dirty migration => the container shutting down => can't connect to postgres to clean it up. I don't know how our customers fixed this situation before. But this is currently occurring for our server dogfooding instance, hence the motivation to introduce it.

There are also two commits refactoring parts of Goreman to make it cleaner to introduce this change.