### PR TITLE
Set HOSTNAME variable to (re)enable server docker image indexing

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -35,6 +35,7 @@ var defaultEnv = map[string]string{
 	"SRC_HTTPS_ADDR":        ":8443",
 	"SRC_FRONTEND_INTERNAL": FrontendInternalHost,
 	"GITHUB_BASE_URL":       "http://127.0.0.1:3180", // points to github-proxy
+	"HOSTNAME":              "http://127.0.0.1:3070",
 
 	"GRAFANA_SERVER_URL": "http://127.0.0.1:3370",
 


### PR DESCRIPTION
The server docker image won't return the [default hostname expected by Zoekt](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@91a0eed/-/blob/cmd/server/shared/zoekt.go#L18-19) (it is `127.0.0.1:3070`) and instead returns the container hash. This change sets the expected host name.

Test plan: 

I will build a server image from this patch and confirm indexing works. We should add a regression test.
