### PR TITLE
github: Add CreatePullRequest method to client

### DIFF
--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -425,3 +425,6 @@ func APIRoot(baseURL *url.URL) (apiURL *url.URL, githubDotCom bool) {
 
 // ErrIncompleteResults is returned when the GitHub Search API returns an `incomplete_results: true` field in their response
 var ErrIncompleteResults = errors.New("github repository search returned incomplete results. This is an ephemeral error from GitHub, so does not indicate a problem with your configuration. See https://developer.github.com/changes/2014-04-07-understanding-search-results-and-potential-timeouts/ for more information")
+
+// ErrPullRequestAlreadyExists is when the requested GitHub Pull Request already exists.
+var ErrPullRequestAlreadyExists = errors.New("GitHub pull request already exists")

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -167,7 +167,7 @@ func TestClient_CreatePullRequest(t *testing.T) {
 
 	// Repository used: sourcegraph/automation-testing
 	// The requests here cannot be easily rerun with `-update` since you can
-	// only open a pull request a single time.
+	// only open a pull request once.
 	// In order to update specific tests, comment out the other ones and then
 	// run with -update.
 	for i, tc := range []struct {

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -161,6 +161,81 @@ func TestClient_LoadPullRequests(t *testing.T) {
 	}
 }
 
+func TestClient_CreatePullRequest(t *testing.T) {
+	cli, save := newClient(t, "CreatePullRequest")
+	defer save()
+
+	// Repository used: sourcegraph/automation-testing
+	// The requests here cannot be easily rerun with `-update` since you can
+	// only open a pull request a single time.
+	// In order to update specific tests, comment out the other ones and then
+	// run with -update.
+	for i, tc := range []struct {
+		name  string
+		ctx   context.Context
+		input *CreatePullRequestInput
+		err   string
+	}{
+		{
+			name: "success",
+			input: &CreatePullRequestInput{
+				RepositoryID: "MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=",
+				BaseRefName:  "master",
+				HeadRefName:  "test-pr-2",
+				Title:        "This is a test PR, feel free to ignore",
+				Body:         "I'm opening this PR to test something. Please ignore.",
+			},
+		},
+		{
+			name: "already-existing-pr",
+			input: &CreatePullRequestInput{
+				RepositoryID: "MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=",
+				BaseRefName:  "master",
+				HeadRefName:  "always-open-pr",
+				Title:        "This is a test PR that is always open",
+				Body:         "Feel free to ignore this. This is a test PR that is always open.",
+			},
+			err: ErrPullRequestAlreadyExists.Error(),
+		},
+		{
+			name: "invalid-head-ref",
+			input: &CreatePullRequestInput{
+				RepositoryID: "MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=",
+				BaseRefName:  "master",
+				HeadRefName:  "this-head-ref-should-not-exist",
+				Title:        "Test",
+			},
+			err: "error in GraphQL response: Head sha can't be blank, Base sha can't be blank, No commits between master and this-head-ref-should-not-exist, Head ref must be a branch",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			pr, err := cli.CreatePullRequest(tc.ctx, tc.input)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			assertGolden(t,
+				"testdata/golden/CreatePullRequest-"+strconv.Itoa(i),
+				*update,
+				pr,
+			)
+		})
+	}
+}
+
 func assertGolden(t testing.TB, path string, update bool, want interface{}) {
 	t.Helper()
 

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -338,6 +338,60 @@ func (i *TimelineItem) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, i.Item)
 }
 
