### PR TITLE
Add shouldReadURLQuery to FilteredConnection.

### DIFF
--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -291,11 +291,8 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
     /** Autofocuses the filter input field. */
     autoFocus?: boolean
 
-    /** Whether we will read initial filter and pagination state from the URL. */
-    shouldReadURLQuery?: boolean
-
-    /** Whether we will update the URL query string to reflect the filter and pagination state or not. */
-    shouldUpdateURLQuery?: boolean
+    /** Whether we will use the URL query string to reflect teh filter and pagination state or not. */
+    useURLQuery?: boolean
 
     /**
      * Filters to display next to the filter input field.
@@ -414,8 +411,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
 > {
     public static defaultProps: Partial<FilteredConnectionProps<any, any>> = {
         defaultFirst: 20,
-        shouldReadURLQuery: true,
-        shouldUpdateURLQuery: true,
+        useURLQuery: true,
     }
 
     private queryInputChanges = new Subject<string>()
@@ -585,7 +581,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                 )
                 .subscribe(
                     ({ connectionOrError, previousPage, ...rest }) => {
-                        if (this.props.shouldUpdateURLQuery) {
+                        if (this.props.useURLQuery) {
                             this.props.history.replace({
                                 search: this.urlQuery({ visible: previousPage.length }),
                                 hash: this.props.location.hash,

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -291,6 +291,9 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
     /** Autofocuses the filter input field. */
     autoFocus?: boolean
 
+    /** Whether we will read initial filter and pagination state from the URL. */
+    shouldReadURLQuery?: boolean
+
     /** Whether we will update the URL query string to reflect the filter and pagination state or not. */
     shouldUpdateURLQuery?: boolean
 
@@ -411,6 +414,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
 > {
     public static defaultProps: Partial<FilteredConnectionProps<any, any>> = {
         defaultFirst: 20,
+        shouldReadURLQuery: true,
         shouldUpdateURLQuery: true,
     }
 
@@ -441,10 +445,10 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
 
         this.state = {
             loading: true,
-            query: (!this.props.hideSearch && q.get(QUERY_KEY)) || '',
-            activeFilter: getFilterFromURL(q, this.props.filters),
-            first: parseQueryInt(q, 'first') || this.props.defaultFirst!,
-            visible: parseQueryInt(q, 'visible') || 0,
+            query: (!this.props.hideSearch && this.props.shouldReadURLQuery && q.get(QUERY_KEY)) || '',
+            activeFilter: getFilterFromURL(q, !!this.props.shouldReadURLQuery, this.props.filters),
+            first: (this.props.shouldReadURLQuery && parseQueryInt(q, 'first')) || this.props.defaultFirst!,
+            visible: (this.props.shouldReadURLQuery && parseQueryInt(q, 'visible')) || 0,
         }
     }
 
