### PR TITLE
bitbucket_cloud: allow hyphens in team name (#6154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed unable to use hyphens in Bitbucket Cloud team name. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
+
 ### Removed
 
 ## 3.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fixed unable to use hyphens in Bitbucket Cloud team name. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
+- Support hyphens in Bitbucket Cloud team names. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
 
 ### Removed
 

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -290,7 +290,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"url": "https://bitbucket.org/",
 				"username": "admin",
 				"appPassword": "app-password",
-				"teams": ["sglocal", "sg_local"]
+				"teams": ["sglocal", "sg_local", "--a-team----name-"]
 			}`,
 			assert: equals("<nil>"),
 		},
@@ -319,10 +319,9 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		{
 			kind:   "BITBUCKETCLOUD",
 			desc:   "invalid team name",
-			config: `{"teams": ["sg-local", "sg local"]}`,
+			config: `{"teams": ["sg local"]}`,
 			assert: includes(
-				`teams.0: Does not match pattern '^\w+$'`,
-				`teams.1: Does not match pattern '^\w+$'`,
+				`teams.0: Does not match pattern '^[\w-]+$'`,
 			),
 		},
 		{

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -42,7 +42,7 @@
     "teams": {
       "description": "An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^\\w+$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+$" },
       "examples": [["name"], ["kubernetes", "golang", "facebook"]]
     }
   }

--- a/schema/bitbucket_cloud_stringdata.go
+++ b/schema/bitbucket_cloud_stringdata.go
@@ -47,7 +47,7 @@ const BitbucketCloudSchemaJSON = `{
     "teams": {
       "description": "An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^\\w+$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+$" },
       "examples": [["name"], ["kubernetes", "golang", "facebook"]]
     }
   }


### PR DESCRIPTION
Allow use of hyphens in team name for Bitbucket Cloud external service.

Addresses #6154.

Test plan: CI and locally verified.
