### PR TITLE
reenable docsite link checking, fix broken links

### DIFF
--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -326,7 +326,6 @@
                             <li><a href="/dev/release_issue_template">MAJOR.MINOR release (YYYY-MM-20)</a></li>
                             <li><a href="/dev/patch_release_issue_template">MAJOR.MINOR.PATCH release</a></li>
                             <li><a href="/dev/devrel_release_issue_template">MAJOR.MINOR release: DevRel tasks</a></li>
-                            <li><a href="/dev/architecture-mermaid">N# Sourcegraph Architecture diagram</a></li>
                             <li><a href="/dev/postgresql">PostgreSQL storage tips</a></li>
                             <li><a href="/dev/phabricator_gitolite">Print info from Gitolite</a></li>
                             <li><a href="/dev/architecture">Sourcegraph Architecture Overview</a></li>

--- a/doc/dev/documentation/index.md
+++ b/doc/dev/documentation/index.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](../../documentation/index.md).
+This document was moved to [another location](../../team/product-dev/documentation/index.md).

--- a/doc/dev/documentation/separate_website.md
+++ b/doc/dev/documentation/separate_website.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](../../documentation/separate_website.md).
+This document was moved to [another location](../../team/product-dev/documentation/separate_website.md).

--- a/doc/dev/documentation/site.md
+++ b/doc/dev/documentation/site.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](../../documentation/site.md).
+This document was moved to [another location](../../team/product-dev/documentation/site.md).

--- a/doc/dev/documentation/structure.md
+++ b/doc/dev/documentation/structure.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](../../documentation/structure.md).
+This document was moved to [another location](../../team/product-dev/documentation/structure.md).

--- a/doc/dev/documentation/style_guide.md
+++ b/doc/dev/documentation/style_guide.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](../../documentation/style_guide.md).
+This document was moved to [another location](../../team/product-dev/documentation/style_guide.md).

--- a/doc/dev/go_style_guide.md
+++ b/doc/dev/go_style_guide.md
@@ -1,6 +1,6 @@
 # Go style guide
 
-This file documents the style used in Sourcegraph's code. For non-code text, see the overall [style guide](..../../team/style_guide.md).
+This file documents the style used in Sourcegraph's code. For non-code text, see the overall [style guide](../../team/style_guide.md).
 
 For all things not covered in this document, defer to
 [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)

--- a/doc/dev/incidents.md
+++ b/doc/dev/incidents.md
@@ -2,4 +2,4 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-This document was moved to [another location](..../../team/product-dev/incidents.md).
+This document was moved to [another location](../../team/product-dev/incidents.md).

--- a/doc/docsite.json
+++ b/doc/docsite.json
@@ -6,6 +6,6 @@
   "assets": "_resources/assets",
   "assetsBaseURLPath": "/assets/",
   "check": {
-    "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:(hi|support|security)@sourcegraph\\.com(\\?|$))|(^chrome://)|(^/@)|(^/)"
+    "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:(hi|support|security)@sourcegraph\\.com(\\?|$))|(^chrome://)|(^/@)"
   }
 }

--- a/doc/team/product-dev/documentation/index.md
+++ b/doc/team/product-dev/documentation/index.md
@@ -120,7 +120,7 @@ See "[Documentation site](site.md)" for more information.
 
 ### Previewing changes locally
 
-You can preview the documentation site at http://localhost:5080 when running Sourcegraph in [local development](../local_development.md) (using `dev/launch.sh` or `enterprise/dev/start.sh`). It uses content, templates, and assets from the local disk. There is no caching or background build process, so you'll see all changes reflected immediately after you reload the page in your browser.
+You can preview the documentation site at http://localhost:5080 when running Sourcegraph in [local development](../../../dev/local_development.md) (using `dev/launch.sh` or `enterprise/dev/start.sh`). It uses content, templates, and assets from the local disk. There is no caching or background build process, so you'll see all changes reflected immediately after you reload the page in your browser.
 
 See also "[Other ways of previewing changes locally (very rare)](site.md#other-ways-of-previewing-changes-locally-very-rare)".
 

--- a/doc/team/product-dev/documentation/style_guide.md
+++ b/doc/team/product-dev/documentation/style_guide.md
@@ -4,7 +4,7 @@
 
 The documentation style guide defines the markup structure used in Sourcegraph documentation. Check the [documentation guidelines](index.md) for general development instructions.
 
