### PR TITLE
bitbucketserver: Implement LoadPullRequestActivities

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -384,6 +384,39 @@ func (c *Client) LoadPullRequest(ctx context.Context, pr *PullRequest) error {
 	return c.send(ctx, "GET", path, nil, nil, pr)
 }
 
+// LoadPullRequestActivities loads the given PullRequest's timeline of activities,
+// returning an error in case of failure.
+func (c *Client) LoadPullRequestActivities(ctx context.Context, pr *PullRequest) (err error) {
+	if pr.ToRef.Repository.Slug == "" {
+		return errors.New("repository slug empty")
+	}
+
+	if pr.ToRef.Repository.Project.Key == "" {
+		return errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf(
+		"rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/activities",
+		pr.ToRef.Repository.Project.Key,
+		pr.ToRef.Repository.Slug,
+		pr.ID,
+	)
+
+	t := &PageToken{Limit: 1000}
+
+	var activities []Activity
+	for t.HasMore() {
+		var page []Activity
+		if t, err = c.page(ctx, path, nil, t, &page); err != nil {
+			return err
+		}
+		activities = append(activities, page...)
+	}
+
+	pr.Activities = activities
+	return nil
+}
+
 func (c *Client) Repo(ctx context.Context, projectKey, repoSlug string) (*Repo, error) {
 	u := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s", projectKey, repoSlug)
 	req, err := http.NewRequest("GET", u, nil)
@@ -779,6 +812,98 @@ type PullRequest struct {
 			Href string `json:"href"`
 		} `json:"self"`
 	} `json:"links"`
+
+	Activities []Activity `json:"activities,omitempty"`
+}
+
+// Activity is a union type of all supported pull request activity items.
+type Activity struct {
+	ID          int            `json:"id"`
+	CreatedDate int            `json:"createdDate"`
+	User        User           `json:"user"`
+	Action      ActivityAction `json:"action"`
+
+	// Comment activity fields.
+	CommentAction string         `json:"commentAction,omitempty"`
+	Comment       *Comment       `json:"comment,omitempty"`
+	CommentAnchor *CommentAnchor `json:"commentAnchor,omitempty"`
+
+	// Reviewers change fields.
+	AddedReviewers   []User `json:"addedReviewers,omitempty"`
+	RemovedReviewers []User `json:"removedReviewers,omitempty"`
+
+	// Merged event fields.
+	Commit *Commit `json:"commit,omitempty"`
+}
+
+// ActivityAction defines the action taken in an Activity.
+type ActivityAction string
+
+// Known ActivityActions
+const (
+	ApprovedActivitiyAction   ActivityAction = "APPROVED"
+	UnapprovedActivitiyAction ActivityAction = "UNAPPROVED"
+	DeclinedActivitiyAction   ActivityAction = "DECLINED"
+	ReviewedActivitiyAction   ActivityAction = "REVIEWED"
+	OpenedActivitiyAction     ActivityAction = "OPENED"
+	RepenedActivitiyAction    ActivityAction = "REOPENED"
+	UpdatedActivitiyAction    ActivityAction = "UPDATED"
+	CommentedActivitiyAction  ActivityAction = "COMMENTED"
+	MergedActivitiyAction     ActivityAction = "MERGED"
+)
+
+// A Comment in a PullRequest.
+type Comment struct {
+	ID                  int                 `json:"id"`
+	Version             int                 `json:"version"`
+	Text                string              `json:"text"`
+	Author              User                `json:"author"`
+	CreatedDate         int                 `json:"createdDate"`
+	UpdatedDate         int                 `json:"updatedDate"`
+	Comments            []Comment           `json:"comments"` // Replies to the comment
+	Tasks               []Task              `json:"tasks"`
+	PermittedOperations PermittedOperations `json:"permittedOperations"`
+}
+
+// A CommentAnchor captures the location of a code comment in a PullRequest.
+type CommentAnchor struct {
+	FromHash string `json:"fromHash"`
+	ToHash   string `json:"toHash"`
+	Line     int    `json:"line"`
+	LineType string `json:"lineType"`
+	FileType string `json:"fileType"`
+	Path     string `json:"path"`
+	DiffType string `json:"diffType"`
+	Orphaned bool   `json:"orphaned"`
+}
+
+// A Task in a PullRequest.
+type Task struct {
+	ID                  int                 `json:"id"`
+	Author              User                `json:"author"`
+	Text                string              `json:"text"`
+	State               string              `json:"state"`
+	CreatedDate         int                 `json:"createdDate"`
+	PermittedOperations PermittedOperations `json:"permittedOperations"`
+}
+
+// PermittedOperations of a Comment or Task.
+type PermittedOperations struct {
+	Editable       bool `json:"editable,omitempty"`
+	Deletable      bool `json:"deletable,omitempty"`
+	Transitionable bool `json:"transitionable,omitempty"`
+}
+
+// A Commit in a Repository.
+type Commit struct {
+	ID                 string   `json:"id,omitempty"`
+	DisplayID          string   `json:"displayId,omitempty"`
+	Author             *User    `json:"user,omitempty"`
+	AuthorTimestamp    int64    `json:"authorTimestamp,omitempty"`
+	Committer          *User    `json:"committer,omitempty"`
+	CommitterTimestamp int64    `json:"committerTimestamp,omitempty"`
+	Message            string   `json:"message,omitempty"`
+	Parents            []Commit `json:"parents,omitempty"`
 }
 
 // IsNotFound reports whether err is a Bitbucket Server API not found error.

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -411,3 +411,97 @@ func TestClient_LoadPullRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_LoadPullRequestActivities(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		instanceURL = "http://127.0.0.1:7990"
+	}
+
+	cli, save := NewTestClient(t, "PullRequestActivities", *update)
+	defer save()
+
+	timeout, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	pr := &PullRequest{ID: 2}
+	pr.ToRef.Repository.Slug = "vegeta"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		pr   func() *PullRequest
+		err  string
+	}{
+		{
+			name: "timeout",
+			pr:   func() *PullRequest { return pr },
+			ctx:  timeout,
+			err:  "context deadline exceeded",
+		},
+		{
+			name: "repo not set",
+			pr:   func() *PullRequest { return &PullRequest{ID: 2} },
+			err:  "repository slug empty",
+		},
+		{
+			name: "project not set",
+			pr: func() *PullRequest {
+				pr := &PullRequest{ID: 2}
+				pr.ToRef.Repository.Slug = "vegeta"
+				return pr
+			},
+			err: "project key empty",
+		},
+		{
+			name: "success",
+			pr:   func() *PullRequest { return pr },
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			pr := tc.pr()
+			err := cli.LoadPullRequestActivities(tc.ctx, pr)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Fatalf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil || tc.err != "<nil>" {
+				return
+			}
+
+			data, err := json.MarshalIndent(pr, " ", " ")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			path := "testdata/golden/LoadPullRequestActivities-" + strings.Replace(tc.name, " ", "-", -1)
+			if *update {
+				if err = ioutil.WriteFile(path, data, 0640); err != nil {
+					t.Fatalf("failed to update golden file %q: %s", path, err)
+				}
+			}
+
+			golden, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read golden file %q: %s", path, err)
+			}
+
+			if have, want := string(data), string(golden); have != want {
+				dmp := diffmatchpatch.New()
+				diffs := dmp.DiffMain(have, want, false)
+				t.Error(dmp.DiffPrettyText(diffs))
+			}
+		})
+	}
+}

