### PR TITLE
GitLab: code intelligence on MR fixes

### DIFF
--- a/browser/src/libs/gitlab/file_info.ts
+++ b/browser/src/libs/gitlab/file_info.ts
@@ -61,9 +61,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 // Head commit is found in the "View file @ ..." button in the code view.
                 const commitID = getHeadCommitIDFromCodeView(codeView)
                 const { filePath, baseFilePath } = getFilePathsFromCodeView(codeView)
-                const diffFileInfo = { baseCommitID, baseFilePath, commitID, filePath, rawRepoName, baseRawRepoName }
-                console.log({ diffFileInfo })
-                return diffFileInfo
+                return { baseCommitID, baseFilePath, commitID, filePath, rawRepoName, baseRawRepoName }
             }
         )
     )

--- a/browser/src/libs/gitlab/file_info.ts
+++ b/browser/src/libs/gitlab/file_info.ts
@@ -47,21 +47,23 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
     of(undefined).pipe(
         map(getDiffPageInfo),
         // Resolve base commit ID.
-        switchMap(({ owner, projectName, mergeRequestID, diffID, baseCommitID, rawRepoName }) => {
+        switchMap(({ owner, projectName, mergeRequestID, diffID, baseCommitID, rawRepoName, baseRawRepoName }) => {
             const gettingBaseCommitID = baseCommitID
                 ? // Commit was found in URL.
                   of(baseCommitID)
                 : // Commit needs to be fetched from the API.
                   getBaseCommitIDForMergeRequest({ owner, projectName, mergeRequestID, diffID })
 
-            return gettingBaseCommitID.pipe(map(baseCommitID => ({ baseCommitID, rawRepoName })))
+            return gettingBaseCommitID.pipe(map(baseCommitID => ({ baseCommitID, rawRepoName, baseRawRepoName })))
         }),
         map(
-            ({ baseCommitID, rawRepoName }): FileInfo => {
+            ({ baseCommitID, rawRepoName, baseRawRepoName }): FileInfo => {
                 // Head commit is found in the "View file @ ..." button in the code view.
                 const commitID = getHeadCommitIDFromCodeView(codeView)
                 const { filePath, baseFilePath } = getFilePathsFromCodeView(codeView)
-                return { baseCommitID, baseFilePath, commitID, filePath, rawRepoName }
+                const diffFileInfo = { baseCommitID, baseFilePath, commitID, filePath, rawRepoName, baseRawRepoName }
+                console.log({ diffFileInfo })
+                return diffFileInfo
             }
         )
     )

--- a/browser/src/libs/gitlab/scrape.ts
+++ b/browser/src/libs/gitlab/scrape.ts
@@ -157,10 +157,11 @@ export function getFilePathsFromCodeView(codeView: HTMLElement): Pick<FileInfo, 
     }
 
     const filePathDidChange = filePathElements.length > 1
+    const filePath = getFilePathFromElem(filePathElements.item(filePathDidChange ? 1 : 0))
 
     return {
-        filePath: getFilePathFromElem(filePathElements.item(filePathDidChange ? 1 : 0)),
-        baseFilePath: filePathDidChange ? getFilePathFromElem(filePathElements.item(0)) : undefined,
+        filePath,
+        baseFilePath: filePathDidChange ? getFilePathFromElem(filePathElements.item(0)) : filePath,
     }
 }
 

--- a/browser/src/libs/gitlab/scrape.ts
+++ b/browser/src/libs/gitlab/scrape.ts
@@ -95,6 +95,7 @@ export interface GitLabDiffInfo extends RawRepoSpec, Pick<GitLabInfo, 'owner' | 
 
     diffID?: string
     baseCommitID?: string
+    baseRawRepoName: string
 }
 
 /**
@@ -110,7 +111,22 @@ export function getDiffPageInfo(): GitLabDiffInfo {
         throw new Error('Unable to determine merge request ID')
     }
 
+    const sourceRepoLink = document.querySelector<HTMLLinkElement>('.js-source-branch a:first-child')
+    if (!sourceRepoLink) {
+        throw new Error('Could not find merge request source repo link')
+    }
+    const [baseRepoOwner, baseRepoProjectName] = new URL(sourceRepoLink.href).pathname.split('/').slice(1)
+    if (!baseRepoOwner) {
+        throw new Error('Could not determine MR baseRawRepoName: no baseRepoOwner')
+    }
+    if (!baseRepoProjectName) {
+        throw new Error('Could not determine MR baseRawRepoName: no baseRepoProjectName')
+    }
+    const hostname = isExtension ? window.location.hostname : new URL(gon.gitlab_url).hostname
+    const baseRawRepoName = `${hostname}/${owner}/${projectName}`
+
     return {
+        baseRawRepoName,
         rawRepoName,
         owner,
         projectName,


### PR DESCRIPTION
GitLab's `resolveDiffFileInfo()` did not return a `baseRawRepoName` or a `baseFilePath`, which led to `DocumentNotFoundError` being thrown when hovering symbols in the base (red) part of a diff.

Rel #3107 🤦‍♂ ...