### PR TITLE
a8n: Ignore jobs with empty diff as completed in CampaignPlan status

### DIFF
--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -1375,7 +1375,7 @@ var getCampaignPlanStatusQueryFmtstr = `
 SELECT
   COUNT(*) AS total,
   COUNT(*) FILTER (WHERE finished_at IS NULL) AS pending,
-  COUNT(*) FILTER (WHERE finished_at IS NOT NULL) AS completed,
+  COUNT(*) FILTER (WHERE finished_at IS NOT NULL AND (diff != '' OR error != '')) AS completed,
   array_agg(error) FILTER (WHERE error != '') AS errors
 FROM campaign_jobs
 WHERE %s

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -1376,12 +1376,14 @@ func testStore(db *sql.DB) func(*testing.T) {
 				},
 				{
 					jobs: []*a8n.CampaignJob{
-						// completed, no errors
+						// completed, no errors, no diff
 						{StartedAt: now, FinishedAt: now},
+						// completed, no errors, diff
+						{StartedAt: now, FinishedAt: now, Diff: "+foobar\n-barfoo"},
 					},
 					want: &a8n.BackgroundProcessStatus{
 						ProcessState:  a8n.BackgroundProcessStateCompleted,
-						Total:         1,
+						Total:         2,
 						Completed:     1,
 						Pending:       0,
 						ProcessErrors: nil,
@@ -1406,8 +1408,10 @@ func testStore(db *sql.DB) func(*testing.T) {
 						{},
 						// started (pending)
 						{StartedAt: now},
-						// completed, no errors
+						// completed, no errors, no diff
 						{StartedAt: now, FinishedAt: now},
+						// completed, no errors, diff
+						{StartedAt: now, FinishedAt: now, Diff: "+foobar\n-barfoo"},
 						// completed, error
 						{StartedAt: now, FinishedAt: now, Error: "error1"},
 						// completed, another error
@@ -1415,7 +1419,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					},
 					want: &a8n.BackgroundProcessStatus{
 						ProcessState:  a8n.BackgroundProcessStateProcessing,
-						Total:         5,
+						Total:         6,
 						Completed:     3,
 						Pending:       2,
 						ProcessErrors: []string{"error1", "error2"},


### PR DESCRIPTION
I ran into this while testing.

When 2 CampaignJobs are created for two repositories and one CampaignJob finishes successfully but has an empty diff it was counted towards the "completed" count in the `campaignPlan.status`.

From an API consumer perspective, this can be confusing since it means that this might be true:

    campaignPlan.changesets.totalCount != campaignPlan.status.completedCount

Since we already filter out changesets that have finished but have no diff, with this change the following will always be true:

    campaignPlan.changesets.totalCount == campaignPlan.status.completedCount