### PR TITLE
a8n: Delete expired CampaignPlans in background

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	shared.Main(nil)
+	shared.Main(nil, nil)
 }

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -30,7 +30,7 @@ import (
 
 const port = "3182"
 
-func Main(newPreSync repos.NewPreSync) {
+func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
 
 	ctx := context.Background()
@@ -65,6 +65,10 @@ func Main(newPreSync repos.NewPreSync) {
 	db, err := dbutil.NewDB(dsn, "repo-updater")
 	if err != nil {
 		log.Fatalf("failed to initialize db store: %v", err)
+	}
+
+	if dbInitHook != nil {
+		go dbInitHook(db)
 	}
 
 	var store repos.Store

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 func main() {
@@ -19,7 +21,7 @@ func main() {
 		log.Println("enterprise edition")
 	}
 
-	shared.Main(func(db *sql.DB, rs repos.Store, cf *httpcli.Factory) func(context.Context) error {
+	newPreSync := func(db *sql.DB, rs repos.Store, cf *httpcli.Factory) func(context.Context) error {
 		syncer := &a8n.ChangesetSyncer{
 			Store:       a8n.NewStore(db),
 			ReposStore:  rs,
@@ -27,5 +29,23 @@ func main() {
 		}
 
 		return syncer.Sync
-	})
+	}
+
+	dbInitHook := func(db *sql.DB) {
+		ctx := context.Background()
+		store := a8n.NewStore(db)
+
+		for {
+			log15.Info("DeleteExpiredCampaignPlans running")
+
+			err := store.DeleteExpiredCampaignPlans(ctx)
+			if err != nil {
+				log15.Error("DeleteExpiredCampaignPlans", "error", err)
+			}
+
+			time.Sleep(2 * time.Minute)
+		}
+	}
+
+	shared.Main(newPreSync, dbInitHook)
 }

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -1444,5 +1444,104 @@ func testStore(db *sql.DB) func(*testing.T) {
 				}
 			}
 		})
+
+		t.Run("CampaignPlan DeleteExpired", func(t *testing.T) {
+			tests := []struct {
+				hasCampaign bool
+				jobs        []*a8n.CampaignJob
+				wantDeleted bool
+				want        *a8n.BackgroundProcessStatus
+			}{
+				{
+					hasCampaign: false,
+					jobs: []*a8n.CampaignJob{
+						// completed more than 1 hour ago
+						{FinishedAt: now.Add(-61 * time.Minute)},
+					},
+					wantDeleted: true,
+				},
+				{
+					hasCampaign: false,
+					jobs: []*a8n.CampaignJob{
+						// completed 30 min ago
+						{FinishedAt: now.Add(30 * time.Minute)},
+					},
+					wantDeleted: false,
+				},
+				{
+					hasCampaign: false,
+					jobs: []*a8n.CampaignJob{
+						// completed more than 1 hour ago
+						{FinishedAt: now.Add(-61 * time.Minute)},
+						// completed 30 min ago
+						{FinishedAt: now.Add(30 * time.Minute)},
+					},
+					wantDeleted: false,
+				},
+				{
+					hasCampaign: false,
+					jobs: []*a8n.CampaignJob{
+						// completed more than 1 hour ago
+						{FinishedAt: now.Add(-61 * time.Minute)},
+						// not completed
+						{},
+					},
+					wantDeleted: false,
+				},
+				{
+					hasCampaign: false,
+					jobs: []*a8n.CampaignJob{
+						// completed more than 1 hour ago
+						{FinishedAt: now.Add(-61 * time.Minute)},
+						// completed more than 2 hours ago
+						{FinishedAt: now.Add(-121 * time.Minute)},
+					},
+					wantDeleted: true,
+				},
+			}
+
+			for _, tc := range tests {
+				plan := &a8n.CampaignPlan{CampaignType: "comby", Arguments: "{}"}
+
+				err := s.CreateCampaignPlan(ctx, plan)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if tc.hasCampaign {
+					// TODO(a8n): Create a Campaign with CampaignPlanID = plan.ID
+				}
+
+				for i, j := range tc.jobs {
+					j.StartedAt = now.Add(-2 * time.Hour)
+					j.CampaignPlanID = plan.ID
+					j.RepoID = int32(i)
+					j.Rev = api.CommitID(fmt.Sprintf("deadbeef-%d", i))
+
+					err := s.CreateCampaignJob(ctx, j)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				err = s.DeleteExpiredCampaignPlans(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				_, err = s.GetCampaignPlan(ctx, GetCampaignPlanOpts{ID: plan.ID})
+				if err != nil && err != ErrNoResults {
+					t.Fatal(err)
+				}
+
+				if tc.wantDeleted && err != ErrNoResults {
+					t.Fatalf("want campaign to be deleted. got error: %s", err)
+				}
+
+				if !tc.wantDeleted && err == ErrNoResults {
+					t.Fatalf("want campaign not to be deletedbut got deleted")
+				}
+			}
+		})
 	}
 }

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -1519,9 +1519,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					}
 				}
 
-				if tc.hasCampaign {
-					// TODO(a8n): Create a Campaign with CampaignPlanID = plan.ID
-				}
+				// TODO(a8n): Create a Campaign with CampaignPlanID = plan.ID
 
 				for i, j := range tc.jobs {
 					j.StartedAt = now.Add(-2 * time.Hour)


### PR DESCRIPTION
A `CampaignPlan` is expired when

- all its `CampaignJobs` have finished execution
- they have finished > 1 hour ago
- the `CampaignPlan` has not been attached to a `Campaign`

In the background of the enterprise `repo-updater` (since its a single instance) now runs a goroutine that deletes these expired `CampaignPlan`s every 2 minutes.

What's still missing: the tests that make sure a `CampaignPlan` is not deleted when attached to a `Campaign`. That depends on changes to the `a8n.Store` that @tsenart made in another branch that hasn't been merged yet. But... the test is also not really strictly necessary, so, ready for review.