### PR TITLE
search pagination: use a much less strict timeout for very large repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+### Fixed
+
+- The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)
+
 ### Removed
 
 ## 3.10.0


### PR DESCRIPTION
Fixes #6384

Test plan: Manually tested (this one aspect would be very hard to automatically test)