### PR TITLE
graphqlbackend: Expose GitTreeEntryResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -275,7 +275,7 @@ type PreviewFileDiff interface {
 	NewPath() *string
 	Hunks() []FileDiffHunk
 	Stat() DiffStat
-	OldFile() *gitTreeEntryResolver
+	OldFile() *GitTreeEntryResolver
 	InternalID() string
 }
 

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-func (r *gitTreeEntryResolver) Content(ctx context.Context) (string, error) {
+func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -31,7 +31,7 @@ func (r *gitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 	return string(contents), nil
 }
 
-func (r *gitTreeEntryResolver) RichHTML(ctx context.Context) (string, error) {
+func (r *GitTreeEntryResolver) RichHTML(ctx context.Context) (string, error) {
 	switch path.Ext(r.Path()) {
 	case ".md", ".mdown", ".markdown", ".markdn":
 		break
@@ -76,7 +76,7 @@ func (*schemaResolver) HighlightCode(ctx context.Context, args *struct {
 	return string(html), nil
 }
 
-func (r *gitTreeEntryResolver) Binary(ctx context.Context) (bool, error) {
+func (r *GitTreeEntryResolver) Binary(ctx context.Context) (bool, error) {
 	content, err := r.Content(ctx)
 	if err != nil {
 		return false, err
@@ -92,7 +92,7 @@ type highlightedFileResolver struct {
 func (h *highlightedFileResolver) Aborted() bool { return h.aborted }
 func (h *highlightedFileResolver) HTML() string  { return h.html }
 
-func (r *gitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
+func (r *GitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
 	DisableTimeout bool
 	IsLightTheme   bool
 }) (*highlightedFileResolver, error) {

--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-func (r *gitTreeEntryResolver) Blame(ctx context.Context,
+func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 	args *struct {
 		StartLine int32
 		EndLine   int32

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -124,7 +124,7 @@ func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.R
 func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	Path      string
 	Recursive bool
-}) (*gitTreeEntryResolver, error) {
+}) (*GitTreeEntryResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo.repo)
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	if !stat.Mode().IsDir() {
 		return nil, fmt.Errorf("not a directory: %q", args.Path)
 	}
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit:      r,
 		stat:        stat,
 		isRecursive: args.Recursive,
@@ -145,7 +145,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 
 func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	Path string
-}) (*gitTreeEntryResolver, error) {
+}) (*GitTreeEntryResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo.repo)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	if !stat.Mode().IsRegular() {
 		return nil, fmt.Errorf("not a blob: %q", args.Path)
 	}
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit: r,
 		stat:   stat,
 	}, nil
@@ -165,7 +165,7 @@ func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 
 func (r *GitCommitResolver) File(ctx context.Context, args *struct {
 	Path string
-}) (*gitTreeEntryResolver, error) {
+}) (*GitTreeEntryResolver, error) {
 	return r.Blob(ctx, args)
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-func (r *gitTreeEntryResolver) IsRoot() bool {
+func (r *GitTreeEntryResolver) IsRoot() bool {
 	path := path.Clean(r.Path())
 	return path == "/" || path == "." || path == ""
 }
@@ -26,19 +26,19 @@ type gitTreeEntryConnectionArgs struct {
 	RecursiveSingleChild bool
 }
 
-func (r *gitTreeEntryResolver) Entries(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*gitTreeEntryResolver, error) {
+func (r *GitTreeEntryResolver) Entries(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*GitTreeEntryResolver, error) {
 	return r.entries(ctx, args, nil)
 }
 
-func (r *gitTreeEntryResolver) Directories(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*gitTreeEntryResolver, error) {
+func (r *GitTreeEntryResolver) Directories(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*GitTreeEntryResolver, error) {
 	return r.entries(ctx, args, func(fi os.FileInfo) bool { return fi.Mode().IsDir() })
 }
 
-func (r *gitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*gitTreeEntryResolver, error) {
+func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConnectionArgs) ([]*GitTreeEntryResolver, error) {
 	return r.entries(ctx, args, func(fi os.FileInfo) bool { return !fi.Mode().IsDir() })
 }
 
-func (r *gitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi os.FileInfo) bool) ([]*gitTreeEntryResolver, error) {
+func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi os.FileInfo) bool) ([]*GitTreeEntryResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.commit.repo.repo)
 	if err != nil {
 		return nil, err
@@ -58,10 +58,10 @@ func (r *gitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 		entries = entries[:int(*args.First)]
 	}
 
-	var l []*gitTreeEntryResolver
+	var l []*GitTreeEntryResolver
 	for _, entry := range entries {
 		if filter == nil || filter(entry) {
-			l = append(l, &gitTreeEntryResolver{
+			l = append(l, &GitTreeEntryResolver{
 				commit: r.commit,
 				stat:   entry,
 			})

--- a/cmd/frontend/graphqlbackend/location.go
+++ b/cmd/frontend/graphqlbackend/location.go
@@ -9,11 +9,11 @@ import (
 )
 
 type locationResolver struct {
-	resource *gitTreeEntryResolver
+	resource *GitTreeEntryResolver
 	lspRange *lsp.Range
 }
 
-func (r *locationResolver) Resource() *gitTreeEntryResolver { return r.resource }
+func (r *locationResolver) Resource() *GitTreeEntryResolver { return r.resource }
 
 func (r *locationResolver) Range() *rangeResolver {
 	if r.lspRange == nil {

--- a/cmd/frontend/graphqlbackend/lsif_dump.go
+++ b/cmd/frontend/graphqlbackend/lsif_dump.go
@@ -48,13 +48,13 @@ func (r *lsifDumpResolver) ID() graphql.ID {
 	return marshalLSIFDumpGQLID(r.lsifDump.Repository, r.lsifDump.ID)
 }
 
-func (r *lsifDumpResolver) ProjectRoot() *gitTreeEntryResolver {
+func (r *lsifDumpResolver) ProjectRoot() *GitTreeEntryResolver {
 	commitResolver := &GitCommitResolver{
 		repo: &RepositoryResolver{repo: r.repo},
 		oid:  GitObjectID(r.lsifDump.Commit),
 	}
 
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit: commitResolver,
 		stat:   createFileInfo(r.lsifDump.Root, true),
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -312,27 +312,27 @@ func (r *fileDiffResolver) Stat() DiffStat {
 	}
 }
 
-func (r *fileDiffResolver) OldFile() *gitTreeEntryResolver {
+func (r *fileDiffResolver) OldFile() *GitTreeEntryResolver {
 	if diffPathOrNull(r.fileDiff.OrigName) == nil {
 		return nil
 	}
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit: r.cmp.base,
 		stat:   createFileInfo(r.fileDiff.OrigName, false),
 	}
 }
 
-func (r *fileDiffResolver) NewFile() *gitTreeEntryResolver {
+func (r *fileDiffResolver) NewFile() *GitTreeEntryResolver {
 	if diffPathOrNull(r.fileDiff.NewName) == nil {
 		return nil
 	}
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit: r.cmp.head,
 		stat:   createFileInfo(r.fileDiff.NewName, false),
 	}
 }
 
-func (r *fileDiffResolver) MostRelevantFile() *gitTreeEntryResolver {
+func (r *fileDiffResolver) MostRelevantFile() *GitTreeEntryResolver {
 	if newFile := r.NewFile(); newFile != nil {
 		return newFile
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -839,7 +839,7 @@ func (e *badRequestError) Cause() error {
 
 // searchSuggestionResolver is a resolver for the GraphQL union type `SearchSuggestion`
 type searchSuggestionResolver struct {
-	// result is either a RepositoryResolver or a gitTreeEntryResolver
+	// result is either a RepositoryResolver or a GitTreeEntryResolver
 	result interface{}
 	// score defines how well this item matches the query for sorting purposes
 	score int
@@ -854,18 +854,18 @@ func (r *searchSuggestionResolver) ToRepository() (*RepositoryResolver, bool) {
 	return res, ok
 }
 
-func (r *searchSuggestionResolver) ToFile() (*gitTreeEntryResolver, bool) {
-	res, ok := r.result.(*gitTreeEntryResolver)
+func (r *searchSuggestionResolver) ToFile() (*GitTreeEntryResolver, bool) {
+	res, ok := r.result.(*GitTreeEntryResolver)
 	return res, ok
 }
 
-func (r *searchSuggestionResolver) ToGitBlob() (*gitTreeEntryResolver, bool) {
-	res, ok := r.result.(*gitTreeEntryResolver)
+func (r *searchSuggestionResolver) ToGitBlob() (*GitTreeEntryResolver, bool) {
+	res, ok := r.result.(*GitTreeEntryResolver)
 	return res, ok && res.stat.Mode().IsRegular()
 }
 
-func (r *searchSuggestionResolver) ToGitTree() (*gitTreeEntryResolver, bool) {
-	res, ok := r.result.(*gitTreeEntryResolver)
+func (r *searchSuggestionResolver) ToGitTree() (*GitTreeEntryResolver, bool) {
+	res, ok := r.result.(*GitTreeEntryResolver)
 	return res, ok && res.stat.Mode().IsDir()
 }
 
@@ -885,14 +885,14 @@ func (r *searchSuggestionResolver) ToLanguage() (*languageResolver, bool) {
 // newSearchResultResolver returns a new searchResultResolver wrapping the
 // given result.
 //
-// A panic occurs if the type of result is not a *RepositoryResolver, *gitTreeEntryResolver,
+// A panic occurs if the type of result is not a *RepositoryResolver, *GitTreeEntryResolver,
 // *searchSymbolResult or *languageResolver.
 func newSearchResultResolver(result interface{}, score int) *searchSuggestionResolver {
 	switch r := result.(type) {
 	case *RepositoryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.repo.Name), label: string(r.repo.Name)}
 
-	case *gitTreeEntryResolver:
+	case *GitTreeEntryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.Path()), label: r.Path()}
 
 	case *searchSymbolResult:

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -334,7 +334,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		switch s := s.result.(type) {
 		case *RepositoryResolver:
 			k.repoName = s.repo.Name
-		case *gitTreeEntryResolver:
+		case *GitTreeEntryResolver:
 			k.repoName = s.commit.repo.repo.Name
 			// We explicitely do not use GitCommitResolver.OID() to get the OID here
 			// because it could significantly slow down search suggestions from zoekt as

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -230,7 +230,7 @@ func testStringResult(result *searchSuggestionResolver) string {
 	switch r := result.result.(type) {
 	case *RepositoryResolver:
 		name = "repo:" + string(r.repo.Name)
-	case *gitTreeEntryResolver:
+	case *GitTreeEntryResolver:
 		name = "file:" + r.Path()
 	case *languageResolver:
 		name = "lang:" + r.name

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -19,7 +19,7 @@ type symbolsArgs struct {
 	IncludePatterns *[]string
 }
 
-func (r *gitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
+func (r *GitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
 	symbols, err := computeSymbols(ctx, r.commit, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
@@ -95,7 +95,7 @@ func toSymbolResolver(symbol protocol.Symbol, baseURI *gituri.URI, lang string, 
 	}
 	symbolRange := symbolRange(symbol)
 	resolver.location = &locationResolver{
-		resource: &gitTreeEntryResolver{
+		resource: &GitTreeEntryResolver{
 			commit: commitResolver,
 			stat:   createFileInfo(resolver.uri.Fragment, false), // assume the path refers to a file (not dir)
 		},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -74,11 +74,11 @@ func (fm *fileMatchResolver) Key() string {
 	return fm.uri
 }
 
-func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
+func (fm *fileMatchResolver) File() *GitTreeEntryResolver {
 	// NOTE(sqs): Omits other commit fields to avoid needing to fetch them
 	// (which would make it slow). This GitCommitResolver will return empty
 	// values for all other fields.
-	return &gitTreeEntryResolver{
+	return &GitTreeEntryResolver{
 		commit: &GitCommitResolver{
 			repo:     &RepositoryResolver{repo: fm.repo},
 			oid:      GitObjectID(fm.commitID),


### PR DESCRIPTION
This is a preparation step in order to implement the `graphqlbackend.PreviewFileDiff` interface in `a8n` packages.

I created a separate PR for this in order to make reviewing easier.

This only does two things:
- Rename `gitTreeEntryResolver` to `GitTreeEntryResolver`
- Add `NewGitTreeEntryResolver` function in order to not have to expose the fields of `GitTreeEntryResolver`