### PR TITLE
Specify when to have the release notice from Sourcegraph.com removed

### DIFF
--- a/doc/dev/devrel_release_issue_template.md
+++ b/doc/dev/devrel_release_issue_template.md
@@ -77,3 +77,7 @@ Add events to the shared Release Schedule calendar in Google and invite team@sou
    ```
 - [ ] Use tweet or email content for post on the [LinkedIn Sourcegraph company page](https://www.linkedin.com/company/sourcegraph/)
 - [ ] Put notification in #dev-rel Slack channel with links to blog post and tweet
+
+## 1 week after release
+
+Comment out the [release notice on Sourcegraph.com](https://sourcegraph.com/site-admin/global-settings)


### PR DESCRIPTION
@christinaforney Need your guidance here as to whether it should be 1 or 2 weeks.