### PR TITLE
a8n: Add Bitbucket Server support to burndown chart

### DIFF
--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -520,6 +520,8 @@ func (e *ChangesetEvent) Timestamp() time.Time {
 		t = e.CreatedAt
 	case *github.UnassignedEvent:
 		t = e.CreatedAt
+	case *bitbucketserver.Activity:
+		t = unixMilliToTime(int64(e.CreatedDate))
 	}
 
 	return t


### PR DESCRIPTION
This extends the existing CalcCounts function we use to calculate
changeset counts (used by the burndown chart) to take Bitbucket Server
changeset events into account.

Differences between Bitbucket Server and GitHub:

* On BBS a pull request is not "closed" but "declined"
* On BBS a "changes requested" review is simply called "reviewed" in the event names
* On BBS every reviewer only has one review state they can switch between
* On BBS a reviewer can unapprove their previous approval (but only an approval! You cannot undo a "changes requested")

The changes here take all of these into account.

While writing the tests it occurred to me that I _could_ write them on
an even higher level and find an abstraction layer that lets me say
"changes requested event" and that layer would map it to "changes
requested" on GitHub and "reviewed" events on BBS. But right now these
tests are easy to read and to debug, which are nice properties to
conserve right now. I might take a stab at the new abstraction layer in
the future though.



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
