### PR TITLE
Gitlab: fix command palette overflow

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -319,8 +319,8 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
     buttonElement: ButtonElement = 'span',
     buttonOpenClassName = '',
     showCaret = true,
-    popoverClassName = '',
-    popoverInnerClassName = '',
+    popoverClassName,
+    popoverInnerClassName,
     keyboardShortcutForShow,
     ...props
 }) => {
@@ -343,8 +343,8 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
             <TooltipPopoverWrapper
                 isOpen={isOpen}
                 toggle={toggleIsOpen}
-                popperClassName={`popover show ${popoverClassName}`}
-                innerClassName={`popover-inner ${popoverInnerClassName}`}
+                popperClassName={classNames('show', popoverClassName)}
+                innerClassName={classNames('popover-inner', popoverInnerClassName)}
                 placement="bottom-end"
                 target={id}
                 trigger="legacy"

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -24,6 +24,7 @@ export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPop
     <CommandListPopoverButton
         {...props}
         buttonClassName="btn btn-link"
+        popoverClassName="popover"
         popoverInnerClassName="border rounded overflow-hidden"
         formClassName="form"
         inputClassName="form-control px-2 py-1 rounded-0"


### PR DESCRIPTION
Fixes #6151

The fix here is to stop applying the `popover` class to the popover by default, as in Gitlab styles a `.popover` has a max width (while in Sourcegraph styles `.command-list` has a fixed width of 24rem).

The Bootstrap `popover` class was applied in `shared/src/commandPalette/CommandList.tsx`, it wasn't intentionally used to match Gitlab styles.

Since with this fix, the popover class will no longer be applied by default on other code hosts either, I verified that display of the command palette on GitHub and Bitbucket Server was unaffected. No need to check on Phabricator, where we still don't inject the command palette.  
