### PR TITLE
Implement urlToFile for Gitlab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "**/coverage": true,
     "/cmd/management-console/assets/": true,
     "**/__fixtures__/**": true,
+    "**/.cache": true,
   },
   "files.associations": {
     "**/dev/critical-config.json": "jsonc",

--- a/browser/src/libs/gitlab/code_intelligence.test.ts
+++ b/browser/src/libs/gitlab/code_intelligence.test.ts
@@ -11,4 +11,66 @@ describe('gitlab/code_intelligence', () => {
     describe('getToolbarMount()', () => {
         testToolbarMountGetter(`${__dirname}/__fixtures__/code-views/merge-request/unified.html`, getToolbarMount)
     })
+
+    describe('urlToFile()', () => {
+        const { urlToFile } = gitlabCodeHost
+        const sourcegraphURL = 'https://sourcegraph.my.org'
+
+        beforeAll(() => {
+            jsdom.reconfigure({
+                url:
+                    'https://gitlab.com/sourcegraph/sourcegraph/blob/master/browser/src/libs/code_intelligence/code_intelligence.tsx',
+            })
+        })
+        it('returns an URL to the Sourcegraph instance if the location has a viewState', () => {
+            expect(
+                urlToFile(sourcegraphURL, {
+                    repoName: 'sourcegraph/sourcegraph',
+                    rawRepoName: 'gitlab.com/sourcegraph/sourcegraph',
+                    rev: 'master',
+                    filePath: 'browser/src/libs/code_intelligence/code_intelligence.tsx',
+                    position: {
+                        line: 5,
+                        character: 12,
+                    },
+                    viewState: 'references',
+                })
+            ).toBe(
+                'https://sourcegraph.my.org/sourcegraph/sourcegraph@master/-/blob/browser/src/libs/code_intelligence/code_intelligence.tsx#L5:12&tab=references'
+            )
+        })
+
+        it('returns an absolute URL if the location is not on the same code host', () => {
+            expect(
+                urlToFile(sourcegraphURL, {
+                    repoName: 'sourcegraph/sourcegraph',
+                    rawRepoName: 'gitlab.sgdev.org/sourcegraph/sourcegraph',
+                    rev: 'master',
+                    filePath: 'browser/src/libs/code_intelligence/code_intelligence.tsx',
+                    position: {
+                        line: 5,
+                        character: 12,
+                    },
+                })
+            ).toBe(
+                'https://sourcegraph.my.org/sourcegraph/sourcegraph@master/-/blob/browser/src/libs/code_intelligence/code_intelligence.tsx#L5:12'
+            )
+        })
+        it('returns an URL to a blob on the same code host if possible', () => {
+            expect(
+                urlToFile(sourcegraphURL, {
+                    repoName: 'sourcegraph/sourcegraph',
+                    rawRepoName: 'gitlab.com/sourcegraph/sourcegraph',
+                    rev: 'master',
+                    filePath: 'browser/src/libs/code_intelligence/code_intelligence.tsx',
+                    position: {
+                        line: 5,
+                        character: 12,
+                    },
+                })
+            ).toBe(
+                'https://gitlab.com/sourcegraph/sourcegraph/blob/master/browser/src/libs/code_intelligence/code_intelligence.tsx#L5:12'
+            )
+        })
+    })
 })

--- a/shared/src/util/types.ts
+++ b/shared/src/util/types.ts
@@ -1,4 +1,12 @@
 /**
+ * Identity-function helper to ensure a value `T` is a subtype of `U`.
+ *
+ * @template U The type to check for (explicitely specify this)
+ * @template T The actual type (inferred, don't specify this)
+ */
+export const subTypeOf = <U>() => <T extends U>(value: T): T => value
+
+/**
  * Returns true if `val` is not `null` or `undefined`
  */
 export const isDefined = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null


### PR DESCRIPTION
This allows j2d on Gitlab to stay on the Gitlab instance. It does not yet implement staying on the _same MR_, which is broken even for GitHub and more complicated.