### PR TITLE
fix: show survey results even if a user has been deleted

### DIFF
--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -26,6 +26,7 @@ func (s *surveyResponseResolver) User(ctx context.Context) (*UserResolver, error
 	if s.surveyResponse.UserID != nil {
 		user, err := UserByIDInt32(ctx, *s.surveyResponse.UserID)
 		if err != nil && errcode.IsNotFound(err) {
+			// This can happen if the user has been deleted, see issue #4888 and #6454
 			return nil, nil
 		}
 		return user, err

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -24,7 +24,11 @@ func marshalSurveyResponseID(id int32) graphql.ID { return relay.MarshalID("Surv
 
 func (s *surveyResponseResolver) User(ctx context.Context) (*UserResolver, error) {
 	if s.surveyResponse.UserID != nil {
-		return UserByIDInt32(ctx, *s.surveyResponse.UserID)
+		user, err := UserByIDInt32(ctx, *s.surveyResponse.UserID)
+		if err != nil && errcode.IsNotFound(err) {
+			return nil, nil
+		}
+		return user, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
fixes https://github.com/sourcegraph/sourcegraph/issues/4888
fixes https://github.com/sourcegraph/sourcegraph/issues/6454

With this fix, the result and user's email address will still be shown, but it won't be a link to the user's profile.