### PR TITLE
LSIF: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -251,6 +251,7 @@ README.md @sqs
 /cmd/frontend/db/discussion* @slimsag
 
 # LSIF
+/cmd/frontend/internal/httpapi/lsif.go @sourcegraph/code-intel
 /lsif/ @sourcegraph/code-intel
 
 # Development


### PR DESCRIPTION
Assigns @sourcegraph/code-intel to `cmd/frontend/internal/httpapi/lsif.go`.