### PR TITLE
update docsite template

### DIFF
--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -745,12 +745,6 @@ li.content-nav-no-hover:hover {
     padding-bottom: 2rem;
 }
 
-/* Because there is no breadcrumb trail */
-
-#home .page-nav {
-    top: 106px;
-}
-
 .page-nav-title {
     border-bottom: 1px solid #eaeaea;
 }

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -1,53 +1,12 @@
-{{define "root"}}
-<html>
+{{define "title"}}{{with .Content}}{{.Doc.Title}}{{else}}Error{{end}}{{end}}
 
-<head>
-    <title>{{with .Content}}{{.Doc.Title}}{{if gt (len .Breadcrumbs ) 0}} - Sourcegraph docs{{end}}{{else}}Error{{end}}</title>
-    <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
-    <link rel="stylesheet" href="{{asset "bootstrap.min.css"}}?4.3.1" />
-    <link rel="stylesheet" href="{{asset "layout.css"}}?12" />
-    <link rel="stylesheet" href="{{asset "content.css"}}?12" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" /> {{if (or (not .Content) .ContentVersion)}}
-    <meta name="robots" content="noindex">{{end}}
-</head>
-<body{{with .Content}}{{if eq (len .Breadcrumbs ) 0}} id="home" {{end}}{{if gt (len .Breadcrumbs ) 1}} data-path="{{.Path}}" {{end}}{{end}} class="theme theme-light">
-    <div class="global-navbar">
-        <input type="checkbox" id="nav-state" class="nav-state" />
-        <div class="nav-content">
-            <div class="nav-container flex-container">
-                <div class="nav-header">
-                    <a href="/" class="nav-logo">
-                        <img class="nav-logo-image small-hidden" src="/assets/sourcegraph-logo-docs.svg" alt="Sourcegraph Documentation">
-                        <img class="nav-logo-image-small large-hidden medium-hidden" src="/assets/sourcegraph-logo-docs-small.svg" alt="Sourcegraph Documentation">
-                    </a>
-                    <div id="version-selector" class="dropdown version-dropdown ml-2">
-                        <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                {{.ContentVersion}}{{/* If no version is specified we are on the master branch */}}{{if eq .ContentVersion ""}}master{{end}}
-                            </button>
-                        <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
+{{define "head"}}
+    {{if (or (not .Content) .ContentVersion)}}
+        <meta name="robots" content="noindex">
+    {{end}}
+{{end}}
 
-                            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.8.2"}} {{$previousReleaseVersion := "3.8"}} {{$currentReleaseRevspec := "v3.9.4"}} {{$currentReleaseVersion := "3.9"}} {{$nextReleaseVersion := "master"}}
-                            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">master</a>
-                            <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
-                            <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
-                        </details-menu>
-                    </div>
-                </div>
-                <span class="mobile-nav-button"></span>
-                <div class="nav-links">
-                    <ul class="nav-link-container">
-                        <li class="nav-link"><a href="https://about.sourcegraph.com">About</a></li>
-                        <li class="nav-link"><a href="https://github.com/sourcegraph/sourcegraph">Code</a></li>
-                        <li class="nav-link"><a href="https://sourcegraph.com">Sourcegraph.com</a></li>
-                    </ul>
-                    <form class="search-form form-inline small-hidden">
-                        <input name="search" class="nav-search form-control" type="search" id="search" placeholder="Search docs..." spellcheck="false">
-                        <button class="btn btn-primary nav-search-button ml-2" id="search-button" type="submit">Search</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
+{{define "content"}}
     <div class="docs-content">
         <div class="nav-sticky-wrapper content-nav-wrapper column large-2 medium-3 mobile-show">
             <nav id="breadcrumbs-mobile" class="breadcrumbs large-hidden medium-hidden">
@@ -373,93 +332,7 @@
             {{end}}
         </section>
     </div>
