### PR TITLE
Exclude __fixtures__ from VS Code search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "browser/build": true,
     "**/coverage": true,
     "/cmd/management-console/assets/": true,
+    "**/__fixtures__/**": true,
   },
   "files.associations": {
     "**/dev/critical-config.json": "jsonc",


### PR DESCRIPTION
This avoids accidental search+replace.