### PR TITLE
RFC ci: Only E2E run for releases

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -123,6 +123,9 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 
 // End-to-end tests.
 func addE2E(c Config) func(*bk.Pipeline) {
+	if !(c.taggedRelease || c.isBextReleaseBranch || c.patchNoTest || c.patch) {
+		return noop
+	}
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":chromium:",
 			// Avoid crashing the sourcegraph/server containers. See
@@ -188,6 +191,8 @@ func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
 		bk.Cmd("popd"))
 }
 
+func noop(*bk.Pipeline) {}
+
 // Adds a Buildkite pipeline "Wait".
 func wait(pipeline *bk.Pipeline) {
 	pipeline.AddWait()
@@ -195,6 +200,9 @@ func wait(pipeline *bk.Pipeline) {
 
 // Build Sourcegraph Server Docker image candidate
 func addServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
+	if !(c.taggedRelease || c.isBextReleaseBranch || c.patchNoTest || c.patch) {
+		return noop
+	}
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":docker:",
 			bk.Cmd("pushd enterprise"),
@@ -208,6 +216,9 @@ func addServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
 
 // Clean up Sourcegraph Server Docker image candidate
 func addCleanUpServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
+	if !(c.taggedRelease || c.isBextReleaseBranch || c.patchNoTest || c.patch) {
+		return noop
+	}
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":sparkles:",
 			bk.Cmd("docker image rm -f sourcegraph/server:"+c.version+"_candidate"))


### PR DESCRIPTION
I expect this to be a bit controversial. This is a request for comment in the form of a PR. Please state your opinions as comments. cc @sourcegraph/code-intel @sourcegraph/core-services @sourcegraph/distribution 

E2E test reliability only seems to be getting worse. Just today I have had to hit retry 3 times on builds I landed in master. This has been an ongoing issue, and I believe we have reached the point where running E2E on PRs/master provides more bad than good. This is one possible short-term solution.

PRs and master will no longer run E2E tests. This should improve reliability
and speed of CI for the general case, while still ensuring e2e tests pass on
tagged releases.

The downside is we won't notice severe regressions to e2e, so will have to
deal with the issues once we do a release. But as it stands the e2e tests are
in a bad shape and no one is fixing them. We are building a pavlovian response
to e2e failing and the retry button.