### PR TITLE
LSIF: Ensure url only controls historic uploads.

### DIFF
--- a/web/src/repo/settings/RepoSettingsCodeIntelligencePage.tsx
+++ b/web/src/repo/settings/RepoSettingsCodeIntelligencePage.tsx
@@ -118,6 +118,7 @@ export const RepoSettingsCodeIntelligencePage: FunctionComponent<Props> = ({ rep
                     noun="upload"
                     pluralNoun="uploads"
                     hideSearch={true}
+                    useURLQuery={false}
                     noSummaryIfAllNodesVisible={true}
                     queryConnection={queryLatestDumps}
                     nodeComponent={LsifDumpNode}


### PR DESCRIPTION
The top filter component shouldn't use or update state from the URL.