### PR TITLE
LSIF: Fix dumps sort order.

### DIFF
--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -94,7 +94,7 @@ export class XrepoDatabase {
                 .getRepository(LsifDump)
                 .createQueryBuilder()
                 .where({ repository })
-                .orderBy('uploaded_at')
+                .orderBy('uploaded_at', 'DESC')
                 .limit(limit)
                 .offset(offset)
 


### PR DESCRIPTION
Dumps should be returned from newest to oldest, not the other way around.