### PR TITLE
search: Deduplicate results w.r.t. repositories

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -46,7 +46,7 @@ func (s *HorizontalSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.
 		}(c)
 	}
 
-	// During rebalancing a repository can appear on more than on replica.
+	// During rebalancing a repository can appear on more than one replica.
 	dedupper := dedupper{}
 
 	var aggregate zoekt.SearchResult

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -46,6 +46,9 @@ func (s *HorizontalSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.
 		}(c)
 	}
 
+	// During rebalancing a repository can appear on more than on replica.
+	dedupper := dedupper{}
+
 	var aggregate zoekt.SearchResult
 	for range clients {
 		r := <-results
@@ -53,7 +56,7 @@ func (s *HorizontalSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.
 			return nil, r.err
 		}
 
-		aggregate.Files = append(aggregate.Files, r.sr.Files...)
+		aggregate.Files = append(aggregate.Files, dedupper.Dedup(r.sr.Files)...)
 		aggregate.Stats.Add(r.sr.Stats)
 	}
 
@@ -84,6 +87,9 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoLi
 			results <- result{rl: rl, err: err}
 		}(c)
 	}
+
+	// PERF: We don't deduplicate Repos since the only user of List already
+	// does deduplication.
 
 	var aggregate zoekt.RepoList
 	for range clients {
@@ -185,4 +191,32 @@ func equalKeys(a map[string]zoekt.Searcher, b map[string]struct{}) bool {
 		}
 	}
 	return true
+}
+
+type dedupper map[string]struct{}
+
+// Dedup will in-place filter out matches on Repositories we already have
+// already seen. A Repository has been seen if a previous call to Dedup had a
+// match in it.
+func (seenRepo dedupper) Dedup(fms []zoekt.FileMatch) []zoekt.FileMatch {
+	if len(fms) == 0 { // handles fms being nil
+		return fms
+	}
+
+	// Remove entries for repos we have already seen.
+	dedup := fms[:0]
+	for _, fm := range fms {
+		if _, ok := seenRepo[fm.Repository]; ok {
+			continue
+		}
+		dedup = append(dedup, fm)
+	}
+
+	// Update seenRepo now, so the next call of dedup will contain the
+	// repos.
+	for _, fm := range dedup {
+		seenRepo[fm.Repository] = struct{}{}
+	}
+
+	return dedup
 }

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -214,7 +214,14 @@ type mockSearcher struct {
 }
 
 func (s *mockSearcher) Search(context.Context, query.Q, *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	return s.searchResult, s.searchError
+	res := s.searchResult
+	if s.searchResult != nil {
+		// Copy since we mutate the File slice
+		sr := *res
+		sr.Files = append([]zoekt.FileMatch{}, sr.Files...)
+		res = &sr
+	}
+	return res, s.searchError
 }
 
 func (s *mockSearcher) List(context.Context, query.Q) (*zoekt.RepoList, error) {


### PR DESCRIPTION
During a rebalancing event repositories can be indexed on multiple nodes. This
is temporary, but will lead to us returning duplicate results. To avoid this
situation we do not aggregate a filematch from a shard if another shard has
already returned a result for the same repository.

Notes:
- RFC 30 encourages we split up the RepoSet to avoid duplicate results. This
  is something we may still do, but this is a more incremental change and will
  allow us to focus on making indexing more intelligent first.
- The map this allocates can be as large as our RepoSet. However, this should
  be much smaller in practice, and will always be smaller than the memory used
  by []FileMatch. As such this shouldn't impact performance.
- We don't dedup List since the only use of it already does
  deduplication. Avoiding this coupling we will address later and is noted in
  the code.
- The Stats struct has fields for MatchCount and FileCount. We don't update
  these fields w.r.t. deduplication since we do not consume them. Related to
  above we can address this at a later stage.

Test plan: Unit tests

Part of https://github.com/sourcegraph/sourcegraph/issues/5725