### PR TITLE
lsif: Fix `no such file or directory [...] search-jobs.lua`

### DIFF
--- a/lsif/package.json
+++ b/lsif/package.json
@@ -82,8 +82,8 @@
     "typecheck": "tsc --noEmit",
     "tslint": "../node_modules/.bin/tslint -p tsconfig.json",
     "eslint": "../node_modules/.bin/eslint 'src/**/*.ts?(x)'",
-    "run:server": "tsc-watch --onFirstSuccess \"yarn postbuild \" --onSuccess \"node -r source-map-support/register out/server.js\" --noClear",
-    "run:worker": "tsc-watch --onFirstSuccess \"yarn postbuild \" --onSuccess \"node -r source-map-support/register out/worker.js\" --noClear",
+    "run:server": "tsc-watch --onFirstSuccess \"yarn postbuild\" --onSuccess \"node -r source-map-support/register out/server.js\" --noClear",
+    "run:worker": "tsc-watch --onFirstSuccess \"yarn postbuild\" --onSuccess \"node -r source-map-support/register out/worker.js\" --noClear",
     "schema": "typescript-json-schema ./node_modules/lsif-protocol/lib/protocol.d.ts '*' -o src/lsif.schema.json --titles --ignoreErrors --noExtraProps --required --strictNullChecks"
   }
 }

--- a/lsif/package.json
+++ b/lsif/package.json
@@ -82,8 +82,8 @@
     "typecheck": "tsc --noEmit",
     "tslint": "../node_modules/.bin/tslint -p tsconfig.json",
     "eslint": "../node_modules/.bin/eslint 'src/**/*.ts?(x)'",
-    "run:server": "tsc-watch --onSuccess \"node -r source-map-support/register out/server.js\" --noClear",
-    "run:worker": "tsc-watch --onSuccess \"node -r source-map-support/register out/worker.js\" --noClear",
+    "run:server": "tsc-watch --onFirstSuccess \"yarn postbuild \" --onSuccess \"node -r source-map-support/register out/server.js\" --noClear",
+    "run:worker": "tsc-watch --onFirstSuccess \"yarn postbuild \" --onSuccess \"node -r source-map-support/register out/worker.js\" --noClear",
     "schema": "typescript-json-schema ./node_modules/lsif-protocol/lib/protocol.d.ts '*' -o src/lsif.schema.json --titles --ignoreErrors --noExtraProps --required --strictNullChecks"
   }
 }

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -594,7 +594,7 @@ type ScriptedRedis = Redis & {
 async function defineRedisCommands(client: Redis): Promise<ScriptedRedis> {
     client.defineCommand('searchJobs', {
         numberOfKeys: 2,
-        lua: (await fs.readFile(`${__dirname}/search-jobs.lua`)).toString(),
+        lua: (await fs.readFile(`${__dirname}/../src/search-jobs.lua`)).toString(),
     })
 
     // The defineCommand method on the client dynamically defines a new method, but

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -594,7 +594,7 @@ type ScriptedRedis = Redis & {
 async function defineRedisCommands(client: Redis): Promise<ScriptedRedis> {
     client.defineCommand('searchJobs', {
         numberOfKeys: 2,
-        lua: (await fs.readFile(`${__dirname}/../src/search-jobs.lua`)).toString(),
+        lua: (await fs.readFile(`${__dirname}/search-jobs.lua`)).toString(),
     })
 
     // The defineCommand method on the client dynamically defines a new method, but


### PR DESCRIPTION
When I run `./enterprise/dev/start.sh` I got the following output:

    lsif-server | ERROR failed to start process { service: 'lsif-server',
    lsif-server |   error:
    lsif-server |    { Error: ENOENT: no such file or directory, open '/Users/thorstenball/work/sourcegraph/lsif/out/search-jobs.lua'
    lsif-server |      errno: -2,
    lsif-server |      code: 'ENOENT',
    lsif-server |      syscall: 'open',
    lsif-server |      path:
    lsif-server |       '/Users/thorstenball/work/sourcegraph/lsif/out/search-jobs.lua' } }

I assumed it was because this

https://github.com/sourcegraph/sourcegraph/blob/61c29221e06580e831d6119ab16cfe524928c4f4/lsif/src/server.ts#L597

is relative to the location of the `server.ts` file and when that is compiled to `out/server.js` the path is wrong.

I don't know enough about the TypeScript build process to be sure that my change here is correct and won't break with a different build config, but, well, I thought I'd give it a shot.