### PR TITLE
Add EditorNotFoundError and DocumentNotFoundError

### DIFF
--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -121,6 +121,15 @@ export interface EditorService {
     removeAllEditors(): void
 }
 
+const EEDITORNOTFOUND = 'EditorNotFoundError'
+class EditorNotFoundError extends Error {
+    public readonly name = EEDITORNOTFOUND
+    public readonly code = EEDITORNOTFOUND
+    constructor(editorId: string) {
+        super(`editor not found: ${editorId}`)
+    }
+}
+
 /**
  * Creates a {@link EditorService} instance.
  */
@@ -141,7 +150,7 @@ export function createEditorService(modelService: Pick<ModelService, 'removeMode
     const getEditor = (editorId: EditorId['editorId']): CodeEditor => {
         const editor = editors.get(editorId)
         if (!editor) {
-            throw new Error(`editor not found: ${editorId}`)
+            throw new EditorNotFoundError(editorId)
         }
         return editor
     }

--- a/shared/src/api/extension/api/documents.ts
+++ b/shared/src/api/extension/api/documents.ts
@@ -9,6 +9,15 @@ export interface ExtDocumentsAPI extends ProxyValue {
     $acceptDocumentData(modelUpdates: readonly TextModelUpdate[]): void
 }
 
+const EDOCUMENTNOTFOUND = 'DocumentNotFoundError'
+class DocumentNotFoundError extends Error {
+    public readonly name = EDOCUMENTNOTFOUND
+    public readonly code = EDOCUMENTNOTFOUND
+    constructor(resource: string) {
+        super(`document not found: ${resource}`)
+    }
+}
+
 /** @internal */
 export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
     public readonly [proxyValueSymbol] = true
@@ -25,7 +34,7 @@ export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
     public get(resource: string): ExtDocument {
         const doc = this.documents.get(resource)
         if (!doc) {
-            throw new Error(`document not found: ${resource}`)
+            throw new DocumentNotFoundError(resource)
         }
         return doc
     }


### PR DESCRIPTION
Adding this so that these errors can be better grouped on Sentry: https://sentry.io/organizations/sourcegraph/issues/?project=1334031&query=is%3Aunresolved+%22not+found%3A%22&statsPeriod=14d
