### PR TITLE
GitLab: account for debug header to adjust hover position

### DIFF
--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -18,9 +18,17 @@ export function checkIsGitlab(): boolean {
 
 const adjustOverlayPosition: CodeHost['adjustOverlayPosition'] = ({ top, left }) => {
     const header = document.querySelector('header')
-
+    if (header) {
+        top += header.getBoundingClientRect().height
+    }
+    // When running GitLab from source, we also need to take into account
+    // the debug header shown at the top of the page.
+    const debugHeader = document.querySelector('#js-peek.development')
+    if (debugHeader) {
+        top += debugHeader.getBoundingClientRect().height
+    }
     return {
-        top: header ? top + header.getBoundingClientRect().height : 0,
+        top,
         left,
     }
 }


### PR DESCRIPTION
When running GitLab from source, a debug header is shown at the top of the page:

![image](https://user-images.githubusercontent.com/1741180/68422006-a18cab80-019f-11ea-83f8-d60697d5dcae.png)

This trips up our `adjustOverlayPosition` function and affects hover tooltip display:

![image](https://user-images.githubusercontent.com/1741180/68422090-cc76ff80-019f-11ea-8439-5b4f1a80d957.png)


Fixes https://github.com/sourcegraph/sourcegraph/issues/4843
 