### PR TITLE
reword no-externalURL config alert

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -63,7 +63,7 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 func init() {
 	conf.ContributeWarning(func(c conf.Unified) (problems conf.Problems) {
 		if c.Critical.ExternalURL == "" {
-			problems = append(problems, conf.NewCriticalProblem("`externalURL` was empty and it is required to be configured for Sourcegraph to work correctly."))
+			problems = append(problems, conf.NewCriticalProblem("`externalURL` is required to be set for many features of Sourcegraph to work correctly."))
 		}
 		return problems
 	})


### PR DESCRIPTION
The intent of this wording change is to avoid implying that Sourcegraph is broken out of the box (which the previous wording implies).

Closes https://github.com/sourcegraph/sourcegraph/issues/6614

This should be cherry-picked into the 3.10 release branch.