### PR TITLE
CHANGELOG: Mention Kubernetes migration for 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- **Kubernetes Migration:** The [Kubernetes deployment](https://github.com/sourcegraph/deploy-sourcegraph) manifest for indexed-search services has changed from a Normal Service to a Headless Service. This is to enable Sourcegraph to individually resolve indexed-search pods. Services are immutable, so please follow the [migration guide](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/migrate.md#310).
 - Fields of type `String` in our GraphQL API that contain [JSONC](https://komkom.github.io/) now have the custom scalar type `JSONCString`. [#6209](https://github.com/sourcegraph/sourcegraph/pull/6209)
 
 ### Fixed


### PR DESCRIPTION
CHANGELOG entry for https://github.com/sourcegraph/deploy-sourcegraph/pull/428

Part of https://github.com/sourcegraph/sourcegraph/issues/5725