+type CreatePullRequestInput struct {
+	// The Node ID of the repository.
+	RepositoryID string `json:"repositoryId"`
+	// The name of the branch you want your changes pulled into. This should be
+	// an existing branch on the current repository.
+	BaseRefName string `json:"baseRefName"`
+	// The name of the branch where your changes are implemented.
+	HeadRefName string `json:"headRefName"`
+	// The title of the pull request.
+	Title string `json:"title"`
+	// The body of the pull request (optional).
+	Body string `json:"body"`
+}
+
+// CreatePullRequest creates a PullRequest on Github.
+func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error) {
+	var q strings.Builder
+	q.WriteString(pullRequestFragments)
+	q.WriteString(`mutation	CreatePullRequest($input:CreatePullRequestInput!) {
+  createPullRequest(input:$input) {
+    pullRequest {
+      ... pr
+    }
+  }
+}`)
+
+	var result struct {
+		CreatePullRequest struct {
+			PullRequest struct {
+				PullRequest
+				Participants  struct{ Nodes []Actor }
+				TimelineItems struct{ Nodes []TimelineItem }
+			} `json:"pullRequest"`
+		} `json:"createPullRequest"`
+	}
+
+	input := map[string]interface{}{"input": in}
+	err := c.requestGraphQL(ctx, "", q.String(), input, &result)
+	if err != nil {
+		if gqlErrs, ok := err.(graphqlErrors); ok && len(gqlErrs) == 1 {
+			e := gqlErrs[0]
+			if strings.Contains(e.Message, "A pull request already exists for") {
+				return nil, ErrPullRequestAlreadyExists
+			}
+		}
+		return nil, err
+	}
+
+	pr := &result.CreatePullRequest.PullRequest.PullRequest
+	pr.TimelineItems = result.CreatePullRequest.PullRequest.TimelineItems.Nodes
+	pr.Participants = result.CreatePullRequest.PullRequest.Participants.Nodes
+	return pr, nil
+}
+
 // LoadPullRequests loads a list of PullRequests from Github.
 func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
 	type repository struct {
@@ -369,136 +423,8 @@ func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) erro
 	}
 
 	var q strings.Builder
