### PR TITLE
LSIF: Prune old dumps

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -300,16 +300,19 @@ Indexes:
 
 # Table "public.lsif_dumps"
 ```
-     Column     |  Type   |                        Modifiers                        
-----------------+---------+---------------------------------------------------------
- id             | integer | not null default nextval('lsif_dumps_id_seq'::regclass)
- repository     | text    | not null
- commit         | text    | not null
- root           | text    | not null default ''::text
- visible_at_tip | boolean | not null default false
+     Column     |           Type           |                        Modifiers                        
+----------------+--------------------------+---------------------------------------------------------
+ id             | integer                  | not null default nextval('lsif_dumps_id_seq'::regclass)
+ repository     | text                     | not null
+ commit         | text                     | not null
+ root           | text                     | not null default ''::text
+ visible_at_tip | boolean                  | not null default false
+ uploaded_at    | timestamp with time zone | not null default now()
 Indexes:
     "lsif_dumps_pkey" PRIMARY KEY, btree (id)
     "lsif_dumps_repository_commit_root" UNIQUE CONSTRAINT, btree (repository, commit, root)
+    "lsif_dumps_uploaded_at" btree (uploaded_at)
+    "lsif_dumps_visible_repository_commit" btree (repository, commit) WHERE visible_at_tip
 Check constraints:
     "lsif_dumps_commit_check" CHECK (length(commit) = 40)
     "lsif_dumps_repository_check" CHECK (repository <> ''::text)

--- a/lsif/docs/jobs.md
+++ b/lsif/docs/jobs.md
@@ -20,3 +20,7 @@ Fetch the tip of the default branch for each repository with LSIF data from gits
 ### `clean-old-jobs({})`
 
 Remove old job data from the system. This is based on a configurable age, `JOB_MAX_AGE`, within the worker process.
+
+### `clean-failed-jobs({})`
+
+Remove the upload and temporary files left over from a failed conversion job. Only files older than `FAILED_JOB_MAX_AGE` are deleted.

--- a/lsif/package.json
+++ b/lsif/package.json
@@ -10,6 +10,7 @@
     "bloomfilter": "^0.0.18",
     "body-parser": "^1.19.0",
     "bull": "^3.11.0",
+    "crc-32": "^1.2.0",
     "delay": "^4.3.0",
     "express": "^4.17.1",
     "express-opentracing": "^0.1.1",

--- a/lsif/src/backend.ts
+++ b/lsif/src/backend.ts
@@ -3,20 +3,20 @@ import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
 import { dbFilename, mustGet, NoLSIFDumpError } from './util'
 import { XrepoDatabase } from './xrepo'
 import { TracingContext, logAndTraceCall, addTags, logSpan } from './tracing'
-import * as constants from './constants'
 import { Database, sortMonikers, createRemoteUri } from './database'
 import { ConfigurationFetcher } from './config'
 import { DocumentData, MonikerData, DefinitionModel, ReferenceModel } from './database.models'
 import { uniqWith, isEqual } from 'lodash'
 import { LsifDump, DumpId } from './xrepo.models'
+import * as settings from './settings'
 
 /**
  * A wrapper around code intelligence operations.
  */
 export class Backend {
-    private connectionCache = new ConnectionCache(constants.CONNECTION_CACHE_CAPACITY)
-    private documentCache = new DocumentCache(constants.DOCUMENT_CACHE_CAPACITY)
-    private resultChunkCache = new ResultChunkCache(constants.RESULT_CHUNK_CACHE_CAPACITY)
+    private connectionCache = new ConnectionCache(settings.CONNECTION_CACHE_CAPACITY)
+    private documentCache = new DocumentCache(settings.DOCUMENT_CACHE_CAPACITY)
+    private resultChunkCache = new ResultChunkCache(settings.RESULT_CHUNK_CACHE_CAPACITY)
 
     /**
      * Create a new `Backend`.

--- a/lsif/src/commits.test.ts
+++ b/lsif/src/commits.test.ts
@@ -23,7 +23,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase(connection)
+            const xrepoDatabase = new XrepoDatabase('', connection)
             await xrepoDatabase.insertDump('test-repo', ca, '')
 
             await discoverAndUpdateCommit({
@@ -50,7 +50,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase(connection)
+            const xrepoDatabase = new XrepoDatabase('', connection)
             await xrepoDatabase.insertDump('test-repo', ca, '')
             await xrepoDatabase.updateCommits('test-repo', [[cb, '']])
 
@@ -76,7 +76,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase(connection)
+            const xrepoDatabase = new XrepoDatabase('', connection)
 
             // This test ensures the following does not make a gitserver request.
             // As we did not register a nock interceptor, any request will result
@@ -110,7 +110,7 @@ describe('discoverAndUpdateTips', () => {
         const { connection, cleanup } = await createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase(connection)
+            const xrepoDatabase = new XrepoDatabase('', connection)
             await xrepoDatabase.updateCommits('test-repo', [[ca, ''], [cb, ca], [cc, cb], [cd, cc], [ce, cd]])
             await xrepoDatabase.insertDump('test-repo', ca, 'foo')
             await xrepoDatabase.insertDump('test-repo', cb, 'foo')
@@ -158,7 +158,7 @@ describe('discoverTips', () => {
         const { connection, cleanup } = await createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase(connection)
+            const xrepoDatabase = new XrepoDatabase('', connection)
 
             for (let i = 0; i < 15; i++) {
                 await xrepoDatabase.insertDump(`test-repo-${i}`, createCommit('c'), '')

--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -14,7 +14,7 @@ import { TlsOptions } from 'tls'
  * version prior to making use of the DB (which the frontend may still be
  * migrating).
  */
-const MINIMUM_MIGRATION_VERSION = 1528395606
+const MINIMUM_MIGRATION_VERSION = 1528395607
 
 /**
  * How many times to try to check the current database migration version on startup.

--- a/lsif/src/constants.ts
+++ b/lsif/src/constants.ts
@@ -1,18 +1,3 @@
-import { readEnvInt } from './util'
-
-/**
- * The number of SQLite connections that can be opened at once. This
- * value may be exceeded for a short period if many handles are held
- * at once.
- */
-export const CONNECTION_CACHE_CAPACITY = readEnvInt('CONNECTION_CACHE_CAPACITY', 100)
-
-/**
- * The maximum number of documents that can be held in memory at once.
- */
-export const DOCUMENT_CACHE_CAPACITY = readEnvInt('DOCUMENT_CACHE_CAPACITY', 1024 * 1024 * 1024)
-
-/**
- * The maximum number of result chunks that can be held in memory at once.
- */
-export const RESULT_CHUNK_CACHE_CAPACITY = readEnvInt('RESULT_CHUNK_CACHE_CAPACITY', 1024 * 1024 * 1024)
+export const DBS_DIR = 'dbs'
+export const TEMP_DIR = 'temp'
+export const UPLOADS_DIR = 'uploads'

--- a/lsif/src/cpp.test.ts
+++ b/lsif/src/cpp.test.ts
@@ -1,7 +1,12 @@
-import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
-import { createCommit, createLocation, convertTestData, createCleanPostgresDatabase } from './test-utils'
+import {
+    createCommit,
+    createLocation,
+    convertTestData,
+    createCleanPostgresDatabase,
+    createStorageRoot,
+} from './test-utils'
 import { dbFilename } from './util'
 import { Database } from './database'
 import { XrepoDatabase } from './xrepo'
@@ -22,8 +27,8 @@ describe('Database', () => {
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())
-        storageRoot = await fs.mkdtemp('cpp-', { encoding: 'utf8' })
-        xrepoDatabase = new XrepoDatabase(connection)
+        storageRoot = await createStorageRoot('cpp')
+        xrepoDatabase = new XrepoDatabase(storageRoot, connection)
 
         // Prepare test data
         await convertTestData(xrepoDatabase, storageRoot, repository, commit, '', 'cpp/data/data.lsif.gz')

--- a/lsif/src/retention.ts
+++ b/lsif/src/retention.ts
@@ -1,0 +1,107 @@
+import * as path from 'path'
+import { XrepoDatabase } from './xrepo'
+import * as fs from 'mz/fs'
+import { TracingContext } from './tracing'
+import { createSilentLogger } from './logging'
+import { Logger } from 'winston'
+import { hasErrorCode, dbFilename } from './util'
+import * as constants from './constants'
+
+/**
+ * Remove dumps until the space occupied by the dbs directory is below
+ * the given limit.
+ *
+ * @param storageRoot The path where SQLite databases are stored.
+ * @param xrepoDatabase The cross-repo database.
+ * @param maximumBytes The maximum number of bytes.
+ * @param ctx The tracing context.
+ */
+export async function purgeOldDumps(
+    storageRoot: string,
+    xrepoDatabase: XrepoDatabase,
+    maximumBytes: number,
+    { logger = createSilentLogger() }: TracingContext = {}
+): Promise<void> {
+    if (maximumBytes < 0) {
+        return
+    }
+
+    const lockName = 'retention'
+    await xrepoDatabase.lock(lockName)
+
+    try {
+        // Ensure only one worker is doing this at the same time so that we don't
+        // choose more dumps than necessary to purge. This can happen if the directory
+        // size check and the selection of a purgeable dump are interleaved between
+        // multiple workers.
+
+        await purgeOldDumpsLocked(storageRoot, xrepoDatabase, maximumBytes, logger)
+    } finally {
+        await xrepoDatabase.unlock(lockName)
+    }
+}
+
+/**
+ * Remove dumps until the space occupied by the dbs directory is below
+ * the given limit.
+ *
+ * @param storageRoot The path where SQLite databases are stored.
+ * @param xrepoDatabase The cross-repo database.
+ * @param maximumBytes The maximum number of bytes.
+ * @param logger The logger instance.
+ */
+async function purgeOldDumpsLocked(
+    storageRoot: string,
+    xrepoDatabase: XrepoDatabase,
+    maximumBytes: number,
+    logger: Logger
+): Promise<void> {
+    let currentSizeBytes = await dirsize(path.join(storageRoot, constants.DBS_DIR))
+
+    while (currentSizeBytes > maximumBytes) {
+        // While our current data usage is too big, find candidate dumps to delete
+        const dumps = await xrepoDatabase.getOldestPrunableDumps()
+        if (dumps.length === 0) {
+            logger.error('Failed to select a prunable dump', { currentSizeBytes, maximumBytes })
+            break
+        }
+
+        logger.debug('pruning dumps', {
+            repository: dumps[0].repository,
+            commit: dumps[0].commit,
+        })
+
+        for (const dump of dumps) {
+            // Delete this dump and subtract its size from the current dir size
+            const filename = dbFilename(storageRoot, dump.id, dump.repository, dump.commit)
+            await xrepoDatabase.deleteDump(dump)
+            currentSizeBytes -= await filesize(filename)
+        }
+    }
+}
+
+/**
+ * Calculate the size of a directory.
+ *
+ * @param directory The directory path.
+ */
+async function dirsize(directory: string): Promise<number> {
+    return (await Promise.all((await fs.readdir(directory)).map(filesize))).reduce((a, b) => a + b, 0)
+}
+
+/**
+ * Get the file size or zero if it doesn't exist.
+ *
+ * @param filename The filename.
+ */
+async function filesize(filename: string): Promise<number> {
+    try {
+        return (await fs.stat(filename)).size
+    } catch (error) {
+        if (!hasErrorCode(error, 'ENOENT')) {
+            throw error
+        }
+
+        return 0
+    }
+}

--- a/lsif/src/retention.ts
+++ b/lsif/src/retention.ts
@@ -83,7 +83,9 @@ async function withLock<T>(xrepoDatabase: XrepoDatabase, name: string, f: () => 
  * @param directory The directory path.
  */
 async function dirsize(directory: string): Promise<number> {
-    return (await Promise.all((await fs.readdir(directory)).map(filesize))).reduce((a, b) => a + b, 0)
+    return (await Promise.all(
+        (await fs.readdir(directory)).map(filename => filesize(path.join(directory, filename)))
+    )).reduce((a, b) => a + b, 0)
 }
 
 /**

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -66,12 +66,12 @@ const UPDATE_TIPS_JOB_SCHEDULE_INTERVAL = readEnvInt('UPDATE_TIPS_JOB_SCHEDULE_I
 /**
  * The interval (in seconds) to schedule the clean-old-jobs job.
  */
-const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 5)
+const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 60 * 60 * 8)
 
 /**
  * The interval (in seconds) to schedule the clean-failed-jobs job.
  */
-const CLEAN_FAILED_JOBS_INTERVAL = readEnvInt('CLEAN_FAILED_JOBS_INTERVAL', 5)
+const CLEAN_FAILED_JOBS_INTERVAL = readEnvInt('CLEAN_FAILED_JOBS_INTERVAL', 60 * 60 * 8)
 
 /**
  * Middleware function used to convert uncaught exceptions into 500 responses.

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -32,6 +32,7 @@ import { enqueue, createQueue, ensureOnlyRepeatableJob } from './queue'
 import { Connection } from 'typeorm'
 import { LsifDump } from './xrepo.models'
 import * as constants from './constants'
+import * as settings from './settings'
 
 const pipeline = promisify(_pipeline)
 
@@ -65,7 +66,12 @@ const UPDATE_TIPS_JOB_SCHEDULE_INTERVAL = readEnvInt('UPDATE_TIPS_JOB_SCHEDULE_I
 /**
  * The interval (in seconds) to schedule the clean-old-jobs job.
  */
-const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 60 * 60)
+const CLEAN_OLD_JOBS_INTERVAL = readEnvInt('CLEAN_OLD_JOBS_INTERVAL', 5)
+
+/**
+ * The interval (in seconds) to schedule the clean-failed-jobs job.
+ */
+const CLEAN_FAILED_JOBS_INTERVAL = readEnvInt('CLEAN_FAILED_JOBS_INTERVAL', 5)
 
 /**
  * Middleware function used to convert uncaught exceptions into 500 responses.
@@ -106,14 +112,15 @@ async function main(logger: Logger): Promise<void> {
     const tracer = createTracer('lsif-server', fetchConfiguration())
 
     // Update cache capacities on startup
-    connectionCacheCapacityGauge.set(constants.CONNECTION_CACHE_CAPACITY)
-    documentCacheCapacityGauge.set(constants.DOCUMENT_CACHE_CAPACITY)
-    resultChunkCacheCapacityGauge.set(constants.RESULT_CHUNK_CACHE_CAPACITY)
+    connectionCacheCapacityGauge.set(settings.CONNECTION_CACHE_CAPACITY)
+    documentCacheCapacityGauge.set(settings.DOCUMENT_CACHE_CAPACITY)
+    resultChunkCacheCapacityGauge.set(settings.RESULT_CHUNK_CACHE_CAPACITY)
 
     // Ensure storage roots exist
     await ensureDirectory(STORAGE_ROOT)
-    await ensureDirectory(path.join(STORAGE_ROOT, 'tmp'))
-    await ensureDirectory(path.join(STORAGE_ROOT, 'uploads'))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.DBS_DIR))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.TEMP_DIR))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.UPLOADS_DIR))
 
     // Create queue to publish convert
     const queue = createQueue('lsif', REDIS_ENDPOINT, logger)
@@ -121,9 +128,17 @@ async function main(logger: Logger): Promise<void> {
     // Schedule jobs on timers
     await ensureOnlyRepeatableJob(queue, 'update-tips', {}, UPDATE_TIPS_JOB_SCHEDULE_INTERVAL)
     await ensureOnlyRepeatableJob(queue, 'clean-old-jobs', {}, CLEAN_OLD_JOBS_INTERVAL)
+    await ensureOnlyRepeatableJob(queue, 'clean-failed-jobs', {}, CLEAN_FAILED_JOBS_INTERVAL)
 
     // Update queue size metric on a timer
-    setInterval(() => queue.count().then(count => queueSizeGauge.set(count)), 1000)
+    setInterval(
+        () =>
+            queue
+                .count()
+                .then(count => queueSizeGauge.set(count))
+                .catch(() => {}),
+        1000
+    )
 
     const app = express()
 
@@ -150,6 +165,17 @@ async function main(logger: Logger): Promise<void> {
     app.use(errorHandler(logger))
 
     app.listen(HTTP_PORT, () => logger.debug('listening', { port: HTTP_PORT }))
+}
+
+/**
+ * Move all db files in storage root to a subdirectory.
+ */
+async function moveDatabaseFilesToSubdir(): Promise<void> {
+    for (const filename of await fs.readdir(STORAGE_ROOT)) {
+        if (filename.endsWith('.db')) {
+            await fs.rename(path.join(STORAGE_ROOT, filename), path.join(STORAGE_ROOT, constants.DBS_DIR, filename))
+        }
+    }
 }
 
 /**
@@ -240,11 +266,12 @@ async function lsifEndpoints(
 
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const xrepoDatabase = new XrepoDatabase(connection)
-
-    await ensureFilenamesAreIDs(connection)
-
+    const xrepoDatabase = new XrepoDatabase(STORAGE_ROOT, connection)
     const backend = new Backend(STORAGE_ROOT, xrepoDatabase, fetchConfiguration)
+
+    // Temporary migrations
+    await moveDatabaseFilesToSubdir() // TODO - remove after 3.12
+    await ensureFilenamesAreIDs(connection) // TODO - remove after 3.10
 
     /**
      * Create a tracing context from the request logger and tracing span
@@ -270,7 +297,7 @@ async function lsifEndpoints(
                 checkCommit(commit)
 
                 const ctx = createTracingContext(req, { repository, commit, root })
-                const filename = path.join(STORAGE_ROOT, 'uploads', uuid.v4())
+                const filename = path.join(STORAGE_ROOT, constants.UPLOADS_DIR, uuid.v4())
                 const output = fs.createWriteStream(filename)
 
                 try {

--- a/lsif/src/settings.ts
+++ b/lsif/src/settings.ts
@@ -1,0 +1,18 @@
+import { readEnvInt } from './util'
+
+/**
+ * The number of SQLite connections that can be opened at once. This
+ * value may be exceeded for a short period if many handles are held
+ * at once.
+ */
+export const CONNECTION_CACHE_CAPACITY = readEnvInt('CONNECTION_CACHE_CAPACITY', 100)
+
+/**
+ * The maximum number of documents that can be held in memory at once.
+ */
+export const DOCUMENT_CACHE_CAPACITY = readEnvInt('DOCUMENT_CACHE_CAPACITY', 1024 * 1024 * 1024)
+
+/**
+ * The maximum number of result chunks that can be held in memory at once.
+ */
+export const RESULT_CHUNK_CACHE_CAPACITY = readEnvInt('RESULT_CHUNK_CACHE_CAPACITY', 1024 * 1024 * 1024)

--- a/lsif/src/typescript-linked-reference-results.test.ts
+++ b/lsif/src/typescript-linked-reference-results.test.ts
@@ -1,7 +1,12 @@
-import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import { ConnectionCache, DocumentCache, ResultChunkCache } from './cache'
-import { createCommit, createLocation, createCleanPostgresDatabase, convertTestData } from './test-utils'
+import {
+    createCommit,
+    createLocation,
+    createCleanPostgresDatabase,
+    convertTestData,
+    createStorageRoot,
+} from './test-utils'
 import { dbFilename } from './util'
 import { Database } from './database'
 import { XrepoDatabase } from './xrepo'
@@ -22,8 +27,8 @@ describe('Database', () => {
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())
-        storageRoot = await fs.promises.mkdtemp('typescript-')
-        xrepoDatabase = new XrepoDatabase(connection)
+        storageRoot = await createStorageRoot('typescript')
+        xrepoDatabase = new XrepoDatabase(storageRoot, connection)
 
         // Prepare test data
         await convertTestData(

--- a/lsif/src/typescript-xrepo.test.ts
+++ b/lsif/src/typescript-xrepo.test.ts
@@ -1,4 +1,3 @@
-import * as fs from 'mz/fs'
 import rmfr from 'rmfr'
 import {
     createCommit,
@@ -6,11 +5,11 @@ import {
     createRemoteLocation,
     createCleanPostgresDatabase,
     convertTestData,
+    createStorageRoot,
 } from './test-utils'
 import { XrepoDatabase } from './xrepo'
 import { Connection } from 'typeorm'
 import { Backend } from './backend'
-import { Configuration } from './config'
 
 describe('Database', () => {
     let connection!: Connection
@@ -21,9 +20,9 @@ describe('Database', () => {
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await createCleanPostgresDatabase())
-        storageRoot = await fs.mkdtemp('typescript-', { encoding: 'utf8' })
-        xrepoDatabase = new XrepoDatabase(connection)
-        backend = new Backend(storageRoot, xrepoDatabase, () => ({} as Configuration))
+        storageRoot = await createStorageRoot('typescript')
+        xrepoDatabase = new XrepoDatabase(storageRoot, connection)
+        backend = new Backend(storageRoot, xrepoDatabase, () => ({} as never))
 
         // Prepare test data
         for (const repository of ['a', 'b1', 'b2', 'b3', 'c1', 'c2', 'c3']) {

--- a/lsif/src/util.ts
+++ b/lsif/src/util.ts
@@ -2,6 +2,7 @@ import * as fs from 'mz/fs'
 import * as path from 'path'
 import { DefinitionReferenceResultId } from './database.models'
 import { Id } from 'lsif-protocol'
+import * as constants from './constants'
 
 /**
  * Reads an integer from an environment variable or defaults to the given value.
@@ -118,7 +119,7 @@ export function dbFilenameOld(storageRoot: string, repository: string, commit: s
  * @param id The ID of the dump.
  */
 export function dbFilename(storageRoot: string, id: number, repository: string, commit: string): string {
-    return path.join(storageRoot, `${id}-${encodeURIComponent(repository)}@${commit}.lsif.db`)
+    return path.join(storageRoot, constants.DBS_DIR, `${id}-${encodeURIComponent(repository)}@${commit}.lsif.db`)
 }
 
 /**
@@ -133,6 +134,24 @@ export async function ensureDirectory(path: string): Promise<void> {
         if (!hasErrorCode(e, 'EEXIST')) {
             throw e
         }
+    }
+}
+
+/**
+ * Delete the file if it exists. Throws errors that are nto ENOENT.
+ *
+ * @param path The path to delete.
+ */
+export async function tryDeleteFile(path: string): Promise<boolean> {
+    try {
+        await fs.unlink(path)
+        return true
+    } catch (error) {
+        if (!hasErrorCode(error, 'ENOENT')) {
+            throw error
+        }
+
+        return false
     }
 }
 

--- a/lsif/src/util.ts
+++ b/lsif/src/util.ts
@@ -138,7 +138,7 @@ export async function ensureDirectory(path: string): Promise<void> {
 }
 
 /**
- * Delete the file if it exists. Throws errors that are nto ENOENT.
+ * Delete the file if it exists. Throws errors that are not ENOENT.
  *
  * @param path The path to delete.
  */

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -124,9 +124,6 @@ const createConvertJobProcessor = (xrepoDatabase: XrepoDatabase, fetchConfigurat
             await fs.unlink(tempFile)
             throw e
         }
-
-        // Clean up disk space if necessary
-        await purgeOldDumps(STORAGE_ROOT, xrepoDatabase, DBS_DIR_MAXIMUM_SIZE_BYTES, ctx)
     })
 
     // Update commit parentage information for this commit
@@ -140,6 +137,9 @@ const createConvertJobProcessor = (xrepoDatabase: XrepoDatabase, fetchConfigurat
 
     // Remove input
     await fs.unlink(filename)
+
+    // Clean up disk space if necessary
+    await purgeOldDumps(STORAGE_ROOT, xrepoDatabase, DBS_DIR_MAXIMUM_SIZE_BYTES, ctx)
 }
 
 const cleanStatuses: JobStatusClean[] = ['completed', 'wait', 'active', 'delayed', 'failed']

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -54,7 +54,7 @@ const FAILED_JOB_MAX_AGE = readEnvInt('FAILED_JOB_MAX_AGE', 24 * 60 * 60)
 /**
  * The maximum space (in bytes) that the dbs directory can use.
  */
-const DBS_DIR_MAXIMUM_BYTES = readEnvInt('DBS_DIR_MAXIMUM_BYTES', 1024 * 1024 * 1024)
+const DBS_DIR_MAXIMUM_SIZE_BYTES = readEnvInt('DBS_DIR_MAXIMUM_SIZE_BYTES', 1024 * 1024 * 1024 * 10)
 
 /**
  * Wrap a job processor with instrumentation.
@@ -126,7 +126,7 @@ const createConvertJobProcessor = (xrepoDatabase: XrepoDatabase, fetchConfigurat
         }
 
         // Clean up disk space if necessary
-        await purgeOldDumps(STORAGE_ROOT, xrepoDatabase, DBS_DIR_MAXIMUM_BYTES, ctx)
+        await purgeOldDumps(STORAGE_ROOT, xrepoDatabase, DBS_DIR_MAXIMUM_SIZE_BYTES, ctx)
     })
 
     // Update commit parentage information for this commit

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -196,6 +196,7 @@ const createCleanFailedJobsProcessor = () => async (_: {}, ctx: TracingContext):
                 await fs.unlink(filename)
             }
         }
+
         for (const directory of [constants.TEMP_DIR, constants.UPLOADS_DIR]) {
             for (const filename of await fs.readdir(path.join(STORAGE_ROOT, directory))) {
                 await purgeFile(path.join(STORAGE_ROOT, directory, filename))

--- a/lsif/src/worker.ts
+++ b/lsif/src/worker.ts
@@ -2,7 +2,6 @@ import * as fs from 'mz/fs'
 import * as path from 'path'
 import express from 'express'
 import promClient from 'prom-client'
-import uuid from 'uuid'
 import { convertLsif } from './importer'
 import { dbFilename, ensureDirectory, readEnvInt } from './util'
 import { createLogger } from './logging'
@@ -17,6 +16,8 @@ import { jobDurationHistogram, jobDurationErrorsCounter } from './worker.metrics
 import { Job, JobStatusClean, Queue } from 'bull'
 import { createQueue } from './queue'
 import { instrument } from './metrics'
+import { purgeOldDumps } from './retention'
+import * as constants from './constants'
 
 /**
  * Which port to run the worker metrics server on. Defaults to 3187.
@@ -44,6 +45,16 @@ const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
  * The maximum age (in seconds) that a job (completed or queued) will remain in redis.
  */
 const JOB_MAX_AGE = readEnvInt('JOB_MAX_AGE', 7 * 24 * 60 * 60)
+
+/**
+ * The maximum age (in seconds) that the files for a failed job can remain on disk.
+ */
+const FAILED_JOB_MAX_AGE = readEnvInt('FAILED_JOB_MAX_AGE', 24 * 60 * 60)
+
+/**
+ * The maximum space (in bytes) that the dbs directory can use.
+ */
+const DBS_DIR_MAXIMUM_BYTES = readEnvInt('DBS_DIR_MAXIMUM_BYTES', 1024 * 1024 * 1024)
 
 /**
  * Wrap a job processor with instrumentation.
@@ -95,7 +106,7 @@ const createConvertJobProcessor = (xrepoDatabase: XrepoDatabase, fetchConfigurat
 ): Promise<void> => {
     await logAndTraceCall(ctx, 'converting LSIF data', async (ctx: TracingContext) => {
         const input = fs.createReadStream(filename)
-        const tempFile = path.join(STORAGE_ROOT, 'tmp', uuid.v4())
+        const tempFile = path.join(STORAGE_ROOT, constants.TEMP_DIR, path.basename(filename))
 
         try {
             // Create database in a temp path
@@ -113,6 +124,9 @@ const createConvertJobProcessor = (xrepoDatabase: XrepoDatabase, fetchConfigurat
             await fs.unlink(tempFile)
             throw e
         }
+
+        // Clean up disk space if necessary
+        await purgeOldDumps(STORAGE_ROOT, xrepoDatabase, DBS_DIR_MAXIMUM_BYTES, ctx)
     })
 
     // Update commit parentage information for this commit
@@ -170,6 +184,30 @@ const createCleanOldJobsProcessor = (queue: Queue, logger: Logger) => async (
 }
 
 /**
+ * Create a job that removes upload and temp files that are older than `FAILED_JOB_MAX_AGE`.
+ * This assumes that a conversion job's total duration (from enqueue to completion) is less
+ * than this interval during healthy operation.
+ *
+ * @param queue The queue.
+ * @param logger The logger instance.
+ */
+const createCleanFailedJobsProcessor = () => async (_: {}, ctx: TracingContext): Promise<void> => {
+    await logAndTraceCall(ctx, 'cleaning failed jobs', async (ctx: TracingContext) => {
+        const purgeFile = async (filename: string): Promise<void> => {
+            const stat = await fs.stat(filename)
+            if (Date.now() - stat.mtimeMs >= FAILED_JOB_MAX_AGE) {
+                await fs.unlink(filename)
+            }
+        }
+        for (const directory of [constants.TEMP_DIR, constants.UPLOADS_DIR]) {
+            for (const filename of await fs.readdir(path.join(STORAGE_ROOT, directory))) {
+                await purgeFile(path.join(STORAGE_ROOT, directory, filename))
+            }
+        }
+    })
+}
+
+/**
  * Runs the worker which accepts LSIF conversion jobs from the work queue.
  *
  * @param logger The logger instance.
@@ -186,12 +224,13 @@ async function main(logger: Logger): Promise<void> {
 
     // Ensure storage roots exist
     await ensureDirectory(STORAGE_ROOT)
-    await ensureDirectory(path.join(STORAGE_ROOT, 'tmp'))
-    await ensureDirectory(path.join(STORAGE_ROOT, 'uploads'))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.DBS_DIR))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.TEMP_DIR))
+    await ensureDirectory(path.join(STORAGE_ROOT, constants.UPLOADS_DIR))
 
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const xrepoDatabase = new XrepoDatabase(connection)
+    const xrepoDatabase = new XrepoDatabase(STORAGE_ROOT, connection)
 
     // Start metrics server
     startMetricsServer(logger)
@@ -220,10 +259,18 @@ async function main(logger: Logger): Promise<void> {
         tracer
     )
 
+    const cleanFailedJobsProcessor = wrapJobProcessor(
+        'clean-failed-jobs',
+        createCleanFailedJobsProcessor(),
+        logger,
+        tracer
+    )
+
     // Start processing work
     queue.process('convert', convertJobProcessor).catch(() => {})
     queue.process('update-tips', updateTipsJobProcessor).catch(() => {})
     queue.process('clean-old-jobs', cleanOldJobsProcessor).catch(() => {})
+    queue.process('clean-failed-jobs', cleanFailedJobsProcessor).catch(() => {})
 }
 
 /**

--- a/lsif/yarn.lock
+++ b/lsif/yarn.lock
@@ -1353,6 +1353,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 cron-parser@^2.13.0:
   version "2.13.0"
   resolved "https://registry.npmjs.org/cron-parser/-/cron-parser-2.13.0.tgz#6f930bb6f2931790d2a9eec83b3ec276e27a6725"
@@ -1760,6 +1768,11 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 exit@^0.1.2:
   version "0.1.2"
@@ -4015,6 +4028,11 @@ pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/migrations/1528395607_lsif_add_dump_uploaded_at.down.sql
+++ b/migrations/1528395607_lsif_add_dump_uploaded_at.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_dumps_uploaded_at;
+DROP INDEX IF EXISTS lsif_dumps_visible_at_tip;
+ALTER TABLE lsif_dumps DROP COLUMN uploaded_at;
+
+COMMIT;

--- a/migrations/1528395607_lsif_add_dump_uploaded_at.up.sql
+++ b/migrations/1528395607_lsif_add_dump_uploaded_at.up.sql
@@ -1,0 +1,9 @@
+-- Note: `commit` is a reserved word, so it's quoted.
+
+BEGIN;
+
+ALTER TABLE lsif_dumps ADD COLUMN uploaded_at timestamp with time zone NOT NULL DEFAULT now();
+CREATE INDEX lsif_dumps_uploaded_at ON lsif_dumps(uploaded_at);
+CREATE INDEX lsif_dumps_visible_repository_commit ON lsif_dumps(repository, "commit") WHERE visible_at_tip;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -50,6 +50,8 @@
 // 1528395605_drop_recent_searches.up.sql (55B)
 // 1528395606_lsif_add_visible_at_tip_flag.down.sql (361B)
 // 1528395606_lsif_add_visible_at_tip_flag.up.sql (273B)
+// 1528395607_lsif_add_dump_uploaded_at.down.sql (158B)
+// 1528395607_lsif_add_dump_uploaded_at.up.sql (339B)
 
 package migrations
 
@@ -1118,6 +1120,46 @@ func _1528395606_lsif_add_visible_at_tip_flagUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395607_lsif_add_dump_uploaded_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\xf0\xf4\x73\x71\x8d\x50\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\xc8\x29\xce\x4c\x8b\x4f\x29\xcd\x2d\x28\x8e\x2f\x2d\xc8\xc9\x4f\x4c\x49\x4d\x89\x4f\x2c\xb1\x26\xa8\xb8\x2c\xb3\x38\x33\x29\x27\x35\x3e\xb1\x24\xbe\x24\xb3\xc0\x9a\xcb\xd1\x27\xc4\x35\x48\x21\xc4\xd1\xc9\xc7\x15\x49\x99\x02\xd8\x18\x67\x7f\x9f\x50\x5f\x3f\x05\x14\xf3\xb9\x9c\xfd\x7d\x7d\x3d\x43\xac\xb9\x00\x01\x00\x00\xff\xff\x28\x1b\x2f\x90\x9e\x00\x00\x00")
+
+func _1528395607_lsif_add_dump_uploaded_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395607_lsif_add_dump_uploaded_atDownSql,
+		"1528395607_lsif_add_dump_uploaded_at.down.sql",
+	)
+}
+
+func _1528395607_lsif_add_dump_uploaded_atDownSql() (*asset, error) {
+	bytes, err := _1528395607_lsif_add_dump_uploaded_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395607_lsif_add_dump_uploaded_at.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbc, 0xe4, 0x76, 0x2a, 0x94, 0xf0, 0x62, 0xa3, 0xf5, 0xec, 0x1b, 0x9b, 0xef, 0x0, 0x48, 0xa9, 0x91, 0x9f, 0x7, 0x17, 0x67, 0x50, 0x38, 0xba, 0xbc, 0xb6, 0xbd, 0x4, 0x7f, 0xee, 0x41, 0xee}}
+	return a, nil
+}
+
+var __1528395607_lsif_add_dump_uploaded_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\xcf\xc1\x4a\xfc\x30\x10\xc7\xf1\x7b\x9e\xe2\xc7\x5e\xfe\xbb\xb0\xfb\x7f\x00\x7b\xea\xb6\x51\x0b\x69\x0a\x25\x45\x6f\xd9\x6a\x22\x06\xda\x9d\x9a\x4c\xb7\xe8\xd3\x0b\x2e\x62\xf1\xe0\x71\xf8\xce\x7c\x60\x0e\x07\x68\x62\x7f\x83\xd3\x33\x8d\x63\xe0\x13\x42\x42\x8f\xe8\x93\x8f\x17\xef\xb0\x50\x74\x7b\x24\x42\xe0\x7f\x09\x6f\x33\xb1\x77\xff\x85\x38\xca\xbb\x4a\x67\x42\xe4\xca\xc8\x16\x26\x3f\x2a\x89\x21\x85\x17\xeb\xe6\x71\x4a\xc8\xcb\x12\x45\xa3\xba\x5a\x63\x9e\x06\xea\x9d\x77\xb6\x67\x70\x18\x7d\xe2\x7e\x9c\xb0\x04\x7e\xfd\x1a\xf1\x41\x67\x0f\xdd\x18\xe8\x4e\x29\x94\xf2\x36\xef\x94\xc1\x99\x96\xed\x2e\x13\x45\x2b\x73\x23\x51\xe9\x52\x3e\xae\x7c\xbb\x46\x1b\xbd\x2a\xdb\x55\xf9\xe3\xfe\x12\x52\x78\x1a\xbc\x8d\x7e\xa2\x14\x98\xe2\xbb\xbd\xbe\xff\x4b\xfb\xe9\x7b\x6c\xae\x1b\x9b\x1d\x1e\xee\x65\x2b\xf1\x6d\xf4\x6c\x39\x4c\x99\x10\x45\x53\xd7\x95\xc9\xc4\x67\x00\x00\x00\xff\xff\x81\x3e\xef\x7c\x53\x01\x00\x00")
+
+func _1528395607_lsif_add_dump_uploaded_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395607_lsif_add_dump_uploaded_atUpSql,
+		"1528395607_lsif_add_dump_uploaded_at.up.sql",
+	)
+}
+
+func _1528395607_lsif_add_dump_uploaded_atUpSql() (*asset, error) {
+	bytes, err := _1528395607_lsif_add_dump_uploaded_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395607_lsif_add_dump_uploaded_at.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x25, 0x85, 0x2e, 0x57, 0x57, 0x7b, 0x8, 0x94, 0xdd, 0x27, 0x6e, 0xf3, 0x67, 0x5d, 0x48, 0x83, 0x3d, 0x3d, 0xe1, 0xc4, 0x87, 0x60, 0x43, 0xaa, 0x47, 0xce, 0x59, 0xfa, 0xb7, 0x95, 0xd3, 0xa9}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1308,6 +1350,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395606_lsif_add_visible_at_tip_flag.down.sql": _1528395606_lsif_add_visible_at_tip_flagDownSql,
 
 	"1528395606_lsif_add_visible_at_tip_flag.up.sql": _1528395606_lsif_add_visible_at_tip_flagUpSql,
+
+	"1528395607_lsif_add_dump_uploaded_at.down.sql": _1528395607_lsif_add_dump_uploaded_atDownSql,
+
+	"1528395607_lsif_add_dump_uploaded_at.up.sql": _1528395607_lsif_add_dump_uploaded_atUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1401,6 +1447,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395605_drop_recent_searches.up.sql":                                   {_1528395605_drop_recent_searchesUpSql, map[string]*bintree{}},
 	"1528395606_lsif_add_visible_at_tip_flag.down.sql":                         {_1528395606_lsif_add_visible_at_tip_flagDownSql, map[string]*bintree{}},
 	"1528395606_lsif_add_visible_at_tip_flag.up.sql":                           {_1528395606_lsif_add_visible_at_tip_flagUpSql, map[string]*bintree{}},
+	"1528395607_lsif_add_dump_uploaded_at.down.sql":                            {_1528395607_lsif_add_dump_uploaded_atDownSql, map[string]*bintree{}},
+	"1528395607_lsif_add_dump_uploaded_at.up.sql":                              {_1528395607_lsif_add_dump_uploaded_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This implements a superset of functionality as discussed in [RFC 55](https://docs.google.com/document/d/1q7e0Rl9O9Weu33JDlcCz-3N1VGnnfI1zINppRNT60bQ). 

Relevant changes:
- Moved databases into a subdir `dbs` in the storage root. This is so we can iterate the entire directory without worrying about walking/omitting the temp or upload files. There is an automatic migration that occurs on the startup of the server.
- Create a new scheduled job type, clean-failed-jobs, that will remove all files in the uploads and temp directories if they are older than a configurable maximum age. This will delete files that stuck around from a failed conversion. This also assumes that the maximum age is greater than the time it takes to process an LSIF dump upload (from the time the upload is accepted until the time the job has completed).
- After each successful upload, delete the oldest non-visible dumps (as discussed in the RFC) while the space occupied by dumps is above a configurable maximum. To reduce issues with two workers trying to clean the same directory concurrently, this process happens while holding a postgres advisory lock.

This closes #6148.