-    {{/* Keep up-to-date with Sourcegraph.com */}}
-    <div class="footer-container column large-12">
-        <div class="footer__block">
-            <footer class="footer pt-6 pb-2">
-                <div class="footer__container container">
-                    <div class="row footer__nav-sections">
-                        <div class="col-12 col-lg-3 mb-5">
-                            <a aria-current="page" class="" href="https://about.sourcegraph.com/"><img class="footer__logo" src="https://d33wubrfki0l68.cloudfront.net/3ec402edbb475d12a54b840445834e4943985e74/c29e2/sourcegraph/logo--light.svg"></a>
-                            <ul class="nav footer__social mt-1">
-                                <li class="nav-item"><a href="https://github.com/sourcegraph" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M12,2C6.48,2 2,6.48 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12C22,6.48 17.52,2 12,2Z"></path></svg></a></li>
-                                <li class="nav-item"><a href="https://twitter.com/srcgraph" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"></path></svg></a></li>
-                                <li class="nav-item"><a href="https://www.linkedin.com/company/4803356/" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M19,3C20.1,3 21,3.9 21,5V19C21,20.1 20.1,21 19,21H5C3.9,21 3,20.1 3,19V5C3,3.9 3.9,3 5,3H19M18.5,18.5V13.2C18.5,11.4 17.04,9.94 15.24,9.94C14.39,9.94 13.4,10.46 12.92,11.24V10.13H10.13V18.5H12.92V13.57C12.92,12.8 13.54,12.17 14.31,12.17C15.08,12.17 15.71,12.8 15.71,13.57V18.5H18.5M6.88,8.56C7.81,8.56 8.56,7.81 8.56,6.88C8.56,5.95 7.81,5.19 6.88,5.19C5.95,5.19 5.19,5.95 5.19,6.88C5.19,7.81 5.95,8.56 6.88,8.56M8.27,18.5V10.13H5.5V18.5H8.27Z"></path></svg></a></li>
-                            </ul>
-                        </div>
-                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
-                            <h3 class="footer__nav-header">Why Sourcegraph?</h3>
-                            <ul class="nav flex-column">
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product">Product</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product">What is a developer platform?</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/pricing">Pricing</a></li>
-                            </ul>
-                        </div>
-                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
-                            <h3 class="footer__nav-header">Features &amp; use cases</h3>
-                            <ul class="nav flex-column">
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-search-navigation">Code search</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-review">Code review</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-alerts-automation">Code alerts &amp; automation</a></li>
-                            </ul>
-                        </div>
-                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
-                            <h3 class="footer__nav-header">Resources</h3>
-                            <ul class="nav flex-column">
-                                <li class="nav-item"><a href="https://docs.sourcegraph.com">Documentation</a></li>
-                                <li class="nav-item"><a href="https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md">Changelog</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/blog">Blog</a></li>
-                            </ul>
-                        </div>
-                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
-                            <h3 class="footer__nav-header">Company</h3>
-                            <ul class="nav flex-column">
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/plan">Master plan</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/about">About</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/contact">Contact</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/jobs">Careers</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="footer__postscript d-flex justify-content-between pt-4 pb-2 small">
-                        <ul class="nav">
-                            <li class="nav-item text-muted mr-3">Copyright © 2019 Sourcegraph</li>
-                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/terms">Terms</a></li>
-                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/security">Security</a></li>
-                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/privacy">Privacy</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </footer>
-        </div>
-    </div>
-    <script src="{{asset "docs.js"}}?12"></script>
-    {{with .Content}}
-        <script>sgdocs.init(breadcrumbs = {{ .Breadcrumbs }});</script>
-    {{else}}
-        <script>
-            sgdocs.init(breadcrumbs = null);
-        </script>
-    {{ end }}
-
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-20"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
-        gtag('config', 'UA-40540747-20');
-    </script>
-    </body>
-</html>
 {{end}}
