### PR TITLE
Reinstate AggregateError interface

### DIFF
--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -21,6 +21,21 @@ export const asError = (value: unknown): Error => {
     return new Error(String(value))
 }
 
+const EAGGREGATEERROR = 'AggregateError'
+
+/**
+ * An Error that aggregates multiple errors
+ */
+interface AggregateError extends Error {
+    name: typeof EAGGREGATEERROR
+    errors: Error[]
+}
+
+/**
+ * A type guard checking whether the given value is an {@link AggregateError}
+ */
+export const isAggregateError = (e: any): e is AggregateError => isErrorLike(e) && e.code === EAGGREGATEERROR
+
 /**
  * DEPRECATED: use dataOrThrowErrors instead
  * Creates an aggregate error out of multiple provided error likes
@@ -31,7 +46,8 @@ export const createAggregateError = (errors: ErrorLike[] = []): Error =>
     errors.length === 1
         ? asError(errors[0])
         : Object.assign(new Error(errors.map(e => e.message).join('\n')), {
-              name: 'AggregateError' as const,
+              name: EAGGREGATEERROR,
+              code: EAGGREGATEERROR,
               errors: errors.map(asError),
           })
 

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -34,7 +34,7 @@ interface AggregateError extends Error {
 /**
  * A type guard checking whether the given value is an {@link AggregateError}
  */
-export const isAggregateError = (e: any): e is AggregateError => isErrorLike(e) && e.code === EAGGREGATEERROR
+export const isAggregateError = (e: any): e is AggregateError => isErrorLike(e) && e.name === EAGGREGATEERROR
 
 /**
  * DEPRECATED: use dataOrThrowErrors instead
@@ -47,7 +47,6 @@ export const createAggregateError = (errors: ErrorLike[] = []): Error =>
         ? asError(errors[0])
         : Object.assign(new Error(errors.map(e => e.message).join('\n')), {
               name: EAGGREGATEERROR,
-              code: EAGGREGATEERROR,
               errors: errors.map(asError),
           })
 

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -21,7 +21,7 @@ export const asError = (value: unknown): Error => {
     return new Error(String(value))
 }
 
-const EAGGREGATEERROR = 'AggregateError'
+const AGGREGATE_ERROR_NAME = 'AggregateError'
 
 /**
  * An Error that aggregates multiple errors

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -34,7 +34,7 @@ interface AggregateError extends Error {
 /**
  * A type guard checking whether the given value is an {@link AggregateError}
  */
-export const isAggregateError = (e: any): e is AggregateError => isErrorLike(e) && e.name === EAGGREGATEERROR
+export const isAggregateError = (value: unknown): value is AggregateError => isErrorLike(value) && value.name === AGGREGATE_ERROR_NAME
 
 /**
  * DEPRECATED: use dataOrThrowErrors instead

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -46,7 +46,7 @@ export const createAggregateError = (errors: ErrorLike[] = []): Error =>
     errors.length === 1
         ? asError(errors[0])
         : Object.assign(new Error(errors.map(e => e.message).join('\n')), {
-              name: EAGGREGATEERROR,
+              name: AGGREGATE_ERROR_NAME,
               errors: errors.map(asError),
           })
 

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -34,7 +34,8 @@ interface AggregateError extends Error {
 /**
  * A type guard checking whether the given value is an {@link AggregateError}
  */
-export const isAggregateError = (value: unknown): value is AggregateError => isErrorLike(value) && value.name === AGGREGATE_ERROR_NAME
+export const isAggregateError = (value: unknown): value is AggregateError =>
+    isErrorLike(value) && value.name === AGGREGATE_ERROR_NAME
 
 /**
  * DEPRECATED: use dataOrThrowErrors instead

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -27,7 +27,7 @@ const AGGREGATE_ERROR_NAME = 'AggregateError'
  * An Error that aggregates multiple errors
  */
 interface AggregateError extends Error {
-    name: typeof EAGGREGATEERROR
+    name: typeof AGGREGATE_ERROR_NAME
     errors: Error[]
 }
 


### PR DESCRIPTION
From https://github.com/sourcegraph/sourcegraph/pull/6246#pullrequestreview-309286218:

> This interface would still be good to keep (and export) so that a consumer can check if an error is an aggregate error and iterate over the errors
