### PR TITLE
LSIF: Extract CTEs into global scope.

### DIFF
--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -25,6 +25,49 @@ const insertionMetrics = {
 }
 
 /**
+ * A CTE definition that gets all ancestors of a commit recursively.
+ */
+const lineage_ancestors = `
+    -- Get all ancestors of the tip
+    WITH RECURSIVE lineage(id, repository, "commit", parent) AS (
+        SELECT c.* FROM lsif_commits c WHERE c.repository = $1 AND c."commit" = $2
+        UNION
+        SELECT c.* FROM lineage a JOIN lsif_commits c ON a.repository = c.repository AND a.parent = c."commit"
+    ),
+`
+
+/**
+ * A set of CTE definitions that prune LSIF dump identifiers so that only the ones that
+ * are visible from a source commit remain. This assumes that a CTE definition `lineage`
+ * is available earlier in the query. The CTE `lineage_fanout` (defined above) can be used
+ * as such a CTE definition.
+ */
+const ctes = `
+    -- Limit the visibility to the maximum traversal depth and approximate
+    -- each commit's depth by its row number.
+    limited_lineage AS (
+        SELECT a.*, row_number() OVER() as n from lineage a LIMIT $3
+    ),
+    -- Correlate commits to dumps and filter out commits without LSIF data
+    lineage_with_dumps AS (
+        SELECT a.*, d.root, d.id as dump_id FROM limited_lineage a
+        JOIN lsif_dumps d ON d.repository = a.repository AND d."commit" = a."commit"
+    ),
+    visible_ids AS (
+        -- Remove dumps where there exists another visible dump of smaller depth with an overlapping root.
+        -- Such dumps would not be returned with a closest commit query so we don't want to return results
+        -- for them in global find-reference queries either.
+        SELECT DISTINCT t1.dump_id as id FROM lineage_with_dumps t1 WHERE NOT EXISTS (
+            SELECT 1 FROM lineage_with_dumps t2
+            WHERE t2.n < t1.n AND (
+                t2.root LIKE (t1.root || '%') OR
+                t1.root LIKE (t2.root || '%')
+            )
+        )
+    )
+`
+
+/**
  * Represents a package provided by a project or a package that is a dependency
  * of a project, depending on its use.
  */
@@ -176,46 +219,18 @@ export class XrepoDatabase {
      * @param commit The head of the default branch.
      */
     public async updateDumpsVisibleFromTip(repository: string, commit: string): Promise<void> {
+        // Update dump records by:
+        //   (1) unsetting the visibility flag of all previously visible dumps, and
+        //   (2) setting the visibility flag of all currently visible dumps
         const query = `
-            -- Get all ancestors of the tip
-            WITH RECURSIVE ancestors(id, repository, "commit", parent) AS (
-                SELECT c.* FROM lsif_commits c WHERE c.repository = $1 AND c."commit" = $2
-                UNION
-                SELECT c.* FROM ancestors a JOIN lsif_commits c ON a.repository = c.repository AND a.parent = c."commit"
-            ),
-            -- Limit the visibility to the maximum traversal depth and approximate
-            -- each commit's depth by its row number.
-            limited_ancestors AS (
-                SELECT a.*, row_number() OVER() as n from ancestors a LIMIT $3
-            ),
-            -- Correlate commits to dumps and filter out commits without LSIF data
-            ancestors_with_dumps AS (
-                SELECT a.*, d.root, d.id as dump_id FROM limited_ancestors a
-                JOIN lsif_dumps d ON d.repository = a.repository AND d."commit" = a."commit"
-            ),
-            visible_ids AS (
-                -- Remove dumps where there exists another visible dump of smaller depth with an overlapping root.
-                -- Such dumps would not be returned with a closest commit query so we don't want to return results
-                -- for them in global find-reference queries either.
-                SELECT DISTINCT t1.dump_id as id FROM ancestors_with_dumps t1 WHERE NOT EXISTS (
-                    SELECT 1 FROM ancestors_with_dumps t2
-                    WHERE t2.n < t1.n AND (
-                        t2.root LIKE (t1.root || '%') OR
-                        t1.root LIKE (t2.root || '%')
-                    )
-                )
-            )
-
-            -- Update dump records by:
-            --   (1) unsetting the visibility flag of all previously visible dumps, and
-            --   (2) setting the visibility flag of all currently visible dumps
-
             UPDATE lsif_dumps d
             SET visible_at_tip = id IN (SELECT * from visible_ids)
             WHERE d.repository = $1 AND (d.id IN (SELECT * from visible_ids) OR d.visible_at_tip)
         `
 
-        await this.withConnection(connection => connection.query(query, [repository, commit, MAX_TRAVERSAL_LIMIT]))
+        await this.withConnection(connection =>
+            connection.query(lineage_ancestors + ctes + query, [repository, commit, MAX_TRAVERSAL_LIMIT])
+        )
     }
 
     /**

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -42,7 +42,7 @@ const lineage_ancestors = `
  * is available earlier in the query. The CTE `lineage_ancestors` (defined above) can be used
  * as such a CTE definition.
  */
-const ctes = `
+const visibleDumps = `
     -- Limit the visibility to the maximum traversal depth and approximate
     -- each commit's depth by its row number.
     limited_lineage AS (

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -229,7 +229,7 @@ export class XrepoDatabase {
         `
 
         await this.withConnection(connection =>
-            connection.query(lineage_ancestors + ctes + query, [repository, commit, MAX_TRAVERSAL_LIMIT])
+            connection.query(lineage_ancestors + visibleDumps + query, [repository, commit, MAX_TRAVERSAL_LIMIT])
         )
     }
 

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -697,7 +697,7 @@ export class XrepoDatabase {
  * commit occurs in `lineage` (within the given traversal limit) and whose root does not
  * overlap another visible dump.
  *
- * @param limit The maximum
+ * @param limit The maximum number of dumps that can be extracted from `lineage`.
  */
 function visibleDumps(limit: number = MAX_TRAVERSAL_LIMIT): string {
     return `

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -39,7 +39,7 @@ const lineage_ancestors = `
 /**
  * A set of CTE definitions that prune LSIF dump identifiers so that only the ones that
  * are visible from a source commit remain. This assumes that a CTE definition `lineage`
- * is available earlier in the query. The CTE `lineage_fanout` (defined above) can be used
+ * is available earlier in the query. The CTE `lineage_ancestors` (defined above) can be used
  * as such a CTE definition.
  */
 const ctes = `


### PR DESCRIPTION
This breaks common CTE definitions out into its own global variable. These CTEs will be used later when RFC 58 is implemented.