### PR TITLE
fix: fields with values wrapped in single-quotes were broken in literal search

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/pattern_type.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type.go
@@ -43,7 +43,7 @@ func ConvertToLiteral(input string) string {
 	return input
 }
 
-var fieldWithQuotedTokenValue = lazyregexp.New(`(\b-?[a-zA-Z]+:"([^"\\]|[\\].)*")`)
+var fieldWithQuotedTokenValue = lazyregexp.New(`(\b-?[a-zA-Z]+:("([^"\\]|[\\].)*"|'([^'\\]|[\\].)*'))`)
 var tokenRx = lazyregexp.New(`("([^"\\]|[\\].)*"|\s+|\S+)`)
 
 // tokenize returns a slice of the double-quoted strings, contiguous chunks

--- a/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
+++ b/cmd/frontend/internal/pkg/search/query/pattern_type_test.go
@@ -47,6 +47,7 @@ func TestConvertToLiteral(t *testing.T) {
 		{`type:commit message:"a commit message" after:"10 days ago" test`, `message:"a commit message" after:"10 days ago" type:commit "test"`},
 		{`type:commit message:"a commit message" after:"10 days ago" test test2`, `message:"a commit message" after:"10 days ago" type:commit "test test2"`},
 		{`type:commit message:"a commit message" test after:"10 days ago" test2`, `message:"a commit message" after:"10 days ago" type:commit "test  test2"`},
+		{`type:commit message:'a commit message' test after:'10 days ago' test2`, `message:'a commit message' after:'10 days ago' type:commit "test  test2"`},
 	}
 
 	for _, test := range tests {
@@ -91,6 +92,7 @@ func TestTokenize(t *testing.T) {
 		{`type:commit message:"a commit message" test after:"10 days ago"`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "  ", "test", " "}},
 		{`type:commit message:"a commit message" after:"10 days ago" test`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "   ", "test"}},
 		{`type:commit message:"a commit message" after:"10 days ago" test test2`, []string{"message:\"a commit message\"", "after:\"10 days ago\"", "type:commit", "   ", "test", " ", "test2"}},
+		{`type:commit message:'a commit message' after:'10 days ago' test test2`, []string{"message:'a commit message'", "after:'10 days ago'", "type:commit", "   ", "test", " ", "test2"}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Addresses @rvantonder's [comment in the previous fix for double quoted values](https://github.com/sourcegraph/sourcegraph/pull/6256#issuecomment-547687596).