### PR TITLE
Support adding gitlab.com repos on demand in sourcegraph.com

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
@@ -102,10 +103,10 @@ func (s *repos) AddGitHubDotComRepository(ctx context.Context, name api.RepoName
 	ctx, done := trace(ctx, "Repos", "AddGitHubDotComRepository", name, &err)
 	defer done()
 
-	// Avoid hitting the repoupdater (and incurring a hit against our GitHub/etc. API rate
+	// Avoid hitting repoupdater (and incurring a hit against our GitHub/etc. API rate
 	// limit) for repositories that don't exist or private repositories that people attempt to
 	// access.
-	gitserverRepo, err := quickGitserverRepo(ctx, name, "github.com")
+	gitserverRepo, err := quickGitserverRepo(ctx, name, github.ServiceType)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -122,7 +122,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName) (err error) {
 	}
 
 	// Looking up the repo in repo-updater makes it sync that repo to the
-	// database in sourcegraph.com if that repo is from github.com or gitlab.com
+	// database on sourcegraph.com if that repo is from github.com or gitlab.com
 	_, err = repoupdater.DefaultClient.RepoLookup(ctx, protocol.RepoLookupArgs{Repo: name})
 	return err
 }

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -99,7 +99,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName) (err error) {
 	ctx, done := trace(ctx, "Repos", "Add", name, &err)
 	defer done()
 
-	// Avoid hitting repoupdater (and incurring a hit against our GitHub/etc. API rate
+	// Avoid hitting repo-updater (and incurring a hit against our GitHub/etc. API rate
 	// limit) for repositories that don't exist or private repositories that people attempt to
 	// access.
 	var serviceType string

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -16,13 +16,12 @@ import (
 )
 
 type MockRepos struct {
-	Get                       func(v0 context.Context, id api.RepoID) (*types.Repo, error)
-	GetByName                 func(v0 context.Context, name api.RepoName) (*types.Repo, error)
-	AddGitHubDotComRepository func(name api.RepoName) error
-	List                      func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
-	GetCommit                 func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
-	ResolveRev                func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
-	GetInventory              func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
+	Get          func(v0 context.Context, id api.RepoID) (*types.Repo, error)
+	GetByName    func(v0 context.Context, name api.RepoName) (*types.Repo, error)
+	List         func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
+	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
+	ResolveRev   func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
+	GetInventory func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
 }
 
 var errRepoNotFound = &errcode.Mock{

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -63,7 +63,7 @@ func TestReposService_List(t *testing.T) {
 	}
 }
 
-func TestRepos_Add(t *testing.T) {
+func TestRepos_AddRepository(t *testing.T) {
 	var s repos
 	ctx := testContext()
 
@@ -81,23 +81,11 @@ func TestRepos_Add(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 
-	calledUpsert := false
-	db.Mocks.Repos.Upsert = func(op api.InsertRepoOp) error {
-		calledUpsert = true
-		if want := (api.InsertRepoOp{Name: repoName, Description: "d"}); !reflect.DeepEqual(op, want) {
-			t.Errorf("got %+v, want %+v", op, want)
-		}
-		return nil
-	}
-
-	if err := s.AddGitHubDotComRepository(ctx, repoName); err != nil {
+	if err := s.Add(ctx, repoName); err != nil {
 		t.Fatal(err)
 	}
 	if !calledRepoLookup {
 		t.Error("!calledRepoLookup")
-	}
-	if !calledUpsert {
-		t.Error("!calledUpsert")
 	}
 }
 

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -63,7 +63,7 @@ func TestReposService_List(t *testing.T) {
 	}
 }
 
-func TestRepos_AddRepository(t *testing.T) {
+func TestRepos_Add(t *testing.T) {
 	var s repos
 	ctx := testContext()
 

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -96,6 +96,20 @@ func (s GitLabSource) ListRepos(ctx context.Context, results chan SourceResult) 
 	s.listAllProjects(ctx, results)
 }
 
+// GetRepo returns the GitLab repository with the given pathWithNamespace.
+func (s GitLabSource) GetRepo(ctx context.Context, pathWithNamespace string) (*Repo, error) {
+	proj, err := s.client.GetProject(ctx, gitlab.GetProjectOp{
+		PathWithNamespace: pathWithNamespace,
+		CommonOp:          gitlab.CommonOp{NoCache: true},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return s.makeRepo(proj), nil
+}
+
 // ExternalServices returns a singleton slice containing the external service.
 func (s GitLabSource) ExternalServices() ExternalServices {
 	return ExternalServices{s.svc}

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -1,8 +1,17 @@
 package repos
 
 import (
+	"context"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/schema"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 func Test_projectQueryToURL(t *testing.T) {
@@ -46,5 +55,101 @@ func Test_projectQueryToURL(t *testing.T) {
 		if !reflect.DeepEqual(test.expErr, err) {
 			t.Errorf("expected err %v, got %v", test.expErr, err)
 		}
+	}
+}
+
+func TestGitLabSource_GetRepo(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		projectWithNamespace string
+		assert               func(*testing.T, *Repo)
+		err                  string
+	}{
+		{
+			name:                 "not found",
+			projectWithNamespace: "foobarfoobarfoobar/please-let-this-not-exist",
+			err:                  `unexpected response from GitLab API (https://gitlab.com/api/v4/projects/foobarfoobarfoobar%2Fplease-let-this-not-exist): HTTP error status 404`,
+		},
+		{
+			name:                 "found",
+			projectWithNamespace: "gitlab-org/gitaly",
+			assert: func(t *testing.T, have *Repo) {
+				t.Helper()
+
+				want := &Repo{
+					Name:        "gitlab.com/gitlab-org/gitaly",
+					Description: "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
+					Enabled:     true,
+					URI:         "gitlab.com/gitlab-org/gitaly",
+					ExternalRepo: api.ExternalRepoSpec{
+						ID:          "2009901",
+						ServiceType: "gitlab",
+						ServiceID:   "https://gitlab.com/",
+					},
+					Sources: map[string]*SourceInfo{
+						"extsvc:gitlab:0": {
+							ID:       "extsvc:gitlab:0",
+							CloneURL: "https://gitlab.com/gitlab-org/gitaly.git",
+						},
+					},
+					Metadata: &gitlab.Project{
+						ProjectCommon: gitlab.ProjectCommon{
+							ID:                2009901,
+							PathWithNamespace: "gitlab-org/gitaly",
+							Description:       "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
+							WebURL:            "https://gitlab.com/gitlab-org/gitaly",
+							HTTPURLToRepo:     "https://gitlab.com/gitlab-org/gitaly.git",
+							SSHURLToRepo:      "git@gitlab.com:gitlab-org/gitaly.git",
+						},
+						Visibility: "",
+						Archived:   false,
+					},
+				}
+
+				if !reflect.DeepEqual(have, want) {
+					t.Errorf("response: %s", cmp.Diff(have, want))
+				}
+			},
+			err: "<nil>",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "GITLAB-DOT-COM/" + tc.name
+
+		t.Run(tc.name, func(t *testing.T) {
+			// The GitLabSource uses the gitlab.Client under the hood, which
+			// uses rcache, a caching layer that uses Redis.
+			// We need to clear the cache before we run the tests
+			rcache.SetupForTest(t)
+
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &ExternalService{
+				Kind: "GITLAB",
+				Config: marshalJSON(t, &schema.GitLabConnection{
+					Url: "https://gitlab.com",
+				}),
+			}
+
+			gitlabSrc, err := NewGitLabSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			repo, err := gitlabSrc.GetRepo(context.Background(), tc.projectWithNamespace)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if tc.assert != nil {
+				tc.assert(t, repo)
+			}
+		})
 	}
 }

--- a/cmd/repo-updater/repos/testdata/sources/GITLAB-DOT-COM/found.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GITLAB-DOT-COM/found.yaml
@@ -1,0 +1,49 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/gitlab-org%2Fgitaly
+    method: GET
+  response:
+    body: '{"id":2009901,"description":"Gitaly is a Git RPC service for handling all
+      the git calls made by GitLab","name":"gitaly","name_with_namespace":"GitLab.org
+      / gitaly","path":"gitaly","path_with_namespace":"gitlab-org/gitaly","created_at":"2016-11-14T21:07:35.543Z","default_branch":"master","tag_list":["git","gitlab","rpc"],"ssh_url_to_repo":"git@gitlab.com:gitlab-org/gitaly.git","http_url_to_repo":"https://gitlab.com/gitlab-org/gitaly.git","web_url":"https://gitlab.com/gitlab-org/gitaly","readme_url":"https://gitlab.com/gitlab-org/gitaly/blob/master/README.md","avatar_url":"https://assets.gitlab-static.net/uploads/-/system/project/avatar/2009901/gitaly7.png","star_count":168,"forks_count":76,"last_activity_at":"2019-10-24T12:40:27.069Z","namespace":{"id":9970,"name":"GitLab.org","path":"gitlab-org","kind":"group","full_path":"gitlab-org","parent_id":null,"avatar_url":"/uploads/-/system/group/avatar/9970/logo-extra-whitespace.png","web_url":"https://gitlab.com/groups/gitlab-org"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "991"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Oct 2019 14:07:27 GMT
+      Etag:
+      - W/"add54269ca3bfda0908ec842e6ac52f5"
+      Gitlab-Lb:
+      - fe-08-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 23Y6wkoFnd2
+      X-Runtime:
+      - "0.061710"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/GITLAB-DOT-COM/not-found.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GITLAB-DOT-COM/not-found.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/foobarfoobarfoobar%2Fplease-let-this-not-exist
+    method: GET
+  response:
+    body: '{"message":"404 Project Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "35"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Oct 2019 14:07:27 GMT
+      Gitlab-Lb:
+      - fe-08-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Server:
+      - nginx
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - j4INbhtT3o3
+      X-Runtime:
+      - "0.021143"
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -27,8 +27,12 @@ import (
 type Server struct {
 	repos.Store
 	*repos.Syncer
-	GithubDotComSource interface {
+	SourcegraphDotComMode bool
+	GithubDotComSource    interface {
 		GetRepo(ctx context.Context, nameWithOwner string) (*repos.Repo, error)
+	}
+	GitLabDotComSource interface {
+		GetRepo(ctx context.Context, projectWithNamespace string) (*repos.Repo, error)
 	}
 	Scheduler interface {
 		UpdateOnce(id uint32, name api.RepoName, url string)
@@ -393,10 +397,35 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		return mockRepoLookup(args)
 	}
 
-	var repo *repos.Repo
 	result = &protocol.RepoLookupResult{}
+	src := sourceFromRepoName(strings.ToLower(string(args.Repo)))
 
-	if s.shouldGetGithubDotComRepo(args) {
+	if !s.SourcegraphDotComMode || src == "" {
+		repos, err := s.Store.ListRepos(ctx, repos.StoreListReposArgs{
+			Names: []string{string(args.Repo)},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(repos) != 1 {
+			result.ErrorNotFound = true
+			return result, nil
+		}
+
+		repoInfo, err := newRepoInfo(repos[0])
+		if err != nil {
+			return nil, err
+		}
+
+		result.Repo = repoInfo
+		return result, nil
+	}
+
+	var repo *repos.Repo
+
+	switch src {
+	case "github.com":
 		nameWithOwner := strings.TrimPrefix(string(args.Repo), "github.com/")
 		repo, err = s.GithubDotComSource.GetRepo(ctx, nameWithOwner)
 		if err != nil {
@@ -415,23 +444,25 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 			return nil, err
 		}
 
-		err = s.Syncer.SyncSubset(ctx, repo)
+	case "gitlab.com":
+		projectWithNamespace := strings.TrimPrefix(string(args.Repo), "gitlab.com/")
+		repo, err = s.GitLabDotComSource.GetRepo(ctx, projectWithNamespace)
 		if err != nil {
+			if gitlab.IsNotFound(err) {
+				result.ErrorNotFound = true
+				return result, nil
+			}
+			if isUnauthorized(err) {
+				result.ErrorUnauthorized = true
+				return result, nil
+			}
 			return nil, err
 		}
-	} else {
-		repos, err := s.Store.ListRepos(ctx, repos.StoreListReposArgs{
-			Names: []string{string(args.Repo)},
-		})
-		if err != nil {
-			return nil, err
-		}
+	}
 
-		if len(repos) != 1 {
-			result.ErrorNotFound = true
-			return result, nil
-		}
-		repo = repos[0]
+	err = s.Syncer.SyncSubset(ctx, repo)
+	if err != nil {
+		return nil, err
 	}
 
 	repoInfo, err := newRepoInfo(repo)
@@ -443,13 +474,15 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	return result, nil
 }
 
-func (s *Server) shouldGetGithubDotComRepo(args protocol.RepoLookupArgs) bool {
-	if s.GithubDotComSource == nil {
-		return false
+func sourceFromRepoName(repoName string) string {
+	switch {
+	case strings.HasPrefix(repoName, "github.com/"):
+		return "github.com"
+	case strings.HasPrefix(repoName, "gitlab.com/"):
+		return "gitlab.com"
+	default:
+		return ""
 	}
-
-	repoName := strings.ToLower(string(args.Repo))
-	return strings.HasPrefix(repoName, "github.com/")
 }
 
 func (s *Server) handleStatusMessages(w http.ResponseWriter, r *http.Request) {
@@ -619,6 +652,9 @@ func pathAppend(base, p string) string {
 
 func isUnauthorized(err error) bool {
 	code := github.HTTPErrorCode(err)
+	if code == 0 {
+		code = gitlab.HTTPErrorCode(err)
+	}
 	return code == http.StatusUnauthorized || code == http.StatusForbidden
 }
 

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -13,6 +13,20 @@ type CodeHost struct {
 	BaseURL     *url.URL
 }
 
+// Known public code hosts and their URLs
+var (
+	GitHubDotComURL = mustParseURL("https://github.com")
+	GitHubDotCom    = NewCodeHost(GitHubDotComURL, "github")
+
+	GitLabDotComURL = mustParseURL("https://gitlab.com")
+	GitLabDotCom    = NewCodeHost(GitLabDotComURL, "gitlab")
+
+	PublicCodeHosts = []*CodeHost{
+		GitHubDotCom,
+		GitLabDotCom,
+	}
+)
+
 func NewCodeHost(baseURL *url.URL, serviceType string) *CodeHost {
 	return &CodeHost{
 		ServiceID:   NormalizeBaseURL(baseURL).String(),
@@ -35,4 +49,24 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 		baseURL.Path += "/"
 	}
 	return baseURL
+}
+
+// CodeHostOf returns the CodeHost of the given repo, if any, as
+// determined by a common prefix between the repo name and the
+// codehosts' URL hostname component.
+func CodeHostOf(name api.RepoName, codehosts ...*CodeHost) *CodeHost {
+	for _, c := range codehosts {
+		if strings.HasPrefix(strings.ToLower(string(name)), c.BaseURL.Hostname()) {
+			return c
+		}
+	}
+	return nil
+}
+
+func mustParseURL(rawurl string) *url.URL {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -1,0 +1,49 @@
+package extsvc
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestCodeHostOf(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		repo      api.RepoName
+		codehosts []*CodeHost
+		want      *CodeHost
+	}{{
+		name:      "none",
+		repo:      "github.com/foo/bar",
+		codehosts: nil,
+		want:      nil,
+	}, {
+		name:      "out",
+		repo:      "github.com/foo/bar",
+		codehosts: []*CodeHost{GitLabDotCom},
+		want:      nil,
+	}, {
+		name:      "in",
+		repo:      "github.com/foo/bar",
+		codehosts: PublicCodeHosts,
+		want:      GitHubDotCom,
+	}, {
+		name:      "case-insensitive",
+		repo:      "GITHUB.COM/foo/bar",
+		codehosts: PublicCodeHosts,
+		want:      GitHubDotCom,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			have := CodeHostOf(tc.repo, tc.codehosts...)
+			if have != tc.want {
+				t.Errorf(
+					"CodeHostOf(%q, %#v): want %#v, have %#v",
+					tc.repo,
+					tc.codehosts,
+					tc.want,
+					have,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change set adds support for adding gitlab.com repos on demand in our sourcegraph.com environment, similarly to what we already do for github.com.

Context: https://sourcegraph.slack.com/archives/C07KZF47K/p1571913420280900?thread_ts=1571858609.253800&cid=C07KZF47K

Test plan: Manual testing + automated tests

Release notes:
- [x] We need to add a Gitlab external service with a url=gitlab.com and an access token from some shared sourcegraph gitlab.com account before merging this.
