### PR TITLE
LSIF: Fix empty string bug in git log parsing.

### DIFF
--- a/lsif/src/shared/xrepo/commits.test.ts
+++ b/lsif/src/shared/xrepo/commits.test.ts
@@ -31,7 +31,7 @@ describe('getCommitsNear', () => {
 
 describe('flattenCommitParents', () => {
     it('should handle multiple commits', () => {
-        expect(flattenCommitParents(['a', 'b c', 'd e f', 'g h i j k l'])).toEqual([
+        expect(flattenCommitParents(['a', 'b c', 'd e f', 'g h i j k l', 'm '])).toEqual([
             ['a', undefined],
             ['b', 'c'],
             ['d', 'e'],
@@ -41,6 +41,7 @@ describe('flattenCommitParents', () => {
             ['g', 'j'],
             ['g', 'k'],
             ['g', 'l'],
+            ['m', undefined],
         ])
     })
 })

--- a/lsif/src/shared/xrepo/commits.test.ts
+++ b/lsif/src/shared/xrepo/commits.test.ts
@@ -31,7 +31,7 @@ describe('getCommitsNear', () => {
 
 describe('flattenCommitParents', () => {
     it('should handle multiple commits', () => {
-        expect(flattenCommitParents(['a', 'b c', 'd e f', 'g h i j k l', 'm '])).toEqual([
+        expect(flattenCommitParents(['a', 'b c', 'd e f', '', 'g h i j k l', 'm '])).toEqual([
             ['a', undefined],
             ['b', 'c'],
             ['d', 'e'],

--- a/lsif/src/shared/xrepo/commits.ts
+++ b/lsif/src/shared/xrepo/commits.ts
@@ -94,7 +94,12 @@ export async function getCommitsNear(
  */
 export function flattenCommitParents(lines: string[]): [string, string | undefined][] {
     return lines.flatMap(line => {
-        const [child, ...commits] = line.trim().split(' ')
+        const trimmed = line.trim()
+        if (trimmed === '') {
+            return []
+        }
+
+        const [child, ...commits] = trimmed.split(' ')
         if (commits.length === 0) {
             return [[child, undefined]]
         }

--- a/lsif/src/shared/xrepo/commits.ts
+++ b/lsif/src/shared/xrepo/commits.ts
@@ -88,13 +88,13 @@ export async function getCommitsNear(
  * Convert git log output into a parentage map. Each line of the input should have the
  * form `commit p1 p2 p3...`, where commits without a parent appear on a line of their
  * own. The output is a set of pairs `(child, parent)`. Commits without a parent will
- * be returend as `(child, undefined)`.
+ * be returned as `(child, undefined)`.
  *
  * @param lines The output lines of `git log`.
  */
 export function flattenCommitParents(lines: string[]): [string, string | undefined][] {
     return lines.flatMap(line => {
-        const [child, ...commits] = line.split(' ')
+        const [child, ...commits] = line.trim().split(' ')
         if (commits.length === 0) {
             return [[child, undefined]]
         }


### PR DESCRIPTION
There can be trailing whitespace in git log with '<c1> ' indicating no parent. This isn't accounted for and returns `''` rather than `undefined` causing a check constraint violation.