### PR TITLE
use docsite built-in search

### DIFF
--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -1,6 +1,5 @@
 window.sgdocs = (() => {
   let VERSION_SELECT_BUTTON,
-    SEARCH_FORMS,
     CONTENT_NAV,
     BREADCRUMBS,
     BREADCRUMBS_DATA = [],
@@ -12,8 +11,6 @@ window.sgdocs = (() => {
       BREADCRUMBS = document.querySelector('#breadcrumbs')
       BREADCRUMBS_MOBILE = document.querySelector('#breadcrumbs-mobile')
 
-      SEARCH_FORMS = document.querySelectorAll('.search-form')
-
       VERSION_SELECTOR = document.querySelector('#version-selector')
       VERSION_SELECT_BUTTON = VERSION_SELECTOR.querySelector('#version-selector button')
       VERSION_OPTIONS = VERSION_SELECTOR.querySelector('#version-selector details-menu')
@@ -22,7 +19,6 @@ window.sgdocs = (() => {
 
       MOBILE_NAV_BUTTON = BREADCRUMBS_MOBILE.querySelector('input[type="button"]')
 
-      searchInit()
       versionSelectorInit()
       mobileNavInit()
       navInit()
@@ -46,17 +42,6 @@ window.sgdocs = (() => {
       top: element.offsetTop - elementOffsetTop,
       left: 0,
       behavior: 'smooth',
-    })
-  }
-
-  function searchInit() {
-    SEARCH_FORMS.forEach(form => {
-      form.addEventListener('submit', e => {
-        const search = e.srcElement.querySelector('input[name="search"]').value
-        e.preventDefault()
-        window.location.href =
-          'https://www.google.com/search?ie=UTF-8&q=site%3Adocs.sourcegraph.com+' + encodeURIComponent(search)
-      })
     })
   }
 

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -12,19 +12,14 @@
     --body-color: #2b3750;
     --body-bg: #fbfdff;
     --text-muted: #6d727c;
-    --link-color: #566e9f;
-    --link-hover-color: #1d2535 --body-color: #2b3750;
+    --link-color: #0055c5;
+	--link-hover-color: #1986ea;
     --body-bg: #fbfdff;
     --text-muted: #6d727c;
-    --link-color: #566e9f;
-    --link-hover-color: #1d2535 --loading-spinner-outer-color: rgba(43, 55, 80, 0.3);
-    --loading-spinner-inner-color: #2b3750;
     --secondary: #e1e6ef;
     --border-color: #cad2e2;
     --body-bg: #ffffff;
     --text-muted: #{$color-light-text-2};
-    --link-color: #566e9f;
-    --link-hover-color: #1d2535;
     --dropdown-bg: #{$color-light-bg-1};
     --dropdown-border-color: #{$color-light-border};
 }

--- a/doc/_resources/assets/search.css
+++ b/doc/_resources/assets/search.css
@@ -1,0 +1,44 @@
+/* SEARCH RESULT */
+.search-result {
+    padding: 80px 1rem 0;
+}
+.search-result h1 {
+    font-size: 1.5rem;
+    margin-bottom: 1.25rem;
+}
+.search-result h1, .search-result h2, .search-result h3 {
+	font-weight: normal;
+}
+.search-result .document-results, .search-result .section-results {
+	list-style-type: none;
+	padding-left: 0;
+}
+.search-result .document-result {
+	margin-bottom: 1.5rem;
+}
+.search-result .document-result-title {
+	font-size: 1.35rem;
+	margin-top: 0;
+	margin-bottom: 0.1rem;
+}
+.search-result .document-result-path {
+	color: green;
+	font-size: 0.8rem;
+}
+.search-result .section-results {
+}
+.search-result .section-result {
+	margin: 0.25rem 0;
+}
+.search-result .section-result-title {
+	white-space: nowrap;
+	font-size: unset;
+	margin: 0;
+}
+.search-result .section-result-title::after {
+	padding-right: 0.25rem;
+}
+.search-result .excerpt {
+	display: inline-block;
+	margin: 0;
+}

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -6,6 +6,21 @@
     {{end}}
 {{end}}
 
+{{define "versionSelector"}}
+    <div id="version-selector" class="dropdown version-dropdown ml-2">
+        <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            {{.ContentVersion}}{{/* If no version is specified we are on the master branch */}}{{if eq .ContentVersion ""}}master{{end}}
+        </button>
+        <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
+
+            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.8.2"}} {{$previousReleaseVersion := "3.8"}} {{$currentReleaseRevspec := "v3.9.4"}} {{$currentReleaseVersion := "3.9"}} {{$nextReleaseVersion := "master"}}
+            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">master</a>
+            <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
+            <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
+        </details-menu>
+    </div>
+{{end}}
+
 {{define "content"}}
     <div class="docs-content">
         <div class="nav-sticky-wrapper content-nav-wrapper column large-2 medium-3 mobile-show">
@@ -363,5 +378,16 @@
                 </ul>
             {{end}}
         </li>
+    {{end}}
+{{end}}
+
+{{define "afterBody"}}
+    <script src="{{asset "docs.js"}}?12"></script>
+    {{with .Content}}
+        <script>sgdocs.init(breadcrumbs = {{ .Breadcrumbs }});</script>
+    {{else}}
+        <script>
+            sgdocs.init(breadcrumbs = null);
+        </script>
     {{end}}
 {{end}}

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
     <link rel="stylesheet" href="{{asset "bootstrap.min.css"}}?4.3.1" />
     <link rel="stylesheet" href="{{asset "layout.css"}}?13" />
+    <link rel="stylesheet" href="{{asset "search.css"}}" />
     <link rel="stylesheet" href="{{asset "content.css"}}?13" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />
     {{block "head" .}}{{end}}
@@ -19,18 +20,7 @@
                         <img class="nav-logo-image small-hidden" src="/assets/sourcegraph-logo-docs.svg" alt="Sourcegraph Documentation">
                         <img class="nav-logo-image-small large-hidden medium-hidden" src="/assets/sourcegraph-logo-docs-small.svg" alt="Sourcegraph Documentation">
                     </a>
-                    <div id="version-selector" class="dropdown version-dropdown ml-2">
-                        <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                {{.ContentVersion}}{{/* If no version is specified we are on the master branch */}}{{if eq .ContentVersion ""}}master{{end}}
-                            </button>
-                        <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
-
-                            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.8.2"}} {{$previousReleaseVersion := "3.8"}} {{$currentReleaseRevspec := "v3.9.4"}} {{$currentReleaseVersion := "3.9"}} {{$nextReleaseVersion := "master"}}
-                            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">master</a>
-                            <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
-                            <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
-                        </details-menu>
-                    </div>
+                    {{block "versionSelector" .}}{{end}}
                 </div>
                 <span class="mobile-nav-button"></span>
                 <div class="nav-links">
@@ -39,8 +29,9 @@
                         <li class="nav-link"><a href="https://github.com/sourcegraph/sourcegraph">Code</a></li>
                         <li class="nav-link"><a href="https://sourcegraph.com">Sourcegraph.com</a></li>
                     </ul>
-                    <form class="search-form form-inline small-hidden">
-                        <input name="search" class="nav-search form-control" type="search" id="search" placeholder="Search docs..." spellcheck="false">
+                    <form class="search-form form-inline small-hidden" method="get" action="/search">
+                        <input type="text" name="q" class="nav-search form-control" id="search" value="{{block "query" .}}{{end}}" placeholder="Search docs..." spellcheck="false">
+                        <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
                         <button class="btn btn-primary nav-search-button ml-2" id="search-button" type="submit">Search</button>
                     </form>
                 </div>
@@ -108,14 +99,8 @@
             </footer>
         </div>
     </div>
-    <script src="{{asset "docs.js"}}?12"></script>
-    {{with .Content}}
-        <script>sgdocs.init(breadcrumbs = {{ .Breadcrumbs }});</script>
-    {{else}}
-        <script>
-            sgdocs.init(breadcrumbs = null);
-        </script>
-    {{end}}
+
+    {{block "afterBody" .}}{{end}}
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-20"></script>
     <script>

--- a/doc/_resources/templates/search.html
+++ b/doc/_resources/templates/search.html
@@ -1,0 +1,50 @@
+{{define "title"}}
+	{{.Query}} - Search
+{{end}}
+
+{{define "head"}}
+	<meta name="robots" content="noindex">
+{{end}}
+
+{{define "query"}}{{.Query}}{{end}}
+
+{{define "content"}}
+	<section id="content" class="search-result">
+		<h1>{{.Result.Total}} result{{if ne .Result.Total 1}}s{{end}} found for <strong>{{.Query}}</strong></h1>
+		{{if .Result.DocumentResults}}
+		<ol class="document-results">
+			{{range $dr := .Result.DocumentResults}}
+			<li class="document-result">
+				<h2 class="document-result-title"><a href="{{$dr.URL}}">{{with $dr.Title}}{{highlight .}}{{else}}Untitled{{end}}</a></h2>
+				<span class="document-result-path">{{highlight (replace (trimPrefix $dr.URL "/") "/" " › " -1)}}</span>
+				{{if $dr.SectionResults}}
+					<ol class="section-results">
+					{{range $sr := $dr.SectionResults}}
+						<li class="section-result">
+							{{if $sr.ID}}
+								<h3 class="section-result-title">
+									<a href="{{$dr.URL}}{{with $sr.ID}}#{{.}}{{end}}">
+										{{range $i, $titleEntry := $sr.TitleStack}}
+											{{if ge $i 2}}
+												{{highlight $titleEntry}}
+												{{if ne $i (subtract (len $sr.TitleStack) 1)}}›{{end}}
+											{{end}}
+										{{end}}
+									</a>
+								</h3>
+							{{end}}
+							{{if $sr.Excerpts}}
+								{{range (slice $sr.Excerpts 0 1)}}
+									<p class="excerpt">{{highlight .}}</p>
+								{{end}}
+							{{end}}
+						</li>
+					{{end}}
+					</ol>
+				{{end}}
+			</li>
+			{{end}}
+		</ol>
+		{{end}}
+	</section>
+{{end}}


### PR DESCRIPTION
This uses docsite built-in search instead of a Google search with `site:docs.sourcegraph.com`. The benefits of this are:

- new results are available immediately instead of waiting for Google to reindex
- search results show the matching sections *within* the document, not just the document title
- the search is built into the UI, so there is no context switching when searching
- search is more precise and doesn't filter out special characters or code (as Google sometimes does)
- (in the future) you will be able to search over any version, not just the default version

docsite already supports search, but this commit (1) adds a template and styles to display search results and (2) makes the root template's search form submit to the docsite search handler, not Google.