### PR TITLE
Make error alerts consistent

### DIFF
--- a/shared/src/components/Markdown.tsx
+++ b/shared/src/components/Markdown.tsx
@@ -2,16 +2,22 @@ import classNames from 'classnames'
 import * as React from 'react'
 
 interface Props {
+    wrapper?: 'div' | 'span'
     dangerousInnerHTML: string
     className?: string
     /** A function to attain a reference to the top-level div from a parent component. */
     refFn?: (ref: HTMLElement | null) => void
 }
 
-export const Markdown: React.FunctionComponent<Props> = (props: Props) => (
-    <div
-        ref={props.refFn}
-        className={classNames(props.className, 'markdown')}
-        dangerouslySetInnerHTML={{ __html: props.dangerousInnerHTML }}
+export const Markdown: React.FunctionComponent<Props> = ({
+    wrapper: RootComponent = 'div',
+    refFn,
+    className,
+    dangerousInnerHTML,
+}: Props) => (
+    <RootComponent
+        ref={refFn}
+        className={classNames(className, 'markdown')}
+        dangerouslySetInnerHTML={{ __html: dangerousInnerHTML }}
     />
 )

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -60,6 +60,9 @@ $alert-bg-level-light: -10;
 $alert-border-level-light: -9;
 $alert-color-level-light: 6;
 
+$alert-padding-y: 0.75rem;
+$alert-padding-x: 0.75rem;
+
 // Forms
 
 $input-btn-focus-width: 2px;

--- a/web/src/api/APIConsole.tsx
+++ b/web/src/api/APIConsole.tsx
@@ -1,13 +1,13 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as _graphiqlModule from 'graphiql' // type only
 import * as H from 'history'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { from as fromPromise, Subject, Subscription } from 'rxjs'
 import { catchError, debounceTime } from 'rxjs/operators'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { eventLogger } from '../tracking/eventLogger'
+import { ErrorAlert } from '../components/alerts'
 
 const defaultQuery = `# Type queries here, with completion, validation, and hovers.
 #
@@ -126,9 +126,7 @@ export class APIConsole extends React.PureComponent<Props, State> {
                         <LoadingSpinner className="icon-inline" /> Loading…
                     </span>
                 ) : isErrorLike(this.state.graphiqlOrError) ? (
-                    <div className="alert alert-danger">
-                        <strong>Error loading API console:</strong> {upperFirst(this.state.graphiqlOrError.message)}
-                    </div>
+                    <ErrorAlert prefix="Error loading API console" error={this.state.graphiqlOrError} />
                 ) : (
                     this.renderGraphiQL()
                 )}

--- a/web/src/auth/ResetPasswordPage.tsx
+++ b/web/src/auth/ResetPasswordPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import KeyIcon from 'mdi-react/KeyIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
@@ -10,6 +9,7 @@ import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { PasswordInput } from './SignInSignUpCommon'
+import { ErrorAlert } from '../components/alerts'
 
 interface ResetPasswordInitFormState {
     /** The user's email input value. */
@@ -67,7 +67,7 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
                 </button>
                 {this.state.submitOrError === 'loading' && <LoadingSpinner className="icon-inline mt-2" />}
                 {isErrorLike(this.state.submitOrError) && (
-                    <div className="alert alert-danger mt-2">{upperFirst(this.state.submitOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
                 )}
             </Form>
         )
@@ -163,7 +163,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
                 </button>
                 {this.state.submitOrError === 'loading' && <LoadingSpinner className="icon-inline mt-2" />}
                 {isErrorLike(this.state.submitOrError) && (
-                    <div className="alert alert-danger mt-2">{upperFirst(this.state.submitOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
                 )}
             </Form>
         )

--- a/web/src/auth/SignUpForm.tsx
+++ b/web/src/auth/SignUpForm.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { upperFirst } from 'lodash'
 import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
 import * as React from 'react'
 import { from, Subscription } from 'rxjs'
@@ -9,6 +8,7 @@ import { Form } from '../components/Form'
 import { eventLogger } from '../tracking/eventLogger'
 import { enterpriseTrial, signupTerms } from '../util/features'
 import { EmailInput, PasswordInput, UsernameInput } from './SignInSignUpCommon'
+import { ErrorAlert } from '../components/alerts'
 
 export interface SignUpArgs {
     email: string
@@ -53,9 +53,7 @@ export class SignUpForm extends React.Component<SignUpFormProps, SignUpFormState
     public render(): JSX.Element | null {
         return (
             <Form className="signin-signup-form signup-form e2e-signup-form" onSubmit={this.handleSubmit}>
-                {this.state.error && (
-                    <div className="alert alert-danger my-2">Error: {upperFirst(this.state.error.message)}</div>
-                )}
+                {this.state.error && <ErrorAlert className="my-2" error={this.state.error} />}
                 <div className="form-group">
                     <EmailInput
                         className="signin-signup-form__input"

--- a/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -1,11 +1,12 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Form } from '../components/Form'
 import { eventLogger } from '../tracking/eventLogger'
 import { getReturnTo, PasswordInput } from './SignInSignUpCommon'
+import { ErrorAlert } from '../components/alerts'
+import { asError } from '../../../shared/src/util/errors'
 
 interface Props {
     location: H.Location
@@ -15,7 +16,7 @@ interface Props {
 interface State {
     email: string
     password: string
-    errorDescription: string
+    error?: Error
     loading: boolean
 }
 
@@ -28,7 +29,6 @@ export class UsernamePasswordSignInForm extends React.Component<Props, State> {
         this.state = {
             email: '',
             password: '',
-            errorDescription: '',
             loading: false,
         }
     }
@@ -43,9 +43,7 @@ export class UsernamePasswordSignInForm extends React.Component<Props, State> {
                 ) : (
                     <p className="text-muted">To create an account, contact the site admin.</p>
                 )}
-                {this.state.errorDescription !== '' && (
-                    <div className="alert alert-danger my-2">Error: {upperFirst(this.state.errorDescription)}</div>
-                )}
+                {this.state.error && <ErrorAlert className="my-2" error={this.state.error} icon={false} />}
                 <div className="form-group">
                     <input
                         className="form-control signin-signup-form__input"
@@ -128,9 +126,9 @@ export class UsernamePasswordSignInForm extends React.Component<Props, State> {
                     throw new Error('Unknown Error')
                 }
             })
-            .catch(err => {
-                console.error('auth error: ', err)
-                this.setState({ loading: false, errorDescription: (err && err.message) || 'Unknown Error' })
+            .catch(error => {
+                console.error('Auth error:', error)
+                this.setState({ loading: false, error: asError(error) })
             })
     }
 }

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { uniq, upperFirst } from 'lodash'
+import { uniq } from 'lodash'
 import * as React from 'react'
 import { combineLatest, merge, Observable, of, Subject, Subscription } from 'rxjs'
 import {
@@ -23,6 +23,7 @@ import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors
 import { pluralize } from '../../../shared/src/util/strings'
 import { Form } from './Form'
 import { RadioButtons } from './RadioButtons'
+import { ErrorMessage } from './alerts'
 
 /** Checks if the passed value satisfies the GraphQL Node interface */
 const hasID = (obj: any): obj is { id: GQL.ID } => obj && typeof obj.id === 'string'
@@ -753,10 +754,9 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                 )}
                 {errors.length > 0 && (
                     <div className="alert alert-danger filtered-connection__error">
-                        {errors.map((m, i) => (
+                        {errors.map((error, i) => (
                             <React.Fragment key={i}>
-                                {upperFirst(m)}
-                                <br />
+                                <ErrorMessage error={error} />
                             </React.Fragment>
                         ))}
                     </div>

--- a/web/src/components/__snapshots__/alerts.test.tsx.snap
+++ b/web/src/components/__snapshots__/alerts.test.tsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorAlert should add a prefix if given 1`] = `
+<div>
+  <div
+    class="alert alert-danger"
+  >
+    <svg
+      class="mdi-icon icon icon-inline"
+      fill="currentColor"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M13,13H11V7H13M13,17H11V15H13M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+      />
+    </svg>
+     
+    <strong>
+      An error happened
+      :
+    </strong>
+     
+    <span
+      class="markdown"
+    >
+      An error happened
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ErrorAlert should omit the icon if icon={false} 1`] = `
+<div>
+  <div
+    class="alert alert-danger"
+  >
+     
+     
+    <span
+      class="markdown"
+    >
+      An error happened
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ErrorAlert should render a Go multierror nicely 1`] = `
+<div>
+  <div
+    class="alert alert-danger"
+  >
+    <svg
+      class="mdi-icon icon icon-inline"
+      fill="currentColor"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M13,13H11V7H13M13,17H11V15H13M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+      />
+    </svg>
+     
+     
+    <span
+      class="markdown"
+    >
+      <ul>
+        
+
+        <li>
+          Additional property asdasd is not allowed
+        </li>
+        
+
+        <li>
+          projectQuery.0: String length must be greater than or equal to 1
+        </li>
+        
+
+      </ul>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ErrorAlert should render an Error object as an alert 1`] = `
+<div>
+  <div
+    class="alert alert-danger"
+  >
+    <svg
+      class="mdi-icon icon icon-inline"
+      fill="currentColor"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M13,13H11V7H13M13,17H11V15H13M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+      />
+    </svg>
+     
+     
+    <span
+      class="markdown"
+    >
+      An error happened
+    </span>
+  </div>
+</div>
+`;