-
-{{/*
-	The index and doc_nav templates are copied to the https://github.com/sourcegraph/sourcegraph
-	repository's docsite package. They should be kept in sync.
-*/}}
 
 {{/* Define Page (Right Hand) Nav */}}
 {{define "index"}}

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -1,0 +1,132 @@
+{{define "root"}}
+<html>
+<head>
+    <title>{{block "title" .}}Home{{end}} - Sourcegraph docs</title>
+    <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
+    <link rel="stylesheet" href="{{asset "bootstrap.min.css"}}?4.3.1" />
+    <link rel="stylesheet" href="{{asset "layout.css"}}?13" />
+    <link rel="stylesheet" href="{{asset "content.css"}}?13" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />
+    {{block "head" .}}{{end}}
+</head>
+<body class="theme theme-light">
+    <div class="global-navbar">
+        <input type="checkbox" id="nav-state" class="nav-state" />
+        <div class="nav-content">
+            <div class="nav-container flex-container">
+                <div class="nav-header">
+                    <a href="/" class="nav-logo">
+                        <img class="nav-logo-image small-hidden" src="/assets/sourcegraph-logo-docs.svg" alt="Sourcegraph Documentation">
+                        <img class="nav-logo-image-small large-hidden medium-hidden" src="/assets/sourcegraph-logo-docs-small.svg" alt="Sourcegraph Documentation">
+                    </a>
+                    <div id="version-selector" class="dropdown version-dropdown ml-2">
+                        <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                {{.ContentVersion}}{{/* If no version is specified we are on the master branch */}}{{if eq .ContentVersion ""}}master{{end}}
+                            </button>
+                        <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
+
+                            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.8.2"}} {{$previousReleaseVersion := "3.8"}} {{$currentReleaseRevspec := "v3.9.4"}} {{$currentReleaseVersion := "3.9"}} {{$nextReleaseVersion := "master"}}
+                            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">master</a>
+                            <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
+                            <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
+                        </details-menu>
+                    </div>
+                </div>
+                <span class="mobile-nav-button"></span>
+                <div class="nav-links">
+                    <ul class="nav-link-container">
+                        <li class="nav-link"><a href="https://about.sourcegraph.com">About</a></li>
+                        <li class="nav-link"><a href="https://github.com/sourcegraph/sourcegraph">Code</a></li>
+                        <li class="nav-link"><a href="https://sourcegraph.com">Sourcegraph.com</a></li>
+                    </ul>
+                    <form class="search-form form-inline small-hidden">
+                        <input name="search" class="nav-search form-control" type="search" id="search" placeholder="Search docs..." spellcheck="false">
+                        <button class="btn btn-primary nav-search-button ml-2" id="search-button" type="submit">Search</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {{block "content" .}}{{end}}
+    {{/* Keep up-to-date with Sourcegraph.com */}}
+    <div class="footer-container column large-12">
+        <div class="footer__block">
+            <footer class="footer pt-6 pb-2">
+                <div class="footer__container container">
+                    <div class="row footer__nav-sections">
+                        <div class="col-12 col-lg-3 mb-5">
+                            <a aria-current="page" class="" href="https://about.sourcegraph.com/"><img class="footer__logo" src="https://d33wubrfki0l68.cloudfront.net/3ec402edbb475d12a54b840445834e4943985e74/c29e2/sourcegraph/logo--light.svg"></a>
+                            <ul class="nav footer__social mt-1">
+                                <li class="nav-item"><a href="https://github.com/sourcegraph" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M12,2C6.48,2 2,6.48 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12C22,6.48 17.52,2 12,2Z"></path></svg></a></li>
+                                <li class="nav-item"><a href="https://twitter.com/srcgraph" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"></path></svg></a></li>
+                                <li class="nav-item"><a href="https://www.linkedin.com/company/4803356/" target="_blank"><svg class="mdi-icon " width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M19,3C20.1,3 21,3.9 21,5V19C21,20.1 20.1,21 19,21H5C3.9,21 3,20.1 3,19V5C3,3.9 3.9,3 5,3H19M18.5,18.5V13.2C18.5,11.4 17.04,9.94 15.24,9.94C14.39,9.94 13.4,10.46 12.92,11.24V10.13H10.13V18.5H12.92V13.57C12.92,12.8 13.54,12.17 14.31,12.17C15.08,12.17 15.71,12.8 15.71,13.57V18.5H18.5M6.88,8.56C7.81,8.56 8.56,7.81 8.56,6.88C8.56,5.95 7.81,5.19 6.88,5.19C5.95,5.19 5.19,5.95 5.19,6.88C5.19,7.81 5.95,8.56 6.88,8.56M8.27,18.5V10.13H5.5V18.5H8.27Z"></path></svg></a></li>
+                            </ul>
+                        </div>
+                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
+                            <h3 class="footer__nav-header">Why Sourcegraph?</h3>
+                            <ul class="nav flex-column">
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product">Product</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product">What is a developer platform?</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/pricing">Pricing</a></li>
+                            </ul>
+                        </div>
+                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
+                            <h3 class="footer__nav-header">Features &amp; use cases</h3>
+                            <ul class="nav flex-column">
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-search-navigation">Code search</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-review">Code review</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-alerts-automation">Code alerts &amp; automation</a></li>
+                            </ul>
+                        </div>
+                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
+                            <h3 class="footer__nav-header">Resources</h3>
+                            <ul class="nav flex-column">
+                                <li class="nav-item"><a href="https://docs.sourcegraph.com">Documentation</a></li>
+                                <li class="nav-item"><a href="https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md">Changelog</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/blog">Blog</a></li>
+                            </ul>
+                        </div>
+                        <div class="col-sm-6 col-md-3 col-lg-2 mb-3">
+                            <h3 class="footer__nav-header">Company</h3>
+                            <ul class="nav flex-column">
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/plan">Master plan</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/about">About</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/contact">Contact</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/jobs">Careers</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="footer__postscript d-flex justify-content-between pt-4 pb-2 small">
+                        <ul class="nav">
+                            <li class="nav-item text-muted mr-3">Copyright © 2019 Sourcegraph</li>
+                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/terms">Terms</a></li>
+                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/security">Security</a></li>
+                            <li class="nav-item"><a class="nav-link" href="https://about.sourcegraph.com/privacy">Privacy</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </footer>
+        </div>
+    </div>
+    <script src="{{asset "docs.js"}}?12"></script>
+    {{with .Content}}
+        <script>sgdocs.init(breadcrumbs = {{ .Breadcrumbs }});</script>
+    {{else}}
+        <script>
+            sgdocs.init(breadcrumbs = null);
+        </script>
+    {{end}}
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-20"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag('js', new Date());
+        gtag('config', 'UA-40540747-20');
+    </script>
+    </body>
+</html>
+{{end}}

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/sloonz/go-qprintable v0.0.0-20160203160305-775b3a4592d5 // indirect
 	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
