### PR TITLE
ui/handlers: response 404 when repository not found

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -147,6 +147,12 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				return nil, nil
 			}
 			if _, ok := errors.Cause(err).(*gitserver.RepoNotCloneableErr); ok {
+				if errcode.IsNotFound(err) {
+					// Repository is not found.
+					serveError(w, r, err, http.StatusNotFound)
+					return nil, nil
+				}
+
 				// Repository is not clonable.
 				dangerouslyServeError(w, r, errors.New("repository could not be cloned"), http.StatusInternalServerError)
 				return nil, nil


### PR DESCRIPTION
This PR addresses #4826 and responses 404 to the UI if the error is not clone-able because of "repository not found".

Test plan: Tested locally and CI
