### PR TITLE
LSIF: Decode URI password when constructing postgres connection arguments

### DIFF
--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -75,7 +75,7 @@ export async function createPostgresConnection(configuration: Configuration, log
     const url = new URL(configuration.postgresDSN)
 
     // TODO(efritz) - handle allow, prefer, 'verify-ca', and 'verify-full'
-    const sslThings: { [K: string]: boolean | TlsOptions | undefined } = {
+    const sslModes: { [K: string]: boolean | TlsOptions } = {
         disable: false,
         require: true,
     }

--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -85,9 +85,9 @@ export async function createPostgresConnection(configuration: Configuration, log
     const connectionOptions = {
         host: url.hostname,
         port: parseInt(url.port, 10) || 5432,
-        username: url.username,
-        password: url.password,
-        database: url.pathname.substring(1),
+        username: decodeURIComponent(url.username),
+        password: decodeURIComponent(url.password),
+        database: decodeURIComponent(url.pathname).substring(1),
         ssl: sslMode ? sslModes[sslMode] : undefined,
     }
 

--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -74,10 +74,9 @@ export async function createPostgresConnection(configuration: Configuration, log
     // the typeorm postgres adapter.
     const url = new URL(configuration.postgresDSN)
 
-    // TODO(efritz) - handle allow, prefer, 'verify-ca', and 'verify-full'
+    // TODO(efritz) - handle allow, prefer, require, 'verify-ca', and 'verify-full'
     const sslModes: { [K: string]: boolean | TlsOptions } = {
         disable: false,
-        require: true,
     }
 
     const sslMode = url.searchParams.get('sslmode')

--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -88,7 +88,7 @@ export async function createPostgresConnection(configuration: Configuration, log
         username: url.username,
         password: url.password,
         database: url.pathname.substring(1),
-        ssl: sslMode ? sslThings[sslMode] : undefined,
+        ssl: sslMode ? sslModes[sslMode] : undefined,
     }
 
     // Get a working connection


### PR DESCRIPTION
Fixes a customer's issue attaching to postgres with a password containing special characters.