### PR TITLE
dev: Set DEV_SEARCH_SHARDING for sharded search

### DIFF
--- a/dev/Procfile
+++ b/dev/Procfile
@@ -10,8 +10,10 @@ watch: ./dev/changewatch.sh
 nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could not open error log file'
 web: ./node_modules/.bin/gulp --color watch
 syntect_server: ./dev/syntect_server
-zoekt-indexserver: ./dev/zoekt/wrapper indexserver
-zoekt-webserver: ./dev/zoekt/wrapper webserver
+zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
+zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
+zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
+zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
 management-console: PROJECT_ROOT=./cmd/management-console TLS_CERT=$HOME/.sourcegraph/management/cert.pem TLS_KEY=$HOME/.sourcegraph/management/key.pem management-console
 management-console-web: cd ./cmd/management-console/web && ./serve.sh
 keycloak: ./dev/auth-provider/keycloak.sh

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -10,8 +10,8 @@ watch: ./dev/changewatch.sh
 nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could not open error log file'
 web: ./node_modules/.bin/gulp --color watch
 syntect_server: ./dev/syntect_server
-zoekt-indexserver: ./dev/zoekt/wrapper zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
-zoekt-webserver: ./dev/zoekt/wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc -listen :3070
+zoekt-indexserver: ./dev/zoekt/wrapper indexserver
+zoekt-webserver: ./dev/zoekt/wrapper webserver
 management-console: PROJECT_ROOT=./cmd/management-console TLS_CERT=$HOME/.sourcegraph/management/cert.pem TLS_KEY=$HOME/.sourcegraph/management/key.pem management-console
 management-console-web: cd ./cmd/management-console/web && ./serve.sh
 keycloak: ./dev/auth-provider/keycloak.sh

--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -63,6 +63,9 @@ export ZOEKT_HOST=localhost:3070
 export USE_ENHANCED_LANGUAGE_DETECTION=${USE_ENHANCED_LANGUAGE_DETECTION:-1}
 export GRAFANA_SERVER_URL=http://localhost:3370
 
+# Enable sharded indexed search mode
+[ -z "${DEV_SEARCH_SHARDING-}" ] || export INDEXED_SEARCH_SERVERS="localhost:3070 localhost:3071"
+
 # webpack-dev-server is a proxy running on port 3080 that (1) serves assets, waiting to respond
 # until they are (re)built and (2) otherwise proxies to nginx running on port 3081 (which proxies to
 # Sourcegraph running on port 3082). That is why Sourcegraph listens on 3081 despite the externalURL

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -12,6 +12,7 @@ if (( replica != 0 )) && [[ -z "${DEV_SEARCH_SHARDING-}" ]]; then
 fi
 
 webport=$((3070 + replica))
+indexport=$((6072 + replica))
 
 # Mirroring:
 # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-indexserver/Dockerfile#L28-L35
@@ -21,13 +22,12 @@ export GOGC=50
 case "$cmd" in
 
     indexserver)
-        port=$((6072 + replica))
         exec zoekt-sourcegraph-indexserver \
              -sourcegraph_url http://localhost:3090 \
              -index "$index" \
              -hostname "localhost:$webport" \
              -interval 1m \
-             -listen ":$port"
+             -listen ":$indexport"
         ;;
 
     webserver)

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -2,19 +2,36 @@
 
 set -euf -o pipefail
 
+cmd="${1:-}"
+replica="${2:-0}"
+index="$HOME/.sourcegraph/zoekt/index-$replica"
+
+if (( replica != 0 )) && [[ -z "${DEV_SEARCH_SHARDING-}" ]]; then
+    echo "set DEV_SEARCH_SHARDING=t to enable horizontal indexed search"
+    exit 0
+fi
+
+webport=$((3070 + replica))
+
 # Mirroring:
 # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-indexserver/Dockerfile#L28-L35
 # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-webserver/Dockerfile#L27-L34
 export GOGC=50
 
-case "$1" in
+case "$cmd" in
 
     indexserver)
-        exec zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
+        port=$((6072 + replica))
+        exec zoekt-sourcegraph-indexserver \
+             -sourcegraph_url http://localhost:3090 \
+             -index "$index" \
+             -hostname "localhost:$webport" \
+             -interval 1m \
+             -listen ":$port"
         ;;
 
     webserver)
-        exec zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc -listen :3070
+        exec zoekt-webserver -index "$index" -pprof -rpc -listen ":$webport"
         ;;
 
     *)

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -7,4 +7,19 @@ set -euf -o pipefail
 # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-webserver/Dockerfile#L27-L34
 export GOGC=50
 
-exec $@
+case "$1" in
+
+    indexserver)
+        exec zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
+        ;;
+
+    webserver)
+        exec zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc -listen :3070
+        ;;
+
+    *)
+        echo "USAGE: $0 (indexserver|webserver)"
+        exit 1
+        ;;
+
+esac


### PR DESCRIPTION
We update our zoekt wrapper to understand a replica number. If `DEV_SEARCH_SHARDING` is set we then start up two replicas locally, each pointing to `~/.sourcegraph/zoekt/index-$replica`.

Test plan: Run `./dev/launch.sh` with and without `DEV_SEARCH_SHARDING` set. When not set ensure replica 1 does not start. When set visit check that there are disjoint subsets of indexes:

```shellsession
$ ls ~/.sourcegraph/zoekt-*/index
/Users/keegan/.sourcegraph/zoekt-0/index:
github.com%2Fsourcegraph%2Femacs-sourcegraph-mode_v16.00000.zoekt github.com%2Fsourcegraph%2Fthyme_v16.00000.zoekt

/Users/keegan/.sourcegraph/zoekt-1/index:
github.com%2Fsourcegraph%2Fsourcegraph-typescript_v16.00000.zoekt
```

Part of https://github.com/sourcegraph/sourcegraph/issues/5725