### PR TITLE
LSIF: warn on unknown type of item edge

### DIFF
--- a/lsif/src/correlator.ts
+++ b/lsif/src/correlator.ts
@@ -96,6 +96,7 @@ export class Correlator {
     public hoverData = new Map<HoverResultId, string>()
     public monikerData = new Map<MonikerId, MonikerData>()
     public packageInformationData = new Map<PackageInformationId, PackageInformationData>()
+    public unsupportedVertexes = new Set<Id>()
 
     // Edge data
     public nextData = new Map<RangeId | ResultSetId, ResultSetId>()
@@ -200,6 +201,19 @@ export class Correlator {
                         name: element.name,
                         version: element.version || null,
                     })
+                    break
+
+                default:
+                    // Some vertex labels are not yet supported:
+                    //
+                    // - typeDefinitionResult
+                    // - implementationResult
+                    // - ... others in the future
+                    //
+                    // We keep track of these unsupported vertexes so that we
+                    // don't mistake it for a missing vertex later when visiting
+                    // edges.
+                    this.unsupportedVertexes.add(element.id)
                     break
             }
         }
@@ -315,7 +329,12 @@ export class Correlator {
             return
         }
 
-        this.logger.debug(`Unknown definition or reference result ${edge.outV}.`)
+        if (this.unsupportedVertexes.has(edge.outV)) {
+            this.logger.debug('Skipping edge from an unsupported vertex', { edge })
+            return
+        }
+
+        throw new Error(`Item edge references a nonexistent vertex ${JSON.stringify(edge)}`)
     }
 
     /**

--- a/lsif/src/correlator.ts
+++ b/lsif/src/correlator.ts
@@ -126,7 +126,7 @@ export class Correlator {
 
     private logger: Logger
 
-    constructor({ logger = createSilentLogger() }: TracingContext = { logger: createSilentLogger() }) {
+    constructor({ logger = createSilentLogger() }: TracingContext = {}) {
         this.logger = logger
     }
 

--- a/lsif/src/correlator.ts
+++ b/lsif/src/correlator.ts
@@ -34,6 +34,9 @@ import {
     RangeId,
 } from 'lsif-protocol'
 import { DisjointSet } from './disjoint-set'
+import { TracingContext } from './tracing'
+import { createSilentLogger } from './logging'
+import { Logger } from 'winston'
 
 /**
  * Identifiers of result set vertices.
@@ -119,6 +122,12 @@ export class Correlator {
      * The set of exported moniker identifiers that have package information attached.
      */
     public exportedMonikers = new Set<MonikerId>()
+
+    private logger: Logger
+
+    constructor({ logger = createSilentLogger() }: TracingContext = { logger: createSilentLogger() }) {
+        this.logger = logger
+    }
 
     /**
      * Process a single vertex or edge.
@@ -306,7 +315,7 @@ export class Correlator {
             return
         }
 
-        console.warn(`Unknown definition or reference result ${edge.outV}.`)
+        this.logger.debug(`Unknown definition or reference result ${edge.outV}.`)
     }
 
     /**

--- a/lsif/src/correlator.ts
+++ b/lsif/src/correlator.ts
@@ -306,7 +306,7 @@ export class Correlator {
             return
         }
 
-        throw new Error(`Unknown definition or reference result ${edge.outV}.`)
+        console.warn(`Unknown definition or reference result ${edge.outV}.`)
     }
 
     /**

--- a/lsif/src/importer.ts
+++ b/lsif/src/importer.ts
@@ -101,7 +101,7 @@ export async function importLsif(
     ctx: TracingContext
 ): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
     // Correlate input data into in-memory maps
-    const correlator = new Correlator()
+    const correlator = new Correlator(ctx)
     await logAndTraceCall(ctx, 'correlating LSIF data', async () => {
         for await (const element of readGzippedJsonElements(input) as AsyncIterable<Vertex | Edge>) {
             correlator.insert(element)


### PR DESCRIPTION
Prior to this change, lsif-server would throw an error when it encountered any item edge that it didn't recognize. Some indexers such as https://github.com/microsoft/lsif-java emit `textDocument/typeDefinition`, which lsif-server currently doesn't support.

After this change, lsif-server will log that it didn't recognize the edge and continue processing.