### PR TITLE
a8n: Remove duplicated waitgroup.Wait() in Runner

### DIFF
--- a/enterprise/pkg/a8n/run/runner.go
+++ b/enterprise/pkg/a8n/run/runner.go
@@ -160,7 +160,6 @@ func (r *Runner) Run(ctx context.Context, plan *a8n.CampaignPlan) error {
 		queue <- job
 	}
 
-	r.wg.Wait()
 	close(queue)
 
 	return nil


### PR DESCRIPTION
@efritz spotted this. This is wrong. We only want to wait in the `Wait()` method of the Runner. I introduced this in #6598.