### PR TITLE
Add additional filter component to filtered connection.

### DIFF
--- a/web/src/components/FilteredConnection.scss
+++ b/web/src/components/FilteredConnection.scss
@@ -1,4 +1,10 @@
 .filtered-connection {
+    &__control {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
     &__nodes {
         list-style-type: none;
         padding: 0;

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -116,7 +116,7 @@ interface ConnectionPropsCommon<N, NP = {}> extends ConnectionDisplayProps {
     nodeComponentProps?: NP
 
     /** An element rendered as a sibling of the filters. */
-    additionalFilterComponent?: React.ReactElement
+    additionalFilterElement?: React.ReactElement
 }
 
 /** State related to the ConnectionNodes component. */
@@ -731,7 +731,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 onDidSelectFilter={this.onDidSelectFilter}
                                 value={this.state.activeFilter.id}
                             >
-                                {this.props.additionalFilterComponent}
+                                {this.props.additionalFilterElement}
                             </FilteredConnectionFilterControl>
                         )}
                     </Form>

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -732,8 +732,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 onDidSelectFilter={this.onDidSelectFilter}
                                 value={this.state.activeFilter.id}
                             >
-                                {' '}
-                                {AdditionalFilters && <AdditionalFilters />}{' '}
+                                {AdditionalFilters && <AdditionalFilters />}
                             </FilteredConnectionFilterControl>
                         )}
                     </Form>

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -115,8 +115,8 @@ interface ConnectionPropsCommon<N, NP = {}> extends ConnectionDisplayProps {
     /** Props to pass to each nodeComponent in addition to `{ node: N }`. */
     nodeComponentProps?: NP
 
-    /** The component type to use to display additional filters. */
-    additionalFilterComponent?: React.ComponentType<{}>
+    /** An element rendered as a sibling of the filters. */
+    additionalFilterComponent?: React.ReactElement
 }
 
 /** State related to the ConnectionNodes component. */
@@ -701,7 +701,6 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             errors.push(this.state.connectionOrError.error)
         }
 
-        const AdditionalFilters = this.props.additionalFilterComponent
         const compactnessClass = `filtered-connection--${this.props.compact ? 'compact' : 'noncompact'}`
         return (
             <div
@@ -732,7 +731,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 onDidSelectFilter={this.onDidSelectFilter}
                                 value={this.state.activeFilter.id}
                             >
-                                {AdditionalFilters && <AdditionalFilters />}
+                                {this.props.additionalFilterComponent}
                             </FilteredConnectionFilterControl>
                         )}
                     </Form>

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -36,13 +36,23 @@ interface FilterProps {
 
     /** The ID of the active filter. */
     value: string
+
+    /** The component type to use to display additional filters. */
+    additionalFilterComponent?: React.ComponentType<{}>
 }
 
 interface FilterState {}
 
 class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, FilterState> {
     public render(): React.ReactFragment {
-        return <RadioButtons nodes={this.props.filters} selected={this.props.value} onChange={this.onChange} />
+        return (
+            <RadioButtons
+                nodes={this.props.filters}
+                selected={this.props.value}
+                onChange={this.onChange}
+                additionalComponent={this.props.additionalFilterComponent}
+            />
+        )
     }
 
     private onChange: React.ChangeEventHandler<HTMLInputElement> = e => {
@@ -109,6 +119,9 @@ interface ConnectionPropsCommon<N, NP = {}> extends ConnectionDisplayProps {
 
     /** Props to pass to each nodeComponent in addition to `{ node: N }`. */
     nodeComponentProps?: NP
+
+    /** The component type to use to display additional filters. */
+    additionalFilterComponent?: React.ComponentType<{}>
 }
 
 /** State related to the ConnectionNodes component. */
@@ -722,6 +735,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 filters={this.props.filters}
                                 onDidSelectFilter={this.onDidSelectFilter}
                                 value={this.state.activeFilter.id}
+                                additionalFilterComponent={this.props.additionalFilterComponent}
                             />
                         )}
                     </Form>

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -36,9 +36,6 @@ interface FilterProps {
 
     /** The ID of the active filter. */
     value: string
-
-    /** The component type to use to display additional filters. */
-    additionalFilterComponent?: React.ComponentType<{}>
 }
 
 interface FilterState {}
