### PR TITLE
Fix `type:path` not working on zoekt codepath

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -95,6 +95,21 @@ func TestQueryToZoektQuery(t *testing.T) {
 			},
 			Query: `foo case:yes f:\.go$ f:\.yaml$ -f:\bvendor\b`,
 		},
+		{
+			Name: "path matches only",
+			Pattern: &search.PatternInfo{
+				IsRegExp:                     true,
+				IsCaseSensitive:              false,
+				Pattern:                      "test",
+				IncludePatterns:              []string{},
+				ExcludePattern:               ``,
+				PathPatternsAreRegExps:       true,
+				PathPatternsAreCaseSensitive: true,
+				PatternMatchesContent:        false,
+				PatternMatchesPath:           true,
+			},
+			Query: `f:test`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -421,7 +421,8 @@ func queryToZoektQuery(query *search.PatternInfo, isSymbol bool) (zoektquery.Q, 
 	var q zoektquery.Q
 	if query.IsRegExp {
 		var err error
-		q, err = parseRe(query.Pattern, false, query.IsCaseSensitive)
+		fileNameOnly := query.PatternMatchesPath && !query.PatternMatchesContent
+		q, err = parseRe(query.Pattern, fileNameOnly, query.IsCaseSensitive)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6220.

Zoekt codepath previously always passed `false` to the `fileMatchOnly` param in `parseRe`. Now it looks at `patternMatchesPath` and `patternMatchesContent` args to pass the correct value.

Test plan: added unit test