### PR TITLE
prometheus image: entry uses exec instead of sh -c

### DIFF
--- a/docker-images/prometheus/entry.sh
+++ b/docker-images/prometheus/entry.sh
@@ -7,4 +7,4 @@ if test "$USE_KUBERNETES_DISCOVERY" = 'true'; then
     CONFIG_FILE=/sg_config_prometheus/prometheus_k8s.yml
 fi
 
-sh -c "/bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=/prometheus $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
+exec /bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=/prometheus $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles $@


### PR DESCRIPTION
Allows easier way to pass command line args to prometheus executable.

Fixes https://github.com/sourcegraph/issues-uber/issues/212