### PR TITLE
Fix exception on GitLab MRs

### DIFF
--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -70,6 +70,11 @@ const commitCodeView: Omit<CodeView, 'element'> = {
 }
 
 const resolveView: ViewResolver<CodeView>['resolveView'] = (element: HTMLElement): CodeView | null => {
+    if (element.classList.contains('discussion-wrapper')) {
+        // This is a commented snippet in a merge request discussion timeline,
+        // we don't support adding code intelligence on those.
+        return null
+    }
     const { pageKind } = getPageInfo()
 
     if (pageKind === GitLabPageKind.Other) {

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -71,7 +71,8 @@ const commitCodeView: Omit<CodeView, 'element'> = {
 
 const resolveView: ViewResolver<CodeView>['resolveView'] = (element: HTMLElement): CodeView | null => {
     if (element.classList.contains('discussion-wrapper')) {
-        // This is a commented snippet in a merge request discussion timeline,
+        // This is a commented snippet in a merge request discussion timeline
+        // (a snippet where somebody added a review comment on a piece of code in the MR),
         // we don't support adding code intelligence on those.
         return null
     }


### PR DESCRIPTION
Fixes an exception thrown on GitLab merge requests if they contained commented snippets in the MR discussion timeline (which is always present on merge requests, even on the "Changes" tab, where it is hidden).
