### PR TITLE
tracing: include graphql_err field in request log

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -135,7 +135,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		// if it's not a graphql request, then this includes graphql_err=false in the log entry
 		gqlErr := false
-		span.Context().ForeachBaggageItem(func(k string, v string) bool {
+		span.Context().ForeachBaggageItem(func(k, v string) bool {
 			if k == "graphql.error" {
 				gqlErr = true
 				return false

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -133,7 +133,7 @@ func Middleware(next http.Handler) http.Handler {
 		requestDuration.With(labels).Observe(m.Duration.Seconds())
 		requestHeartbeat.With(labels).Set(float64(time.Now().Unix()))
 
-		// if it's not a graphql request, then this includes graphql_err=false in the log entry
+		// if it's not a graphql request, then this includes graphql_error=false in the log entry
 		gqlErr := false
 		span.Context().ForeachBaggageItem(func(k, v string) bool {
 			if k == "graphql.error" {
@@ -153,7 +153,7 @@ func Middleware(next http.Handler) http.Handler {
 			"written", m.Written,
 			"code", m.Code,
 			"duration", m.Duration,
-			"graphql_err", strconv.FormatBool(gqlErr),
+			"graphql_error", strconv.FormatBool(gqlErr),
 		)
 
 		// Notify sentry if the status code indicates our system had an error (e.g. 5xx).

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -138,10 +138,8 @@ func Middleware(next http.Handler) http.Handler {
 		span.Context().ForeachBaggageItem(func(k, v string) bool {
 			if k == "graphql.error" {
 				gqlErr = true
-				return false
 			}
-			// keep looking
-			return true
+			return !gqlErr
 		})
 
 		log15.Debug("TRACE HTTP",


### PR DESCRIPTION
We decided to return 200 when some GraphQL fields have errors. This PR adds a field to the request log to mark those cases so that using span ids we can dig into them with jaeger traces.