### PR TITLE
a8n: Introduce PreviewDiff to simplify CampaignPlan diffs

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -181,13 +181,6 @@ type CampaignsConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type ChangesetResolver interface {
-	Title() (string, error)
-	Body() (string, error)
-	Repository(ctx context.Context) (*RepositoryResolver, error)
-	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
-}
-
 type ExternalChangesetsConnectionResolver interface {
 	Nodes(ctx context.Context) ([]ExternalChangesetResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
@@ -207,8 +200,6 @@ type ExternalChangesetResolver interface {
 	Campaigns(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (CampaignsConnectionResolver, error)
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
 	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
-	ToChangesetPlan() (ChangesetPlanResolver, bool)
-	ToExternalChangeset() (ExternalChangesetResolver, bool)
 }
 
 type ChangesetPlansConnectionResolver interface {
@@ -221,8 +212,7 @@ type ChangesetPlanResolver interface {
 	Title() (string, error)
 	Body() (string, error)
 	Repository(ctx context.Context) (*RepositoryResolver, error)
-	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
-	ToExternalChangeset() (ExternalChangesetResolver, bool)
+	Diff(ctx context.Context) (PreviewRepositoryDiff, error)
 }
 
 type ChangesetEventsConnectionResolver interface {
@@ -278,4 +268,32 @@ type CampaignPlanResolver interface {
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
 
 	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewRepositoryDiffConnectionResolver, error)
+}
+
+type PreviewFileDiff interface {
+	OldPath() *string
+	NewPath() *string
+	Hunks() []FileDiffHunk
+	Stat() DiffStat
+	OldFile() *gitTreeEntryResolver
+	InternalID() string
+}
+
+type PreviewFileDiffConnection interface {
+	Nodes(ctx context.Context) ([]PreviewFileDiff, error)
+	TotalCount(ctx context.Context) (*int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+	DiffStat(ctx context.Context) (DiffStat, error)
+	RawDiff(ctx context.Context) (string, error)
+}
+
+type PreviewRepositoryDiff interface {
+	BaseRepository() *RepositoryResolver
+	FileDiffs(*graphqlutil.ConnectionArgs) PreviewFileDiffConnection
+}
+
+type PreviewRepositoryDiffConnectionResolver interface {
+	Nodes(ctx context.Context) ([]PreviewRepositoryDiff, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -85,11 +85,6 @@ func (r *NodeResolver) ToCampaignPlan() (CampaignPlanResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToChangeset() (ChangesetResolver, bool) {
-	n, ok := r.Node.(ChangesetResolver)
-	return n, ok
-}
-
 func (r *NodeResolver) ToExternalChangeset() (ExternalChangesetResolver, bool) {
 	n, ok := r.Node.(ExternalChangesetResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -626,24 +626,8 @@ input CreateChangesetInput {
     externalID: String!
 }
 
-# Basic fields of a changeset.
-interface Changeset {
-    # The repository changed by the changeset.
-    repository: Repository!
-
-    # The title of the changeset.
-    title: String!
-
-    # The body of the changeset.
-    body: String!
-
-    # The diff of the changeset.
-    # Only returned if the changeset has not been merged or closed.
-    diff: RepositoryDiff
-}
-
 # Preview of a changeset planned to be created.
-type ChangesetPlan implements Changeset {
+type ChangesetPlan {
     # The repository changed by the changeset.
     repository: Repository!
 
@@ -654,11 +638,11 @@ type ChangesetPlan implements Changeset {
     body: String!
 
     # The diff of the changeset.
-    diff: RepositoryDiff!
+    diff: PreviewRepositoryDiff!
 }
 
 # A changeset in a code host (e.g. a PR on Github)
-type ExternalChangeset implements Changeset & Node {
+type ExternalChangeset implements Node {
     # The unique ID for the changeset.
     id: ID!
 
@@ -694,7 +678,7 @@ type ExternalChangeset implements Changeset & Node {
 
     # The diff of this changeset.
     # Only returned if the changeset has not been merged or closed.
-    diff: RepositoryDiff
+    diff: RepositoryComparison
 }
 
 # A list of changesets.
@@ -1918,25 +1902,53 @@ type GitRefConnection {
 }
 
 # A not-yet-committed preview of a diff on a repository.
-type PreviewRepositoryDiff implements RepositoryDiff {
+type PreviewRepositoryDiff {
     # The repository that this diff is targeting.
     baseRepository: Repository!
 
-    # The file diffs for each changed file.
-    fileDiffs(first: Int): FileDiffConnection!
+    # The preview of the file diffs for each file in the diff.
+    fileDiffs(first: Int): PreviewFileDiffConnection!
 }
 
-# Any diff on a concrete repository.
-interface RepositoryDiff {
-    # The repository that this diff is targeting.
-    baseRepository: Repository!
+# A list of file diffs that might be applied.
+type PreviewFileDiffConnection {
+    # A list of file diffs that might be applied.
+    nodes: [PreviewFileDiff!]!
+    # The total count of file diffs in the connection, if available. This total count may be larger than the number
+    # of nodes in this object when the result is paginated.
+    totalCount: Int
+    # Pagination information.
+    pageInfo: PageInfo!
+    # The diff stat for the file diffs in this object, which may be a subset of the entire diff if the result is
+    # paginated.
+    diffStat: DiffStat!
+    # The raw diff for the file diffs in this object, which may be a subset of the entire diff if the result is
+    # paginated.
+    rawDiff: String!
+}
 
-    # The file diffs for each changed file.
-    fileDiffs(first: Int): FileDiffConnection!
+# A diff for a single file that has not been applied yet.
+# Subset of the FileDiff type.
+type PreviewFileDiff {
+    # The old (original) path of the file, or null if the file was added.
+    oldPath: String
+    # The old file, or null if the file was created (oldFile.path == oldPath).
+    oldFile: File2
+    # The new path of the file if the diff was applied, or null if the file was deleted.
+    newPath: String
+    # Hunks that were would be changed from old to new.
+    hunks: [FileDiffHunk!]!
+    # The diff stat for the whole file.
+    stat: DiffStat!
+    # FOR INTERNAL USE ONLY.
+    #
+    # An identifier for the file diff that is unique among all other file diffs in the list that
+    # contains it.
+    internalID: String!
 }
 
 # The differences between two concrete Git commits in a repository.
-type RepositoryComparison implements RepositoryDiff {
+type RepositoryComparison {
     # The repository that is the base (left-hand side) of this comparison.
     baseRepository: Repository!
 

--- a/enterprise/pkg/a8n/resolvers/campaigns.go
+++ b/enterprise/pkg/a8n/resolvers/campaigns.go
@@ -219,12 +219,12 @@ type changesetDiffsConnectionResolver struct {
 	*changesetsConnectionResolver
 }
 
-func (r *changesetDiffsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.RepositoryComparison, error) {
+func (r *changesetDiffsConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.RepositoryComparisonResolver, error) {
 	changesets, err := r.changesetsConnectionResolver.Nodes(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resolvers := make([]graphqlbackend.RepositoryComparison, 0, len(changesets))
+	resolvers := make([]*graphqlbackend.RepositoryComparisonResolver, 0, len(changesets))
 	for _, c := range changesets {
 		comp, err := c.Diff(ctx)
 		if err != nil {

--- a/enterprise/pkg/a8n/resolvers/changesets.go
+++ b/enterprise/pkg/a8n/resolvers/changesets.go
@@ -80,14 +80,6 @@ func unmarshalChangesetID(id graphql.ID) (cid int64, err error) {
 	return
 }
 
-func (r *changesetResolver) ToChangesetPlan() (graphqlbackend.ChangesetPlanResolver, bool) {
-	return r, true
-}
-
-func (r *changesetResolver) ToExternalChangeset() (graphqlbackend.ExternalChangesetResolver, bool) {
-	return r, true
-}
-
 func (r *changesetResolver) ID() graphql.ID {
 	return marshalChangesetID(r.Changeset.ID)
 }


### PR DESCRIPTION
This solves the problem discussed [in this comment chain](https://github.com/sourcegraph/sourcegraph/pull/6135/files#r341095143) and on the Zoom call.

It splits up `ChangesetPlan` and `ExternalChangeset` into two different types that do not implement the same interface in order to give `ChangesetPlan` a new `diff` type: `PreviewRepositoryDiff`

The difference between `PreviewRepositoryDiff` and the type we had before is that this new one doesn't rely on `FileDiff`.

The problem with `FileDiff` was that it requires a `newFile: File2` field and that was/is too much effort to implement now.

The reason why it's hard to implement: in the backend we only have the "old" file at hand and a patch to generate a new file. We don't have a new file, especially not one that could easily satisfy the `File2` interface , due to its `url`, `canonicalURL`, `externalURLs` fields. And even if we take these out of the `File2` interface we'd still have to implement `content`, `richHTML`, `highlight` for a file _that does not exist yet_.

Theoretically we could return the `content` (and `richHTML` and `highlight`) by computing the new file content in memory, as if the diff we have at hand was applied. But not only is that computation heavy (we'd have to fetch the old file from gitserver, load it into memory, apply the diff in memory and then send the file down the wire — potentially for every file in campaign plan's diff), it's also a lot of effort to implement in this iteration.

So instead, we decided to introduce a new type in which we don't have to represent the new file in memory, but only the old file, which already exists on `gitserver` and for which we can use the already existing `*gitTreeEntryResolver` to fulfill the `File2` interface.
