### PR TITLE
Automatically retry e2e on release branches; else soft fail

### DIFF
--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -27,6 +27,7 @@ type Config struct {
 	taggedRelease       bool
 	releaseBranch       bool
 	isBextReleaseBranch bool
+	isRenovateBranch    bool
 	patch               bool
 	patchNoTest         bool
 	isQuick             bool
@@ -77,6 +78,7 @@ func ComputeConfig() Config {
 		taggedRelease:       taggedRelease,
 		releaseBranch:       regexp.MustCompile(`^[0-9]+\.[0-9]+$`).MatchString(branch),
 		isBextReleaseBranch: branch == "bext/release",
+		isRenovateBranch:    strings.HasPrefix(branch, "renovate/"),
 		patch:               patch,
 		patchNoTest:         patchNoTest,
 		isQuick:             isQuick,

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -124,7 +124,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 // End-to-end tests.
 func addE2E(c Config) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(":chromium:",
+		opts := []bk.StepOpt{
 			// Avoid crashing the sourcegraph/server containers. See
 			// https://github.com/sourcegraph/sourcegraph/issues/2657
 			bk.ConcurrencyGroup("e2e"),
@@ -134,7 +134,15 @@ func addE2E(c Config) func(*bk.Pipeline) {
 			bk.Env("VERSION", c.version),
 			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
 			bk.Cmd("./dev/ci/e2e.sh"),
-			bk.ArtifactPaths("./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log"))
+			bk.ArtifactPaths("./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log"),
+		}
+		requireE2E := c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+		if requireE2E {
+			opts = append(opts, bk.AutomaticRetry(1))
+		} else {
+			opts = append(opts, bk.SoftFail(true))
+		}
+		pipeline.AddStep(":chromium:", opts...)
 	}
 }
 
@@ -210,6 +218,7 @@ func addServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
 func addCleanUpServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":sparkles:",
+			bk.SoftFail(true),
 			bk.Cmd("docker image rm -f sourcegraph/server:"+c.version+"_candidate"))
 	}
 }

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -136,9 +136,9 @@ func addE2E(c Config) func(*bk.Pipeline) {
 			bk.Cmd("./dev/ci/e2e.sh"),
 			bk.ArtifactPaths("./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log"),
 		}
-		requireE2E := c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+		requireE2E := c.branch == "master" || c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 		if requireE2E {
-			opts = append(opts, bk.AutomaticRetry(1))
+			opts = append(opts, bk.AutomaticRetry(2))
 		} else {
 			opts = append(opts, bk.SoftFail(true))
 		}

--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -34,6 +34,16 @@ type Step struct {
 	ArtifactPaths    string                 `json:"artifact_paths,omitempty"`
 	ConcurrencyGroup string                 `json:"concurrency_group,omitempty"`
 	Concurrency      int                    `json:"concurrency,omitempty"`
+	SoftFail         bool                   `json:"soft_fail,omitempty"`
+	Retry            *RetryOptions          `json:"retry,omitempty"`
+}
+
+type RetryOptions struct {
+	Automatic *AutomaticRetryOptions `json:"automatic,omitempty"`
+}
+
+type AutomaticRetryOptions struct {
+	Limit int `json:"limit,omitempty"`
 }
 
 var Plugins = make(map[string]interface{})
@@ -121,6 +131,22 @@ func Concurrency(limit int) StepOpt {
 func Env(name, value string) StepOpt {
 	return func(step *Step) {
 		step.Env[name] = value
+	}
+}
+
+func SoftFail(softFail bool) StepOpt {
+	return func(step *Step) {
+		step.SoftFail = softFail
+	}
+}
+
+func AutomaticRetry(limit int) StepOpt {
+	return func(step *Step) {
+		step.Retry = &RetryOptions{
+			Automatic: &AutomaticRetryOptions{
+				Limit: limit,
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
This is an alternative to disabling e2e tests outright, as proposed in https://github.com/sourcegraph/sourcegraph/pull/6163.

e2e test will still run on all branches so we can continue collecting data, but [failures will not block merging](https://buildkite.com/changelog/56-command-steps-can-now-be-made-to-soft-fail). Unfortunately, we still have to wait for tests to complete before getting a green status so there is no "builds are faster" win here.

In the cases where we do want to block on e2e tests (e.g. renovate branches, release branches), failures will be automatically retried once.