### PR TITLE
search: Zoekt sends list of indexed repos when requesting what to index

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -95,7 +95,7 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		Repos:                 backend.Repos,
 		Indexers:              search.Indexers(),
-	}).serve)))
+	}).serveList)))
 	m.Get(apirouter.ReposListEnabled).Handler(trace.TraceRoute(handler(serveReposListEnabled)))
 	m.Get(apirouter.ReposGetByName).Handler(trace.TraceRoute(handler(serveReposGetByName)))
 	m.Get(apirouter.SettingsGetForSubject).Handler(trace.TraceRoute(handler(serveSettingsGetForSubject)))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -91,11 +91,13 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.TraceRoute(handler(servePhabricatorRepoCreate)))
 	m.Get(apirouter.ReposCreateIfNotExists).Handler(trace.TraceRoute(handler(serveReposCreateIfNotExists)))
 	m.Get(apirouter.ReposUpdateMetadata).Handler(trace.TraceRoute(handler(serveReposUpdateMetadata)))
-	m.Get(apirouter.ReposList).Handler(trace.TraceRoute(handler((&reposListServer{
+	reposList := &reposListServer{
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		Repos:                 backend.Repos,
 		Indexers:              search.Indexers(),
-	}).serveList)))
+	}
+	m.Get(apirouter.ReposList).Handler(trace.TraceRoute(handler(reposList.serveList)))
+	m.Get(apirouter.ReposIndex).Handler(trace.TraceRoute(handler(reposList.serveIndex)))
 	m.Get(apirouter.ReposListEnabled).Handler(trace.TraceRoute(handler(serveReposListEnabled)))
 	m.Get(apirouter.ReposGetByName).Handler(trace.TraceRoute(handler(serveReposGetByName)))
 	m.Get(apirouter.SettingsGetForSubject).Handler(trace.TraceRoute(handler(serveSettingsGetForSubject)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -216,7 +216,7 @@ type reposListServer struct {
 	}
 }
 
-func (h *reposListServer) serve(w http.ResponseWriter, r *http.Request) error {
+func (h *reposListServer) serveList(w http.ResponseWriter, r *http.Request) error {
 	var opt struct {
 		Hostname string
 		db.ReposListOptions

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -89,7 +89,7 @@ func TestReposList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte(tc.body)))
 			w := httptest.NewRecorder()
-			if err := tc.srv.serve(w, req); err != nil {
+			if err := tc.srv.serveList(w, req); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -40,6 +40,7 @@ const (
 	ReposInventoryUncached = "internal.repos.inventory-uncached"
 	ReposInventory         = "internal.repos.inventory"
 	ReposList              = "internal.repos.list"
+	ReposIndex             = "internal.repos.index"
 	ReposListEnabled       = "internal.repos.list-enabled"
 	ReposUpdateMetadata    = "internal.repos.update-metadata"
 	Configuration          = "internal.configuration"
@@ -106,6 +107,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/repos/inventory-uncached").Methods("POST").Name(ReposInventoryUncached)
 	base.Path("/repos/inventory").Methods("POST").Name(ReposInventory)
 	base.Path("/repos/list").Methods("POST").Name(ReposList)
+	base.Path("/repos/index").Methods("POST").Name(ReposIndex)
 	base.Path("/repos/list-enabled").Methods("POST").Name(ReposListEnabled)
 	base.Path("/repos/update-metadata").Methods("POST").Name(ReposUpdateMetadata)
 	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20191022114252-c1011d80f8fa
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20191031085051-5bd7e84795f0
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -740,6 +740,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20191022114252-c1011d80f8fa h1:xhiPn7RhSiw0+lczj/inAH6W0AQcF1F8tC+vi2Ac3NQ=
 github.com/sourcegraph/zoekt v0.0.0-20191022114252-c1011d80f8fa/go.mod h1:H8z9wvHGyu+MiKyVKkJza8B+SWZispxX23A692cJAno=
+github.com/sourcegraph/zoekt v0.0.0-20191031085051-5bd7e84795f0 h1:KC0BfCqh/CGopE/Jk9BgrZ1DnqRv7hDhnLOnSliFpL4=
+github.com/sourcegraph/zoekt v0.0.0-20191031085051-5bd7e84795f0/go.mod h1:H8z9wvHGyu+MiKyVKkJza8B+SWZispxX23A692cJAno=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/internal/search/backend/indexers.go
+++ b/internal/search/backend/indexers.go
@@ -31,8 +31,10 @@ type Indexers struct {
 //
 // ReposSubset reuses the underlying array of repoNames.
 //
+// indexed is the set of repositories currently indexed by hostname.
+//
 // An error is returned if hostname is not part of the Indexers endpoints.
-func (c *Indexers) ReposSubset(ctx context.Context, hostname string, repoNames []string) ([]string, error) {
+func (c *Indexers) ReposSubset(ctx context.Context, hostname string, indexed map[string]struct{}, repoNames []string) ([]string, error) {
 	if !c.Enabled() {
 		return repoNames, nil
 	}
@@ -52,12 +54,10 @@ func (c *Indexers) ReposSubset(ctx context.Context, hostname string, repoNames [
 		return nil, err
 	}
 
-	// Rebalancing: Get the currently indexed repositories so we can populate
-	// other. Other contains all repositories endpoint has indexed which it
-	// should drop. We will only drop them if the assigned endpoint has
+	// Rebalancing: Other contains all repositories endpoint has indexed which
+	// it should drop. We will only drop them if the assigned endpoint has
 	// indexed it. This is to prevent dropping a computed index until
 	// rebalancing is finished.
-	indexed := c.Indexed(ctx, endpoint)
 	other := map[string][]string{}
 
 	subset := repoNames[:0]

--- a/internal/search/backend/indexers_test.go
+++ b/internal/search/backend/indexers_test.go
@@ -74,8 +74,9 @@ func TestReposSubset(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 			indexed = tc.indexed
-			got, err := index.ReposSubset(context.Background(), tc.hostname, tc.repos)
+			got, err := index.ReposSubset(ctx, tc.hostname, index.Indexed(ctx, tc.hostname), tc.repos)
 			if tc.errS != "" {
 				got := fmt.Sprintf("%v", err)
 				if !strings.Contains(got, tc.errS) {


### PR DESCRIPTION
Previously there was a race condition when computing the list of repositories to index. We try to avoid dropping repos that are already indexed by a node if no other node has indexed it. We did this by asking zoekt-webserver the list of repos. However, zoekt-indexserver may ask for the list of repos before zoekt-webserver has started => this list being empty.

This resolves this comment https://github.com/sourcegraph/sourcegraph/pull/6277#discussion_r340840535

Test plan: CI and testing locally `DEV_SEARCH_SHARDING=t dev/launch.sh`

Part of https://github.com/sourcegraph/sourcegraph/issues/5725