### PR TITLE
search: extract pattern type with regex instead of the parse tree

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -152,24 +153,16 @@ func detectSearchType(version string, patternType *string, input string) (Search
 		}
 	}
 
-	parseTree, err := query.Parse(input)
-	if err != nil {
-		return -1, err
-	}
-
-	patternTypes := parseTree.Values(query.FieldPatternType)
-
-	// Override the searchType if the query explicitly specifies one. If
-	// there are multiple patternTypes, use the last one we encounter.
-	// Since this field is Singular, the validation check on the
-	// parse tree wil reject patterns with duplicate fields.
-	for _, pat := range patternTypes {
-		switch pat {
-		case "regex", "regexp":
+	var patternTypeRegex = lazyregexp.New(`patterntype:([a-zA-Z"']+)`)
+	patternFromField := patternTypeRegex.FindStringSubmatch(input)
+	if len(patternFromField) > 1 {
+		extracted := patternFromField[1]
+		if match, _ := regexp.MatchString("regex", extracted); match {
 			searchType = SearchTypeRegex
-		case "literal":
+		} else if match, _ := regexp.MatchString("literal", extracted); match {
 			searchType = SearchTypeLiteral
-		case "structural":
+
+		} else if match, _ := regexp.MatchString("structural", extracted); match {
 			searchType = SearchTypeStructural
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -153,6 +153,9 @@ func detectSearchType(version string, patternType *string, input string) (Search
 		}
 	}
 
+	// The patterntype field is Singular, but not enforced since we do not
+	// properly parse the input. The regex extraction, takes the left-most
+	// "patterntype:value" match.
 	var patternTypeRegex = lazyregexp.New(`patterntype:([a-zA-Z"']+)`)
 	patternFromField := patternTypeRegex.FindStringSubmatch(input)
 	if len(patternFromField) > 1 {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -322,6 +322,7 @@ func Test_detectSearchType(t *testing.T) {
 		{"V2, regexp pattern type", "V2", &typeRegexp, "", SearchTypeRegex},
 		{"V1, literal pattern type", "V1", &typeLiteral, "", SearchTypeLiteral},
 		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", SearchTypeRegex},
+		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", SearchTypeRegex},
 		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, SearchTypeRegex},
 		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, SearchTypeRegex},
 		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", SearchTypeLiteral},

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -317,11 +317,13 @@ func Test_detectSearchType(t *testing.T) {
 	}{
 		{"V1, no pattern type", "V1", nil, "", SearchTypeRegex},
 		{"V2, no pattern type", "V2", nil, "", SearchTypeLiteral},
+		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", SearchTypeLiteral},
 		{"V1, regexp pattern type", "V1", &typeRegexp, "", SearchTypeRegex},
 		{"V2, regexp pattern type", "V2", &typeRegexp, "", SearchTypeRegex},
 		{"V1, literal pattern type", "V1", &typeLiteral, "", SearchTypeLiteral},
 		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", SearchTypeRegex},
-		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", SearchTypeRegex},
+		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, SearchTypeRegex},
+		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, SearchTypeRegex},
 		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", SearchTypeLiteral},
 	}
 


### PR DESCRIPTION
Addresses #6314. Not happy with a regex approach, but it's a compromise until we can do this in a principled way with a literal parser.

Test plan: Yes
