### PR TITLE
LSIF: Fix bad postgres connection default

### DIFF
--- a/lsif/src/connection.ts
+++ b/lsif/src/connection.ts
@@ -79,20 +79,17 @@ export async function createPostgresConnection(configuration: Configuration, log
         disable: false,
     }
 
+    const host = url.hostname
+    const port = parseInt(url.port, 10) || 5432
+    const username = decodeURIComponent(url.username)
+    const password = decodeURIComponent(url.password)
+    const database = decodeURIComponent(url.pathname).substring(1) || username
     const sslMode = url.searchParams.get('sslmode')
-
-    const connectionOptions = {
-        host: url.hostname,
-        port: parseInt(url.port, 10) || 5432,
-        username: decodeURIComponent(url.username),
-        password: decodeURIComponent(url.password),
-        database: decodeURIComponent(url.pathname).substring(1),
-        ssl: sslMode ? sslModes[sslMode] : undefined,
-    }
+    const ssl = sslMode ? sslModes[sslMode] : undefined
 
     // Get a working connection
     const connection = await connect(
-        connectionOptions,
+        { host, port, username, password, database, ssl },
         logger
     )
 


### PR DESCRIPTION
When doing a dogfooding run, @attfarhan ran into an issue where PGDATABASE was not set and the lsif-server and frontend/management-console connected to diffferent databases. It happens that he had both a `sourcegraph` as well as a `farhan` db with the schema migrations table. The `farhan` db was out of date and stopped the lsif-server from starting up.

It appears that if no dbname is explicitlty supplied that the Go/pg driver will default to the name of the user trying to connect, where typeorm/node-postgres will use the current OS user. This PR explicitly supplies a database name if one is not given so that it matches this behavior.

I've tried tracing both code paths down to the driver, but did not find a line I could refer to for this defaults. This changed is based on observable behavior only.