### PR TITLE
graphqlbackend: Remove double otlog.Error(err) in search

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -640,7 +640,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		if limitHit {
 			common.limitHit = true
 		}
-		tr.LogFields(otlog.Error(err), otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+		tr.LogFields(otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
 		if err != nil && searchErr == nil && !overLimitCanceled {
 			searchErr = err
 			tr.LazyPrintf("cancel indexed search due to error: %v", err)


### PR DESCRIPTION
Follow-up of https://github.com/sourcegraph/sourcegraph/pull/6197#discussion_r339934505