### PR TITLE
a8n: Implement `previewCampaignPlan`

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -208,7 +208,7 @@ func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResol
 	return results, common, nil
 }
 
-var replacerURL = env.Get("REPLACER_URL", "http://replacer:3185", "replacer server URL")
+var ReplacerURL = env.Get("REPLACER_URL", "http://replacer:3185", "replacer server URL")
 
 func toMatchResolver(fileURL string, raw *rawCodemodResult) ([]*searchResultMatchResolver, error) {
 	if !strings.Contains(raw.Diff, "@@") {
@@ -240,7 +240,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 		return nil, errors.Wrap(err, "codemod repo lookup failed: it's possible that the repo is not cloned in gitserver. Try force a repo update another way.")
 	}
 
-	u, err := url.Parse(replacerURL)
+	u, err := url.Parse(ReplacerURL)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 
 	"github.com/graph-gophers/graphql-go"
@@ -408,9 +407,6 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 	campaignType, err := run.NewCampaignType(typeName, specArgs)
 	if err != nil {
 		return nil, err
-	}
-	if err := campaignType.Valid(); err != nil {
-		return nil, fmt.Errorf("invalid specification: %s", err)
 	}
 
 	plan := &a8n.CampaignPlan{CampaignType: typeName, Arguments: specArgs}

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -17,11 +15,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n/run"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/jsonc"
-	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 // Resolver is the GraphQL resolver of all things A8N.
@@ -402,104 +399,42 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 		return nil, err
 	}
 
+	specArgs := string(args.Specification.Arguments)
 	typeName := strings.ToLower(args.Specification.Type)
 	if typeName == "" {
 		return nil, errors.New("cannot create CampaignPlan without Type")
 	}
-	campaignType, ok := a8n.CampaignTypes[typeName]
-	if !ok {
-		return nil, errors.New("campaign type does not exist. Don't know how to plan this campaign")
-	}
 
-	specArgs := make(map[string]string)
-	// TODO(a8n): This turns the JSONC into JSON. We need to preserve the JSONC.
-	if err := jsonc.Unmarshal(string(args.Specification.Arguments), &specArgs); err != nil {
-		return nil, err
-	}
-	if len(specArgs) != len(campaignType.Parameters) {
-		return nil, errors.New("not enough arguments for campaign type specified")
-	}
-	for _, param := range campaignType.Parameters {
-		if _, ok := specArgs[param]; !ok {
-			return nil, fmt.Errorf("missing argument in specification: %s", param)
-		}
-	}
-
-	plan := &a8n.CampaignPlan{
-		CampaignType: typeName,
-		Arguments:    string(args.Specification.Arguments),
-	}
-	if err := r.store.CreateCampaignPlan(ctx, plan); err != nil {
-		return nil, err
-	}
-
-	// Search repositories over which to execute code modification
-	repos, err := graphqlbackend.SearchRepos(ctx, specArgs["searchScope"])
+	campaignType, err := run.NewCampaignType(typeName, specArgs)
 	if err != nil {
 		return nil, err
 	}
