### PR TITLE
LSIF: Add endpoint to explicitly delete a dump.

### DIFF
--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -230,6 +230,29 @@ paths:
                 $ref: '#/components/schemas/Dump'
         '404':
           description: Not found
+    delete:
+      description: Delete an LSIF dump by its identifier.
+      tags:
+        - Dumps
+      parameters:
+        - name: repository
+          in: path
+          description: The url-encoded repository name.
+          required: true
+          example: github.com%2Fsourcegraph%2Flsif-go
+          schema:
+            type: string
+        - name: id
+          in: path
+          description: The dump identifier.
+          required: true
+          schema:
+            type: number
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: Not found
   /jobs:
     post:
       description: Immediately queue a job.

--- a/lsif/src/server/backend/backend.ts
+++ b/lsif/src/server/backend/backend.ts
@@ -136,6 +136,15 @@ export class Backend {
     }
 
     /**
+     * Delete a dump.
+     *
+     * @param dump The dump.
+     */
+    public deleteDump(dump: xrepoModels.LsifDump): Promise<void> {
+        return this.xrepoDatabase.deleteDump(dump)
+    }
+
+    /**
      * Determine if data exists for a particular document in this database.
      *
      * @param repository The repository name.

--- a/lsif/src/server/routes/dumps.ts
+++ b/lsif/src/server/routes/dumps.ts
@@ -65,5 +65,21 @@ export function createDumpRouter(backend: Backend): express.Router {
         )
     )
 
+    router.delete(
+        '/dumps/:repository/:id',
+        wrap(
+            async (req: express.Request, res: express.Response): Promise<void> => {
+                const { repository, id } = req.params
+                const dump = await backend.dump(parseInt(id, 10))
+                if (!dump || dump.repository !== decodeURIComponent(repository)) {
+                    throw Object.assign(new Error('LSIF dump not found'), { status: 404 })
+                }
+
+                await backend.deleteDump(dump)
+                res.status(204).send()
+            }
+        )
+    )
+
     return router
 }


### PR DESCRIPTION
We should allow a user to remove dumps due to incorrect uploads (and this will also enable better support for e2e tests).