### PR TITLE
a8n: Enqueue CampaignJobs in goroutine to not block request

### DIFF
--- a/enterprise/pkg/a8n/run/runner.go
+++ b/enterprise/pkg/a8n/run/runner.go
@@ -155,12 +155,15 @@ func (r *Runner) Run(ctx context.Context, plan *a8n.CampaignPlan) error {
 		go worker(queue)
 	}
 
-	for _, job := range jobs {
-		r.wg.Add(1)
-		queue <- job
-	}
+	r.wg.Add(len(jobs))
 
-	close(queue)
+	go func() {
+		for _, job := range jobs {
+			queue <- job
+		}
+
+		close(queue)
+	}()
 
 	return nil
 }


### PR DESCRIPTION
This was an oversight on my part when doing #6598. (I think I failed a lot of "Concurrency in Go" tests in the past 24 hours.)

Since #6598 we have a fixed number of workers working off `CampaignJobs`. We only want to wait for their completion by calling `(&Runner).Wait`.

The previous version of the code here, though, blocked until all jobs were enqueued. And since the queue is an unbuffered channel, that might take a while since we only ever work off $num-of-workers at the same time.

This fixes what @eseliger reported [in Slack](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1573821272145900)