### PR TITLE
dev: Enable sharded search by default

### DIFF
--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -64,7 +64,7 @@ export USE_ENHANCED_LANGUAGE_DETECTION=${USE_ENHANCED_LANGUAGE_DETECTION:-1}
 export GRAFANA_SERVER_URL=http://localhost:3370
 
 # Enable sharded indexed search mode
-[ -z "${DEV_SEARCH_SHARDING-}" ] || export INDEXED_SEARCH_SERVERS="localhost:3070 localhost:3071"
+[ -n "${DISABLE_SEARCH_SHARDING-}" ] || export INDEXED_SEARCH_SERVERS="localhost:3070 localhost:3071"
 
 # webpack-dev-server is a proxy running on port 3080 that (1) serves assets, waiting to respond
 # until they are (re)built and (2) otherwise proxies to nginx running on port 3081 (which proxies to

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -6,8 +6,7 @@ cmd="${1:-}"
 replica="${2:-0}"
 index="$HOME/.sourcegraph/zoekt/index-$replica"
 
-if (( replica != 0 )) && [[ -z "${DEV_SEARCH_SHARDING-}" ]]; then
-    echo "set DEV_SEARCH_SHARDING=t to enable horizontal indexed search"
+if (( replica != 0 )) && [[ -n "${DISABLE_SEARCH_SHARDING-}" ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
This is only for dev mode, we will follow up with enabling horizontal search
by default in docker and k8s in a later commit.

Part of https://github.com/sourcegraph/sourcegraph/issues/5725