### PR TITLE
a8n: Filter out repositories of unsupported external services

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -74,6 +74,10 @@ func (r *RepositoryResolver) Name() string {
 	return string(r.repo.Name)
 }
 
+func (r *RepositoryResolver) ExternalRepo() *api.ExternalRepoSpec {
+	return &r.repo.ExternalRepo
+}
+
 func (r *RepositoryResolver) URI(ctx context.Context) (string, error) {
 	err := r.hydrate(ctx)
 	if err != nil {

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -346,6 +346,15 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	}
 
 	for _, r := range rs {
+		if !a8n.IsRepoSupported(&r.ExternalRepo) {
+			err = errors.Errorf(
+				"External service type %s of repository %q is currently not supported in Automation features",
+				r.ExternalRepo.ServiceType,
+				r.Name,
+			)
+			return nil, err
+		}
+
 		repoSet[r.ID] = r
 	}
 

--- a/enterprise/pkg/a8n/run/runner.go
+++ b/enterprise/pkg/a8n/run/runner.go
@@ -198,6 +198,10 @@ func (r *Runner) createPlanAndJobs(
 
 	jobs := make([]*a8n.CampaignJob, 0, len(rs))
 	for _, repo := range rs {
+		if !a8n.IsRepoSupported(repo.ExternalRepo()) {
+			continue
+		}
+
 		var repoID int32
 		if err = relay.UnmarshalSpec(repo.ID(), &repoID); err != nil {
 			return jobs, err

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -10,6 +10,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
 
+// SupportedExternalServices are the external service types currently supported
+// by Automation features. Repos that are associated with external services
+// whose type is not in this list will simply be filtered out from the search
+// results.
+var SupportedExternalServices = map[string]struct{}{
+	github.ServiceType:          {},
+	bitbucketserver.ServiceType: {},
+}
+
+// IsRepoSupported returns whether the given ExternalRepoSpec is supported by
+// Automation features, based on the external service type.
+func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
+	_, ok := SupportedExternalServices[spec.ServiceType]
+	return ok
+}
+
 // A CampaignPlan represents the application of a CampaignType to the Arguments
 // over multiple repositories.
 type CampaignPlan struct {


### PR DESCRIPTION
We currently only support GitHub and Bitbucket Server.

It doesn't make sense and only leads to bugs if we try to run CampaignJobs over repositories whose external service we don't support, because we later can't turn those CampaignJobs into Changesets on the codehost.

And before manually creating a changeset we check that all repositories are supported.