### PR TITLE
search: temporarily run comby-related tests only in CI

### DIFF
--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -15,7 +15,7 @@ import (
 // Tests that structural search correctly infers the Go matcher from the .go
 // file extension.
 func TestInferredMatcher(t *testing.T) {
-	// If we are not on CI skip the test if comby is not installed.
+	// If we are not on CI skip the test.
 	if os.Getenv("CI") == "" {
 		t.Skip("Not on CI, skipping comby-dependent test")
 	}
@@ -66,7 +66,7 @@ func foo(real string) {}
 // instead (currently) expects a list of patterns that represent a set of file
 // paths to search.
 func TestIncludePatterns(t *testing.T) {
-	// If we are not on CI skip the test if comby is not installed.
+	// If we are not on CI skip the test.
 	if os.Getenv("CI") == "" {
 		t.Skip("Not on CI, skipping comby-dependent test")
 	}

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -15,6 +15,11 @@ import (
 // Tests that structural search correctly infers the Go matcher from the .go
 // file extension.
 func TestInferredMatcher(t *testing.T) {
+	// If we are not on CI skip the test if comby is not installed.
+	if os.Getenv("CI") == "" {
+		t.Skip("Not on CI, skipping comby-dependent test")
+	}
+
 	input := map[string]string{
 		"main.go": `
 /* This foo(ignore string) {} is in a Go comment should not match */
@@ -61,6 +66,11 @@ func foo(real string) {}
 // instead (currently) expects a list of patterns that represent a set of file
 // paths to search.
 func TestIncludePatterns(t *testing.T) {
+	// If we are not on CI skip the test if comby is not installed.
+	if os.Getenv("CI") == "" {
+		t.Skip("Not on CI, skipping comby-dependent test")
+	}
+
 	input := map[string]string{
 		"/a/b/c":         "",
 		"/a/b/c/foo.go":  "",

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -88,15 +88,6 @@ main.go:1:package main
 main.go:5:func main() {
 `},
 
-		{protocol.PatternInfo{Pattern: "main", IsStructuralPat: true}, `
-main.go:1:main
-main.go:5:main
-`},
-
-		{protocol.PatternInfo{Pattern: "Println(:[args])", IsStructuralPat: true}, `
-main.go:6:Println("Hello world")
-`},
-
 		// Ensure we handle CaseInsensitive regexp searches with
 		// special uppercase chars in pattern.
 		{protocol.PatternInfo{Pattern: `printL\B`, IsRegExp: true}, `


### PR DESCRIPTION
A version mismatch on local dev installations can cause certain tests to break if `comby` is not upgraded. There is work-in-progress for smoothly integrating `comby` installation and upgrades via `./dev/launch.sh` #6503, but until then, these tests can cause problems for local dev environments.

This PR:
- removes two noncritical tests that are specific to structural search only, and which will be reintroduced after #6503
- _temporarily_ disables these tests _only in local dev environments_ (they still run in the CI, which always has the correct version) until #6503 is done.

Test plan: Tested that local development builds do not break for older versions of `comby`.
