### PR TITLE
LSIF: Remove noisy NoLSIFDumpError

### DIFF
--- a/lsif/src/server/backend/backend.ts
+++ b/lsif/src/server/backend/backend.ts
@@ -135,7 +135,6 @@ export class Backend {
         if (!closestDatabaseAndDump) {
             return false
         }
-
         const { database, dump } = closestDatabaseAndDump
         return database.exists(this.pathToDatabase(dump.root, path))
     }
@@ -165,9 +164,9 @@ export class Backend {
 
             return undefined
         }
+        const { database, dump, ctx: newCtx } = closestDatabaseAndDump
 
         // Construct path within dump
-        const { database, dump, ctx: newCtx } = closestDatabaseAndDump
         const pathInDb = this.pathToDatabase(dump.root, path)
 
         // Try to find definitions in the same dump.
@@ -481,9 +480,9 @@ export class Backend {
 
             return undefined
         }
+        const { database, dump, ctx: newCtx } = closestDatabaseAndDump
 
         // Construct path within dump
-        const { database, dump, ctx: newCtx } = closestDatabaseAndDump
         const pathInDb = this.pathToDatabase(dump.root, path)
 
         // Try to find references in the same dump
@@ -692,7 +691,6 @@ export class Backend {
 
             return undefined
         }
-
         const { database, dump, ctx: newCtx } = closestDatabaseAndDump
         return database.hover(this.pathToDatabase(dump.root, path), position, newCtx)
     }

