### PR TITLE
dbutil: Introduce DBTx

### DIFF
--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -995,25 +995,6 @@ func testStoreListReposPagination(store repos.Store) func(*testing.T) {
 	}
 }
 
-func testDBStoreTransact(store *repos.DBStore) func(*testing.T) {
-	return func(t *testing.T) {
-		ctx := context.Background()
-
-		txstore, err := store.Transact(ctx)
-		if err != nil {
-			t.Fatal("expected DBStore to support transactions", err)
-		}
-		defer txstore.Done()
-
-		_, err = txstore.(repos.Transactor).Transact(ctx)
-		have := fmt.Sprintf("%s", err)
-		want := "dbstore: already in a transaction"
-		if have != want {
-			t.Errorf("error:\nhave: %v\nwant: %v", have, want)
-		}
-	}
-}
-
 func mkRepos(n int, base ...*repos.Repo) repos.Repos {
 	if len(base) == 0 {
 		return nil

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -3,7 +3,6 @@ package bitbucketserver
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -34,7 +34,7 @@ var clock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond
 // the given bitbucketserver.Client to talk to a Bitbucket Server API that is
 // the source of truth for permissions. It assumes usernames of Sourcegraph accounts
 // match 1-1 with usernames of Bitbucket Server API users.
-func NewProvider(cli *bitbucketserver.Client, db *sql.DB, ttl, hardTTL time.Duration) *Provider {
+func NewProvider(cli *bitbucketserver.Client, db dbutil.DB, ttl, hardTTL time.Duration) *Provider {
 	return &Provider{
 		client:   cli,
 		codeHost: extsvc.NewCodeHost(cli.URL, bitbucketserver.ServiceType),

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 )
@@ -69,7 +70,7 @@ func TestProvider_Validate(t *testing.T) {
 	}
 }
 
-func testProviderRepoPerms(db *sql.DB) func(*testing.T) {
+func testProviderRepoPerms(db dbutil.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		cli, save := newClient(t, "RepoPerms")
 		defer save()
@@ -484,7 +485,7 @@ func newClient(t *testing.T, name string) (*bitbucketserver.Client, func()) {
 	return cli, save
 }
 
-func newProvider(cli *bitbucketserver.Client, db *sql.DB, ttl time.Duration) *Provider {
+func newProvider(cli *bitbucketserver.Client, db dbutil.DB, ttl time.Duration) *Provider {
 	p := NewProvider(cli, db, ttl, DefaultHardTTL)
 	p.pageSize = 1       // Exercise pagination
 	p.store.block = true // Wait for first update to complete.

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 )
@@ -80,7 +81,7 @@ func BenchmarkStore(b *testing.B) {
 	})
 }
 
-func testStore(db *sql.DB) func(*testing.T) {
+func testStore(db dbutil.DB) func(*testing.T) {
 	equal := func(t testing.TB, name string, have, want interface{}) {
 		t.Helper()
 		if !reflect.DeepEqual(have, want) {

--- a/enterprise/pkg/a8n/integration_test.go
+++ b/enterprise/pkg/a8n/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
@@ -19,6 +20,11 @@ func TestIntegration(t *testing.T) {
 	db, cleanup := dbtest.NewDB(t, *dsn)
 	defer cleanup()
 
-	t.Run("Store", testStore(db))
-	t.Run("GitHubWebhook", testGitHubWebhook(db))
+	tx, done := dbtest.NewTx(t, db)
+	defer done()
+
+	dbtx := dbutil.NewDBTx(tx)
+
+	t.Run("Store", testStore(dbtx))
+	t.Run("GitHubWebhook", testGitHubWebhook(dbtx))
 }

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -2,7 +2,6 @@ package a8n
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 	"testing"
@@ -11,19 +10,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
 
 // Ran in integration_test.go
-func testStore(db *sql.DB) func(*testing.T) {
+func testStore(db dbutil.DB) func(*testing.T) {
 	return func(t *testing.T) {
-		tx, done := dbtest.NewTx(t, db)
-		defer done()
-
 		now := time.Now().UTC().Truncate(time.Microsecond)
-		s := NewStoreWithClock(tx, func() time.Time {
+		s := NewStoreWithClock(db, func() time.Time {
 			return now.UTC().Truncate(time.Microsecond)
 		})
 
@@ -274,7 +270,6 @@ func testStore(db *sql.DB) func(*testing.T) {
 					}
 				}
 			})
-
 		})
 
 		t.Run("Changesets", func(t *testing.T) {

--- a/enterprise/pkg/a8n/webhooks_test.go
+++ b/enterprise/pkg/a8n/webhooks_test.go
@@ -24,6 +24,7 @@ import (
 	gh "github.com/google/go-github/github"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
@@ -34,7 +35,7 @@ import (
 var update = flag.Bool("update", false, "update testdata")
 
 // Ran in integration_test.go
-func testGitHubWebhook(db *sql.DB) func(*testing.T) {
+func testGitHubWebhook(db dbutil.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		now := time.Now()
 		clock := func() time.Time {


### PR DESCRIPTION
This PR introduces `dbutil.DBTx` which implements the `dbutil.DB` interface
backed by either a `sql.DB` or a `sql.Tx`, with additional support for
nested transactions using Postgres savepoints.

This allows us to run a suite of integration tests in the context of single transaction (that will be rolled back at the end), even if those tests start transactions themselves.

It also allows us to explicitly rollback to a previous savepoint in tests when we know a given test will result in a SQL level exception / error and proceed safely from there within the context of a parent transaction.

One situation where using a single transaction for integration tests isn't currently supported is when concurrency is involved, due to this limitation: https://github.com/lib/pq/issues/81

That's why we didn't change the integration tests of the Bitbucket Server provider store, which do lots of concurrency and fail when operating with a `DBTx`.