### PR TITLE
LSIF: make the trailing slash on roots optional

### DIFF
--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -43,7 +43,8 @@ paths:
             type: string
         - name: root
           in: query
-          description: The root-relative path of the dump.
+          description: The path to the directory associated with the dump, relative to the repository root.
+          example: cmd/project1
           required: false
           schema:
             type: string


### PR DESCRIPTION
Prior to this change, you had to remember to always put a trailing slash on the path in the `?root` parameter.

After this change, the trailing slash in `?root` is optional. Internally, lsif-server will add the trailing slash if it's missing (except when the root already refers to the top level of the repository).

See https://github.com/sourcegraph/sourcegraph/pull/6294#discussion_r341817765