### PR TITLE
Configure Beyang as owner of dev/release deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "labels": ["bot", "npm", "nightly"]
     },
     {
-      "paths": ["dev/release/*"],
+      "packageNames": ["@octokit/rest", "@slack/web-api", "googleapis"],
       "reviewers": ["beyang"]
     },
     {


### PR DESCRIPTION
I had moved these to the top-level package.json so the Renovate config needs to be adapted