### PR TITLE
endpoint: Ignore empty Hostname from endpoints

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -199,7 +199,7 @@ func endpointsToMap(u *k8sURL, eps *corev1.Endpoints) (*hashMap, error) {
 	var urls []string
 	for _, subset := range eps.Subsets {
 		for _, addr := range subset.Addresses {
-			if addr.Hostname != nil {
+			if addr.Hostname != nil && *addr.Hostname != "" {
 				urls = append(urls, u.endpointURL(*addr.Hostname+"."+u.Service))
 			} else if addr.Ip != nil {
 				urls = append(urls, u.endpointURL(*addr.Ip))


### PR DESCRIPTION
In production we are getting empty hostnames from the searcher endpoints. When
manually running `kubectl get endpoints -o json searcher` the `hostname` field
is not set. However, the k8s client library we are using may be marshalling
the field anyways for some reason. Either way this is causing searcher
unavailability in production.
