### PR TITLE
3.9: search pagination: switch from ID to String for cursors

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/page_info.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/page_info.go
@@ -1,10 +1,8 @@
 package graphqlutil
 
-import graphql "github.com/graph-gophers/graphql-go"
-
 // PageInfo implements the GraphQL type PageInfo.
 type PageInfo struct {
-	endCursor   *graphql.ID
+	endCursor   *string
 	hasNextPage bool
 }
 
@@ -15,9 +13,9 @@ func HasNextPage(hasNextPage bool) *PageInfo {
 
 // NextPageCursor returns a new PageInfo indicating there is a next page with
 // the given end cursor.
-func NextPageCursor(endCursor graphql.ID) *PageInfo {
+func NextPageCursor(endCursor string) *PageInfo {
 	return &PageInfo{endCursor: &endCursor, hasNextPage: true}
 }
 
-func (r *PageInfo) EndCursor() *graphql.ID { return r.endCursor }
-func (r *PageInfo) HasNextPage() bool      { return r.hasNextPage }
+func (r *PageInfo) EndCursor() *string { return r.endCursor }
+func (r *PageInfo) HasNextPage() bool  { return r.hasNextPage }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1046,7 +1046,7 @@ type Query {
         #
         # A future request can be made for more results by passing in the
         # 'SearchResults.pageInfo.endCursor' that is returned.
-        after: ID
+        after: String
 
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
@@ -1055,9 +1055,6 @@ type Query {
         # When specified, indicates that this request should be paginated and
         # the first N results (relative to the cursor) should be returned. i.e.
         # how many results to return per page. It must be in the range of 0-5000.
-        #
-        # A future request can be made for more results by passing in the
-        # 'SearchResults.pageInfo.endCursor' that is returned.
         first: Int
     ): Search
     # All saved searches configured for the current user, merged from all configurations.
@@ -2037,7 +2034,7 @@ type PhabricatorRepo {
 # Pagination information. See https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.
 type PageInfo {
     # When paginating forwards, the cursor to continue.
-    endCursor: ID
+    endCursor: String
     # When paginating forwards, are there more items?
     hasNextPage: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1053,7 +1053,7 @@ type Query {
         #
         # A future request can be made for more results by passing in the
         # 'SearchResults.pageInfo.endCursor' that is returned.
-        after: ID
+        after: String
 
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
@@ -1062,9 +1062,6 @@ type Query {
         # When specified, indicates that this request should be paginated and
         # the first N results (relative to the cursor) should be returned. i.e.
         # how many results to return per page. It must be in the range of 0-5000.
-        #
-        # A future request can be made for more results by passing in the
-        # 'SearchResults.pageInfo.endCursor' that is returned.
         first: Int
     ): Search
     # All saved searches configured for the current user, merged from all configurations.
@@ -2044,7 +2041,7 @@ type PhabricatorRepo {
 # Pagination information. See https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.
 type PageInfo {
     # When paginating forwards, the cursor to continue.
-    endCursor: ID
+    endCursor: String
     # When paginating forwards, are there more items?
     hasNextPage: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	graphql "github.com/graph-gophers/graphql-go"
 	"gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/neelance/parallel"
@@ -60,7 +59,7 @@ func (r *schemaResolver) Search(args *struct {
 	Version     string
 	PatternType *string
 	Query       string
-	After       *graphql.ID
+	After       *string
 	First       *int32
 }) (interface {
 	Results(context.Context) (*searchResultsResolver, error)

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -39,20 +39,20 @@ type searchCursor struct {
 const searchCursorKind = "SearchCursor"
 
 // marshalSearchCursor marshals a search pagination cursor.
-func marshalSearchCursor(c *searchCursor) graphql.ID {
-	return relay.MarshalID(searchCursorKind, c)
+func marshalSearchCursor(c *searchCursor) string {
+	return string(relay.MarshalID(searchCursorKind, c))
 }
 
 // unmarshalSearchCursor unmarshals a search pagination cursor.
-func unmarshalSearchCursor(cursor *graphql.ID) (*searchCursor, error) {
+func unmarshalSearchCursor(cursor *string) (*searchCursor, error) {
 	if cursor == nil {
 		return nil, nil
 	}
-	if kind := relay.UnmarshalKind(*cursor); kind != searchCursorKind {
+	if kind := relay.UnmarshalKind(graphql.ID(*cursor)); kind != searchCursorKind {
 		return nil, fmt.Errorf("cannot unmarshal search cursor type: %q", kind)
 	}
 	var spec *searchCursor
-	if err := relay.UnmarshalSpec(*cursor, &spec); err != nil {
+	if err := relay.UnmarshalSpec(graphql.ID(*cursor), &spec); err != nil {
 		return nil, err
 	}
 	return spec, nil

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/zoekt"
 	zoektrpc "github.com/google/zoekt/rpc"
-	"github.com/graph-gophers/graphql-go"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
@@ -33,7 +32,7 @@ func TestSearchResults(t *testing.T) {
 			Version     string
 			PatternType *string
 			Query       string
-			After       *graphql.ID
+			After       *string
 			First       *int32
 		}{Query: query, Version: version})
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"testing"
 
-	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
@@ -24,7 +23,7 @@ func TestSearchSuggestions(t *testing.T) {
 			Version     string
 			PatternType *string
 			Query       string
-			After       *graphql.ID
+			After       *string
 			First       *int32
 		}{Query: query, Version: version})
 		if err != nil {
@@ -125,7 +124,7 @@ func TestSearchSuggestions(t *testing.T) {
 			Version     string
 			PatternType *string
 			Query       string
-			After       *graphql.ID
+			After       *string
 			First       *int32
 		}{Query: "[foo", PatternType: nil, Version: "V1"})
 		if err != nil {


### PR DESCRIPTION
This is a partial backport of 9ae81827e5ffd1a11113d7175e46dc8eb8d837a9 for the 3.9.4 patch release.