-	q.WriteString(`
-    fragment actor on Actor { avatarUrl, login, url }
-    fragment commit on Commit {
-      oid, message, messageHeadline, committedDate, pushedDate, url
-      committer {
-        avatarUrl, email, name
-        user { ...actor }
-      }
-    }
-    fragment review on PullRequestReview {
-      databaseId
-      author { ...actor }
-      authorAssociation
-      body
-      state
-      url
-      createdAt
-      updatedAt
-      commit { ...commit }
-      includesCreatedEdit
-    }
-    fragment pr on PullRequest {
-      id, title, body, state, url, number, createdAt, updatedAt
-	  headRefOid, baseRefOid
-      author { ...actor }
-      participants(first: 100) { nodes { ...actor } }
-      timelineItems(
-        first: 250
-        itemTypes: [
-          ASSIGNED_EVENT
-          CLOSED_EVENT
-          ISSUE_COMMENT
-          RENAMED_TITLE_EVENT
-          MERGED_EVENT
-          PULL_REQUEST_REVIEW
-          PULL_REQUEST_REVIEW_THREAD
-          REOPENED_EVENT
-          REVIEW_DISMISSED_EVENT
-          REVIEW_REQUEST_REMOVED_EVENT
-          REVIEW_REQUESTED_EVENT
-          UNASSIGNED_EVENT
-        ]
-      ) {
-        nodes {
-          __typename
-          ... on AssignedEvent {
-            actor { ...actor }
-            assignee { ...actor }
-            createdAt
-          }
-          ... on ClosedEvent {
-            actor { ...actor }
-            createdAt
-            url
-          }
-          ... on IssueComment {
-            databaseId
-            author { ...actor }
-            authorAssociation
-            body
-            createdAt
-            editor { ...actor }
-            url
-            updatedAt
-            includesCreatedEdit
-            publishedAt
-          }
-          ... on RenamedTitleEvent {
-            actor { ...actor }
-            previousTitle
-            currentTitle
-            createdAt
-          }
-          ... on MergedEvent {
-            actor { ...actor }
-            mergeRefName
-            url
-            commit { ...commit }
-            createdAt
-          }
-          ... on PullRequestReview {
-            ...review
-          }
-          ... on PullRequestReviewThread {
-            comments(last: 100) {
-              nodes {
-                databaseId
-                author { ...actor }
-                authorAssociation
-                editor { ...actor }
-                commit { ...commit }
-                body
-                state
-                url
-                createdAt
-                updatedAt
-                includesCreatedEdit
-              }
-            }
-          }
-          ... on ReopenedEvent {
-            actor { ...actor }
-            createdAt
-          }
-          ... on ReviewDismissedEvent {
-            actor { ...actor }
-            review { ...review }
-            dismissalMessage
-            createdAt
-          }
-          ... on ReviewRequestRemovedEvent {
-            actor { ...actor }
-            requestedReviewer { ...actor }
-            createdAt
-          }
-          ... on ReviewRequestedEvent {
-            actor { ...actor }
-            requestedReviewer { ...actor }
-            createdAt
-          }
-          ... on UnassignedEvent {
-            actor { ...actor }
-            assignee { ...actor }
-            createdAt
-          }
-        }
-      }
-    }
-    query {
-   `)
+	q.WriteString(pullRequestFragments)
+	q.WriteString("query {\n")
 
 	for repoLabel, r := range labeled {
 		q.WriteString(fmt.Sprintf("%s: repository(owner: %q, name: %q) {\n",
@@ -536,3 +462,133 @@ func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) erro
 
 	return nil
 }
+
+const pullRequestFragments = `
+fragment actor on Actor { avatarUrl, login, url }
+fragment commit on Commit {
+	oid, message, messageHeadline, committedDate, pushedDate, url
+	committer {
+	avatarUrl, email, name
+	user { ...actor }
+	}
+}
+fragment review on PullRequestReview {
+	databaseId
+	author { ...actor }
+	authorAssociation
+	body
+	state
+	url
+	createdAt
+	updatedAt
+	commit { ...commit }
+	includesCreatedEdit
+}
+fragment pr on PullRequest {
+	id, title, body, state, url, number, createdAt, updatedAt
+	headRefOid, baseRefOid
+	author { ...actor }
+	participants(first: 100) { nodes { ...actor } }
+	timelineItems(
+	first: 250
+	itemTypes: [
+		ASSIGNED_EVENT
+		CLOSED_EVENT
+		ISSUE_COMMENT
+		RENAMED_TITLE_EVENT
+		MERGED_EVENT
+		PULL_REQUEST_REVIEW
+		PULL_REQUEST_REVIEW_THREAD
+		REOPENED_EVENT
+		REVIEW_DISMISSED_EVENT
+		REVIEW_REQUEST_REMOVED_EVENT
+		REVIEW_REQUESTED_EVENT
+		UNASSIGNED_EVENT
+	]
+	) {
+	nodes {
+		__typename
+		... on AssignedEvent {
+		actor { ...actor }
+		assignee { ...actor }
+		createdAt
+		}
+		... on ClosedEvent {
+		actor { ...actor }
+		createdAt
+		url
+		}
+		... on IssueComment {
+		databaseId
+		author { ...actor }
+		authorAssociation
+		body
+		createdAt
+		editor { ...actor }
+		url
+		updatedAt
+		includesCreatedEdit
+		publishedAt
+		}
+		... on RenamedTitleEvent {
+		actor { ...actor }
+		previousTitle
+		currentTitle
+		createdAt
+		}
+		... on MergedEvent {
+		actor { ...actor }
+		mergeRefName
+		url
+		commit { ...commit }
+		createdAt
+		}
+		... on PullRequestReview {
+		...review
+		}
+		... on PullRequestReviewThread {
+		comments(last: 100) {
+			nodes {
+			databaseId
+			author { ...actor }
+			authorAssociation
+			editor { ...actor }
+			commit { ...commit }
+			body
+			state
+			url
+			createdAt
+			updatedAt
+			includesCreatedEdit
+			}
+		}
+		}
+		... on ReopenedEvent {
+		actor { ...actor }
+		createdAt
+		}
+		... on ReviewDismissedEvent {
+		actor { ...actor }
+		review { ...review }
+		dismissalMessage
+		createdAt
+		}
+		... on ReviewRequestRemovedEvent {
+		actor { ...actor }
+		requestedReviewer { ...actor }
+		createdAt
+		}
+		... on ReviewRequestedEvent {
+		actor { ...actor }
+		requestedReviewer { ...actor }
+		createdAt
+		}
+		... on UnassignedEvent {
+		actor { ...actor }
+		assignee { ...actor }
+		createdAt
+		}
+	}
+	}
+}
+`

--- a/internal/extsvc/github/testdata/golden/CreatePullRequest-0
+++ b/internal/extsvc/github/testdata/golden/CreatePullRequest-0
@@ -1,0 +1,25 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0MzM5NzUzMzQy",
+  "Title": "This is a test PR, feel free to ignore",
+  "Body": "I'm opening this PR to test something. Please ignore.",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/3",
+  "HeadRefOid": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
+  "BaseRefOid": "c75943274b322ffef2230df8f8049de84ddf12c1",
+  "Number": 3,
+  "Author": {
+   "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "TimelineItems": [],
+  "CreatedAt": "2019-11-12T06:43:39Z",
+  "UpdatedAt": "2019-11-12T06:43:39Z"
+ }

--- a/internal/extsvc/github/testdata/vcr/CreatePullRequest.yaml
+++ b/internal/extsvc/github/testdata/vcr/CreatePullRequest.yaml
@@ -1,0 +1,261 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid\n\tauthor
+      { ...actor }\n\tparticipants(first: 100) { nodes { ...actor } }\n\ttimelineItems(\n\tfirst:
+      250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tCreatePullRequest($input:CreatePullRequestInput!)
+      {\n  createPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"repositoryId":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","baseRefName":"master","headRefName":"test-pr-2","title":"This
+      is a test PR, feel free to ignore","body":"I''m opening this PR to test something.
+      Please ignore."}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"createPullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0MzM5NzUzMzQy","title":"This
+      is a test PR, feel free to ignore","body":"I''m opening this PR to test something.
+      Please ignore.","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/3","number":3,"createdAt":"2019-11-12T06:43:39Z","updatedAt":"2019-11-12T06:43:39Z","headRefOid":"9d04a0d8733dafbb5d75e594a9ec525c49dfc975","baseRefOid":"c75943274b322ffef2230df8f8049de84ddf12c1","author":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"timelineItems":{"nodes":[]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Nov 2019 06:43:40 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - D5FC:43EEE:15A9887:19D0E45:5DCA549A
+      X-Oauth-Scopes:
+      - public_repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4997"
+      X-Ratelimit-Reset:
+      - "1573544619"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid\n\tauthor
+      { ...actor }\n\tparticipants(first: 100) { nodes { ...actor } }\n\ttimelineItems(\n\tfirst:
+      250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tCreatePullRequest($input:CreatePullRequestInput!)
+      {\n  createPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"repositoryId":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","baseRefName":"master","headRefName":"always-open-pr","title":"This
+      is a test PR that is always open","body":"Feel free to ignore this. This is
+      a test PR that is always open."}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"createPullRequest":{"pullRequest":null}},"errors":[{"type":"UNPROCESSABLE","path":["createPullRequest"],"locations":[{"line":130,"column":3}],"message":"A
+      pull request already exists for sourcegraph:always-open-pr."}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Nov 2019 06:43:40 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - D5FC:43EEE:15A98C7:19D0E8A:5DCA549C
+      X-Oauth-Scopes:
+      - public_repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4994"
+      X-Ratelimit-Reset:
+      - "1573544619"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid\n\tauthor
+      { ...actor }\n\tparticipants(first: 100) { nodes { ...actor } }\n\ttimelineItems(\n\tfirst:
+      250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tCreatePullRequest($input:CreatePullRequestInput!)
+      {\n  createPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"repositoryId":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","baseRefName":"master","headRefName":"this-head-ref-should-not-exist","title":"Test","body":""}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"createPullRequest":{"pullRequest":null}},"errors":[{"type":"UNPROCESSABLE","path":["createPullRequest"],"locations":[{"line":130,"column":3}],"message":"Head
+      sha can''t be blank, Base sha can''t be blank, No commits between master and
+      this-head-ref-should-not-exist, Head ref must be a branch"}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Nov 2019 06:43:40 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - D5FC:43EEE:15A98E7:19D0EA8:5DCA549C
+      X-Oauth-Scopes:
+      - public_repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4991"
+      X-Ratelimit-Reset:
+      - "1573544619"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This is part of #6085.

The interface of this is a bit "low-level" since it requires the GraphQL
repository ID. But I wanted to keep it like this for now, instead of
adding a second call that fetches the repository ID.

