### PR TITLE
LSIF: Ensure job state is converted from api.

### DIFF
--- a/lsif/src/api-job.ts
+++ b/lsif/src/api-job.ts
@@ -1,4 +1,5 @@
 import { Job } from 'bull'
+import { ApiJobState } from './queue'
 
 /**
  * The representation of a job as returned by the API.
@@ -7,7 +8,7 @@ export interface ApiJob {
     id: string
     name: string
     args: object
-    state: string
+    state: ApiJobState
     progress: number
     failedReason: string | null
     stacktrace: string[] | null
@@ -44,7 +45,7 @@ const toMaybeInt = (value: string | undefined): number | null => (value ? parseI
  * @param job The job to format.
  * @param state The job's state.
  */
-export const formatJob = (job: Job, state: string): ApiJob => {
+export const formatJob = (job: Job, state: ApiJobState): ApiJob => {
     const payload = job.toJSON()
 
     return {
@@ -67,7 +68,7 @@ export const formatJob = (job: Job, state: string): ApiJob => {
  * @param values A map of values composing the job.
  * @param state The job's state.
  */
-export const formatJobFromMap = (values: Map<string, string>, state: string): ApiJob => {
+export const formatJobFromMap = (values: Map<string, string>, state: ApiJobState): ApiJob => {
     const rawData = values.get('data')
     const rawStacktrace = values.get('stacktrace')
 

--- a/lsif/src/queue.ts
+++ b/lsif/src/queue.ts
@@ -19,15 +19,27 @@ export const QUEUE_PREFIX = `bull:${QUEUE_NAME}:`
 export type QueueTypes = 'active' | 'failed' | 'completed' | 'wait' | 'delayed'
 
 /**
+ * The names of job states in the API.
+ */
+export type ApiJobState = 'processing' | 'errored' | 'completed' | 'queued' | 'scheduled'
+
+/**
  * A mapping from job states to queue names.
  */
-export const queueTypes = new Map<string, QueueTypes>([
+export const queueTypes = new Map<ApiJobState, QueueTypes>([
     ['processing', 'active'],
     ['errored', 'failed'],
     ['completed', 'completed'],
     ['queued', 'wait'],
     ['scheduled', 'delayed'],
 ])
+
+/**
+ * A mapping from queue names to job states.
+ */
+export const statesByQueue = new Map(
+    Array.from(queueTypes.entries()).map(([state, queue]) => [queue, state] as [QueueTypes, ApiJobState])
+)
 
 /**
  * Creates a queue instance.

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -28,7 +28,15 @@ import { Span, Tracer } from 'opentracing'
 import { default as tracingMiddleware } from 'express-opentracing'
 import { waitForConfiguration } from './config'
 import { createLogger } from './logging'
-import { enqueue, createQueue, ensureOnlyRepeatableJob, queueTypes, QUEUE_PREFIX } from './queue'
+import {
+    enqueue,
+    createQueue,
+    ensureOnlyRepeatableJob,
+    queueTypes,
+    QUEUE_PREFIX,
+    statesByQueue,
+    ApiJobState,
+} from './queue'
 import { Connection } from 'typeorm'
 import { LsifDump } from './xrepo.models'
 import * as constants from './constants'
@@ -508,7 +516,7 @@ function jobEndpoints(
         `/jobs/:state(${Array.from(queueTypes.keys()).join('|')})`,
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
-                const { state } = req.params
+                const { state } = req.params as { state: ApiJobState }
                 const { query } = req.query
                 const { limit, offset } = limitOffset(req, DEFAULT_JOB_PAGE_SIZE)
 
@@ -564,7 +572,13 @@ function jobEndpoints(
                     })
                 }
 
-                res.send(formatJob(job, await job.getState()))
+                let rawState = await job.getState()
+                const state = statesByQueue.get(rawState === 'waiting' ? 'wait' : rawState)
+                if (!state) {
+                    throw new Error(`Unknown job state ${state}.`)
+                }
+
+                res.send(formatJob(job, state))
             }
         )
     )

--- a/lsif/src/server.ts
+++ b/lsif/src/server.ts
@@ -572,7 +572,7 @@ function jobEndpoints(
                     })
                 }
 
-                let rawState = await job.getState()
+                const rawState = await job.getState()
                 const state = statesByQueue.get(rawState === 'waiting' ? 'wait' : rawState)
                 if (!state) {
                     throw new Error(`Unknown job state ${state}.`)


### PR DESCRIPTION
Adds a type for job states so that we don't return bare strings that aren't the correct mapped values.