### PR TITLE
WIP: Better Sourcegraph URL handling

### DIFF
--- a/browser/src/extension/scripts/background.tsx
+++ b/browser/src/extension/scripts/background.tsx
@@ -43,7 +43,7 @@ if (contentScripts) {
     }
 }
 
-const configureOmnibox = (serverUrl: string): void => {
+const configureOmnibox = (serverUrl: URL): void => {
     browser.omnibox.setDefaultSuggestion({
         description: `Search code on ${serverUrl}`,
     })
@@ -58,11 +58,11 @@ const requestGraphQL = <T extends GQL.IQuery | GQL.IMutation>({
 }): Observable<GraphQLResult<T>> =>
     observeSourcegraphURL(IS_EXTENSION).pipe(
         take(1),
-        switchMap(sourcegraphURL =>
+        switchMap(baseURL =>
             requestGraphQLCommon<T>({
                 request,
                 variables,
-                baseUrl: sourcegraphURL,
+                baseURL,
                 headers: getHeaders(),
                 credentials: 'include',
             })

--- a/browser/src/extension/scripts/options.tsx
+++ b/browser/src/extension/scripts/options.tsx
@@ -94,7 +94,7 @@ class Options extends React.Component<{}, State> {
 
         this.subscriptions.add(
             observeSourcegraphURL(IS_EXTENSION).subscribe(sourcegraphURL => {
-                this.setState({ sourcegraphURL })
+                this.setState({ sourcegraphURL: sourcegraphURL.href })
             })
         )
 

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -33,6 +33,7 @@ import {
     switchMap,
     withLatestFrom,
     tap,
+    first,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
 import { DecorationMapByLine } from '../../../../shared/src/api/client/services/decoration'
@@ -98,6 +99,7 @@ import { observeStorageKey } from '../../browser/storage'
 import { SourcegraphIntegrationURLs } from '../../platform/context'
 import { requestGraphQLHelper } from '../../shared/backend/requestGraphQL'
 import { checkUserLoggedInAndFetchSettings } from '../../platform/settings'
+import { observeSourcegraphURL } from '../../shared/util/context'
 
 registerHighlightContributions()
 
@@ -280,7 +282,12 @@ export interface FileInfoWithRepoNames extends FileInfo, RepoSpec {
 
 export interface CodeIntelligenceProps
     extends PlatformContextProps<
-            'forceUpdateTooltip' | 'urlToFile' | 'sideloadedExtensionURL' | 'requestGraphQL' | 'settings'
+            | 'forceUpdateTooltip'
+            | 'urlToFile'
+            | 'sideloadedExtensionURL'
+            | 'requestGraphQL'
+            | 'settings'
+            | 'sourcegraphURL'
         >,
         TelemetryProps {
     codeHost: CodeHost
@@ -443,13 +450,11 @@ export function handleCodeHost({
     extensionsController,
     platformContext,
     showGlobalDebug,
-    sourcegraphURL,
     telemetryService,
     render,
     minimalUI,
 }: CodeIntelligenceProps & {
     mutations: Observable<MutationRecordLike[]>
-    sourcegraphURL: string
     render: typeof reactDOMRender
     minimalUI?: boolean
 }): Subscription {
@@ -523,7 +528,7 @@ export function handleCodeHost({
     // so we don't need to subscribe to mutations.
     if (showGlobalDebug) {
         const mount = createGlobalDebugMount()
-        renderGlobalDebug({ extensionsController, platformContext, history, sourcegraphURL, render })(mount)
+        renderGlobalDebug({ extensionsController, platformContext, history, render })(mount)
     }
 
     // Render view on Sourcegraph button
@@ -537,7 +542,7 @@ export function handleCodeHost({
                 )
                 .subscribe(
                     renderViewContextOnSourcegraph({
-                        sourcegraphURL,
+                        sourcegraphURL: platformContext.sourcegraphURL,
                         getContext,
                         viewOnSourcegraphButtonClassProps,
                         ensureRepoExists,
@@ -809,7 +814,6 @@ export function handleCodeHost({
                     <CodeViewToolbar
                         {...fileInfo}
                         {...codeHost.codeViewToolbarClassProps}
-                        sourcegraphURL={sourcegraphURL}
                         telemetryService={telemetryService}
                         platformContext={platformContext}
                         extensionsController={extensionsController}
@@ -856,11 +860,14 @@ export const determineCodeHost = (): CodeHost | undefined => CODE_HOSTS.find(cod
 export async function injectCodeIntelligenceToCodeHost(
     mutations: Observable<MutationRecordLike[]>,
     codeHost: CodeHost,
-    { sourcegraphURL, assetsURL }: SourcegraphIntegrationURLs,
+    { assetsURL }: SourcegraphIntegrationURLs,
     isExtension: boolean,
     showGlobalDebug = SHOW_DEBUG()
 ): Promise<Subscription> {
     const subscriptions = new Subscription()
+    const sourcegraphURL = await observeSourcegraphURL(isExtension)
+        .pipe(first())
+        .toPromise()
     const initialSettingsResult = await checkUserLoggedInAndFetchSettings(
         requestGraphQLHelper(isExtension, sourcegraphURL)
     ).toPromise()
@@ -869,9 +876,9 @@ export async function injectCodeIntelligenceToCodeHost(
         console.warn(`Sourcegraph is disabled: you must be logged in to ${sourcegraphURL} to use Sourcegraph.`)
         return subscriptions
     }
-    const { platformContext, extensionsController } = initializeExtensions(
+    const { platformContext, extensionsController } = await initializeExtensions(
         codeHost,
-        { sourcegraphURL, assetsURL },
+        { sourcegraphURL: sourcegraphURL.href, assetsURL },
         initialSettingsResult.settings,
         isExtension
     )
@@ -903,7 +910,6 @@ export async function injectCodeIntelligenceToCodeHost(
                     extensionsController,
                     platformContext,
                     showGlobalDebug,
-                    sourcegraphURL,
                     telemetryService,
                     render: reactDOMRender,
                     minimalUI,

--- a/browser/src/libs/code_intelligence/extensions.tsx
+++ b/browser/src/libs/code_intelligence/extensions.tsx
@@ -34,19 +34,19 @@ import { ISettingsCascade } from '../../../../shared/src/graphql/schema'
  * Initializes extensions for a page. It creates the {@link PlatformContext} and extensions controller.
  *
  */
-export function initializeExtensions(
+export async function initializeExtensions(
     { urlToFile, getContext }: Pick<CodeHost, 'urlToFile' | 'getContext'>,
     urls: SourcegraphIntegrationURLs,
     initialSettings: Pick<ISettingsCascade, 'subjects' | 'final'>,
     isExtension: boolean
-): PlatformContextProps & ExtensionsControllerProps {
+): Promise<PlatformContextProps & ExtensionsControllerProps> {
     const platformContext = createPlatformContext({ urlToFile, getContext }, urls, initialSettings, isExtension)
-    const extensionsController = createExtensionsController(platformContext)
+    const extensionsController = await createExtensionsController(platformContext)
     return { platformContext, extensionsController }
 }
 
 interface InjectProps
-    extends PlatformContextProps<'forceUpdateTooltip' | 'sideloadedExtensionURL'>,
+    extends PlatformContextProps<'forceUpdateTooltip' | 'sideloadedExtensionURL' | 'sourcegraphURL'>,
         ExtensionsControllerProps {
     history: H.History
     render: typeof render
@@ -83,14 +83,12 @@ export const renderGlobalDebug = ({
     platformContext,
     history,
     render,
-    sourcegraphURL,
-}: InjectProps & { sourcegraphURL: string; showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
+}: InjectProps & { showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
     render(
         <GlobalDebug
             extensionsController={extensionsController}
             location={history.location}
             platformContext={platformContext}
-            sourcegraphURL={sourcegraphURL}
         />,
         mount
     )

--- a/browser/src/platform/context.ts
+++ b/browser/src/platform/context.ts
@@ -55,7 +55,7 @@ export function createPlatformContext(
         observeSourcegraphURL(isExtension).pipe(
             take(1),
             switchMap(sourcegraphURL => {
-                if (mightContainPrivateInfo && sourcegraphURL === DEFAULT_SOURCEGRAPH_URL) {
+                if (mightContainPrivateInfo && sourcegraphURL.href === DEFAULT_SOURCEGRAPH_URL.href) {
                     // If we can't determine the code host context, assume the current repository is private.
                     const privateRepository = getContext ? getContext().privateRepository : true
                     if (privateRepository) {
@@ -139,7 +139,7 @@ export function createPlatformContext(
             // Otherwise fall back to linking to Sourcegraph (with an absolute URL).
             return `${sourcegraphURL}${toPrettyBlobURL(location)}`
         },
-        sourcegraphURL,
+        sourcegraphURL: observeSourcegraphURL(isExtension),
         clientApplication: 'other',
         sideloadedExtensionURL: isInPage
             ? new LocalStorageSubject<string | null>('sideloadedExtensionURL', null)

--- a/browser/src/shared/backend/requestGraphQL.ts
+++ b/browser/src/shared/backend/requestGraphQL.ts
@@ -10,7 +10,7 @@ import { background } from '../../browser/runtime'
  *
  * In the native integration, the returned function will rely on the `requestGraphQL` implementation from `/shared`.
  */
-export const requestGraphQLHelper = (isExtension: boolean, baseUrl: string) => <T extends IQuery | IMutation>({
+export const requestGraphQLHelper = (isExtension: boolean, baseURL: URL) => <T extends IQuery | IMutation>({
     request,
     variables,
 }: {
@@ -22,6 +22,6 @@ export const requestGraphQLHelper = (isExtension: boolean, baseUrl: string) => <
         : requestGraphQL<T>({
               request,
               variables,
-              baseUrl,
+              baseURL,
               credentials: 'include',
           })

--- a/browser/src/shared/components/GlobalDebug.tsx
+++ b/browser/src/shared/components/GlobalDebug.tsx
@@ -3,35 +3,40 @@ import * as React from 'react'
 import { Controller as ClientController } from '../../../../shared/src/extensions/controller'
 import { ExtensionStatusPopover } from '../../../../shared/src/extensions/ExtensionStatus'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
+import { useObservable } from '../../../../shared/src/util/useObservable'
 import { ShortcutProvider } from './ShortcutProvider'
 
-interface Props extends PlatformContextProps<'sideloadedExtensionURL'> {
+interface Props extends PlatformContextProps<'sideloadedExtensionURL' | 'sourcegraphURL'> {
     location: H.Location
     extensionsController: ClientController
-    sourcegraphURL: string
 }
 
-const makeExtensionLink = (sourcegraphURL: string): React.FunctionComponent<{ id: string }> => props => {
-    const extensionURL = new URL(sourcegraphURL)
-    extensionURL.pathname = `extensions/${props.id}`
+const makeExtensionLink = (sourcegraphURL: URL): React.FunctionComponent<{ id: string }> => props => {
+    const extensionURL = new URL(`extensions/${props.id}`, sourcegraphURL)
     return <a href={extensionURL.href}>{props.id}</a>
 }
 
 /**
  * A global debug toolbar shown in the bottom right of the window.
  */
-export const GlobalDebug: React.FunctionComponent<Props> = props => (
-    <div className="global-debug navbar navbar-expand">
-        <div className="navbar-nav align-items-center">
-            <div className="nav-item">
-                <ShortcutProvider>
-                    <ExtensionStatusPopover
-                        extensionsController={props.extensionsController}
-                        link={makeExtensionLink(props.sourcegraphURL)}
-                        platformContext={props.platformContext}
-                    />
-                </ShortcutProvider>
+export const GlobalDebug: React.FunctionComponent<Props> = props => {
+    const sourcegraphURL = useObservable(props.platformContext.sourcegraphURL)
+    if (!sourcegraphURL) {
+        return null
+    }
+    return (
+        <div className="global-debug navbar navbar-expand">
+            <div className="navbar-nav align-items-center">
+                <div className="nav-item">
+                    <ShortcutProvider>
+                        <ExtensionStatusPopover
+                            extensionsController={props.extensionsController}
+                            link={makeExtensionLink(sourcegraphURL)}
+                            platformContext={props.platformContext}
+                        />
+                    </ShortcutProvider>
+                </div>
             </div>
         </div>
-    </div>
-)
+    )
+}

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -1,5 +1,5 @@
 import { from, Observable, Subject, Subscription, Unsubscribable } from 'rxjs'
-import { map, publishReplay, refCount } from 'rxjs/operators'
+import { map, publishReplay, refCount, take } from 'rxjs/operators'
 import { createExtensionHostClient } from '../api/client/client'
 import { Services } from '../api/client/services'
 import { ExecuteCommandParams } from '../api/client/services/command'
@@ -60,13 +60,14 @@ export interface ExtensionsControllerProps<K extends keyof Controller = keyof Co
  * There should only be a single controller for the entire client application. The controller's model represents
  * all of the client application state that the client needs to know.
  */
-export function createController(context: PlatformContext): Controller {
+export async function createController(context: PlatformContext): Promise<Controller> {
     const subscriptions = new Subscription()
 
     const services = new Services(context)
     const extensionHostEndpoint = context.createExtensionHost()
     const initData: InitData = {
-        sourcegraphURL: context.sourcegraphURL,
+        // TODO should observe sourcegraphURL in extensions as well
+        sourcegraphURL: (await context.sourcegraphURL.pipe(take(1)).toPromise()).href,
         clientApplication: context.clientApplication,
     }
     const client = createExtensionHostClient(services, extensionHostEndpoint, initData)

--- a/shared/src/graphql/graphql.ts
+++ b/shared/src/graphql/graphql.ts
@@ -51,21 +51,20 @@ export const createInvalidGraphQLMutationResponseError = (queryName: string): Gr
         queryName,
     })
 
-export interface GraphQLRequestOptions extends Omit<RequestInit, 'method' | 'body'> {
-    baseUrl?: string
-}
-
 export function requestGraphQL<T extends GQL.IQuery | GQL.IMutation>({
     request,
     variables = {},
-    baseUrl = '',
+    baseURL,
     ...options
-}: GraphQLRequestOptions & {
+}: Omit<RequestInit, 'method' | 'body'> & {
     request: string
     variables?: {}
+    baseURL?: URL
 }): Observable<GraphQLResult<T>> {
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
-    return fromFetch(`${baseUrl}/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`, {
+    const apiURL = `/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`
+    const fetchURL = baseURL ? new URL(apiURL, baseURL).href : apiURL
+    return fromFetch(fetchURL, {
         ...options,
         method: 'POST',
         body: JSON.stringify({ query: request, variables }),

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -123,7 +123,7 @@ export interface PlatformContext {
      *
      * @example `https://sourcegraph.com`
      */
-    sourcegraphURL: string
+    sourcegraphURL: Observable<URL>
 
     /**
      * The client application that is running this extension, either 'sourcegraph' for Sourcegraph

--- a/shared/src/util/useObservable.ts
+++ b/shared/src/util/useObservable.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Observable, Observer, Subject } from 'rxjs'
+
+/**
+ * Returns a function that will trigger an error on the next render,
+ * which can be caught by an ErrorBoundary higher up in the component tree.
+ */
+export function useError(): (error: any) => void {
+    const [error, setError] = useState<any>()
+    if (error) {
+        throw error
+    }
+    return setError
+}
+
+/**
+ * React hook to get the latest value of an Observable.
+ * Will return `undefined` if the Observable didn't emit yet.
+ * If the Observable errors, will throw an error that can be caught with `try`/`catch` or with a React error boundary.
+ * The Observable is subscribed on the first render and unsubscribed on unmount or whenever it changes (wrap it in `useMemo()` to prevent this).
+ *
+ * @param observable The Observable to subscribe to.
+ *                   If this is the return value of a function, you should use `useMemo()` to make sure it is not resubscribed on every render.
+ * @throws If the Observable pipeline errors.
+ */
+export function useObservable<T>(observable: Observable<T>): T | undefined {
+    const [error, setError] = useState<any>()
+    const [currentValue, setCurrentValue] = useState<T>()
+
+    useEffect(() => {
+        setCurrentValue(undefined)
+        const subscription = observable.subscribe({ next: setCurrentValue, error: setError })
+        return () => subscription.unsubscribe()
+    }, [observable])
+
+    if (error) {
+        throw error
+    }
+
+    return currentValue
+}
+
+/**
+ * A React hook to handle a React event with an RxJS pipeline.
+ *
+ * @param transform An RxJS operator pipeline that is passed an Observable of
+ * the events triggered on the next function and can transform it to values of
+ * which the latest one is returned. **You need to wrap this callback with `useCallback()`**.
+ * @returns A next function to be used in JSX as an event handler, and the latest result of the Observable pipeline.
+ * @throws If the Observable pipeline errors.
+ */
+export function useEventObservable<T, R>(
+    transform: (events: Observable<T>) => Observable<R>
+): [Observer<T>['next'], R | undefined] {
+    const events = useMemo(() => new Subject<T>(), [])
+    const observable = useMemo(() => events.pipe(transform), [events, transform])
+    const value = useObservable(observable)
+    return [events.next.bind(events), value]
+}

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -1,4 +1,4 @@
-import { concat, Observable, ReplaySubject } from 'rxjs'
+import { concat, Observable, ReplaySubject, of } from 'rxjs'
 import { map, publishReplay, refCount } from 'rxjs/operators'
 import { createExtensionHost } from '../../../shared/src/api/extension/worker'
 import { gql } from '../../../shared/src/graphql/graphql'
@@ -66,7 +66,7 @@ export function createPlatformContext(): PlatformContext {
         createExtensionHost: () => createExtensionHost({ wrapEndpoints: false }),
         urlToFile: toPrettyBlobURL,
         getScriptURLForExtension: bundleURL => bundleURL,
-        sourcegraphURL: window.context.externalURL,
+        sourcegraphURL: of(new URL(window.context.externalURL)),
         clientApplication: 'sourcegraph',
         sideloadedExtensionURL: new LocalStorageSubject<string | null>('sideloadedExtensionURL', null),
         telemetryService: eventLogger,


### PR DESCRIPTION
Fixes #6521, #3990

- Expose `sourcegraphURL` as `Observable<URL>`, not `string`.
- Build URLs for API requests, link hrefs, etc. using `new URL('/some/path', sourcegraphURL)` rather than string concatenation.
- Validate Sourcegraph URL in the options popup/page with `new URL()`, report to the user when the URL is invalid