### PR TITLE
a8n: Remove RepoSearcher interface and expose SearchRepos directly

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -63,10 +63,6 @@ type CreateChangesetsArgs struct {
 	}
 }
 
-type RepoSearcher interface {
-	SearchRepos(ctx context.Context, query string) ([]*RepositoryResolver, error)
-}
-
 type A8NResolver interface {
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
 	UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error)
@@ -84,9 +80,6 @@ type A8NResolver interface {
 	PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error)
 	CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error)
 	CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error)
-
-	HasRepoSearcher() bool
-	SetRepoSearcher(RepoSearcher)
 }
 
 var onlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
@@ -101,9 +94,6 @@ func (r *schemaResolver) AddChangesetsToCampaign(ctx context.Context, args *AddC
 func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error) {
 	if r.a8nResolver == nil {
 		return nil, onlyInEnterprise
-	}
-	if !r.a8nResolver.HasRepoSearcher() {
-		r.a8nResolver.SetRepoSearcher(r)
 	}
 	return r.a8nResolver.PreviewCampaignPlan(ctx, args)
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -778,7 +778,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 // SearchRepos searches for the provided query but only the the unique list of
 // repositories belonging to the search results.
 // It's used by a8n to search.
-func (r *schemaResolver) SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver, error) {
+func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver, error) {
 	queryString := query.ConvertToLiteral(plainQuery)
 
 	q, err := query.ParseAndCheck(queryString)

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -28,21 +28,11 @@ import (
 type Resolver struct {
 	store       *ee.Store
 	httpFactory *httpcli.Factory
-
-	repoSearcher graphqlbackend.RepoSearcher
 }
 
 // NewResolver returns a new Resolver whose store uses the given db
 func NewResolver(db *sql.DB) graphqlbackend.A8NResolver {
 	return &Resolver{store: ee.NewStore(db)}
-}
-
-func (r *Resolver) HasRepoSearcher() bool {
-	return r.repoSearcher != nil
-}
-
-func (r *Resolver) SetRepoSearcher(rs graphqlbackend.RepoSearcher) {
-	r.repoSearcher = rs
 }
 
 func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbackend.ExternalChangesetResolver, error) {
@@ -440,12 +430,8 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 		return nil, err
 	}
 
-	// TODO(a8n): Implement this according to the `Arguments["scope"]`
 	// Search repositories over which to execute code modification
-	if r.repoSearcher == nil {
-		return nil, errors.New("No repo search possible")
-	}
-	repos, err := r.repoSearcher.SearchRepos(ctx, specArgs["searchScope"])
+	repos, err := graphqlbackend.SearchRepos(ctx, specArgs["searchScope"])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As discussed with @tsenart. We can get rid of method receiver and just use a function. It still requires global state (DB connection, but it gets rid of the getters/setters, runtime state in the `a8nResolver` and keeps the search logic in the same file.
