### PR TITLE
a8n: Implement campaignPlan.Status

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -261,7 +261,7 @@ type CampaignPlanResolver interface {
 	Type() string
 	Arguments() (JSONCString, error)
 
-	Status() BackgroundProcessStatus
+	Status(ctx context.Context) (BackgroundProcessStatus, error)
 
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
 }

--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -44,14 +44,8 @@ func (r *campaignPlanResolver) Arguments() (graphqlbackend.JSONCString, error) {
 	return graphqlbackend.JSONCString(r.campaignPlan.Arguments), nil
 }
 
-func (r *campaignPlanResolver) Status() graphqlbackend.BackgroundProcessStatus {
-	// TODO(a8n): Implement this
-	return a8n.BackgroundProcessStatus{
-		Completed:     0,
-		Pending:       99,
-		ProcessState:  a8n.BackgroundProcessStateErrored,
-		ProcessErrors: []string{"this is just a skeleton api"},
-	}
+func (r *campaignPlanResolver) Status(ctx context.Context) (graphqlbackend.BackgroundProcessStatus, error) {
+	return r.store.GetCampaignPlanStatus(ctx, r.campaignPlan.ID)
 }
 
 func (r *campaignPlanResolver) Changesets(

--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -894,10 +894,18 @@ func TestCampaignPlanResolver(t *testing.T) {
 		FileDiffs  FileDiffs
 	}
 
+	type Status struct {
+		CompletedCount int
+		PendingCount   int
+		State          string
+		Errors         []string
+	}
+
 	type CampaignPlan struct {
 		ID           string
 		CampaignType string `json:"type"`
 		Arguments    string
+		Status       Status
 		Changesets   struct {
 			Nodes []ChangesetPlan
 		}
@@ -977,6 +985,16 @@ func TestCampaignPlanResolver(t *testing.T) {
 
 	if have, want := response.Node.Arguments, plan.Arguments; have != want {
 		t.Fatalf("have Arguments %q, want %q", have, want)
+	}
+
+	wantStatus := Status{
+		State:          "COMPLETED",
+		CompletedCount: len(jobs),
+		Errors:         []string{},
+	}
+
+	if diff := cmp.Diff(response.Node.Status, wantStatus); diff != "" {
+		t.Fatalf("wrong Status. diff=%s", diff)
 	}
 
 	if have, want := len(response.Node.Changesets.Nodes), len(jobs); have != want {

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
@@ -875,6 +876,13 @@ func nullInt32Column(n int32) *int32 {
 	return &n
 }
 
+func nullTimeColumn(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
 // UpdateCampaign updates the given Campaign.
 func (s *Store) UpdateCampaign(ctx context.Context, c *a8n.Campaign) error {
 	q, err := s.updateCampaignQuery(c)
@@ -1289,6 +1297,44 @@ func getCampaignPlanQuery(opts *GetCampaignPlanOpts) *sqlf.Query {
 	return sqlf.Sprintf(getCampaignPlansQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
+// GetCampaignPlanStatus gets the a8n.BackgroundProcessStatus for a CampaignPlan
+func (s *Store) GetCampaignPlanStatus(ctx context.Context, id int64) (*a8n.BackgroundProcessStatus, error) {
+	q := sqlf.Sprintf(
+		getCampaignPlanStatussQueryFmtstr,
+		sqlf.Sprintf("campaign_plan_id = %s", id),
+	)
+
+	var status a8n.BackgroundProcessStatus
+	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
+		return 0, 0, scanBackgroundProcessStatus(&status, sc)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	status.ProcessState = a8n.BackgroundProcessStateCompleted
+	if status.Pending > 0 {
+		status.ProcessState = a8n.BackgroundProcessStateProcessing
+	} else if status.Completed == status.Total && len(status.ProcessErrors) == 0 {
+		status.ProcessState = a8n.BackgroundProcessStateCompleted
+	} else if status.Completed == status.Total && len(status.ProcessErrors) != 0 {
+		status.ProcessState = a8n.BackgroundProcessStateErrored
+	}
+	return &status, nil
+}
+
+var getCampaignPlanStatussQueryFmtstr = `
+-- source: pkg/a8n/store.go:GetCampaignPlanStatus
+SELECT
+  COUNT(*) AS total,
+  COUNT(*) FILTER (WHERE finished_at IS NULL) AS pending,
+  COUNT(*) FILTER (WHERE finished_at IS NOT NULL) AS completed,
+  array_agg(error) FILTER (WHERE error != '') AS errors
+FROM campaign_jobs
+WHERE %s
+LIMIT 1
+`
+
 // ListCampaignPlansOpts captures the query options needed for
 // listing code mods.
 type ListCampaignPlansOpts struct {
@@ -1405,8 +1451,8 @@ func (s *Store) createCampaignJobQuery(c *a8n.CampaignJob) (*sqlf.Query, error) 
 		c.Rev,
 		c.Diff,
 		c.Error,
-		c.StartedAt,
-		c.FinishedAt,
+		nullTimeColumn(c.StartedAt),
+		nullTimeColumn(c.FinishedAt),
 		c.CreatedAt,
 		c.UpdatedAt,
 	), nil
@@ -1781,10 +1827,19 @@ func scanCampaignJob(c *a8n.CampaignJob, s scanner) error {
 		&c.Rev,
 		&c.Diff,
 		&c.Error,
-		&c.StartedAt,
-		&c.FinishedAt,
+		&dbutil.NullTime{Time: &c.StartedAt},
+		&dbutil.NullTime{Time: &c.FinishedAt},
 		&c.CreatedAt,
 		&c.UpdatedAt,
+	)
+}
+
+func scanBackgroundProcessStatus(b *a8n.BackgroundProcessStatus, s scanner) error {
+	return s.Scan(
+		&b.Total,
+		&b.Pending,
+		&b.Completed,
+		pq.Array(&b.ProcessErrors),
 	)
 }
 

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -1313,11 +1313,12 @@ func (s *Store) GetCampaignPlanStatus(ctx context.Context, id int64) (*a8n.Backg
 	}
 
 	status.ProcessState = a8n.BackgroundProcessStateCompleted
-	if status.Pending > 0 {
+	switch {
+	case status.Pending > 0:
 		status.ProcessState = a8n.BackgroundProcessStateProcessing
-	} else if status.Completed == status.Total && len(status.ProcessErrors) == 0 {
+	case status.Completed == status.Total && len(status.ProcessErrors) == 0:
 		status.ProcessState = a8n.BackgroundProcessStateCompleted
-	} else if status.Completed == status.Total && len(status.ProcessErrors) != 0 {
+	case status.Completed == status.Total && len(status.ProcessErrors) != 0:
 		status.ProcessState = a8n.BackgroundProcessStateErrored
 	}
 	return &status, nil

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -101,6 +101,7 @@ func (s ChangesetState) Valid() bool {
 
 // BackgroundProcessStatus defines the status of a background process.
 type BackgroundProcessStatus struct {
+	Total         int32
 	Completed     int32
 	Pending       int32
 	ProcessState  BackgroundProcessState
@@ -119,7 +120,7 @@ type BackgroundProcessState string
 const (
 	BackgroundProcessStateProcessing BackgroundProcessState = "PROCESSING"
 	BackgroundProcessStateErrored    BackgroundProcessState = "ERRORED"
-	BackgroundProcessStateDone       BackgroundProcessState = "DONE"
+	BackgroundProcessStateCompleted  BackgroundProcessState = "COMPLETED"
 )
 
 // ChangesetReviewState defines the possible states of a Changeset's review.


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/6085 and implements the background process status for `CampaignPlan`s

... in one neat SQL query.