--- a/internal/extsvc/bitbucketserver/testdata/golden/LoadPullRequestActivities-success
+++ b/internal/extsvc/bitbucketserver/testdata/golden/LoadPullRequestActivities-success
@@ -1,0 +1,316 @@
+{
+  "id": 2,
+  "version": 0,
+  "title": "",
+  "description": "",
+  "state": "",
+  "open": false,
+  "closed": false,
+  "createdDate": 0,
+  "updatedDate": 0,
+  "fromRef": {
+   "id": "",
+   "repository": {
+    "slug": "",
+    "project": {
+     "key": ""
+    }
+   }
+  },
+  "toRef": {
+   "id": "",
+   "repository": {
+    "slug": "vegeta",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": null,
+   "role": "",
+   "approved": false,
+   "status": ""
+  },
+  "reviewers": null,
+  "participants": null,
+  "links": {
+   "self": null
+  },
+  "activities": [
+   {
+    "id": 87,
+    "createdDate": 1572432617016,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "MERGED",
+    "commit": {
+     "id": "be4d84e9c4b0a15e59c5f52900e6d55c7525b8d3",
+     "displayId": "be4d84e9c4b",
+     "authorTimestamp": 1572432617000,
+     "committer": {
+      "name": "tomas",
+      "emailAddress": "tomas@sourcegraph.com",
+      "id": 3,
+      "displayName": "Tomás Senart",
+      "active": true,
+      "slug": "tomas",
+      "type": "NORMAL"
+     },
+     "committerTimestamp": 1572432617000,
+     "message": "Merge pull request #2 in SOUR/vegeta from release-testing-pr to master\n\n* commit '1f63e719a65cad47a0a272d3d6eef05f4da427bb':\n  make make make\n  Remove dump.go",
+     "parents": [
+      {
+       "id": "13613ac741e0f14f179e552ca428401ca83fe28a",
+       "displayId": "13613ac741e",
+       "authorTimestamp": 1572431324000,
+       "committer": {
+        "name": "Tomás Senart",
+        "emailAddress": "tomas@sourcegraph.com"
+       },
+       "committerTimestamp": 1572431324000,
+       "message": "Merge pull request #4 in SOUR/vegeta from encode-comment to master\n\n* commit 'db6f6959b162f5501f43898e1d44c03de5de6202':\n  Encode comment is fun!",
+       "parents": [
+        {
+         "id": "0f5577eaf11a136541b8c667273b6bc5eba51a8b",
+         "displayId": "0f5577eaf11"
+        },
+        {
+         "id": "db6f6959b162f5501f43898e1d44c03de5de6202",
+         "displayId": "db6f6959b16"
+        }
+       ]
+      },
+      {
+       "id": "1f63e719a65cad47a0a272d3d6eef05f4da427bb",
+       "displayId": "1f63e719a65",
+       "authorTimestamp": 1563286282000,
+       "committer": {
+        "name": "Tomás Senart",
+        "emailAddress": "tsenart@gmail.com"
+       },
+       "committerTimestamp": 1563286282000,
+       "message": "make make make",
+       "parents": [
+        {
+         "id": "7b71906bf3b3ec81a4d013b7f59ceb34b3c4105b",
+         "displayId": "7b71906bf3b"
+        }
+       ]
+      }
+     ]
+    }
+   },
+   {
+    "id": 85,
+    "createdDate": 1572432552916,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "COMMENTED",
+    "commentAction": "ADDED",
+    "comment": {
+     "id": 8,
+     "version": 0,
+     "text": "Comment.",
+     "author": {
+      "name": "tomas",
+      "emailAddress": "tomas@sourcegraph.com",
+      "id": 3,
+      "displayName": "Tomás Senart",
+      "active": true,
+      "slug": "tomas",
+      "type": "NORMAL"
+     },
+     "createdDate": 1572432552916,
+     "updatedDate": 1572432552916,
+     "comments": [
+      {
+       "id": 9,
+       "version": 0,
+       "text": "Reply.",
+       "author": {
+        "name": "tomas",
+        "emailAddress": "tomas@sourcegraph.com",
+        "id": 3,
+        "displayName": "Tomás Senart",
+        "active": true,
+        "slug": "tomas",
+        "type": "NORMAL"
+       },
+       "createdDate": 1572432558954,
+       "updatedDate": 1572432558954,
+       "comments": [],
+       "tasks": [
+        {
+         "id": 4,
+         "author": {
+          "name": "tomas",
+          "emailAddress": "tomas@sourcegraph.com",
+          "id": 3,
+          "displayName": "Tomás Senart",
+          "active": true,
+          "slug": "tomas",
+          "type": "NORMAL"
+         },
+         "text": "Task",
+         "state": "RESOLVED",
+         "createdDate": 1572432564000,
+         "permittedOperations": {
+          "transitionable": true
+         }
+        }
+       ],
+       "permittedOperations": {}
+      }
+     ],
+     "tasks": [
+      {
+       "id": 5,
+       "author": {
+        "name": "tomas",
+        "emailAddress": "tomas@sourcegraph.com",
+        "id": 3,
+        "displayName": "Tomás Senart",
+        "active": true,
+        "slug": "tomas",
+        "type": "NORMAL"
+       },
+       "text": "Another task.",
+       "state": "OPEN",
+       "createdDate": 1572432578000,
+       "permittedOperations": {
+        "editable": true,
+        "deletable": true,
+        "transitionable": true
+       }
+      }
+     ],
+     "permittedOperations": {}
+    }
+   },
+   {
+    "id": 77,
+    "createdDate": 1572430034930,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "REOPENED"
+   },
+   {
+    "id": 76,
+    "createdDate": 1572429831834,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "DECLINED"
+   },
+   {
+    "id": 75,
+    "createdDate": 1572429777823,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "UNAPPROVED"
+   },
+   {
+    "id": 74,
+    "createdDate": 1572429738565,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "APPROVED"
+   },
+   {
+    "id": 73,
+    "createdDate": 1572429681822,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "REVIEWED"
+   },
+   {
+    "id": 72,
+    "createdDate": 1572429656637,
+    "user": {
+     "name": "tomas",
+     "emailAddress": "tomas@sourcegraph.com",
+     "id": 3,
+     "displayName": "Tomás Senart",
+     "active": true,
+     "slug": "tomas",
+     "type": "NORMAL"
+    },
+    "action": "UPDATED",
+    "addedReviewers": [
+     {
+      "name": "tomas",
+      "emailAddress": "tomas@sourcegraph.com",
+      "id": 3,
+      "displayName": "Tomás Senart",
+      "active": true,
+      "slug": "tomas",
+      "type": "NORMAL"
+     }
+    ]
+   },
+   {
+    "id": 44,
+    "createdDate": 1563286308065,
+    "user": {
+     "name": "milton",
+     "emailAddress": "dev@sourcegraph.com",
+     "id": 1,
+     "displayName": "milton woof",
+     "active": true,
+     "slug": "milton",
+     "type": "NORMAL"
+    },
+    "action": "OPENED"
+   }
+  ]
+ }

--- a/internal/extsvc/bitbucketserver/testdata/vcr/PullRequestActivities.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/PullRequestActivities.yaml
@@ -1,0 +1,70 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/vegeta/pull-requests/2/activities?limit=1000
+    method: GET
+  response:
+    body: '{"size":9,"limit":500,"isLastPage":true,"values":[{"id":87,"createdDate":1572432617016,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"MERGED","commit":{"id":"be4d84e9c4b0a15e59c5f52900e6d55c7525b8d3","displayId":"be4d84e9c4b","author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"authorTimestamp":1572432617000,"committer":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"committerTimestamp":1572432617000,"message":"Merge
+      pull request #2 in SOUR/vegeta from release-testing-pr to master\n\n* commit
+      ''1f63e719a65cad47a0a272d3d6eef05f4da427bb'':\n  make make make\n  Remove dump.go","parents":[{"id":"13613ac741e0f14f179e552ca428401ca83fe28a","displayId":"13613ac741e","author":{"name":"Tomás
+      Senart","emailAddress":"tomas@sourcegraph.com"},"authorTimestamp":1572431324000,"committer":{"name":"Tomás
+      Senart","emailAddress":"tomas@sourcegraph.com"},"committerTimestamp":1572431324000,"message":"Merge
+      pull request #4 in SOUR/vegeta from encode-comment to master\n\n* commit ''db6f6959b162f5501f43898e1d44c03de5de6202'':\n  Encode
+      comment is fun!","parents":[{"id":"0f5577eaf11a136541b8c667273b6bc5eba51a8b","displayId":"0f5577eaf11"},{"id":"db6f6959b162f5501f43898e1d44c03de5de6202","displayId":"db6f6959b16"}]},{"id":"1f63e719a65cad47a0a272d3d6eef05f4da427bb","displayId":"1f63e719a65","author":{"name":"Tomás
+      Senart","emailAddress":"tsenart@gmail.com"},"authorTimestamp":1563286282000,"committer":{"name":"Tomás
+      Senart","emailAddress":"tsenart@gmail.com"},"committerTimestamp":1563286282000,"message":"make
+      make make","parents":[{"id":"7b71906bf3b3ec81a4d013b7f59ceb34b3c4105b","displayId":"7b71906bf3b"}]}]}},{"id":85,"createdDate":1572432552916,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"COMMENTED","commentAction":"ADDED","comment":{"properties":{"repositoryId":2},"id":8,"version":0,"text":"Comment.","author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432552916,"updatedDate":1572432552916,"comments":[{"properties":{"repositoryId":2},"id":9,"version":0,"text":"Reply.","author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432558954,"updatedDate":1572432558954,"comments":[],"tasks":[{"anchor":{"properties":{"repositoryId":2},"id":9,"version":0,"text":"Reply.","author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432558954,"updatedDate":1572432558954,"permittedOperations":{"editable":false,"deletable":false},"type":"COMMENT"},"author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432564000,"id":4,"text":"Task","state":"RESOLVED","permittedOperations":{"deletable":false,"editable":false,"transitionable":true}}],"permittedOperations":{"editable":false,"deletable":false}}],"tasks":[{"anchor":{"properties":{"repositoryId":2},"id":8,"version":0,"text":"Comment.","author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432552916,"updatedDate":1572432552916,"permittedOperations":{"editable":false,"deletable":false},"type":"COMMENT"},"author":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"createdDate":1572432578000,"id":5,"text":"Another
+      task.","state":"OPEN","permittedOperations":{"deletable":true,"editable":true,"transitionable":true}}],"permittedOperations":{"editable":false,"deletable":false}}},{"id":77,"createdDate":1572430034930,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"REOPENED"},{"id":76,"createdDate":1572429831834,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"DECLINED"},{"id":75,"createdDate":1572429777823,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"UNAPPROVED"},{"id":74,"createdDate":1572429738565,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"APPROVED"},{"id":73,"createdDate":1572429681822,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"REVIEWED"},{"id":72,"createdDate":1572429656637,"user":{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}},"action":"UPDATED","addedReviewers":[{"name":"tomas","emailAddress":"tomas@sourcegraph.com","id":3,"displayName":"Tomás
+      Senart","active":true,"slug":"tomas","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/tomas"}]}}],"removedReviewers":[]},{"id":44,"createdDate":1563286308065,"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
+      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"action":"OPENED"}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Oct 2019 11:01:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@1IK17DGx661x1760665x0'
+      X-Asen:
+      - SEN-L13789548
+      X-Asessionid:
+      - 4w0mag
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This method is needed in the context of a8n to load all activity that
happened in a PR. These activities will later be converted into
ChangesetEvents.

Part of #6085

