### PR TITLE
RFC Use python for shell scripts

### DIFF
--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -1,10 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-set -euf -o pipefail
 
-# Mirroring:
-# - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-indexserver/Dockerfile#L28-L35
-# - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-webserver/Dockerfile#L27-L34
-export GOGC=50
+def main(args, env):
+    """Return the zoekt command to run based on the arguments passed to this script.
 
-exec $@
+    >>> main(['zoekt-sourcegraph-indexserver', '-sourcegraph_url', 'http://localhost:3090', '-index', '/Users/test/.sourcegraph/zoekt/index', '-interval', '1m', '-listen', ':6072'], {})
+    (['zoekt-sourcegraph-indexserver', '-sourcegraph_url', 'http://localhost:3090', '-index', '/Users/test/.sourcegraph/zoekt/index', '-interval', '1m', '-listen', ':6072'], {'GOGC': '50'})
+    """
+
+    # Mirroring:
+    # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-indexserver/Dockerfile#L28-L35
+    # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-webserver/Dockerfile#L27-L34
+    env["GOGC"] = "50"
+
+    return args, env
+
+# We always run tests since they are silent on success.
+import doctest; doctest.testmod()
+
+if __name__ == "__main__":
+    import os, sys
+
+    argv, env = main(sys.argv[1:], os.environ.copy())
+    os.execvpe(argv[0], argv, env)


### PR DESCRIPTION
I got started down a path of making the zoekt shell script very complicated, so first I converted it to python. I've stopped that path for now since I started getting into over-engineering territory. But I was really enjoying using a cleaner and more powerful language.

Things you get:
- Testability
- A REPL
- Easy to use data structures (maps, sets, etc)
- Batteries included.

This PR is for others to comment on the idea of using python (or another "OS default" scripting language) for our dev scripts. This is just the initial commit I did to show the basic setup replacing a very simple shell script. WDYT?

Note: I do not intend on landing this PR, it exists for discussion.