### PR TITLE
search pagination: add more tests & fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,15 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Support hyphens in Bitbucket Cloud team names. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
-- Fixed an issue where the experimental search pagination API could omit a single repository worth of results at the end of the result set.
 
 ### Removed
+
+## 3.9.4
+
+### Fixed
+
+- The experimental search pagination API no longer omits a single repository worth of results at the end of the result set. [#6286](https://github.com/sourcegraph/sourcegraph/issues/6286)
+- The experimental search pagination API no longer produces search cursors that can get "stuck". [#6287](https://github.com/sourcegraph/sourcegraph/issues/6287)
 
 ## 3.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Support hyphens in Bitbucket Cloud team names. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
+- Fixed an issue where the experimental search pagination API could omit a single repository worth of results at the end of the result set.
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -417,6 +417,7 @@ func sliceSearchResults(results []searchResultResolver, common *searchResultsCom
 		return
 	}
 	final.limitHit = true
+	originalResults := results
 	results = results[offset:]
 
 	// Break results into repositories because for each result we need to add
@@ -443,7 +444,7 @@ func sliceSearchResults(results []searchResultResolver, common *searchResultsCom
 	// request should use a Cursor.ResultOffset == 2 to indicate we should
 	// resume fetching results starting at b3.
 	lastResultRepo, _ := results[len(results)-1].searchResultURIs()
-	for _, r := range results[:limit] {
+	for _, r := range originalResults[:offset+limit] {
 		repo, _ := r.searchResultURIs()
 		if repo != lastResultRepo {
 			final.resultOffset = 0

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -337,7 +337,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 			break
 		}
 
-		batch := repos[start:clamp(start+batchSize, 0, len(repos)-1)]
+		batch := repos[start:clamp(start+batchSize, 0, len(repos))]
 		batchResults, batchCommon, err := exec(batch)
 		if err != nil {
 			return nil, nil, nil, err

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -253,7 +253,8 @@ func paginatedSearchFilesInRepos(ctx context.Context, args *search.Args, paginat
 		if err != nil {
 			return nil, nil, err
 		}
-		// fileCommon is sorted, but fileResults is not so we must sort it now.
+		// fileResults is not sorted so we must sort it now. fileCommon may or
+		// may not be sorted, but we do not rely on its order.
 		sort.Slice(fileResults, func(i, j int) bool {
 			return fileResults[i].uri < fileResults[j].uri
 		})

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -359,22 +359,19 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			wantSearchedBatches: [][]*search.RepositoryRevisions{
 				{
 					repoRevs("4", "master"),
-					// BUG: repo 5 should be included!
-					//repoRevs("5", "master"),
+					repoRevs("5", "master"),
 				},
 			},
-			wantCursor: &searchCursor{RepositoryOffset: 4, ResultOffset: 0, Finished: true},
+			wantCursor: &searchCursor{RepositoryOffset: 5, ResultOffset: 0, Finished: true},
 			wantResults: []searchResultResolver{
 				result(repo("4"), "some/file1.go", "master"),
 				result(repo("4"), "some/file2.go", "master"),
-				// BUG: These should be included!
-				//result(repo("5"), "some/file0.go", "master"),
-				//result(repo("5"), "some/file1.go", "master"),
-				//result(repo("5"), "some/file2.go", "master"),
+				result(repo("5"), "some/file0.go", "master"),
+				result(repo("5"), "some/file1.go", "master"),
+				result(repo("5"), "some/file2.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				// BUG: repo 5 should be included!
-				repos:   []*types.Repo{repo("4")},
+				repos:   []*types.Repo{repo("4"), repo("5")},
 				partial: map[api.RepoName]struct{}{},
 			},
 		},

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -374,8 +374,6 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		{
 			name: "second request",
 			request: &searchPaginationInfo{
-				// Not a user-facing bug, but we should probably make this
-				// repo=3 offset=0 for sanity sake.
 				cursor: &searchCursor{RepositoryOffset: 2, ResultOffset: 4},
 				limit:  10,
 			},

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -81,7 +81,10 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		result(repo("org/repo5"), "e.go"),
 	}
 	sharedCommon := &searchResultsCommon{
-		repos: []*types.Repo{repo("org/repo1"), repo("org/repo2"), repo("org/repo3")},
+		// Note: this is an intentionally unordered list to ensure we do not
+		// rely on the order of lists in common (which is not guaranteed by
+		// tests).
+		repos: []*types.Repo{repo("org/repo1"), repo("org/repo3"), repo("org/repo2")},
 	}
 	tests := []struct {
 		name          string

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -381,6 +381,55 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				partial: map[api.RepoName]struct{}{},
 			},
 		},
+		{
+			name: "small limit, first request",
+			request: &searchPaginationInfo{
+				cursor: &searchCursor{},
+				limit:  1,
+			},
+			wantSearchedBatches: [][]*search.RepositoryRevisions{
+				{
+					repoRevs("1", "master"),
+					repoRevs("2", "master"),
+					repoRevs("3", "master", "feature"),
+					repoRevs("4", "master"),
+				},
+			},
+			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 1},
+			wantResults: []searchResultResolver{
+				result(repo("1"), "some/file0.go", "master"),
+			},
+			wantCommon: &searchResultsCommon{
+				repos:       []*types.Repo{repo("1")},
+				partial:     map[api.RepoName]struct{}{},
+				resultCount: 1,
+			},
+		},
+		{
+			name: "small limit, second request",
+			request: &searchPaginationInfo{
+				cursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 1},
+				limit:  1,
+			},
+			wantSearchedBatches: [][]*search.RepositoryRevisions{
+				{
+					repoRevs("1", "master"),
+					repoRevs("2", "master"),
+					repoRevs("3", "master", "feature"),
+					repoRevs("4", "master"),
+				},
+			},
+			// BUG: ResultOffset should be 2! Issue #6287
+			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 1},
+			wantResults: []searchResultResolver{
+				result(repo("1"), "some/file1.go", "master"),
+			},
+			wantCommon: &searchResultsCommon{
+				repos:       []*types.Repo{repo("1")},
+				partial:     map[api.RepoName]struct{}{},
+				resultCount: 1,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -254,8 +254,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
-				// BUG: resultOffset should be 2! Issue #6287
-				resultOffset:              1,
+				resultOffset:              2,
 				lastRepoConsumed:          repo("org/repo1"),
 				lastRepoConsumedPartially: true,
 				limitHit:                  true,
@@ -441,8 +440,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 					repoRevs("4", "master"),
 				},
 			},
-			// BUG: ResultOffset should be 2! Issue #6287
-			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 1},
+			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 2},
 			wantResults: []searchResultResolver{
 				result(repo("1"), "some/file1.go", "master"),
 			},

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -239,6 +239,28 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				limitHit:                  false,
 			},
 		},
