### PR TITLE
Update docs regarding required Git version

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -25,7 +25,7 @@ Sourcegraph server is a collection of smaller binaries. The development server, 
 
 Sourcegraph has the following dependencies:
 
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (v2.18 or higher)
 - [Go](https://golang.org/doc/install) (v1.13 or higher)
 - [Node JS](https://nodejs.org/en/download/) (version 8 or 10)
 - [make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
In order for tests in `internal/vcs/git` to pass we need to be running at least Git 2.18



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
