### PR TITLE
graphqlbackend: Introduce JSONCString scalar type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Fields of type `String` in our GraphQL API that contain [JSONC](https://komkom.github.io/) now have the custom scalar type `JSONCString`. [#6209](https://github.com/sourcegraph/sourcegraph/pull/6209)
+
 ### Fixed
 
 - Support hyphens in Bitbucket Cloud team names. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -781,7 +781,7 @@ func viewerCanUseDiscussions(ctx context.Context) error {
 		return err
 	}
 	var settings schema.Settings
-	if err := jsonc.Unmarshal(merged.Contents(), &settings); err != nil {
+	if err := jsonc.Unmarshal(string(merged.Contents()), &settings); err != nil {
 		return err
 	}
 	enabled, ok := settings.Extensions["sourcegraph/code-discussions"]

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -62,8 +62,8 @@ func (r *externalServiceResolver) DisplayName() string {
 	return r.externalService.DisplayName
 }
 
-func (r *externalServiceResolver) Config() string {
-	return r.externalService.Config
+func (r *externalServiceResolver) Config() JSONCString {
+	return JSONCString(r.externalService.Config)
 }
 
 func (r *externalServiceResolver) CreatedAt() DateTime {

--- a/cmd/frontend/graphqlbackend/json.go
+++ b/cmd/frontend/graphqlbackend/json.go
@@ -1,6 +1,9 @@
 package graphqlbackend
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // JSONValue implements the JSONValue scalar type. In GraphQL queries, it is represented the JSON
 // representation of its Go value.
@@ -17,4 +20,24 @@ func (v *JSONValue) UnmarshalGraphQL(input interface{}) error {
 
 func (v JSONValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.Value)
+}
+
+// JSONCString implements the JSONCString scalar type.
+type JSONCString string
+
+func (JSONCString) ImplementsGraphQLType(name string) bool {
+	return name == "JSONCString"
+}
+
+func (j *JSONCString) UnmarshalGraphQL(input interface{}) error {
+	s, ok := input.(string)
+	if !ok {
+		return fmt.Errorf("invalid GraphQL JSONCString scalar value input (got %T, expected string)", input)
+	}
+	*j = JSONCString(s)
+	return nil
+}
+
+func (j JSONCString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(j))
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -25,6 +25,9 @@ interface Node {
 # A valid JSON value.
 scalar JSONValue
 
+# A string that contains valid JSON, with additional support for //-style comments and trailing commas.
+scalar JSONCString
+
 # A mutation.
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
@@ -1420,7 +1423,7 @@ type ExternalService implements Node {
     # The display name of the external service.
     displayName: String!
     # The JSON configuration of the external service.
-    config: String!
+    config: JSONCString!
     # When the external service was created.
     createdAt: DateTime!
     # When the external service was last updated.
@@ -3169,7 +3172,7 @@ type SiteConfiguration {
     # The unique identifier of this site configuration version.
     id: Int!
     # The effective configuration JSON.
-    effectiveContents: String!
+    effectiveContents: JSONCString!
     # Messages describing validation problems or usage of deprecated configuration in the configuration JSON.
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
@@ -3181,7 +3184,7 @@ type CriticalConfiguration {
     # The unique identifier of this site configuration version.
     id: Int!
     # The effective configuration JSON.
-    effectiveContents: String!
+    effectiveContents: JSONCString!
 }
 
 # Information about software updates for Sourcegraph.
@@ -3271,7 +3274,7 @@ type Settings {
     createdAt: DateTime!
     # The stringified JSON contents of the settings. The contents may include "//"-style comments and trailing
     # commas in the JSON.
-    contents: String!
+    contents: JSONCString!
     # DEPRECATED: This field will be removed in a future release.
     #
     # The configuration.
@@ -3283,7 +3286,7 @@ type Configuration {
     # DEPRECATED: This field will be removed in a future release.
     #
     # The raw JSON contents, encoded as a string.
-    contents: String! @deprecated(reason: "use the contents field on the parent type instead")
+    contents: JSONCString! @deprecated(reason: "use the contents field on the parent type instead")
     # DEPRECATED: This field is always empty. It will be removed in a future release.
     messages: [String!]! @deprecated(reason: "use client-side JSON Schema validation instead")
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -27,6 +27,9 @@ interface Node {
 # A valid JSON value.
 scalar JSONValue
 
+# A string that contains valid JSON, with additional support for //-style comments and trailing commas.
+scalar JSONCString
+
 # A mutation.
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
@@ -1427,7 +1430,7 @@ type ExternalService implements Node {
     # The display name of the external service.
     displayName: String!
     # The JSON configuration of the external service.
-    config: String!
+    config: JSONCString!
     # When the external service was created.
     createdAt: DateTime!
     # When the external service was last updated.
@@ -3176,7 +3179,7 @@ type SiteConfiguration {
     # The unique identifier of this site configuration version.
     id: Int!
     # The effective configuration JSON.
-    effectiveContents: String!
+    effectiveContents: JSONCString!
     # Messages describing validation problems or usage of deprecated configuration in the configuration JSON.
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
@@ -3188,7 +3191,7 @@ type CriticalConfiguration {
     # The unique identifier of this site configuration version.
     id: Int!
     # The effective configuration JSON.
-    effectiveContents: String!
+    effectiveContents: JSONCString!
 }
 
 # Information about software updates for Sourcegraph.
@@ -3278,7 +3281,7 @@ type Settings {
     createdAt: DateTime!
     # The stringified JSON contents of the settings. The contents may include "//"-style comments and trailing
     # commas in the JSON.
-    contents: String!
+    contents: JSONCString!
     # DEPRECATED: This field will be removed in a future release.
     #
     # The configuration.
@@ -3290,7 +3293,7 @@ type Configuration {
     # DEPRECATED: This field will be removed in a future release.
     #
     # The raw JSON contents, encoded as a string.
-    contents: String! @deprecated(reason: "use the contents field on the parent type instead")
+    contents: JSONCString! @deprecated(reason: "use the contents field on the parent type instead")
     # DEPRECATED: This field is always empty. It will be removed in a future release.
     messages: [String!]! @deprecated(reason: "use client-side JSON Schema validation instead")
 }

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -27,7 +27,9 @@ func (o *settingsResolver) Configuration() *configurationResolver {
 	return &configurationResolver{contents: o.settings.Contents}
 }
 
-func (o *settingsResolver) Contents() string { return o.settings.Contents }
+func (o *settingsResolver) Contents() JSONCString {
+	return JSONCString(o.settings.Contents)
+}
 
 func (o *settingsResolver) CreatedAt() DateTime {
 	return DateTime{Time: o.settings.CreatedAt}

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -20,7 +20,9 @@ type configurationResolver struct {
 	messages []string // error and warning messages
 }
 
-func (r *configurationResolver) Contents() string { return r.contents }
+func (r *configurationResolver) Contents() JSONCString {
+	return JSONCString(r.contents)
+}
 
 func (r *configurationResolver) Messages() []string {
 	if r.messages == nil {

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -168,5 +168,5 @@ func (s *settingsSubject) readSettings(ctx context.Context, v interface{}) error
 	if settings == nil {
 		return nil
 	}
-	return jsonc.Unmarshal(settings.Contents(), &v)
+	return jsonc.Unmarshal(string(settings.Contents()), &v)
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -172,13 +172,14 @@ func (r *siteConfigurationResolver) ID(ctx context.Context) (int32, error) {
 	return 0, nil // TODO(slimsag): future: return the real ID here to prevent races
 }
 
-func (r *siteConfigurationResolver) EffectiveContents(ctx context.Context) (string, error) {
+func (r *siteConfigurationResolver) EffectiveContents(ctx context.Context) (JSONCString, error) {
 	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
 	// so only admins may view it.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return "", err
+		return JSONCString(""), err
 	}
-	return globals.ConfigurationServerFrontendOnly.Raw().Site, nil
+	siteConfig := globals.ConfigurationServerFrontendOnly.Raw().Site
+	return JSONCString(siteConfig), nil
 }
 
 func (r *siteConfigurationResolver) ValidationMessages(ctx context.Context) ([]string, error) {
@@ -186,7 +187,7 @@ func (r *siteConfigurationResolver) ValidationMessages(ctx context.Context) ([]s
 	if err != nil {
 		return nil, err
 	}
-	return conf.ValidateSite(contents)
+	return conf.ValidateSite(string(contents))
 }
 
 var siteConfigAllowEdits, _ = strconv.ParseBool(env.Get("SITE_CONFIG_ALLOW_EDITS", "false", "When SITE_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
@@ -226,11 +227,12 @@ func (r *criticalConfigurationResolver) ID(ctx context.Context) (int32, error) {
 	return 0, nil // TODO(slimsag): future: return the real ID here to prevent races
 }
 
-func (r *criticalConfigurationResolver) EffectiveContents(ctx context.Context) (string, error) {
+func (r *criticalConfigurationResolver) EffectiveContents(ctx context.Context) (JSONCString, error) {
 	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
 	// so only admins may view it.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return "", err
+		return JSONCString(""), err
 	}
-	return globals.ConfigurationServerFrontendOnly.Raw().Critical, nil
+	criticalConf := globals.ConfigurationServerFrontendOnly.Raw().Critical
+	return JSONCString(criticalConf), nil
 }


### PR DESCRIPTION
This is the first step towards implementing #6135.

In order to keep the pull requests and diffs as small was possible, I split this out, since it's generic and can already be merged.

I manually tested editing the site configuration, critical config in the management console, user and org settings. External service configuration is tested by e2e tests.