### PR TITLE
LSIF: Update logging

### DIFF
--- a/lsif/src/server/routes/jobs.ts
+++ b/lsif/src/server/routes/jobs.ts
@@ -179,7 +179,7 @@ export function createJobRouter(
 
                 // Enqueue job
                 const ctx = createTracingContext(req, { name })
-                logger.debug(`enqueueing ${name} job`)
+                logger.debug(`Enqueueing ${name} job`)
                 const job = await enqueue(queue, name, {}, {}, tracer, ctx.span)
 
                 if (blocking && (await waitForJob(job, maxWait))) {

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -92,10 +92,10 @@ export function createLsifRouter(
                 const ctx = createTracingContext(req, { repository, commit, root })
                 const filename = path.join(settings.STORAGE_ROOT, constants.UPLOADS_DIR, uuid.v4())
                 const output = fs.createWriteStream(filename)
-                await logAndTraceCall(ctx, 'uploading dump', () => pipeline(req, output))
+                await logAndTraceCall(ctx, 'Uploading dump', () => pipeline(req, output))
 
                 // Enqueue convert job
-                logger.debug('enqueueing convert job', { repository, commit, root })
+                logger.debug('Enqueueing convert job', { repository, commit, root })
                 const args = { repository, commit, root, filename }
                 const job = await enqueue(queue, 'convert', args, {}, tracer, ctx.span)
 

--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -96,7 +96,7 @@ async function main(logger: Logger): Promise<void> {
             level: 'debug',
             ignoredRoutes: ['/ping', '/healthz', '/metrics'],
             requestWhitelist: ['method', 'url', 'query'],
-            msg: 'request',
+            msg: 'Handled request',
         })
     )
     app.use(metricsMiddleware)
@@ -110,7 +110,7 @@ async function main(logger: Logger): Promise<void> {
     // Error handler must be registered last
     app.use(errorHandler(logger))
 
-    app.listen(settings.HTTP_PORT, () => logger.debug('listening', { port: settings.HTTP_PORT }))
+    app.listen(settings.HTTP_PORT, () => logger.debug('LSIF API server listening on', { port: settings.HTTP_PORT }))
 }
 
 /**

--- a/lsif/src/shared/config/config.ts
+++ b/lsif/src/shared/config/config.ts
@@ -88,7 +88,7 @@ async function updateConfiguration(logger: Logger, onChange: (configuration: Con
             // given the frontend enough time to initialize (in case other services start up before
             // the frontend), to reduce log spam.
             if (Date.now() - start > settings.DELAY_BEFORE_UNREACHABLE_LOG * 1000 || error.code !== 'ECONNREFUSED') {
-                logger.error('failed to retrieve configuration from frontend', { error })
+                logger.error('Failed to retrieve configuration from frontend', { error })
             }
         }
 

--- a/lsif/src/shared/database/postgres.ts
+++ b/lsif/src/shared/database/postgres.ts
@@ -86,7 +86,7 @@ export async function createPostgresConnection(configuration: Configuration, log
 function connect(connectionOptions: PostgresConnectionCredentialsOptions, logger: Logger): Promise<Connection> {
     return pRetry(
         () => {
-            logger.debug('connecting to cross-repository database')
+            logger.debug('Connecting to cross-repository database')
             return connectPostgres(connectionOptions, '')
         },
         {
@@ -127,11 +127,11 @@ export function connectPostgres(
  */
 function waitForMigrations(connection: Connection, logger: Logger): Promise<void> {
     const check = async (): Promise<void> => {
-        logger.debug('checking database version', { requiredVersion: MINIMUM_MIGRATION_VERSION })
+        logger.debug('Checking database version', { requiredVersion: MINIMUM_MIGRATION_VERSION })
 
         const version = parseInt(await getMigrationVersion(connection), 10)
         if (isNaN(version) || version < MINIMUM_MIGRATION_VERSION) {
-            throw new Error('cross-repository database not up to date')
+            throw new Error('Cross-repository database not up to date')
         }
     }
 

--- a/lsif/src/shared/logging.ts
+++ b/lsif/src/shared/logging.ts
@@ -76,14 +76,14 @@ export function createSilentLogger(): Logger {
  */
 export async function logCall<T>(name: string, logger: Logger, f: () => Promise<T> | T): Promise<T> {
     const timer = logger.startTimer()
-    logger.debug(name)
+    logger.debug(`${name}: starting`)
 
     try {
         const value = await f()
-        timer.done({ message: `finished ${name}`, level: 'debug' })
+        timer.done({ message: `${name}: finished`, level: 'debug' })
         return value
     } catch (error) {
-        timer.done({ message: `failed ${name}`, level: 'error', error })
+        timer.done({ message: `${name}: failed`, level: 'error', error })
         throw error
     }
 }

--- a/lsif/src/shared/queue/queue.ts
+++ b/lsif/src/shared/queue/queue.ts
@@ -56,8 +56,8 @@ export function createQueue(endpoint: string, logger: Logger): Queue {
     }
 
     const queue = new Bull(QUEUE_NAME, { redis })
-    queue.on('error', (error: Error) => logger.error('queue error', { error }))
-    queue.on('global:stalled', (id: string) => logger.error('job stalled', { jobId: id }))
+    queue.on('error', (error: Error) => logger.error('Queue error', { error }))
+    queue.on('global:stalled', (id: string) => logger.error('Job stalled', { jobId: id }))
 
     return queue
 }

--- a/lsif/src/shared/xrepo/commits.test.ts
+++ b/lsif/src/shared/xrepo/commits.test.ts
@@ -103,7 +103,7 @@ describe('hashmod', () => {
 describe('gitserverExec', () => {
     it('should not allow git as first argument', async () => {
         await expect(gitserverExecLines('', 'r', ['git', 'log'])).rejects.toThrowError(
-            new Error('gitserver commands should not be prefixed with `git`')
+            new Error('Gitserver commands should not be prefixed with `git`')
         )
     })
 })

--- a/lsif/src/shared/xrepo/metrics.ts
+++ b/lsif/src/shared/xrepo/metrics.ts
@@ -8,6 +8,7 @@ export const xrepoQueryDurationHistogram = new promClient.Histogram({
     help: 'Total time spent on cross-repo database queries.',
     buckets: [0.2, 0.5, 1, 2, 5, 10, 30],
 })
+
 export const xrepoQueryErrorsCounter = new promClient.Counter({
     name: 'lsif_xrepo_query_errors_total',
     help: 'The number of errors that occurred during a cross-repo database query.',
@@ -34,4 +35,18 @@ export const bloomFilterEventsCounter = new promClient.Counter({
     name: 'lsif_bloom_filter_events_total',
     help: 'The number of bloom filter hits and misses.',
     labelNames: ['type'],
+})
+
+//
+// Gitserver Metrics
+
+export const gitserverDurationHistogram = new promClient.Histogram({
+    name: 'lsif_gitserver_duration_seconds',
+    help: 'Total time spent on gitserver exec queries.',
+    buckets: [0.2, 0.5, 1, 2, 5, 10, 30],
+})
+
+export const gitserverErrorsCounter = new promClient.Counter({
+    name: 'lsif_gitserver_errors_total',
+    help: 'The number of errors that occurred during a gitserver exec query.',
 })

--- a/lsif/src/shared/xrepo/xrepo.ts
+++ b/lsif/src/shared/xrepo/xrepo.ts
@@ -8,7 +8,7 @@ import { chunk } from 'lodash'
 import { createFilter, testFilter } from './bloom-filter'
 import { dbFilename, tryDeleteFile } from '../paths'
 import { instrument } from '../metrics'
-import { logAndTraceCall, TracingContext } from '../tracing'
+import { logAndTraceCall, TracingContext, logSpan } from '../tracing'
 import { TableInserter } from '../database/inserter'
 
 /**
@@ -176,8 +176,9 @@ export class XrepoDatabase {
      *
      * @param repository The repository name.
      * @param commit The head of the default branch.
+     * @param ctx The tracing context.
      */
-    public async updateDumpsVisibleFromTip(repository: string, commit: string): Promise<void> {
+    public updateDumpsVisibleFromTip(repository: string, commit: string, ctx: TracingContext = {}): Promise<void> {
         const query = `
             -- Get all ancestors of the tip
             WITH RECURSIVE lineage(id, repository, "commit", parent) AS (
@@ -195,13 +196,15 @@ export class XrepoDatabase {
             WHERE d.repository = $1 AND (d.id IN (SELECT * from visible_ids) OR d.visible_at_tip)
         `
 
-        await this.withConnection(connection => connection.query(query, [repository, commit]))
+        return logAndTraceCall(ctx, 'Updating dumps visible from tip', () =>
+            this.withConnection(connection => connection.query(query, [repository, commit]))
+        )
     }
 
     /**
      * Return the commit that has LSIF data 'closest' to the given target commit (a direct descendant
-     * or ancestor of the target commit). If no closest commit can be determined, this method returns
-     * undefined.s
+or ancestor of the target commit). If no closest commit can be determined, this method returns
+undefined.s
      *
      * @param repository The repository name.
      * @param commit The target commit.
@@ -225,45 +228,54 @@ export class XrepoDatabase {
             await this.discoverAndUpdateCommit({ repository, commit, gitserverUrls, ctx })
         }
 
-        return this.withConnection(async connection => {
-            const results = (await connection.query('select * from closest_dump($1, $2, $3, $4)', [
-                repository,
-                commit,
-                file,
-                MAX_TRAVERSAL_LIMIT,
-            ])) as xrepoModels.LsifDump[]
+        return logAndTraceCall(ctx, 'Finding closest dump', () =>
+            this.withConnection(async connection => {
+                const results = (await connection.query('select * from closest_dump($1, $2, $3, $4)', [
+                    repository,
+                    commit,
+                    file,
+                    MAX_TRAVERSAL_LIMIT,
+                ])) as xrepoModels.LsifDump[]
 
-            if (results.length === 0) {
-                return undefined
-            }
+                if (results.length === 0) {
+                    return undefined
+                }
 
-            return results[0]
-        })
+                return results[0]
+            })
+        )
     }
 
     /**
      * Update the known commits for a repository. The given commit list is a set of pairs of the
-     * form `(child, parent)`. Commits without a parent will be returend as  `(child, undefined)`.
+     * form `(child, parent)`. Commits without a parent will be returned as `(child, undefined)`.
      *
      * @param repository The repository name.
      * @param commits The commit parentage data.
+     * @param ctx The tracing context.
      */
-    public updateCommits(repository: string, commits: [string, string | undefined][]): Promise<void> {
-        return this.withTransactionalEntityManager(async entityManager => {
-            const commitInserter = new TableInserter(
-                entityManager,
-                xrepoModels.Commit,
-                xrepoModels.Commit.BatchSize,
-                insertionMetrics,
-                true // Do nothing on conflict
-            )
+    public updateCommits(
+        repository: string,
+        commits: [string, string | undefined][],
+        ctx: TracingContext = {}
+    ): Promise<void> {
+        return logAndTraceCall(ctx, 'Updating commits', () =>
+            this.withTransactionalEntityManager(async entityManager => {
+                const commitInserter = new TableInserter(
+                    entityManager,
+                    xrepoModels.Commit,
+                    xrepoModels.Commit.BatchSize,
+                    insertionMetrics,
+                    true // Do nothing on conflict
+                )
 
-            for (const [commit, parentCommit] of commits) {
-                await commitInserter.insert({ repository, commit, parentCommit })
-            }
+                for (const [commit, parentCommit] of commits) {
+                    await commitInserter.insert({ repository, commit, parentCommit })
+                }
 
-            await commitInserter.flush()
-        })
+                await commitInserter.flush()
+            })
+        )
     }
 
     /**
@@ -299,6 +311,7 @@ export class XrepoDatabase {
      * @param uploadedAt The time the dump was uploaded.
      * @param packages The list of packages that this repository defines (scheme, name, and version).
      * @param references The list of packages that this repository depends on (scheme, name, and version) and the symbols that the package references.
+     * @param ctx The tracing context.
      */
     public addPackagesAndReferences(
         repository: string,
@@ -306,41 +319,45 @@ export class XrepoDatabase {
         root: string,
         uploadedAt: Date,
         packages: Package[],
-        references: SymbolReferences[]
+        references: SymbolReferences[],
+        ctx: TracingContext = {}
     ): Promise<xrepoModels.LsifDump> {
-        return this.withTransactionalEntityManager(async entityManager => {
-            const dump = await this.insertDump(repository, commit, root, uploadedAt, entityManager)
+        // TODO - break this up
+        return logAndTraceCall(ctx, 'Inserting dump', () =>
+            this.withTransactionalEntityManager(async entityManager => {
+                const dump = await this.insertDump(repository, commit, root, uploadedAt, entityManager)
 
-            const packageInserter = new TableInserter<xrepoModels.PackageModel, new () => xrepoModels.PackageModel>(
-                entityManager,
-                xrepoModels.PackageModel,
-                xrepoModels.PackageModel.BatchSize,
-                insertionMetrics,
-                true // Do nothing on conflict
-            )
+                const packageInserter = new TableInserter<xrepoModels.PackageModel, new () => xrepoModels.PackageModel>(
+                    entityManager,
+                    xrepoModels.PackageModel,
+                    xrepoModels.PackageModel.BatchSize,
+                    insertionMetrics,
+                    true // Do nothing on conflict
+                )
 
-            const referenceInserter = new TableInserter<
-                xrepoModels.ReferenceModel,
-                new () => xrepoModels.ReferenceModel
-            >(entityManager, xrepoModels.ReferenceModel, xrepoModels.ReferenceModel.BatchSize, insertionMetrics)
+                const referenceInserter = new TableInserter<
+                    xrepoModels.ReferenceModel,
+                    new () => xrepoModels.ReferenceModel
+                >(entityManager, xrepoModels.ReferenceModel, xrepoModels.ReferenceModel.BatchSize, insertionMetrics)
 
-            for (const pkg of packages) {
-                await packageInserter.insert({ dump_id: dump.id, ...pkg })
-            }
+                for (const pkg of packages) {
+                    await packageInserter.insert({ dump_id: dump.id, ...pkg })
+                }
 
-            for (const reference of references) {
-                await referenceInserter.insert({
-                    dump_id: dump.id,
-                    filter: await createFilter(reference.identifiers),
-                    ...reference.package,
-                })
-            }
+                for (const reference of references) {
+                    await referenceInserter.insert({
+                        dump_id: dump.id,
+                        filter: await createFilter(reference.identifiers),
+                        ...reference.package,
+                    })
+                }
 
-            await packageInserter.flush()
-            await referenceInserter.flush()
+                await packageInserter.flush()
+                await referenceInserter.flush()
 
-            return dump
-        })
+                return dump
+            })
+        )
     }
 
     /**
@@ -481,6 +498,7 @@ export class XrepoDatabase {
         identifier,
         limit,
         offset,
+        ctx = {},
     }: {
         /** The source repository of the search. */
         repository: string
@@ -496,6 +514,8 @@ export class XrepoDatabase {
         limit: number
         /** The number of repository records to skip. */
         offset: number
+        /** The tracing context. */
+        ctx?: TracingContext
     }): Promise<{ references: xrepoModels.ReferenceModel[]; totalCount: number; newOffset: number }> {
         // We do this inside of a transaction so that we get consistent results from multiple
         // distinct queries: one count query and one or more select queries, depending on the
@@ -532,6 +552,7 @@ export class XrepoDatabase {
                 offset,
                 limit,
                 totalCount,
+                ctx,
             })
 
             return { references, totalCount, newOffset }
@@ -556,6 +577,7 @@ export class XrepoDatabase {
         identifier,
         limit,
         offset,
+        ctx = {},
     }: {
         /** The source repository of the search. */
         repository: string
@@ -573,6 +595,8 @@ export class XrepoDatabase {
         limit: number
         /** The number of repository records to skip. */
         offset: number
+        /** The tracing context. */
+        ctx?: TracingContext
     }): Promise<{ references: xrepoModels.ReferenceModel[]; totalCount: number; newOffset: number }> {
         const visibleIdsQuery = `
             -- lineage is a recursively defined CTE that returns all ancestor an descendants
@@ -666,6 +690,7 @@ export class XrepoDatabase {
                 offset,
                 limit,
                 totalCount,
+                ctx,
             })
 
             return { references, totalCount, newOffset }
@@ -686,6 +711,7 @@ export class XrepoDatabase {
         offset,
         limit,
         totalCount,
+        ctx = {},
     }: {
         /** The function to invoke to query the next set of references. */
         getPage: (offset: number) => Promise<xrepoModels.ReferenceModel[]>
@@ -700,30 +726,47 @@ export class XrepoDatabase {
          * number of items that can be returned by `getPage` starting from offset zero.
          */
         totalCount: number
+        /** The tracing context. */
+        ctx?: TracingContext
     }): Promise<{ references: xrepoModels.ReferenceModel[]; newOffset: number }> {
-        const references: xrepoModels.ReferenceModel[] = []
-        while (references.length < limit && offset < totalCount) {
-            const page = await getPage(offset)
-            if (page.length === 0) {
-                // Shouldn't happen, but just in case of a bug we
-                // don't want this to throw up into an infinite loop.
-                break
+        return logAndTraceCall(ctx, 'Gathering references', async ctx => {
+            let numScanned = 0
+            let numFetched = 0
+            let numFiltered = 0
+            let newOffset = offset
+            const references: xrepoModels.ReferenceModel[] = []
+
+            while (references.length < limit && newOffset < totalCount) {
+                // Copy for use in the following anonymous function, otherwise the
+                // re-assignment of newOffset triggers a non-atomic update warning.
+                const localOffset = newOffset
+
+                const page = await logAndTraceCall(ctx, 'Fetching page of references', () => getPage(localOffset))
+                if (page.length === 0) {
+                    // Shouldn't happen, but just in case of a bug we
+                    // don't want this to throw up into an infinite loop.
+                    break
+                }
+
+                const { references: filtered, scanned } = await this.applyBloomFilter(
+                    page,
+                    identifier,
+                    limit - references.length
+                )
+
+                for (const reference of filtered) {
+                    references.push(reference)
+                }
+
+                newOffset += scanned
+                numScanned += scanned
+                numFetched += page.length
+                numFiltered += scanned - filtered.length
             }
 
-            const { references: filtered, scanned } = await this.applyBloomFilter(
-                page,
-                identifier,
-                limit - references.length
-            )
-
-            for (const reference of filtered) {
-                references.push(reference)
-            }
-
-            offset += scanned
-        }
-
-        return { references, newOffset: offset }
+            logSpan(ctx, 'reference_results', { numScanned, numFetched, numFiltered })
+            return { references, newOffset }
+        })
     }
 
     /**
@@ -836,7 +879,7 @@ export class XrepoDatabase {
         repository,
         commit,
         gitserverUrls,
-        ctx,
+        ctx = {},
     }: {
         /** The repository name. */
         repository: string
@@ -845,7 +888,7 @@ export class XrepoDatabase {
         /** The set of ordered gitserver urls. */
         gitserverUrls: string[]
         /** The tracing context. */
-        ctx: TracingContext
+        ctx?: TracingContext
     }): Promise<void> {
         // No need to update if we already know about this commit
         if (await this.isCommitTracked(repository, commit)) {
@@ -858,10 +901,8 @@ export class XrepoDatabase {
         }
 
         const gitserverUrl = addrFor(repository, gitserverUrls)
-        const commits = await logAndTraceCall(ctx, 'querying commits', () =>
-            getCommitsNear(gitserverUrl, repository, commit)
-        )
-        await logAndTraceCall(ctx, 'updating commits', () => this.updateCommits(repository, commits))
+        const commits = await getCommitsNear(gitserverUrl, repository, commit, ctx)
+        await this.updateCommits(repository, commits, ctx)
     }
 
     /**
@@ -874,13 +915,13 @@ export class XrepoDatabase {
      */
     public async discoverAndUpdateTips({
         gitserverUrls,
-        ctx,
+        ctx = {},
         batchSize = MAX_CONCURRENT_GITSERVER_REQUESTS,
     }: {
         /** The set of ordered gitserver urls. */
         gitserverUrls: string[]
         /** The tracing context. */
-        ctx: TracingContext
+        ctx?: TracingContext
         /** The maximum number of requests to make at once. Set during testing.*/
         batchSize?: number
     }): Promise<void> {
@@ -891,7 +932,7 @@ export class XrepoDatabase {
                 batchSize,
             })
         ).entries()) {
-            await this.updateDumpsVisibleFromTip(repository, commit)
+            await this.updateDumpsVisibleFromTip(repository, commit, ctx)
         }
     }
 
@@ -903,13 +944,13 @@ export class XrepoDatabase {
      */
     public async discoverTips({
         gitserverUrls,
-        ctx,
+        ctx = {},
         batchSize = MAX_CONCURRENT_GITSERVER_REQUESTS,
     }: {
         /** The set of ordered gitserver urls. */
         gitserverUrls: string[]
         /** The tracing context. */
-        ctx: TracingContext
+        ctx?: TracingContext
         /** The maximum number of requests to make at once. Set during testing.*/
         batchSize?: number
     }): Promise<Map<string, string>> {
@@ -921,10 +962,12 @@ export class XrepoDatabase {
         const factories: (() => Promise<{ repository: string; commit: string }>)[] = []
         for (const repository of await this.getTrackedRepositories()) {
             factories.push(async () => {
-                const lines = await gitserverExecLines(addrFor(repository, gitserverUrls), repository, [
-                    'rev-parse',
-                    'HEAD',
-                ])
+                const lines = await gitserverExecLines(
+                    addrFor(repository, gitserverUrls),
+                    repository,
+                    ['rev-parse', 'HEAD'],
+                    ctx
+                )
 
                 return { repository, commit: lines ? lines[0] : '' }
             })
@@ -933,7 +976,7 @@ export class XrepoDatabase {
         const tips = new Map<string, string>()
         for (const batch of chunk(factories, batchSize)) {
             // Perform this batch of calls to the appropriate gitserver instance
-            const responses = await logAndTraceCall(ctx, 'getting repository metadata', () =>
+            const responses = await logAndTraceCall(ctx, 'Getting repository metadata', () =>
                 Promise.all(batch.map(factory => factory()))
             )
 

--- a/lsif/src/tests/integration/xrepo/commits.test.ts
+++ b/lsif/src/tests/integration/xrepo/commits.test.ts
@@ -22,7 +22,6 @@ describe('discoverAndUpdateCommit', () => {
                 repository: 'test-repo', // hashes to gitserver1
                 commit: cc,
                 gitserverUrls: ['gitserver0', 'gitserver1', 'gitserver2'],
-                ctx: {},
             })
 
             // Ensure all commits are now tracked
@@ -53,7 +52,6 @@ describe('discoverAndUpdateCommit', () => {
                 repository: 'test-repo', // hashes to gitserver1
                 commit: cb,
                 gitserverUrls: ['gitserver0', 'gitserver1', 'gitserver2'],
-                ctx: {},
             })
         } finally {
             await cleanup()
@@ -76,7 +74,6 @@ describe('discoverAndUpdateCommit', () => {
                 repository: 'test-repo', // hashes to gitserver1
                 commit: ca,
                 gitserverUrls: ['gitserver0', 'gitserver1', 'gitserver2'],
-                ctx: {},
             })
         } finally {
             await cleanup()
@@ -113,7 +110,6 @@ describe('discoverAndUpdateTips', () => {
 
             await xrepoDatabase.discoverAndUpdateTips({
                 gitserverUrls: ['gitserver0'],
-                ctx: {},
             })
 
             const d1 = await xrepoDatabase.getDump('test-repo', ca, 'foo/test.ts')
@@ -164,7 +160,6 @@ describe('discoverTips', () => {
 
             const tips = await xrepoDatabase.discoverTips({
                 gitserverUrls: ['gitserver0', 'gitserver1', 'gitserver2'],
-                ctx: {},
                 batchSize: 5,
             })
 

--- a/lsif/src/worker/importer/importer.ts
+++ b/lsif/src/worker/importer/importer.ts
@@ -84,7 +84,7 @@ export async function importLsif(
 ): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
     // Correlate input data into in-memory maps
     const correlator = new Correlator(ctx)
-    await logAndTraceCall(ctx, 'correlating LSIF data', async () => {
+    await logAndTraceCall(ctx, 'Correlating LSIF data', async () => {
         for await (const element of readGzippedJsonElementsFromFile(path) as AsyncIterable<lsif.Vertex | lsif.Edge>) {
             correlator.insert(element)
         }
@@ -98,7 +98,7 @@ export async function importLsif(
     // reference result for each set so that we can remap all identifiers to the
     // chosen one.
 
-    const canonicalReferenceResultIds = await logAndTraceCall(ctx, 'canonicalizing reference results', () =>
+    const canonicalReferenceResultIds = await logAndTraceCall(ctx, 'Canonicalizing reference results', () =>
         canonicalizeReferenceResults(correlator)
     )
 
@@ -117,7 +117,7 @@ export async function importLsif(
     await metaInserter.flush()
 
     // Insert documents
-    await logAndTraceCall(ctx, 'populating documents', async () => {
+    await logAndTraceCall(ctx, 'Populating documents', async () => {
         const documentInserter = new TableInserter(
             entityManager,
             dumpModels.DocumentModel,
@@ -129,7 +129,7 @@ export async function importLsif(
     })
 
     // Insert result chunks
-    await logAndTraceCall(ctx, 'populating result chunks', async () => {
+    await logAndTraceCall(ctx, 'Populating result chunks', async () => {
         const resultChunkInserter = new TableInserter(
             entityManager,
             dumpModels.ResultChunkModel,
@@ -141,7 +141,7 @@ export async function importLsif(
     })
 
     // Insert definitions and references
-    await logAndTraceCall(ctx, 'populating definitions and references', async () => {
+    await logAndTraceCall(ctx, 'Populating definitions and references', async () => {
         const definitionInserter = new TableInserter(
             entityManager,
             dumpModels.DefinitionModel,
@@ -636,5 +636,5 @@ function assertId<T extends lsif.Id>(id: T | undefined): T {
         return id
     }
 
-    throw new Error('id is undefined')
+    throw new Error('Id is undefined')
 }

--- a/lsif/src/worker/processors/clean-failed-jobs.ts
+++ b/lsif/src/worker/processors/clean-failed-jobs.ts
@@ -10,7 +10,7 @@ import { logAndTraceCall, TracingContext } from '../../shared/tracing'
  * than this interval during healthy operation.
  */
 export const createCleanFailedJobsProcessor = () => async (_: unknown, ctx: TracingContext): Promise<void> => {
-    await logAndTraceCall(ctx, 'cleaning failed jobs', async () => {
+    await logAndTraceCall(ctx, 'Cleaning failed jobs', async () => {
         const purgeFile = async (filename: string): Promise<void> => {
             const stat = await fs.stat(filename)
             if (Date.now() - stat.mtimeMs >= settings.FAILED_JOB_MAX_AGE) {

--- a/lsif/src/worker/processors/clean-old-jobs.ts
+++ b/lsif/src/worker/processors/clean-old-jobs.ts
@@ -15,7 +15,7 @@ export const createCleanOldJobsProcessor = (queue: Queue, logger: Logger) => asy
     _: unknown,
     ctx: TracingContext
 ): Promise<void> => {
-    const removedJobs = await logAndTraceCall(ctx, 'cleaning old jobs', () =>
+    const removedJobs = await logAndTraceCall(ctx, 'Cleaning old jobs', () =>
         Promise.all(cleanStatuses.map(status => queue.clean(settings.JOB_MAX_AGE * 1000, status)))
     )
 
@@ -23,7 +23,7 @@ export const createCleanOldJobsProcessor = (queue: Queue, logger: Logger) => asy
 
     for (const [status, count] of removedJobs.map((jobs, i) => [cleanStatuses[i], jobs.length])) {
         if (count > 0) {
-            jobLogger.debug('cleaned old jobs', { status, count })
+            jobLogger.debug('Cleaned old jobs', { status, count })
         }
     }
 }

--- a/lsif/src/worker/server.ts
+++ b/lsif/src/worker/server.ts
@@ -16,5 +16,7 @@ export function startMetricsServer(logger: Logger): void {
         res.end(promClient.register.metrics())
     })
 
-    app.listen(settings.WORKER_METRICS_PORT, () => logger.debug('listening', { port: settings.WORKER_METRICS_PORT }))
+    app.listen(settings.WORKER_METRICS_PORT, () =>
+        logger.debug('Worker metrics server listening', { port: settings.WORKER_METRICS_PORT })
+    )
 }

--- a/lsif/src/worker/worker.ts
+++ b/lsif/src/worker/worker.ts
@@ -34,7 +34,7 @@ const wrapJobProcessor = <T>(
     logger: Logger,
     tracer: Tracer | undefined
 ): ((job: Job) => Promise<void>) => async (job: Job) => {
-    logger.debug(`${type} job accepted`, { jobId: job.id })
+    logger.debug(`Accepted ${type} job`, { jobId: job.id })
 
     // Destructure arguments and injected tracing context
     const { args, tracing }: { args: T; tracing: object } = job.data
@@ -53,7 +53,8 @@ const wrapJobProcessor = <T>(
         metrics.jobDurationHistogram,
         metrics.jobDurationErrorsCounter,
         { class: type },
-        (): Promise<void> => logAndTraceCall(ctx, `${type} job`, (ctx: TracingContext) => jobProcessor(job, args, ctx))
+        (): Promise<void> =>
+            logAndTraceCall(ctx, `Running ${type} job`, (ctx: TracingContext) => jobProcessor(job, args, ctx))
     )
 }
 
@@ -128,7 +129,7 @@ const appLogger = createLogger('lsif-worker')
 
 // Launch!
 main(appLogger).catch(error => {
-    appLogger.error('failed to start process', { error })
+    appLogger.error('Failed to start process', { error })
     appLogger.on('finish', () => process.exit(1))
     appLogger.end()
 })


### PR DESCRIPTION
This PR moves all of the `logAndTraceSpan` to the "leaves" of the callstack where the work is non-trivial. This will help us better pin-point which of these atomic operations are happening too frequently or taking too long to occur. The following are logged:

- all gitserver requests
- all jobs
- all steps of importing a dump (correlation, canonicalization, insertion of docs, result chunks)
- insertion of dump/packages/references into the cross-repo database
- non-trivial cross-repo queries: closest-commit, update tips, update commits
- all public methods of database (defs, refs, hover, rangeByPosition, and monikerResults)

Previously we logged some of these, but some were collapsed into larger spans, which can hide the reason a request or job can take a long time.

This additionally adds metrics around gitserver requests.