### PR TITLE
a8n: Simplify ChangesetPlan and CampaignPlan in schema

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -210,8 +210,6 @@ type ChangesetPlansConnectionResolver interface {
 
 type ChangesetPlanResolver interface {
 	Repository(ctx context.Context) (*RepositoryResolver, error)
-	BaseRepository(ctx context.Context) (*RepositoryResolver, error)
-	Diff(ctx context.Context) ChangesetPlanResolver
 	FileDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewFileDiffConnection, error)
 }
 
@@ -266,8 +264,6 @@ type CampaignPlanResolver interface {
 	Status() BackgroundProcessStatus
 
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
-
-	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetPlansConnectionResolver, error)
 }
 
 type PreviewFileDiff interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -460,21 +460,6 @@ type CampaignPlan implements Node {
 
     # The changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!
-
-    # The combined diff of all changesets that will be created by the campaign.
-    repositoryDiffs(first: Int): PreviewRepositoryDiffConnection!
-}
-
-# A paginated list of repository diff previews.
-type PreviewRepositoryDiffConnection {
-    # A list of repository diffs.
-    nodes: [PreviewRepositoryDiff!]!
-
-    # The total number of repository diffs in the connection.
-    totalCount: Int!
-
-    # Pagination information.
-    pageInfo: PageInfo!
 }
 
 # A paginated list of repository diffs committed to git.
@@ -624,8 +609,8 @@ type ChangesetPlan {
     # The repository changed by the changeset.
     repository: Repository!
 
-    # The diff of the changeset.
-    diff: PreviewRepositoryDiff!
+    # The preview of the file diffs for each file in the diff.
+    fileDiffs(first: Int): PreviewFileDiffConnection!
 }
 
 # A changeset in a code host (e.g. a PR on Github)
@@ -1914,15 +1899,6 @@ type GitRefConnection {
     totalCount: Int!
     # Pagination information.
     pageInfo: PageInfo!
-}
-
-# A not-yet-committed preview of a diff on a repository.
-type PreviewRepositoryDiff {
-    # The repository that this diff is targeting.
-    baseRepository: Repository!
-
-    # The preview of the file diffs for each file in the diff.
-    fileDiffs(first: Int): PreviewFileDiffConnection!
 }
 
 # A list of file diffs that might be applied.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -467,21 +467,6 @@ type CampaignPlan implements Node {
 
     # The changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!
-
-    # The combined diff of all changesets that will be created by the campaign.
-    repositoryDiffs(first: Int): PreviewRepositoryDiffConnection!
-}
-
-# A paginated list of repository diff previews.
-type PreviewRepositoryDiffConnection {
-    # A list of repository diffs.
-    nodes: [PreviewRepositoryDiff!]!
-
-    # The total number of repository diffs in the connection.
-    totalCount: Int!
-
-    # Pagination information.
-    pageInfo: PageInfo!
 }
 
 # A paginated list of repository diffs committed to git.
@@ -631,8 +616,8 @@ type ChangesetPlan {
     # The repository changed by the changeset.
     repository: Repository!
 
-    # The diff of the changeset.
-    diff: PreviewRepositoryDiff!
+    # The preview of the file diffs for each file in the diff.
+    fileDiffs(first: Int): PreviewFileDiffConnection!
 }
 
 # A changeset in a code host (e.g. a PR on Github)
@@ -1921,15 +1906,6 @@ type GitRefConnection {
     totalCount: Int!
     # Pagination information.
     pageInfo: PageInfo!
-}
-
-# A not-yet-committed preview of a diff on a repository.
-type PreviewRepositoryDiff {
-    # The repository that this diff is targeting.
-    baseRepository: Repository!
-
-    # The preview of the file diffs for each file in the diff.
-    fileDiffs(first: Int): PreviewFileDiffConnection!
 }
 
 # A list of file diffs that might be applied.

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -65,17 +65,6 @@ func (r *campaignPlanResolver) Changesets(
 	}
 }
 
