### PR TITLE
all: Enabled horizontal indexed search code path by default

### DIFF
--- a/cmd/frontend/internal/pkg/search/env_test.go
+++ b/cmd/frontend/internal/pkg/search/env_test.go
@@ -1,0 +1,55 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestZoektAddr(t *testing.T) {
+	cases := []struct {
+		name    string
+		environ []string
+		want    string
+	}{{
+		name: "default",
+		want: "indexed-search-0.indexed-search:6070",
+	}, {
+		name:    "old",
+		environ: []string{"ZOEKT_HOST=127.0.0.1:3070"},
+		want:    "127.0.0.1:3070",
+	}, {
+		name:    "new",
+		environ: []string{"INDEXED_SEARCH_SERVERS=indexed-search-0.indexed-search:6070 indexed-search-1.indexed-search:6070"},
+		want:    "indexed-search-0.indexed-search:6070 indexed-search-1.indexed-search:6070",
+	}, {
+		name: "prefer new",
+		environ: []string{
+			"ZOEKT_HOST=127.0.0.1:3070",
+			"INDEXED_SEARCH_SERVERS=indexed-search-0.indexed-search:6070 indexed-search-1.indexed-search:6070",
+		},
+		want: "indexed-search-0.indexed-search:6070 indexed-search-1.indexed-search:6070",
+	}, {
+		name: "unset new",
+		environ: []string{
+			"ZOEKT_HOST=127.0.0.1:3070",
+			"INDEXED_SEARCH_SERVERS=",
+		},
+		want: "",
+	}, {
+		name: "unset old",
+		environ: []string{
+			"ZOEKT_HOST=",
+		},
+		want: "",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := zoektAddr(tc.environ)
+			if got != tc.want {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -11,9 +11,12 @@ func maybeZoektProcFile() []string {
 	if os.Getenv("ZOEKT_HOST") != "" {
 		return nil
 	}
+	if os.Getenv("INDEXED_SEARCH_SERVERS") != "" {
+		return nil
+	}
 
 	defaultHost := "127.0.0.1:3070"
-	SetDefaultEnv("ZOEKT_HOST", defaultHost)
+	SetDefaultEnv("INDEXED_SEARCH_SERVERS", defaultHost)
 
 	frontendInternalHost := os.Getenv("SRC_FRONTEND_INTERNAL")
 	indexDir := filepath.Join(DataDir, "zoekt/index")


### PR DESCRIPTION
We now enabled the new horizontal indexed search by default. Even if you only
have one replica (the default and usual case), this slightly changes the
codepath we take when doing a search. Additionally, we now prefer the
INDEXED_SEARCH_SERVERS environment variable and have deprecated the old
environment variable (ZOEKT_HOST).

This commit also updates the default address to
"indexed-search-0.indexed-search:6070". The old address won't be valid on k8s
deployments from the next release.

Part of https://github.com/sourcegraph/sourcegraph/issues/5725
