### PR TITLE
Add steps for submitting Sourcegraph metric dumps to support

### DIFF
--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -23,7 +23,7 @@ See [sourcegraph/sourcegraph#398](https://github.com/sourcegraph/sourcegraph/iss
 
 ### Submitting a metrics dump
 
-When you encounter performance or instability problem with Sourcegraph, we may ask you to submit a metrics dump to us. This allows us to inspect the performance and health of various parts of your Sourcegraph instance in the past and can often be the most effective way for us to identify the cause of your issue.
+If you encounter performance or instability issues with Sourcegraph, we may ask you to submit a metrics dump to us. This allows us to inspect the performance and health of various parts of your Sourcegraph instance in the past and can often be the most effective way for us to identify the cause of your issue.
 
 The metrics dump includes non-sensitive aggregate statistics of Sourcegraph like CPU & memory usage, number of successful and error requests between Sourcegraph services, and more. It does NOT contain sensitive information like code, repository names, user names, etc.
 

--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -20,3 +20,25 @@ docker container run -e LOGO=false ... sourcegraph/server
 ```
 
 See [sourcegraph/sourcegraph#398](https://github.com/sourcegraph/sourcegraph/issues/398) for more information.
+
+### Submitting a metrics dump
+
+When you encounter performance or instability problem with Sourcegraph, we may ask you to submit a metrics dump to us. This allows us to inspect the performance and health of various parts of your Sourcegraph instance in the past and can often be the most effective way for us to identify the cause of your issue.
+
+The metrics dump includes non-sensitive aggregate statistics of Sourcegraph like CPU & memory usage, number of successful and error requests between Sourcegraph services, and more. It does NOT contain sensitive information like code, repository names, user names, etc.
+
+#### Single-container `sourcegraph/server` deployments
+
+To create a metrics dump from a single-container `sourcegraph/server` deployment, run this command on the host machine:
+
+```sh
+cd ~/.sourcegraph/data/prometheus && tar -czvf /tmp/sourcegraph-metrics-dump.tgz .
+```
+
+If needed, you can download the metrics dump to your local machine (current directory) using `scp`:
+
+```sh
+scp -r username@hostname:/tmp/sourcegraph-metrics-dump.tgz .
+```
+
+Please then upload the `sourcegraph-metrics-dump.tgz` for Sourcegraph support to access it. If desired, we can send you a shared private Google Drive folder for the upload as it can sometimes be a few gigabytes.


### PR DESCRIPTION
The goal of this PR is to add steps we can link customers with performance/instability issues to such that we can then inspect the Prometheus metrics interactively ourselves to identify the root cause of their issue. The process looks like this:

1. Send customer a link to this docs section, and a share a private Google Drive folder with them so they can upload (the sometimes quite large) metrics dump.
2. Once it is uploaded, download it and copy the extracted metrics dump into ~/.sourcegraph/prometheus.
3. Run the same Sourcegraph version as them, investigate via the local Grafana instance / by running Prometheus queries directly.

In the future we can:

1) Provide the same steps for Kubernetes
2) Modify `dev/run-server-image.sh` to accept a `PROMETHEUS_DUMP=somedump.tgz` env var so the process is seamless for us.