-See the [Sourcegraph style guide](../style_guide.md) for general information.
+See the [Sourcegraph style guide](../../style_guide.md) for general information.
 
 For help adhering to the guidelines, see [Linting](index.md#linting).
 

--- a/doc/team/product-dev/incidents.md
+++ b/doc/team/product-dev/incidents.md
@@ -72,6 +72,6 @@ After the incident is resolved:
 
 Here is the high level flow:
 
-![flowchart](img/incident-flow.svg)
+![flowchart](../../dev/img/incident-flow.svg)
 
 Source: https://drive.google.com/file/d/1kTZ-_N1ulx9Kf0vZyn5BWTrtipbvN9jH/view?usp=sharing

--- a/doc/team/product-dev/issues.md
+++ b/doc/team/product-dev/issues.md
@@ -21,7 +21,7 @@ The **primary triage process** is how most issues will be triaged:
 1. Assignment. Anyone who sees an unassigned issue should assign it if they know the right assignee.
 1. Prioritization. The assignee adds a milestone to the issue to indicate when it'll be closed, one of:
    - *The current release milestone:* if the assignee commits to closing it for the upcoming release.
-   - *A future release milestone:* if the assignee, consulting the [roadmap](roadmap/index.md) (and the [product manager](product/index.md#product-manager) if necessary), thinks it's likely that it will/should be prioritized for that future release. The issue will be reviewed again in [product planning](product/index.md#planning) as a check.
+   - *A future release milestone:* if the assignee, consulting the [roadmap](../roadmap/index.md) (and the [product manager](product/index.md#product-manager) if necessary), thinks it's likely that it will/should be prioritized for that future release. The issue will be reviewed again in [product planning](product/index.md#planning) as a check.
    - Backlog: for all other issues.
 1. Details: The assignee is responsible for obtaining the information necessary for them to fix the issue and updating the first issue comment to reflect/summarize the current state so readers don't have to scan the entire conversation of the issue to get caught up.
    - For issues in the current release milestone, each project's [tech lead](releases.md#tech-lead) is ultimately responsible for ensuring that these details are present in their project's issues.

--- a/doc/team/product-dev/open_source_open_company.md
+++ b/doc/team/product-dev/open_source_open_company.md
@@ -1,12 +1,12 @@
 # Sourcegraph: open product, open company, open source
 
-As part of making Sourcegraph open source, we now build Sourcegraph ([roadmap](roadmap/index.md) and [issues](http://github.com/sourcegraph/sourcegraph/issues/)) as an **open product**, and **open company**. Our [website](https://github.com/sourcegraph/about) and [documentation](https://github.com/sourcegraph/sourcegraph/tree/master/doc) is now open source  which holds product- and company-related docs.
+As part of making Sourcegraph open source, we now build Sourcegraph ([roadmap](../roadmap/index.md) and [issues](http://github.com/sourcegraph/sourcegraph/issues/)) as an **open product**, and **open company**. Our [website](https://github.com/sourcegraph/about) and [documentation](https://github.com/sourcegraph/sourcegraph/tree/master/doc) is now open source  which holds product- and company-related docs.
 
 Here's how we define these terms:
 
 ## Open product
 
-This means the [product roadmap](roadmap/index.md) is public and open for input.
+This means the [product roadmap](../roadmap/index.md) is public and open for input.
 
 You might not realize it, but the products you use every day are not just open source; they are also open products. Products like [Kubernetes](https://github.com/kubernetes/kubernetes/milestones?direction=asc&sort=due_date) and [Visual Studio Code](https://github.com/Microsoft/vscode/wiki/Iteration-Plans) do all their product planning in the open. They get useful input from the community and make it easy to integrate and rely on their products.
 
@@ -20,4 +20,4 @@ Open company doesn't mean that everything is public; only principles, strategies
 
 ## Open source
 
-To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](faq.md) and [license documentation](https://github.com/sourcegraph/sourcegraph#license).
+To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](../../dev/faq.md) and [license documentation](https://github.com/sourcegraph/sourcegraph#license).

--- a/doc/team/product-dev/product/index.md
+++ b/doc/team/product-dev/product/index.md
@@ -1,12 +1,12 @@
 # Product
 
-This document is about *how* we plan product changes at Sourcegraph. For the *what*, see the [product roadmap](../roadmap/index.md).
+This document is about *how* we plan product changes at Sourcegraph. For the *what*, see the [product roadmap](../../roadmap/index.md).
 
 ## Goals
 
 The goals of product at Sourcegraph are to make the following true:
 
-- The team is working on the most important things (listed in the [product roadmap](../roadmap/index.md)) to achieve our company goals.
+- The team is working on the most important things (listed in the [product roadmap](../../roadmap/index.md)) to achieve our company goals.
 - Each teammate has the customer and product context needed (about customer problems, likely future priorities, possible solutions, etc.) to perform their work effectively.
 - The product vision and roadmap are communicated well to teammates and everyone outside Sourcegraph.
 
@@ -21,7 +21,7 @@ Product planning has 3 parts:
 The [product manager](#product-manager) and project team plan each project at least through the [current release](../releases.md). The outcome of planning a project is that:
 
 - The project has a [tracking issue](tracking_issue_template.md) in each release milestone that ships something related to the project. The tracking issue describes what a project will ship in a specific release. It is the source of truth for the description and status of a project.
-- The [product roadmap](../roadmap/index.md) links to the project's [tracking issues](tracking_issue_template.md).
+- The [product roadmap](../../roadmap/index.md) links to the project's [tracking issues](tracking_issue_template.md).
 - The [issues](../issues.md) for the project are correctly prioritized, assigned, and documented.
 - The project team has the context necessary to work effectively and to [triage issues](../issues.md#triage) that are filed between now and the next planning session.
 
@@ -39,7 +39,7 @@ Project planning is a continuous process, punctuated with meetings to ensure eve
 
 The agenda for a project planning kickoff or checkin is:
 
-1. Review, update, and/or create the project's tracking issue on the [product roadmap](../roadmap/index.md) for the next release.
+1. Review, update, and/or create the project's tracking issue on the [product roadmap](../../roadmap/index.md) for the next release.
    - Use the [**tracking issue template**](tracking_issue_template.md).
    - Are the tasks the most important things to work on?
    - Are they realistic?

--- a/doc/team/product-dev/product/tracking_issue_template.md
+++ b/doc/team/product-dev/product/tracking_issue_template.md
@@ -1,6 +1,6 @@
 # Tracking issue template
 
-This is the template for the [project tracking issue](index.md#planning) that the [roadmap](../roadmap/index.md) links to.
+This is the template for the [project tracking issue](index.md#planning) that the [roadmap](../../roadmap/index.md) links to.
 
 1. [Create a new GitHub issue on sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph/issues/new?label=roadmap)
    - Label: `roadmap` and any other relevant labels

--- a/doc/team/product-dev/releases.md
+++ b/doc/team/product-dev/releases.md
@@ -35,7 +35,7 @@ In the future, we may introduce continuous releases if these issues become surmo
 
 [Monthly releases](#releases-are-monthly) of Sourcegraph increase the minor version number (e.g. 3.1 -> 3.2). These releases **never** require any manual migration steps.
 
-Patch releases (e.g. 3.0.0 -> 3.0.1) are released on an as-needed basis to fix bugs and security issues. These releases **never** require any manual migration steps. To create a patch release, create a tracking issue using the [patch release issue template](patch_release_issue_template.md) and complete all listed steps.
+Patch releases (e.g. 3.0.0 -> 3.0.1) are released on an as-needed basis to fix bugs and security issues. These releases **never** require any manual migration steps. To create a patch release, create a tracking issue using the [patch release issue template](../../dev/patch_release_issue_template.md) and complete all listed steps.
 
 On rare occasions we may decide to increase the major version number (e.g. 2.13 -> 3.0). These releases **may** require manual migration steps.
 
@@ -47,13 +47,13 @@ What is the process we follow to release?
 
 The release captain is _responsible_ for managing the release process and ensuring that the release happens on time. The release captain may _delegate_ work to other teammates, but such delegation does not absolve the release captain of their responsibility to ensure that delegated work gets done.
 
-The release captain should create a tracking issue using the [release issue template](release_issue_template.md) at the beginning of the release cycle.
+The release captain should create a tracking issue using the [release issue template](../../dev/release_issue_template.md) at the beginning of the release cycle.
 
 ### Release templates
 
-- [Release issue template](release_issue_template.md)
-- [Patch release issue template](patch_release_issue_template.md)
-- [DevRel release issue template](devrel_release_issue_template.md)
+- [Release issue template](../../dev/release_issue_template.md)
+- [Patch release issue template](../../dev/patch_release_issue_template.md)
+- [DevRel release issue template](../../dev/devrel_release_issue_template.md)
 
 ### Schedule
 

--- a/doc/team/roadmap/index.md
+++ b/doc/team/roadmap/index.md
@@ -7,7 +7,7 @@ We want Sourcegraph to be:
 
 This roadmap is an overview of what’s coming in the next 3-6 months.  More details are in the [project roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit?usp=sharing). Our high-level vision is outlined in the [Sourcegraph master plan](https://about.sourcegraph.com/plan).
 
-We ship a release on the [20th day of each month](../releases.md#releases-are-monthly).
+We ship a release on the [20th day of each month](../product-dev/releases.md#releases-are-monthly).
 
 Want to help us achieve these goals? [We're hiring!](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer.md)
 


### PR DESCRIPTION
297a6e5841378cd9138ad22878b156d7c86fbdca erroneously told docsite to NOT check for broken links that matched the regexp `^/`, which covers basically all links between documents (because links are checked in the rendered HTML, not Markdown, and the rendered HTML links all prefix the base URL path).

This fixes broken links that crept in and reenables broken link checking for relative links.