### PR TITLE
LSIF: GraphQL enhancements

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -85,73 +85,73 @@ type A8NResolver interface {
 var a8nOnlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
 
 func (r *schemaResolver) AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.AddChangesetsToCampaign(ctx, args)
+	return EnterpriseResolvers.a8nResolver.AddChangesetsToCampaign(ctx, args)
 }
 
 func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.PreviewCampaignPlan(ctx, args)
+	return EnterpriseResolvers.a8nResolver.PreviewCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.CancelCampaignPlan(ctx, args)
+	return EnterpriseResolvers.a8nResolver.CancelCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.CreateCampaign(ctx, args)
+	return EnterpriseResolvers.a8nResolver.CreateCampaign(ctx, args)
 }
 
 func (r *schemaResolver) UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.UpdateCampaign(ctx, args)
+	return EnterpriseResolvers.a8nResolver.UpdateCampaign(ctx, args)
 }
 
 func (r *schemaResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.DeleteCampaign(ctx, args)
+	return EnterpriseResolvers.a8nResolver.DeleteCampaign(ctx, args)
 }
 
 func (r *schemaResolver) RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.RetryCampaign(ctx, args)
+	return EnterpriseResolvers.a8nResolver.RetryCampaign(ctx, args)
 }
 
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.Campaigns(ctx, args)
+	return EnterpriseResolvers.a8nResolver.Campaigns(ctx, args)
 }
 
 func (r *schemaResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.CreateChangesets(ctx, args)
+	return EnterpriseResolvers.a8nResolver.CreateChangesets(ctx, args)
 }
 
 func (r *schemaResolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ExternalChangesetsConnectionResolver, error) {
-	if OptionalResolvers.a8nResolver == nil {
+	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return OptionalResolvers.a8nResolver.Changesets(ctx, args)
+	return EnterpriseResolvers.a8nResolver.Changesets(ctx, args)
 }
 
 type ChangesetCountsArgs struct {

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -85,73 +85,73 @@ type A8NResolver interface {
 var a8nOnlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
 
 func (r *schemaResolver) AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.AddChangesetsToCampaign(ctx, args)
+	return OptionalResolvers.a8nResolver.AddChangesetsToCampaign(ctx, args)
 }
 
 func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.PreviewCampaignPlan(ctx, args)
+	return OptionalResolvers.a8nResolver.PreviewCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.CancelCampaignPlan(ctx, args)
+	return OptionalResolvers.a8nResolver.CancelCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.CreateCampaign(ctx, args)
+	return OptionalResolvers.a8nResolver.CreateCampaign(ctx, args)
 }
 
 func (r *schemaResolver) UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.UpdateCampaign(ctx, args)
+	return OptionalResolvers.a8nResolver.UpdateCampaign(ctx, args)
 }
 
 func (r *schemaResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.DeleteCampaign(ctx, args)
+	return OptionalResolvers.a8nResolver.DeleteCampaign(ctx, args)
 }
 
 func (r *schemaResolver) RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.RetryCampaign(ctx, args)
