### PR TITLE
LSIF: Remove unnecessary async/awaits.

### DIFF
--- a/lsif/.eslintrc.js
+++ b/lsif/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     'no-console': ['error'],
     'import/no-cycle': ['error'],
+    'no-return-await': ['error'],
   },
   overrides: require('../.eslintrc').overrides,
 }

--- a/lsif/src/backend.ts
+++ b/lsif/src/backend.ts
@@ -499,7 +499,7 @@ export class Backend {
         ctx: TracingContext = {}
     ): Promise<lsp.Hover | null> {
         const { database, dump, ctx: newCtx } = await this.loadClosestDatabase(repository, commit, path, ctx)
-        return await database.hover(this.pathToDatabase(dump.root, path), position, newCtx)
+        return database.hover(this.pathToDatabase(dump.root, path), position, newCtx)
     }
 
     /**
@@ -515,13 +515,13 @@ export class Backend {
      * @param file One of the files in the dump.
      * @param ctx The tracing context.
      */
-    private async loadClosestDatabase(
+    private loadClosestDatabase(
         repository: string,
         commit: string,
         file: string,
         ctx: TracingContext = {}
     ): Promise<{ database: Database; dump: LsifDump; ctx: TracingContext }> {
-        return await logAndTraceCall(ctx, 'loading closest database', async ctx => {
+        return logAndTraceCall(ctx, 'loading closest database', async ctx => {
             // Determine the closest commit that we actually have LSIF data for. If the commit is
             // not tracked, then commit data is requested from gitserver and insert the ancestors
             // data for this commit.

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -88,7 +88,7 @@ export class Database {
             // lsif-tsc to handle node_modules inclusion (or somehow blacklist it on import).
 
             if (!definitionResults.some(v => v.documentPath.includes('node_modules'))) {
-                return await this.convertRangesToLspLocations(path, document, definitionResults)
+                return this.convertRangesToLspLocations(path, document, definitionResults)
             }
         }
 
@@ -319,7 +319,7 @@ export class Database {
             }
         }
 
-        return await this.resultChunkCache.withValue(`${this.databasePath}::${index}`, factory, resultChunk =>
+        return this.resultChunkCache.withValue(`${this.databasePath}::${index}`, factory, resultChunk =>
             Promise.resolve(resultChunk.data)
         )
     }
@@ -345,8 +345,8 @@ export class Database {
      *
      * @param callback The function invoke with the SQLite connection.
      */
-    private async withConnection<T>(callback: (connection: Connection) => Promise<T>): Promise<T> {
-        return await this.connectionCache.withConnection(this.databasePath, entities, connection =>
+    private withConnection<T>(callback: (connection: Connection) => Promise<T>): Promise<T> {
+        return this.connectionCache.withConnection(this.databasePath, entities, connection =>
             instrument(databaseQueryDurationHistogram, databaseQueryErrorsCounter, () => callback(connection))
         )
     }

--- a/lsif/src/retention.ts
+++ b/lsif/src/retention.ts
@@ -15,14 +15,14 @@ import * as constants from './constants'
  * @param maximumSizeBytes The maximum number of bytes.
  * @param ctx The tracing context.
  */
-export async function purgeOldDumps(
+export function purgeOldDumps(
     storageRoot: string,
     xrepoDatabase: XrepoDatabase,
     maximumSizeBytes: number,
     { logger = createSilentLogger() }: TracingContext = {}
 ): Promise<void> {
     if (maximumSizeBytes < 0) {
-        return
+        return Promise.resolve()
     }
 
     const purge = async (): Promise<void> => {
@@ -58,7 +58,7 @@ export async function purgeOldDumps(
     // choose more dumps than necessary to purge. This can happen if the directory
     // size check and the selection of a purgeable dump are interleaved between
     // multiple workers.
-    return await withLock(xrepoDatabase, 'retention', purge)
+    return withLock(xrepoDatabase, 'retention', purge)
 }
 
 /**

--- a/lsif/src/xrepo.test.ts
+++ b/lsif/src/xrepo.test.ts
@@ -379,8 +379,8 @@ describe('XrepoDatabase', () => {
         const ce = createCommit('e')
         const cf = createCommit('f')
 
-        const updatePackages = async (commit: string, root: string, identifiers: string[]): Promise<LsifDump> =>
-            await xrepoDatabase.addPackagesAndReferences(
+        const updatePackages = (commit: string, root: string, identifiers: string[]): Promise<LsifDump> =>
+            xrepoDatabase.addPackagesAndReferences(
                 'foo',
                 commit,
                 root,

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -269,8 +269,8 @@ export class XrepoDatabase {
      * @param repository The repository name.
      * @param commits The commit parentage data.
      */
-    public async updateCommits(repository: string, commits: [string, string][]): Promise<void> {
-        return await this.withTransactionalEntityManager(async entityManager => {
+    public updateCommits(repository: string, commits: [string, string][]): Promise<void> {
+        return this.withTransactionalEntityManager(async entityManager => {
             const commitInserter = new TableInserter(
                 entityManager,
                 Commit,


### PR DESCRIPTION
Remove `return await` pairs that aren't also in a try/catch.