### PR TITLE
src-expose: Fix out of bounds on args when using yaml config

### DIFF
--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -27,32 +27,33 @@ func (e *usageError) Error() string {
 	return e.Msg
 }
 
-func dockerAddr(addr string) string {
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		port = "3434"
-	}
-	return "host.docker.internal:" + port
-}
-
 func explain(s *Snapshotter, addr string) string {
 	var dirs []string
 	for _, d := range s.Dirs {
 		dirs = append(dirs, "- "+d.Dir)
 	}
 
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		port = "3434"
+	}
+
 	return fmt.Sprintf(`Periodically syncing directories as git repositories to %s.
 %s
 Serving the repositories at http://%s.
-Paste the following configuration as an Other External Service in Sourcegraph:
+
+FIRST RUN NOTE: If src-expose has not yet been setup on Sourcegraph, then you
+need to configure Sourcegraph to sync with src-expose. Paste the following
+configuration as an Other External Service in Sourcegraph:
 
   {
-    // url should be reachable by Sourcegraph. host.docker.internal works for Sourcegraph
-    // in Docker on the same machine.
-    "url": "http://%s",
+    // url is the http url to src-expose (listening on %s)
+    // url should be reachable by Sourcegraph.
+    // "http://host.docker.internal:%s" works from Sourcegraph when using Docker for Desktop.
+    "url": "http://host.docker.internal:%s",
     "repos": ["src-expose"] // This may change in versions later than 3.9
   }
-`, s.Destination, strings.Join(dirs, "\n"), addr, dockerAddr(addr))
+`, s.Destination, strings.Join(dirs, "\n"), addr, addr, port, port)
 }
 
 func usageErrorOutput(cmd *ffcli.Command, cmdPath string, err error) string {

--- a/dev/src-expose/main_test.go
+++ b/dev/src-expose/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExplain(t *testing.T) {
+	want := `Periodically syncing directories as git repositories to bam.
+- foo/bar
+- baz
+Serving the repositories at http://[::]:10810.
+
+FIRST RUN NOTE: If src-expose has not yet been setup on Sourcegraph, then you
+need to configure Sourcegraph to sync with src-expose. Paste the following
+configuration as an Other External Service in Sourcegraph:
+
+  {
+    // url is the http url to src-expose (listening on [::]:10810)
+    // url should be reachable by Sourcegraph.
+    // "http://host.docker.internal:10810" works from Sourcegraph when using Docker for Desktop.
+    "url": "http://host.docker.internal:10810",
+    "repos": ["src-expose"] // This may change in versions later than 3.9
+  }
+`
+
+	s := &Snapshotter{
+		Destination: "bam",
+		Dirs:        []*SyncDir{{Dir: "foo/bar"}, {Dir: "baz"}},
+	}
+	addr := "[::]:10810"
+
+	if got := explain(s, addr); got != want {
+		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+	}
+}


### PR DESCRIPTION
Should be reading Snapshotter for the list of directories, not args.

Test Plan: `src-expose --config test.yaml`