### PR TITLE
all: Use Deprecated: style comments as encouraged by some tools.

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -24,8 +24,8 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 	return &OrgResolver{org: org}, nil
 }
 
-// Org is DEPRECATED (but still in use by sourcegraph/src). Use Node to look up an org by its
-// graphql.ID instead.
+// Deprecated: Org is only in use by sourcegraph/src. Use Node to look up an
+// org by its graphql.ID instead.
 func (r *schemaResolver) Org(ctx context.Context, args *struct {
 	ID graphql.ID
 }) (*OrgResolver, error) {

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -95,7 +95,7 @@ func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 	return string(final), err
 }
 
-// DEPRECATED (in the GraphQL API)
+// Deprecated: in the GraphQL API
 func (r *settingsCascade) Merged(ctx context.Context) (*configurationResolver, error) {
 	var messages []string
 	s, err := r.Final(ctx)
@@ -181,7 +181,7 @@ func (schemaResolver) ViewerSettings(ctx context.Context) (*settingsCascade, err
 	return &settingsCascade{subject: &settingsSubject{user: user}}, nil
 }
 
-// DEPRECATED (in the GraphQL API)
+// Deprecated: in the GraphQL API
 func (schemaResolver) ViewerConfiguration(ctx context.Context) (*settingsCascade, error) {
 	return schemaResolver{}.ViewerSettings(ctx)
 }

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -72,7 +72,7 @@ func (r *schemaResolver) SettingsMutation(ctx context.Context, args *struct {
 	}, nil
 }
 
-// DEPRECATED in the GraphQL API
+// Deprecated: in the GraphQL API
 func (r *schemaResolver) ConfigurationMutation(ctx context.Context, args *struct {
 	Input *settingsMutationGroupInput
 }) (*settingsMutation, error) {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -216,7 +216,7 @@ type reposListServer struct {
 	}
 }
 
-// serveList is deprecated. It used to be used by Zoekt to get the list of
+// Deprecated: serveList used to be used by Zoekt to get the list of
 // repositories to index. Can be removed in 3.11.
 func (h *reposListServer) serveList(w http.ResponseWriter, r *http.Request) error {
 	var opt struct {

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -10,12 +10,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httputil"
 )
 
+// Deprecated: NormalizeBaseURL should not be used, instead use
+// externalservice.NormalizeBaseURL
+//
 // NormalizeBaseURL modifies the input and returns a normalized form of the a base URL with insignificant
 // differences (such as in presence of a trailing slash, or hostname case) eliminated. Its return value should be
 // used for the (ExternalRepoSpec).ServiceID field (and passed to XyzExternalRepoSpec) instead of a non-normalized
 // base URL.
-//
-// DEPRECATED in favor of externalservice.NormalizeBaseURL
 func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 	baseURL.Host = strings.ToLower(baseURL.Host)
 	if !strings.HasSuffix(baseURL.Path, "/") {


### PR DESCRIPTION
Staticcheck automatically picks up on this, and GoLand warns if you don't use
this format.