### PR TITLE
LSIF: Prevent worker from crashing on missing input dump file

### DIFF
--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -145,12 +145,10 @@ export async function convertTestData(
 ): Promise<void> {
     // Create a filesystem read stream for the given test file. This will cover
     // the cases where `yarn test` is run from the root or from the lsif directory.
-    const input = fs.createReadStream(
-        path.join((await fs.exists('lsif')) ? 'lsif' : '', 'src/tests/integration/data', filename)
-    )
+    const fullFilename = path.join((await fs.exists('lsif')) ? 'lsif' : '', 'src/tests/integration/data', filename)
 
     const tmp = path.join(storageRoot, constants.TEMP_DIR, uuid.v4())
-    const { packages, references } = await convertLsif(input, tmp)
+    const { packages, references } = await convertLsif(fullFilename, tmp)
     const dump = await xrepoDatabase.addPackagesAndReferences(
         repository,
         commit,

--- a/lsif/src/worker/importer/importer.ts
+++ b/lsif/src/worker/importer/importer.ts
@@ -12,7 +12,7 @@ import { logAndTraceCall, TracingContext } from '../../shared/tracing'
 import { mustGet } from '../../shared/maps'
 import { Package, SymbolReferences } from '../../shared/xrepo/xrepo'
 import { readEnvInt } from '../../shared/settings'
-import {  readGzippedJsonElementsFromFile } from './input'
+import { readGzippedJsonElementsFromFile } from './input'
 import { TableInserter } from '../../shared/database/inserter'
 
 /**

--- a/lsif/src/worker/importer/importer.ts
+++ b/lsif/src/worker/importer/importer.ts
@@ -11,9 +11,8 @@ import { isEqual, uniqWith } from 'lodash'
 import { logAndTraceCall, TracingContext } from '../../shared/tracing'
 import { mustGet } from '../../shared/maps'
 import { Package, SymbolReferences } from '../../shared/xrepo/xrepo'
-import { Readable } from 'stream'
 import { readEnvInt } from '../../shared/settings'
-import { readGzippedJsonElements } from './input'
+import {  readGzippedJsonElementsFromFile } from './input'
 import { TableInserter } from '../../shared/database/inserter'
 
 /**
@@ -48,12 +47,12 @@ const MAX_NUM_RESULT_CHUNKS = readEnvInt('MAX_NUM_RESULT_CHUNKS', 1000)
  * Populate a SQLite database with the given input stream. Returns the
  * data required to populate the cross-repo database.
  *
- * @param input The input stream containing JSON-encoded LSIF data.
+ * @param path The filepath containing a gzipped compressed stream of JSON lines composing the LSIF dump.
  * @param database The filepath of the database to populate.
  * @param ctx The tracing context.
  */
 export async function convertLsif(
-    input: Readable,
+    path: string,
     database: string,
     ctx: TracingContext = {}
 ): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
@@ -63,7 +62,7 @@ export async function convertLsif(
         await connection.query('PRAGMA synchronous = OFF')
         await connection.query('PRAGMA journal_mode = OFF')
 
-        return await connection.transaction(entityManager => importLsif(entityManager, input, ctx))
+        return await connection.transaction(entityManager => importLsif(entityManager, path, ctx))
     } finally {
         await connection.close()
     }
@@ -75,18 +74,18 @@ export async function convertLsif(
  * external reference data needed to populate the cross-repo database.
  *
  * @param entityManager A transactional SQLite entity manager.
- * @param input A gzipped compressed stream of JSON lines composing the LSIF dump.
+ * @param path The filepath containing a gzipped compressed stream of JSON lines composing the LSIF dump.
  * @param ctx The tracing context.
  */
 export async function importLsif(
     entityManager: EntityManager,
-    input: Readable,
+    path: string,
     ctx: TracingContext
 ): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
     // Correlate input data into in-memory maps
     const correlator = new Correlator(ctx)
     await logAndTraceCall(ctx, 'correlating LSIF data', async () => {
-        for await (const element of readGzippedJsonElements(input) as AsyncIterable<lsif.Vertex | lsif.Edge>) {
+        for await (const element of readGzippedJsonElementsFromFile(path) as AsyncIterable<lsif.Vertex | lsif.Edge>) {
             correlator.insert(element)
         }
     })

--- a/lsif/src/worker/importer/input.ts
+++ b/lsif/src/worker/importer/input.ts
@@ -10,18 +10,8 @@ export function readGzippedJsonElementsFromFile(path: string): AsyncIterable<unk
     const input = fs.createReadStream(path)
     const piped = input.pipe(createGunzip())
 
-    // If we get an error opening or reading the file, we need to ensure that
-    // we forward the error to the readable stream that `splitLines` is consuming.
-    // If we don't register this error handler in the same tick as the call to
-    // `createReadStream`, we may miss the error. This uncaught error causes the
-    // process to crash.
-    //
-    // We should obviously like to catch this error instead and fail the single
-    // job for which that file is missing.
-    //
-    // This is a source of problems for others as well:
-    // https://stackoverflow.com/questions/17136536/is-enoent-from-fs-createreadstream-uncatchable
-
+    // Ensure we forward errors opening/reading the file to the async
+    // iterator opened below.
     input.on('error', error => piped.emit('error', error))
 
     // Create the iterable

--- a/lsif/src/worker/importer/input.ts
+++ b/lsif/src/worker/importer/input.ts
@@ -11,9 +11,9 @@ export function readGzippedJsonElementsFromFile(path: string): AsyncIterable<unk
     const piped = input.pipe(createGunzip())
 
     // If we get an error opening or reading the file, we need to ensure that
-    // we forward the error to the readable stream that splitLines is consuming.
+    // we forward the error to the readable stream that `splitLines` is consuming.
     // If we don't register this error handler in the same tick as the call to
-    // createReadStream, we may miss the error. This uncaught error causes the
+    // `createReadStream`, we may miss the error. This uncaught error causes the
     // process to crash.
     //
     // We should obviously like to catch this error instead and fail the single

--- a/lsif/src/worker/importer/input.ts
+++ b/lsif/src/worker/importer/input.ts
@@ -13,8 +13,11 @@ export function readGzippedJsonElementsFromFile(path: string): AsyncIterable<unk
     // If we get an error opening or reading the file, we need to ensure that
     // we forward the error to the readable stream that splitLines is consuming.
     // If we don't register this error handler in the same tick as the call to
-    // createReadStream, we may miss the error. This causes the process to lock
-    // up indefinitely waiting for the next line of results from the file.
+    // createReadStream, we may miss the error. This uncaught error causes the
+    // process to crash.
+    //
+    // We should obviously like to catch this error instead and fail the single
+    // job for which that file is missing.
     //
     // This is a source of problems for others as well:
     // https://stackoverflow.com/questions/17136536/is-enoent-from-fs-createreadstream-uncatchable

--- a/lsif/src/worker/processors/convert.ts
+++ b/lsif/src/worker/processors/convert.ts
@@ -26,12 +26,11 @@ export const createConvertJobProcessor = (
     ctx: TracingContext
 ): Promise<void> => {
     await logAndTraceCall(ctx, 'converting LSIF data', async (ctx: TracingContext) => {
-        const input = fs.createReadStream(filename)
         const tempFile = path.join(settings.STORAGE_ROOT, constants.TEMP_DIR, path.basename(filename))
 
         try {
             // Create database in a temp path
-            const { packages, references } = await convertLsif(input, tempFile, ctx)
+            const { packages, references } = await convertLsif(filename, tempFile, ctx)
 
             // Add packages and references to the xrepo db
             const dump = await logAndTraceCall(ctx, 'populating cross-repo database', () =>


### PR DESCRIPTION
This one took a LONG time to track down.

**Current organization**: `createReadStream` returns a `Readable` stream which is then passed to `splitLines` through two promise boundaries (`convertLsif` and `importLsif`). This means that the creation of the read stream and the use of it is NOT within the same tick.

**Current behavior**: `createReadStream` synchronously returns a `Readable` stream, which is also an event emitter. On IO error of opening the file, an error is emitted. Since this happened on a tick that occurs before `splitLines` has started, no error is caught and it crashes the process.

**New organization**: Instead of passing the readable down into `splitLines`, we pass the filename and the input functions are responsible for creating the stream. This allows us to bind to the error event in the same tick as we create it so that we can inject the error into the async iterable produced by `splitLines`.

**Current behavior**: On IO error opening the file (specifically ENOENT), we throw from `splitLines`. This causes the job to fail (rightfully) instead of the the entire process to crash (which is amateur hour).