### PR TITLE
a8n: Support BitbucketServer when creating campaigns from campaign plans

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -103,6 +103,32 @@ func (s BitbucketServerSource) ListRepos(ctx context.Context, results chan Sourc
 	s.listAllRepos(ctx, results)
 }
 
+// CreateChangeset creates the given *Changeset in the code host.
+func (s BitbucketServerSource) CreateChangeset(ctx context.Context, c *Changeset) error {
+	repo := c.Repo.Metadata.(*bitbucketserver.Repo)
+
+	pr := &bitbucketserver.PullRequest{Title: c.Title, Description: c.Body}
+
+	pr.ToRef.Repository.Slug = repo.Slug
+	pr.ToRef.Repository.Project.Key = repo.Project.Key
+	pr.ToRef.ID = fmt.Sprintf("refs/heads/%s", c.BaseRefName)
+
+	pr.FromRef.Repository.Slug = repo.Slug
+	pr.FromRef.Repository.Project.Key = repo.Project.Key
+	pr.FromRef.ID = fmt.Sprintf("refs/heads/%s", c.HeadRefName)
+
+	err := s.client.CreatePullRequest(ctx, pr)
+	if err != nil {
+		return err
+	}
+
+	c.Changeset.Metadata = pr
+	c.Changeset.ExternalID = strconv.FormatInt(int64(pr.ID), 10)
+	c.Changeset.ExternalServiceType = bitbucketserver.ServiceType
+
+	return nil
+}
+
 // LoadChangesets loads the latest state of the given Changesets from the codehost.
 func (s BitbucketServerSource) LoadChangesets(ctx context.Context, cs ...*Changeset) error {
 	for i := range cs {

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -90,6 +90,7 @@ type Source interface {
 // A ChangesetSource can load the latest state of a list of Changesets.
 type ChangesetSource interface {
 	LoadChangesets(context.Context, ...*Changeset) error
+	CreateChangeset(context.Context, *Changeset) error
 }
 
 // A SourceResult is sent by a Source over a channel for each repository it

--- a/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_CreateChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_CreateChangeset_success
@@ -1,0 +1,53 @@
+{
+  "id": 6,
+  "version": 0,
+  "title": "This is a test PR",
+  "description": "This is the body of a test PR",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1573651655982,
+  "updatedDate": 1573651655982,
+  "fromRef": {
+   "id": "refs/heads/test-pr-bbs-6",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "milton",
+    "emailAddress": "dev@sourcegraph.com",
+    "id": 1,
+    "displayName": "milton woof",
+    "active": true,
+    "slug": "milton",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/6"
+    }
+   ]
+  }
+ }

--- a/cmd/repo-updater/repos/testdata/golden/GithubSource_CreateChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/GithubSource_CreateChangeset_success
@@ -1,0 +1,27 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0MzQwNDY3NDcx",
+  "Title": "This is a test PR",
+  "Body": "This is the description of the test PR",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/14",
+  "HeadRefOid": "05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80",
+  "BaseRefOid": "c75943274b322ffef2230df8f8049de84ddf12c1",
+  "HeadRefName": "test-pr-6",
+  "BaseRefName": "master",
+  "Number": 14,
+  "Author": {
+   "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "TimelineItems": [],
+  "CreatedAt": "2019-11-13T13:38:11Z",
+  "UpdatedAt": "2019-11-13T13:38:11Z"
+ }

--- a/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_CreateChangeset_already-exists.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_CreateChangeset_already-exists.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/always-open-pr-bbs","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"Only one pull request may be open
+      for a given source and target branch","exceptionName":"com.atlassian.bitbucket.pull.DuplicatePullRequestException","existingPullRequest":{"id":3,"version":0,"title":"This
+      testing PR is always open","description":"Ignore this. This is a testing PR
+      that is always open.","state":"OPEN","open":true,"closed":false,"createdDate":1573644199945,"updatedDate":1573644199945,"fromRef":{"id":"refs/heads/always-open-pr-bbs","displayId":"always-open-pr-bbs","latestCommit":"b939ea0debe88e145c5409230b29e7dbbedcb9da","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"c75943274b322ffef2230df8f8049de84ddf12c1","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/3"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 13 Nov 2019 13:27:35 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@1IK17DGx807x2509173x0'
+      X-Asen:
+      - SEN-L13789548
+      X-Asessionid:
+      - zsuwcj
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_CreateChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_CreateChangeset_success.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-6","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
+    method: POST
+  response:
+    body: '{"id":6,"version":0,"title":"This is a test PR","description":"This is
+      the body of a test PR","state":"OPEN","open":true,"closed":false,"createdDate":1573651655982,"updatedDate":1573651655982,"fromRef":{"id":"refs/heads/test-pr-bbs-6","displayId":"test-pr-bbs-6","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"c75943274b322ffef2230df8f8049de84ddf12c1","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
+      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/6"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 13 Nov 2019 13:27:35 GMT
+      Location:
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/6
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@1IK17DGx807x2509172x0'
+      X-Asen:
+      - SEN-L13789548
+      X-Asessionid:
+      - 1i7rs6s
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/GithubSource_CreateChangeset_already-exists.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GithubSource_CreateChangeset_already-exists.yaml
@@ -1,0 +1,82 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid,
+      headRefName, baseRefName\n\tauthor { ...actor }\n\tparticipants(first: 100)
+      { nodes { ...actor } }\n\ttimelineItems(\n\tfirst: 250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tCreatePullRequest($input:CreatePullRequestInput!)
+      {\n  createPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"repositoryId":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","baseRefName":"master","headRefName":"always-open-pr","title":"This
+      is a test PR","body":"This is the description of the test PR"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"createPullRequest":{"pullRequest":null}},"errors":[{"type":"UNPROCESSABLE","path":["createPullRequest"],"locations":[{"line":130,"column":3}],"message":"A
+      pull request already exists for sourcegraph:always-open-pr."}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 13 Nov 2019 13:38:13 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - D0E6:43EF3:3E95FB7:4B0465B:5DCC0744
+      X-Oauth-Scopes:
+      - public_repo
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/GithubSource_CreateChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GithubSource_CreateChangeset_success.yaml
@@ -1,0 +1,82 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid,
+      headRefName, baseRefName\n\tauthor { ...actor }\n\tparticipants(first: 100)
+      { nodes { ...actor } }\n\ttimelineItems(\n\tfirst: 250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tCreatePullRequest($input:CreatePullRequestInput!)
+      {\n  createPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"repositoryId":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","baseRefName":"master","headRefName":"test-pr-6","title":"This
+      is a test PR","body":"This is the description of the test PR"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"createPullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0MzQwNDY3NDcx","title":"This
+      is a test PR","body":"This is the description of the test PR","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/14","number":14,"createdAt":"2019-11-13T13:38:11Z","updatedAt":"2019-11-13T13:38:11Z","headRefOid":"05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80","baseRefOid":"c75943274b322ffef2230df8f8049de84ddf12c1","headRefName":"test-pr-6","baseRefName":"master","author":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"timelineItems":{"nodes":[]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 13 Nov 2019 13:38:12 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - D0E4:43EF8:925B8B7:AE725D7:5DCC0743
+      X-Oauth-Scopes:
+      - public_repo
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/pkg/a8n/service.go
+++ b/enterprise/pkg/a8n/service.go
@@ -187,9 +187,17 @@ func (s *Service) runChangesetJob(
 				return err
 			}
 
-			c := cfg.(*schema.GitHubConnection)
-			if c.Token != "" {
-				externalService = e
+			switch cfg := cfg.(type) {
+			case *schema.GitHubConnection:
+				if cfg.Token != "" {
+					externalService = e
+				}
+			case *schema.BitbucketServerConnection:
+				if cfg.Token != "" {
+					externalService = e
+				}
+			}
+			if externalService != nil {
 				break
 			}
 		}

--- a/enterprise/pkg/a8n/service.go
+++ b/enterprise/pkg/a8n/service.go
@@ -216,15 +216,12 @@ func (s *Service) runChangesetJob(
 		},
 	}
 
-	cc, ok := src.(interface {
-		CreateChangeset(context.Context, *repos.Changeset) error
-	})
-
+	ccs, ok := src.(repos.ChangesetSource)
 	if !ok {
 		return errors.Errorf("creating changesets on code host of repo %q is not implemented", repo.Name)
 	}
 
-	if err = cc.CreateChangeset(ctx, &cs); err != nil {
+	if err = ccs.CreateChangeset(ctx, &cs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is part of #6085 and does the following:

* Add `CreateChangeset` to `BitbucketServerSource` (including tests)
* Add tests for the `GithubSource` `CreateChangeset` method
* Change the existing `ChangesetSource` interface to include `CreateChangeset`