### PR TITLE
Search: lift out searcher callout in frontend.

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -612,7 +612,6 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 				addMatches(matches)
 			}(limitCtx, limitDone, repoRev)
 		}
-		wg.Wait()
 		return common, err
 	}
 
@@ -649,6 +648,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 	}()
 
 	common, err = callSearcherOverRepos(searcherRepos, common)
+	wg.Wait()
 	if err != nil {
 		return nil, common, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -431,7 +431,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		return mockSearchFilesInRepos(args)
 	}
 
-	// The number of errors that saerchFilesInRepos can report is the size
+	// The number of errors that searchFilesInRepos can report is the size
 	// of the number of go routines we fan out. This number is at most the
 	// size of repos.
 	errc := make(chan error, len(args.Repos))

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -431,11 +430,6 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		return mockSearchFilesInRepos(args)
 	}
 
-	// The number of errors that searchFilesInRepos can report is the size
-	// of the number of go routines we fan out. This number is at most the
-	// size of repos.
-	errc := make(chan error, len(args.Repos))
-
 	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.Pattern, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
@@ -508,6 +502,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		// TODO: convert wg to an errgroup
 		wg                sync.WaitGroup
 		mu                sync.Mutex
+		searchErr         error
 		unflattened       [][]*fileMatchResolver
 		flattenedSize     int
 		overLimitCanceled bool // canceled because we were over the limit
@@ -537,7 +532,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 	}
 
 	// This function calls searcher on a set of repos.
-	callSearcherOverRepos := func(searcherRepos []*search.RepositoryRevisions) {
+	callSearcherOverRepos := func(searcherRepos []*search.RepositoryRevisions) error {
 		var fetchTimeout time.Duration
 		if len(searcherRepos) == 1 || args.UseFullDeadline {
 			// When searching a single repo or when an explicit timeout was specified, give it the remaining deadline to fetch the archive.
@@ -560,8 +555,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 			// searchers.
 			eps, err := args.SearcherURLs.Endpoints()
 			if err != nil {
-				errc <- err
-				return
+				return err
 			}
 			textSearchLimiter.SetLimit(len(eps) * 32)
 		}
@@ -571,8 +565,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 				continue
 			}
 			if len(repoRev.Revs) >= 2 {
-				errc <- errMultipleRevsNotSupported
-				return
+				return errMultipleRevsNotSupported
 			}
 
 			// Only reason acquire can fail is if ctx is cancelled. So we can stop
@@ -588,10 +581,10 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 				defer done()
 
 				rev := repoRev.RevSpecs()[0] // TODO(sqs): search multiple revs
-				matches, repoLimitHit, searchErr := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.Pattern, fetchTimeout)
-				if searchErr != nil {
-					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
-					log15.Warn("searchFilesInRepo failed", "error", searchErr, "repo", repoRev.Repo.Name)
+				matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.Pattern, fetchTimeout)
+				if err != nil {
+					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
+					log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
 				}
 				mu.Lock()
 				defer mu.Unlock()
@@ -602,8 +595,8 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 					// We did not return all results in this repository.
 					common.partial[repoRev.Repo.Name] = struct{}{}
 				}
-				// non-diff search reports timeout through searchErr, so pass false for timedOut
-				if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, searchErr); fatalErr != nil {
+				// non-diff search reports timeout through err, so pass false for timedOut
+				if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, err); fatalErr != nil {
 					if ctx.Err() == context.Canceled {
 						// Our request has been canceled (either because another one of searcherRepos
 						// had a fatal error, or otherwise), so we can just ignore these results. We
@@ -612,21 +605,23 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 						// handle cancellations differently.
 						return
 					}
-					err := errors.Wrapf(searchErr, "failed to search %s", repoRev.String())
-					tr.LazyPrintf("cancel due to error: %v", err)
-					cancel()
-					errc <- err
+					if searchErr == nil {
+						searchErr = errors.Wrapf(err, "failed to search %s", repoRev.String())
+						tr.LazyPrintf("cancel due to error: %v", searchErr)
+						cancel()
+					}
 				}
 				addMatches(matches)
 			}(limitCtx, limitDone, repoRev) // ends the Go routine for a call to searcher for a repo
 		} // ends the for loop iterating over repos
