### PR TITLE
LSIF: Add filter for visibleAtTip-only dumps.

### DIFF
--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -170,6 +170,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: visbleAtTip
+          in: query
+          description: If true, only show dumps visible at tip.
+          required: false
+          schema:
+            type: boolean
         - name: limit
           in: query
           description: The maximum number of dumps to return in one page.

--- a/lsif/src/backend.ts
+++ b/lsif/src/backend.ts
@@ -86,16 +86,18 @@ export class Backend {
      *
      * @param repository The repository.
      * @param query A search query.
+     * @param visibleAtTip If true, only return dumps visible at tip.
      * @param limit The maximum number of dumps to return.
      * @param offset The number of dumps to skip.
      */
     public dumps(
         repository: string,
         query: string,
+        visibleAtTip: boolean,
         limit: number,
         offset: number
     ): Promise<{ dumps: LsifDump[]; totalCount: number }> {
-        return this.xrepoDatabase.getDumps(repository, query, limit, offset)
+        return this.xrepoDatabase.getDumps(repository, query, visibleAtTip, limit, offset)
     }
 
     /**

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -440,9 +440,16 @@ function dumpEndpoints(backend: Backend, logger: Logger, tracer: Tracer | undefi
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
                 const { repository } = req.params
-                const { query } = req.query
+                const { query, visibleAtTip: visibleAtTipRaw } = req.query
                 const { limit, offset } = limitOffset(req, DEFAULT_DUMP_PAGE_SIZE)
-                const { dumps, totalCount } = await backend.dumps(decodeURIComponent(repository), query, limit, offset)
+                const visibleAtTip = visibleAtTipRaw === 'true'
+                const { dumps, totalCount } = await backend.dumps(
+                    decodeURIComponent(repository),
+                    query,
+                    visibleAtTip,
+                    limit,
+                    offset
+                )
 
                 if (offset + dumps.length < totalCount) {
                     res.set('Link', nextLink(req, { limit, offset: offset + dumps.length }))

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -80,12 +80,14 @@ export class XrepoDatabase {
      *
      * @param repository The repository.
      * @param query A search query.
+     * @param visibleAtTip If true, only return dumps visible at tip.
      * @param limit The maximum number of dumps to return.
      * @param offset The number of dumps to skip.
      */
     public async getDumps(
         repository: string,
         query: string,
+        visibleAtTip: boolean,
         limit: number,
         offset: number
     ): Promise<{ dumps: LsifDump[]; totalCount: number }> {
@@ -106,6 +108,10 @@ export class XrepoDatabase {
                             .orWhere("root LIKE '%' || :query || '%'", { query })
                     )
                 )
+            }
+
+            if (visibleAtTip) {
+                queryBuilder = queryBuilder.andWhere('visible_at_tip = true')
             }
 
             return queryBuilder.getManyAndCount()


### PR DESCRIPTION
Add a query parameter to return only LSIF dumps that are flagged with visibleAtTip.