### PR TITLE
fix: set HOSTNAME variable to (re)enable server image indexing

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -35,7 +35,6 @@ var defaultEnv = map[string]string{
 	"SRC_HTTPS_ADDR":        ":8443",
 	"SRC_FRONTEND_INTERNAL": FrontendInternalHost,
 	"GITHUB_BASE_URL":       "http://127.0.0.1:3180", // points to github-proxy
-	"HOSTNAME":              "http://127.0.0.1:3070",
 
 	"GRAFANA_SERVER_URL": "http://127.0.0.1:3370",
 

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -27,7 +27,7 @@ func maybeZoektProcFile() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("zoekt-indexserver: env GOGC=50 zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", frontendInternalHost, indexDir, debugFlag),
+		fmt.Sprintf("zoekt-indexserver: env GOGC=50 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
 		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
 	}
 }


### PR DESCRIPTION
Updates the `HOSTNAME` fix in the right place for docker images. See #6550 for details.

Test plan: Tested against the built docker image: https://buildkite.com/sourcegraph/sourcegraph/builds/48500#9a43fd21-5021-4585-b1d7-3eac0299fdbf
