### PR TITLE
show dir links on tree page in bold to make visual scanning easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - **Kubernetes Migration:** The [Kubernetes deployment](https://github.com/sourcegraph/deploy-sourcegraph) manifest for indexed-search services has changed from a Normal Service to a Headless Service. This is to enable Sourcegraph to individually resolve indexed-search pods. Services are immutable, so please follow the [migration guide](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/migrate.md#310).
 - Fields of type `String` in our GraphQL API that contain [JSONC](https://komkom.github.io/) now have the custom scalar type `JSONCString`. [#6209](https://github.com/sourcegraph/sourcegraph/pull/6209)
 - `ZOEKT_HOST` environment variable has been deprecated. Please use `INDEXED_SEARCH_SERVERS` instead. `ZOEKT_HOST` will be removed in 3.12.
+- Directory names on the repository tree page are now shown in bold to improve readability.
 
 ### Fixed
 

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -49,7 +49,7 @@ const TreeEntry: React.FunctionComponent<{
 }> = ({ isDir, name, parentPath, url }) => {
     const filePath = parentPath ? parentPath + '/' + name : name
     return (
-        <Link to={url} className="tree-entry" title={filePath}>
+        <Link to={url} className={`tree-entry ${isDir ? 'font-weight-bold' : ''}`} title={filePath}>
             {name}
             {isDir && '/'}
         </Link>


### PR DESCRIPTION
Implements feature request https://twitter.com/mholt6/status/1188154480337940480.

HT @mholt

![nowbold](https://user-images.githubusercontent.com/1976/68229270-c4566e80-ffab-11e9-9ce6-1b13c3e48d74.png)
