### PR TITLE
LSIF: Fix bad limit/offset query string parsing

### DIFF
--- a/lsif/src/server/middleware/validation.ts
+++ b/lsif/src/server/middleware/validation.ts
@@ -52,8 +52,6 @@ export const validateQuery = validateOptionalString('query')
 
 /**
  * Create a validator for an integer limit field.
- *
- * @param defaultValue The default value.
  */
 export const validateLimit = validateOptionalInt('limit')
 

--- a/lsif/src/server/middleware/validation.ts
+++ b/lsif/src/server/middleware/validation.ts
@@ -51,17 +51,16 @@ export const validateOptionalInt = (key: string): ValidationChain =>
 export const validateQuery = validateOptionalString('query')
 
 /**
- * Create a validator for an integer limit field. Defaults to the given limit if not supplied.
+ * Create a validator for an integer limit field.
  *
  * @param defaultValue The default value.
  */
-export const validateLimit = (defaultValue: number): ValidationChain =>
-    validateOptionalInt('limit').customSanitizer(value => value || defaultValue)
+export const validateLimit = validateOptionalInt('limit')
 
 /**
- * A validator used for an integer offset field. Defaults to zero if not supplied.
+ * A validator used for an integer offset field.
  */
-export const validateOffset = validateOptionalInt('offset').customSanitizer(value => value || 0)
+export const validateOffset = validateOptionalInt('offset')
 
 /**
  * Create a validator for a cursor that is serialized as the supplied generic type.

--- a/lsif/src/server/pagination/limit-offset.ts
+++ b/lsif/src/server/pagination/limit-offset.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize limit and offset values extracted from the query string.
+ *
+ * @param param0 Parameter bag.
+ * @param defaultLimit The limit to use if one is not supplied.
+ */
+export const extractLimitOffset = (
+    {
+        limit,
+        offset,
+    }: {
+        /** The limit value extracted from the query string. */
+        limit?: number
+        /** The offset value extracted from the query string. */
+        offset?: number
+    },
+    defaultLimit: number
+): { limit: number; offset: number } => ({ limit: limit || defaultLimit, offset: offset || 0 })