+		{
+			name:    "limit non-repo boundary small",
+			results: sharedResult,
+			common:  sharedCommon,
+			offset:  1,
+			limit:   1,
+			want: slicedSearchResults{
+				results: []searchResultResolver{
+					result(repo("org/repo1"), "b.go"),
+				},
+				common: &searchResultsCommon{
+					resultCount: 1,
+					repos:       []*types.Repo{repo("org/repo1")},
+					partial:     make(map[api.RepoName]struct{}),
+				},
+				// BUG: resultOffset should be 2! Issue #6287
+				resultOffset:              1,
+				lastRepoConsumed:          repo("org/repo1"),
+				lastRepoConsumedPartially: true,
+				limitHit:                  true,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -88,6 +89,10 @@ func (c *searchResultsCommon) Timedout() []*RepositoryResolver {
 
 func (c *searchResultsCommon) IndexUnavailable() bool {
 	return c.indexUnavailable
+}
+
+func (c *searchResultsCommon) Equal(other *searchResultsCommon) bool {
+	return reflect.DeepEqual(c, other)
 }
 
 func RepositoryResolvers(repos types.Repos) []*RepositoryResolver {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,6 +64,10 @@ type fileMatchResolver struct {
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
 	inputRev *string
+}
+
+func (fm *fileMatchResolver) Equal(other *fileMatchResolver) bool {
+	return reflect.DeepEqual(fm, other)
 }
 
 func (fm *fileMatchResolver) Key() string {

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"reflect"
 	"strings"
 	"sync"
 
@@ -62,6 +63,10 @@ type RepositoryRevisions struct {
 	// rationale.
 	mu                sync.Mutex
 	indexedHEADCommit api.CommitID
+}
+
+func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
+	return reflect.DeepEqual(r, other)
 }
 
 func (r *RepositoryRevisions) IndexedHEADCommit() api.CommitID {

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -66,7 +66,7 @@ type RepositoryRevisions struct {
 }
 
 func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
-	return reflect.DeepEqual(r, other)
+	return reflect.DeepEqual(r.Repo, other.Repo) && reflect.DeepEqual(r.Revs, other.Revs)
 }
 
 func (r *RepositoryRevisions) IndexedHEADCommit() api.CommitID {


### PR DESCRIPTION
After this PR, all of the complex logic in the search pagination API (planning and slicing) is covered by tests extensively. The addition of the tests in this PR caught one off-by-one issue #6286 which is also fixed by this PR.

Fixes #5999
Fixes #6286
Fixes #6287 