### PR TITLE
Add ResolveRev call to upload proxy handler.

### DIFF
--- a/cmd/frontend/internal/httpapi/lsif.go
+++ b/cmd/frontend/internal/httpapi/lsif.go
@@ -26,8 +26,9 @@ func lsifProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.
 
 func lsifUploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		repoName := r.URL.Query().Get("repository")
-		commit := r.URL.Query().Get("commit")
+		q := r.URL.Query()
+		repoName := q.Get("repository")
+		commit := q.Get("commit")
 
 		repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(repoName))
 		if err != nil {

--- a/cmd/frontend/internal/httpapi/lsif.go
+++ b/cmd/frontend/internal/httpapi/lsif.go
@@ -26,9 +26,18 @@ func lsifProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.
 
 func lsifUploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, err := backend.Repos.GetByName(r.Context(), api.RepoName(r.URL.Query().Get("repository")))
+		repoName := r.URL.Query().Get("repository")
+		commit := r.URL.Query().Get("commit")
+
+		repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(repoName))
 		if err != nil {
 			http.Error(w, "Unknown repository.", http.StatusNotFound)
+			return
+		}
+
+		_, err = backend.Repos.ResolveRev(r.Context(), repo, commit)
+		if err != nil {
+			http.Error(w, "Unknown commit.", http.StatusNotFound)
 			return
 		}
 


### PR DESCRIPTION
Currently only repository is validated when LSIF data is uploaded. This adds a validation check to ensure that the commit is known (or fetched) by gitserver. Closes #6268.