### PR TITLE
dev env: fix prometheus target discovery after config file change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,7 @@ libsqlite3-pcre.so
 # Direnv
 .envrc
 
+# Docker images
+docker-images/prometheus/config/prometheus_targets.yml
+
 comment.txt

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -7,9 +7,11 @@ set -euf -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+CONFIG_DIR="${DIR}/../docker-images/prometheus/config"
+
 PROMETHEUS_DISK="${HOME}/.sourcegraph-dev/data/prometheus"
 
-IMAGE=sourcegraph/prometheus:10.0.1
+IMAGE=sourcegraph/prometheus:10.0.4
 CONTAINER=prometheus
 
 CID_FILE="${PROMETHEUS_DISK}/prometheus.cid"
@@ -23,17 +25,20 @@ function finish {
       docker stop $(cat ${CID_FILE})
       rm -f  ${CID_FILE}
   fi
+  rm -f ${CONFIG_DIR}/prometheus_targets.yml
   docker rm -f $CONTAINER
 }
 trap finish EXIT
 
 NET_ARG=""
-CONFIG_SUB_DIR="all"
+PROM_TARGETS="${DIR}/prometheus/all/prometheus_targets.yml"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
    NET_ARG="--net=host"
-   CONFIG_SUB_DIR="linux"
+   PROM_TARGETS="${DIR}/prometheus/linux/prometheus_targets.yml"
 fi
+
+cp ${PROM_TARGETS} ${CONFIG_DIR}/prometheus_targets.yml
 
 docker inspect $CONTAINER > /dev/null 2>&1 && docker rm -f $CONTAINER
 docker run --rm ${NET_ARG} --cidfile ${CID_FILE} \
@@ -43,6 +48,6 @@ docker run --rm ${NET_ARG} --cidfile ${CID_FILE} \
     --user=$UID \
     -p 0.0.0.0:9090:9090 \
     -v ${PROMETHEUS_DISK}:/prometheus \
-    -v ${DIR}/prometheus/${CONFIG_SUB_DIR}:/sg_prometheus_add_ons \
+    -v ${CONFIG_DIR}:/sg_prometheus_add_ons \
     ${IMAGE} >> ${PROMETHEUS_DISK}/logs/prometheus.log 2>&1 &
 wait $!

--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -20,10 +20,9 @@ USER root
 RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/sourcegraph sourcegraph
 USER sourcegraph
 
-# hadolint ignore=DL3020
-ADD config /sg_config_prometheus
+COPY config/*_rules.yml /sg_config_prometheus/
+COPY config/prometheus.yml /sg_config_prometheus/
 
-# hadolint ignore=DL3020
-ADD entry.sh /
+COPY entry.sh /
 
 ENTRYPOINT ["/entry.sh"]


### PR DESCRIPTION
This PR lets you edit *_rules.yml files on the fly  (reloaded at runtime by sending SIGHUP to the Prometheus process).

This is a follow-up of https://github.com/sourcegraph/sourcegraph/pull/6275