### PR TITLE
Add streaming read for git blobs

### DIFF
--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -75,6 +75,8 @@ func readFileBytes(ctx context.Context, repo gitserver.Repo, commit api.CommitID
 	return data, nil
 }
 
+// blobReader, which should be created using newBlobReader, is a struct that allows
+// us to get a ReadCloser to a specific named file at a specific commit
 type blobReader struct {
 	ctx    context.Context
 	repo   gitserver.Repo
@@ -118,7 +120,7 @@ func (br *blobReader) Close() error {
 	return br.rc.Close()
 }
 
-// convertError converts an error returned from git show into a more appropriate error type
+// convertError converts an error returned from 'git show' into a more appropriate error type
 func (br *blobReader) convertError(err error) error {
 	if err == nil {
 		return nil

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -38,9 +38,9 @@ func ReadFile(ctx context.Context, repo gitserver.Repo, commit api.CommitID, nam
 	return b, nil
 }
 
-// GetFileReader returns an io.ReadCloser reading from the named file at commit.
+// NewFileReader returns an io.ReadCloser reading from the named file at commit.
 // The caller should always close the reader after use
-func GetFileReader(ctx context.Context, repo gitserver.Repo, commit api.CommitID, name string) (io.ReadCloser, error) {
+func NewFileReader(ctx context.Context, repo gitserver.Repo, commit api.CommitID, name string) (io.ReadCloser, error) {
 	if Mocks.GetFileReader != nil {
 		return Mocks.GetFileReader(commit, name)
 	}

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -85,7 +85,6 @@ type blobReader struct {
 }
 
 func newBlobReader(ctx context.Context, repo gitserver.Repo, commit api.CommitID, name string) (*blobReader, error) {
-	// NOTE: Do we really want to panic here? Surely returning an error is enough?
 	ensureAbsCommit(commit)
 
 	cmd := gitserver.DefaultClient.Command("git", "show", string(commit)+":"+name)

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -85,7 +85,9 @@ type blobReader struct {
 }
 
 func newBlobReader(ctx context.Context, repo gitserver.Repo, commit api.CommitID, name string) (*blobReader, error) {
-	ensureAbsCommit(commit)
+	if err := ensureAbsoluteCommit(commit); err != nil {
+		return nil, err
+	}
 
 	cmd := gitserver.DefaultClient.Command("git", "show", string(commit)+":"+name)
 	cmd.Repo = repo

--- a/internal/vcs/git/blob_test.go
+++ b/internal/vcs/git/blob_test.go
@@ -2,13 +2,14 @@ package git_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-func TestReadFile(t *testing.T) {
+func TestRead(t *testing.T) {
 	t.Parallel()
 
 	const wantData = "abcd\n"
@@ -21,25 +22,51 @@ func TestReadFile(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("all", func(t *testing.T) {
-		data, err := git.ReadFile(ctx, repo, commitID, "file1", -1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(data) != wantData {
-			t.Errorf("got %q, want %q", data, wantData)
-		}
-	})
+	tests := map[string]struct {
+		file     string
+		maxBytes int64
+		checkFn  func(*testing.T, error, []byte)
+	}{
+		"all": {
+			file: "file1",
+			checkFn: func(t *testing.T, err error, data []byte) {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != wantData {
+					t.Errorf("got %q, want %q", data, wantData)
+				}
+			},
+		},
 
-	t.Run("nonexistent", func(t *testing.T) {
-		_, err := git.ReadFile(ctx, repo, commitID, "filexyz", -1)
-		if err == nil {
-			t.Fatal("err == nil")
-		}
-		if !os.IsNotExist(err) {
-			t.Fatalf("got err %v, want os.IsNotExist", err)
-		}
-	})
+		"nonexistent": {
+			file: "filexyz",
+			checkFn: func(t *testing.T, err error, data []byte) {
+				if err == nil {
+					t.Fatal("err == nil")
+				}
+				if !os.IsNotExist(err) {
+					t.Fatalf("got err %v, want os.IsNotExist", err)
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name+"-"+"ReadFile", func(t *testing.T) {
+			data, err := git.ReadFile(ctx, repo, commitID, test.file, test.maxBytes)
+			test.checkFn(t, err, data)
+		})
+		t.Run(name+"-"+"GetFileReader", func(t *testing.T) {
+			rc, err := git.GetFileReader(ctx, repo, commitID, test.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rc.Close()
+			data, err := ioutil.ReadAll(rc)
+			test.checkFn(t, err, data)
+		})
+	}
 
 	t.Run("maxBytes", func(t *testing.T) {
 		data, err := git.ReadFile(ctx, repo, commitID, "file1", 3)

--- a/internal/vcs/git/blob_test.go
+++ b/internal/vcs/git/blob_test.go
@@ -53,12 +53,12 @@ func TestRead(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		t.Run(name+"-"+"ReadFile", func(t *testing.T) {
+		t.Run(name+"-ReadFile", func(t *testing.T) {
 			data, err := git.ReadFile(ctx, repo, commitID, test.file, test.maxBytes)
 			test.checkFn(t, err, data)
 		})
-		t.Run(name+"-"+"GetFileReader", func(t *testing.T) {
-			rc, err := git.GetFileReader(ctx, repo, commitID, test.file)
+		t.Run(name+"-GetFileReader", func(t *testing.T) {
+			rc, err := git.NewFileReader(ctx, repo, commitID, test.file)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"io"
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -14,6 +15,7 @@ var Mocks, emptyMocks struct {
 	GetCommit        func(api.CommitID) (*Commit, error)
 	ExecSafe         func(params []string) (stdout, stderr []byte, exitCode int, err error)
 	RawLogDiffSearch func(opt RawLogDiffSearchOptions) ([]*LogCommitSearchResult, bool, error)
+	GetFileReader    func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile         func(commit api.CommitID, name string) ([]byte, error)
 	ReadDir          func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error)
 	ResolveRevision  func(spec string, opt *ResolveRevisionOptions) (api.CommitID, error)

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -30,13 +30,14 @@ func IsAbsoluteRevision(s string) bool {
 	return true
 }
 
-func ensureAbsCommit(commitID api.CommitID) {
+func ensureAbsoluteCommit(commitID api.CommitID) error {
 	// We don't want to even be running commands on non-absolute
 	// commit IDs if we can avoid it, because we can't cache the
 	// expensive part of those computations.
 	if !IsAbsoluteRevision(string(commitID)) {
-		panic(fmt.Errorf("non-absolute commit ID: %q", commitID))
+		return fmt.Errorf("non-absolute commit ID: %q", commitID)
 	}
+	return nil
 }
 
 type ResolveRevisionOptions struct {

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -165,7 +165,9 @@ func lsTree(ctx context.Context, repo gitserver.Repo, commit api.CommitID, path 
 }
 
 func lsTreeUncached(ctx context.Context, repo gitserver.Repo, commit api.CommitID, path string, recurse bool) ([]os.FileInfo, error) {
-	ensureAbsCommit(commit)
+	if err := ensureAbsoluteCommit(commit); err != nil {
+		return nil, err
+	}
 
 	// Don't call filepath.Clean(path) because ReadDir needs to pass
 	// path with a trailing slash.


### PR DESCRIPTION
This change allows us to perform streaming reads of git blobs. We'll need this in order to safely count the number of lines in a source file without loading the entire file into memory.

Related issue: https://github.com/sourcegraph/sourcegraph/issues/2587

<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
