### PR TITLE
a8n: Only create new Changesets if they can be synced

### DIFF
--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -366,15 +366,10 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 		}
 	}
 
-	tx.Done()
-
-	// Only fetch metadata if none of these changesets existed before.
-	// We do this outside of a transaction.
-
-	store = repos.NewDBStore(r.store.DB(), sql.TxOptions{})
+	store = repos.NewDBStore(tx.DB(), sql.TxOptions{})
 	syncer := ee.ChangesetSyncer{
 		ReposStore:  store,
-		Store:       r.store,
+		Store:       tx,
 		HTTPFactory: r.httpFactory,
 	}
 	if err = syncer.SyncChangesets(ctx, cs...); err != nil {


### PR DESCRIPTION
This fixes #6535 by extending the transaction to also include the
syncing of the to-be-created changesets.

With that, the transaction rolls back and doesn't create potentially
invalid changesets in case one of them cannot be synced.

That is much better than adding invalid state to the database which then
leads to the changesets syncer failing to sync changesets every time.



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
