### PR TITLE
Fix test after switch from CEST to CET

### DIFF
--- a/enterprise/pkg/a8n/counts_test.go
+++ b/enterprise/pkg/a8n/counts_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCalcCounts(t *testing.T) {
-	now := time.Now().Truncate(time.Microsecond)
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
 	tests := []struct {


### PR DESCRIPTION
This failed, because something always fails when a switch from DST to
non-DST occurs. Using UTC as input, as we intend to do, fixes it.

P.S.: :raised_fist: stop DST! stop timezones! UTC worldwide! :raised_fist:
