### PR TITLE
a8n: Implement CampaignPlan & ChangesetPlan in GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -212,7 +212,9 @@ type ChangesetPlanResolver interface {
 	Title() (string, error)
 	Body() (string, error)
 	Repository(ctx context.Context) (*RepositoryResolver, error)
-	Diff(ctx context.Context) (PreviewRepositoryDiff, error)
+	BaseRepository(ctx context.Context) (*RepositoryResolver, error)
+	Diff(ctx context.Context) ChangesetPlanResolver
+	FileDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewFileDiffConnection, error)
 }
 
 type ChangesetEventsConnectionResolver interface {
@@ -267,7 +269,7 @@ type CampaignPlanResolver interface {
 
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
 
-	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewRepositoryDiffConnectionResolver, error)
+	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetPlansConnectionResolver, error)
 }
 
 type PreviewFileDiff interface {
@@ -285,15 +287,4 @@ type PreviewFileDiffConnection interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	RawDiff(ctx context.Context) (string, error)
-}
-
-type PreviewRepositoryDiff interface {
-	BaseRepository() *RepositoryResolver
-	FileDiffs(*graphqlutil.ConnectionArgs) PreviewFileDiffConnection
-}
-
-type PreviewRepositoryDiffConnectionResolver interface {
-	Nodes(ctx context.Context) ([]PreviewRepositoryDiff, error)
-	TotalCount(ctx context.Context) (int32, error)
-	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -209,8 +209,6 @@ type ChangesetPlansConnectionResolver interface {
 }
 
 type ChangesetPlanResolver interface {
-	Title() (string, error)
-	Body() (string, error)
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 	BaseRepository(ctx context.Context) (*RepositoryResolver, error)
 	Diff(ctx context.Context) ChangesetPlanResolver

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -624,12 +624,6 @@ type ChangesetPlan {
     # The repository changed by the changeset.
     repository: Repository!
 
-    # The title of the changeset.
-    title: String!
-
-    # The body of the changeset.
-    body: String!
-
     # The diff of the changeset.
     diff: PreviewRepositoryDiff!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -631,12 +631,6 @@ type ChangesetPlan {
     # The repository changed by the changeset.
     repository: Repository!
 
-    # The title of the changeset.
-    title: String!
-
-    # The body of the changeset.
-    body: String!
-
     # The diff of the changeset.
     diff: PreviewRepositoryDiff!
 }

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -59,6 +59,7 @@ func (r *campaignPlanResolver) Changesets(
 	return &campaignJobsConnectionResolver{
 		store:        r.store,
 		campaignPlan: r.campaignPlan,
+		limit:        int(args.GetFirst()),
 	}
 }
 
@@ -69,12 +70,14 @@ func (r *campaignPlanResolver) RepositoryDiffs(
 	return &campaignJobsConnectionResolver{
 		store:        r.store,
 		campaignPlan: r.campaignPlan,
+		limit:        int(args.GetFirst()),
 	}, nil
 }
 
 type campaignJobsConnectionResolver struct {
 	store        *ee.Store
 	campaignPlan *a8n.CampaignPlan
+	limit        int
 
 	// cache results because they are used by multiple fields
 	once sync.Once
@@ -99,6 +102,7 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 	r.once.Do(func() {
 		r.jobs, r.next, r.err = r.store.ListCampaignJobs(ctx, ee.ListCampaignJobsOpts{
 			CampaignPlanID: r.campaignPlan.ID,
+			Limit:          r.limit,
 		})
 		// TODO(a8n): To avoid n+1 queries, we could preload all repositories here
 		// and save them

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -2,14 +2,19 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 const campaignPlanIDKind = "CampaignPlan"
@@ -34,12 +39,7 @@ func (r *campaignPlanResolver) ID() graphql.ID {
 
 func (r *campaignPlanResolver) Type() string { return r.campaignPlan.CampaignType }
 func (r *campaignPlanResolver) Arguments() (graphqlbackend.JSONCString, error) {
-	b, err := json.Marshal(r.campaignPlan.Arguments)
-	if err != nil {
-		return graphqlbackend.JSONCString(""), err
-	}
-
-	return graphqlbackend.JSONCString(string(b)), nil
+	return graphqlbackend.JSONCString(r.campaignPlan.Arguments), nil
 }
 
 func (r *campaignPlanResolver) Status() graphqlbackend.BackgroundProcessStatus {
@@ -56,34 +56,250 @@ func (r *campaignPlanResolver) Changesets(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,
 ) graphqlbackend.ChangesetPlansConnectionResolver {
-	// TODO(a8n): Implement this. We need to fetch the CampaignJobs and their
-	// diffs/errors and return them as a `campaignJobConnectionResolver` that
-	// implements the `ChangesetsConnectionResolver` interface.
-	return &changesetPlansConnectionResolver{store: r.store, campaignPlan: r.campaignPlan}
+	return &campaignJobsConnectionResolver{
+		store:        r.store,
+		campaignPlan: r.campaignPlan,
+	}
 }
 
 func (r *campaignPlanResolver) RepositoryDiffs(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,
-) (graphqlbackend.PreviewRepositoryDiffConnectionResolver, error) {
-	// TODO(a8n): Implement this. We need to fetch the CampaignJobs diffs
-	// and return them as a `PreviewRepositoryDiffConnectionResolver`
+) (graphqlbackend.ChangesetPlansConnectionResolver, error) {
+	// TODO(a8n): We should cache this resolver. See `Changesets` method above
+	return &campaignJobsConnectionResolver{
+		store:        r.store,
+		campaignPlan: r.campaignPlan,
+	}, nil
+}
+
+type campaignJobsConnectionResolver struct {
+	store        *ee.Store
+	campaignPlan *a8n.CampaignPlan
+
+	// cache results because they are used by multiple fields
+	once sync.Once
+	jobs []*a8n.CampaignJob
+	next int64
+	err  error
+}
+
+func (r *campaignJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetPlanResolver, error) {
+	jobs, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvers := make([]graphqlbackend.ChangesetPlanResolver, 0, len(jobs))
+	for _, j := range jobs {
+		resolvers = append(resolvers, &campaignJobResolver{
+			store:        r.store,
+			job:          j,
+			campaignPlan: r.campaignPlan,
+		})
+	}
+	return resolvers, nil
+}
+
+func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.CampaignJob, int64, error) {
+	r.once.Do(func() {
+		r.jobs, r.next, r.err = r.store.ListCampaignJobs(ctx, ee.ListCampaignJobsOpts{
+			CampaignPlanID: r.campaignPlan.ID,
+		})
+		// TODO(a8n): To avoid n+1 queries, we could preload all repositories here
+		// and save them
+	})
+	return r.jobs, r.next, r.err
+}
+
+func (r *campaignJobsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	opts := ee.CountCampaignJobsOpts{CampaignPlanID: r.campaignPlan.ID}
+	count, err := r.store.CountCampaignJobs(ctx, opts)
+	return int32(count), err
+}
+
+func (r *campaignJobsConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return graphqlutil.HasNextPage(next != 0), nil
+}
+
+type campaignJobResolver struct {
+	store        *ee.Store
+	job          *a8n.CampaignJob
+	campaignPlan *a8n.CampaignPlan
+
+	// cache repo because it's called more than one time
+	once   sync.Once
+	repo   *graphqlbackend.RepositoryResolver
+	commit *graphqlbackend.GitCommitResolver
+	err    error
+}
+
+func (r *campaignJobResolver) Title() (string, error) { return "Title placeholder", nil }
+func (r *campaignJobResolver) Body() (string, error)  { return "Body placeholder", nil }
+
+func (r *campaignJobResolver) computeRepoCommit(ctx context.Context) (*graphqlbackend.RepositoryResolver, *graphqlbackend.GitCommitResolver, error) {
+	r.once.Do(func() {
+		r.repo, r.err = graphqlbackend.RepositoryByIDInt32(ctx, api.RepoID(r.job.RepoID))
+		if r.err != nil {
+			return
+		}
+		args := &graphqlbackend.RepositoryCommitArgs{Rev: string(r.job.Rev)}
+		r.commit, r.err = r.repo.Commit(ctx, args)
+	})
+	return r.repo, r.commit, r.err
+}
+
+func (r *campaignJobResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
+	repo, _, err := r.computeRepoCommit(ctx)
+	return repo, err
+}
+
+func (r *campaignJobResolver) BaseRepository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
+	repo, _, err := r.computeRepoCommit(ctx)
+	return repo, err
+}
+
+func (r *campaignJobResolver) Diff(ctx context.Context) graphqlbackend.ChangesetPlanResolver {
+	return r
+}
+
+func (r *campaignJobResolver) FileDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (graphqlbackend.PreviewFileDiffConnection, error) {
+	_, commit, err := r.computeRepoCommit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &previewFileDiffConnectionResolver{
+		job:    r.job,
+		commit: commit,
+		first:  args.First,
+	}, nil
+}
+
+type previewFileDiffConnectionResolver struct {
+	job    *a8n.CampaignJob
+	commit *graphqlbackend.GitCommitResolver
+	first  *int32
+
+	// cache result because it is used by multiple fields
+	once        sync.Once
+	fileDiffs   []*diff.FileDiff
+	hasNextPage bool
+	err         error
+}
+
+func (r *previewFileDiffConnectionResolver) compute(ctx context.Context) ([]*diff.FileDiff, error) {
+	r.once.Do(func() {
+		r.fileDiffs, r.err = diff.ParseMultiFileDiff([]byte(r.job.Diff))
+		if r.err != nil {
+			return
+		}
+
+		if r.first != nil && len(r.fileDiffs) > int(*r.first) {
+			r.hasNextPage = true
+		}
+	})
+	return r.fileDiffs, r.err
+}
+
+func (r *previewFileDiffConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.PreviewFileDiff, error) {
+	fileDiffs, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.first != nil && len(fileDiffs) > int(*r.first) {
+		fileDiffs = fileDiffs[:*r.first]
+	}
+
+	resolvers := make([]graphqlbackend.PreviewFileDiff, len(fileDiffs))
+	for i, fileDiff := range fileDiffs {
+		resolvers[i] = &previewFileDiffResolver{
+			fileDiff: fileDiff,
+			commit:   r.commit,
+		}
+	}
+	return resolvers, nil
+}
+
+func (r *previewFileDiffConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+	fileDiffs, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if r.first == nil || (len(fileDiffs) > int(*r.first)) {
+		n := int32(len(fileDiffs))
+		return &n, nil
+	}
+	// This is taken from fileDiffConnectionResolver.TotalCount
 	return nil, nil
 }
 
-type changesetPlansConnectionResolver struct {
-	store        *ee.Store
-	campaignPlan *a8n.CampaignPlan
+func (r *previewFileDiffConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	if _, err := r.compute(ctx); err != nil {
+		return nil, err
+	}
+	return graphqlutil.HasNextPage(r.hasNextPage), nil
 }
 
-func (r *changesetPlansConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetPlanResolver, error) {
-	return []graphqlbackend.ChangesetPlanResolver{}, nil
+func (r *previewFileDiffConnectionResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
+	fileDiffs, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stat := &graphqlbackend.DiffStat{}
+	for _, fileDiff := range fileDiffs {
+		s := fileDiff.Stat()
+		stat.AddStat(s)
+	}
+	return stat, nil
+}
+func (r *previewFileDiffConnectionResolver) RawDiff(ctx context.Context) (string, error) {
+	fileDiffs, err := r.compute(ctx)
+	if err != nil {
+		return "", err
+	}
+	b, err := diff.PrintMultiFileDiff(fileDiffs)
+	return string(b), err
 }
 
-func (r *changesetPlansConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	return 0, nil
+type previewFileDiffResolver struct {
+	fileDiff *diff.FileDiff
+	commit   *graphqlbackend.GitCommitResolver
 }
 
-func (r *changesetPlansConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
+func (r *previewFileDiffResolver) OldPath() *string { return diffPathOrNull(r.fileDiff.OrigName) }
+func (r *previewFileDiffResolver) NewPath() *string { return diffPathOrNull(r.fileDiff.NewName) }
+
+func (r *previewFileDiffResolver) Hunks() []*graphqlbackend.DiffHunk {
+	hunks := make([]*graphqlbackend.DiffHunk, len(r.fileDiff.Hunks))
+	for i, hunk := range r.fileDiff.Hunks {
+		hunks[i] = graphqlbackend.NewDiffHunk(hunk)
+	}
+	return hunks
+}
+
+func (r *previewFileDiffResolver) Stat() *graphqlbackend.DiffStat {
+	stat := r.fileDiff.Stat()
+	return graphqlbackend.NewDiffStat(stat)
+}
+
+func (r *previewFileDiffResolver) OldFile() *graphqlbackend.GitTreeEntryResolver {
+	fileStat := graphqlbackend.CreateFileInfo(r.fileDiff.OrigName, false)
+	return graphqlbackend.NewGitTreeEntryResolver(r.commit, fileStat)
+}
+
+func (r *previewFileDiffResolver) InternalID() string {
+	b := sha256.Sum256([]byte(fmt.Sprintf("%d:%s:%s", len(r.fileDiff.OrigName), r.fileDiff.OrigName, r.fileDiff.NewName)))
+	return hex.EncodeToString(b[:])[:32]
+}
+
+func diffPathOrNull(path string) *string {
+	if path == "/dev/null" || path == "" {
+		return nil
+	}
+	return &path
 }

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -239,7 +239,7 @@ func (r *previewFileDiffConnectionResolver) Nodes(ctx context.Context) ([]graphq
 		return nil, err
 	}
 
-	if r.first != nil && len(fileDiffs) > int(*r.first) {
+	if r.first != nil && int(*r.first) <= len(fileDiffs) {
 		fileDiffs = fileDiffs[:*r.first]
 	}
 

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -66,7 +66,6 @@ func (r *campaignPlanResolver) RepositoryDiffs(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,
 ) (graphqlbackend.ChangesetPlansConnectionResolver, error) {
-	// TODO(a8n): We should cache this resolver. See `Changesets` method above
 	return &campaignJobsConnectionResolver{
 		store:        r.store,
 		campaignPlan: r.campaignPlan,
@@ -91,11 +90,7 @@ func (r *campaignJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlba
 	}
 	resolvers := make([]graphqlbackend.ChangesetPlanResolver, 0, len(jobs))
 	for _, j := range jobs {
-		resolvers = append(resolvers, &campaignJobResolver{
-			store:        r.store,
-			job:          j,
-			campaignPlan: r.campaignPlan,
-		})
+		resolvers = append(resolvers, &campaignJobResolver{job: j})
 	}
 	return resolvers, nil
 }
@@ -126,9 +121,7 @@ func (r *campaignJobsConnectionResolver) PageInfo(ctx context.Context) (*graphql
 }
 
 type campaignJobResolver struct {
-	store        *ee.Store
-	job          *a8n.CampaignJob
-	campaignPlan *a8n.CampaignPlan
+	job *a8n.CampaignJob
 
 	// cache repo because it's called more than one time
 	once   sync.Once

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -162,9 +162,6 @@ type campaignJobResolver struct {
 	err    error
 }
 
-func (r *campaignJobResolver) Title() (string, error) { return "Title placeholder", nil }
-func (r *campaignJobResolver) Body() (string, error)  { return "Body placeholder", nil }
-
 func (r *campaignJobResolver) computeRepoCommit(ctx context.Context) (*graphqlbackend.RepositoryResolver, *graphqlbackend.GitCommitResolver, error) {
 	r.once.Do(func() {
 		if r.preloadedRepo != nil {

--- a/enterprise/pkg/a8n/resolvers/changesets.go
+++ b/enterprise/pkg/a8n/resolvers/changesets.go
@@ -90,17 +90,7 @@ func (r *changesetResolver) Repository(ctx context.Context) (*graphqlbackend.Rep
 
 func (r *changesetResolver) repoResolver(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
 	if r.repo != nil {
-		return graphqlbackend.NewRepositoryResolver(&types.Repo{
-			ID:           api.RepoID(r.repo.ID),
-			ExternalRepo: r.repo.ExternalRepo,
-			Name:         api.RepoName(r.repo.Name),
-			RepoFields: &types.RepoFields{
-				URI:         r.repo.URI,
-				Description: r.repo.Description,
-				Language:    r.repo.Language,
-				Fork:        r.repo.Fork,
-			},
-		}), nil
+		return newRepositoryResolver(r.repo), nil
 	}
 	return graphqlbackend.RepositoryByIDInt32(ctx, api.RepoID(r.Changeset.RepoID))
 }
@@ -221,5 +211,19 @@ func (r *changesetResolver) Diff(ctx context.Context) (*graphqlbackend.Repositor
 	return graphqlbackend.NewRepositoryComparison(ctx, repo, &graphqlbackend.RepositoryComparisonInput{
 		Base: &base,
 		Head: &head,
+	})
+}
+
+func newRepositoryResolver(r *repos.Repo) *graphqlbackend.RepositoryResolver {
+	return graphqlbackend.NewRepositoryResolver(&types.Repo{
+		ID:           api.RepoID(r.ID),
+		ExternalRepo: r.ExternalRepo,
+		Name:         api.RepoName(r.Name),
+		RepoFields: &types.RepoFields{
+			URI:         r.URI,
+			Description: r.Description,
+			Language:    r.Language,
+			Fork:        r.Fork,
+		},
 	})
 }

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -890,9 +890,8 @@ func TestCampaignPlanResolver(t *testing.T) {
 	}
 
 	type ChangesetPlan struct {
-		Title, Body string
-		Repository  struct{ Name, URL string }
-		Diff        struct {
+		Repository struct{ Name, URL string }
+		Diff       struct {
 			FileDiffs      FileDiffs
 			BaseRepository Repository
 		}
@@ -934,8 +933,6 @@ func TestCampaignPlanResolver(t *testing.T) {
             }
             changesets(first: %d) {
               nodes {
-                title
-                body
                 repository {
                   name
                 }

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -932,7 +932,7 @@ func TestCampaignPlanResolver(t *testing.T) {
               state
               errors
             }
-            changesets {
+            changesets(first: %d) {
               nodes {
                 title
                 body
@@ -980,7 +980,7 @@ func TestCampaignPlanResolver(t *testing.T) {
           }
         }
       }
-	`, marshalCampaignPlanID(plan.ID)))
+	`, marshalCampaignPlanID(plan.ID), len(jobs)))
 
 	if have, want := response.Node.CampaignType, plan.CampaignType; have != want {
 		t.Fatalf("have CampaignType %q, want %q", have, want)

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
@@ -32,6 +33,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -748,6 +750,303 @@ func TestChangesetCountsOverTime(t *testing.T) {
 
 	if !reflect.DeepEqual(have, want) {
 		t.Errorf("wrong counts listed. diff=%s", cmp.Diff(have, want))
+	}
+}
+
+const testDiff = `diff --git a/README.md b/README.md
+index 671e50a..851b23a 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,3 @@
+ # README
+ 
+-This file is hosted at example.com and is a test file.
++This file is hosted at sourcegraph.com and is a test file.
+diff --git a/urls.txt b/urls.txt
+index 6f8b5d9..17400bc 100644
+--- a/urls.txt
++++ b/urls.txt
+@@ -1,3 +1,3 @@
+ another-url.com
+-example.com
++sourcegraph.com
+ never-touch-the-mouse.com
+`
+
+func TestCampaignPlanResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+	rcache.SetupForTest(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+
+	var rs []*repos.Repo
+	for i := 0; i < 3; i++ {
+		repo := &repos.Repo{
+			Name:        fmt.Sprintf("github.com/sourcegraph/sourcegraph-%d", i),
+			URI:         fmt.Sprintf("github.com/sourcegraph/sourcegraph-%d", i),
+			Description: "Code search and navigation tool",
+			Enabled:     true,
+			ExternalRepo: api.ExternalRepoSpec{
+				ID:          fmt.Sprintf("external-id-%d", i),
+				ServiceType: "github",
+				ServiceID:   "https://github.com/",
+			},
+			Sources: map[string]*repos.SourceInfo{
+				"extsvc:github:4": {
+					ID:       "extsvc:github:4",
+					CloneURL: "https://secrettoken@github.com/sourcegraph/sourcegraph",
+				},
+			},
+		}
+		err := reposStore.UpsertRepos(ctx, repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rs = append(rs, repo)
+	}
+
+	// For testing purposes they all share the same rev, across repos
+	rev := api.CommitID("24f7ca7c1190835519e261d7eefa09df55ceea4f")
+
+	backend.Mocks.Repos.ResolveRev = func(_ context.Context, _ *types.Repo, _ string) (api.CommitID, error) {
+		return rev, nil
+	}
+	defer func() { backend.Mocks.Repos.ResolveRev = nil }()
+
+	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, _ api.CommitID) (*git.Commit, error) {
+		return &git.Commit{ID: rev}, nil
+	}
+	defer func() { backend.Mocks.Repos.GetCommit = nil }()
+
+	store := ee.NewStoreWithClock(dbconn.Global, clock)
+
+	plan := &a8n.CampaignPlan{
+		CampaignType: "COMBY",
+		Arguments:    `{"scopeQuery": "file:README.md"}`,
+	}
+	err := store.CreateCampaignPlan(ctx, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var jobs []*a8n.CampaignJob
+	for _, repo := range rs {
+		job := &a8n.CampaignJob{
+			CampaignPlanID: plan.ID,
+			StartedAt:      now,
+			FinishedAt:     now,
+			RepoID:         int32(repo.ID),
+			Rev:            rev,
+			Diff:           testDiff,
+		}
+
+		err := store.CreateCampaignJob(ctx, job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jobs = append(jobs, job)
+	}
+
+	type DiffRange struct{ StartLine, Lines int }
+	type FileDiffHunk struct {
+		Body, Section      string
+		OldNoNewlineAt     bool
+		OldRange, NewRange DiffRange
+	}
+
+	type DiffStat struct{ Added, Deleted, Changed int }
+
+	type File struct {
+		Name string
+		// Ignoring other fields of File2, since that would require gitserver
+	}
+
+	type FileDiff struct {
+		OldPath, NewPath string
+		Hunks            []FileDiffHunk
+		Stat             DiffStat
+		OldFile          File
+	}
+
+	type FileDiffs struct {
+		RawDiff  string
+		DiffStat DiffStat
+		Nodes    []FileDiff
+	}
+
+	type Repository struct {
+		Name string
+	}
+	type ChangesetPlan struct {
+		Title, Body string
+		Repository  struct {
+			Name, URL string
+		}
+		Diff struct {
+			FileDiffs      FileDiffs
+			BaseRepository Repository
+		}
+	}
+
+	type CampaignPlan struct {
+		ID           string
+		CampaignType string `json:"type"`
+		Arguments    string
+		Changesets   struct {
+			Nodes []ChangesetPlan
+		}
+	}
+
+	type Response struct {
+		Node CampaignPlan
+	}
+	var response Response
+
+	sr := &Resolver{store: store}
+
+	s, err := graphqlbackend.NewSchema(sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mustExec(ctx, t, s, nil, &response, fmt.Sprintf(`
+      query {
+        node(id: %q) {
+          ... on CampaignPlan {
+            id
+            type
+            arguments
+            status {
+              completedCount
+              pendingCount
+              state
+              errors
+            }
+            changesets {
+              nodes {
+                title
+                body
+                repository {
+                  name
+                }
+                diff {
+                  baseRepository {
+                    name
+                  }
+                  fileDiffs {
+                    rawDiff
+                    diffStat {
+                      added
+                      deleted
+                      changed
+                    }
+                    nodes {
+                      oldPath
+                      newPath
+                      hunks {
+                        body
+                        section
+                        newRange { startLine, lines }
+                        oldRange { startLine, lines }
+                        oldNoNewlineAt
+                      }
+                      stat {
+                        added
+                        deleted
+                        changed
+                      }
+                      oldFile {
+                        name
+                        externalURLs {
+                          serviceType
+                          url
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+	`, marshalCampaignPlanID(plan.ID)))
+
+	if have, want := response.Node.CampaignType, plan.CampaignType; have != want {
+		t.Fatalf("have CampaignType %q, want %q", have, want)
+	}
+
+	if have, want := response.Node.Arguments, plan.Arguments; have != want {
+		t.Fatalf("have Arguments %q, want %q", have, want)
+	}
+
+	if have, want := len(response.Node.Changesets.Nodes), len(jobs); have != want {
+		t.Fatalf("have %d changeset plans, want %d", have, want)
+	}
+
+	for i, changesetPlan := range response.Node.Changesets.Nodes {
+		if have, want := changesetPlan.Repository.Name, rs[i].Name; have != want {
+			t.Fatalf("wrong Repository Name %q. want=%q", have, want)
+		}
+
+		if have, want := changesetPlan.Diff.BaseRepository.Name, rs[i].Name; have != want {
+			t.Fatalf("wrong Repository Name %q. want=%q", have, want)
+		}
+
+		if have, want := changesetPlan.Diff.FileDiffs.RawDiff, testDiff; have != want {
+			t.Fatalf("wrong RawDiff. diff=%s", cmp.Diff(have, want))
+		}
+
+		if have, want := changesetPlan.Diff.FileDiffs.DiffStat.Changed, 2; have != want {
+			t.Fatalf("wrong DiffStat.Changed %d, want=%d", have, want)
+		}
+
+		wantFileDiffs := FileDiffs{
+			RawDiff:  testDiff,
+			DiffStat: DiffStat{Changed: 2},
+			Nodes: []FileDiff{
+				{
+					OldPath: "a/README.md",
+					NewPath: "b/README.md",
+					OldFile: File{Name: "README.md"},
+					Hunks: []FileDiffHunk{
+						{
+							Body:     " # README\n \n-This file is hosted at example.com and is a test file.\n+This file is hosted at sourcegraph.com and is a test file.\n",
+							OldRange: DiffRange{StartLine: 1, Lines: 3},
+							NewRange: DiffRange{StartLine: 1, Lines: 3},
+						},
+					},
+					Stat: DiffStat{Changed: 1},
+				},
+				{
+					OldPath: "a/urls.txt",
+					NewPath: "b/urls.txt",
+					OldFile: File{Name: "urls.txt"},
+					Hunks: []FileDiffHunk{
+						{
+							Body:     " another-url.com\n-example.com\n+sourcegraph.com\n never-touch-the-mouse.com\n",
+							OldRange: DiffRange{StartLine: 1, Lines: 3},
+							NewRange: DiffRange{StartLine: 1, Lines: 3},
+						},
+					},
+					Stat: DiffStat{Changed: 1},
+				},
+			},
+		}
+		haveFileDiffs := changesetPlan.Diff.FileDiffs
+		if !reflect.DeepEqual(haveFileDiffs, wantFileDiffs) {
+			t.Fatal(cmp.Diff(haveFileDiffs, wantFileDiffs))
+		}
 	}
 }
 


### PR DESCRIPTION
This is part of #6085 (and RFC 42) and implements the GraphQL resolvers for the `CampaignPlan` and `ChangesetPlan` entities that were stubbed out until now.

There's nothing really tricky here: it pulls `CampaignPlan`s and `CampaignJob`s out of the database and wraps them in resolvers so that the all the fields of in the schema work.

It's a massive amount of boilerplate.

Noteworthy is that I could reduce the number of Go interfaces needed by having the `ChangesetPlansConnectionResolver`, which is `*campaignJobsConnectionResolver` here, implement two GraphQL fields on `CampaignPlan`: `RepositoryDiffs` and `Changesets`. That gets rid of having to have an intermediate `PreviewRepositoryDiffsConnectionResolver` and doing that whole dance twice.

TODOs:

- [x] Change the placerholder title and description (@sqs what should those be? Since the plan is not connected to a Campaign yet and the possibly hasn't entered title/description yet, we can't use that)
- [x] Respect connection args in `campaignPlanResolver.Changesets` & `campaignPlanResolver.RepositoryDiffs`