### PR TITLE
search: add comby result types

### DIFF
--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -135,7 +135,7 @@ func Matches(args Args) (matches []FileMatch, err error) {
 	}
 
 	if len(matches) > 0 {
-		log15.Info("comby invocation found %d file matches", len(matches))
+		log15.Info("comby invocation", "num_matches", fmt.Sprintf("%d", len(matches)))
 	}
 	return matches, nil
 }

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -24,7 +24,6 @@ func exists() bool {
 
 func rawArgs(args Args) (rawArgs []string) {
 	rawArgs = append(rawArgs, args.MatchTemplate, args.RewriteTemplate)
-	rawArgs = append(rawArgs, args.FilePatterns...)
 	if len(args.FilePatterns) > 0 {
 		rawArgs = append(rawArgs, "-f", strings.Join(args.FilePatterns, ","))
 	}

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -106,9 +106,12 @@ func PipeTo(args Args, w io.Writer) (err error) {
 	return nil
 }
 
+// Matches returns all matches in all files for which comby finds matches.
 func Matches(args Args) (matches []FileMatch, err error) {
 	b := new(bytes.Buffer)
 	w := bufio.NewWriter(b)
+
+	args.MatchOnly = true
 
 	err = PipeTo(args, w)
 	if err != nil {

--- a/internal/comby/comby_test.go
+++ b/internal/comby/comby_test.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"os"
@@ -51,7 +50,8 @@ func main() {
 				FilePatterns:  []string{".go"},
 				Matcher:       ".go",
 			},
-			want: `[{"uri":"main.go","matches":[{"range":{"start":{"offset":28,"line":5,"column":1},"end":{"offset":32,"line":5,"column":5}},"matched":"func"}]}]`},
+			want: "func",
+		},
 	}
 
 	for _, test := range cases {
@@ -59,12 +59,9 @@ func main() {
 		if err != nil {
 			t.Fatal(err)
 		}
-		got, _ := json.Marshal(m)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(got[:]) != test.want {
-			t.Errorf("got %v, want %v", string(got[:]), test.want)
+		got := m[0].Matches[0].Matched
+		if got != test.want {
+			t.Errorf("got %v, want %v", got, test.want)
 			continue
 		}
 	}

--- a/internal/comby/comby_test.go
+++ b/internal/comby/comby_test.go
@@ -46,7 +46,6 @@ func main() {
 			args: Args{
 				Input:         ZipPath(zipPath),
 				MatchTemplate: "func",
-				MatchOnly:     true,
 				FilePatterns:  []string{".go"},
 				Matcher:       ".go",
 			},

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -32,3 +32,29 @@ type Args struct {
 	// NumWorkers is the number of worker processes to fork in parallel
 	NumWorkers int
 }
+
+type Location struct {
+	Offset int `json:"offset"`
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Range struct {
+	Start Location `json:"start"`
+	End   Location `json:"end"`
+}
+
+type Match struct {
+	Range   Range  `json:"range"`
+	Matched string `json:"matched"`
+}
+
+type FileMatch struct {
+	URI     string  `json:"uri"`
+	Matches []Match `json:"matches"`
+}
+
+type FileDiff struct {
+	URI  string   `json:"uri"`
+	Diff []string `json:"diff"`
+}

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -33,28 +33,33 @@ type Args struct {
 	NumWorkers int
 }
 
+// Location is the location in a file
 type Location struct {
 	Offset int `json:"offset"`
 	Line   int `json:"line"`
 	Column int `json:"column"`
 }
 
+// Range is a range of start location to end location
 type Range struct {
 	Start Location `json:"start"`
 	End   Location `json:"end"`
 }
 
+// Match represents a range of matched characters and the matched content
 type Match struct {
 	Range   Range  `json:"range"`
 	Matched string `json:"matched"`
 }
 
+// FileMatch represents all the matches in a single file
 type FileMatch struct {
 	URI     string  `json:"uri"`
 	Matches []Match `json:"matches"`
 }
 
+// FileDiff represents a diff for a file
 type FileDiff struct {
-	URI  string   `json:"uri"`
-	Diff []string `json:"diff"`
+	URI  string `json:"uri"`
+	Diff string `json:"diff"`
 }


### PR DESCRIPTION
Summary:

- Adds Go types  to deserialize comby results (e.g.,  `FileMatch` and `FileDiff`)
- Adds a `Matches` convenience function for turning raw results into `[]FileMatch`
- Updates a `-f` flag that I need for structural search

Test plan: Added tests for functionality
