### PR TITLE
a8n: Use request's actor when running CampaignPlan async

### DIFF
--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -16,6 +16,7 @@ import (
 	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n/run"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -442,7 +443,8 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 			return nil, err
 		}
 	} else {
-		err := runner.Run(context.Background(), plan)
+		backgroundCtx := actor.WithActor(context.Background(), actor.FromContext(ctx))
+		err := runner.Run(backgroundCtx, plan)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes #6620 by taking the (if it's there) actor from the current requests and passing it along with the `context.Background()` we use when running a `CampaignPlan` in the background.

Both functions, `actor.FromContext` and `actor.WithActor`, are `nil`-aware, so we're safe using them like and trying to pass on the actor every time.