### PR TITLE
all: Avoid cost of regex compilation at init time.

### DIFF
--- a/cmd/frontend/auth/auth.go
+++ b/cmd/frontend/auth/auth.go
@@ -4,10 +4,10 @@ package auth
 import (
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/suspiciousnames"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // AuthURLPrefix is the URL path prefix under which to attach authentication handlers
@@ -90,6 +90,6 @@ func NormalizeUsername(name string) (string, error) {
 }
 
 var (
-	disallowedSymbols   = regexp.MustCompile(`(^[\-\.])|(\.$)|([\-\.]{2,})`)
-	disallowedCharacter = regexp.MustCompile(`[^a-zA-Z0-9\-\.]`)
+	disallowedSymbols   = lazyregexp.New(`(^[\-\.])|(\.$)|([\-\.]{2,})`)
+	disallowedCharacter = lazyregexp.New(`[^a-zA-Z0-9\-\.]`)
 )

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 
 	_ "github.com/lib/pq"
 )
@@ -33,7 +34,7 @@ func generate(log *log.Logger) (string, error) {
 		run        func(cmd ...string) (string, error)
 	)
 	// If we are using pg9.6 use it locally since it is faster (CI \o/)
-	versionRe := regexp.MustCompile(fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta("9.6")))
+	versionRe := lazyregexp.New(fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta("9.6")))
 	if out, _ := exec.Command("psql", "--version").CombinedOutput(); versionRe.Match(out) {
 		dataSource = "dbname=" + dbname
 		run = func(cmd ...string) (string, error) {

--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"golang.org/x/net/context/ctxhttp"
@@ -125,7 +125,7 @@ func validateQuery(q *query.Query) (*args, error) {
 	if len(includeFileFilter) > 0 {
 		includeFileFilterText = includeFileFilter[0]
 		// only file names or files with extensions in the following characterset are allowed
-		IsAlphanumericWithPeriod := regexp.MustCompile(`^[a-zA-Z0-9_.]+$`).MatchString
+		IsAlphanumericWithPeriod := lazyregexp.New(`^[a-zA-Z0-9_.]+$`).MatchString
 		if !IsAlphanumericWithPeriod(includeFileFilterText) {
 			return nil, errors.New("the 'file:' filter cannot contain regex when using the 'replace:' filter currently. Only alphanumeric characters or '.'")
 		}
@@ -134,7 +134,7 @@ func validateQuery(q *query.Query) (*args, error) {
 	var excludeFileFilterText string
 	if len(excludeFileFilter) > 0 {
 		excludeFileFilterText = excludeFileFilter[0]
-		IsAlphanumericWithPeriod := regexp.MustCompile(`^[a-zA-Z_.]+$`).MatchString
+		IsAlphanumericWithPeriod := lazyregexp.New(`^[a-zA-Z_.]+$`).MatchString
 		if !IsAlphanumericWithPeriod(includeFileFilterText) {
 			return nil, errors.New("the '-file:' filter cannot contain regex when using the 'replace:' filter currently. Only alphanumeric characters or '.'")
 		}

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"errors"
-	"regexp"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -282,7 +281,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-var patternTypeRegexp *regexp.Regexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp)\b`)
+var patternTypeRegexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp)\b`)
 
 func queryHasPatternType(query string) bool {
 	return patternTypeRegexp.Match([]byte(query))

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/query-runner/queryrunnerapi"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 type savedSearchResolver struct {
@@ -281,7 +282,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-var patternTypeRegexp *regexp.Regexp = regexp.MustCompile(`(?i)\bpatternType:(literal|regexp)\b`)
+var patternTypeRegexp *regexp.Regexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp)\b`)
 
 func queryHasPatternType(query string) bool {
 	return patternTypeRegexp.Match([]byte(query))

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -181,7 +181,7 @@ func (sr *searchResultsResolver) ElapsedMilliseconds() int32 {
 // commonFileFilters are common filters used. It is used by DynamicFilters to
 // propose them if they match shown results.
 var commonFileFilters = []struct {
-	Regexp *regexp.Regexp
+	Regexp *lazyregexp.Regexp
 	Filter string
 }{
 	// Exclude go tests

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -185,17 +186,17 @@ var commonFileFilters = []struct {
 }{
 	// Exclude go tests
 	{
-		Regexp: regexp.MustCompile(`_test\.go$`),
+		Regexp: lazyregexp.New(`_test\.go$`),
 		Filter: `-file:_test\.go$`,
 	},
 	// Exclude go vendor
 	{
-		Regexp: regexp.MustCompile(`(^|/)vendor/`),
+		Regexp: lazyregexp.New(`(^|/)vendor/`),
 		Filter: `-file:(^|/)vendor/`,
 	},
 	// Exclude node_modules
 	{
-		Regexp: regexp.MustCompile(`(^|/)node_modules/`),
+		Regexp: lazyregexp.New(`(^|/)node_modules/`),
 		Filter: `-file:(^|/)node_modules/`,
 	},
 }
@@ -521,7 +522,7 @@ func longer(N int, dt time.Duration) time.Duration {
 	return dt2
 }
 
-var decimalRx = regexp.MustCompile(`\d+\.\d+`)
+var decimalRx = lazyregexp.New(`\d+\.\d+`)
 
 // roundStr rounds the first number containing a decimal within a string
 func roundStr(s string) string {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"net/url"
-	"regexp"
 	"regexp/syntax"
 	"strings"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -388,7 +388,7 @@ func splitOnHolesPattern() string {
 	}, "|")
 }
 
-var matchHoleRegexp = regexp.MustCompile(splitOnHolesPattern())
+var matchHoleRegexp = lazyregexp.New(splitOnHolesPattern())
 
 // Parses comby a structural syntax by stripping holes and returns a Zoekt
 // query. The Zoekt query is (only) a a conjunction of constant substrings.

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 func editorRev(ctx context.Context, repoName api.RepoName, rev string, beExplicit bool) (string, error) {
@@ -149,7 +149,7 @@ func serveEditor(w http.ResponseWriter, r *http.Request) error {
 }
 
 // gitProtocolRegExp is a regular expression that matches any URL that looks like it has a git protocol
-var gitProtocolRegExp = regexp.MustCompile("^(git|(git+)?(https?|ssh))://")
+var gitProtocolRegExp = lazyregexp.New("^(git|(git+)?(https?|ssh))://")
 
 // guessRepoNameFromRemoteURL return a guess at the repo name for the given remote URL.
 //

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -15,12 +15,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/sourcegraph/ctxvfs"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/vfsutil"
 	"golang.org/x/tools/go/buildutil"
 
@@ -374,7 +374,7 @@ func UriToPath(uri lsp.DocumentURI) string {
 	return u.Path
 }
 
-var regDriveLetter = regexp.MustCompile("^/[a-zA-Z]:")
+var regDriveLetter = lazyregexp.New("^/[a-zA-Z]:")
 
 // UriToRealPath converts the given file URI to the platform specific path
 func UriToRealPath(uri lsp.DocumentURI) string {

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/gorilla/csrf"
@@ -21,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -193,7 +193,7 @@ func publicCriticalConfiguration() schema.CriticalConfiguration {
 	}
 }
 
-var isBotPat = regexp.MustCompile(`(?i:googlecloudmonitoring|pingdom.com|go .* package http|sourcegraph e2etest|bot|crawl|slurp|spider|feed|rss|camo asset proxy|http-client|sourcegraph-client)`)
+var isBotPat = lazyregexp.New(`(?i:googlecloudmonitoring|pingdom.com|go .* package http|sourcegraph e2etest|bot|crawl|slurp|spider|feed|rss|camo asset proxy|http-client|sourcegraph-client)`)
 
 func isBot(userAgent string) bool {
 	return isBotPat.MatchString(userAgent)

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/internal/hubspot"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/pubsub/pubsubutil"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -121,7 +121,7 @@ func canUpdateVersion(clientVersionString string, latestReleaseBuild build) (boo
 	return clientVersion.LessThan(latestReleaseBuild.Version), nil
 }
 
-var dateRegex = regexp.MustCompile("_([0-9]{4}-[0-9]{2}-[0-9]{2})_")
+var dateRegex = lazyregexp.New("_([0-9]{4}-[0-9]{2}-[0-9]{2})_")
 var timeNow = time.Now
 
 // canUpdateDate returns true if clientVersionString contains a date

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"net/http"
-	"regexp"
 
 	log15 "gopkg.in/inconshreveable/log15.v2"
 
@@ -13,9 +12,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/handlerutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-var goSymbolReg = regexp.MustCompile("/info/GoPackage/(.+)$")
+var goSymbolReg = lazyregexp.New("/info/GoPackage/(.+)$")
 
 // serveRepoLanding simply redirects the old (sourcegraph.com/<repo>/-/info) repo landing page
 // URLs directly to the repo itself (sourcegraph.com/<repo>).

--- a/cmd/frontend/internal/graphqlfile/strip_internal_comments.go
+++ b/cmd/frontend/internal/graphqlfile/strip_internal_comments.go
@@ -5,7 +5,8 @@ package graphqlfile
 import (
 	"bufio"
 	"bytes"
-	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // StripInternalComments removes lines starting with #! (e.g. internal
@@ -14,7 +15,7 @@ func StripInternalComments(schema []byte) ([]byte, error) {
 	var (
 		scanner = bufio.NewScanner(bytes.NewReader(schema))
 		out     []byte
-		re      = regexp.MustCompile("^ *#!")
+		re      = lazyregexp.New("^ *#!")
 	)
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/cmd/frontend/internal/pkg/discussions/format.go
+++ b/cmd/frontend/internal/pkg/discussions/format.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/highlight"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 func formatTargetRepoLinesText(tr *types.DiscussionThreadTargetRepo) string {
@@ -35,7 +35,7 @@ func formatTargetRepoLinesText(tr *types.DiscussionThreadTargetRepo) string {
 	return b.String()
 }
 
-var dataLineMatch = regexp.MustCompile(`\<tr\>\<td class\=\"line\" data\-line\=\"(\d+)\"\>`)
+var dataLineMatch = lazyregexp.New(`\<tr\>\<td class\=\"line\" data\-line\=\"(\d+)\"\>`)
 
 func formatTargetRepoLinesHTML(ctx context.Context, tr *types.DiscussionThreadTargetRepo) (template.HTML, error) {
 	if !tr.HasSelection() || tr.Path == nil {

--- a/cmd/frontend/internal/pkg/discussions/mailreply/worker.go
+++ b/cmd/frontend/internal/pkg/discussions/mailreply/worker.go
@@ -4,7 +4,6 @@ package mailreply
 
 import (
 	"context"
-	"regexp"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/discussions"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -148,7 +148,7 @@ func workForever(ctx context.Context) {
 	}
 }
 
-var gmailQuoteMatch = regexp.MustCompile(`(\r\n|\n).*On .* at .*, (.|\r\n|\n)*wrote\:(.|\r\n|\n)*(\r\n|\n)+(>.*(\r\n|\n))+(.|\r\n|\n)*`)
+var gmailQuoteMatch = lazyregexp.New(`(\r\n|\n).*On .* at .*, (.|\r\n|\n)*wrote\:(.|\r\n|\n)*(\r\n|\n)+(>.*(\r\n|\n))+(.|\r\n|\n)*`)
 
 // trimGmailReplyQuote trims the gmail reply quotation out of the given
 // message. This is a best-effort approach. In specific, it looks for the

--- a/cmd/frontend/internal/pkg/discussions/mentions/mentions.go
+++ b/cmd/frontend/internal/pkg/discussions/mentions/mentions.go
@@ -1,9 +1,9 @@
 // Package mentions provides utilities for at mentions in discussions.
 package mentions
 
-import "regexp"
+import "github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 
-var mentions = regexp.MustCompile(`(^|\s)@(\S*)`)
+var mentions = lazyregexp.New(`(^|\s)@(\S*)`)
 
 // Parse parses the @mentions from the given markdown comment contents and
 // returns a list of usernames without the @ prefixes.

--- a/cmd/frontend/internal/pkg/discussions/searchquery/searchquery.go
+++ b/cmd/frontend/internal/pkg/discussions/searchquery/searchquery.go
@@ -2,9 +2,10 @@
 package searchquery
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 var (
@@ -15,7 +16,7 @@ var (
 	reUnquotedValue          = `([^ ]+(\s|$))`
 	reValue                  = `(?P<Value>` + reQuotedValue + `|` + reUnquotedValue + `)`
 	reOperationAndValue      = `(?P<OperationAndValue>` + reOperationPrefix + `:` + reValue + `)`
-	re                       = regexp.MustCompile(`\s?` + reOperationAndValue + `\s?`)
+	re                       = lazyregexp.New(`\s?` + reOperationAndValue + `\s?`)
 )
 
 // Parse parses a search query. See the tests for examples of what this looks like.

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -2,11 +2,12 @@ package query
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-var fieldRx = regexp.MustCompile(`^-?[a-zA-Z]+:`)
+var fieldRx = lazyregexp.New(`^-?[a-zA-Z]+:`)
 
 // ConvertToLiteral quotes the input query for literal search.
 func ConvertToLiteral(input string) string {
@@ -41,7 +42,7 @@ func ConvertToLiteral(input string) string {
 	return input
 }
 
-var tokenRx = regexp.MustCompile(`("([^"\\]|[\\].)*"|\s+|\S+)`)
+var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
 
 // tokenize returns a slice of the double-quoted strings, contiguous chunks
 // of non-whitespace, and contiguous chunks of whitespace in the input.

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // TypeError describes an error in query typechecking.
@@ -141,8 +142,8 @@ func setValue(dst *Value, valueString string, valueType ValueType) error {
 	return nil
 }
 
-var leftParenRx = regexp.MustCompile(`([^\\]|^)\($`)
-var squareBraceRx = regexp.MustCompile(`([^\\]|^)\[$`)
+var leftParenRx = lazyregexp.New(`([^\\]|^)\($`)
+var squareBraceRx = lazyregexp.New(`([^\\]|^)\[$`)
 
 // autoFix escapes various patterns that are very likely not meant to be
 // treated as regular expressions.

--- a/cmd/gitserver/server/gitolite-phabricator.go
+++ b/cmd/gitserver/server/gitolite-phabricator.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -68,7 +68,7 @@ func (s *Server) handleGetGitolitePhabricatorMetadata(w http.ResponseWriter, r *
 	}
 }
 
-var callSignPattern = regexp.MustCompile("^[A-Z]+$")
+var callSignPattern = lazyregexp.New("^[A-Z]+$")
 
 func getGitolitePhabCallsign(ctx context.Context, gconf *schema.GitoliteConnection, repo string, command string) (string, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,6 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -1024,7 +1024,7 @@ func init() {
 	prometheus.MustRegister(repoClonedCounter)
 }
 
-var headBranchPattern = regexp.MustCompile(`HEAD branch: (.+?)\n`)
+var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, url string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Server.doRepoUpdate")

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -502,7 +503,7 @@ func (s *GithubSource) listSearch(ctx context.Context, query string, results cha
 // - only single hyphens and alphanumeric characters allowed.
 // - cannot begin/end with hyphen.
 // - up to 38 characters.
-var regOrg = regexp.MustCompile(`^org:([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})$`)
+var regOrg = lazyregexp.New(`^org:([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})$`)
 
 // matchOrg extracts the org name from the pattern `org:<org-name>` if it exists.
 func matchOrg(q string) string {

--- a/cmd/server/internal/goreman/goreman.go
+++ b/cmd/server/internal/goreman/goreman.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // -- process information structure.
@@ -31,7 +32,7 @@ var maxProcNameLength int
 // read Procfile and parse it.
 func readProcfile(content []byte) error {
 	procs = map[string]*procInfo{}
-	re := regexp.MustCompile(`\$([a-zA-Z]+[a-zA-Z0-9_]+)`)
+	re := lazyregexp.New(`\$([a-zA-Z]+[a-zA-Z0-9_]+)`)
 	for _, line := range strings.Split(string(content), "\n") {
 		tokens := strings.SplitN(line, ":", 2)
 		if len(tokens) != 2 || tokens[0][0] == '#' {

--- a/dev/migrate-vanity.go
+++ b/dev/migrate-vanity.go
@@ -14,15 +14,15 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"golang.org/x/tools/imports"
 
 	"github.com/fatih/astrewrite"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-var vendorRe = regexp.MustCompile(`(/|^)vendor/`)
+var vendorRe = lazyregexp.New(`(/|^)vendor/`)
 
 func main() {
 	rewriteFunc := func(n ast.Node) (ast.Node, bool) {

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 func init() {
@@ -22,7 +22,7 @@ func init() {
 }
 
 // sourceMappingURLLineRegex is a regular expression that matches all lines with a `//# sourceMappingURL` comment
-var sourceMappingURLLineRegex = regexp.MustCompile(`(?m)\r?\n?^//# sourceMappingURL=.+$`)
+var sourceMappingURLLineRegex = lazyregexp.New(`(?m)\r?\n?^//# sourceMappingURL=.+$`)
 
 // handleRegistryExtensionBundle serves the bundled JavaScript source file or the source map for an
 // extension in the registry as a raw JavaScript or JSON file.

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // validateExtensionManifest validates a JSON extension manifest for syntax.
@@ -63,7 +63,7 @@ func getExtensionManifestWithBundleURL(ctx context.Context, extensionID string, 
 	return manifest, publishedAt, nil
 }
 
-var nonLettersDigits = regexp.MustCompile(`[^a-zA-Z0-9-]`)
+var nonLettersDigits = lazyregexp.New(`[^a-zA-Z0-9-]`)
 
 func makeExtensionBundleURL(registryExtensionReleaseID int64, timestamp int64, extensionIDHint string) (string, error) {
 	u, err := url.Parse(conf.Get().Critical.ExternalURL)

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // Config is the set of configuration parameters that determine the structure of the CI build. These
@@ -75,7 +75,7 @@ func ComputeConfig() Config {
 		mustIncludeCommit: mustIncludeCommits,
 
 		taggedRelease:       taggedRelease,
-		releaseBranch:       regexp.MustCompile(`^[0-9]+\.[0-9]+$`).MatchString(branch),
+		releaseBranch:       lazyregexp.New(`^[0-9]+\.[0-9]+$`).MatchString(branch),
 		isBextReleaseBranch: branch == "bext/release",
 		patch:               patch,
 		patchNoTest:         patchNoTest,

--- a/internal/conf/reposource/common.go
+++ b/internal/conf/reposource/common.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // RepoSource is a wrapper around a repository source (typically a code host config) that provides a
@@ -36,7 +37,7 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 	return baseURL
 }
 
-var nonSCPURLRegex = regexp.MustCompile(`^(git\+)?(https?|ssh|rsync|file|git)://`)
+var nonSCPURLRegex = lazyregexp.New(`^(git\+)?(https?|ssh|rsync|file|git)://`)
 
 // parseCloneURL parses a git clone URL into a URL struct. It supports the SCP-style git@host:path
 // syntax that is common among code hosts.

--- a/internal/extsvc/bitbucketcloud/testing.go
+++ b/internal/extsvc/bitbucketcloud/testing.go
@@ -3,11 +3,11 @@ package bitbucketcloud
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 func GetenvTestBitbucketCloudUsername() string {
@@ -45,7 +45,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 	}
 }
 
-var normalizer = regexp.MustCompile("[^A-Za-z0-9-]+")
+var normalizer = lazyregexp.New("[^A-Za-z0-9-]+")
 
 func normalize(path string) string {
 	return normalizer.ReplaceAllLiteralString(path, "-")

--- a/internal/extsvc/bitbucketserver/testing.go
+++ b/internal/extsvc/bitbucketserver/testing.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // NewTestClient returns a bitbucketserver.Client that records its interactions
@@ -50,7 +50,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 	}
 }
 
-var normalizer = regexp.MustCompile("[^A-Za-z0-9-]+")
+var normalizer = lazyregexp.New("[^A-Za-z0-9-]+")
 
 func normalize(path string) string {
 	return normalizer.ReplaceAllLiteralString(path, "-")

--- a/internal/gosrc/import_path.go
+++ b/internal/gosrc/import_path.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // Adapted from github.com/golang/gddo/gosrc.
@@ -77,7 +78,7 @@ func resolveStaticImportPath(importPath string) (*Directory, error) {
 
 // gopkgSrcTemplate matches the go-source dir templates specified by the
 // popular gopkg.in
-var gopkgSrcTemplate = regexp.MustCompile(`https://(github.com/[^/]*/[^/]*)/tree/([^/]*)\{/dir\}`)
+var gopkgSrcTemplate = lazyregexp.New(`https://(github.com/[^/]*/[^/]*)/tree/([^/]*)\{/dir\}`)
 
 func resolveDynamicImportPath(client *http.Client, importPath string) (*Directory, error) {
 	metaProto, im, sm, err := fetchMeta(client, importPath)

--- a/internal/lazyregexp/NOTICE
+++ b/internal/lazyregexp/NOTICE
@@ -1,4 +1,4 @@
-Code copied from https://raw.githubusercontent.com/golang/go/go1.13.3/src/internal/lazyregexp/lazyre.go
+Code extended from https://raw.githubusercontent.com/golang/go/go1.13.3/src/internal/lazyregexp/lazyre.go
 
 Copyright (c) 2019 The Go Authors. All rights reserved.
 

--- a/internal/lazyregexp/NOTICE
+++ b/internal/lazyregexp/NOTICE
@@ -1,0 +1,29 @@
+Code copied from https://raw.githubusercontent.com/golang/go/go1.13.3/src/internal/lazyregexp/lazyre.go
+
+Copyright (c) 2019 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/lazyregexp/lazyre.go
+++ b/internal/lazyregexp/lazyre.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package lazyregexp is a thin wrapper over regexp, allowing the use of global
+// regexp variables without forcing them to be compiled at init.
+package lazyregexp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Regexp is a wrapper around regexp.Regexp, where the underlying regexp will be
+// compiled the first time it is needed.
+type Regexp struct {
+	str  string
+	once sync.Once
+	rx   *regexp.Regexp
+}
+
+func (r *Regexp) re() *regexp.Regexp {
+	r.once.Do(r.build)
+	return r.rx
+}
+
+func (r *Regexp) build() {
+	r.rx = regexp.MustCompile(r.str)
+	r.str = ""
+}
+
+func (r *Regexp) FindSubmatch(s []byte) [][]byte {
+	return r.re().FindSubmatch(s)
+}
+
+func (r *Regexp) FindStringSubmatch(s string) []string {
+	return r.re().FindStringSubmatch(s)
+}
+
+func (r *Regexp) FindStringSubmatchIndex(s string) []int {
+	return r.re().FindStringSubmatchIndex(s)
+}
+
+func (r *Regexp) ReplaceAllString(src, repl string) string {
+	return r.re().ReplaceAllString(src, repl)
+}
+
+func (r *Regexp) FindString(s string) string {
+	return r.re().FindString(s)
+}
+
+func (r *Regexp) FindAllString(s string, n int) []string {
+	return r.re().FindAllString(s, n)
+}
+
+func (r *Regexp) MatchString(s string) bool {
+	return r.re().MatchString(s)
+}
+
+func (r *Regexp) SubexpNames() []string {
+	return r.re().SubexpNames()
+}
+
+var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
+
+// New creates a new lazy regexp, delaying the compiling work until it is first
+// needed. If the code is being run as part of tests, the regexp compiling will
+// happen immediately.
+func New(str string) *Regexp {
+	lr := &Regexp{str: str}
+	if inTest {
+		// In tests, always compile the regexps early.
+		lr.re()
+	}
+	return lr
+}

--- a/internal/lazyregexp/lazyre.go
+++ b/internal/lazyregexp/lazyre.go
@@ -63,6 +63,34 @@ func (r *Regexp) SubexpNames() []string {
 	return r.re().SubexpNames()
 }
 
+func (r *Regexp) FindAllStringSubmatch(s string, n int) [][]string {
+	return r.re().FindAllStringSubmatch(s, n)
+}
+
+func (r *Regexp) Split(s string, n int) []string {
+	return r.re().Split(s, n)
+}
+
+func (r *Regexp) ReplaceAllLiteralString(src, repl string) string {
+	return r.re().ReplaceAllLiteralString(src, repl)
+}
+
+func (r *Regexp) FindAllIndex(b []byte, n int) [][]int {
+	return r.re().FindAllIndex(b, n)
+}
+
+func (r *Regexp) Match(b []byte) bool {
+	return r.re().Match(b)
+}
+
+func (r *Regexp) ReplaceAllStringFunc(src string, repl func(string) string) string {
+	return r.re().ReplaceAllStringFunc(src, repl)
+}
+
+func (r *Regexp) ReplaceAll(src, repl []byte) []byte {
+	return r.re().ReplaceAll(src, repl)
+}
+
 var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
 
 // New creates a new lazy regexp, delaying the compiling work until it is first

--- a/internal/lazyregexp/lazyre.go
+++ b/internal/lazyregexp/lazyre.go
@@ -27,7 +27,7 @@ func (r *Regexp) re() *regexp.Regexp {
 }
 
 func (r *Regexp) build() {
-	r.rx = lazyregexp.New(r.str)
+	r.rx = regexp.MustCompile(r.str)
 	r.str = ""
 }
 

--- a/internal/lazyregexp/lazyre.go
+++ b/internal/lazyregexp/lazyre.go
@@ -27,7 +27,7 @@ func (r *Regexp) re() *regexp.Regexp {
 }
 
 func (r *Regexp) build() {
-	r.rx = regexp.MustCompile(r.str)
+	r.rx = lazyregexp.New(r.str)
 	r.str = ""
 }
 

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -1,10 +1,9 @@
 package markdown
 
 import (
-	"regexp"
-
 	"github.com/microcosm-cc/bluemonday"
 	gfm "github.com/shurcooL/github_flavored_markdown"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // Render renders Markdown content into sanitized HTML that is safe to render anywhere.
@@ -13,11 +12,11 @@ func Render(content string) string {
 
 	p := bluemonday.UGCPolicy()
 	p.AllowAttrs("name").Matching(bluemonday.SpaceSeparatedTokens).OnElements("a")
-	p.AllowAttrs("rel").Matching(regexp.MustCompile(`^nofollow$`)).OnElements("a")
-	p.AllowAttrs("class").Matching(regexp.MustCompile(`^anchor$`)).OnElements("a")
-	p.AllowAttrs("aria-hidden").Matching(regexp.MustCompile(`^true$`)).OnElements("a")
-	p.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
-	p.AllowAttrs("checked", "disabled").Matching(regexp.MustCompile(`^$`)).OnElements("input")
-	p.AllowAttrs("class").Matching(regexp.MustCompile("^language-[a-zA-Z0-9]+$")).OnElements("code")
+	p.AllowAttrs("rel").Matching(lazyregexp.New(`^nofollow$`)).OnElements("a")
+	p.AllowAttrs("class").Matching(lazyregexp.New(`^anchor$`)).OnElements("a")
+	p.AllowAttrs("aria-hidden").Matching(lazyregexp.New(`^true$`)).OnElements("a")
+	p.AllowAttrs("type").Matching(lazyregexp.New(`^checkbox$`)).OnElements("input")
+	p.AllowAttrs("checked", "disabled").Matching(lazyregexp.New(`^$`)).OnElements("input")
+	p.AllowAttrs("class").Matching(lazyregexp.New("^language-[a-zA-Z0-9]+$")).OnElements("code")
 	return string(p.SanitizeBytes(unsafeHTML))
 }

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -1,22 +1,31 @@
 package markdown
 
 import (
+	"regexp"
+	"sync"
+
 	"github.com/microcosm-cc/bluemonday"
 	gfm "github.com/shurcooL/github_flavored_markdown"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+)
+
+var (
+	once   sync.Once
+	policy *bluemonday.Policy
 )
 
 // Render renders Markdown content into sanitized HTML that is safe to render anywhere.
 func Render(content string) string {
-	unsafeHTML := gfm.Markdown([]byte(content))
+	once.Do(func() {
+		policy = bluemonday.UGCPolicy()
+		policy.AllowAttrs("name").Matching(bluemonday.SpaceSeparatedTokens).OnElements("a")
+		policy.AllowAttrs("rel").Matching(regexp.MustCompile(`^nofollow$`)).OnElements("a")
+		policy.AllowAttrs("class").Matching(regexp.MustCompile(`^anchor$`)).OnElements("a")
+		policy.AllowAttrs("aria-hidden").Matching(regexp.MustCompile(`^true$`)).OnElements("a")
+		policy.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
+		policy.AllowAttrs("checked", "disabled").Matching(regexp.MustCompile(`^$`)).OnElements("input")
+		policy.AllowAttrs("class").Matching(regexp.MustCompile("^language-[a-zA-Z0-9]+$")).OnElements("code")
+	})
 
-	p := bluemonday.UGCPolicy()
-	p.AllowAttrs("name").Matching(bluemonday.SpaceSeparatedTokens).OnElements("a")
-	p.AllowAttrs("rel").Matching(lazyregexp.New(`^nofollow$`)).OnElements("a")
-	p.AllowAttrs("class").Matching(lazyregexp.New(`^anchor$`)).OnElements("a")
-	p.AllowAttrs("aria-hidden").Matching(lazyregexp.New(`^true$`)).OnElements("a")
-	p.AllowAttrs("type").Matching(lazyregexp.New(`^checkbox$`)).OnElements("input")
-	p.AllowAttrs("checked", "disabled").Matching(lazyregexp.New(`^$`)).OnElements("input")
-	p.AllowAttrs("class").Matching(lazyregexp.New("^language-[a-zA-Z0-9]+$")).OnElements("code")
-	return string(p.SanitizeBytes(unsafeHTML))
+	unsafeHTML := gfm.Markdown([]byte(content))
+	return string(policy.SanitizeBytes(unsafeHTML))
 }

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -3,12 +3,12 @@ package redispool
 
 import (
 	"errors"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 var (
@@ -52,7 +52,7 @@ func init() {
 	}
 }
 
-var schemeMatcher = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9\+\-\.]*://`)
+var schemeMatcher = lazyregexp.New(`^[A-Za-z][A-Za-z0-9\+\-\.]*://`)
 
 // dialRedis dials Redis given the raw endpoint string. The string can have two formats:
 // 1) If there is a HTTP scheme, it should be either be "redis://" or "rediss://" and the URL

--- a/internal/repotrackutil/repouri.go
+++ b/internal/repotrackutil/repouri.go
@@ -1,10 +1,10 @@
 package repotrackutil
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 var trackedRepo = []string{
@@ -13,7 +13,7 @@ var trackedRepo = []string{
 	"github.com/golang/go",
 	"sourcegraph/sourcegraph",
 }
-var trackedRepoRe = regexp.MustCompile(`\b(` + strings.Join(trackedRepo, "|") + `)\b`)
+var trackedRepoRe = lazyregexp.New(`\b(` + strings.Join(trackedRepo, "|") + `)\b`)
 
 // GetTrackedRepo guesses which repo a request URL path is for. It only looks
 // at a certain subset of repos for its guess.

--- a/internal/routevar/regexp.go
+++ b/internal/routevar/regexp.go
@@ -1,6 +1,6 @@
 package routevar
 
-import "regexp"
+import "github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 
 // namedToNonCapturingGroups converts named capturing groups
 // `(?P<myname>...)` to non-capturing groups `(?:...)` for use in mux
@@ -12,4 +12,4 @@ func namedToNonCapturingGroups(pat string) string {
 
 // namedCaptureGroup matches the syntax for the opening of a regexp
 // named capture group (`(?P<name>`).
-var namedCaptureGroup = regexp.MustCompile(`\(\?P<[^>]+>`)
+var namedCaptureGroup = lazyregexp.New(`\(\?P<[^>]+>`)

--- a/internal/routevar/repo.go
+++ b/internal/routevar/repo.go
@@ -1,10 +1,10 @@
 package routevar
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // A RepoRev specifies a repo at a revision. The revision need not be an absolute
@@ -37,7 +37,7 @@ const (
 	RevPattern = `(?P<rev>(?:` + pathComponentNotDelim + `/)*` + pathComponentNotDelim + `)`
 )
 
-var repoPattern = regexp.MustCompile("^" + RepoPattern + "$")
+var repoPattern = lazyregexp.New("^" + RepoPattern + "$")
 
 // ParseRepo parses a repo path string. If spec is invalid, an
 // InvalidError is returned.

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 type Commit struct {
@@ -53,7 +53,7 @@ type CommitsOptions struct {
 
 // logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
 // -sne` command.
-var logEntryPattern = regexp.MustCompile(`^\s*([0-9]+)\s+(.*)$`)
+var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
 
 // getCommit returns the commit with the given id.
 func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID) (*Commit, error) {

--- a/internal/vfsutil/github_archive.go
+++ b/internal/vfsutil/github_archive.go
@@ -2,9 +2,9 @@ package vfsutil
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // NewGitHubRepoVFS creates a new VFS backed by a GitHub downloadable
@@ -18,7 +18,7 @@ func NewGitHubRepoVFS(repo, rev string) (*ArchiveFS, error) {
 	return NewZipVFS(url, ghFetch.Inc, ghFetchFailed.Inc, false)
 }
 
-var githubRepoRx = regexp.MustCompile(`^github\.com/[\w.-]{1,100}/[\w.-]{1,100}$`)
+var githubRepoRx = lazyregexp.New(`^github\.com/[\w.-]{1,100}/[\w.-]{1,100}$`)
 
 var ghFetch = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: "vfsutil",


### PR DESCRIPTION
This is a technique copied from the go stdlib. See individual commits.