### PR TITLE
GitLab: do not resolve MR code views without '.file-actions'

### DIFF
--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -87,6 +87,11 @@ const resolveView: ViewResolver<CodeView>['resolveView'] = (element: HTMLElement
     }
 
     if (pageKind === GitLabPageKind.MergeRequest) {
+        if (!element.querySelector('.file-actions')) {
+            // If the code view has no file actions, we cannot resolve its head commit ID.
+            // This can be the case for code views representing added git submodules.
+            return null
+        }
         return { element, ...mergeRequestCodeView }
     }
 


### PR DESCRIPTION
Fixes an exception thrown on MRs that contain changes to git submodules. 

![image](https://user-images.githubusercontent.com/1741180/68425784-0e577400-01a7-11ea-8006-8ff9e723d477.png)
