### PR TITLE
Add isLatestForRepo option to lsifDumps GraphQL endpoint

### DIFF
--- a/cmd/frontend/graphqlbackend/lsif_dumps.go
+++ b/cmd/frontend/graphqlbackend/lsif_dumps.go
@@ -16,10 +16,11 @@ import (
 )
 
 type LSIFDumpsListOptions struct {
-	Repository graphql.ID
-	Query      *string
-	Limit      *int32
-	NextURL    *string
+	Repository      graphql.ID
+	Query           *string
+	IsLatestForRepo *bool
+	Limit           *int32
+	NextURL         *string
 }
 
 // This method implements cursor-based forward pagination. The `after` parameter
@@ -31,13 +32,15 @@ type LSIFDumpsListOptions struct {
 
 func (r *schemaResolver) LSIFDumps(args *struct {
 	graphqlutil.ConnectionArgs
-	Repository graphql.ID
-	Query      *string
-	After      *string
+	Repository      graphql.ID
+	Query           *string
+	IsLatestForRepo *bool
+	After           *string
 }) (*lsifDumpConnectionResolver, error) {
 	opt := LSIFDumpsListOptions{
-		Repository: args.Repository,
-		Query:      args.Query,
+		Repository:      args.Repository,
+		Query:           args.Query,
+		IsLatestForRepo: args.IsLatestForRepo,
 	}
 	if args.First != nil {
 		if *args.First < 0 || *args.First > 5000 {
@@ -90,6 +93,9 @@ func (r *lsifDumpConnectionResolver) compute(ctx context.Context) ([]*types.LSIF
 		query := url.Values{}
 		if r.opt.Query != nil {
 			query.Set("query", *r.opt.Query)
+		}
+		if r.opt.IsLatestForRepo != nil && *r.opt.IsLatestForRepo {
+			query.Set("visibleAtTip", "true")
 		}
 		if r.opt.Limit != nil {
 			query.Set("limit", strconv.FormatInt(int64(*r.opt.Limit), 10))

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1252,6 +1252,9 @@ type Query {
         # An (optional) search query that searches over the commit and root properties.
         query: String
 
+        # When specified, shows only dumps that are latest for the given repository.
+        isLatestForRepo: Boolean
+
         # When specified, indicates that this request should be paginated and
         # the first N results (relative to the cursor) should be returned. i.e.
         # how many results to return per page. It must be in the range of 0-5000.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1259,6 +1259,9 @@ type Query {
         # An (optional) search query that searches over the commit and root properties.
         query: String
 
+        # When specified, shows only dumps that are latest for the given repository.
+        isLatestForRepo: Boolean
+
         # When specified, indicates that this request should be paginated and
         # the first N results (relative to the cursor) should be returned. i.e.
         # how many results to return per page. It must be in the range of 0-5000.


### PR DESCRIPTION
Allow filtering of only isLatestForRepo/visibleAtTip LSIF dumps.