-
-	var wg sync.WaitGroup
-	for _, repo := range repos {
-		job := &a8n.CampaignJob{
-			CampaignPlanID: plan.ID,
-			StartedAt:      time.Now().UTC(),
-		}
-
-		err := relay.UnmarshalSpec(repo.ID(), &job.RepoID)
-		if err != nil {
-			return nil, err
-		}
-
-		defaultBranch, err := repo.DefaultBranch(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if defaultBranch != nil {
-			commit, err := defaultBranch.Target().Commit(ctx)
-			if err != nil {
-				return nil, err
-			}
-			job.Rev = api.CommitID(commit.OID())
-		}
-
-		err = r.store.CreateCampaignJob(ctx, job)
-		if err != nil {
-			return nil, err
-		}
-
-		wg.Add(1)
-		go func(plan *a8n.CampaignPlan, job *a8n.CampaignJob) {
-			// TODO(a8n): Do real work.
-			// Send request to service with Repo, Ref, Arguments.
-			// Receive diff.
-			job.Diff = bogusDiff
-			job.FinishedAt = time.Now()
-
-			err := r.store.UpdateCampaignJob(ctx, job)
-			if err != nil {
-				log15.Error("RunCampaign.UpdateCampaignJob failed", "err", err)
-			}
-
-			wg.Done()
-		}(plan, job)
+	if err := campaignType.Valid(); err != nil {
+		return nil, fmt.Errorf("invalid specification: %s", err)
 	}
 
-	// TODO(a8n): Implement this so that `if !args.Wait` this mutation is
-	// asynchronous
-	wg.Wait()
+	plan := &a8n.CampaignPlan{CampaignType: typeName, Arguments: specArgs}
+
+	runner := run.New(r.store, campaignType, graphqlbackend.SearchRepos, nil)
+
+	if args.Wait {
+		err := runner.Run(ctx, plan)
+		if err != nil {
+			return nil, err
+		}
+		err = runner.Wait()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := runner.Run(context.Background(), plan)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return &campaignPlanResolver{store: r.store, campaignPlan: plan}, nil
 }
-
-const bogusDiff = `diff --git a/README.md b/README.md
-index 323fae0..34a3ec2 100644
---- a/README.md
-+++ b/README.md
-@@ -1 +1 @@
--foobar
-+barfoo
-`
 
 func (r *Resolver) CancelCampaignPlan(ctx context.Context, args graphqlbackend.CancelCampaignPlanArgs) (*graphqlbackend.EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins may update campaigns for now

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -404,7 +404,7 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 		return nil, errors.New("cannot create CampaignPlan without Type")
 	}
 
-	campaignType, err := run.NewCampaignType(typeName, specArgs)
+	campaignType, err := run.NewCampaignType(typeName, specArgs, r.httpFactory)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -98,7 +98,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", err
+		return "", fmt.Errorf("unexpected response status from replacer service: %q", resp.Status)
 	}
 
 	scanner := bufio.NewScanner(resp.Body)

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -1,0 +1,142 @@
+package run
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+// NewCampaignType returns a new Campaign for the given CampaignType and
+// arguments.
+// Before the returned CampaignType can be passed to a Runner its Valid method
+// needs to be called.
+func NewCampaignType(campaignTypeName, args string) (CampaignType, error) {
+	switch strings.ToLower(campaignTypeName) {
+	case "comby":
+		return &comby{rawArgs: args}, nil
+	default:
+		return nil, fmt.Errorf("unknown campaign type: %s", campaignTypeName)
+	}
+}
+
+// A CampaignType provides a search query, argument validation and generates a
+// diff in a given repository.
+type CampaignType interface {
+	Valid() error
+
+	searchQuery() string
+	generateDiff(context.Context, api.RepoName, api.CommitID) (string, error)
+}
+
+type combyArgs struct {
+	ScopeQuery      string `json:"scopeQuery"`
+	MatchTemplate   string `json:"matchTemplate"`
+	RewriteTemplate string `json:"rewriteTemplate"`
+}
+
+type comby struct {
+	rawArgs string
+	args    combyArgs
+}
+
+func (c *comby) Valid() error {
+	if err := jsonc.Unmarshal(c.rawArgs, &c.args); err != nil {
+		return err
+	}
+
+	if c.args.ScopeQuery == "" {
+		return errors.New("missing argument in specification: scopeQuery")
+	}
+
+	if c.args.MatchTemplate == "" {
+		return errors.New("missing argument in specification: matchTemplate")
+	}
+
+	if c.args.RewriteTemplate == "" {
+		return errors.New("missing argument in specification: rewriteTemplate")
+	}
+
+	return nil
+}
+
+func (c *comby) searchQuery() string { return c.args.ScopeQuery }
+func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
+	u, err := url.Parse(graphqlbackend.ReplacerURL)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("repo", string(repo))
+	q.Set("commit", string(commit))
+	q.Set("matchtemplate", c.args.MatchTemplate)
+	q.Set("rewritetemplate", c.args.RewriteTemplate)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	cl := &http.Client{}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 100), 10*bufio.MaxScanTokenSize)
+
+	type rawCodemodResult struct {
+		URI  string `json:"uri"`
+		Diff string
+	}
+
+	var diffs []*diff.FileDiff
+	for scanner.Scan() {
+		var raw *rawCodemodResult
+		b := scanner.Bytes()
+		if err := scanner.Err(); err != nil {
+			log15.Info(fmt.Sprintf("Skipping codemod scanner error (line too long?): %s", err.Error()))
+			continue
+		}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			log15.Error("unmarshalling raw diff failed", "err", err)
+			continue
+		}
+		// TODO(a8n): Do we need to use `diff.ParseFileDiff` or can we just concatenate?
+		parsed, err := diff.ParseFileDiff([]byte(raw.Diff))
+		if err != nil {
+			log15.Error("parsing diff failed", "err", err)
+			continue
+		}
+		diffs = append(diffs, parsed)
+	}
+
+	// TODO(a8n): The diffs returned by Comby and then produced by this are
+	// missing the "extended" fields in a `diff.FileDiff` that would allow
+	// `diff.Parse*` to parse the diffs properly again. We need to change the
+	// comby API so that it returns proper git diffs.
+	multiDiff, err := diff.PrintMultiFileDiff(diffs)
+	if err != nil {
+		return "", err
+	}
+
+	return string(multiDiff), nil
+}

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -19,8 +19,8 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// NewCampaignType returns a new Campaign for the given CampaignType and
-// arguments.
+// NewCampaignType returns a new CampaignType for the given campaign type name
+// and arguments.
 // Before the returned CampaignType can be passed to a Runner its Valid method
 // needs to be called.
 func NewCampaignType(campaignTypeName, args string) (CampaignType, error) {
@@ -112,7 +112,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 			continue
 		}
 
