### PR TITLE
LSIF: Simplify parameter of createRemoteUri.

### DIFF
--- a/lsif/src/backend.ts
+++ b/lsif/src/backend.ts
@@ -279,7 +279,7 @@ export class Backend {
         )
         return (await db.monikerResults(model, moniker, ctx)).map(loc =>
             mapLocation(
-                uri => createRemoteUri(packageEntity, uri),
+                uri => createRemoteUri(packageEntity.dump, uri),
                 this.locationFromDatabase(packageEntity.dump.root, loc)
             )
         )
@@ -288,13 +288,13 @@ export class Backend {
     /**
      * Find the references of the target moniker outside of the current database. If the moniker
      * has attached package information, then the cross-repo database is queried for the packages
-     * that require this particular moniker identifier. These databases are opened, and their
+     * that require this particular moniker identifier. These dumps are opened, and their
      * references tables are queried for the target moniker.
      *
      * @param dumpId The ID of the dump for which this database answers queries.
      * @param moniker The target moniker.
      * @param packageInformation The target package.
-     * @param limit The maximum number of remote repositodumpsries to search.
+     * @param limit The maximum number of remote dumps to search.
      * @param offset The number of remote dumps to skip.
      * @param ctx The tracing context.
      */
@@ -336,7 +336,10 @@ export class Backend {
             )
 
             const references = (await db.monikerResults(ReferenceModel, moniker, ctx)).map(loc =>
-                mapLocation(uri => createRemoteUri(reference, uri), this.locationFromDatabase(reference.dump.root, loc))
+                mapLocation(
+                    uri => createRemoteUri(reference.dump, uri),
+                    this.locationFromDatabase(reference.dump.root, loc)
+                )
             )
             locations = locations.concat(references)
         }

--- a/lsif/src/database.test.ts
+++ b/lsif/src/database.test.ts
@@ -115,23 +115,16 @@ describe('comparePosition', () => {
 
 describe('createRemoteUri', () => {
     it('should generate a URI to another project', () => {
-        const pkg = {
+        const dump = {
             id: 0,
-            scheme: '',
-            name: '',
-            version: '',
-            dump: {
-                id: 0,
-                repository: 'github.com/sourcegraph/codeintellify',
-                commit: 'deadbeef',
-                root: '',
-                visibleAtTip: false,
-                uploadedAt: new Date(),
-            },
-            dump_id: 0,
+            repository: 'github.com/sourcegraph/codeintellify',
+            commit: 'deadbeef',
+            root: '',
+            visibleAtTip: false,
+            uploadedAt: new Date(),
         }
 
-        const uri = createRemoteUri(pkg, 'src/position.ts')
+        const uri = createRemoteUri(dump, 'src/position.ts')
         expect(uri).toEqual('git://github.com/sourcegraph/codeintellify?deadbeef#src/position.ts')
     })
 })

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -7,7 +7,7 @@ import { databaseQueryDurationHistogram, databaseQueryErrorsCounter } from './da
 import { DefaultMap } from './default-map'
 import { gunzipJSON } from './encoding'
 import { isEqual, uniqWith } from 'lodash'
-import { PackageModel, DumpId } from './xrepo.models'
+import { DumpId, LsifDump } from './xrepo.models'
 import {
     DefinitionModel,
     DocumentData,
@@ -445,12 +445,12 @@ export function sortMonikers(monikers: MonikerData[]): MonikerData[] {
  * Construct a URI that can be used by the frontend to switch to another
  * directory.
  *
- * @param pkg The target package.
+ * @param dump The target dump.
  * @param path The path relative to the project root.
  */
-export function createRemoteUri(pkg: PackageModel, path: string): string {
-    const url = new URL(`git://${pkg.dump.repository}`)
-    url.search = pkg.dump.commit
+export function createRemoteUri(dump: LsifDump, path: string): string {
+    const url = new URL(`git://${dump.repository}`)
+    url.search = dump.commit
     url.hash = path
     return url.href
 }


### PR DESCRIPTION
We were previously passing around too much data for this method. This is a pre-refactor step to implement RFC 58 (we have the dump but not the package entity required to call this method encoded in the pagination cursor).