### PR TITLE
fix build: switch alpine mirror

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -14,8 +14,8 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN echo "@edge http://sjc.edge.kernel.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edge http://sjc.edge.kernel.org/alpine/edge/community" >> /etc/apk/repositories
 # hadolint ignore=DL3018
 RUN apk add --no-cache git@edge openssh-client
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -27,14 +27,14 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/v3.6/main" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories
+RUN echo "@edge http://sjc.edge.kernel.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edge http://sjc.edge.kernel.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    echo "@edge http://sjc.edge.kernel.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "http://sjc.edge.kernel.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "http://sjc.edge.kernel.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    echo "http://sjc.edge.kernel.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "http://sjc.edge.kernel.org/alpine/v3.6/main" >> /etc/apk/repositories && \
+    echo "http://sjc.edge.kernel.org/alpine/v3.6/community" >> /etc/apk/repositories
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
Fix builds by switching the Alpine Linux mirror we use (https://mirrors.alpinelinux.org/).