### PR TITLE
test: add missing '?' query delimiter

### DIFF
--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -365,7 +365,7 @@ describe('Search regression test suite', () => {
                 'repo:^github\\.com/facebook/react$ componentDidMount\\(\\) {\\n\\s*this\\.props\\.sourcegraph\\( index:no',
                 GQL.SearchPatternType.regexp
             )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search' + urlQuery)
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length === 0)
         })
     })


### PR DESCRIPTION
All the other test cases build the URL with `/search?` and this one is missing it. I copy-pasted this test case to make a new one and realized it was missing a `?`

Test plan: Tests pass.
