### PR TITLE
LSIF: Update job schedules

### DIFF
--- a/lsif/src/queue.ts
+++ b/lsif/src/queue.ts
@@ -69,7 +69,7 @@ export const ensureOnlyRepeatableJob = async (
     for (const job of await queue.getRepeatableJobs()) {
         if (job.name === name) {
             // Job already scheduled with correct interval
-            if (job.every === intervalMs * 1000) {
+            if (job.every === intervalMs) {
                 return
             }
 
@@ -83,5 +83,5 @@ export const ensureOnlyRepeatableJob = async (
     }
 
     // Schedule job with correct interval
-    await enqueue(queue, name, args, { repeat: { every: intervalMs * 1000 } })
+    await enqueue(queue, name, args, { repeat: { every: intervalMs } })
 }

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -60,12 +60,12 @@ const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
 /**
  * The interval (in seconds) to schedule the update-tips job.
  */
-const UPDATE_TIPS_JOB_SCHEDULE_INTERVAL = readEnvInt('UPDATE_TIPS_JOB_SCHEDULE_INTERVAL', 30)
+const UPDATE_TIPS_JOB_SCHEDULE_INTERVAL = readEnvInt('UPDATE_TIPS_JOB_SCHEDULE_INTERVAL', 60 * 5)
 
 /**
  * The interval (in seconds) to schedule the clean-old-jobs job.
  */
-const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 60 * 60)
+const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 60 * 60 * 8)
 
 /**
  * Middleware function used to convert uncaught exceptions into 500 responses.

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -119,8 +119,8 @@ async function main(logger: Logger): Promise<void> {
     const queue = createQueue('lsif', REDIS_ENDPOINT, logger)
 
     // Schedule jobs on timers
-    await ensureOnlyRepeatableJob(queue, 'update-tips', {}, UPDATE_TIPS_JOB_SCHEDULE_INTERVAL)
-    await ensureOnlyRepeatableJob(queue, 'clean-old-jobs', {}, CLEAN_OLD_JOBS_INTERVAL)
+    await ensureOnlyRepeatableJob(queue, 'update-tips', {}, UPDATE_TIPS_JOB_SCHEDULE_INTERVAL * 1000)
+    await ensureOnlyRepeatableJob(queue, 'clean-old-jobs', {}, CLEAN_OLD_JOBS_INTERVAL * 1000)
 
     // Update queue size metric on a timer
     setInterval(() => queue.count().then(count => queueSizeGauge.set(count)), 1000)

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -59,7 +59,7 @@ const wrapJobProcessor = <T>(
     logger: Logger,
     tracer: Tracer | undefined
 ): ((job: Job) => Promise<void>) => async (job: Job) => {
-    logger.debug('convert job accepted', { jobId: job.id })
+    logger.debug(`${name} job accepted`, { jobId: job.id })
 
     // Destructure arguments and injected tracing context
     const { args, tracing } = job.data as { args: T; tracing: object }

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -43,7 +43,7 @@ const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
 /**
  * The maximum age (in seconds) that a job (completed or queued) will remain in redis.
  */
-const JOB_MAX_AGE = readEnvInt('JOB_MAX_AGE', 7 * 24 * 60 * 60)
+const JOB_MAX_AGE = readEnvInt('JOB_MAX_AGE', 60 * 60 * 24 * 7)
 
 /**
  * Wrap a job processor with instrumentation.


### PR DESCRIPTION
Update default intervals for scheduled jobs.

- update-tips runs every 5 minutes
- clean-old-jobs runs every 8 hours