### PR TITLE
Move cyclic constants into the same file.

### DIFF
--- a/lsif/src/commits.ts
+++ b/lsif/src/commits.ts
@@ -1,20 +1,9 @@
 import got from 'got'
-import { XrepoDatabase, MAX_TRAVERSAL_LIMIT } from './xrepo'
+import { XrepoDatabase } from './xrepo'
 import * as crypto from 'crypto'
 import { TracingContext, logAndTraceCall } from './tracing'
 import { chunk } from 'lodash'
-
-/**
- * The number of commits to ask gitserver for when updating commit data for
- * a particular repository. This should be just slightly above the max traversal
- * limit.
- */
-const MAX_COMMITS_PER_UPDATE = MAX_TRAVERSAL_LIMIT * 1.5
-
-/**
- * The maximum number of requests we can make to gitserver in a single batch.
- */
-const MAX_CONCURRENT_GITSERVER_REQUESTS = 100
+import { MAX_CONCURRENT_GITSERVER_REQUESTS, MAX_COMMITS_PER_UPDATE } from './constants'
 
 /**
  * Update the commits tables in the cross-repository database with the current

--- a/lsif/src/constants.ts
+++ b/lsif/src/constants.ts
@@ -1,3 +1,26 @@
 export const DBS_DIR = 'dbs'
 export const TEMP_DIR = 'temp'
 export const UPLOADS_DIR = 'uploads'
+
+/**
+ * The maximum number of commits to visit breadth-first style when when finding
+ * the closest commit.
+ */
+export const MAX_TRAVERSAL_LIMIT = 100
+
+/**
+ * A random integer specific to the xrepo database used to generate advisory lock ids.
+ */
+export const ADVISORY_LOCK_ID_SALT = 1688730858
+
+/**
+ * The number of commits to ask gitserver for when updating commit data for
+ * a particular repository. This should be just slightly above the max traversal
+ * limit.
+ */
+export const MAX_COMMITS_PER_UPDATE = MAX_TRAVERSAL_LIMIT * 1.5
+
+/**
+ * The maximum number of requests we can make to gitserver in a single batch.
+ */
+export const MAX_CONCURRENT_GITSERVER_REQUESTS = 100

--- a/lsif/src/xrepo.test.ts
+++ b/lsif/src/xrepo.test.ts
@@ -1,5 +1,6 @@
 import rmfr from 'rmfr'
-import { XrepoDatabase, MAX_TRAVERSAL_LIMIT } from './xrepo'
+import { XrepoDatabase } from './xrepo'
+import { MAX_TRAVERSAL_LIMIT } from './constants'
 import { createCleanPostgresDatabase, createCommit, truncatePostgresTables, createStorageRoot } from './test-utils'
 import { Connection } from 'typeorm'
 import { fail } from 'assert'

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -13,17 +13,7 @@ import { TableInserter } from './inserter'
 import { discoverAndUpdateCommit } from './commits'
 import { TracingContext } from './tracing'
 import { dbFilename, tryDeleteFile } from './util'
-
-/**
- * The maximum number of commits to visit breadth-first style when when finding
- * the closest commit.
- */
-export const MAX_TRAVERSAL_LIMIT = 100
-
-/**
- * A random integer specific to the xrepo database used to generate advisory lock ids.
- */
-const ADVISORY_LOCK_ID_SALT = 1688730858
+import { MAX_TRAVERSAL_LIMIT, ADVISORY_LOCK_ID_SALT } from './constants'
 
 /**
  * The insertion metrics for the cross-repo database.


### PR DESCRIPTION
We were sending -NaN to gitserver because the import order was all messed up between commits and xrepo files. This doesn't fix the cyclic dependency, but does ensure that both constants are actually defined as numbers.