+		return nil
 	} // ends callSearcherOverRepos
 
 	wg.Add(1)
 	go func() {
 		// TODO limitHit, handleRepoSearchResult
 		defer wg.Done()
-		matches, limitHit, reposLimitHit, searchErr := zoektSearchHEAD(ctx, args, zoektRepos, false, time.Since)
+		matches, limitHit, reposLimitHit, err := zoektSearchHEAD(ctx, args, zoektRepos, false, time.Since)
 		mu.Lock()
 		defer mu.Unlock()
 		if ctx.Err() == nil {
@@ -645,23 +640,24 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		if limitHit {
 			common.limitHit = true
 		}
-		tr.LogFields(otlog.Object("searchErr", searchErr), otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
-		if searchErr != nil && err == nil && !overLimitCanceled {
-			errc <- searchErr
+		tr.LogFields(otlog.Error(err), otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+		if err != nil && searchErr == nil && !overLimitCanceled {
+			searchErr = err
 			tr.LazyPrintf("cancel indexed search due to error: %v", err)
 			cancel()
 		}
 		addMatches(matches)
 	}()
 
-	callSearcherOverRepos(searcherRepos)
-	wg.Wait()
-	close(errc)
-	for e := range errc {
-		err = multierror.Append(err, e)
+	if err := callSearcherOverRepos(searcherRepos); err != nil {
+		mu.Lock()
+		searchErr = err
+		mu.Unlock()
 	}
-	if err != nil {
-		return nil, common, err
+
+	wg.Wait()
+	if searchErr != nil {
+		return nil, common, searchErr
 	}
 
 	flattened := flattenFileMatches(unflattened, int(args.Pattern.FileMatchLimit))

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -530,7 +530,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		}
 	}
 
-	// This  function calls searcher on a set of repos.
+	// This function calls searcher on a set of repos.
 	callSearcherOverRepos := func(searcherRepos []*search.RepositoryRevisions, common *searchResultsCommon) (*searchResultsCommon, error) {
 		var err error
 		var fetchTimeout time.Duration

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -530,6 +530,92 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		}
 	}
 
+	// This  function calls searcher on a set of repos.
+	callSearcherOverRepos := func(searcherRepos []*search.RepositoryRevisions, common *searchResultsCommon) (*searchResultsCommon, error) {
+		var err error
+		var fetchTimeout time.Duration
+		if len(searcherRepos) == 1 || args.UseFullDeadline {
+			// When searching a single repo or when an explicit timeout was specified, give it the remaining deadline to fetch the archive.
+			deadline, ok := ctx.Deadline()
+			if ok {
+				fetchTimeout = time.Until(deadline)
+			} else {
+				// In practice, this case should not happen because a deadline should always be set
+				// but if it does happen just set a long but finite timeout.
+				fetchTimeout = time.Minute
+			}
+		} else {
+			// When searching many repos, don't wait long for any single repo to fetch.
+			fetchTimeout = 500 * time.Millisecond
+		}
+
+		if len(searcherRepos) > 0 {
+			// The number of searcher endpoints can change over time. Inform our
+			// limiter of the new limit, which is a multiple of the number of
+			// searchers.
+			eps, err := args.SearcherURLs.Endpoints()
+			if err != nil {
+				return common, err
+			}
+			textSearchLimiter.SetLimit(len(eps) * 32)
+		}
+
+		for _, repoRev := range searcherRepos {
+			if len(repoRev.Revs) == 0 {
+				continue
+			}
+			if len(repoRev.Revs) >= 2 {
+				return common, errMultipleRevsNotSupported
+			}
+
+			// Only reason acquire can fail is if ctx is cancelled. So we can stop
+			// looping through searcherRepos.
+			limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)
+			if acquireErr != nil {
+				break
+			}
+
+			wg.Add(1)
+			go func(ctx context.Context, done context.CancelFunc, repoRev *search.RepositoryRevisions) {
+				defer wg.Done()
+				defer done()
+
+				rev := repoRev.RevSpecs()[0] // TODO(sqs): search multiple revs
+				matches, repoLimitHit, searchErr := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.Pattern, fetchTimeout)
+				if searchErr != nil {
+					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
+					log15.Warn("searchFilesInRepo failed", "error", searchErr, "repo", repoRev.Repo.Name)
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				if ctx.Err() == nil {
+					common.searched = append(common.searched, repoRev.Repo)
+				}
+				if repoLimitHit {
+					// We did not return all results in this repository.
+					common.partial[repoRev.Repo.Name] = struct{}{}
+				}
+				// non-diff search reports timeout through searchErr, so pass false for timedOut
+				if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, searchErr); fatalErr != nil {
+					if ctx.Err() == context.Canceled {
+						// Our request has been canceled (either because another one of searcherRepos
+						// had a fatal error, or otherwise), so we can just ignore these results. We
+						// handle this here, not in handleRepoSearchResult, because different callers of
+						// handleRepoSearchResult (for different result types) currently all need to
+						// handle cancellations differently.
+						return
+					}
+					err = errors.Wrapf(searchErr, "failed to search %s", repoRev.String())
+					tr.LazyPrintf("cancel due to error: %v", err)
+					cancel()
+				}
+				addMatches(matches)
+			}(limitCtx, limitDone, repoRev)
+		}
+		wg.Wait()
+		return common, err
+	}
+
 	wg.Add(1)
 	go func() {
 		// TODO limitHit, handleRepoSearchResult
@@ -562,87 +648,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		addMatches(matches)
 	}()
 
-	var fetchTimeout time.Duration
-	if len(searcherRepos) == 1 || args.UseFullDeadline {
-		// When searching a single repo or when an explicit timeout was specified, give it the remaining deadline to fetch the archive.
-		deadline, ok := ctx.Deadline()
-		if ok {
-			fetchTimeout = time.Until(deadline)
-		} else {
-			// In practice, this case should not happen because a deadline should always be set
-			// but if it does happen just set a long but finite timeout.
-			fetchTimeout = time.Minute
-		}
-	} else {
-		// When searching many repos, don't wait long for any single repo to fetch.
-		fetchTimeout = 500 * time.Millisecond
-	}
-
-	if len(searcherRepos) > 0 {
-		// The number of searcher endpoints can change over time. Inform our
-		// limiter of the new limit, which is a multiple of the number of
-		// searchers.
-		eps, err := args.SearcherURLs.Endpoints()
-		if err != nil {
-			return nil, common, err
-		}
-		textSearchLimiter.SetLimit(len(eps) * 32)
-	}
-
-	for _, repoRev := range searcherRepos {
-		if len(repoRev.Revs) == 0 {
-			continue
-		}
-		if len(repoRev.Revs) >= 2 {
-			return nil, common, errMultipleRevsNotSupported
-		}
-
-		// Only reason acquire can fail is if ctx is cancelled. So we can stop
-		// looping through searcherRepos.
-		limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)
-		if acquireErr != nil {
-			break
-		}
-
-		wg.Add(1)
-		go func(ctx context.Context, done context.CancelFunc, repoRev *search.RepositoryRevisions) {
-			defer wg.Done()
-			defer done()
-
-			rev := repoRev.RevSpecs()[0] // TODO(sqs): search multiple revs
-			matches, repoLimitHit, searchErr := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.Pattern, fetchTimeout)
-			if searchErr != nil {
-				tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
-				log15.Warn("searchFilesInRepo failed", "error", searchErr, "repo", repoRev.Repo.Name)
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			if ctx.Err() == nil {
-				common.searched = append(common.searched, repoRev.Repo)
-			}
-			if repoLimitHit {
-				// We did not return all results in this repository.
-				common.partial[repoRev.Repo.Name] = struct{}{}
-			}
-			// non-diff search reports timeout through searchErr, so pass false for timedOut
-			if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, searchErr); fatalErr != nil {
-				if ctx.Err() == context.Canceled {
-					// Our request has been canceled (either because another one of searcherRepos
-					// had a fatal error, or otherwise), so we can just ignore these results. We
-					// handle this here, not in handleRepoSearchResult, because different callers of
-					// handleRepoSearchResult (for different result types) currently all need to
-					// handle cancellations differently.
-					return
-				}
-				err = errors.Wrapf(searchErr, "failed to search %s", repoRev.String())
-				tr.LazyPrintf("cancel due to error: %v", err)
-				cancel()
-			}
-			addMatches(matches)
-		}(limitCtx, limitDone, repoRev)
-	}
-
-	wg.Wait()
+	common, err = callSearcherOverRepos(searcherRepos, common)
 	if err != nil {
 		return nil, common, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -353,9 +353,14 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
+
+	want := `1 error occurred:
+	* failed to search foo/no-rev@dev: revision not found: foo/no-rev@missing
+
+`
 	_, _, err = searchFilesInRepos(context.Background(), args)
-	if !gitserver.IsRevisionNotFound(errors.Cause(err)) {
-		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
+	if err.Error() != want {
+		t.Fatalf("searching non-existent rev expected to fail, want error message: %v, got: %v", want, err)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -354,13 +354,9 @@ func TestSearchFilesInRepos(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	want := `1 error occurred:
-	* failed to search foo/no-rev@dev: revision not found: foo/no-rev@missing
-
-`
 	_, _, err = searchFilesInRepos(context.Background(), args)
-	if err.Error() != want {
-		t.Fatalf("searching non-existent rev expected to fail, want error message: %v, got: %v", want, err)
+	if !gitserver.IsRevisionNotFound(errors.Cause(err)) {
+		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
 	}
 }
 


### PR DESCRIPTION
- It's useful to have a generic function that does "run all of these repos through the searcher endpoint", for an arbitrary list of repos. 
- Right now, such logic is inlined in `searchFilesinRepos` and only does "run all of these (unindexed repos) through searcher endpoint". 
- I want to preserve this logic, but also make it possible to "run all of these <repos/files zoekt tells me about> through the searcher endpoint", for structural search.

Such a function cannot be extracted to the top level because it runs goroutines that rely on `addMatches` (which seeks to be race safe), and is also inlined. This PR extracts the desired logic into a dedicated inline function `callSearcherOverRepos`, which I will use in subsequent diffs to call out to searcher for structural search.

 What I need is for Go experts to confirm that what I've done here is semantics preserving and race safe.