--- a/lsif/src/server/backend/backend.ts
+++ b/lsif/src/server/backend/backend.ts
@@ -141,7 +141,8 @@ export class Backend {
     }
 
     /**
-     * Return the location for the definition of the reference at the given position.
+     * Return the location for the definition of the reference at the given position. Returns
+     * undefined if no dump can be loaded to answer this query.
      *
      * @param repository The repository name.
      * @param commit The commit.
@@ -155,14 +156,14 @@ export class Backend {
         path: string,
         position: lsp.Position,
         ctx: TracingContext = {}
-    ): Promise<lsp.Location[]> {
+    ): Promise<lsp.Location[] | undefined> {
         const closestDatabaseAndDump = await this.loadClosestDatabase(repository, commit, path, ctx)
         if (!closestDatabaseAndDump) {
             if (ctx.logger) {
                 ctx.logger.warn('No database could be loaded', { repository, commit, path })
             }
 
-            return []
+            return undefined
         }
 
         // Construct path within dump
@@ -437,7 +438,8 @@ export class Backend {
     }
 
     /**
-     * Return a list of locations which reference the definition at the given position.
+     * Return a list of locations which reference the definition at the given position. Returns
+     * undefined if no dump can be loaded to answer this query.
      *
      * @param repository The repository name.
      * @param commit The commit.
@@ -453,7 +455,7 @@ export class Backend {
         position: lsp.Position,
         paginationContext: ReferencePaginationContext = { limit: 10 },
         ctx: TracingContext = {}
-    ): Promise<{ locations: lsp.Location[]; cursor?: ReferencePaginationCursor }> {
+    ): Promise<{ locations: lsp.Location[]; cursor?: ReferencePaginationCursor } | undefined> {
         if (paginationContext.cursor) {
             // Continue from previous page
             const results = await this.performRemoteReferences(
@@ -477,7 +479,7 @@ export class Backend {
                 ctx.logger.warn('No database could be loaded', { repository, commit, path })
             }
 
-            return { locations: [] }
+            return undefined
         }
 
         // Construct path within dump
@@ -666,7 +668,8 @@ export class Backend {
     }
 
     /**
-     * Return the hover content for the definition or reference at the given position.
+     * Return the hover content for the definition or reference at the given position. Returns
+     * undefined if no dump can be loaded to answer this query.
      *
      * @param repository The repository name.
      * @param commit The commit.
@@ -680,14 +683,14 @@ export class Backend {
         path: string,
         position: lsp.Position,
         ctx: TracingContext = {}
-    ): Promise<lsp.Hover | null> {
+    ): Promise<lsp.Hover | null | undefined> {
         const closestDatabaseAndDump = await this.loadClosestDatabase(repository, commit, path, ctx)
         if (!closestDatabaseAndDump) {
             if (ctx.logger) {
                 ctx.logger.warn('No database could be loaded', { repository, commit, path })
             }
 
-            return null
+            return undefined
         }
 
         const { database, dump, ctx: newCtx } = closestDatabaseAndDump

--- a/lsif/src/tests/integration/backend/linked-reference-results.test.ts
+++ b/lsif/src/tests/integration/backend/linked-reference-results.test.ts
@@ -29,7 +29,7 @@ describe('Backend', () => {
 
         for (const position of positions) {
             const { locations } = util.filterNodeModules(
-                await ctx.backend.references(repository, commit, 'src/index.ts', position)
+                (await ctx.backend.references(repository, commit, 'src/index.ts', position)) || { locations: [] }
             )
 
             expect(locations).toContainEqual(util.createLocation('src/index.ts', 1, 4, 1, 7)) // abstract def in I

--- a/lsif/src/tests/integration/backend/reference-pagination-monorepo.test.ts
+++ b/lsif/src/tests/integration/backend/reference-pagination-monorepo.test.ts
@@ -104,7 +104,7 @@ describe('Backend', () => {
         for (const { commit, refs } of testCases) {
             const fetch = async (paginationContext?: ReferencePaginationContext) =>
                 util.filterNodeModules(
-                    await backend.references(
+                    (await backend.references(
                         repository,
                         commit,
                         'a/src/index.ts',
@@ -113,7 +113,7 @@ describe('Backend', () => {
                             character: 17,
                         },
                         paginationContext
-                    )
+                    )) || { locations: [] }
                 )
 
             const { locations, cursor } = await fetch()
@@ -140,7 +140,7 @@ describe('Backend', () => {
 
         const fetch = async (paginationContext?: ReferencePaginationContext) =>
             util.filterNodeModules(
-                await backend.references(
+                (await backend.references(
                     repository,
                     c3,
                     'a/src/index.ts',
@@ -149,7 +149,7 @@ describe('Backend', () => {
                         character: 17,
                     },
                     paginationContext
-                )
+                )) || { locations: [] }
             )
 
         const { locations: locations0, cursor: cursor0 } = await fetch({ limit: 50 }) // all local

--- a/lsif/src/tests/integration/backend/reference-pagination.test.ts
+++ b/lsif/src/tests/integration/backend/reference-pagination.test.ts
@@ -26,7 +26,7 @@ describe('Backend', () => {
 
         const fetch = async (paginationContext?: ReferencePaginationContext) =>
             util.filterNodeModules(
-                await backend.references(
+                (await backend.references(
                     'a',
                     util.createCommit(0),
                     'src/index.ts',
@@ -35,7 +35,7 @@ describe('Backend', () => {
                         character: 17,
                     },
                     paginationContext
-                )
+                )) || { locations: [] }
             )
 
         const { locations: locations0, cursor: cursor0 } = await fetch() // everything

--- a/lsif/src/tests/integration/backend/simple.test.ts
+++ b/lsif/src/tests/integration/backend/simple.test.ts
@@ -38,7 +38,9 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            await ctx.backend.references(repository, commit, 'src/a.ts', { line: 0, character: 17 })
+            (await ctx.backend.references(repository, commit, 'src/a.ts', { line: 0, character: 17 })) || {
+                locations: [],
+            }
         )
 
         expect(locations).toContainEqual(util.createLocation('src/a.ts', 0, 16, 0, 19)) // def

--- a/lsif/src/tests/integration/backend/xrepo.test.ts
+++ b/lsif/src/tests/integration/backend/xrepo.test.ts
@@ -58,10 +58,10 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
+            (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
                 line: 4,
                 character: 19,
-            })
+            })) || { locations: [] }
         )
 
         expect(locations).toContainEqual(util.createLocation('src/index.ts', 4, 16, 4, 19)) // def
@@ -85,10 +85,10 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            await ctx.backend.references('b1', util.createCommit(0), 'src/index.ts', {
+            (await ctx.backend.references('b1', util.createCommit(0), 'src/index.ts', {
                 line: 3,
                 character: 16,
-            })
+            })) || { locations: [] }
         )
 
         expect(locations).toContainEqual(util.createRemoteLocation('a', 'src/index.ts', 4, 16, 4, 19)) // def
@@ -112,10 +112,10 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
+            (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
                 line: 0,
                 character: 17,
-            })
+            })) || { locations: [] }
         )
 
         expect(locations).toContainEqual(util.createLocation('src/index.ts', 0, 16, 0, 19)) // def
@@ -149,10 +149,10 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            await ctx.backend.references('c1', util.createCommit(0), 'src/index.ts', {
+            (await ctx.backend.references('c1', util.createCommit(0), 'src/index.ts', {
                 line: 3,
                 character: 16,
-            })
+            })) || { locations: [] }
         )
 
         expect(locations).toContainEqual(util.createRemoteLocation('a', 'src/index.ts', 0, 16, 0, 19)) // def


### PR DESCRIPTION
Throwing `NoLSIFDumpError` causes instrumented blocks to emit the exception. This makes it very noisy (and alarming) in prod where there are no actual errors, but the /exists endpoint working normally.

This returns undefined database/dump in place of a thrown exception. This has the (intended) consequence of emitting a warning _only_ in places that don't expect such a condition (the endpoints that are meant to be called after checking if code intelligence data exists).

A secondary consequence changes the behavior of /request endpoints by returning a 200 when no intelligence data is found where it used to return a 500. I think this is an improvement, but we could do even better with a specialized error message or status code to indicate that the request was not called with the correct ordering (or was called in the presence of a race condition such as a dump being deleted).