### PR TITLE
monitoring: high level gitserver metrics part 2

### DIFF
--- a/docker-images/prometheus/config/gitserver_rules.yml
+++ b/docker-images/prometheus/config/gitserver_rules.yml
@@ -5,5 +5,7 @@ groups:
         expr: sum(src_gitserver_disk_space_available) / sum(src_gitserver_disk_space_total)
       - record: gitserver_error_rate10m_percent
         expr: sum(rate(src_gitserver_request_duration_seconds_count{code=~"5.."}[10m])) / sum(rate(src_gitserver_request_duration_seconds_count[10m]))
+      - record: gitserver_deadline_exceeded_rate10m_percent
+        expr: sum(rate(src_gitserver_client_deadline_exceeded[10m]))/ sum(rate(src_gitserver_request_duration_seconds_count[10m]))
       - record: gitserver_health_warning
-        expr: clamp_max(clamp_min((gitserver_error_rate10m_percent or vector(0)) - 0.2, 0) / 0.8 + clamp_min(0.3 - gitserver_disk_free_percent, 0) / 0.3 + clamp_min(avg(go_memstats_gc_cpu_fraction{job="gitserver"}) - 0.01, 0) / 0.99, 1)
+        expr: clamp_max(clamp_min((gitserver_error_rate10m_percent or vector(0)) - 0.2, 0) / 0.8 + clamp_min((gitserver_deadline_exceeded_rate10m_percent or vector(0)) - 0.2, 0) / 0.8 + clamp_min(0.3 - gitserver_disk_free_percent, 0) / 0.3 + clamp_min(avg(go_memstats_gc_cpu_fraction{job="gitserver"}) - 0.01, 0) / 0.99, 1)


### PR DESCRIPTION
Adds deadline exceeded to the mix of high level gitserver health metric