-	github.com/sourcegraph/docsite v0.0.0-20190808202107-429b97fc9faf
+	github.com/sourcegraph/docsite v1.1.0
 	github.com/sourcegraph/go-diff v0.5.1
 	github.com/sourcegraph/go-jsonschema v0.0.0-20191016093209-4dfde5805930
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible

--- a/go.sum
+++ b/go.sum
@@ -712,6 +712,8 @@ github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWif
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/docsite v0.0.0-20190808202107-429b97fc9faf h1:FyxKjkXE1GblbpF0Ugj9ZYEE4fI5Dxk+su81QgMjiFI=
 github.com/sourcegraph/docsite v0.0.0-20190808202107-429b97fc9faf/go.mod h1:ucjBn4OyVoeap7hT5bHGPKAwD0FVWnuu69idPvNIcwg=
+github.com/sourcegraph/docsite v1.1.0 h1:Ilg2iWBhGteavTfJBJMWty6gmsMHcaQpc7caJL2cedQ=
+github.com/sourcegraph/docsite v1.1.0/go.mod h1:XpXb/UTQM3Bf2ynTYtw18rJzQXFIC3WMv6VfCLr1ck0=
 github.com/sourcegraph/go-diff v0.5.1 h1:gO6i5zugwzo1RVTvgvfwCOSVegNuvnNi6bAD1QCmkHs=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-jsonschema v0.0.0-20190205151546-7939fa138765 h1:bFHV2WYU7J7MPdKTyaR6M7Ahhbn4cIdvbTRIRXprenM=


### PR DESCRIPTION
This separates the root and document templates for [docsite](https://github.com/sourcegraph/docsite), which will allow us to use docsite's built-in search (which will need a separate template to be added in the future).