+	return OptionalResolvers.a8nResolver.RetryCampaign(ctx, args)
 }
 
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.Campaigns(ctx, args)
+	return OptionalResolvers.a8nResolver.Campaigns(ctx, args)
 }
 
 func (r *schemaResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.CreateChangesets(ctx, args)
+	return OptionalResolvers.a8nResolver.CreateChangesets(ctx, args)
 }
 
 func (r *schemaResolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ExternalChangesetsConnectionResolver, error) {
-	if r.a8nResolver == nil {
+	if OptionalResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return r.a8nResolver.Changesets(ctx, args)
+	return OptionalResolvers.a8nResolver.Changesets(ctx, args)
 }
 
 type ChangesetCountsArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -29,7 +29,7 @@ type LSIFDumpsQueryArgs struct {
 
 type LSIFRepositoryDumpsQueryArgs struct {
 	*LSIFDumpsQueryArgs
-	Repository graphql.ID
+	RepositoryID graphql.ID
 }
 
 type LSIFJobsQueryArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -87,15 +87,15 @@ type LSIFJobConnectionResolver interface {
 var codeIntelOnlyInEnterprise = errors.New("lsif dumps and jobs are only available in enterprise")
 
 func (r *schemaResolver) LSIFJobs(ctx context.Context, args *LSIFJobsQueryArgs) (LSIFJobConnectionResolver, error) {
-	if OptionalResolvers.codeIntelResolver == nil {
+	if EnterpriseResolvers.codeIntelResolver == nil {
 		return nil, codeIntelOnlyInEnterprise
 	}
-	return OptionalResolvers.codeIntelResolver.LSIFJobs(ctx, args)
+	return EnterpriseResolvers.codeIntelResolver.LSIFJobs(ctx, args)
 }
 
 func (r *schemaResolver) LSIFJobStats(ctx context.Context) (LSIFJobStatsResolver, error) {
-	if OptionalResolvers.codeIntelResolver == nil {
+	if EnterpriseResolvers.codeIntelResolver == nil {
 		return nil, codeIntelOnlyInEnterprise
 	}
-	return OptionalResolvers.codeIntelResolver.LSIFJobStats(ctx)
+	return EnterpriseResolvers.codeIntelResolver.LSIFJobStats(ctx)
 }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -12,22 +12,24 @@ import (
 var NewCodeIntelResolver func() CodeIntelResolver
 
 type CodeIntelResolver interface {
-	LSIFDump(ctx context.Context, args *struct{ ID graphql.ID }) (LSIFDumpResolver, error)
-	LSIFDumpByGQLID(ctx context.Context, id graphql.ID) (LSIFDumpResolver, error)
-	LSIFDumps(ctx context.Context, args *LSIFDumpsQueryArgs) (LSIFDumpConnectionResolver, error)
-	LSIFJob(ctx context.Context, args *struct{ ID graphql.ID }) (LSIFJobResolver, error)
-	LSIFJobByGQLID(ctx context.Context, id graphql.ID) (LSIFJobResolver, error)
+	LSIFDumpByID(ctx context.Context, id graphql.ID) (LSIFDumpResolver, error)
+	LSIFDumps(ctx context.Context, args *LSIFRepositoryDumpsQueryArgs) (LSIFDumpConnectionResolver, error)
+	LSIFJobByID(ctx context.Context, id graphql.ID) (LSIFJobResolver, error)
 	LSIFJobs(ctx context.Context, args *LSIFJobsQueryArgs) (LSIFJobConnectionResolver, error)
 	LSIFJobStats(ctx context.Context) (LSIFJobStatsResolver, error)
-	LSIFJobStatsByGQLID(ctx context.Context, id graphql.ID) (LSIFJobStatsResolver, error)
+	LSIFJobStatsByID(ctx context.Context, id graphql.ID) (LSIFJobStatsResolver, error)
 }
 
 type LSIFDumpsQueryArgs struct {
 	graphqlutil.ConnectionArgs
-	Repository      graphql.ID
 	Query           *string
 	IsLatestForRepo *bool
 	After           *string
+}
+
+type LSIFRepositoryDumpsQueryArgs struct {
+	*LSIFDumpsQueryArgs
+	Repository graphql.ID
 }
 
 type LSIFJobsQueryArgs struct {
@@ -84,58 +86,16 @@ type LSIFJobConnectionResolver interface {
 
 var codeIntelOnlyInEnterprise = errors.New("lsif dumps and jobs are only available in enterprise")
 
-func (r *schemaResolver) LSIFDump(ctx context.Context, args *struct{ ID graphql.ID }) (LSIFDumpResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFDump(ctx, args)
-}
-
-func (r *schemaResolver) LSIFDumpByGQLID(ctx context.Context, id graphql.ID) (LSIFDumpResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFDumpByGQLID(ctx, id)
-}
-
-func (r *schemaResolver) LSIFDumps(ctx context.Context, args *LSIFDumpsQueryArgs) (LSIFDumpConnectionResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFDumps(ctx, args)
-}
-
-func (r *schemaResolver) LSIFJob(ctx context.Context, args *struct{ ID graphql.ID }) (LSIFJobResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFJob(ctx, args)
-}
-
-func (r *schemaResolver) LSIFJobByGQLID(ctx context.Context, id graphql.ID) (LSIFJobResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFJobByGQLID(ctx, id)
-}
-
 func (r *schemaResolver) LSIFJobs(ctx context.Context, args *LSIFJobsQueryArgs) (LSIFJobConnectionResolver, error) {
-	if r.codeIntelResolver == nil {
+	if OptionalResolvers.codeIntelResolver == nil {
 		return nil, codeIntelOnlyInEnterprise
 	}
-	return r.codeIntelResolver.LSIFJobs(ctx, args)
+	return OptionalResolvers.codeIntelResolver.LSIFJobs(ctx, args)
 }
 
 func (r *schemaResolver) LSIFJobStats(ctx context.Context) (LSIFJobStatsResolver, error) {
-	if r.codeIntelResolver == nil {
+	if OptionalResolvers.codeIntelResolver == nil {
 		return nil, codeIntelOnlyInEnterprise
 	}
-	return r.codeIntelResolver.LSIFJobStats(ctx)
-}
-
-func (r *schemaResolver) LSIFJobStatsByGQLID(ctx context.Context, id graphql.ID) (LSIFJobStatsResolver, error) {
-	if r.codeIntelResolver == nil {
-		return nil, codeIntelOnlyInEnterprise
-	}
-	return r.codeIntelResolver.LSIFJobStatsByGQLID(ctx, id)
+	return OptionalResolvers.codeIntelResolver.LSIFJobStats(ctx)
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -45,9 +45,12 @@ func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldNa
 }
 
 func NewSchema(a8n A8NResolver, codeIntel CodeIntelResolver) (*graphql.Schema, error) {
+	OptionalResolvers.a8nResolver = a8n
+	OptionalResolvers.codeIntelResolver = codeIntel
+
 	return graphql.ParseSchema(
 		Schema,
-		&schemaResolver{a8nResolver: a8n, codeIntelResolver: codeIntel},
+		&schemaResolver{},
 		graphql.Tracer(prometheusTracer{}),
 	)
 }
@@ -187,13 +190,17 @@ func (r *NodeResolver) ToLSIFJob() (LSIFJobResolver, bool) {
 	return n, ok
 }
 
-// schemaResolver handles all GraphQL queries for Sourcegraph.  To do this, it
-// uses subresolvers, some of which are globals and some of which are fields on
-// schemaResolver.
-type schemaResolver struct {
+// schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it
+// uses subresolvers which are globals. Enterprise-only resolvers are assigned
+// to a field of OptionalResolvers.
+type schemaResolver struct{}
+
+// OptionalResolvers holds the instances of resolvers which are enabled only
+// in enterprise mode. These resolver instances are nil when running as OSS.
+var OptionalResolvers = struct {
 	a8nResolver       A8NResolver
 	codeIntelResolver CodeIntelResolver
-}
+}{}
 
 // DEPRECATED
 func (r *schemaResolver) Root() *schemaResolver {
@@ -213,20 +220,20 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	case "AccessToken":
 		return accessTokenByID(ctx, id)
 	case "Campaign":
-		if r.a8nResolver == nil {
+		if OptionalResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return r.a8nResolver.CampaignByID(ctx, id)
+		return OptionalResolvers.a8nResolver.CampaignByID(ctx, id)
 	case "CampaignPlan":
-		if r.a8nResolver == nil {
+		if OptionalResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return r.a8nResolver.CampaignPlanByID(ctx, id)
+		return OptionalResolvers.a8nResolver.CampaignPlanByID(ctx, id)
 	case "ExternalChangeset":
-		if r.a8nResolver == nil {
+		if OptionalResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return r.a8nResolver.ChangesetByID(ctx, id)
+		return OptionalResolvers.a8nResolver.ChangesetByID(ctx, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":
@@ -264,20 +271,20 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	case "Site":
 		return siteByGQLID(ctx, id)
 	case "LSIFDump":
-		if r.codeIntelResolver == nil {
+		if OptionalResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return r.codeIntelResolver.LSIFDumpByGQLID(ctx, id)
+		return OptionalResolvers.codeIntelResolver.LSIFDumpByID(ctx, id)
 	case "LSIFJobStats":
-		if r.codeIntelResolver == nil {
+		if OptionalResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return r.codeIntelResolver.LSIFJobStatsByGQLID(ctx, id)
+		return OptionalResolvers.codeIntelResolver.LSIFJobStatsByID(ctx, id)
 	case "LSIFJob":
-		if r.codeIntelResolver == nil {
+		if OptionalResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return r.codeIntelResolver.LSIFJobByGQLID(ctx, id)
+		return OptionalResolvers.codeIntelResolver.LSIFJobByID(ctx, id)
 	default:
 		return nil, errors.New("invalid id")
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -45,8 +45,8 @@ func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldNa
 }
 
 func NewSchema(a8n A8NResolver, codeIntel CodeIntelResolver) (*graphql.Schema, error) {
-	OptionalResolvers.a8nResolver = a8n
-	OptionalResolvers.codeIntelResolver = codeIntel
+	EnterpriseResolvers.a8nResolver = a8n
+	EnterpriseResolvers.codeIntelResolver = codeIntel
 
 	return graphql.ParseSchema(
 		Schema,
@@ -192,12 +192,12 @@ func (r *NodeResolver) ToLSIFJob() (LSIFJobResolver, bool) {
 
 // schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it
 // uses subresolvers which are globals. Enterprise-only resolvers are assigned
-// to a field of OptionalResolvers.
+// to a field of EnterpriseResolvers.
 type schemaResolver struct{}
 
-// OptionalResolvers holds the instances of resolvers which are enabled only
+// EnterpriseResolvers holds the instances of resolvers which are enabled only
 // in enterprise mode. These resolver instances are nil when running as OSS.
-var OptionalResolvers = struct {
+var EnterpriseResolvers = struct {
 	a8nResolver       A8NResolver
 	codeIntelResolver CodeIntelResolver
 }{}
@@ -220,20 +220,20 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	case "AccessToken":
 		return accessTokenByID(ctx, id)
 	case "Campaign":
-		if OptionalResolvers.a8nResolver == nil {
+		if EnterpriseResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return OptionalResolvers.a8nResolver.CampaignByID(ctx, id)
+		return EnterpriseResolvers.a8nResolver.CampaignByID(ctx, id)
 	case "CampaignPlan":
-		if OptionalResolvers.a8nResolver == nil {
+		if EnterpriseResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return OptionalResolvers.a8nResolver.CampaignPlanByID(ctx, id)
+		return EnterpriseResolvers.a8nResolver.CampaignPlanByID(ctx, id)
 	case "ExternalChangeset":
-		if OptionalResolvers.a8nResolver == nil {
+		if EnterpriseResolvers.a8nResolver == nil {
 			return nil, a8nOnlyInEnterprise
 		}
-		return OptionalResolvers.a8nResolver.ChangesetByID(ctx, id)
+		return EnterpriseResolvers.a8nResolver.ChangesetByID(ctx, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":
@@ -271,20 +271,20 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	case "Site":
 		return siteByGQLID(ctx, id)
 	case "LSIFDump":
-		if OptionalResolvers.codeIntelResolver == nil {
+		if EnterpriseResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return OptionalResolvers.codeIntelResolver.LSIFDumpByID(ctx, id)
+		return EnterpriseResolvers.codeIntelResolver.LSIFDumpByID(ctx, id)
 	case "LSIFJobStats":
-		if OptionalResolvers.codeIntelResolver == nil {
+		if EnterpriseResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return OptionalResolvers.codeIntelResolver.LSIFJobStatsByID(ctx, id)
+		return EnterpriseResolvers.codeIntelResolver.LSIFJobStatsByID(ctx, id)
 	case "LSIFJob":
-		if OptionalResolvers.codeIntelResolver == nil {
+		if EnterpriseResolvers.codeIntelResolver == nil {
 			return nil, codeIntelOnlyInEnterprise
 		}
-		return OptionalResolvers.codeIntelResolver.LSIFJobByID(ctx, id)
+		return EnterpriseResolvers.codeIntelResolver.LSIFJobByID(ctx, id)
 	default:
 		return nil, errors.New("invalid id")
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -266,7 +266,7 @@ func (r *RepositoryResolver) LSIFDumps(ctx context.Context, args *LSIFDumpsQuery
 	}
 	return EnterpriseResolvers.codeIntelResolver.LSIFDumps(ctx, &LSIFRepositoryDumpsQueryArgs{
 		LSIFDumpsQueryArgs: args,
-		Repository:         r.ID(),
+		RepositoryID:       r.ID(),
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -260,6 +260,16 @@ func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 	return r.err
 }
 
+func (r *RepositoryResolver) LSIFDumps(ctx context.Context, args *LSIFDumpsQueryArgs) (LSIFDumpConnectionResolver, error) {
+	if OptionalResolvers.codeIntelResolver == nil {
+		return nil, codeIntelOnlyInEnterprise
+	}
+	return OptionalResolvers.codeIntelResolver.LSIFDumps(ctx, &LSIFRepositoryDumpsQueryArgs{
+		LSIFDumpsQueryArgs: args,
+		Repository:         r.ID(),
+	})
+}
+
 func (*schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
 	Callsign string
 	Name     *string

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -261,10 +261,10 @@ func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 }
 
 func (r *RepositoryResolver) LSIFDumps(ctx context.Context, args *LSIFDumpsQueryArgs) (LSIFDumpConnectionResolver, error) {
-	if OptionalResolvers.codeIntelResolver == nil {
+	if EnterpriseResolvers.codeIntelResolver == nil {
 		return nil, codeIntelOnlyInEnterprise
 	}
-	return OptionalResolvers.codeIntelResolver.LSIFDumps(ctx, &LSIFRepositoryDumpsQueryArgs{
+	return EnterpriseResolvers.codeIntelResolver.LSIFDumps(ctx, &LSIFRepositoryDumpsQueryArgs{
 		LSIFDumpsQueryArgs: args,
 		Repository:         r.ID(),
 	})

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1226,54 +1226,9 @@ type Query {
     # Look up a namespace by ID.
     namespace(id: ID!): Namespace
 
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Lookup an LSIF dump by ID.
-    lsifDump(id: ID!): LSIFDump
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Retrieve the LSIF dumps for a repository.
-    lsifDumps(
-        # The repository ID that this LSIF dump belongs to.
-        repository: ID!
-
-        # An (optional) search query that searches over the commit and root properties.
-        query: String
-
-        # When specified, shows only dumps that are latest for the given repository.
-        isLatestForRepo: Boolean
-
-        # When specified, indicates that this request should be paginated and
-        # the first N results (relative to the cursor) should be returned. i.e.
-        # how many results to return per page. It must be in the range of 0-5000.
-        first: Int
-
-        # When specified, indicates that this request should be paginated and
-        # to fetch results starting at this cursor.
-        #
-        # A future request can be made for more results by passing in the
-        # 'LSIFDumpConnection.pageInfo.endCursor' that is returned.
-        after: String
-    ): LSIFDumpConnection!
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # Retrieve counts of jobs by state in the LSIF work queue.
     lsifJobStats: LSIFJobStats!
 
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Look up an LSIF job by ID.
-    lsifJob(id: ID!): LSIFJob
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # Search for LSIF jobs by state and query term.
     lsifJobs(
         # The state of returned jobs.
@@ -1793,6 +1748,27 @@ type Repository implements Node & GenericSearchResultInterface {
     detail: Markdown!
     # The result previews of the result.
     matches: [SearchResultMatch!]!
+
+    # The repository's LSIF dumps.
+    lsifDumps(
+        # An (optional) search query that searches over the commit and root properties.
+        query: String
+
+        # When specified, shows only dumps that are latest for the given repository.
+        isLatestForRepo: Boolean
+
+        # When specified, indicates that this request should be paginated and
+        # the first N results (relative to the cursor) should be returned. i.e.
+        # how many results to return per page. It must be in the range of 0-5000.
+        first: Int
+
+        # When specified, indicates that this request should be paginated and
+        # to fetch results starting at this cursor.
+        #
+        # A future request can be made for more results by passing in the
+        # 'LSIFDumpConnection.pageInfo.endCursor' that is returned.
+        after: String
+    ): LSIFDumpConnection!
 }
 
 # A URL to a resource on an external service, such as the URL to a repository on its external (origin) code host.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1233,54 +1233,9 @@ type Query {
     # Look up a namespace by ID.
     namespace(id: ID!): Namespace
 
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Lookup an LSIF dump by ID.
-    lsifDump(id: ID!): LSIFDump
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Retrieve the LSIF dumps for a repository.
-    lsifDumps(
-        # The repository ID that this LSIF dump belongs to.
-        repository: ID!
-
-        # An (optional) search query that searches over the commit and root properties.
-        query: String
-
-        # When specified, shows only dumps that are latest for the given repository.
-        isLatestForRepo: Boolean
-
-        # When specified, indicates that this request should be paginated and
-        # the first N results (relative to the cursor) should be returned. i.e.
-        # how many results to return per page. It must be in the range of 0-5000.
-        first: Int
-
-        # When specified, indicates that this request should be paginated and
-        # to fetch results starting at this cursor.
-        #
-        # A future request can be made for more results by passing in the
-        # 'LSIFDumpConnection.pageInfo.endCursor' that is returned.
-        after: String
-    ): LSIFDumpConnection!
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # Retrieve counts of jobs by state in the LSIF work queue.
     lsifJobStats: LSIFJobStats!
 
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
-    # Look up an LSIF job by ID.
-    lsifJob(id: ID!): LSIFJob
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # Search for LSIF jobs by state and query term.
     lsifJobs(
         # The state of returned jobs.
@@ -1800,6 +1755,27 @@ type Repository implements Node & GenericSearchResultInterface {
     detail: Markdown!
     # The result previews of the result.
     matches: [SearchResultMatch!]!
+
+    # The repository's LSIF dumps.
+    lsifDumps(
+        # An (optional) search query that searches over the commit and root properties.
+        query: String
+
+        # When specified, shows only dumps that are latest for the given repository.
+        isLatestForRepo: Boolean
+
+        # When specified, indicates that this request should be paginated and
+        # the first N results (relative to the cursor) should be returned. i.e.
+        # how many results to return per page. It must be in the range of 0-5000.
+        first: Int
+
+        # When specified, indicates that this request should be paginated and
+        # to fetch results starting at this cursor.
+        #
+        # A future request can be made for more results by passing in the
+        # 'LSIFDumpConnection.pageInfo.endCursor' that is returned.
+        after: String
+    ): LSIFDumpConnection!
 }
 
 # A URL to a resource on an external service, such as the URL to a repository on its external (origin) code host.

--- a/enterprise/pkg/codeintel/resolvers/dump.go
+++ b/enterprise/pkg/codeintel/resolvers/dump.go
@@ -57,7 +57,7 @@ func (r *lsifDumpResolver) ProcessedAt() graphqlbackend.DateTime {
 // Connection Resolver
 
 type LSIFDumpsListOptions struct {
-	Repository      graphql.ID
+	RepositoryID    graphql.ID
 	Query           *string
 	IsLatestForRepo *bool
 	Limit           *int32
@@ -114,7 +114,7 @@ func (r *lsifDumpConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil
 
 func (r *lsifDumpConnectionResolver) compute(ctx context.Context) ([]*lsif.LSIFDump, *graphqlbackend.RepositoryResolver, int, string, error) {
 	r.once.Do(func() {
-		repo, err := graphqlbackend.RepositoryByID(ctx, r.opt.Repository)
+		repo, err := graphqlbackend.RepositoryByID(ctx, r.opt.RepositoryID)
 		if err != nil {
 			r.err = err
 			return

--- a/enterprise/pkg/codeintel/resolvers/resolver.go
+++ b/enterprise/pkg/codeintel/resolvers/resolver.go
@@ -59,7 +59,7 @@ func (r *Resolver) LSIFDumpByID(ctx context.Context, id graphql.ID) (graphqlback
 
 func (r *Resolver) LSIFDumps(ctx context.Context, args *graphqlbackend.LSIFRepositoryDumpsQueryArgs) (graphqlbackend.LSIFDumpConnectionResolver, error) {
 	opt := LSIFDumpsListOptions{
-		Repository:      args.RepositoryID,
+		RepositoryID:    args.RepositoryID,
 		Query:           args.Query,
 		IsLatestForRepo: args.IsLatestForRepo,
 	}

--- a/enterprise/pkg/codeintel/resolvers/resolver.go
+++ b/enterprise/pkg/codeintel/resolvers/resolver.go
@@ -26,11 +26,7 @@ func NewResolver() graphqlbackend.CodeIntelResolver {
 //
 // Dump Node Resolvers
 
-func (r *Resolver) LSIFDump(ctx context.Context, args *struct{ ID graphql.ID }) (graphqlbackend.LSIFDumpResolver, error) {
-	return r.LSIFDumpByGQLID(ctx, args.ID)
-}
-
-func (r *Resolver) LSIFDumpByGQLID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFDumpResolver, error) {
+func (r *Resolver) LSIFDumpByID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFDumpResolver, error) {
 	repoName, dumpID, err := unmarshalLSIFDumpGQLID(id)
 	if err != nil {
 		return nil, err
@@ -61,7 +57,7 @@ func (r *Resolver) LSIFDumpByGQLID(ctx context.Context, id graphql.ID) (graphqlb
 // dependent on the limit, so we can overwrite this value if the user has changed its
 // value since making the last request.
 
-func (r *Resolver) LSIFDumps(ctx context.Context, args *graphqlbackend.LSIFDumpsQueryArgs) (graphqlbackend.LSIFDumpConnectionResolver, error) {
+func (r *Resolver) LSIFDumps(ctx context.Context, args *graphqlbackend.LSIFRepositoryDumpsQueryArgs) (graphqlbackend.LSIFDumpConnectionResolver, error) {
 	opt := LSIFDumpsListOptions{
 		Repository:      args.Repository,
 		Query:           args.Query,
@@ -89,11 +85,7 @@ func (r *Resolver) LSIFDumps(ctx context.Context, args *graphqlbackend.LSIFDumps
 //
 // Job Node Resolvers
 
-func (r *Resolver) LSIFJob(ctx context.Context, args *struct{ ID graphql.ID }) (graphqlbackend.LSIFJobResolver, error) {
-	return r.LSIFJobByGQLID(ctx, args.ID)
-}
-
-func (r *Resolver) LSIFJobByGQLID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFJobResolver, error) {
+func (r *Resolver) LSIFJobByID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFJobResolver, error) {
 	jobID, err := unmarshalLSIFJobGQLID(id)
 	if err != nil {
 		return nil, err
@@ -145,10 +137,10 @@ func (r *Resolver) LSIFJobs(ctx context.Context, args *graphqlbackend.LSIFJobsQu
 const lsifJobStatsGQLID = "lsifJobStats"
 
 func (r *Resolver) LSIFJobStats(ctx context.Context) (graphqlbackend.LSIFJobStatsResolver, error) {
-	return r.LSIFJobStatsByGQLID(ctx, marshalLSIFJobStatsGQLID(lsifJobStatsGQLID))
+	return r.LSIFJobStatsByID(ctx, marshalLSIFJobStatsGQLID(lsifJobStatsGQLID))
 }
 
-func (r *Resolver) LSIFJobStatsByGQLID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFJobStatsResolver, error) {
+func (r *Resolver) LSIFJobStatsByID(ctx context.Context, id graphql.ID) (graphqlbackend.LSIFJobStatsResolver, error) {
 	lsifJobStatsID, err := unmarshalLSIFJobStatsGQLID(id)
 	if err != nil {
 		return nil, err

--- a/enterprise/pkg/codeintel/resolvers/resolver.go
+++ b/enterprise/pkg/codeintel/resolvers/resolver.go
@@ -59,7 +59,7 @@ func (r *Resolver) LSIFDumpByID(ctx context.Context, id graphql.ID) (graphqlback
 
 func (r *Resolver) LSIFDumps(ctx context.Context, args *graphqlbackend.LSIFRepositoryDumpsQueryArgs) (graphqlbackend.LSIFDumpConnectionResolver, error) {
 	opt := LSIFDumpsListOptions{
-		Repository:      args.Repository,
+		Repository:      args.RepositoryID,
 		Query:           args.Query,
 		IsLatestForRepo: args.IsLatestForRepo,
 	}

--- a/web/src/enterprise/repo/settings/backend.tsx
+++ b/web/src/enterprise/repo/settings/backend.tsx
@@ -13,33 +13,32 @@ export function fetchLsifDumps({
     after,
     query,
     isLatestForRepo,
-}: GQL.ILsifDumpsOnQueryArguments): Observable<GQL.ILSIFDumpConnection> {
+}: { repository: string } & GQL.ILsifDumpsOnRepositoryArguments): Observable<GQL.ILSIFDumpConnection> {
     return queryGraphQL(
         gql`
             query LsifDumps($repository: ID!, $first: Int, $after: String, $query: String, $isLatestForRepo: Boolean) {
-                lsifDumps(
-                    repository: $repository
-                    first: $first
-                    after: $after
-                    query: $query
-                    isLatestForRepo: $isLatestForRepo
-                ) {
-                    nodes {
-                        id
-                        projectRoot {
-                            commit {
-                                abbreviatedOID
+                node(id: $repository) {
+                    __typename
+                    ... on Repository {
+                        lsifDumps(first: $first, after: $after, query: $query, isLatestForRepo: $isLatestForRepo) {
+                            nodes {
+                                id
+                                projectRoot {
+                                    commit {
+                                        abbreviatedOID
+                                    }
+                                    path
+                                    url
+                                }
+                                processedAt
                             }
-                            path
-                            url
-                        }
-                        processedAt
-                    }
 
-                    totalCount
-                    pageInfo {
-                        endCursor
-                        hasNextPage
+                            totalCount
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                        }
                     }
                 }
             }
@@ -47,7 +46,21 @@ export function fetchLsifDumps({
         { repository, first, after, query, isLatestForRepo }
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => data.lsifDumps)
+        map(({ node }) => {
+            if (!node) {
+                return {
+                    __typename: 'LSIFDumpConnection' as const,
+                    nodes: [],
+                    totalCount: 0,
+                    pageInfo: { __typename: 'PageInfo' as const, endCursor: null, hasNextPage: false },
+                }
+            }
+            if (node.__typename !== 'Repository') {
+                throw new Error(`The given ID is a ${node.__typename}, not a Repository`)
+            }
+
+            return node.lsifDumps
+        })
     )
 }
 

--- a/web/src/enterprise/repo/settings/backend.tsx
+++ b/web/src/enterprise/repo/settings/backend.tsx
@@ -48,12 +48,7 @@ export function fetchLsifDumps({
         map(dataOrThrowErrors),
         map(({ node }) => {
             if (!node) {
-                return {
-                    __typename: 'LSIFDumpConnection' as const,
-                    nodes: [],
-                    totalCount: 0,
-                    pageInfo: { __typename: 'PageInfo' as const, endCursor: null, hasNextPage: false },
-                }
+                throw new Error('Invalid repository')
             }
             if (node.__typename !== 'Repository') {
                 throw new Error(`The given ID is a ${node.__typename}, not a Repository`)

--- a/web/src/enterprise/site-admin/backend.ts
+++ b/web/src/enterprise/site-admin/backend.ts
@@ -70,7 +70,7 @@ export function fetchLsifJobs({
 /**
  * Fetch a single LSIF job by id.
  */
-export function fetchLsifJob({ id }: GQL.ILsifJobOnQueryArguments): Observable<GQL.ILSIFJob | null> {
+export function fetchLsifJob({ id }: { id: string }): Observable<GQL.ILSIFJob | null> {
     return queryGraphQL(
         gql`
             query LsifJob($id: ID!) {


### PR DESCRIPTION
This PR improves the LSIF GraphQL API:

- removes LSIFDump and LSIFJob as these can just get a node directly by identifier
- moves LSIFDump under Repository resolver

This PR also changes code structure a bit:

- a8n and codeintel resolvers are no longer assigned to `schemaResolver`, but to a `OptionalResolvers` struct defined in the graphqlbackend package. This is necessary as the repositoryResolver (which is created directly in many places) also needs a reference to these optionally assigned resolvers (and there is no current way to pass them from the schema resolver as repository resolvers can be created independently).