### PR TITLE
FilteredConnection: Do not set visible on url if the value is zero.

### DIFF
--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -666,7 +666,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         if (arg.filter && this.props.filters && arg.filter !== this.props.filters[0]) {
             q.set('filter', arg.filter.id)
         }
-        if (arg.visible !== arg.first) {
+        if (arg.visible !== 0 && arg.visible !== arg.first) {
             q.set('visible', String(arg.visible))
         }
         return q.toString()


### PR DESCRIPTION
This cleans up the current page's URI on cursor paging a bit when navigating between filters and queries.