### PR TITLE
a8n: Only return CampaignPlan.Changesets that have a a final diff

### DIFF
--- a/enterprise/pkg/a8n/resolvers/campaign_plans.go
+++ b/enterprise/pkg/a8n/resolvers/campaign_plans.go
@@ -55,14 +55,19 @@ func (r *campaignPlanResolver) Changesets(
 	return &campaignJobsConnectionResolver{
 		store:        r.store,
 		campaignPlan: r.campaignPlan,
-		limit:        int(args.GetFirst()),
+		opts: ee.ListCampaignJobsOpts{
+			CampaignPlanID: r.campaignPlan.ID,
+			Limit:          int(args.GetFirst()),
+			OnlyFinished:   true,
+			OnlyWithDiff:   true,
+		},
 	}
 }
 
 type campaignJobsConnectionResolver struct {
 	store        *ee.Store
 	campaignPlan *a8n.CampaignPlan
-	limit        int
+	opts         ee.ListCampaignJobsOpts
 
 	// cache results because they are used by multiple fields
 	once      sync.Once
@@ -92,10 +97,7 @@ func (r *campaignJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlba
 
 func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.CampaignJob, map[int32]*repos.Repo, int64, error) {
 	r.once.Do(func() {
-		r.jobs, r.next, r.err = r.store.ListCampaignJobs(ctx, ee.ListCampaignJobsOpts{
-			CampaignPlanID: r.campaignPlan.ID,
-			Limit:          r.limit,
-		})
+		r.jobs, r.next, r.err = r.store.ListCampaignJobs(ctx, r.opts)
 		if r.err != nil {
 			return
 		}
@@ -122,6 +124,8 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 
 func (r *campaignJobsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	opts := ee.CountCampaignJobsOpts{CampaignPlanID: r.campaignPlan.ID}
+	opts.OnlyFinished = r.opts.OnlyFinished
+	opts.OnlyWithDiff = r.opts.OnlyWithDiff
 	count, err := r.store.CountCampaignJobs(ctx, opts)
 	return int32(count), err
 }

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -1536,6 +1536,8 @@ DELETE FROM campaign_jobs WHERE id = %s
 // counting code mods.
 type CountCampaignJobsOpts struct {
 	CampaignPlanID int64
+	OnlyFinished   bool
+	OnlyWithDiff   bool
 }
 
 // CountCampaignJobs returns the number of code mods in the database.
@@ -1558,6 +1560,14 @@ func countCampaignJobsQuery(opts *CountCampaignJobsOpts) *sqlf.Query {
 	var preds []*sqlf.Query
 	if opts.CampaignPlanID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaign_plan_id = %s", opts.CampaignPlanID))
+	}
+
+	if opts.OnlyFinished {
+		preds = append(preds, sqlf.Sprintf("finished_at IS NOT NULL"))
+	}
+
+	if opts.OnlyWithDiff {
+		preds = append(preds, sqlf.Sprintf("diff != ''"))
 	}
 
 	if len(preds) == 0 {
@@ -1628,6 +1638,8 @@ type ListCampaignJobsOpts struct {
 	CampaignPlanID int64
 	Cursor         int64
 	Limit          int
+	OnlyFinished   bool
+	OnlyWithDiff   bool
 }
 
 // ListCampaignJobs lists CampaignJobs with the given filters.
@@ -1683,6 +1695,14 @@ func listCampaignJobsQuery(opts *ListCampaignJobsOpts) *sqlf.Query {
 
 	if opts.CampaignPlanID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaign_plan_id = %s", opts.CampaignPlanID))
+	}
+
+	if opts.OnlyFinished {
+		preds = append(preds, sqlf.Sprintf("finished_at IS NOT NULL"))
+	}
+
+	if opts.OnlyWithDiff {
+		preds = append(preds, sqlf.Sprintf("diff != ''"))
 	}
 
 	return sqlf.Sprintf(


### PR DESCRIPTION
As discussed on today's sync call with @felixfbecker @eseliger @tsenart this changes the `campaignPlan.changesets` field in the GraphQL API to implicitly filter out the underlying `CampaignJob`s that have finished execution and came up with a diff, i.e. those that we would create on the code hosts as pull requests.