### PR TITLE
search: add structural to GQL search pattern type definition

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1294,6 +1294,7 @@ enum SearchVersion {
 enum SearchPatternType {
     literal
     regexp
+    structural
 }
 
 # Configuration details for the browser extension, editor extensions, etc.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1301,6 +1301,7 @@ enum SearchVersion {
 enum SearchPatternType {
     literal
     regexp
+    structural
 }
 
 # Configuration details for the browser extension, editor extensions, etc.

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -368,5 +368,13 @@ describe('Search regression test suite', () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search' + urlQuery)
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length === 0)
         })
+        test('Indexed-only structural search, one or more results', async () => {
+            const urlQuery = buildSearchURLQuery(
+                'repo:^github\\.com/facebook/react$ index:only patterntype:structural toHaveYielded(:[args])',
+                GQL.SearchPatternType.structural
+            )
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
+        })
     })
 })


### PR DESCRIPTION
- Adds `structural` to the GQL search pattern types. This is primarily needed for the backend GQL resolver at this point.

- Adds an integration test for end-to-end structural search code path.

Test plan: Ran the search integration tests with the new test against a server docker image (`yarn jest src/regression/search.test.ts`)