### PR TITLE
search: Add escape hatch DISABLE_HORIZONTAL_INDEXED_SEARCH

### DIFF
--- a/cmd/frontend/internal/pkg/search/env.go
+++ b/cmd/frontend/internal/pkg/search/env.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -47,6 +48,8 @@ func Indexed() *backend.Zoekt {
 				Map:  indexers.Map,
 				Dial: rpc.Client,
 			}
+		} else if addr := zoektAddr(os.Environ()); addr != "" {
+			indexedSearch.Client = rpc.Client(addr)
 		}
 		conf.Watch(func() {
 			indexedSearch.SetEnabled(conf.SearchIndexEnabled())
@@ -57,7 +60,7 @@ func Indexed() *backend.Zoekt {
 
 func Indexers() *backend.Indexers {
 	indexersOnce.Do(func() {
-		if addr := zoektAddr(os.Environ()); addr != "" {
+		if addr := zoektAddr(os.Environ()); addr != "" && !disableHorizontalSearch() {
 			indexers = &backend.Indexers{
 				Map:     endpoint.New(addr),
 				Indexed: reposAtEndpoint,
@@ -69,6 +72,12 @@ func Indexers() *backend.Indexers {
 		}
 	})
 	return indexers
+}
+
+// escape hatch to disable new indexed-search code path. Can remove in 1.11
+func disableHorizontalSearch() bool {
+	v, _ := strconv.ParseBool(os.Getenv("DISABLE_HORIZONTAL_INDEXED_SEARCH"))
+	return v
 }
 
 func zoektAddr(environ []string) string {

--- a/cmd/frontend/internal/pkg/search/env.go
+++ b/cmd/frontend/internal/pkg/search/env.go
@@ -74,7 +74,7 @@ func Indexers() *backend.Indexers {
 	return indexers
 }
 
-// escape hatch to disable new indexed-search code path. Can remove in 1.11
+// escape hatch to disable new indexed-search code path. Can remove in 3.11
 func disableHorizontalSearch() bool {
 	v, _ := strconv.ParseBool(os.Getenv("DISABLE_HORIZONTAL_INDEXED_SEARCH"))
 	return v


### PR DESCRIPTION
Even if you are not using horizontally scaled search, your searches will go
through a new code path. In case this causes issues we introduce an escape
hatch which will fallback to the old behaviour. To use this an admin will
configure the environment:

  DISABLE_HORIZONTAL_INDEXED_SEARCH=true
  ZOEKT_HOST=indexed-search-0.indexed-search:6070

Part of https://github.com/sourcegraph/sourcegraph/issues/5725