@@ -46,12 +43,10 @@ interface FilterState {}
 class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, FilterState> {
     public render(): React.ReactFragment {
         return (
-            <RadioButtons
-                nodes={this.props.filters}
-                selected={this.props.value}
-                onChange={this.onChange}
-                additionalComponent={this.props.additionalFilterComponent}
-            />
+            <div className="filtered-connection__control">
+                <RadioButtons nodes={this.props.filters} selected={this.props.value} onChange={this.onChange} />
+                {this.props.children}
+            </div>
         )
     }
 
@@ -706,6 +701,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             errors.push(this.state.connectionOrError.error)
         }
 
+        const AdditionalFilters = this.props.additionalFilterComponent
         const compactnessClass = `filtered-connection--${this.props.compact ? 'compact' : 'noncompact'}`
         return (
             <div
@@ -735,8 +731,10 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 filters={this.props.filters}
                                 onDidSelectFilter={this.onDidSelectFilter}
                                 value={this.state.activeFilter.id}
-                                additionalFilterComponent={this.props.additionalFilterComponent}
-                            />
+                            >
+                                {' '}
+                                {AdditionalFilters && <AdditionalFilters />}{' '}
+                            </FilteredConnectionFilterControl>
                         )}
                     </Form>
                 )}

--- a/web/src/components/RadioButtons.tsx
+++ b/web/src/components/RadioButtons.tsx
@@ -45,11 +45,6 @@ interface Props {
      * id of the currently selected RadioButtonNode.
      */
     selected?: string
-
-    /**
-     * The component type to render after the set of radio buttons.
-     */
-    additionalComponent?: React.ComponentType<{}>
 }
 
 /**
@@ -57,8 +52,6 @@ interface Props {
  */
 export class RadioButtons extends React.PureComponent<Props> {
     public render(): React.ReactFragment {
-        const AdditionalComponent = this.props.additionalComponent
-
         return (
             <div className="radio-buttons">
                 {this.props.nodes.map(n => (
@@ -76,8 +69,6 @@ export class RadioButtons extends React.PureComponent<Props> {
                         </small>
                     </label>
                 ))}
-
-                {AdditionalComponent && <AdditionalComponent />}
             </div>
         )
     }

--- a/web/src/components/RadioButtons.tsx
+++ b/web/src/components/RadioButtons.tsx
@@ -45,6 +45,11 @@ interface Props {
      * id of the currently selected RadioButtonNode.
      */
     selected?: string
+
+    /**
+     * The component type to render after the set of radio buttons.
+     */
+    additionalComponent?: React.ComponentType<{}>
 }
 
 /**
@@ -52,6 +57,8 @@ interface Props {
  */
 export class RadioButtons extends React.PureComponent<Props> {
     public render(): React.ReactFragment {
+        const AdditionalComponent = this.props.additionalComponent
+
         return (
             <div className="radio-buttons">
                 {this.props.nodes.map(n => (
@@ -69,6 +76,8 @@ export class RadioButtons extends React.PureComponent<Props> {
                         </small>
                     </label>
                 ))}
+
+                {AdditionalComponent && <AdditionalComponent />}
             </div>
         )
     }


### PR DESCRIPTION
Add `additionalComponent`to `RadioButtons` and add `additionalFilterComponent` option to `FilteredConnection` to support additional content within the filter bar.

Example:

<img width="959" alt="Screen Shot 2019-11-06 at 4 46 07 PM" src="https://user-images.githubusercontent.com/103087/68349719-beec4780-00c3-11ea-8526-7f5fc1deaac7.png">

If there is a cleaner way to do this please let me know (e.g. instead of a new option `additionalFilterComponent`, perhaps providing a component to replace `RadioButton` with the same props).