### PR TITLE
monitoring: instrument http clients

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -267,6 +267,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 	// TODO(RVT): Use a separate HTTP client here dedicated to codemod,
 	// not doing so means codemod and searcher share the same HTTP limits
 	// etc. which is fine for now but not if codemod goes in front of users.
+	// Once separated please fix cmd/frontend/graphqlbackend/textsearch:50
 	resp, err := ctxhttp.Do(ctx, searchHTTPClient, req)
 	if err != nil {
 		// If we failed due to cancellation or timeout (with no partial results in the response body), return just that.

--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -267,7 +267,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 	// TODO(RVT): Use a separate HTTP client here dedicated to codemod,
 	// not doing so means codemod and searcher share the same HTTP limits
 	// etc. which is fine for now but not if codemod goes in front of users.
-	// Once separated please fix cmd/frontend/graphqlbackend/textsearch:50 in #6586 
+	// Once separated please fix cmd/frontend/graphqlbackend/textsearch:50 in #6586
 	resp, err := ctxhttp.Do(ctx, searchHTTPClient, req)
 	if err != nil {
 		// If we failed due to cancellation or timeout (with no partial results in the response body), return just that.

--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -267,7 +267,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 	// TODO(RVT): Use a separate HTTP client here dedicated to codemod,
 	// not doing so means codemod and searcher share the same HTTP limits
 	// etc. which is fine for now but not if codemod goes in front of users.
-	// Once separated please fix cmd/frontend/graphqlbackend/textsearch:50
+	// Once separated please fix cmd/frontend/graphqlbackend/textsearch:50 in #6586 
 	resp, err := ctxhttp.Do(ctx, searchHTTPClient, req)
 	if err != nil {
 		// If we failed due to cancellation or timeout (with no partial results in the response body), return just that.

--- a/cmd/frontend/internal/pkg/search/env.go
+++ b/cmd/frontend/internal/pkg/search/env.go
@@ -44,12 +44,12 @@ func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
 		indexedSearch = &backend.Zoekt{}
 		if indexers := Indexers(); indexers.Enabled() {
-			indexedSearch.Client = &backend.HorizontalSearcher{
+			indexedSearch.Client = backend.NewMeteredSearcher(&backend.HorizontalSearcher{
 				Map:  indexers.Map,
 				Dial: rpc.Client,
-			}
+			})
 		} else if addr := zoektAddr(os.Environ()); addr != "" {
-			indexedSearch.Client = rpc.Client(addr)
+			indexedSearch.Client = backend.NewMeteredSearcher(rpc.Client(addr))
 		}
 		conf.Watch(func() {
 			indexedSearch.SetEnabled(conf.SearchIndexEnabled())

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -29,7 +29,7 @@ var InternalClient = &internalClient{URL: "http://" + frontendInternal}
 
 var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: "src",
-	Subsystem: "frontend-internal",
+	Subsystem: "frontend_internal",
 	Name:      "request_duration_seconds",
 	Help:      "Time (in seconds) spent on request.",
 	Buckets:   prometheus.DefBuckets,

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -331,7 +331,7 @@ func (c *internalClient) meteredPost(ctx context.Context, route string, reqBody,
 	err := c.post(ctx, route, reqBody, respBody)
 	d := time.Since(start)
 
-	// TODO(uwedeportivo): break it out more according to response code
+	// TODO(uwedeportivo): might be useful to use actual response status code value
 	code := "200"
 	if err != nil {
 		code = "error"

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -25,6 +26,18 @@ type internalClient struct {
 }
 
 var InternalClient = &internalClient{URL: "http://" + frontendInternal}
+
+var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "src",
+	Subsystem: "frontend-internal",
+	Name:      "request_duration_seconds",
+	Help:      "Time (in seconds) spent on request.",
+	Buckets:   prometheus.DefBuckets,
+}, []string{"category", "code"})
+
+func init() {
+	prometheus.MustRegister(requestDuration)
+}
 
 // WaitForFrontend retries a noop request to the internal API until it is able to reach
 // the endpoint, indicating that the frontend is available.
@@ -310,7 +323,21 @@ func (c *internalClient) LogTelemetry(ctx context.Context, env string, reqBody i
 
 // postInternal sends an HTTP post request to the internal route.
 func (c *internalClient) postInternal(ctx context.Context, route string, reqBody, respBody interface{}) error {
-	return c.post(ctx, "/.internal/"+route, reqBody, respBody)
+	return c.meteredPost(ctx, "/.internal/"+route, reqBody, respBody)
+}
+
+func (c *internalClient) meteredPost(ctx context.Context, route string, reqBody, respBody interface{}) error {
+	start := time.Now()
+	err := c.post(ctx, route, reqBody, respBody)
+	d := time.Since(start)
+
+	// TODO(uwedeportivo): break it out more according to response code
+	code := "200"
+	if err != nil {
+		code = "error"
+	}
+	requestDuration.WithLabelValues(route, code).Observe(d.Seconds())
+	return err
 }
 
 // post sends an HTTP post request to the provided route. If reqBody is

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "src",
+	Subsystem: "zoekt",
+	Name:      "request_duration_seconds",
+	Help:      "Time (in seconds) spent on request.",
+	Buckets:   prometheus.DefBuckets,
+}, []string{"category", "code"})
+
+func init() {
+	prometheus.MustRegister(requestDuration)
+}
+
+type meteredSearcher struct {
+	underlying zoekt.Searcher
+}
+
+func NewMeteredSearcher(z zoekt.Searcher) zoekt.Searcher {
+	return &meteredSearcher{underlying: z}
+}
+
+func (m meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+	start := time.Now()
+	zsr, err := m.underlying.Search(ctx, q, opts)
+	d := time.Since(start)
+
+	code := "200"
+	if err != nil {
+		code = "error"
+	}
+
+	// TODO(uwedeportivo): host label for horizontally scaled zoekt case
+	requestDuration.WithLabelValues("Search", code).Observe(d.Seconds())
+	return zsr, err
+}
+
+func (m meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
+	start := time.Now()
+	zrl, err := m.underlying.List(ctx, q)
+	d := time.Since(start)
+
+	code := "200"
+	if err != nil {
+		code = "error"
+	}
+
+	requestDuration.WithLabelValues("List", code).Observe(d.Seconds())
+	return zrl, err
+}
+
+func (m meteredSearcher) Close() {
+	m.underlying.Close()
+}
+
+func (m meteredSearcher) String() string {
+	return m.underlying.String()
+}

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -29,7 +29,7 @@ func NewMeteredSearcher(z zoekt.Searcher) zoekt.Searcher {
 	return &meteredSearcher{underlying: z}
 }
 
-func (m meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
 	start := time.Now()
 	zsr, err := m.underlying.Search(ctx, q, opts)
 	d := time.Since(start)
@@ -44,7 +44,7 @@ func (m meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sear
 	return zsr, err
 }
 
-func (m meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
+func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
 	start := time.Now()
 	zrl, err := m.underlying.List(ctx, q)
 	d := time.Since(start)
@@ -58,10 +58,10 @@ func (m meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, 
 	return zrl, err
 }
 
-func (m meteredSearcher) Close() {
+func (m *meteredSearcher) Close() {
 	m.underlying.Close()
 }
 
-func (m meteredSearcher) String() string {
+func (m *meteredSearcher) String() string {
 	return m.underlying.String()
 }

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -22,16 +22,16 @@ func init() {
 }
 
 type meteredSearcher struct {
-	underlying zoekt.Searcher
+	zoekt.Searcher
 }
 
 func NewMeteredSearcher(z zoekt.Searcher) zoekt.Searcher {
-	return &meteredSearcher{underlying: z}
+	return &meteredSearcher{z}
 }
 
 func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
 	start := time.Now()
-	zsr, err := m.underlying.Search(ctx, q, opts)
+	zsr, err := m.Searcher.Search(ctx, q, opts)
 	d := time.Since(start)
 
 	code := "200"
@@ -46,7 +46,7 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 
 func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
 	start := time.Now()
-	zrl, err := m.underlying.List(ctx, q)
+	zrl, err := m.Searcher.List(ctx, q)
 	d := time.Since(start)
 
 	code := "200"
@@ -56,12 +56,4 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 
 	requestDuration.WithLabelValues("List", code).Observe(d.Seconds())
 	return zrl, err
-}
-
-func (m *meteredSearcher) Close() {
-	m.underlying.Close()
-}
-
-func (m *meteredSearcher) String() string {
-	return m.underlying.String()
 }


### PR DESCRIPTION
Adds prometheus metering for the remainder of http clients doing internal http requests.

For a full list see https://github.com/sourcegraph/sourcegraph/issues/4240