### PR TITLE
repo-updater: Move deprecated comment to bottom of godoc

### DIFF
--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -10,13 +10,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httputil"
 )
 
-// Deprecated: NormalizeBaseURL should not be used, instead use
-// externalservice.NormalizeBaseURL
-//
 // NormalizeBaseURL modifies the input and returns a normalized form of the a base URL with insignificant
 // differences (such as in presence of a trailing slash, or hostname case) eliminated. Its return value should be
 // used for the (ExternalRepoSpec).ServiceID field (and passed to XyzExternalRepoSpec) instead of a non-normalized
 // base URL.
+//
+// Deprecated: use externalservice.NormalizeBaseURL instead.
 func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 	baseURL.Host = strings.ToLower(baseURL.Host)
 	if !strings.HasSuffix(baseURL.Path, "/") {


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/6306/files#r341469695