-func (r *campaignPlanResolver) RepositoryDiffs(
-	ctx context.Context,
-	args *graphqlutil.ConnectionArgs,
-) (graphqlbackend.ChangesetPlansConnectionResolver, error) {
-	return &campaignJobsConnectionResolver{
-		store:        r.store,
-		campaignPlan: r.campaignPlan,
-		limit:        int(args.GetFirst()),
-	}, nil
-}
-
 type campaignJobsConnectionResolver struct {
 	store        *ee.Store
 	campaignPlan *a8n.CampaignPlan
@@ -181,15 +170,6 @@ func (r *campaignJobResolver) computeRepoCommit(ctx context.Context) (*graphqlba
 func (r *campaignJobResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
 	repo, _, err := r.computeRepoCommit(ctx)
 	return repo, err
-}
-
-func (r *campaignJobResolver) BaseRepository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
-	repo, _, err := r.computeRepoCommit(ctx)
-	return repo, err
-}
-
-func (r *campaignJobResolver) Diff(ctx context.Context) graphqlbackend.ChangesetPlanResolver {
-	return r
 }
 
 func (r *campaignJobResolver) FileDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (graphqlbackend.PreviewFileDiffConnection, error) {

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -891,10 +891,7 @@ func TestCampaignPlanResolver(t *testing.T) {
 
 	type ChangesetPlan struct {
 		Repository struct{ Name, URL string }
-		Diff       struct {
-			FileDiffs      FileDiffs
-			BaseRepository Repository
-		}
+		FileDiffs  FileDiffs
 	}
 
 	type CampaignPlan struct {
@@ -936,38 +933,33 @@ func TestCampaignPlanResolver(t *testing.T) {
                 repository {
                   name
                 }
-                diff {
-                  baseRepository {
-                    name
+                fileDiffs {
+                  rawDiff
+                  diffStat {
+                    added
+                    deleted
+                    changed
                   }
-                  fileDiffs {
-                    rawDiff
-                    diffStat {
+                  nodes {
+                    oldPath
+                    newPath
+                    hunks {
+                      body
+                      section
+                      newRange { startLine, lines }
+                      oldRange { startLine, lines }
+                      oldNoNewlineAt
+                    }
+                    stat {
                       added
                       deleted
                       changed
                     }
-                    nodes {
-                      oldPath
-                      newPath
-                      hunks {
-                        body
-                        section
-                        newRange { startLine, lines }
-                        oldRange { startLine, lines }
-                        oldNoNewlineAt
-                      }
-                      stat {
-                        added
-                        deleted
-                        changed
-                      }
-                      oldFile {
-                        name
-                        externalURLs {
-                          serviceType
-                          url
-                        }
+                    oldFile {
+                      name
+                      externalURLs {
+                        serviceType
+                        url
                       }
                     }
                   }
@@ -996,15 +988,11 @@ func TestCampaignPlanResolver(t *testing.T) {
 			t.Fatalf("wrong Repository Name %q. want=%q", have, want)
 		}
 
-		if have, want := changesetPlan.Diff.BaseRepository.Name, rs[i].Name; have != want {
-			t.Fatalf("wrong Repository Name %q. want=%q", have, want)
-		}
-
-		if have, want := changesetPlan.Diff.FileDiffs.RawDiff, testDiff; have != want {
+		if have, want := changesetPlan.FileDiffs.RawDiff, testDiff; have != want {
 			t.Fatalf("wrong RawDiff. diff=%s", cmp.Diff(have, want))
 		}
 
-		if have, want := changesetPlan.Diff.FileDiffs.DiffStat.Changed, 2; have != want {
+		if have, want := changesetPlan.FileDiffs.DiffStat.Changed, 2; have != want {
 			t.Fatalf("wrong DiffStat.Changed %d, want=%d", have, want)
 		}
 
@@ -1040,7 +1028,7 @@ func TestCampaignPlanResolver(t *testing.T) {
 				},
 			},
 		}
-		haveFileDiffs := changesetPlan.Diff.FileDiffs
+		haveFileDiffs := changesetPlan.FileDiffs
 		if !reflect.DeepEqual(haveFileDiffs, wantFileDiffs) {
 			t.Fatal(cmp.Diff(haveFileDiffs, wantFileDiffs))
 		}


### PR DESCRIPTION
This is a follow-up to the discussion in this comment thread: https://github.com/sourcegraph/sourcegraph/pull/6430#discussion_r342962179

This does two things:
1. Removing `repositoryDiffs` from `CampaignPlan` (as discussed in comment thread)
2. Simplifying `ChangesetPlan` and `CampaignPlan` definitions (@tsenart and I discussed this in a separate call when talking about (1).

Let me explain the reasoning behind (2):

After following the suggestion in the thread and removing `repositoryDiffs` from `CampaignPlan` it also occurred to us, that `ChangesetPlan` has kinda redundant fields:

- On `ChangesetPlan`: `diff: PreviewRepositoryDiff` and `repository: Repository`
- On `PreviewRepositoryDiff`: `baseRepository: Repository` and `fileDiffs: PreviewFileDiffConnection`

So we decided to propose the following: get rid of `PreviewRepositoryDiff` and pull the `fileDiffs` fields up to `ChangesetPlan`.

That would change the way we query diffs on a `CampaignPlan` from this:

```graphql
node(id: "campaignplan-id") {
  ... on CampaignPlan {
    changesets(first: 100) {
      nodes {
        repository {
          name
        }
        diff {
          baseRepository {
            name
          }
          fileDiffs {
            rawDiff
            diffStat {
              added
              deleted
              changed
            }
            nodes {
              placeholderplaceholder
            }
          }
        }
      }
    }
  }
}
```

to this:

```graphql
node(id: "campaignplan-id") {
  ... on CampaignPlan {
    changesets(first: 100) {
      nodes {
        repository {
          name
        }
        fileDiffs {
          rawDiff
          diffStat {
            added
            deleted
            changed
          }
          nodes {
            placeholderplaceholder
          }
        }
      }
    }
  }
}
```

(See also the `schema.graphql` in this PR)

What do you think about (2), @felixfbecker and @eseliger?