-		raw := &cby.FileDiff{}
+		var raw cby.FileDiff
 		if err := json.Unmarshal(b, &raw); err != nil {
 			log15.Error("unmarshalling raw diff failed", "err", err)
 			continue

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -26,7 +26,7 @@ func NewCampaignType(campaignTypeName, args string) (CampaignType, error) {
 		return nil, fmt.Errorf("unknown campaign type: %s", campaignTypeName)
 	}
 
-	ct := &comby{}
+	ct := &comby{replacerURL: graphqlbackend.ReplacerURL}
 
 	if err := jsonc.Unmarshal(args, &ct.args); err != nil {
 		return nil, err
@@ -61,12 +61,13 @@ type combyArgs struct {
 }
 
 type comby struct {
-	args combyArgs
+	args        combyArgs
+	replacerURL string
 }
 
 func (c *comby) searchQuery() string { return c.args.ScopeQuery }
 func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
-	u, err := url.Parse(graphqlbackend.ReplacerURL)
+	u, err := url.Parse(c.replacerURL)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -85,7 +85,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 	}
 
 	cl := &http.Client{}
-	resp, err := cl.Do(req)
+	resp, err := cl.Do(req.WithContext(ctx))
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/pkg/a8n/run/campaign_type_test.go
+++ b/enterprise/pkg/a8n/run/campaign_type_test.go
@@ -1,0 +1,160 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestCampaignType_Comby(t *testing.T) {
+	ctx := context.Background()
+
+	combyJsonLineDiffs := []string{
+		`{"uri":"file1.txt","diff":"--- file1.txt\n+++ file1.txt\n@@ -1,3 +1,3 @@\n file1-line1\n-file1-line2\n+file1-lineFOO\n file1-line3"}`,
+		`{"uri":"file2.txt","diff":"--- file2.txt\n+++ file2.txt\n@@ -1,3 +1,3 @@\n file2-line1\n-file2-line2\n+file2-lineFOO\n file2-line3"}`,
+	}
+
+	tests := []struct {
+		name string
+
+		repoName string
+		commitID string
+		args     combyArgs
+
+		handler func(w http.ResponseWriter, r *http.Request)
+
+		wantDiff string
+		wantErr  string
+	}{
+		{
+			name:     "success single file diff",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: combyArgs{
+				ScopeQuery:      "repo:gorilla",
+				MatchTemplate:   "example.com",
+				RewriteTemplate: "sourcegraph.com",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Transfer-Encoding", "chunked")
+				w.WriteHeader(http.StatusOK)
+
+				fmt.Fprintln(w, combyJsonLineDiffs[0])
+			},
+			wantDiff: `diff a/file1.txt b/file1.txt
+--- file1.txt
++++ file1.txt
+@@ -1,3 +1,3 @@
+ file1-line1
+-file1-line2
++file1-lineFOO
+ file1-line3`,
+		},
+		{
+			name:     "success multiple file diffs",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: combyArgs{
+				ScopeQuery:      "repo:gorilla",
+				MatchTemplate:   "example.com",
+				RewriteTemplate: "sourcegraph.com",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Transfer-Encoding", "chunked")
+				w.WriteHeader(http.StatusOK)
+
+				fmt.Fprintln(w, combyJsonLineDiffs[0])
+				fmt.Fprintln(w, combyJsonLineDiffs[1])
+			},
+			wantDiff: `diff a/file1.txt b/file1.txt
+--- file1.txt
++++ file1.txt
+@@ -1,3 +1,3 @@
+ file1-line1
+-file1-line2
++file1-lineFOO
+ file1-line3
+diff a/file2.txt b/file2.txt
+--- file2.txt
++++ file2.txt
+@@ -1,3 +1,3 @@
+ file2-line1
+-file2-line2
++file2-lineFOO
+ file2-line3`,
+		},
+		{
+			name:     "error",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: combyArgs{
+				ScopeQuery:      "repo:gorilla",
+				MatchTemplate:   "example.com",
+				RewriteTemplate: "sourcegraph.com",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: `unexpected response status from replacer service: "500 Internal Server Error"`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				validateReplacerQuery(t, r.URL.Query(), tc.repoName, tc.commitID, tc.args)
+				tc.handler(w, r)
+			}))
+			defer ts.Close()
+
+			ct := &comby{
+				replacerURL: ts.URL,
+				httpClient:  &http.Client{},
+				args:        tc.args,
+			}
+
+			if tc.wantErr == "" {
+				tc.wantErr = "<nil>"
+			}
+
+			haveDiff, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
+			if have, want := fmt.Sprint(err), tc.wantErr; have != want {
+				t.Fatalf("have error: %q\nwant error: %q", have, want)
+			}
+
+			if haveDiff != tc.wantDiff {
+				t.Fatalf("wrong diff.\nhave=%q\nwant=%q", haveDiff, tc.wantDiff)
+			}
+		})
+	}
+}
+
+func validateReplacerQuery(t *testing.T, vals url.Values, repo, commit string, args combyArgs) {
+	t.Helper()
+
+	tests := []struct {
+		name, want string
+	}{
+		{"repo", repo},
+		{"commit", commit},
+		{"matchtemplate", args.MatchTemplate},
+		{"rewritetemplate", args.RewriteTemplate},
+	}
+
+	for _, tc := range tests {
+		have, ok := vals[tc.name]
+		if !ok || len(have) < 1 {
+			t.Errorf("url param %q missing", tc.name)
+			continue
+		}
+		if have[0] != tc.want {
+			t.Errorf("wrong %q param: %s (want=%s)", tc.name, have[0], tc.want)
+		}
+	}
+}