@@ -828,13 +832,14 @@ function parseQueryInt(q: URLSearchParams, name: string): number | null {
 
 function getFilterFromURL(
     q: URLSearchParams,
+    shouldReadURLQuery: boolean,
     filters: FilteredConnectionFilter[] | undefined
 ): FilteredConnectionFilter | undefined {
     if (filters === undefined || filters.length === 0) {
         return undefined
     }
     const id = q.get('filter')
-    if (id !== null) {
+    if (shouldReadURLQuery && id !== null) {
         const filter = filters.find(f => f.id === id)
         if (filter) {
             return filter

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -442,7 +442,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         this.state = {
             loading: true,
             query: (!this.props.hideSearch && this.props.useURLQuery && q.get(QUERY_KEY)) || '',
-            activeFilter: getFilterFromURL(q, !!this.props.useURLQuery, this.props.filters),
+            activeFilter: (this.props.useURLQuery && getFilterFromURL(q, this.props.filters)) || undefined,
             first: (this.props.useURLQuery && parseQueryInt(q, 'first')) || this.props.defaultFirst!,
             visible: (this.props.useURLQuery && parseQueryInt(q, 'visible')) || 0,
         }
@@ -828,14 +828,13 @@ function parseQueryInt(q: URLSearchParams, name: string): number | null {
 
 function getFilterFromURL(
     q: URLSearchParams,
-    uesURLQuerys: boolean,
     filters: FilteredConnectionFilter[] | undefined
 ): FilteredConnectionFilter | undefined {
     if (filters === undefined || filters.length === 0) {
         return undefined
     }
     const id = q.get('filter')
-    if (uesURLQuerys && id !== null) {
+    if (id !== null) {
         const filter = filters.find(f => f.id === id)
         if (filter) {
             return filter

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -441,10 +441,10 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
 
         this.state = {
             loading: true,
-            query: (!this.props.hideSearch && this.props.shouldReadURLQuery && q.get(QUERY_KEY)) || '',
-            activeFilter: getFilterFromURL(q, !!this.props.shouldReadURLQuery, this.props.filters),
-            first: (this.props.shouldReadURLQuery && parseQueryInt(q, 'first')) || this.props.defaultFirst!,
-            visible: (this.props.shouldReadURLQuery && parseQueryInt(q, 'visible')) || 0,
+            query: (!this.props.hideSearch && this.props.useURLQuery && q.get(QUERY_KEY)) || '',
+            activeFilter: getFilterFromURL(q, !!this.props.useURLQuery, this.props.filters),
+            first: (this.props.useURLQuery && parseQueryInt(q, 'first')) || this.props.defaultFirst!,
+            visible: (this.props.useURLQuery && parseQueryInt(q, 'visible')) || 0,
         }
     }
 
@@ -828,14 +828,14 @@ function parseQueryInt(q: URLSearchParams, name: string): number | null {
 
 function getFilterFromURL(
     q: URLSearchParams,
-    shouldReadURLQuery: boolean,
+    uesURLQuerys: boolean,
     filters: FilteredConnectionFilter[] | undefined
 ): FilteredConnectionFilter | undefined {
     if (filters === undefined || filters.length === 0) {
         return undefined
     }
     const id = q.get('filter')
-    if (shouldReadURLQuery && id !== null) {
+    if (uesURLQuerys && id !== null) {
         const filter = filters.find(f => f.id === id)
         if (filter) {
             return filter

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -291,7 +291,7 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
     /** Autofocuses the filter input field. */
     autoFocus?: boolean
 
-    /** Whether we will use the URL query string to reflect teh filter and pagination state or not. */
+    /** Whether we will use the URL query string to reflect the filter and pagination state or not. */
     useURLQuery?: boolean
 
     /**

--- a/web/src/discussions/DiscussionsList.tsx
+++ b/web/src/discussions/DiscussionsList.tsx
@@ -91,7 +91,7 @@ export class DiscussionsList extends React.PureComponent<Props> {
                 updateOnChange={`${this.props.repoID}:${this.props.rev}:${this.props.filePath}`}
                 defaultFirst={this.props.defaultFirst || 100}
                 hideSearch={this.props.hideSearch}
-                shouldUpdateURLQuery={false}
+                useURLQuery={false}
                 history={this.props.history}
                 location={this.props.location}
             />

--- a/web/src/repo/RepoRevSidebarCommits.tsx
+++ b/web/src/repo/RepoRevSidebarCommits.tsx
@@ -57,7 +57,7 @@ export class RepoRevSidebarCommits extends React.PureComponent<Props> {
                 nodeComponentProps={{ location: this.props.location } as Pick<CommitNodeProps, 'location'>}
                 defaultFirst={100}
                 hideSearch={true}
-                shouldUpdateURLQuery={false}
+                useURLQuery={false}
                 history={this.props.history}
                 location={this.props.location}
             />

--- a/web/src/repo/RepoRevSidebarSymbols.tsx
+++ b/web/src/repo/RepoRevSidebarSymbols.tsx
@@ -83,7 +83,7 @@ export class RepoRevSidebarSymbols extends React.PureComponent<Props> {
                 nodeComponent={SymbolNode}
                 nodeComponentProps={{ location: this.props.location } as Pick<SymbolNodeProps, 'location'>}
                 defaultFirst={100}
-                shouldUpdateURLQuery={false}
+                useURLQuery={false}
                 history={this.props.history}
                 location={this.props.location}
             />

--- a/web/src/repo/RepositoriesPopover.tsx
+++ b/web/src/repo/RepositoriesPopover.tsx
@@ -99,7 +99,7 @@ export class RepositoriesPopover extends React.PureComponent<Props> {
                     history={this.props.history}
                     location={this.props.location}
                     noSummaryIfAllNodesVisible={true}
-                    shouldUpdateURLQuery={false}
+                    useURLQuery={false}
                 />
             </div>
         )

--- a/web/src/repo/RevisionsPopover.tsx
+++ b/web/src/repo/RevisionsPopover.tsx
@@ -239,7 +239,7 @@ export class RevisionsPopover extends React.PureComponent<Props> {
                                 history={this.props.history}
                                 location={this.props.location}
                                 noSummaryIfAllNodesVisible={true}
-                                useURLQuerys={false}
+                                useURLQuery={false}
                             />
                         )
                     )}

--- a/web/src/repo/RevisionsPopover.tsx
+++ b/web/src/repo/RevisionsPopover.tsx
@@ -215,7 +215,7 @@ export class RevisionsPopover extends React.PureComponent<Props> {
                                 defaultFirst={50}
                                 autoFocus={true}
                                 noSummaryIfAllNodesVisible={true}
-                                shouldUpdateURLQuery={false}
+                                useURLQuery={false}
                                 history={this.props.history}
                                 location={this.props.location}
                             />
@@ -239,7 +239,7 @@ export class RevisionsPopover extends React.PureComponent<Props> {
                                 history={this.props.history}
                                 location={this.props.location}
                                 noSummaryIfAllNodesVisible={true}
-                                shouldUpdateURLQuery={false}
+                                useURLQuerys={false}
                             />
                         )
                     )}

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -345,7 +345,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     }}
                                     updateOnChange={`${this.props.repoName}:${this.props.rev}:${this.props.filePath}`}
                                     defaultFirst={7}
-                                    shouldUpdateURLQuery={false}
+                                    useURLQuery={false}
                                     hideSearch={true}
                                 />
                             </div>

--- a/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -356,7 +356,7 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                     }}
                     defaultFirst={20}
                     hideSearch={true}
-                    shouldUpdateURLQuery={false}
+                    useURLQuery={false}
                     updates={this.specChanges}
                     history={this.props.history}
                     location={this.props.location}


### PR DESCRIPTION
Add an option to skip reading filter/pagination state from URL. This is useful if there are two filtered connection components on the same page and one should only use default (uncontrolled) params.