### PR TITLE
Define RFC and make solution part optional

### DIFF
--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -1,8 +1,10 @@
-# RFCs
+# Requests for comments (RFCs)
 
 We value writing down plans so that we can asynchronously communicate to and solicit feedback from our remote-first team. A good plan communicates what problem is being solved, why that problem is being prioritized now, and what the plan is to solve the identified problem.
 
-This document describes how we operationalize written planning through our RFC process. This process is designed to be lightweight so that it can be used for many purposes (e.g. product specs, policy decisions, technical discussion), and it is optimized for facilitating collaboration and feedback. In contrast, GitHub issues are best for tracking concrete bug reports or work that has already been scoped and planned (i.e. there isn't much remaining to discuss).
+This document describes how we operationalize written planning through our RFC process. RFC literally means "Request for Comments" and you can think about it as exactly that, no more, no less.
+
+This process is designed to be lightweight so that it can be used for many purposes (e.g. product specs, policy decisions, technical discussion), and it is optimized for facilitating collaboration and feedback. In contrast, GitHub issues are best for tracking concrete bug reports or work that has already been scoped and planned (i.e. there isn't much remaining to discuss).
 
 _All RFCs are in a [public Google Drive folder](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR)._
 
@@ -83,7 +85,7 @@ Effective RFCs contain the following information:
   - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
 - Background/Situation: A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
 - Problem/Goals/Complication/Constraints: A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.
-- Proposed solution/implementation: A description of HOW to solve the problem.
+- (optional) Proposed solution/implementation: A description of HOW to solve the problem. It is ok to omit this section if you are soliciting feedback or intend to handoff ownership of a problem to someone else.
 
 The precise format is not as important as the content itself. Ultimately RFCs are a tool to communicate and gather feedback, so optimize for that.
 

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -85,7 +85,7 @@ Effective RFCs contain the following information:
   - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
 - Background/Situation: A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
 - Problem/Goals/Complication/Constraints: A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.
-- (optional) Proposed solution/implementation: A description of HOW to solve the problem. It is ok to omit this section if you are soliciting feedback or intend to handoff ownership of a problem to someone else.
+- (optional) Proposed solution/implementation: A description of HOW to solve the problem. It is ok to omit this section if you just want to define a problem. This can be useful if you want help thinking of solutions or want to handoff ownership of this problem to someone else.
 
 The precise format is not as important as the content itself. Ultimately RFCs are a tool to communicate and gather feedback, so optimize for that.
 


### PR DESCRIPTION
Some devs have been hesitant to write RFCs because they aren't confident in a solution. RFCs can be useful for defining problems and facilitating discussions to brainstorm solutions to those problems.

This PR updates the docs to clarify that it is OK to write an RFC that defines a problem but doesn't propose a solution.