--- a/web/src/components/alerts.test.tsx
+++ b/web/src/components/alerts.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react'
+import { ErrorAlert } from './alerts'
+import React from 'react'
+
+describe('ErrorAlert', () => {
+    it('should render an Error object as an alert', () => {
+        expect(render(<ErrorAlert error={new Error('an error happened')} />).container).toMatchSnapshot()
+    })
+
+    it('should add a prefix if given', () => {
+        expect(
+            render(<ErrorAlert error={new Error('an error happened')} prefix="An error happened" />).container
+        ).toMatchSnapshot()
+    })
+
+    it('should omit the icon if icon={false}', () => {
+        expect(render(<ErrorAlert error={new Error('an error happened')} icon={false} />).container).toMatchSnapshot()
+    })
+
+    it('should render a Go multierror nicely', () => {
+        expect(
+            render(
+                <ErrorAlert
+                    error={
+                        new Error(
+                            '- Additional property asdasd is not allowed\n- projectQuery.0: String length must be greater than or equal to 1\n'
+                        )
+                    }
+                />
+            ).container
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/components/alerts.tsx
+++ b/web/src/components/alerts.tsx
@@ -1,0 +1,54 @@
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import React from 'react'
+import { asError } from '../../../shared/src/util/errors'
+import { upperFirst } from 'lodash'
+import { Markdown } from '../../../shared/src/components/Markdown'
+import { renderMarkdown } from '../../../shared/src/util/markdown'
+import classNames from 'classnames'
+
+const renderError = (error: unknown): string =>
+    renderMarkdown(upperFirst((asError(error).message || 'Unknown Error').replace(/\t/g, '')))
+        .trim()
+        .replace(/^<p>/, '')
+        .replace(/<\/p>$/, '')
+
+export const ErrorMessage: React.FunctionComponent<{ error: unknown }> = ({ error }) => (
+    <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} />
+)
+
+/**
+ * Renders a given `Error` object in a Bootstrap danger alert.
+ *
+ * The error message is optimistically formatted as markdown to enrich links,
+ * bullet points, respect line breaks, code and bolded elements.
+ * Made to work with Go `multierror`.
+ */
+export const ErrorAlert: React.FunctionComponent<{
+    /**
+     * An Error-like object or a string.
+     */
+    error: unknown
+
+    /**
+     * Whether to show an icon.
+     *
+     * @default true
+     */
+    icon?: boolean
+
+    /**
+     * Optional prefix for the message
+     */
+    prefix?: string
+
+    className?: string
+    style?: React.CSSProperties
+}> = ({ error, className, icon = true, prefix, ...rest }) => {
+    prefix = prefix && prefix.trim().replace(/:+$/, '')
+    return (
+        <div className={classNames('alert', 'alert-danger', className)} {...rest}>
+            {icon && <AlertCircleIcon className="icon icon-inline" />} {prefix && <strong>{prefix}:</strong>}{' '}
+            <ErrorMessage error={error} />
+        </div>
+    )
+}

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -6,6 +6,7 @@ import { ID } from '../../../../../shared/src/graphql/schema'
 import { RepoNotFoundError } from '../../../../../shared/src/backend/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError } from '../../../../../shared/src/util/errors'
+import { ErrorAlert } from '../../../components/alerts'
 
 async function addChangeset({
     campaignID,
@@ -113,7 +114,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                 </button>
                 {isLoading && <LoadingSpinner className="icon-inline" />}
             </Form>
-            {error && <div className="alert alert-danger">{error.message}</div>}
+            {error && <ErrorAlert error={error} />}
         </>
     )
 }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -8,7 +8,7 @@ import { UserAvatar } from '../../../user/UserAvatar'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { CampaignsIcon } from '../icons'
 import { ExternalChangesetNode } from './changesets/ExternalChangesetNode'
-import { noop, upperFirst } from 'lodash'
+import { noop } from 'lodash'
 import { Form } from '../../../components/Form'
 import { fetchCampaignById, updateCampaign, deleteCampaign, createCampaign, queryChangesets } from './backend'
 import { useError } from '../../../util/useObservable'
@@ -21,6 +21,7 @@ import { AddChangesetForm } from './AddChangesetForm'
 import { Subject } from 'rxjs'
 import { Markdown } from '../../../../../shared/src/components/Markdown'
 import { renderMarkdown } from '../../../../../shared/src/util/markdown'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props {
     /**
@@ -238,7 +239,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         )}
                     </span>
                 </h2>
-                {alertError && <div className="alert alert-danger">{upperFirst(alertError.message)}</div>}
+                {alertError && <ErrorAlert error={alertError} />}
                 <div className="card mb-3">
                     <div className="card-header">
                         <strong>

--- a/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
+++ b/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Observable, Subscription } from 'rxjs'
 import { catchError, map, startWith, tap } from 'rxjs/operators'
@@ -9,6 +8,7 @@ import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../
 import { queryGraphQL } from '../../../backend/graphql'
 import { ProductPlanPrice } from './ProductPlanPrice'
 import { ProductPlanTiered } from './ProductPlanTiered'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props {
     /** The selected plan's billing ID. */
@@ -71,7 +71,7 @@ export class ProductPlanFormControl extends React.Component<Props, State> {
                 {this.state.plansOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.plansOrError) ? (
-                    <div className="alert alert-danger">{upperFirst(this.state.plansOrError.message)}</div>
+                    <ErrorAlert error={this.state.plansOrError.message} />
                 ) : (
                     <>
                         <div className="list-group">

--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
@@ -8,6 +8,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../../backend/graphql'
 import { ExtensionsExploreSectionExtensionCard } from './ExtensionsExploreSectionExtensionCard'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props {}
 
@@ -65,7 +66,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
             <div className="card">
                 <h3 className="card-header">Top Sourcegraph extensions</h3>
                 {isErrorLike(extensionsOrError) ? (
-                    <div className="alert alert-danger">Error: {extensionsOrError.message}</div>
+                    <ErrorAlert error={extensionsOrError} />
                 ) : extensionsOrError.length === 0 ? (
                     <p>No extensions are available.</p>
                 ) : (

--- a/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -7,6 +7,7 @@ import {
     publisherName,
     RegistryPublisher,
 } from '../../../extensions/extension/extension'
+import { ErrorAlert } from '../../../components/alerts'
 
 export const RegistryPublisherFormGroup: React.FunctionComponent<{
     className?: string
@@ -23,7 +24,7 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
     <div className={`form-group ${className}`}>
         <label htmlFor="extension-registry-create-extension-page__publisher">Publisher</label>
         {isErrorLike(publishersOrError) ? (
-            <div className="alert alert-danger">{publishersOrError.message}</div>
+            <ErrorAlert error={publishersOrError} />
         ) : (
             <select
                 id="extension-registry-create-extension-page__publisher"

--- a/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -19,6 +18,7 @@ import { ExtensionAreaRouteContext } from '../../../extensions/extension/Extensi
 import { eventLogger } from '../../../tracking/eventLogger'
 import { RegistryExtensionDeleteButton } from './RegistryExtensionDeleteButton'
 import { RegistryExtensionNameFormGroup, RegistryPublisherFormGroup } from './RegistryExtensionForm'
+import { ErrorAlert } from '../../../components/alerts'
 
 function updateExtension(
     args: Pick<
@@ -178,9 +178,7 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                             )}
                         </button>
                     </Form>
-                    {isErrorLike(this.state.updateOrError) && (
-                        <div className="alert alert-danger">{upperFirst(this.state.updateOrError.message)}</div>
-                    )}
+                    {isErrorLike(this.state.updateOrError) && <ErrorAlert error={this.state.updateOrError} />}
                     <div className="card mt-5 registry-extension-manage-page__other-actions">
                         <div className="card-header">Other actions</div>
                         <div className="card-body">

--- a/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import PuzzleIcon from 'mdi-react/PuzzleIcon'
 import * as React from 'react'
@@ -19,6 +18,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { RegistryExtensionNameFormGroup, RegistryPublisherFormGroup } from '../extension/RegistryExtensionForm'
 import { queryViewerRegistryPublishers } from './backend'
 import { RegistryAreaPageProps } from './RegistryArea'
+import { ErrorAlert } from '../../../components/alerts'
 
 function createExtension(publisher: GQL.ID, name: string): Observable<GQL.IExtensionRegistryCreateExtensionResult> {
     return mutateGraphQL(
@@ -189,9 +189,7 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             </button>
                         </Form>
                         {isErrorLike(this.state.creationOrError) && (
-                            <div className="alert alert-danger mt-3">
-                                {upperFirst(this.state.creationOrError.message)}
-                            </div>
+                            <ErrorAlert className="mt-3" error={this.state.creationOrError} />
                         )}
                     </ModalPage>
                 </>

--- a/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -16,6 +15,7 @@ import { registryExtensionFragment } from '../../extensions/extension/ExtensionA
 import { eventLogger } from '../../tracking/eventLogger'
 import { deleteRegistryExtensionWithConfirmation } from '../extensions/registry/backend'
 import { RegistryExtensionSourceBadge } from '../extensions/registry/RegistryExtensionSourceBadge'
+import { ErrorAlert } from '../../components/alerts'
 
 interface RegistryExtensionNodeSiteAdminProps {
     node: GQL.IRegistryExtension
@@ -118,9 +118,7 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                     </div>
                 </div>
                 {isErrorLike(this.state.deletionOrError) && (
-                    <div className="alert alert-danger mt-2">
-                        Error: {upperFirst(this.state.deletionOrError.message)}
-                    </div>
+                    <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
                 )}
             </li>
         )

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable, Subject, Subscription } from 'rxjs'
@@ -12,6 +11,7 @@ import { Form } from '../../../../components/Form'
 import { PageTitle } from '../../../../components/PageTitle'
 import { eventLogger } from '../../../../tracking/eventLogger'
 import { AccountEmailAddresses } from '../../../dotcom/productSubscriptions/AccountEmailAddresses'
+import { ErrorAlert } from '../../../../components/alerts'
 
 interface Props extends RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
@@ -140,9 +140,11 @@ export class SiteAdminCreateProductSubscriptionPage extends React.Component<Prop
                             )}
                         </select>
                         {isErrorLike(this.state.accountsOrError) ? (
-                            <div className="alert alert-danger mt-2">
-                                Error loading accounts: {upperFirst(this.state.accountsOrError.message)}
-                            </div>
+                            <ErrorAlert
+                                className="mt-2"
+                                error={this.state.accountsOrError}
+                                prefix="Error loading accounts"
+                            />
                         ) : selectedAccount ? (
                             <small className="form-text text-muted">
                                 Email {pluralize('address', selectedAccount.emails.length, 'addresses')}:{' '}
@@ -173,7 +175,7 @@ export class SiteAdminCreateProductSubscriptionPage extends React.Component<Prop
                     </div>
                 </Form>
                 {isErrorLike(this.state.creationOrError) && (
-                    <div className="alert alert-danger mt-3">{upperFirst(this.state.creationOrError.message)}</div>
+                    <ErrorAlert className="mt-3" error={this.state.creationOrError} />
                 )}
             </div>
         )

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -1,6 +1,5 @@
 import addDays from 'date-fns/addDays'
 import endOfDay from 'date-fns/endOfDay'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, map, startWith, switchMap, tap } from 'rxjs/operators'
@@ -10,6 +9,7 @@ import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../
 import { mutateGraphQL } from '../../../../backend/graphql'
 import { Form } from '../../../../components/Form'
 import { ExpirationDate } from '../../../productSubscription/ExpirationDate'
+import { ErrorAlert } from '../../../../components/alerts'
 
 interface Props {
     subscriptionID: GQL.ID
@@ -219,7 +219,7 @@ export class SiteAdminGenerateProductLicenseForSubscriptionForm extends React.Co
                     </Form>
                 )}
                 {isErrorLike(this.state.creationOrError) && (
-                    <div className="alert alert-danger mt-3">{upperFirst(this.state.creationOrError.message)}</div>
+                    <ErrorAlert className="mt-3" error={this.state.creationOrError} />
                 )}
             </div>
         )

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
 import * as React from 'react'
@@ -37,6 +36,7 @@ import {
     SiteAdminProductLicenseNodeProps,
 } from './SiteAdminProductLicenseNode'
 import { SiteAdminProductSubscriptionBillingLink } from './SiteAdminProductSubscriptionBillingLink'
+import { ErrorAlert } from '../../../../components/alerts'
 
 interface Props extends RouteComponentProps<{ subscriptionUUID: string }> {}
 
@@ -155,9 +155,7 @@ export class SiteAdminProductSubscriptionPage extends React.Component<Props, Sta
                 {this.state.productSubscriptionOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.productSubscriptionOrError) ? (
-                    <div className="alert alert-danger my-2">
-                        Error: {this.state.productSubscriptionOrError.message}
-                    </div>
+                    <ErrorAlert className="my-2" error={this.state.productSubscriptionOrError} />
                 ) : (
                     <>
                         <h2>Product subscription {this.state.productSubscriptionOrError.name}</h2>
@@ -171,9 +169,7 @@ export class SiteAdminProductSubscriptionPage extends React.Component<Props, Sta
                                 Archive
                             </button>
                             {isErrorLike(this.state.archivalOrError) && (
-                                <div className="alert alert-danger mt-2">
-                                    Error: {upperFirst(this.state.archivalOrError.message)}
-                                </div>
+                                <ErrorAlert className="mt-2" error={this.state.archivalOrError} />
                             )}
                         </div>
                         <div className="card mt-3">

--- a/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -12,6 +12,7 @@ import { ExpirationDate } from '../../productSubscription/ExpirationDate'
 import { formatUserCount } from '../../productSubscription/helpers'
 import { ProductCertificate } from '../../productSubscription/ProductCertificate'
 import { TrueUpStatusSummary } from '../../productSubscription/TrueUpStatusSummary'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props {
     className?: string
@@ -58,11 +59,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
             return null
         }
         if (isErrorLike(this.state.statusOrError)) {
-            return (
-                <div className="alert alert-danger">
-                    Error checking product license: {this.state.statusOrError.message}
-                </div>
-            )
+            return <ErrorAlert error={this.state.statusOrError} prefix="Error checking product license" />
         }
 
         const {

--- a/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { isEqual, upperFirst } from 'lodash'
+import { isEqual } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { ReactStripeElements } from 'react-stripe-elements'
@@ -16,6 +16,7 @@ import { NewProductSubscriptionPaymentSection } from './NewProductSubscriptionPa
 import { PaymentTokenFormControl } from './PaymentTokenFormControl'
 import { productSubscriptionInputForLocationHash } from './UserSubscriptionsNewProductSubscriptionPage'
 import { ThemeProps } from '../../../../../shared/src/theme'
+import { ErrorAlert } from '../../../components/alerts'
 
 /**
  * The form data that is submitted by the ProductSubscriptionForm component.
@@ -252,10 +253,10 @@ class _ProductSubscriptionForm extends React.Component<Props & ReactStripeElemen
                     </div>
                 </Form>
                 {isErrorLike(this.state.paymentTokenOrError) && (
-                    <div className="alert alert-danger mt-3">{upperFirst(this.state.paymentTokenOrError.message)}</div>
+                    <ErrorAlert className="mt-3" error={this.state.paymentTokenOrError} />
                 )}
                 {isErrorLike(this.props.submissionState) && (
-                    <div className="alert alert-danger mt-3">{upperFirst(this.props.submissionState.message)}</div>
+                    <ErrorAlert className="mt-3" error={this.props.submissionState} />
                 )}
             </div>
         )

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -23,6 +23,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { ProductSubscriptionForm, ProductSubscriptionFormData } from './ProductSubscriptionForm'
 import { ThemeProps } from '../../../../../shared/src/theme'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props extends RouteComponentProps<{ subscriptionUUID: string }>, ThemeProps {
     user: GQL.IUser
@@ -125,9 +126,7 @@ export class UserSubscriptionsEditProductSubscriptionPage extends React.Componen
                 {this.state.productSubscriptionOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.productSubscriptionOrError) ? (
-                    <div className="alert alert-danger my-2">
-                        Error: {this.state.productSubscriptionOrError.message}
-                    </div>
+                    <ErrorAlert className="my-2" error={this.state.productSubscriptionOrError} />
                 ) : (
                     <>
                         <Link to={this.state.productSubscriptionOrError.url} className="btn btn-link btn-sm mb-3">

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -17,6 +17,7 @@ import { BackToAllSubscriptionsLink } from './BackToAllSubscriptionsLink'
 import { ProductSubscriptionBilling } from './ProductSubscriptionBilling'
 import { ProductSubscriptionHistory } from './ProductSubscriptionHistory'
 import { UserProductSubscriptionStatus } from './UserProductSubscriptionStatus'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props extends RouteComponentProps<{ subscriptionUUID: string }> {
     user: GQL.IUser
@@ -96,9 +97,7 @@ export class UserSubscriptionsProductSubscriptionPage extends React.Component<Pr
                 {this.state.productSubscriptionOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.productSubscriptionOrError) ? (
-                    <div className="alert alert-danger my-2">
-                        Error: {this.state.productSubscriptionOrError.message}
-                    </div>
+                    <ErrorAlert className="my-2" error={this.state.productSubscriptionOrError} />
                 ) : (
                     <>
                         <h2>Subscription {this.state.productSubscriptionOrError.name}</h2>

--- a/web/src/enterprise/user/settings/ExternalAccountNode.tsx
+++ b/web/src/enterprise/user/settings/ExternalAccountNode.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
@@ -9,6 +8,7 @@ import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../
 import { mutateGraphQL } from '../../../backend/graphql'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { userURL } from '../../../user'
+import { ErrorAlert } from '../../../components/alerts'
 
 export const externalAccountFragment = gql`
     fragment ExternalAccountFields on ExternalAccount {
@@ -150,9 +150,7 @@ export class ExternalAccountNode extends React.PureComponent<ExternalAccountNode
                             Delete
                         </button>
                         {isErrorLike(this.state.deletionOrError) && (
-                            <div className="alert alert-danger mt-2">
-                                Error: {upperFirst(this.state.deletionOrError.message)}
-                            </div>
+                            <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
                         )}
                     </div>
                 </div>

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -19,6 +19,7 @@ import { Form } from '../components/Form'
 import { extensionsQuery, isExtensionAdded } from './extension/extension'
 import { ExtensionCard } from './ExtensionCard'
 import { ExtensionsQueryInputToolbar } from './ExtensionsQueryInputToolbar'
+import { ErrorAlert } from '../components/alerts'
 
 export const registryExtensionFragment = gql`
     fragment RegistryExtensionFields on RegistryExtension {
@@ -206,11 +207,11 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                 {this.state.data.resultOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.data.resultOrError) ? (
-                    <div className="alert alert-danger">{this.state.data.resultOrError.message}</div>
+                    <ErrorAlert error={this.state.data.resultOrError} />
                 ) : (
                     <>
                         {this.state.data.resultOrError.error && (
-                            <div className="alert alert-danger mb-2">{this.state.data.resultOrError.error}</div>
+                            <ErrorAlert className="mb-2" error={this.state.data.resultOrError.error} />
                         )}
                         {this.state.data.resultOrError.extensions.length === 0 ? (
                             this.state.data.query ? (

--- a/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -8,6 +8,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
 import { ThemeProps } from '../../../../shared/src/theme'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {}
 
@@ -32,7 +33,7 @@ const ContributionsTable: React.FunctionComponent<{ contributionGroups: Contribu
                         <h3>
                             {group.title} ({group.rows.length})
                         </h3>
-                        {group.error && <div className="alert alert-danger mt-1">Error: {group.error.message}</div>}
+                        {group.error && <ErrorAlert className="mt-1" error={group.error} />}
                         <table className="table mb-5">
                             <thead>
                                 <tr>
@@ -148,9 +149,7 @@ export class RegistryExtensionContributionsPage extends React.PureComponent<Prop
                     {this.props.extension.manifest === null ? (
                         <ExtensionNoManifestAlert extension={this.props.extension} />
                     ) : isErrorLike(this.props.extension.manifest) ? (
-                        <div className="alert alert-danger">
-                            Error parsing extension manifest: {this.props.extension.manifest.message}
-                        </div>
+                        <ErrorAlert error={this.props.extension.manifest} prefix="Error parsing extension manifest" />
                     ) : (
                         <ContributionsTable contributionGroups={toContributionsGroups(this.props.extension.manifest)} />
                     )}

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,4 +1,3 @@
-import { startCase } from 'lodash'
 import CloudAlertIcon from 'mdi-react/CloudAlertIcon'
 import CloudCheckIcon from 'mdi-react/CloudCheckIcon'
 import CloudSyncIcon from 'mdi-react/CloudSyncIcon'
@@ -12,6 +11,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { queryGraphQL } from '../backend/graphql'
 import classNames from 'classnames'
+import { ErrorAlert } from '../components/alerts'
 
 export function fetchAllStatusMessages(): Observable<GQL.StatusMessage[]> {
     return queryGraphQL(
@@ -216,10 +216,11 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                 <DropdownMenu right={true} className="status-messages-nav-item__dropdown-menu">
                     <h3>External service status</h3>
                     {isErrorLike(this.state.messagesOrError) ? (
-                        <div className="status-messages-nav-item__entry alert alert-danger mb-0">
-                            <h4>Failed to load status messages:</h4>
-                            <p>{startCase(this.state.messagesOrError.message)}</p>
-                        </div>
+                        <ErrorAlert
+                            className="status-messages-nav-item__entry mb-0"
+                            prefix="Failed to load status messages"
+                            error={this.state.messagesOrError}
+                        />
                     ) : this.state.messagesOrError.length > 0 ? (
                         this.state.messagesOrError.map(m => this.renderMessage(m))
                     ) : (

--- a/web/src/org/area/OrgInvitationPage.tsx
+++ b/web/src/org/area/OrgInvitationPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link, Redirect } from 'react-router-dom'
 import { concat, Observable, Subject, Subscription } from 'rxjs'
@@ -18,6 +17,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { userURL } from '../../user'
 import { OrgAvatar } from '../OrgAvatar'
 import { OrgAreaPageProps } from './OrgArea'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Props extends OrgAreaPageProps {
     authenticatedUser: GQL.IUser
@@ -154,9 +154,7 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     </button>
                                 </div>
                                 {isErrorLike(this.state.submissionOrError) && (
-                                    <div className="alert alert-danger my-2">
-                                        {upperFirst(this.state.submissionOrError.message)}
-                                    </div>
+                                    <ErrorAlert className="my-2" error={this.state.submissionOrError} />
                                 )}
                                 {this.state.submissionOrError === 'loading' && (
                                     <LoadingSpinner className="icon-inline" />

--- a/web/src/org/area/OrgMembersPage.tsx
+++ b/web/src/org/area/OrgMembersPage.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
@@ -15,6 +14,7 @@ import { userURL } from '../../user'
 import { removeUserFromOrganization } from '../backend'
 import { InviteForm } from '../invite/InviteForm'
 import { OrgAreaPageProps } from './OrgArea'
+import { ErrorAlert } from '../../components/alerts'
 
 interface UserNodeProps {
     /** The user to display in this list item. */
@@ -112,7 +112,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                     </div>
                 </div>
                 {isErrorLike(this.state.removalOrError) && (
-                    <div className="alert alert-danger mt-2">{upperFirst(this.state.removalOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.removalOrError} />
                 )}
             </li>
         )

--- a/web/src/org/invite/InviteForm.tsx
+++ b/web/src/org/invite/InviteForm.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
 import EmailOpenOutlineIcon from 'mdi-react/EmailOpenOutlineIcon'
@@ -15,6 +14,7 @@ import { CopyableText } from '../../components/CopyableText'
 import { DismissibleAlert } from '../../components/DismissibleAlert'
 import { Form } from '../../components/Form'
 import { eventLogger } from '../../tracking/eventLogger'
+import { ErrorAlert } from '../../components/alerts'
 
 function inviteUserToOrganization(
     username: string,
@@ -342,11 +342,7 @@ export class InviteForm extends React.PureComponent<Props, State> {
                         />
                         /* eslint-enable react/jsx-no-bind */
                     ))}
-                {this.state.error && (
-                    <div className="invite-form__alert alert alert-danger">
-                        Error: {upperFirst(this.state.error.message)}
-                    </div>
-                )}
+                {this.state.error && <ErrorAlert className="invite-form__alert" error={this.state.error} />}
             </div>
         )
     }

--- a/web/src/org/new/NewOrganizationPage.tsx
+++ b/web/src/org/new/NewOrganizationPage.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
@@ -10,6 +9,7 @@ import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { eventLogger } from '../../tracking/eventLogger'
 import { createOrganization } from '../backend'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Props {
     history: H.History
@@ -89,7 +89,7 @@ export class NewOrganizationPage extends React.Component<Props, State> {
                         <Link to="/help/user/organizations">Sourcegraph documentation</Link> for information about
                         configuring organizations.
                     </p>
-                    {this.state.error && <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>}
+                    {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
                     <div className="form-group">
                         <label htmlFor="new-org-page__form-name">Organization name</label>
                         <input

--- a/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { concat, of, Subject, Subscription } from 'rxjs'
@@ -10,6 +9,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { OrgAreaPageProps } from '../../area/OrgArea'
 import { updateOrganization } from '../../backend'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {}
 
@@ -119,7 +119,7 @@ export class OrgSettingsProfilePage extends React.PureComponent<Props, State> {
                     >
                         <small>Updated!</small>
                     </div>
-                    {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
+                    {this.state.error && <ErrorAlert error={this.state.error} />}
                 </Form>
             </div>
         )

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { escapeRegExp, upperFirst } from 'lodash'
+import { escapeRegExp } from 'lodash'
 import FolderIcon from 'mdi-react/FolderIcon'
 import HistoryIcon from 'mdi-react/HistoryIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
@@ -40,6 +40,7 @@ import { fetchTree } from './backend'
 import { GitCommitNode, GitCommitNodeProps } from './commits/GitCommitNode'
 import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 import { ThemeProps } from '../../../shared/src/theme'
+import { ErrorAlert } from '../components/alerts'
 
 const TreeEntry: React.FunctionComponent<{
     isDir: boolean
@@ -224,7 +225,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                 )}
                 {this.state.treeOrError !== undefined &&
                     (isErrorLike(this.state.treeOrError) ? (
-                        <div className="alert alert-danger">{upperFirst(this.state.treeOrError.message)}</div>
+                        <ErrorAlert error={this.state.treeOrError} />
                     ) : (
                         <>
                             {this.state.treeOrError.isRoot ? (

--- a/web/src/repo/blob/discussions/DiscussionsInput.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsInput.tsx
@@ -1,7 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 import { uniqueId } from 'lodash'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import * as React from 'react'
 import { concat, merge, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, filter, map, mergeMap, startWith, switchMap, tap, withLatestFrom } from 'rxjs/operators'
@@ -21,6 +20,7 @@ import { Form } from '../../../components/Form'
 import { WebEditorCompletionWidget } from '../../../components/shared'
 import { renderMarkdown } from '../../../discussions/backend'
 import { eventLogger } from '../../../tracking/eventLogger'
+import { ErrorAlert } from '../../../components/alerts'
 
 /**
  * How & whether or not to render a title input field.
@@ -318,12 +318,7 @@ export class DiscussionsInput extends React.PureComponent<Props, State> {
                         {this.props.submitLabel}
                     </button>
                 </div>
-                {error && (
-                    <div className="discussions-input__error alert alert-danger">
-                        <AlertCircleIcon className="icon-inline discussions-input__error-icon" />
-                        {error.message}
-                    </div>
-                )}
+                {error && <ErrorAlert className="discussions-input__error" error={error} />}
             </Form>
         )
     }

--- a/web/src/repo/blob/discussions/DiscussionsThread.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsThread.tsx
@@ -1,7 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 import { isEqual } from 'lodash'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import * as React from 'react'
 import { Redirect } from 'react-router'
 import { combineLatest, Subject, Subscription, throwError, Observable } from 'rxjs'
@@ -15,6 +14,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { formatHash } from '../../../util/url'
 import { DiscussionsInput, TitleMode } from './DiscussionsInput'
 import { DiscussionsNavbar } from './DiscussionsNavbar'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props extends ExtensionsControllerProps {
     threadIDWithoutKind: string
@@ -102,10 +102,7 @@ export class DiscussionsThread extends React.PureComponent<Props, State> {
                 <DiscussionsNavbar {...this.props} threadTitle={thread ? thread.title : undefined} />
                 {loading && <LoadingSpinner className="icon-inline" />}
                 {error && (
-                    <div className="discussions-thread__error alert alert-danger">
-                        <AlertCircleIcon className="icon-inline discussions-thread__error-icon" />
-                        Error loading thread: {error.message}
-                    </div>
+                    <ErrorAlert className="discussions-thread__error" prefix="Error loading thread" error={error} />
                 )}
                 {thread && (
                     <div className="discussions-thread__comments">

--- a/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
@@ -14,6 +13,7 @@ import { PageTitle } from '../../components/PageTitle'
 import { eventLogger } from '../../tracking/eventLogger'
 import { gitRefFragment, GitRefNode } from '../GitRef'
 import { RepositoryBranchesAreaPageProps } from './RepositoryBranchesArea'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Data {
     defaultBranch: GQL.IGitRef | null
@@ -117,7 +117,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                 {this.state.dataOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.dataOrError) ? (
-                    <div className="alert alert-danger mt-2">Error: {upperFirst(this.state.dataOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.dataOrError} />
                 ) : (
                     <div className="repository-branches-page__cards">
                         {this.state.dataOrError.defaultBranch && (

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -1,6 +1,6 @@
 import { createHoverifier, HoveredToken, Hoverifier, HoverState } from '@sourcegraph/codeintellify'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { isEqual, upperFirst } from 'lodash'
+import { isEqual } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { merge, Observable, of, Subject, Subscription } from 'rxjs'
@@ -29,6 +29,7 @@ import { FileDiffConnection } from '../compare/FileDiffConnection'
 import { FileDiffNode } from '../compare/FileDiffNode'
 import { queryRepositoryComparisonFileDiffs } from '../compare/RepositoryCompareDiffPage'
 import { ThemeProps } from '../../../../shared/src/theme'
+import { ErrorAlert } from '../../components/alerts'
 
 const queryCommit = memoizeObservable(
     (args: { repo: GQL.ID; revspec: string }): Observable<GQL.IGitCommit> =>
@@ -200,7 +201,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 {this.state.commitOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.commitOrError) ? (
-                    <div className="alert alert-danger mt-2">Error: {upperFirst(this.state.commitOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.commitOrError} />
                 ) : (
                     <>
                         <div className="card repository-commit-page__card">

--- a/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -1,6 +1,5 @@
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { merge, Observable, of, Subject, Subscription } from 'rxjs'
@@ -20,6 +19,7 @@ import { RepositoryCompareAreaPageProps } from './RepositoryCompareArea'
 import { RepositoryCompareCommitsPage } from './RepositoryCompareCommitsPage'
 import { RepositoryCompareDiffPage } from './RepositoryCompareDiffPage'
 import { ThemeProps } from '../../../../shared/src/theme'
+import { ErrorAlert } from '../../components/alerts'
 
 function queryRepositoryComparison(args: {
     repo: GQL.ID
@@ -148,7 +148,7 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                 ) : this.state.rangeOrError === undefined ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.rangeOrError) ? (
-                    <div className="alert alert-danger mt-2">Error: {upperFirst(this.state.rangeOrError.message)}</div>
+                    <ErrorAlert className="mt-2" error={this.state.rangeOrError} />
                 ) : (
                     <>
                         <RepositoryCompareCommitsPage {...this.props} />

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -11,6 +11,7 @@ import { pluralize } from '../../../../shared/src/util/strings'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { PatternTypeProps } from '../../search'
+import { ErrorAlert } from '../../components/alerts'
 
 const LOADING: 'loading' = 'loading'
 
@@ -80,7 +81,7 @@ export class RepositoriesExploreSection extends React.PureComponent<
                 <h3 className="card-header">Repositories</h3>
                 <div className="list-group list-group-flush">
                     {isErrorLike(repositoriesOrError) ? (
-                        <div className="alert alert-danger">Error: {repositoriesOrError.message}</div>
+                        <ErrorAlert error={repositoriesOrError} />
                     ) : repositoriesOrError.length === 0 ? (
                         <p>No repositories.</p>
                     ) : (

--- a/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -15,6 +15,7 @@ import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import { eventLogger } from '../../tracking/eventLogger'
+import { ErrorAlert } from '../../components/alerts'
 
 /**
  * Fetches a repository's text search index information.
@@ -158,11 +159,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                 <h2>Indexing</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.error && (
-                    <div className="alert alert-danger">
-                        Error getting repository index status:
-                        <br />
-                        <code>{this.state.error.message}</code>
-                    </div>
+                    <ErrorAlert prefix="Error getting repository index status" error={this.state.error} />
                 )}
                 {!this.state.error &&
                     !this.state.loading &&

--- a/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import CheckIcon from 'mdi-react/CheckIcon'
 import LockIcon from 'mdi-react/LockIcon'
 import * as React from 'react'
@@ -16,6 +15,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { DirectImportRepoAlert } from '../DirectImportRepoAlert'
 import { fetchRepository } from './backend'
 import { ActionContainer, BaseActionContainer } from './components/ActionContainer'
+import { ErrorAlert } from '../../components/alerts'
 
 interface UpdateMirrorRepositoryActionContainerProps {
     repo: GQL.IRepository
@@ -194,9 +194,7 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                 details={
                     <>
                         {this.state.errorDescription && (
-                            <div className="alert alert-danger action-container__alert">
-                                Error: {this.state.errorDescription}
-                            </div>
+                            <ErrorAlert className="action-container__alert" error={this.state.errorDescription} />
                         )}
                         {this.state.loading && (
                             <div className="alert alert-primary action-container__alert">
@@ -283,7 +281,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Mirror settings" />
                 <h2>Mirroring and cloning</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
+                {this.state.error && <ErrorAlert error={this.state.error} />}
                 <div className="form-group">
                     <label>
                         Remote repository URL{' '}

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
@@ -11,6 +10,7 @@ import { PageTitle } from '../../components/PageTitle'
 import { getExternalService } from '../../site-admin/externalServices'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchRepository } from './backend'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Props extends RouteComponentProps<any> {
     repo: GQL.IRepository
@@ -64,7 +64,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Repository settings" />
                 <h2>Settings</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
+                {this.state.error && <ErrorAlert error={this.state.error} />}
                 {services.length > 0 && (
                     <div className="mb-4">
                         {services.map(service => (

--- a/web/src/repo/settings/components/ActionContainer.tsx
+++ b/web/src/repo/settings/components/ActionContainer.tsx
@@ -1,5 +1,5 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
+import { ErrorAlert } from '../../../components/alerts'
 
 export const BaseActionContainer: React.FunctionComponent<{
     title: React.ReactFragment
@@ -92,10 +92,11 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                 }
                 details={
                     <>
-                        {this.state.error && (
-                            <div className="alert alert-danger mb-0 mt-3">Error: {upperFirst(this.state.error)}</div>
+                        {this.state.error ? (
+                            <ErrorAlert className="mb-0 mt-3" error={this.state.error} />
+                        ) : (
+                            this.props.info
                         )}
-                        {!this.state.error && this.props.info}
                     </>
                 }
             />

--- a/web/src/savedSearches/SavedSearchForm.tsx
+++ b/web/src/savedSearches/SavedSearchForm.tsx
@@ -5,6 +5,7 @@ import { Omit } from 'utility-types'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { Form } from '../components/Form'
 import { NamespaceProps } from '../namespaces'
+import { ErrorAlert } from '../components/alerts'
 
 export interface SavedQueryFields {
     id: GQL.ID
@@ -169,9 +170,7 @@ export class SavedSearchForm extends React.Component<Props, State> {
                         {this.props.submitLabel}
                     </button>
                     {this.props.error && !this.props.loading && (
-                        <div className="alert alert-danger mb-3">
-                            <strong>Error:</strong> {this.props.error.message}
-                        </div>
+                        <ErrorAlert className="mb-3" error={this.props.error} />
                     )}
                 </Form>
             </div>

--- a/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/web/src/savedSearches/SavedSearchListPage.tsx
@@ -13,6 +13,7 @@ import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { NamespaceProps } from '../namespaces'
 import { deleteSavedSearch, fetchSavedSearches } from '../search/backend'
 import { PatternTypeProps } from '../search'
+import { ErrorAlert } from '../components/alerts'
 
 interface NodeProps extends RouteComponentProps, Omit<PatternTypeProps, 'togglePatternType'> {
     savedSearch: GQL.ISavedSearch
@@ -141,9 +142,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                     </div>
                 </div>
                 {this.state.savedSearchesOrError && isErrorLike(this.state.savedSearchesOrError) && (
-                    <div className="alert alert-danger mb-3">
-                        <strong>Error:</strong> {this.state.savedSearchesOrError.message}
-                    </div>
+                    <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} />
                 )}
                 <div className="list-group list-group-flush">
                     {this.state.savedSearchesOrError &&

--- a/web/src/search/input/ScopePage.tsx
+++ b/web/src/search/input/ScopePage.tsx
@@ -19,6 +19,7 @@ import { submitSearch } from '../helpers'
 import { QueryInput, queryUpdates } from './QueryInput'
 import { SearchButton } from './SearchButton'
 import { PatternTypeProps } from '..'
+import { ErrorAlert } from '../../components/alerts'
 
 const ScopeNotFound: React.FunctionComponent = () => (
     <HeroPage
@@ -174,9 +175,7 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
                     <section className="scope-page__repos">
                         <div>
                             <div>
-                                {this.state.errorMessage && (
-                                    <p className="alert alert-danger">{this.state.errorMessage}</p>
-                                )}
+                                {this.state.errorMessage && <ErrorAlert error={this.state.errorMessage} />}
                                 {!this.state.errorMessage &&
                                     (this.state.repositories && this.state.repositories.length > 0 ? (
                                         <div>

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { isEqual, upperFirst } from 'lodash'
+import { isEqual } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
@@ -30,6 +30,7 @@ import { ThemeProps } from '../../../../shared/src/theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { shouldDisplayPerformanceWarning } from '../backend'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
+import { ErrorAlert } from '../../components/alerts'
 
 const isSearchResults = (val: any): val is GQL.ISearchResults => val && val.__typename === 'SearchResults'
 
@@ -336,10 +337,11 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                         </div>
                     ) : isErrorLike(this.props.resultsOrError) ? (
                         /* GraphQL, network, query syntax error */
-                        <div className="alert alert-warning m-2" data-testid="search-results-list-error">
-                            <AlertCircleIcon className="icon-inline" />
-                            {upperFirst(this.props.resultsOrError.message)}
-                        </div>
+                        <ErrorAlert
+                            className="m-2"
+                            data-testid="search-results-list-error"
+                            error={this.props.resultsOrError}
+                        />
                     ) : (
                         (() => {
                             const results = this.props.resultsOrError

--- a/web/src/settings/tokens/AccessTokenNode.tsx
+++ b/web/src/settings/tokens/AccessTokenNode.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
@@ -11,6 +10,7 @@ import { FilteredConnection } from '../../components/FilteredConnection'
 import { Timestamp } from '../../components/time/Timestamp'
 import { userURL } from '../../user'
 import { AccessTokenCreatedAlert } from './AccessTokenCreatedAlert'
+import { ErrorAlert } from '../../components/alerts'
 
 export const accessTokenFragment = gql`
     fragment AccessTokenFields on AccessToken {
@@ -156,9 +156,7 @@ export class AccessTokenNode extends React.PureComponent<AccessTokenNodeProps, A
                             Delete
                         </button>
                         {isErrorLike(this.state.deletionOrError) && (
-                            <div className="alert alert-danger mt-2">
-                                Error: {upperFirst(this.state.deletionOrError.message)}
-                            </div>
+                            <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
                         )}
                     </div>
                 </div>

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -17,6 +17,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { userURL } from '../user'
 import { setUserEmailVerified } from '../user/settings/backend'
 import { deleteUser, fetchAllUsers, randomizeUserPassword, setUserIsSiteAdmin } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface UserNodeProps {
     /**
@@ -164,9 +165,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         )}
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <div className="alert alert-danger mt-2">{this.state.errorDescription}</div>
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
                 {this.state.resetPasswordURL && (
                     <div className="alert alert-success mt-2">
                         <p>

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -12,6 +12,7 @@ import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchSite, reloadSite, updateSiteConfiguration } from './backend'
 import { SiteAdminManagementConsolePassword } from './SiteAdminManagementConsolePassword'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props extends RouteComponentProps<any> {
     isLightTheme: boolean
@@ -128,9 +129,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         const alerts: JSX.Element[] = []
         if (this.state.error) {
             alerts.push(
-                <div key="error" className="alert alert-danger site-admin-configuration-page__alert">
-                    <p>Error: {this.state.error.message}</p>
-                </div>
+                <ErrorAlert key="error" className="site-admin-configuration-page__alert" error={this.state.error} />
             )
         }
         if (this.state.reloadStartedAt) {

--- a/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -10,6 +10,7 @@ import { Form } from '../components/Form'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { createUser } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props extends RouteComponentProps<any> {}
 
@@ -151,7 +152,7 @@ export class SiteAdminCreateUserPage extends React.Component<Props, State> {
                             </small>
                         </div>
                         {this.state.errorDescription && (
-                            <div className="alert alert-danger my-2">{this.state.errorDescription}</div>
+                            <ErrorAlert className="my-2" error={this.state.errorDescription} />
                         )}
                         <button className="btn btn-primary" disabled={this.state.loading} type="submit">
                             {window.context.resetPasswordEnabled

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -1,13 +1,12 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 import * as React from 'react'
-import { Markdown } from '../../../shared/src/components/Markdown'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { ErrorLike } from '../../../shared/src/util/errors'
-import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { Form } from '../components/Form'
 import { DynamicallyImportedMonacoSettingsEditor } from '../settings/DynamicallyImportedMonacoSettingsEditor'
 import { ExternalServiceKindMetadata } from './externalServices'
+import { ErrorAlert, ErrorMessage } from '../components/alerts'
 
 interface Props extends Pick<ExternalServiceKindMetadata, 'jsonSchema' | 'editorActions'> {
     history: H.History
@@ -28,16 +27,11 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
     public render(): JSX.Element | null {
         return (
             <Form className="external-service-form" onSubmit={this.props.onSubmit}>
-                {this.props.error && (
-                    <div className="alert alert-danger">
-                        <p>Error saving configuration:</p>
-                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.error.message.replace(/\t/g, ''))} />
-                    </div>
-                )}
+                {this.props.error && <ErrorAlert error={this.props.error} />}
                 {this.props.warning && (
                     <div className="alert alert-warning">
                         <h4>Warning</h4>
-                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.warning.replace(/\t/g, ''))} />
+                        <ErrorMessage error={this.props.warning} />
                     </div>
                 )}
                 <div className="form-group">

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { concat, Observable, of, Subject, Subscription } from 'rxjs'
@@ -13,6 +12,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { ExternalServiceCard } from '../components/ExternalServiceCard'
 import { getExternalService } from './externalServices'
 import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props extends RouteComponentProps<{ id: GQL.ID }> {
     isLightTheme: boolean
@@ -121,7 +121,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 <h2>Update external service</h2>
                 {this.state.externalServiceOrError === LOADING && <LoadingSpinner className="icon-inline" />}
                 {isErrorLike(this.state.externalServiceOrError) && (
-                    <p className="alert alert-danger">{upperFirst(this.state.externalServiceOrError.message)}</p>
+                    <ErrorAlert className="mb-3" error={this.state.externalServiceOrError} />
                 )}
                 {externalService && (
                     <div className="mb-3">

--- a/web/src/site-admin/SiteAdminExternalServicesPage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicesPage.tsx
@@ -15,6 +15,7 @@ import { FilteredConnection, FilteredConnectionQueryArgs } from '../components/F
 import { PageTitle } from '../components/PageTitle'
 import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
+import { ErrorAlert } from '../components/alerts'
 
 interface ExternalServiceNodeProps {
     node: GQL.IExternalService
@@ -58,9 +59,7 @@ class ExternalServiceNode extends React.PureComponent<ExternalServiceNodeProps, 
                         </button>
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <div className="alert alert-danger mt-2">{this.state.errorDescription}</div>
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
             </li>
         )
     }

--- a/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
+++ b/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
@@ -7,6 +7,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { CopyableText } from '../components/CopyableText'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props {}
 
@@ -60,11 +61,7 @@ export class SiteAdminManagementConsolePassword extends React.Component<Props, S
             return null // loading
         }
         if (isErrorLike(this.state.stateOrError)) {
-            return (
-                <div className="alert alert-danger">
-                    Error fetching management console state: {this.state.stateOrError.message}
-                </div>
-            )
+            return <ErrorAlert error={this.state.stateOrError} prefix="Error fetching management console state" />
         }
 
         const plaintextPassword = this.state.stateOrError.plaintextPassword

--- a/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -13,6 +13,7 @@ import { PageTitle } from '../components/PageTitle'
 import { orgURL } from '../org'
 import { eventLogger } from '../tracking/eventLogger'
 import { deleteOrganization, fetchAllOrganizations } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface OrgNodeProps {
     /**
@@ -79,9 +80,7 @@ class OrgNode extends React.PureComponent<OrgNodeProps, OrgNodeState> {
                         </button>
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <div className="alert alert-danger mt-2">{this.state.errorDescription}</div>
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
             </li>
         )
     }

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import H from 'history'
-import { upperFirst } from 'lodash'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
@@ -17,6 +16,7 @@ import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { SiteAdminManagementConsolePassword } from './SiteAdminManagementConsolePassword'
 import { UsageChart } from './SiteAdminUsageStatisticsPage'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props extends ActivationProps {
     history: H.History
@@ -181,9 +181,7 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                     className="list-group-item"
                                     titleClassName="h5 mb-0 font-weight-normal p-2"
                                 >
-                                    {this.state.error && (
-                                        <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>
-                                    )}
+                                    {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
                                     {this.state.stats && (
                                         <UsageChart
                                             {...this.props}

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -18,6 +18,7 @@ import { PageTitle } from '../components/PageTitle'
 import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchAllRepositoriesAndPollIfEmptyOrAnyCloning } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface RepositoryNodeProps extends ActivationProps {
     node: GQL.IRepository
@@ -72,9 +73,7 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
                         }{' '}
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <div className="alert alert-danger mt-2">{this.state.errorDescription}</div>
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
             </li>
         )
     }

--- a/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -13,6 +13,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchSite, fetchSiteUpdateCheck } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface Props extends RouteComponentProps<any> {}
 
@@ -87,9 +88,11 @@ export class SiteAdminUpdatesPage extends React.Component<Props, State> {
                                 </div>
                             ))}
                         {this.state.updateCheck.errorMessage && (
-                            <div className="site-admin-updates-page__alert alert alert-danger">
-                                Error checking for updates: {this.state.updateCheck.errorMessage}
-                            </div>
+                            <ErrorAlert
+                                className="site-admin-updates-page__alert"
+                                prefix="Error checking for updates"
+                                error={this.state.updateCheck.errorMessage}
+                            />
                         )}
                     </div>
                 )}

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -1,5 +1,4 @@
 import format from 'date-fns/format'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Subscription } from 'rxjs'
@@ -11,6 +10,7 @@ import { RadioButtons } from '../components/RadioButtons'
 import { Timestamp } from '../components/time/Timestamp'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchSiteUsageStatistics, fetchUserUsageStatistics } from './backend'
+import { ErrorAlert } from '../components/alerts'
 
 interface ChartData {
     label: string
@@ -237,7 +237,7 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
                 <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
                     <h2 className="mb-0">Usage statistics</h2>
                 </div>
-                {this.state.error && <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>}
+                {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
                 {this.state.stats && (
                     <>
                         <RadioButtons

--- a/web/src/tree/TreeLayer.tsx
+++ b/web/src/tree/TreeLayer.tsx
@@ -28,6 +28,7 @@ import {
     TreeEntryInfo,
     treePadding,
 } from './util'
+import { ErrorAlert } from '../components/alerts'
 
 export interface TreeLayerProps extends AbsoluteRepo {
     history: H.History
@@ -272,14 +273,14 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     <tr>
                                         <td className="tree__cell">
                                             {isErrorLike(treeOrError) ? (
-                                                <div
-                                                    className="tree__row-alert alert alert-danger"
+                                                <ErrorAlert
+                                                    className="tree__row-alert"
                                                     // needed because of dynamic styling
                                                     // eslint-disable-next-line react/forbid-dom-props
                                                     style={treePadding(this.props.depth, true)}
-                                                >
-                                                    Error loading file tree: {treeOrError.message}
-                                                </div>
+                                                    error={treeOrError}
+                                                    prefix="Error loading file tree"
+                                                />
                                             ) : (
                                                 treeOrError && (
                                                     <ChildTreeLayer

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -20,6 +20,7 @@ import { fetchTreeEntries } from '../repo/backend'
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeNode } from './Tree'
 import { hasSingleChild, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
+import { ErrorAlert } from '../components/alerts'
 
 const maxEntries = 2500
 
@@ -157,14 +158,14 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         return (
             <>
                 {isErrorLike(treeOrError) ? (
-                    <div
+                    <ErrorAlert
                         // needed because of dynamic styling
                         // eslint-disable-next-line react/forbid-dom-props
                         style={errorWidth(localStorage.getItem(this.props.sizeKey) ? this.props.sizeKey : undefined)}
-                        className="tree__row tree__row-alert alert alert-danger"
-                    >
-                        Error loading tree: {treeOrError.message}
-                    </div>
+                        className="tree__row tree__row-alert"
+                        prefix="Error loading tree"
+                        error={treeOrError}
+                    />
                 ) : (
                     <table className="tree-layer" tabIndex={0}>
                         <tbody>

--- a/web/src/usageStatistics/explore/SiteUsageExploreSection.tsx
+++ b/web/src/usageStatistics/explore/SiteUsageExploreSection.tsx
@@ -6,6 +6,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { BarChart } from '../../components/d3/BarChart'
 import { fetchSiteUsageStatistics } from '../../site-admin/backend'
+import { ErrorAlert } from '../../components/alerts'
 
 interface Props {
     isLightTheme: boolean
@@ -43,7 +44,7 @@ export class SiteUsageExploreSection extends React.PureComponent<Props, State> {
             <div className="site-usage-explore-section">
                 <h2>Site usage</h2>
                 {isErrorLike(this.state.siteUsageStatisticsOrError) ? (
-                    <div className="alert alert-danger">Error: {this.state.siteUsageStatisticsOrError.message}</div>
+                    <ErrorAlert error={this.state.siteUsageStatisticsOrError} />
                 ) : this.state.siteUsageStatisticsOrError === LOADING ? (
                     <p>Loading...</p>
                 ) : (

--- a/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -16,6 +15,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { SiteAdminAlert } from '../../../site-admin/SiteAdminAlert'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserAreaRouteContext } from '../../area/UserArea'
+import { ErrorAlert } from '../../../components/alerts'
 
 function createAccessToken(user: GQL.ID, scopes: string[], note: string): Observable<GQL.ICreateAccessTokenResult> {
     return mutateGraphQL(
@@ -196,9 +196,7 @@ export class UserSettingsCreateAccessTokenPage extends React.PureComponent<Props
                     </Link>
                 </Form>
                 {isErrorLike(this.state.creationOrError) && (
-                    <div className="invite-form__alert alert alert-danger">
-                        Error: {upperFirst(this.state.creationOrError.message)}
-                    </div>
+                    <ErrorAlert className="invite-form__alert" error={this.state.creationOrError} />
                 )}
             </div>
         )

--- a/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
@@ -11,6 +10,7 @@ import { Form } from '../../../components/Form'
 import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { updatePassword } from '../backend'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props extends RouteComponentProps<any> {
     user: GQL.IUser
@@ -97,10 +97,8 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                     </div>
                 ) : (
                     <>
-                        {this.state.error && (
-                            <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>
-                        )}
-                        {this.state.saved && <p className="alert alert-success">Password changed!</p>}
+                        {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
+                        {this.state.saved && <div className="alert alert-success mb-3">Password changed!</div>}
                         <Form onSubmit={this.handleSubmit}>
                             {/* Include a username field as a hint for password managers to update the saved password. */}
                             <input

--- a/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -1,4 +1,3 @@
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { merge, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, map, switchMap, tap } from 'rxjs/operators'
@@ -8,6 +7,7 @@ import { createAggregateError, ErrorLike } from '../../../../../shared/src/util/
 import { mutateGraphQL } from '../../../backend/graphql'
 import { Form } from '../../../components/Form'
 import { eventLogger } from '../../../tracking/eventLogger'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface Props {
     /** The GraphQL ID of the user with whom the new emails are associated. */
@@ -82,9 +82,7 @@ export class AddUserEmailForm extends React.PureComponent<Props, State> {
                         {loading ? 'Adding...' : 'Add'}
                     </button>
                 </Form>
-                {this.state.error && (
-                    <div className="alert alert-danger mt-2">{upperFirst(this.state.error.message)}</div>
-                )}
+                {this.state.error && <ErrorAlert className="mt-2" error={this.state.error} />}
             </div>
         )
     }

--- a/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -14,6 +14,7 @@ import { siteFlags } from '../../../site/backend'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { setUserEmailVerified } from '../backend'
 import { AddUserEmailForm } from './AddUserEmailForm'
+import { ErrorAlert } from '../../../components/alerts'
 
 interface UserEmailNodeProps {
     node: GQL.IUserEmail
@@ -71,9 +72,7 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
                         )}
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <div className="alert alert-danger mt-2">{this.state.errorDescription}</div>
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
             </li>
         )
     }

--- a/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { combineLatest, concat, Observable, Subject, Subscription } from 'rxjs'
@@ -19,6 +18,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { UserAreaRouteContext } from '../../area/UserArea'
 import { UserAvatar } from '../../UserAvatar'
 import { updateUser } from '../backend'
+import { ErrorAlert } from '../../../components/alerts'
 
 function queryUser(user: GQL.ID): Observable<GQL.IUser> {
     return queryGraphQL(
@@ -174,12 +174,8 @@ export class UserSettingsProfilePage extends React.Component<Props, State> {
                         </div>
                     )}
 
-                {isErrorLike(this.state.userOrError) && (
-                    <p className="alert alert-danger">Error: {upperFirst(this.state.userOrError.message)}</p>
-                )}
-                {this.state.error && (
-                    <p className="alert alert-danger">Error: {upperFirst(this.state.error.message)}</p>
-                )}
+                {isErrorLike(this.state.userOrError) && <ErrorAlert error={this.state.userOrError.message} />}
+                {this.state.error && <ErrorAlert error={this.state.error.message} />}
                 {this.state.userOrError && !isErrorLike(this.state.userOrError) && (
                     <Form className="user-settings-profile-page__form" onSubmit={this.handleSubmit}>
                         <div className="form-group">


### PR DESCRIPTION
Currently, every component has a different way to display error alerts. Some prefix with an icon, some with "Error:", many upper case the first letter of the error message, many don't, some render as (fixed) markdown, most don't.

This makes it consistent by using one shared `ErrorAlert` component that takes an error object or string. It makes use of the best-effort markdown rendering that works well for external services, so that `\n` newlines, links, bullet list (such as Go's `multierror`) and inline code are rendered correctly. First letter is uppercased because Go errors are usually not, but in the UI they should be.