### PR TITLE
Fix: tokens with quoted values were broken in literal mode

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -12,6 +12,7 @@ var fieldRx = lazyregexp.New(`^-?[a-zA-Z]+:`)
 // ConvertToLiteral quotes the input query for literal search.
 func ConvertToLiteral(input string) string {
 	tokens := tokenize(input)
+	fmt.Println("TOKENS", tokens)
 	// Sort the tokens into fields and non-fields.
 	var fields, nonFields []string
 	for _, t := range tokens {

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -42,30 +42,18 @@ func ConvertToLiteral(input string) string {
 	return input
 }
 
-var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*")`)
 var quotedTokenValueRx = lazyregexp.New(`(\b-?[a-zA-Z]+:"([^"\\]|[\\].)*")`)
-var spaceRx = lazyregexp.New(`\s+`)
-var nonSpaceRx = lazyregexp.New(`\S+`)
+var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
 
 // tokenize returns a slice of the double-quoted strings, contiguous chunks
 // of non-whitespace, and contiguous chunks of whitespace in the input.
 func tokenize(input string) []string {
 	var modifiedInput string
-	matchedTokens := []string{}
-
 	// Find all tokens with quoted values, and then remove them from the original input
-	matchedTokens = quotedTokenValueRx.FindAllString(input, -1)
+	matchedTokens := quotedTokenValueRx.FindAllString(input, -1)
 	modifiedInput = quotedTokenValueRx.ReplaceAllString(input, "")
 
-	// Find all contiguouos non-whitespace, and then remove them from the original input
-	matchedTokens = append(matchedTokens, nonSpaceRx.FindAllString(modifiedInput, -1)...)
-	modifiedInput = nonSpaceRx.ReplaceAllString(modifiedInput, "")
-
-	// Find all contiguous whitespace, and then remove from input
-	matchedTokens = append(matchedTokens, spaceRx.FindAllString(modifiedInput, -1)...)
-	modifiedInput = tokenRx.ReplaceAllString(modifiedInput, "")
-
-	// Find all quoted strings, and then remove from input
+	// Find all remaining tokens
 	matchedTokens = append(matchedTokens, tokenRx.FindAllString(modifiedInput, -1)...)
 	return matchedTokens
 }

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -48,12 +48,10 @@ var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
 // tokenize returns a slice of the double-quoted strings, contiguous chunks
 // of non-whitespace, and contiguous chunks of whitespace in the input.
 func tokenize(input string) []string {
-	var modifiedInput string
 	// Find all tokens with quoted values, and then remove them from the original input
 	matchedTokens := quotedTokenValueRx.FindAllString(input, -1)
-	modifiedInput = quotedTokenValueRx.ReplaceAllString(input, "")
+	modifiedInput := quotedTokenValueRx.ReplaceAllString(input, "")
 
 	// Find all remaining tokens
-	matchedTokens = append(matchedTokens, tokenRx.FindAllString(modifiedInput, -1)...)
-	return matchedTokens
+	return append(matchedTokens, tokenRx.FindAllString(modifiedInput, -1)...)
 }

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -43,15 +43,15 @@ func ConvertToLiteral(input string) string {
 	return input
 }
 
-var quotedTokenValueRx = lazyregexp.New(`(\b-?[a-zA-Z]+:"([^"\\]|[\\].)*")`)
+var fieldWithQuotedTokenValue = lazyregexp.New(`(\b-?[a-zA-Z]+:"([^"\\]|[\\].)*")`)
 var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
 
 // tokenize returns a slice of the double-quoted strings, contiguous chunks
 // of non-whitespace, and contiguous chunks of whitespace in the input.
 func tokenize(input string) []string {
 	// Find all tokens with quoted values, and then remove them from the original input
-	matchedTokens := quotedTokenValueRx.FindAllString(input, -1)
-	modifiedInput := quotedTokenValueRx.ReplaceAllString(input, "")
+	matchedTokens := fieldWithQuotedTokenValue.FindAllString(input, -1)
+	modifiedInput := fieldWithQuotedTokenValue.ReplaceAllString(input, "")
 
 	// Find all remaining tokens
 	return append(matchedTokens, tokenRx.FindAllString(modifiedInput, -1)...)

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -12,7 +12,7 @@ var fieldRx = lazyregexp.New(`^-?[a-zA-Z]+:`)
 // ConvertToLiteral quotes the input query for literal search.
 func ConvertToLiteral(input string) string {
 	tokens := tokenize(input)
-	fmt.Println("TOKENS", tokens)
+
 	// Sort the tokens into fields and non-fields.
 	var fields, nonFields []string
 	for _, t := range tokens {

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -12,15 +12,19 @@ var fieldRx = lazyregexp.New(`^-?[a-zA-Z]+:`)
 // ConvertToLiteral quotes the input query for literal search.
 func ConvertToLiteral(input string) string {
 	tokens := tokenize(input)
+	fmt.Println("TOKENS", tokens)
 	// Sort the tokens into fields and non-fields.
 	var fields, nonFields []string
 	for _, t := range tokens {
+		fmt.Println("token", t)
 		if fieldRx.MatchString(t) {
 			fields = append(fields, t)
 		} else {
 			nonFields = append(nonFields, t)
 		}
 	}
+	fmt.Println("FIELDS", fields)
+	fmt.Println("NON FIELDS", nonFields)
 
 	// Rebuild the input as fields followed by non-fields quoted together.
 	var pieces []string
@@ -39,13 +43,34 @@ func ConvertToLiteral(input string) string {
 		}
 	}
 	input = strings.Join(pieces, " ")
+	fmt.Println("INPUT", input)
 	return input
 }
 
-var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
+var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*")`)
+var quotedTokenValueRx = lazyregexp.New(`(\b-?[a-zA-Z]+:"([^"\\]|[\\].)*")`)
+var spaceRx = lazyregexp.New(`\s+`)
+var nonSpaceRx = lazyregexp.New(`\S+`)
 
 // tokenize returns a slice of the double-quoted strings, contiguous chunks
 // of non-whitespace, and contiguous chunks of whitespace in the input.
 func tokenize(input string) []string {
-	return tokenRx.FindAllString(input, -1)
+	var modifiedInput string
+	matchedTokens := []string{}
+
+	// Find all tokens with quoted values, and then remove them from the original input
+	matchedTokens = quotedTokenValueRx.FindAllString(input, -1)
+	modifiedInput = quotedTokenValueRx.ReplaceAllString(input, "")
+
+	// Find all contiguouos non-whitespace, and then remove them from the original input
+	matchedTokens = append(matchedTokens, nonSpaceRx.FindAllString(modifiedInput, -1)...)
+	modifiedInput = nonSpaceRx.ReplaceAllString(modifiedInput, "")
+
+	// Find all contiguous whitespace, and then remove from input
+	matchedTokens = append(matchedTokens, spaceRx.FindAllString(modifiedInput, -1)...)
+	modifiedInput = tokenRx.ReplaceAllString(modifiedInput, "")
+
+	// Find all quoted strings, and then remove from input
+	matchedTokens = append(matchedTokens, tokenRx.FindAllString(modifiedInput, -1)...)
+	return matchedTokens
 }

--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -12,19 +12,15 @@ var fieldRx = lazyregexp.New(`^-?[a-zA-Z]+:`)
 // ConvertToLiteral quotes the input query for literal search.
 func ConvertToLiteral(input string) string {
 	tokens := tokenize(input)
-	fmt.Println("TOKENS", tokens)
 	// Sort the tokens into fields and non-fields.
 	var fields, nonFields []string
 	for _, t := range tokens {
-		fmt.Println("token", t)
 		if fieldRx.MatchString(t) {
 			fields = append(fields, t)
 		} else {
 			nonFields = append(nonFields, t)
 		}
 	}
-	fmt.Println("FIELDS", fields)
-	fmt.Println("NON FIELDS", nonFields)
 
 	// Rebuild the input as fields followed by non-fields quoted together.
 	var pieces []string
@@ -43,7 +39,6 @@ func ConvertToLiteral(input string) string {
 		}
 	}
 	input = strings.Join(pieces, " ")
-	fmt.Println("INPUT", input)
 	return input
 }
 

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -45,6 +45,8 @@ func TestConvertToLiteral(t *testing.T) {
 		{`\d`, `"\\d"`},
 		{`type:commit message:"a commit message" after:"10 days ago"`, `message:"a commit message" after:"10 days ago" type:commit`},
 		{`type:commit message:"a commit message" after:"10 days ago" test`, `message:"a commit message" after:"10 days ago" type:commit "test"`},
+		{`type:commit message:"a commit message" after:"10 days ago" test test2`, `message:"a commit message" after:"10 days ago" type:commit "test test2"`},
+		{`type:commit message:"a commit message" test after:"10 days ago" test2`, `message:"a commit message" after:"10 days ago" type:commit "test  test2"`},
 	}
 
 	for _, test := range tests {
@@ -86,7 +88,9 @@ func TestTokenize(t *testing.T) {
 		{"/**/", []string{"/**/"}},
 		{`type:commit message:"a commit message"`, []string{"message:\"a commit message\"", "type:commit", " "}},
 		{`type:commit message:"a commit message" after:"10 days ago"`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "  "}},
+		{`type:commit message:"a commit message" test after:"10 days ago"`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "  ", "test", " "}},
 		{`type:commit message:"a commit message" after:"10 days ago" test`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "   ", "test"}},
+		{`type:commit message:"a commit message" after:"10 days ago" test test2`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "   ", "test", " ", "test2"}},
 	}
 
 	for _, test := range tests {

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -43,6 +43,8 @@ func TestConvertToLiteral(t *testing.T) {
 		{`\`, `"\\"`},
 		{`foo\d "bar*"`, `"foo\\d \"bar*\""`},
 		{`\d`, `"\\d"`},
+		{`type:commit message:"a commit message" after:"10 days ago"`, `message:"a commit message" after:"10 days ago" type:commit`},
+		{`type:commit message:"a commit message" after:"10 days ago" test`, `message:"a commit message" after:"10 days ago" type:commit "test"`},
 	}
 
 	for _, test := range tests {
@@ -82,6 +84,9 @@ func TestTokenize(t *testing.T) {
 		{`f:a "r:b"`, []string{`f:a`, " ", `"r:b"`}},
 		{"//", []string{"//"}},
 		{"/**/", []string{"/**/"}},
+		{`type:commit message:"a commit message"`, []string{"message:\"a commit message\"", "type:commit", " "}},
+		{`type:commit message:"a commit message" after:"10 days ago"`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "  "}},
+		{`type:commit message:"a commit message" after:"10 days ago" test`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "   ", "test"}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6255.

Previously, we failed to match search filters that had a quoted string as their value and recognize them as a single token.

In this PR I made it such that we match the different types of regexes sequentially, starting with specifically tokens with quoted strings as values. This fixes cases such as the one mentioned in the issue.