--- a/enterprise/pkg/a8n/run/runner.go
+++ b/enterprise/pkg/a8n/run/runner.go
@@ -136,7 +136,7 @@ func (r *Runner) Run(ctx context.Context, plan *a8n.CampaignPlan) error {
 			defer func() {
 				defer r.wg.Done()
 				job.FinishedAt = r.clock()
-				err = r.store.UpdateCampaignJob(ctx, job)
+				err := r.store.UpdateCampaignJob(ctx, job)
 				if err != nil {
 					log15.Error("UpdateCampaignJob failed", "err", err)
 				}

--- a/enterprise/pkg/a8n/run/runner.go
+++ b/enterprise/pkg/a8n/run/runner.go
@@ -1,0 +1,220 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+// MaxRepositories defines the maximum number of repositories over which a
+// Runner executes CampaignJobs.
+// This upper limit is set while Automation features are still under
+// development.
+const MaxRepositories = 200
+
+// ErrTooManyResults is returned by the Runner's Run method when the
+// CampaignType's searchQuery produced more than MaxRepositories number of
+// repositories.
+var ErrTooManyResults = errors.New("search yielded too many results")
+
+// A Runner executes a CampaignPlan by creating and running CampaignJobs
+// according to the CampaignPlan's Arguments and CampaignType.
+type Runner struct {
+	store    *ee.Store
+	search   repoSearch
+	commitID repoCommitID
+	clock    func() time.Time
+
+	ct CampaignType
+
+	started bool
+	wg      sync.WaitGroup
+}
+
+// repoSearch takes in a raw search query and returns the list of repositories
+// associated with the search results.
+type repoSearch func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error)
+
+// repoCommitID takes in a RepositoryResolver and returns the target commit ID
+// of the repository's default branch.
+type repoCommitID func(ctx context.Context, repo *graphqlbackend.RepositoryResolver) (api.CommitID, error)
+
+// defaultRepoCommitID is an implementation of repoCommit that uses methods
+// defined on RepositoryResolver to talk to gitserver to determine a
+// repository's default branch target commit ID.
+var defaultRepoCommitID = func(ctx context.Context, repo *graphqlbackend.RepositoryResolver) (api.CommitID, error) {
+	var commitID api.CommitID
+
+	defaultBranch, err := repo.DefaultBranch(ctx)
+	if err != nil {
+		return commitID, err
+	}
+	if defaultBranch == nil {
+		return commitID, fmt.Errorf("no default branch for %q", repo.Name())
+	}
+
+	commit, err := defaultBranch.Target().Commit(ctx)
+	if err != nil {
+		return commitID, err
+	}
+
+	commitID = api.CommitID(commit.OID())
+	return commitID, nil
+}
+
+// New returns a Runner for a given CampaignType.
+func New(store *ee.Store, ct CampaignType, search repoSearch, commitID repoCommitID) *Runner {
+	return NewWithClock(store, ct, search, commitID, func() time.Time {
+		return time.Now().UTC().Truncate(time.Microsecond)
+	})
+}
+
+// NewWithClock returns a Runner for a given CampaignType with the given clock used
+// to generate timestamps
+func NewWithClock(store *ee.Store, ct CampaignType, search repoSearch, commitID repoCommitID, clock func() time.Time) *Runner {
+	runner := &Runner{
+		store:    store,
+		search:   search,
+		commitID: commitID,
+		ct:       ct,
+		clock:    clock,
+	}
+	if runner.commitID == nil {
+		runner.commitID = defaultRepoCommitID
+	}
+
+	return runner
+}
+
+// Run executes the CampaignPlan by searching for relevant repositories using
+// the CampaignType specific searchQuery and then executing CampaignJobs for
+// each repository.
+// Before it starts executing CampaignJobs it persists the CampaignPlan and the
+// new CampaignJobs in a transaction.
+// What each CampaignJob then does in each repository depends on the
+// CampaignType set on CampaignPlan.
+// This is a non-blocking method that will possibly return before all
+// CampaignJobs are finished.
+func (r *Runner) Run(ctx context.Context, plan *a8n.CampaignPlan) error {
+	if r.started {
+		return errors.New("already started")
+	}
+	r.started = true
+
+	rs, err := r.search(ctx, r.ct.searchQuery())
+	if err != nil {
+		return err
+	}
+	if len(rs) > MaxRepositories {
+		return ErrTooManyResults
+	}
+
+	jobs, err := r.createPlanAndJobs(ctx, plan, rs)
+	if err != nil {
+		return err
+	}
+
+	for _, job := range jobs {
+		r.wg.Add(1)
+
+		go func(ctx context.Context, ct CampaignType, job *a8n.CampaignJob) {
+			defer func() {
+				defer r.wg.Done()
+				job.FinishedAt = r.clock()
+				err = r.store.UpdateCampaignJob(ctx, job)
+				if err != nil {
+					log15.Error("UpdateCampaignJob failed", "err", err)
+				}
+			}()
+
+			job.StartedAt = r.clock()
+
+			// We load the repository here again so that we decouple the
+			// creation and running of jobs from the start.
+			store := repos.NewDBStore(r.store.DB(), sql.TxOptions{})
+			opts := repos.StoreListReposArgs{IDs: []uint32{uint32(job.RepoID)}}
+			rs, err := store.ListRepos(ctx, opts)
+			if err != nil {
+				job.Error = err.Error()
+				return
+			}
+			if len(rs) != 1 {
+				job.Error = fmt.Sprintf("repository %d not found", job.RepoID)
+				return
+			}
+
+			diff, err := ct.generateDiff(ctx, api.RepoName(rs[0].Name), api.CommitID(job.Rev))
+			if err != nil {
+				job.Error = err.Error()
+			}
+
+			job.Diff = diff
+		}(ctx, r.ct, job)
+	}
+
+	return nil
+}
+
+func (r *Runner) createPlanAndJobs(
+	ctx context.Context,
+	plan *a8n.CampaignPlan,
+	rs []*graphqlbackend.RepositoryResolver,
+) (jobs []*a8n.CampaignJob, err error) {
+	tx, err := r.store.Transact(ctx)
+	if err != nil {
+		return jobs, err
+	}
+	defer tx.Done(&err)
+
+	err = tx.CreateCampaignPlan(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, repo := range rs {
+		var repoID int32
+		if err := relay.UnmarshalSpec(repo.ID(), &repoID); err != nil {
+			return jobs, err
+		}
+
+		rev, err := r.commitID(ctx, repo)
+		if err != nil {
+			return jobs, err
+		}
+
+		job := &a8n.CampaignJob{
+			CampaignPlanID: plan.ID,
+			RepoID:         repoID,
+			Rev:            rev,
+		}
+		if err := tx.CreateCampaignJob(ctx, job); err != nil {
+			return jobs, err
+		}
+		jobs = append(jobs, job)
+	}
+
+	return jobs, err
+}
+
+// Wait blocks until all CampaignJobs created and started by Start have
+// finished.
+func (r *Runner) Wait() error {
+	if !r.started {
+		return errors.New("not started")
+	}
+
+	r.wg.Wait()
+
+	return nil
+}

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -258,8 +258,8 @@ func TestRunner(t *testing.T) {
 			}
 
 			planIgnore := cmpopts.IgnoreFields(a8n.CampaignPlan{}, "ID")
-			if !cmp.Equal(havePlan, tc.wantPlan, planIgnore) {
-				t.Fatalf("CampaignPlan diff: %s", cmp.Diff(havePlan, tc.wantPlan, planIgnore))
+			if diff := cmp.Diff(havePlan, tc.wantPlan, planIgnore); diff != "" {
+				t.Fatalf("CampaignPlan diff: %s", diff)
 			}
 
 			haveJobs, _, err := store.ListCampaignJobs(ctx, ee.ListCampaignJobsOpts{
@@ -275,8 +275,7 @@ func TestRunner(t *testing.T) {
 
 			wantJobs := tc.wantJobs(plan, rs, revs)
 			jobIgnore := cmpopts.IgnoreFields(a8n.CampaignJob{}, "ID")
-			if !cmp.Equal(haveJobs, wantJobs, jobIgnore) {
-				diff := cmp.Diff(haveJobs, wantJobs, jobIgnore)
+			if diff := cmp.Diff(haveJobs, wantJobs, jobIgnore); diff != "" {
 				t.Fatalf("CampaignJobs diff: %s", diff)
 			}
 		})

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -290,7 +290,7 @@ type testCampaignType struct {
 	diffErr string
 }
 
-func (t *testCampaignType) Valid() error        { return nil }
+func (t *testCampaignType) valid() error        { return nil }
 func (t *testCampaignType) searchQuery() string { return "" }
 func (t *testCampaignType) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
 	if t.diffErr != "" {

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -1,0 +1,375 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestRunner(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+
+	store := ee.NewStoreWithClock(dbconn.Global, clock)
+
+	revs := []string{
+		"fc21c1a0a79047416c14642b3ca964faba9442e2",
+		"f3c08ec74a9b3f8af7b5609c9f47cfcb3dc6949b",
+		"09d6921f5ccae24dc2cb3ca2cf263a05e547cf4f",
+	}
+
+	var rs []*repos.Repo
+	for i := 0; i < 3; i++ {
+		rs = append(rs, testRepo(i))
+	}
+
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+	err := reposStore.UpsertRepos(ctx, rs...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testPlan := &a8n.CampaignPlan{CampaignType: "test", Arguments: `{}`}
+
+	tests := []struct {
+		name string
+
+		search       repoSearch
+		commitID     repoCommitID
+		campaignType CampaignType
+
+		runErr string
+
+		wantPlan *a8n.CampaignPlan
+		wantJobs func(plan *a8n.CampaignPlan, rs []*repos.Repo, revs []string) []*a8n.CampaignJob
+	}{
+		{
+			name: "no search results",
+			search: func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error) {
+				return []*graphqlbackend.RepositoryResolver{}, nil
+			},
+			commitID:     yieldCommitIDs(revs),
+			campaignType: &testCampaignType{},
+			wantPlan: func() *a8n.CampaignPlan {
+				p := testPlan.Clone()
+				p.CreatedAt = now
+				p.UpdatedAt = now
+				return p
+			}(),
+			wantJobs: wantNoJobs,
+		},
+		{
+			name: "search error",
+			search: func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error) {
+				return nil, errors.New("search failed")
+			},
+			commitID:     yieldCommitIDs(revs),
+			campaignType: &testCampaignType{},
+			runErr:       "search failed",
+			wantPlan:     nil,
+			wantJobs:     wantNoJobs,
+		},
+		{
+			name: "too many search results",
+			search: func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error) {
+				count := MaxRepositories + 1
+
+				resolvers := make([]*graphqlbackend.RepositoryResolver, count)
+				for i := 0; i < count; i++ {
+					resolvers[i] = repoToResolver(rs[i%len(rs)])
+				}
+				return resolvers, nil
+			},
+			commitID:     yieldCommitIDs(revs),
+			campaignType: &testCampaignType{},
+			runErr:       ErrTooManyResults.Error(),
+			wantPlan:     nil,
+			wantJobs:     wantNoJobs,
+		},
+		{
+			name:         "multi search results and successfull execution",
+			search:       yieldRepos(rs...),
+			commitID:     yieldCommitIDs(revs),
+			campaignType: &testCampaignType{diff: testDiff},
+			wantPlan: func() *a8n.CampaignPlan {
+				p := testPlan.Clone()
+				p.CreatedAt = now
+				p.UpdatedAt = now
+				return p
+			}(),
+			wantJobs: func(plan *a8n.CampaignPlan, rs []*repos.Repo, revs []string) []*a8n.CampaignJob {
+				return []*a8n.CampaignJob{
+					{
+						CampaignPlanID: plan.ID,
+						RepoID:         int32(rs[0].ID),
+						Diff:           testDiff,
+						Rev:            api.CommitID(revs[0]),
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						StartedAt:      now,
+						FinishedAt:     now,
+					},
+					{
+						CampaignPlanID: plan.ID,
+						RepoID:         int32(rs[1].ID),
+						Diff:           testDiff,
+						Rev:            api.CommitID(revs[1]),
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						StartedAt:      now,
+						FinishedAt:     now,
+					},
+					{
+						CampaignPlanID: plan.ID,
+						RepoID:         int32(rs[2].ID),
+						Diff:           testDiff,
+						Rev:            api.CommitID(revs[2]),
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						StartedAt:      now,
+						FinishedAt:     now,
+					},
+				}
+			},
+		},
+		{
+			name:         "multi search results but getting a commit ID fails",
+			search:       yieldRepos(rs...),
+			commitID:     errorOnCall(yieldCommitIDs(revs), 2, "no commit ID found"),
+			campaignType: &testCampaignType{diff: testDiff},
+			runErr:       "no commit ID found",
+			wantPlan:     nil,
+			wantJobs:     wantNoJobs,
+		},
+		{
+			name:     "generating diff fails",
+			search:   yieldRepos(rs[0]),
+			commitID: yieldCommitIDs(revs),
+			campaignType: &testCampaignType{
+				diff:    testDiff,
+				diffErr: "could not generate diff",
+			},
+			wantPlan: func() *a8n.CampaignPlan {
+				p := testPlan.Clone()
+				p.CreatedAt = now
+				p.UpdatedAt = now
+				return p
+			}(),
+			wantJobs: func(plan *a8n.CampaignPlan, rs []*repos.Repo, revs []string) []*a8n.CampaignJob {
+				return []*a8n.CampaignJob{
+					{
+						CampaignPlanID: plan.ID,
+						RepoID:         int32(rs[0].ID),
+						Diff:           "",
+						Error:          "could not generate diff",
+						Rev:            api.CommitID(revs[0]),
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						StartedAt:      now,
+						FinishedAt:     now,
+					},
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.runErr == "" {
+				tc.runErr = "<nil>"
+			}
+
+			plan := testPlan.Clone()
+
+			runner := NewWithClock(store, tc.campaignType, tc.search, tc.commitID, clock)
+			err := runner.Run(ctx, plan)
+			if have, want := fmt.Sprint(err), tc.runErr; have != want {
+				t.Fatalf("have runner.Run error: %q\nwant error: %q", have, want)
+			}
+
+			waitRunner(t, runner)
+
+			if tc.wantPlan == nil && plan.ID == 0 {
+				return
+			}
+
+			havePlan, err := store.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: plan.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			planIgnore := cmpopts.IgnoreFields(a8n.CampaignPlan{}, "ID")
+			if !cmp.Equal(havePlan, tc.wantPlan, planIgnore) {
+				t.Fatalf("CampaignPlan diff: %s", cmp.Diff(havePlan, tc.wantPlan, planIgnore))
+			}
+
+			haveJobs, _, err := store.ListCampaignJobs(ctx, ee.ListCampaignJobsOpts{
+				CampaignPlanID: plan.ID,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sort.Slice(haveJobs, func(i, j int) bool {
+				return haveJobs[i].RepoID < haveJobs[j].RepoID
+			})
+
+			wantJobs := tc.wantJobs(plan, rs, revs)
+			jobIgnore := cmpopts.IgnoreFields(a8n.CampaignJob{}, "ID")
+			if !cmp.Equal(haveJobs, wantJobs, jobIgnore) {
+				diff := cmp.Diff(haveJobs, wantJobs, jobIgnore)
+				t.Fatalf("CampaignJobs diff: %s", diff)
+			}
+		})
+	}
+
+}
+
+type testCampaignType struct {
+	diff    string
+	diffErr string
+}
+
+func (t *testCampaignType) Valid() error        { return nil }
+func (t *testCampaignType) searchQuery() string { return "" }
+func (t *testCampaignType) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
+	if t.diffErr != "" {
+		return "", errors.New(t.diffErr)
+	}
+	return t.diff, nil
+}
+
+const testDiff = `diff --git a/README.md b/README.md
+index 851b23a..140f333 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,4 @@
+ # README
+ 
++Let's add a line here.
+ This file is hostEd at sourcegraph.com and is a test file.
+`
+
+func waitRunner(t *testing.T, r *Runner) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer func() { close(done) }()
+		err := r.Wait()
+		if err != nil {
+			t.Errorf("runner.Wait failed: %s", err)
+		}
+	}()
+
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timeout reached")
+	case <-done:
+	}
+}
+
+func wantNoJobs(plan *a8n.CampaignPlan, rs []*repos.Repo, revs []string) []*a8n.CampaignJob {
+	return []*a8n.CampaignJob{}
+}
+
+func testRepo(num int) *repos.Repo {
+	return &repos.Repo{
+		Name:    fmt.Sprintf("repo-%d", num),
+		URI:     fmt.Sprintf("repo-%d", num),
+		Enabled: true,
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          fmt.Sprintf("external-id-%d", num),
+			ServiceType: "github",
+			ServiceID:   "https://github.com/",
+		},
+		Sources: map[string]*repos.SourceInfo{
+			"extsvc:github:4": {
+				ID:       "extsvc:github:4",
+				CloneURL: "https://secrettoken@github.com/sourcegraph/sourcegraph",
+			},
+		},
+	}
+}
+
+func repoToResolver(r *repos.Repo) *graphqlbackend.RepositoryResolver {
+	return graphqlbackend.NewRepositoryResolver(&types.Repo{
+		ID:           api.RepoID(r.ID),
+		ExternalRepo: r.ExternalRepo,
+		Name:         api.RepoName(r.Name),
+		RepoFields: &types.RepoFields{
+			URI:         r.URI,
+			Description: r.Description,
+			Language:    r.Language,
+			Fork:        r.Fork,
+		},
+	})
+}
+
+func yieldCommitIDs(ids []string) repoCommitID {
+	count := 0
+	return func(ctx context.Context, repo *graphqlbackend.RepositoryResolver) (api.CommitID, error) {
+		id := api.CommitID("invalid")
+
+		if count >= len(ids) {
+			return id, errors.New("exhausted commit ids")
+		}
+
+		id = api.CommitID(ids[count])
+		count++
+
+		return id, nil
+	}
+}
+
+func errorOnCall(f repoCommitID, num int, msg string) repoCommitID {
+	count := 0
+
+	return func(ctx context.Context, repo *graphqlbackend.RepositoryResolver) (api.CommitID, error) {
+		id := api.CommitID("invalid")
+
+		if count == num {
+			return id, errors.New(msg)
+		}
+
+		count++
+
+		return f(ctx, repo)
+	}
+}
+
+func yieldRepos(rs ...*repos.Repo) repoSearch {
+	resolvers := make([]*graphqlbackend.RepositoryResolver, len(rs))
+	for i, r := range rs {
+		resolvers[i] = repoToResolver(r)
+	}
+	return func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error) {
+		return resolvers, nil
+	}
+}

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -290,7 +290,6 @@ type testCampaignType struct {
 	diffErr string
 }
 
-func (t *testCampaignType) valid() error        { return nil }
 func (t *testCampaignType) searchQuery() string { return "" }
 func (t *testCampaignType) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
 	if t.diffErr != "" {

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
+func init() {
+	dbtesting.DBNameSuffix = "a8nrunnerdb"
+}
+
 func TestRunner(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -224,6 +224,9 @@ func TestRunner(t *testing.T) {
 			}
 
 			havePlan, err := store.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: plan.ID})
+			if err == ee.ErrNoResults && tc.wantPlan == nil {
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/pkg/a8n/run/runner_test.go
+++ b/enterprise/pkg/a8n/run/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -101,10 +102,11 @@ func TestRunner(t *testing.T) {
 		{
 			name: "too many search results",
 			search: func(ctx context.Context, query string) ([]*graphqlbackend.RepositoryResolver, error) {
-				count := MaxRepositories + 1
+				m, _ := strconv.ParseInt(maxRepositories, 10, 64)
+				count := m + 1
 
 				resolvers := make([]*graphqlbackend.RepositoryResolver, count)
-				for i := 0; i < count; i++ {
+				for i := 0; i < int(count); i++ {
 					resolvers[i] = repoToResolver(rs[i%len(rs)])
 				}
 				return resolvers, nil

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -6,24 +6,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
-
-type CampaignType struct {
-	// TODO(a8n): This should probably be an `interface{}` and then have
-	// concrete implementations such as `CombyArguments`
-	Parameters []string
-	ServiceURL string
-}
-
-var CampaignTypes = map[string]CampaignType{
-	"comby": {
-		Parameters: []string{"scopeQuery", "matchTemplate", "rewriteTemplate"},
-		ServiceURL: env.Get("COMBY_URL", "http://replacer:3185", "replacer server URL"),
-	},
-}
 
 // A CampaignPlan represents the application of a CampaignType to the Arguments
 // over multiple repositories.


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/6085 and implements the GraphQL `previewCampaign` mutation.

It validates arguments, creates a `CampaignPlan` and multiple `CampaignJob`s (one for each repo yielded by the `CampaignType`s search query).

The single `CampaignType` that's currently implemented is `"comby"`, which does search&replace across repositories. 

What's in this PR already works: a plan is created, jobs are launched, executed and their `Diff` field is updated. 

There are a few things missing that I want to address in follow-up PRs in order to make reviewing easier and to unblock @felixfbecker and @eseliger: 

- The diff produced by reading json-lines from the `replacer` service is not a valid multi-file diff. While it can be parsed again by `diff.ParseMultiFile` the produced `[]*diff.FileDiff` only has a single element. That's enough to use the API for now, which is why I don't want it to block the merging of this PR. I will address this in a separate PR that also adds tests for `comby` (which right now only does a single HTTP request which we likely need to change)
- `CampaignPlan`s are not cleaned up yet. I already discussed this with @tsenart.
- The `CampaignPlan.status` is still a dummy implementation.