--- a/lsif/src/server/pagination/limit-offset.ts
+++ b/lsif/src/server/pagination/limit-offset.ts
@@ -1,7 +1,7 @@
 /**
  * Normalize limit and offset values extracted from the query string.
  *
- * @param param0 Parameter bag.
+ * @param query Parameter bag.
  * @param defaultLimit The limit to use if one is not supplied.
  */
 export const extractLimitOffset = (

--- a/lsif/src/server/routes/dumps.ts
+++ b/lsif/src/server/routes/dumps.ts
@@ -18,7 +18,7 @@ export function createDumpRouter(backend: Backend): express.Router {
         validation.validationMiddleware([
             validation.validateQuery,
             validation.validateOptionalBoolean('visibleAtTip'),
-            validation.validateLimit(settings.DEFAULT_DUMP_PAGE_SIZE),
+            validation.validateLimit,
             validation.validateOffset,
         ]),
         wrap(
@@ -27,9 +27,17 @@ export function createDumpRouter(backend: Backend): express.Router {
                 const {
                     query,
                     visibleAtTip,
-                    limit,
-                    offset,
-                }: { query: string; visibleAtTip: boolean; limit: number; offset: number } = req.query
+                    limit: limitRaw,
+                    offset: offsetRaw,
+                }: {
+                    query: string
+                    visibleAtTip: boolean
+                    limit: number | undefined
+                    offset: number | undefined
+                } = req.query
+
+                const limit = limitRaw || settings.DEFAULT_DUMP_PAGE_SIZE
+                const offset = offsetRaw || 0
 
                 const { dumps, totalCount } = await backend.dumps(
                     decodeURIComponent(repository),

--- a/lsif/src/server/routes/jobs.ts
+++ b/lsif/src/server/routes/jobs.ts
@@ -122,13 +122,20 @@ export function createJobRouter(queue: Queue, scriptedClient: ScriptedRedis): ex
         `/jobs/:state(${Array.from(queueTypes.keys()).join('|')})`,
         validation.validationMiddleware([
             validation.validateQuery,
-            validation.validateLimit(settings.DEFAULT_JOB_PAGE_SIZE),
+            validation.validateLimit,
             validation.validateOffset,
         ]),
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
                 const { state } = req.params as { state: ApiJobState }
-                const { query, limit, offset }: { query: string; limit: number; offset: number } = req.query
+                const {
+                    query,
+                    limit: limitRaw,
+                    offset: offsetRaw,
+                }: { query: string; limit: number | undefined; offset: number | undefined } = req.query
+
+                const limit = limitRaw || settings.DEFAULT_JOB_PAGE_SIZE
+                const offset = offsetRaw || 0
 
                 const queueName = queueTypes.get(state)
                 if (!queueName) {

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -165,7 +165,7 @@ export function createLsifRouter(
         validation.validationMiddleware([
             validation.validateNonEmptyString('repository'),
             validation.validateNonEmptyString('commit').matches(commitPattern),
-            validation.validateLimit(settings.DEFAULT_REFERENCES_NUM_REMOTE_DUMPS),
+            validation.validateLimit,
             validation.validateCursor<ReferencePaginationCursor>(),
             ...checkSchema(requestBodySchema, ['body']),
         ]),
@@ -174,12 +174,12 @@ export function createLsifRouter(
                 const {
                     repository,
                     commit,
-                    limit,
+                    limit: limitRaw,
                     cursor,
                 }: {
                     repository: string
                     commit: string
-                    limit: number
+                    limit: number | undefined
                     cursor: ReferencePaginationCursor | undefined
                 } = req.query
 
@@ -189,6 +189,7 @@ export function createLsifRouter(
                     method,
                 }: { path: string; position: lsp.Position; method: string } = req.body
 
+                const limit = limitRaw || settings.DEFAULT_REFERENCES_NUM_REMOTE_DUMPS
                 const ctx = createTracingContext(logger, req, { repository, commit })
 
                 switch (method) {

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -20,6 +20,7 @@ import { promisify } from 'util'
 import { Queue } from 'bull'
 import { Span, Tracer } from 'opentracing'
 import { wrap } from 'async-middleware'
+import { extractLimitOffset } from '../pagination/limit-offset'
 
 const pipeline = promisify(_pipeline)
 
@@ -69,6 +70,14 @@ export function createLsifRouter(
         return root.endsWith('/') ? root : root + '/'
     }
 
+    interface UploadQueryArgs {
+        repository: string
+        commit: string
+        root: string
+        blocking: boolean
+        maxWait: number
+    }
+
     router.post(
         '/upload',
         validation.validationMiddleware([
@@ -80,20 +89,7 @@ export function createLsifRouter(
         ]),
         wrap(
             async (req: express.Request & { span?: Span }, res: express.Response): Promise<void> => {
-                const {
-                    repository,
-                    commit,
-                    root,
-                    blocking,
-                    maxWait,
-                }: {
-                    repository: string
-                    commit: string
-                    root: string
-                    blocking: boolean
-                    maxWait: number
-                } = req.query
-
+                const { repository, commit, root, blocking, maxWait }: UploadQueryArgs = req.query
                 const ctx = createTracingContext(logger, req, { repository, commit, root })
                 const filename = path.join(settings.STORAGE_ROOT, constants.UPLOADS_DIR, uuid.v4())
                 const output = fs.createWriteStream(filename)
@@ -135,6 +131,12 @@ export function createLsifRouter(
         )
     )
 
+    interface ExistsQueryArgs {
+        repository: string
+        commit: string
+        file: string
+    }
+
     router.post(
         '/exists',
         bodyParser.json({ limit: '1mb' }),
@@ -145,7 +147,7 @@ export function createLsifRouter(
         ]),
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
-                const { repository, commit, file }: { repository: string; commit: string; file: string } = req.query
+                const { repository, commit, file }: ExistsQueryArgs = req.query
                 const ctx = createTracingContext(logger, req, { repository, commit })
                 res.json(await backend.exists(repository, commit, file, ctx))
             }
@@ -157,6 +159,18 @@ export function createLsifRouter(
         'position.line': { isInt: true },
         'position.character': { isInt: true },
         method: { isIn: { options: [['definitions', 'references', 'hover']] } },
+    }
+
+    interface RequestQueryArgs {
+        repository: string
+        commit: string
+        cursor: ReferencePaginationCursor | undefined
+    }
+
+    interface RequestBodyArgs {
+        path: string
+        position: lsp.Position
+        method: string
     }
 
     router.post(
@@ -171,25 +185,9 @@ export function createLsifRouter(
         ]),
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
-                const {
-                    repository,
-                    commit,
-                    limit: limitRaw,
-                    cursor,
-                }: {
-                    repository: string
-                    commit: string
-                    limit: number | undefined
-                    cursor: ReferencePaginationCursor | undefined
-                } = req.query
-
-                const {
-                    path: filePath,
-                    position,
-                    method,
-                }: { path: string; position: lsp.Position; method: string } = req.body
-
-                const limit = limitRaw || settings.DEFAULT_REFERENCES_NUM_REMOTE_DUMPS
+                const { repository, commit, cursor }: RequestQueryArgs = req.query
+                const { path: filePath, position, method }: RequestBodyArgs = req.body
+                const { limit } = extractLimitOffset(req.query, settings.DEFAULT_REFERENCES_NUM_REMOTE_DUMPS)
                 const ctx = createTracingContext(logger, req, { repository, commit })
 
                 switch (method) {


### PR DESCRIPTION
Custom sanitizers are not run when an optional value is not supplied.