### PR TITLE
Show authz provider problems in site alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Support hyphens in Bitbucket Cloud team names. [#6154](https://github.com/sourcegraph/sourcegraph/issues/6154)
+- Authorization provider configuration errors in external services will be shown as site alerts. [#6061](https://github.com/sourcegraph/sourcegraph/issues/6061)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -142,6 +142,15 @@ func init() {
 					"\n* " + strings.Join(siteProblems.Messages(), "\n* "),
 			})
 		}
+
+		externalServiceProblems := problems.ExternalService()
+		if len(externalServiceProblems) > 0 {
+			alerts = append(alerts, &Alert{
+				TypeValue: AlertTypeWarning,
+				MessageValue: `[**Update external service configuration**](/site-admin/external-services) to resolve problems:` +
+					"\n* " + strings.Join(externalServiceProblems.Messages(), "\n* "),
+			})
+		}
 		return alerts
 	})
 }

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -74,7 +73,7 @@ func ProvidersFromConfig(
 }
 
 func init() {
-	graphqlbackend.ContributeConfigWarning(func(cfg conf.Unified) (problems conf.Problems) {
+	conf.ContributeWarning(func(cfg conf.Unified) (problems conf.Problems) {
 		_, _, seriousProblems, warnings := ProvidersFromConfig(context.Background(), &cfg, db.ExternalServices, dbconn.Global)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 		problems = append(problems, conf.NewExternalServiceProblems(warnings...)...)

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -50,8 +50,9 @@ var ignoreLegacyKubernetesFields = map[string]struct{}{
 type problemKind string
 
 const (
-	problemCritical problemKind = "CriticalConfig"
-	problemSite     problemKind = "SiteConfig"
+	problemCritical        problemKind = "CriticalConfig"
+	problemSite            problemKind = "SiteConfig"
+	problemExternalService problemKind = "ExternalService"
 )
 
 // Problem contains kind and description of a specific configuration problem.
@@ -76,6 +77,14 @@ func NewSiteProblem(msg string) *Problem {
 	}
 }
 
+// NewExternalServiceProblem creates a new external service config problem with given message.
+func NewExternalServiceProblem(msg string) *Problem {
+	return &Problem{
+		kind:        problemExternalService,
+		description: msg,
+	}
+}
+
 // IsCritical returns true if the problem is about critical config.
 func (p Problem) IsCritical() bool {
 	return p.kind == problemCritical
@@ -84,6 +93,11 @@ func (p Problem) IsCritical() bool {
 // IsSite returns true if the problem is about site config.
 func (p Problem) IsSite() bool {
 	return p.kind == problemSite
+}
+
+// IsExternalService returns true if the problem is about external service config.
+func (p Problem) IsExternalService() bool {
+	return p.kind == problemExternalService
 }
 
 func (p Problem) String() string {
@@ -115,6 +129,11 @@ func NewSiteProblems(messages ...string) Problems {
 	return newProblems(problemSite, messages...)
 }
 
+// NewExternalServiceProblems converts a list of messages into external service config problems.
+func NewExternalServiceProblems(messages ...string) Problems {
+	return newProblems(problemExternalService, messages...)
+}
+
 // Messages returns the list of problems in strings.
 func (ps Problems) Messages() []string {
 	if len(ps) == 0 {
@@ -142,6 +161,16 @@ func (ps Problems) Critical() (problems Problems) {
 func (ps Problems) Site() (problems Problems) {
 	for i := range ps {
 		if ps[i].IsSite() {
+			problems = append(problems, ps[i])
+		}
+	}
+	return problems
+}
+
+// ExternalService returns all external service config problems in the list.
+func (ps Problems) ExternalService() (problems Problems) {
+	for i := range ps {
+		if ps[i].IsExternalService() {
 			problems = append(problems, ps[i])
 		}
 	}

--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -89,3 +89,24 @@ func TestValidator(t interface {
 		t.Errorf("got no matches for expected error substrings %q", wantSet)
 	}
 }
+
+// ContributeWarning adds the configuration validator function to the validation process.
+// It is called to validate site configuration. Any problems it returns are shown as configuration
+// warnings in the form of site alerts.
+//
+// It may only be called at init time.
+func ContributeWarning(f Validator) {
+	contributedWarnings = append(contributedWarnings, f)
+}
+
+var contributedWarnings []Validator
+
+// GetWarnings identifies problems with the configuration that a site
+// admin should address, but do not prevent Sourcegraph from running.
+func GetWarnings() (problems Problems, err error) {
+	c := *Get()
+	for i := range contributedWarnings {
+		problems = append(problems, contributedWarnings[i](c)...)
+	}
+	return problems, nil
+}

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -85,13 +85,23 @@ func TestProblems(t *testing.T) {
 		"siteProblem2",
 		"siteProblem3",
 	)
+	externalServiceProblems := NewExternalServiceProblems(
+		"externalServiceProblem1",
+		"externalServiceProblem2",
+		"externalServiceProblem3",
+	)
 
 	var problems Problems
 	problems = append(problems, criticalProblems...)
 	problems = append(problems, siteProblems...)
+	problems = append(problems, externalServiceProblems...)
 
 	{
-		messages := append(criticalProblems.Messages(), siteProblems.Messages()...)
+		messages := make([]string, 0, len(problems))
+		messages = append(messages, criticalProblems.Messages()...)
+		messages = append(messages, siteProblems.Messages()...)
+		messages = append(messages, externalServiceProblems.Messages()...)
+
 		want := strings.Join(messages, "\n")
 		got := strings.Join(problems.Messages(), "\n")
 		if want != got {
@@ -110,6 +120,14 @@ func TestProblems(t *testing.T) {
 	{
 		want := strings.Join(siteProblems.Messages(), "\n")
 		got := strings.Join(problems.Site().Messages(), "\n")
+		if want != got {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+
+	{
+		want := strings.Join(externalServiceProblems.Messages(), "\n")
+		got := strings.Join(problems.ExternalService().Messages(), "\n")
 		if want != got {
 			t.Errorf("got %q, want %q", got, want)
 		}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6061.

Notes:
- Used `ContributeXXX` approach (similar to `conf.ContributeValidator`) for config warnings that should only be validated at runtime to avoid preventing server from starting.

Test plan:
- Locally tested with a invalid authz provider config.
- Unit tests for changes to `conf.Problem`.

Preview:
![Screen Shot 2019-10-31 at 3 07 34 PM](https://user-images.githubusercontent.com/2946214/67989486-2e5bc600-fbf0-11e9-9e42-0c4f167e1d45.png)
