### PR TITLE
search: Default to k8s service discovery for indexed-search

### DIFF
--- a/cmd/frontend/internal/pkg/search/env.go
+++ b/cmd/frontend/internal/pkg/search/env.go
@@ -81,8 +81,9 @@ func zoektAddr(environ []string) string {
 		return addr
 	}
 
-	// Not set, use the default
-	return "indexed-search-0.indexed-search:6070"
+	// Not set, use the default (service discovery on the indexed-search
+	// statefulset)
+	return "k8s+rpc://indexed-search:6070"
 }
 
 func getEnv(environ []string, key string) (string, bool) {

--- a/cmd/frontend/internal/pkg/search/env_test.go
+++ b/cmd/frontend/internal/pkg/search/env_test.go
@@ -13,7 +13,7 @@ func TestZoektAddr(t *testing.T) {
 		want    string
 	}{{
 		name: "default",
-		want: "indexed-search-0.indexed-search:6070",
+		want: "k8s+rpc://indexed-search:6070",
 	}, {
 		name:    "old",
 		environ: []string{"ZOEKT_HOST=127.0.0.1:3070"},


### PR DESCRIPTION
This means that admins do not need to configure INDEXED_SEARCH_SERVERS if
using k8s.

Test plan: I was a chaos monkey in production. Tested how Sourcegraph.com behaved when I killed some or all of the indexed-search replicas. `for pod in indexed-search-{0,1,2}; do kubectl exec -it $pod -- pkill zoekt-webserver; done`

Part of https://github.com/sourcegraph/sourcegraph/issues/5725