### PR TITLE
search: parse alphanumeric identifiers in structural search holes

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -167,6 +167,11 @@ lines
  :[2]`,
 			Want: `(and case_content_substr:" spans\nmultiple\nlines\n ")`,
 		},
+		{
+			Name:    "Allow alphanumeric identifiers in holes",
+			Pattern: "sub :[alphanum_ident_123] string",
+			Want:    `(and case_content_substr:"sub " case_content_substr:" string")`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -372,8 +372,8 @@ func fileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 }
 
 func splitOnHolesPattern() string {
-	word := `\w`
-	whitespaceAndOptionalWord := `[ ]+(\w+)?`
+	word := `\w+`
+	whitespaceAndOptionalWord := `[ ]+(` + word + `)?`
 	holeAnything := `:\[` + word + `\]`
 	holeAlphanum := `:\[\[` + word + `\]\]`
 	holeWithPunctuation := `:\[` + word + `\.\]`


### PR DESCRIPTION
Before this change, identifiers in holes could only be one word character. This change allows identifiers with multiple alphanumeric characters.

Test plan: Test added.