### PR TITLE
Fixed broken docs links plus a few syntax improvements

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -59,7 +59,7 @@ Site configuration example:
 
 ## GitHub
 
-> Note: GitHub authentication is currently beta.
+> NOTE: GitHub authentication is currently beta.
 
 [Create a GitHub OAuth
 application](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) (if using
@@ -69,7 +69,7 @@ GitHub Enterprise, create one on your instance, not GitHub.com). Set the followi
 - Homepage URL: `https://sourcegraph.example.com`
 - Authorization callback URL: `https://sourcegraph.example.com/.auth/github/callback`
 
-> Note: If you want to enable repository permissions, you should grant your OAuth app permission to
+> NOTE: If you want to enable repository permissions, you should grant your OAuth app permission to
 > your GitHub organization(s). You can do that either by creating the OAuth app under your GitHub
 > organization (rather than your personal account) or by [following these
 > instructions](https://help.github.com/articles/approving-oauth-apps-for-your-organization/).
@@ -106,7 +106,7 @@ Once you've configured GitHub as a sign-on provider, you may also want to [add G
 
 ## GitLab
 
-> Note: GitLab authentication is currently beta.
+> NOTE: GitLab authentication is currently beta.
 
 [Create a GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html). Set
 the following values, replacing `sourcegraph.example.com` with the IP or hostname of your
@@ -152,10 +152,10 @@ The [`openidconnect` auth provider](../config/critical_config.md#openid-connect-
 
 To configure Sourcegraph to authenticate users via OpenID Connect:
 
-1.  Create a new OpenID Connect client in the external service (such as one of those listed above).
+1. Create a new OpenID Connect client in the external service (such as one of those listed above).
     - **Redirect/callback URI:** `https://sourcegraph.example.com/.auth/callback` (replace `https://sourcegraph.example.com` with the value of the `externalURL` property in your config)
-1.  Provide the OpenID Connect client's issuer, client ID, and client secret in the Sourcegraph critical configuration shown below.
-1.  (Optional) Require users to have a specific email domain name to authenticate (e.g., to limit users to only those from your organization).
+1. Provide the OpenID Connect client's issuer, client ID, and client secret in the Sourcegraph critical configuration shown below.
+1. (Optional) Require users to have a specific email domain name to authenticate (e.g., to limit users to only those from your organization).
 
 Example [`openidconnect` auth provider](../config/critical_config.md#openid-connect-including-g-suite) configuration:
 
@@ -183,13 +183,13 @@ See the [`openid` auth provider documentation](../config/critical_config.md#open
 
 Google's G Suite supports OpenID Connect, which is the best way to enable Sourcegraph authentication using Google accounts. To set it up:
 
-1.  Create an **OAuth client ID** and client secret in the [Google API credentials console](https://console.developers.google.com/apis/credentials). [Google's interactive OpenID Connect documentation page](https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials):
+1. Create an **OAuth client ID** and client secret in the [Google API credentials console](https://console.developers.google.com/apis/credentials). [Google's interactive OpenID Connect documentation page](https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials):
     - **Application type:** Web application
     - **Name:** Sourcegraph (or any other name your users will recognize)
     - **Authorized JavaScript origins:** (leave blank)
     - **Authorized redirect URIs:** `https://sourcegraph.example.com/.auth/callback` (replace `https://sourcegraph.example.com` with the value of the `externalURL` property in your config)
-1.  Use the **client ID** and **client secret** values in Sourcegraph critical configuration (as shown in the example below).
-1.  Set your G Suite domain in `requireEmailDomain` to prevent users outside your organization from signing in.
+1. Use the **client ID** and **client secret** values in Sourcegraph critical configuration (as shown in the example below).
+1. Set your G Suite domain in `requireEmailDomain` to prevent users outside your organization from signing in.
 
 Example [`openidconnect` auth provider](../config/critical_config.md#openid-connect-including-g-suite) configuration for G Suite:
 
@@ -222,14 +222,14 @@ The [`saml` auth provider](../config/critical_config.md#saml) authenticates user
 
 To configure Sourcegraph to authenticate users via SAML:
 
-1.  Register Sourcegraph as a SAML Service Provider in the external SAML Identity Provider (such as one of those listed above). Use the following settings (the exact names and labels vary across services).
+1. Register Sourcegraph as a SAML Service Provider in the external SAML Identity Provider (such as one of those listed above). Use the following settings (the exact names and labels vary across services).
     - **Assertion Consumer Service URL, Recipient URL, Destination URL, Single sign-on URL:** `https://sourcegraph.example.com/.auth/saml/acs` (substituting the `externalURL` from your [critical configuration](../config/critical_config.md))
     - **Service Provider (issuer, entity ID, audience URI, metadata URL):** `https://sourcegraph.example.com/.auth/saml/metadata` (substituting the `externalURL` from your [critical configuration](../config/critical_config.md))
     - **Attribute statements:**
       - `email` (required): the user's email
       - `login` (optional): the user's username
       - `displayName` (optional): the full name of the user
-1.  Obtain the SAML identity provider metadata URL and use it in Sourcegraph critical configuration as shown below.
+1. Obtain the SAML identity provider metadata URL and use it in Sourcegraph critical configuration as shown below.
 
 Example [`saml` auth provider](../config/critical_config.md#saml) configuration:
 
@@ -313,7 +313,6 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
 ## Username normalization
 
 Usernames on Sourcegraph are normalized according to the following rules.
-
 
 - Any characters not in `[a-zA-Z0-9-.]` are replaced with `-`
 - Usernames with exactly one `@` character are interpreted as an email address, so the username will be extracted by truncating at the `@` character.

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -22,7 +22,7 @@ Loading configuration in this manner has two important drawbacks:
 
 Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
 
-```sh
+```bash
 CRITICAL_CONFIG_FILE=critical.json
 ```
 
@@ -30,7 +30,7 @@ CRITICAL_CONFIG_FILE=critical.json
 
 You should also add to the `management-console` container (cluster deployment) or to the `server` container (single-container Docker deployment) the following:
 
-```sh
+```bash
 DISABLE_CONFIG_UPDATES=true
 ```
 
@@ -38,7 +38,7 @@ DISABLE_CONFIG_UPDATES=true
 
 Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
 
-```sh
+```bash
 SITE_CONFIG_FILE=site.json
 ```
 
@@ -50,7 +50,7 @@ If you want to _allow_ edits to be made through the web UI (which will be overwr
 
 Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
 
-```sh
+```bash
 EXTSVC_CONFIG_FILE=extsvc.json
 ```
 

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -13,7 +13,7 @@ There are 2 types of site configuration for a Sourcegraph instance:
 - [Add user authentication providers (SSO)](../auth/index.md)
 - [Configure search scopes](../../user/search/scopes.md)
 - [Integrate with Phabricator](../../integration/phabricator.md)
-- [Add organizations](../../user/organizations.md)
+- [Add organizations](../../user/organizations/index.md)
 - [Set up HTTPS](../nginx.md)
 - [Use a custom domain](../url.md)
 - [Update Sourcegraph](../updates.md)

--- a/doc/admin/external_database.md
+++ b/doc/admin/external_database.md
@@ -43,3 +43,5 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
 <pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.9.2</code></pre>
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
+
+If using Docker for Desktop, `host.docker.internal` will resolve to the host IP address.

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -45,7 +45,7 @@ GitHub's per-user repository permissions, see "[Repository permissions](../repo/
 ## User authentication
 
 To configure GitHub as an authentication provider (which will enable sign-in via GitHub), see the
-[authentication documentation](../auth.md#github).
+[authentication documentation](../auth/index.md#github).
 
 ## Webhooks
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -44,7 +44,7 @@ permissions](../repo/permissions.md#gitlab)".
 ## User authentication
 
 To configure GitLab as an authentication provider (which will enable sign-in via GitLab), see the
-[authentication documentation](../auth.md#gitlab).
+[authentication documentation](../auth/index.md#gitlab).
 
 ## Configuration
 

--- a/doc/admin/faq.md
+++ b/doc/admin/faq.md
@@ -14,7 +14,7 @@ The other option is to deploy and run Sourcegraph on a cloud provider. For an ex
 
 Get the Docker container ID for Sourcegraph:
 
-```shell
+```bash
 docker ps
 CONTAINER ID        IMAGE
 d039ec989761        sourcegraph/server:VERSION
@@ -22,7 +22,7 @@ d039ec989761        sourcegraph/server:VERSION
 
 Open a PostgreSQL interactive terminal:
 
-```shell
+```bash
 docker container exec -it d039ec989761 psql -U postgres sourcegraph
 ```
 
@@ -36,7 +36,7 @@ SELECT * FROM users;
 
 Get the id of one `pgsql` Pod:
 
-```shell
+```bash
 kubectl get pods -l app=pgsql
 NAME                     READY     STATUS    RESTARTS   AGE
 pgsql-76a4bfcd64-rt4cn   2/2       Running   0          19m
@@ -44,7 +44,7 @@ pgsql-76a4bfcd64-rt4cn   2/2       Running   0          19m
 
 Open a PostgreSQL interactive terminal:
 
-```shell
+```bash
 kubectl exec -it pgsql-76a4bfcd64-rt4cn -- psql -U sg
 ```
 

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -2,42 +2,51 @@
 
 Site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users.
 
-- [Install Sourcegraph](install.md)
-  - [Install Sourcegraph with Docker](install/docker.md)
-  - [Install Sourcegraph on a cluster](install/cluster.md)
-- Management, deployment, and configuration:
-  - [Configuration](config/index.md)
-  - [Adding Git repositories](repo/add.md) (from a code host or clone URL)
-  - [NGINX HTTP and HTTPS/SSL configuration](nginx.md)
-  - [Management console](management_console.md)
-  - [Repository webhooks](repo/webhooks.md)
-  - [User authentication](auth.md)
-  - [Upgrading Sourcegraph](updates.md)
-  - [Setting the URL for your instance](url.md)
-  - [Monitoring and tracing](monitoring_and_tracing.md)
-     - [Troubleshooting](monitoring_and_tracing.md#troubleshooting)
-  - [Repository permissions](repo/permissions.md)
-  - [Upgrading PostgreSQL](postgres.md)
-  - [Using external databases (PostgreSQL and Redis)](external_database.md)
-  - [User data deletion](user_data_deletion.md)
-- Features:
-  - [Code intelligence and language servers](../user/code_intelligence/index.md)
-  - [Sourcegraph extensions and extension registry](extensions.md)
-  - [Search](search.md)
-  - [Federation](federation.md)
-  - [Pings](pings.md)
-  - [Usage statistics](../user/usage_statistics.md)
-  - [User feedback surveys](../user/user_surveys.md)
-- Integrations:
-  - [GitHub and GitHub Enterprise](../integration/github.md)
-  - [GitLab](../integration/gitlab.md)
-  - [Bitbucket Server](../integration/bitbucket_server.md)
-  - [AWS CodeCommit](../integration/aws_codecommit.md)
-  - [Phabricator](../integration/phabricator.md)
-  - [All integrations](../integration.md)
-- Migration guides:
-  - [From OpenGrok to Sourcegraph](migration/opengrok.md)
-  - [Migrating to Sourcegraph 3.0.1+](migration/3_0.md)
-  - [Migrating to Sourcegraph 3.7.2+](migration/3_7.md)
+## [Install Sourcegraph](install/index.md)
+
+- [Install Sourcegraph with Docker](install/docker/index.md)
+- [Install Sourcegraph on a cluster](install/cluster.md)
+  
+## Management, deployment, and configuration
+
+- [Configuration](config/index.md)
+- [Adding Git repositories](repo/add.md) (from a code host or clone URL)
+- [NGINX HTTP and HTTPS/SSL configuration](nginx.md)
+- [Management console](management_console.md)
+- [Repository webhooks](repo/webhooks.md)
+- [User authentication](auth/index.md)
+- [Upgrading Sourcegraph](updates.md)
+- [Setting the URL for your instance](url.md)
+- [Monitoring and tracing](monitoring_and_tracing.md)
+    - [Troubleshooting](monitoring_and_tracing.md#troubleshooting)
+- [Repository permissions](repo/permissions.md)
+- [Upgrading PostgreSQL](postgres.md)
+- [Using external databases (PostgreSQL and Redis)](external_database.md)
+- [User data deletion](user_data_deletion.md)
+
+## Features
+
+- [Code intelligence and language servers](../user/code_intelligence/index.md)
+- [Sourcegraph extensions and extension registry](extensions/index.md)
+- [Search](search.md)
+- [Federation](federation/index.md)
+- [Pings](pings.md)
+- [Usage statistics](../user/usage_statistics.md)
+- [User feedback surveys](../user/user_surveys.md)
+
+## Integrations
+
+- [GitHub and GitHub Enterprise](../integration/github.md)
+- [GitLab](../integration/gitlab.md)
+- [Bitbucket Server](../integration/bitbucket_server.md)
+- [AWS CodeCommit](../integration/aws_codecommit.md)
+- [Phabricator](../integration/phabricator.md)
+- [All integrations](../integration/index.md)
+
+## Migration guides
+
+- [From OpenGrok to Sourcegraph](migration/opengrok.md)
+- [Migrating to Sourcegraph 3.0.1+](migration/3_0.md)
+- [Migrating to Sourcegraph 3.7.2+](migration/3_7.md)
 - [Pricing and subscriptions](subscriptions/index.md)
 - [FAQ](faq.md)

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -59,7 +59,7 @@ Substitute the path to your `cloud-init.txt` file, the name of your key pair, an
 
 To update to the most recent version of Sourcegraph (X.Y.Z), SSH into your instance and run the following:
 
-```shell
+```bash
 docker ps # get the $CONTAINER_ID of the running sourcegraph/server container
 docker rm -f $CONTAINER_ID
 docker run docker run -d --publish 80:7080 --publish 443:7080 --publish 2633:2633 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:X.Y.Z

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -1,4 +1,4 @@
 # Installing Sourcegraph
 
-- [Install Sourcegraph with Docker](docker.md) **(recommended, easiest)**
+- [Install Sourcegraph with Docker](docker/index.md) **(recommended, easiest)**
 - [Install Sourcegraph on a cluster](cluster.md)

--- a/doc/admin/migration/3_7.md
+++ b/doc/admin/migration/3_7.md
@@ -18,7 +18,7 @@ For example, in the below examples we see 126 GiB is currently in use. Multiplyi
 <summary><strong>Single-container Docker deployment</strong></summary>
 Run the following on the host machine:
 
-```sh
+```bash
 $ du -sh ~/.sourcegraph/data/zoekt/index/
 126G	/Users/jane/.sourcegraph/data
 ```
@@ -38,7 +38,7 @@ $ POD_NAME='indexed-search-974c74498-6jngm' kubectl --namespace=prod exec -it $P
 <summary><strong>Pure-Docker cluster deployment</strong></summary>
 Run the following against the `zoekt-shared-disk` directory on the host machine:
 
-```sh
+```bash
 $ du -sh ~/sourcegraph-docker/zoekt-shared-disk/
 126G	/home/ec2-user/sourcegraph-docker/zoekt-shared-disk/
 ```
@@ -58,7 +58,7 @@ If you're eager or want to confirm, here's how to check the process has finished
 <summary><strong>Single-container Docker deployment</strong></summary>
 The following command ran on the host machine shows how many repositories have been reindexed:
 
-```sh
+```bash
 $ ls ~/.sourcegraph/data/zoekt/index/*_v16* | wc -l
       12583
 ```
@@ -70,7 +70,7 @@ When it is equal to the number of repositories on your instance, the process has
 <summary><strong>Kubernetes cluster deployment</strong></summary>
 The following command will show how many repositories have been reindexed. Replace the value of `$POD_NAME` with your `indexed-search` pod name from `kubectl get pods`:
 
-```sh
+```bash
 $ kubectl --namespace=prod exec -it indexed-search-974c74498-6jngm -c zoekt-indexserver -- sh -c 'ls /data/index/*_v16* | wc -l'
 12583
 ```
@@ -82,7 +82,7 @@ When it is equal to the number of repositories on your instance, the process has
 <summary><strong>Pure-Docker cluster deployment</strong></summary>
 The following command ran on the host machine against the `zoekt-shared-disk` directory will show how many repositories have been reindexed.
 
-```sh
+```bash
 $ ls ~/sourcegraph-docker/zoekt-shared-disk/*_v16* | wc -l
 12583
 ```

--- a/doc/admin/monitoring_and_tracing.md
+++ b/doc/admin/monitoring_and_tracing.md
@@ -27,7 +27,7 @@ This URL will show the home dashboard and from there you can add, modify and del
 If you're using the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph),  
 you can access Grafana directly using Kubernetes port forwarding to your local machine:
 
-```shell script
+```bash script
 kubectl port-forward svc/grafana 3370:30070
 ``` 
 
@@ -38,14 +38,14 @@ an additional docker port is not recommended since the embedded Grafana runs in 
 the tools `sshuttle` and `socat` to create a secure connection. Log into your remote server using ssh 
 and run these commands: 
 
-```shell script
+```bash script
 docker exec -t XXX_CONTAINER_ID_XXXX apk add --no-cache socat
 socat tcp-listen:3370,reuseaddr,fork system:"docker exec -i 7298cae012eb socat stdio 'tcp:localhost:3370'"
 ```
 
 On your local machine start a `sshuttle` session to your remote server
 
-```shell script
+```bash script
 sshuttle -r xxx_user_xxx@sxxx_remote_server_xxx 0/0
 ```
 
@@ -53,7 +53,7 @@ sshuttle -r xxx_user_xxx@sxxx_remote_server_xxx 0/0
 
 If you are running Sourcegraph as single server behind a firewall you can add an additional publish flag for the Grafana port 3370:
 
-```shell script
+```bash script
 docker run --publish 7080:7080 --publish 2633:2633 --publish 3370:3370 \
   --rm --volume ~/.sourcegraph/config:/etc/sourcegraph \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.9.1
@@ -79,7 +79,7 @@ The environment variable `PROMETHEUS_ADDITIONAL_FLAGS` can be used to pass on ad
 
 We are running our own image of Grafana which contains a standard Grafana installation packaged together with provisioned dashboards.
 
-> Note: Our Grafana instance runs in anonymous mode with all authentication turned off. Please be careful when exposing it directly.
+> NOTE: Our Grafana instance runs in anonymous mode with all authentication turned off. Please be careful when exposing it directly.
 
 A directory containing dashboard json specifications can be mounted in the docker container at
 `/sg_grafana_additional_dashboards` and they will be picked up automatically. Changes to files in that directory

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -2,13 +2,11 @@
 
 Sourcegraph can be configured to enforce repository permissions from code hosts.
 
-Currently, GitHub, GitHub Enterprise, GitLab and Bitbucket Server permissions are supported. Check the [roadmap](../../dev/roadmap.md) for plans to
-support other code hosts. If your desired code host is not yet on the roadmap, please [open a
-feature request](https://github.com/sourcegraph/sourcegraph/issues/new?template=feature_request.md).
+Currently, GitHub, GitHub Enterprise, GitLab and Bitbucket Server permissions are supported. Check the [roadmap](../../dev/roadmap/index.md) for plans to support other code hosts. If your desired code host is not yet on the roadmap, please [open a feature request](https://github.com/sourcegraph/sourcegraph/issues/new?template=feature_request.md).
 
 ## GitHub
 
-Prerequisite: [Add GitHub as an authentication provider.](../auth.md#github)
+Prerequisite: [Add GitHub as an authentication provider.](../auth/index.md#github)
 
 Then, [add or edit a GitHub external service](../external_service/github.md#repository-syncing) and include the `authorization` field:
 
@@ -34,7 +32,7 @@ GitLab permissions can be configured in three ways:
 
 ### OAuth application
 
-Prerequisite: [Add GitLab as an authentication provider.](../auth.md#gitlab)
+Prerequisite: [Add GitLab as an authentication provider.](../auth/index.md#gitlab)
 
 Then, [add or edit a GitLab external service](../external_service/gitlab.md#repository-syncing) and include the `authorization` field:
 
@@ -53,7 +51,7 @@ Then, [add or edit a GitLab external service](../external_service/gitlab.md#repo
 
 ### Sudo access token
 
-Prerequisite: Add the [SAML](../auth.md#saml) or [OpenID Connect](../auth.md#openid-connect)
+Prerequisite: Add the [SAML](../auth/index.md#saml) or [OpenID Connect](../auth/index.md#openid-connect)
 authentication provider you use to sign into GitLab.
 
 Then, [add or edit a GitLab external service](../external_service/gitlab.md#repository-syncing) and include the `authorization` field:
@@ -107,7 +105,7 @@ Enforcing Bitbucket Server permissions can be configured via the `authorization`
 ### Prerequisites
 
 1. You have **fewer than 2500 repositories** on your Bitbucket Server instance.
-1. You have the exact same user accounts, **with matching usernames**, in Sourcegraph and Bitbucket Server. This can be accomplished by configuring an [external authentication provider](../auth.md) that mirrors user accounts from a central directory like LDAP or Active Directory. The same should be done on Bitbucket Server with [external user directories](https://confluence.atlassian.com/bitbucketserver/external-user-directories-776640394.html).
+1. You have the exact same user accounts, **with matching usernames**, in Sourcegraph and Bitbucket Server. This can be accomplished by configuring an [external authentication provider](../auth/index.md) that mirrors user accounts from a central directory like LDAP or Active Directory. The same should be done on Bitbucket Server with [external user directories](https://confluence.atlassian.com/bitbucketserver/external-user-directories-776640394.html).
 1. Ensure you have set `auth.enableUsernameChanges` to **`false`** in the [Critical site config](../config/critical_config.md) to prevent users from changing their usernames and **escalating their privileges**.
 
 

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -25,7 +25,7 @@ To set up mkcert on the Sourcegraph instance:
 1. [Install mkcert](https://github.com/FiloSottile/mkcert#installation)
 1. Create the root [CA](https://en.wikipedia.org/wiki/Certificate_authority) by running:
 
-```shell
+```bash
 sudo CAROOT=~/.sourcegraph/config mkcert -install
 ```
 
@@ -33,7 +33,7 @@ sudo CAROOT=~/.sourcegraph/config mkcert -install
 
 Now that the root CA has been created, mkcert can issue a self-signed certificate (`sourcegraph.crt`) and key (`sourcegraph.key`).
 
-```shell
+```bash
 sudo CAROOT=~/.sourcegraph/config mkcert \
   -cert-file ~/.sourcegraph/config/sourcegraph.crt \
   -key-file ~/.sourcegraph/config/sourcegraph.key \
@@ -77,7 +77,7 @@ http {
 
 Now that NGINX is listening on port 443, we need the Sourcegraph container to listen on port 443 by adding `--publish 443:7080` to the `docker run` command:
 
-```shell
+```bash
 docker container run \
   --rm  \
   --publish 7080:7080 \
@@ -103,24 +103,24 @@ To have the browser trust the certificate, the root CA on the Sourcegraph instan
 
 **2.** Downloading `rootCA-key.pem` and `rootCA.pem` from `~/.sourcegraph/config/mkcert` on the Sourcegraph instance to the location of `mkcert -CAROOT` on your local machine:
 
-```shell
+```bash
 # Run locally: Ensure directory the root CA files will be downloaded to exists
 mkdir -p "$(mkcert -CAROOT)"
 ```
 
-```shell
+```bash
 # Run on Sourcegraph host: Ensure `scp` user can read (and therefore download) the root CA files
 sudo chown $USER ~/.sourcegraph/config/root*
 ```
 
-```shell
+```bash
 # Run locally: Download the files (change username and hostname)
 scp user@example.com:~/.sourcegraph/config/root* "$(mkcert -CAROOT)"
 ```
 
 **3.** Install the root CA by running:
 
-```shell
+```bash
 mkcert -install
 ```
 

--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -4,7 +4,7 @@
 
 If you are using Docker Toolbox on Windows to run Sourcegraph, you may see an error in the `frontend` log output:
 
-```shell
+```bash
 frontend |
      frontend |
      frontend |
@@ -15,7 +15,7 @@ After this error, no more `frontend` log output is printed.
 
 This problem is caused by [docker/toolbox#695](https://github.com/docker/toolbox/issues/695#issuecomment-356218801) in Docker Toolbox on Windows. To work around it, set the environment variable `LOGO=false`, as in:
 
-```shell
+```bash
 docker container run -e LOGO=false ... sourcegraph/server
 ```
 

--- a/doc/adopt/trial/index.md
+++ b/doc/adopt/trial/index.md
@@ -2,7 +2,7 @@
 
 Sourcegraph has been deployed inside of thousands of organizations. From our experience working with those that have been successful, and those that haven't, we have collected a set of recommendations for running an effective trial.
 
-> Note: Trying Sourcegraph during a Hackathon? Check out our [Hackathon offerings](https://about.sourcegraph.com/hackathons) and let us know!
+> NOTE: Trying Sourcegraph during a Hackathon? Check out our [Hackathon offerings](https://about.sourcegraph.com/hackathons) and let us know!
 
 ## 1. Define trial success
 
@@ -67,11 +67,11 @@ A typical message to the team looks like:
 
 ## 4. Deploy integrations
 
-Sourcegraph is most useful when it's at your fingertips. Our [integrations](../../integration/index.md), including our [Chrome and Firefox extensions](../../integration/browser_extension/index.md) which provide code intelligence in GitHub, GitLab, Bitbucket, Phabricator, and more, and also provide a search shortcut from the browser URL bar:
+Sourcegraph is most useful when it's at your fingertips. Our [integrations](../../integration/index.md), including our [Chrome and Firefox extensions](../../integration/browser_extension.md) which provide code intelligence in GitHub, GitLab, Bitbucket, Phabricator, and more, and also provide a search shortcut from the browser URL bar:
 
 ![Sourcegraph browser extension](https://storage.googleapis.com/sourcegraph-assets/BrowserExtension.gif)
 
-For short trials, however, companies often choose to only set up our search shortcut (or "omnibox") integration (though it provides less functionality, it may require fewer internal approvals). See [our guide for setting up search shortcuts](../../integration/browser_search_engine/index.md).
+For short trials, however, companies often choose to only set up our search shortcut (or "omnibox") integration (though it provides less functionality, it may require fewer internal approvals). See [our guide for setting up search shortcuts](../../integration/browser_search_engine.md).
 
 ## 5. Measure success
 

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -3,4 +3,4 @@
 Sourcegraph exposes the following APIs:
 
 - [Sourcegraph GraphQL API](graphql/index.md), for accessing data stored or computed by Sourcegraph
-- [Sourcegraph extension API](../extensions.md), for extending the functionality of Sourcegraph and other tools (including code hosts)
+- [Sourcegraph extension API](../extensions/index.md), for extending the functionality of Sourcegraph and other tools (including code hosts)

--- a/doc/dev/documentation/site.md
+++ b/doc/dev/documentation/site.md
@@ -45,7 +45,7 @@ This runs a docsite server on http://localhost:5081 that reads templates and ass
 
 If you want to run the doc site *exactly* as it's deployed (reading templates and assets from the remote Git repository, too), consult the current Kubernetes deployment spec and invoke `docsite serve` with the deployment's `DOCSITE_CONFIG` env var, the end result looking something like:
 
-```shell
+```bash
 DOCSITE_CONFIG=$(cat <<-'DOCSITE'
 {
   "templates": "https://codeload.github.com/sourcegraph/sourcegraph/zip/master#*/doc/_resources/templates/",

--- a/doc/dev/documentation/style_guide.md
+++ b/doc/dev/documentation/style_guide.md
@@ -182,26 +182,19 @@ below.
 
 ### Sourcegraph versions and tiers
 
-- Every piece of documentation that comes with a new feature should declare the
-  Sourcegraph version that the feature was introduced in. Right below the heading add a
-  blockquote:
+> NOTE: Every feature should link to the blog post, issue, or pull request (in that order) that introduced it.
 
-  ```md
-  > Introduced in Sourcegraph 8.3.
-  ```
+New features should be documented to include the Sourcegraph version in which they were introduced.
 
-- Whenever possible, every feature should have a link to the blog post, issue, or pull request
-  (in that order) that introduced it. The above quote would be then transformed to:
+```md
+> Introduced in Sourcegraph 8.3.
+```
 
-  ```md
-  > [Introduced](link) in Sourcegraph 2.10.
-  ```
+If the feature is only available in Sourcegraph Enterprise, mention that:
 
-- If the feature is only available in Sourcegraph Enterprise, mention that:
-
-  ```md
-  > [Introduced](link) in [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing) 2.10.
-  ```
+```md
+> Introduced in Sourcegraph Enterprise 2.10.
+```
 
 <!-- TODO(sqs): Consider adding product tier badges. -->
 

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -19,7 +19,7 @@ Have a look around, our code is on [GitHub](https://sourcegraph.com/github.com/s
 
 ## Environment
 
-Sourcegraph server is a collection of smaller binaries. The development server, [dev/launch.sh](https://github.com/sourcegraph/sourcegraph/blob/master/dev/launch.sh), initializes the environment and starts a process manager that runs all of the binaries. See the [Architecture doc](architecture.md) for a full description of what each of these services does. The sections below describe the dependencies you need to run `dev/launch.sh`.
+Sourcegraph server is a collection of smaller binaries. The development server, [dev/launch.sh](https://github.com/sourcegraph/sourcegraph/blob/master/dev/launch.sh), initializes the environment and starts a process manager that runs all of the binaries. See the [Architecture doc](architecture/index.md) for a full description of what each of these services does. The sections below describe the dependencies you need to run `dev/launch.sh`.
 
 ## Step 1: Install dependencies
 

--- a/doc/dev/phabricator_gitolite.md
+++ b/doc/dev/phabricator_gitolite.md
@@ -111,9 +111,9 @@ dev/phabricator/stop.sh
 
 #### Add repositories
 
-1. Click the link to [Diffusion](http://127.0.0.1/diffusion/)
+1. Click the link to [Diffusion](http://localhost/diffusion/)
 
-2. [Create a repository](http://127.0.0.1/diffusion/edit) and
+2. [Create a repository](http://localhost/diffusion/edit) and
     select git as the vcs
 
     Give the repository a name and a callsign with only

--- a/doc/dev/retrospectives/customer_license_expiration.md
+++ b/doc/dev/retrospectives/customer_license_expiration.md
@@ -20,7 +20,7 @@ Fundamentally, the process is entirely manual today. It's up to the member of th
 
 What are we going to change to make sure customers get the correct license keys at the correct time?
 
-A few things. These changes all have the goal of making the process less manual/artisinal/custom.
+A few things. These changes all have the goal of making the process less manual/artisanal/custom.
 
 1. Dan will add code that creates a dismissable site alert for admins starting 7 days out from license expiration.
 1. Dan will add a page (or add functionality to an existing page) that shows licenses in ascending order by expiration date on Sourcegraph.com, so we can see which ones will be expiring soon.

--- a/doc/dev/retrospectives/customer_license_expiration.md
+++ b/doc/dev/retrospectives/customer_license_expiration.md
@@ -2,9 +2,9 @@
 
 ## Incident details
 
-* Date: Feb 21, 2019
-* Customer: https://app.hubspot.com/contacts/2762526/company/419771425
-* Discussion: https://sourcegraph.slack.com/archives/G9EN3TJDD/p1553176601007400
+- Date: Feb 21, 2019
+- Customer: https://app.hubspot.com/contacts/2762526/company/419771425
+- Discussion: https://sourcegraph.slack.com/archives/G9EN3TJDD/p1553176601007400
 
 ## Why did this happen?
 
@@ -22,12 +22,8 @@ What are we going to change to make sure customers get the correct license keys 
 
 A few things. These changes all have the goal of making the process less manual/artisinal/custom.
 
-1) Dan will add code that creates a dismissable site alert for admins starting 7 days out from license expiration.
-
-2) Dan will add a page (or add functionality to an existing page) that shows licenses in ascending order by expiration date on Sourcegraph.com, so we can see which ones will be expiring soon.
-
-3) To prevent fixes to similar issues in the future from becoming bottlenecked on GTM team member availability, Engineers will be permanently formally approved to create licenses for unlimited numbers of users for up to 7 days.
-
-  Dan will add information on dev team license key creation permissions, along with steps for creating the license key, to our dev docs at https://docs.sourcegraph.com/dev/incidents/index.md.
-
-4) Dan will audit all current license keys and remove tests and expired keys
+1. Dan will add code that creates a dismissable site alert for admins starting 7 days out from license expiration.
+1. Dan will add a page (or add functionality to an existing page) that shows licenses in ascending order by expiration date on Sourcegraph.com, so we can see which ones will be expiring soon.
+1. To prevent fixes to similar issues in the future from becoming bottlenecked on GTM team member availability, Engineers will be permanently formally approved to create licenses for unlimited numbers of users for up to 7 days.
+1. Dan will add information on dev team license key creation permissions, along with steps for creating the license key, to our development docs.
+1. Dan will audit all current license keys and remove tests and expired keys

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -100,10 +100,9 @@ The default sharing state of documents in our [Google Drive's RFCs](https://driv
 Sometimes there is information relevant to an RFC, but that information can't be made public.
 
 - RFCs should never reference customer names directly, even if they are listed on our homepage. Instead, you can use a Hubspot link or an arbitrary code name (e.g. "ACME", "Customer X") for each customer that you need to reference in the document. Code names do not need to be consistent across documents. The first usage of each code name should be linked to the actual company's profile in Hubspot.
-  - To make this easy, add a search engine to your browser so that you can quickly type `h ACME` or `h sourcegraph` to find the company in Hubspot.
-    - Use this URL https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s
+    - To make this easy, add a search engine to your browser so that you can quickly type `h ACME` or `h sourcegraph` to find the company in         - Use this URL [https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s)
     ![Hubspot search](hubspot-search.png)
-    - Don't share the link to the search results (it has the company name in the search)! Instead, share the direct link to the company; it should look like this: https://app.hubspot.com/contacts/2762526/company/557690851/.
+            - Don't share the link to the search results (it has the company name in the search)! Instead, share the direct link to the company; it should look like this: [https://app.hubspot.com/contacts/2762526/company/557690851/](https://app.hubspot.com/contacts/2762526/company/557690851/)
     ![Hubspot results](hubspot-results.png)
 - If there is strategic information that shouldn't be public, you can post it in Slack and link to it from the public RFC.
 - If a material amount of the content is non-public then it is ok to make the RFC only accessible to the Sourcegraph team.

--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -31,7 +31,8 @@ Our current product priorities are:
 
 Sourcegraph is intuitive to use for a wide range of roles, from developers to PMs, engineering managers, data analysts, and more. It adds value to this wide range of roles by making more information about code available, such as language statistics and dependency graphs. [Search has an improved UI](https://docs.google.com/document/d/1Vo7HlwO_HgrK8O-VEIZ9wHuSyHdEA0zk9qucNCoF0jg/edit?usp=sharing) that makes it more accessible, easier to use, and faster to drill down on what you're looking for.
 
-Improving upon on our [basic code intelligence](../../user/code_intelligence.md) that works for every language, Sourcegraph provides precise code intelligence for a subset of common languages including Go, TypeScript, C/C++, Java, and C#.
+Improving upon on our [basic code intelligence](../../user/code_intelligence/index
+.md) that works for every language, Sourcegraph provides precise code intelligence for a subset of common languages including Go, TypeScript, C/C++, Java, and C#.
 
 ### Enhanced scalablity, reliability, and security
 

--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -31,8 +31,7 @@ Our current product priorities are:
 
 Sourcegraph is intuitive to use for a wide range of roles, from developers to PMs, engineering managers, data analysts, and more. It adds value to this wide range of roles by making more information about code available, such as language statistics and dependency graphs. [Search has an improved UI](https://docs.google.com/document/d/1Vo7HlwO_HgrK8O-VEIZ9wHuSyHdEA0zk9qucNCoF0jg/edit?usp=sharing) that makes it more accessible, easier to use, and faster to drill down on what you're looking for.
 
-Improving upon on our [basic code intelligence](../../user/code_intelligence/index
-.md) that works for every language, Sourcegraph provides precise code intelligence for a subset of common languages including Go, TypeScript, C/C++, Java, and C#.
+Improving upon on our [basic code intelligence](../../user/code_intelligence/index.md) that works for every language, Sourcegraph provides precise code intelligence for a subset of common languages including Go, TypeScript, C/C++, Java, and C#.
 
 ### Enhanced scalablity, reliability, and security
 

--- a/doc/extensions/authoring/creating.md
+++ b/doc/extensions/authoring/creating.md
@@ -21,7 +21,7 @@ You can use any build tool you wish, so long as it meets these requirements.
 
 The easiest way to get an extension ready to publish is to use the [Sourcegraph extension creator](https://github.com/sourcegraph/create-extension):
 
-```shell
+```bash
 mkdir my-extension
 cd my-extension
 npm init sourcegraph-extension
@@ -29,7 +29,7 @@ npm init sourcegraph-extension
 
 Follow the prompts, and when complete, you'll have the following files:
 
-```shell
+```bash
 ├── README.md
 ├── node_modules
 ├── package-lock.json

--- a/doc/extensions/authoring/publishing.md
+++ b/doc/extensions/authoring/publishing.md
@@ -9,7 +9,7 @@ When [setting up your development environment](development_environment.md), you'
 
 Now publish your extension by running:
 
-```shell
+```bash
 src extensions publish
 ```
 

--- a/doc/extensions/authoring/tutorials/hello_world.md
+++ b/doc/extensions/authoring/tutorials/hello_world.md
@@ -17,7 +17,7 @@ Follow the instructions for [setting up your development environment](../develop
 
 Use the [Sourcegraph extension creator](https://github.com/sourcegraph/create-extension) to get started:
 
-```shell
+```bash
 mkdir hello-world-extension
 cd hello-world-extension
 npm init sourcegraph-extension
@@ -31,7 +31,7 @@ Now let's publish it so you (and other people) can use it.
 
 Publish the extension by running:
 
-```shell
+```bash
 src ext publish
 ```
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -60,7 +60,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 - [**Administrator documentation**](admin/index.md)
 - [Install Sourcegraph](admin/install/index.md) or [update Sourcegraph](admin/updates.md)
 - [Sourcegraph extensions](extensions/index.md)
-- [Roadmap](dev/roadmap.md)
+- [Roadmap](dev/roadmap/index.md)
 
 ### Features and tutorials
 

--- a/doc/integration/phabricator.md
+++ b/doc/integration/phabricator.md
@@ -7,7 +7,7 @@ Feature | Supported?
 [Repository syncing and mirroring](../admin/external_service/phabricator.md#repository-linking-and-syncing) | ❌
 [Repository association](../admin/external_service/phabricator.md#repository-linking-and-syncing) | ✅
 [Repository permissions](../admin/repo/permissions.md) | ❌
-[User authentication](../admin/auth.md) | ❌
+[User authentication](../admin/auth/index.md) | ❌
 [Browser extension](#browser-extension) | ✅
 [Native extension](../admin/external_service/phabricator.md#native-extension) | ✅
 

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -11,7 +11,7 @@ Code intelligence works out of the box with all of the most popular [programming
 
 There are two ways to get more precise code intelligence:
 
-- **Recommended**: [upload LSIF code intelligence data](./lsif.md)
+- Recommended: [upload LSIF code intelligence data](./lsif.md)
 - Not recommended: [deploy a language server](./language_servers.md)
 
 Code intelligence is provided by [Sourcegraph extensions](../../extensions/index.md).
@@ -23,34 +23,32 @@ By spinning up Sourcegraph, you can get code intelligence:
 - On diffs in your code review tool, via our [integrations](../../integration/index.md)
 - Via the Sourcegraph API (for programmatic access)
 
-**Hover tooltips with documentation and type signatures (using a language server)**
+## Hover tooltips with documentation and type signatures (using a language server)
 
 <img src="img/hover-tooltip.png" width="500"/>
 
-**Go to definition (using a language server)**
+## Go to definition (using a language server)
 
 <img src="img/go-to-def.gif" width="500"/>
 
-**Find references (using a language server)**
+## Find references (using a language server)
 
 <img src="img/find-refs.gif" width="450"/>
 
-**GitHub pull request and file integration (using a language server)**
+## GitHub pull request and file integration (using a language server)
 
 <img src="img/CodeReview.gif" width="450" style="margin-left:0;margin-right:0;"/>
 
-**Symbol search**
+## Symbol search
 
 <img src="img/Symbols.png" width="500"/>
 
-**Symbol sidebar**
+## Symbol sidebar
 
 <img src="img/SymbolSidebar.png" width="500"/>
-
----
 
 ## Getting started
 
 - [Set up Sourcegraph](../../admin/install/index.md), then enable the [Sourcegraph extension](../index.md) for each language you want to use.
-- To get code intelligence on your code host and/or code review tool, see the [browser extension documentation](../../../integration/browser_extension.md).
+- To get code intelligence on your code host and/or code review tool, see the [browser extension documentation](../../integration/browser_extension.md).
 - Interested in trying it out on public code? See [this sample file](https://sourcegraph.com/github.com/dgrijalva/jwt-go/-/blob/token.go#L37:6$references) on Sourcegraph.com.

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -22,19 +22,19 @@ Several languages are currently supported:
 
 Install the LSIF indexer for your language (e.g. Go):
 
-```
-$ go get github.com/sourcegraph/lsif-go/cmd/lsif-go
+```bash
+go get github.com/sourcegraph/lsif-go/cmd/lsif-go
 ```
 
 Generate `data.lsif` in your project root (most LSIF indexers require a proper build environment: dependencies have been fetched, environment variables are set, etc.):
 
-```
+```bash
 some-project-dir$ lsif-go --noContents --out=data.lsif
 ```
 
 Then, upload `data.lsif` to your Sourcegraph instance via the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli):
 
-```
+```bash
 some-project-dir$ src \
   -endpoint=https://sourcegraph.example.com \
   lsif upload \
@@ -51,10 +51,12 @@ If successful, you'll see the following message:
 
 If an error occurred, you'll see it in the response.
 
-Go to your global settings at https://sourcegraph.example.com/site-admin/global-settings and enable LSIF:
+Go to your global settings at `/site-admin/global-settings` and enable LSIF:
 
 ```json
+{
   "codeIntel.lsif": true
+}
 ```
 
 After uploading LSIF files, your Sourcegraph instance will use these files to power code intelligence so that when you visit a file in that repository on your Sourcegraph instance, the code intelligence should be more precise than it was out-of-the-box.

--- a/doc/user/search/index.md
+++ b/doc/user/search/index.md
@@ -81,7 +81,7 @@ Unscoped search results over large repository sets may trail latest default bran
 
 ### Max file size
 
-By default, files larger than 1 MB are excluded from search results. Use the [search.largeFiles](../../admin/config/site_config/index.md#search-largeFiles) keyword to specify files to be indexed and searched regardless of size.
+By default, files larger than 1 MB are excluded from search results. Use the [search.largeFiles](../../admin/config/site_config.md#search-largeFiles) keyword to specify files to be indexed and searched regardless of size.
 
 ---
 

--- a/doc/user/tour.md
+++ b/doc/user/tour.md
@@ -14,7 +14,7 @@ Using Sourcegraph makes you a more effective code reviewer because code intellig
 
 Requirements:
 
-- [Install Sourcegraph](../admin/install.md) and add repositories
+- [Install Sourcegraph](../admin/install/index.md) and add repositories
 - [Install the integration for your code host/review tool](../integration/index.md)
 
 Workflow:
@@ -35,7 +35,7 @@ Viewing cross-references (internal and external) on Sourcegraph is a great way t
 
 Requirements:
 
-- [Install Sourcegraph](../admin/install.md) and add repositories
+- [Install Sourcegraph](../admin/install/index.md) and add repositories
 - [Install the browser extension and editor plugin](../integration/index.md) for a faster way to initiate searches (optional)
 
 Workflow:
@@ -58,7 +58,7 @@ Navigating your code with code intelligence on Sourcegraph is a great way to und
 
 Requirements:
 
-- [Install Sourcegraph](../admin/install.md) and add repositories
+- [Install Sourcegraph](../admin/install/index.md) and add repositories
 - [Install the browser extension and editor plugin](../integration/index.md) for a faster way to initiate searches (optional)
 
 Workflow:
@@ -80,7 +80,7 @@ Diff search on Sourcegraph is a great starting point for your investigation into
 
 Requirements:
 
-- [Install Sourcegraph](../admin/install.md) and add repositories
+- [Install Sourcegraph](../admin/install/index.md) and add repositories
 - [Install the browser extension and editor plugin](../integration/index.md) for a faster way to initiate searches (optional)
 
 Workflow:


### PR DESCRIPTION
The `docsite check` command has missed a good deal of broken links over time and this PR fixes them.

These were found serving the markdown files from a local http server, then running the macOS app [Integrity](https://apps.apple.com/us/app/integrity/id513610341?mt=12) against it until all broken links were fixed.

Obviously doing this manually is not sustainable, but a similar automated approach may be preferable so broken link and image checking could be decoupled and therefore removed from docsite.