### PR TITLE
Adding quickstart guide and organizing LSIF docs

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -68,6 +68,7 @@
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
                                     <li><a href="/user/code_intelligence/lsif">LSIF</a></li>
+                                    <li><a href="/user/code_intelligence/lsif_quickstart">LSIF Quickstart</a></li>
                                     <li><a href="/user/code_intelligence/lsif_in_ci">LSIF in CI</a></li>
                                     <li><a href="/user/code_intelligence/lsif_on_github">LSIF on GitHub</a></li>
                                     <li><a href="/user/code_intelligence/language_servers">Language servers</a></li>

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -68,7 +68,7 @@
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
                                     <li><a href="/user/code_intelligence/lsif">LSIF</a></li>
-                                    <li><a href="/user/code_intelligence/lsif_quickstart">LSIF Quickstart</a></li>
+                                    <li><a href="/user/code_intelligence/lsif_quickstart">LSIF quickstart</a></li>
                                     <li><a href="/user/code_intelligence/lsif_in_ci">LSIF in CI</a></li>
                                     <li><a href="/user/code_intelligence/lsif_on_github">LSIF on GitHub</a></li>
                                     <li><a href="/user/code_intelligence/language_servers">Language servers</a></li>

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -8,7 +8,7 @@
 
 ## Getting started
 
-Follow our [LSIF quickstart guide](./lsif_quickstart.md) to manually generate and upload LSIF data for your repository. After you are satisfied with the result, you can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](./lsif_in_ci.md), or using [GitHub Actions](./lsif_on_github.md).
+Follow our [LSIF quickstart guide](lsif_quickstart.md) to manually generate and upload LSIF data for your repository. After you are satisfied with the result, you can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](lsif_in_ci.md), or using [GitHub Actions](lsif_on_github.md).
 
 ## Enabling LSIF on your Sourcegraph instance
 

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -1,16 +1,16 @@
-# LSIF
+# LSIF: Fast and precise code intelligence
 
 [LSIF](https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md) is a file format for precomputed code intelligence data. It provides fast and precise code intelligence, but needs to be periodically generated and uploaded to your Sourcegraph instance. LSIF is opt-in: repositories for which you have not uploaded LSIF data will continue to use the out-of-the-box code intelligence.
 
-> LSIF is supported in Sourcegraph 3.8 and up.
+> Precise code intelligence using LSIF is supported in Sourcegraph 3.8 and up.
 
 > For users who have a language server deployed, LSIF will take priority over the language server when LSIF data exists for a repository.
 
-## Generating and uploading LSIF data
+## Getting started
 
-You can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](./lsif_in_ci.md), or using [GitHub Actions](./lsif_on_github.md).
+Follow our [LSIF quickstart guide](./lsif_quickstart.md) to manually generate and upload LSIF data for your repository. After you are satisfied with the result, you can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](./lsif_in_ci.md), or using [GitHub Actions](./lsif_on_github.md).
 
-## Enabling LSIF
+## Enabling LSIF on your Sourcegraph instance
 
 Go to your global settings at https://sourcegraph.example.com/site-admin/global-settings and enable LSIF:
 

--- a/doc/user/code_intelligence/lsif_in_ci.md
+++ b/doc/user/code_intelligence/lsif_in_ci.md
@@ -1,34 +1,20 @@
 # LSIF in continuous integration
 
-## LSIF indexers
-
-An LSIF indexer is a command line tool that analyzes your project's source code and generates a file in LSIF format containing all the definitions, references, and hover documentation in your project. That LSIF file is later uploaded to Sourcegraph to provide code intelligence.
+After walking through the [LSIF quickstart guide](./lsif_quickstart.md), add a job to your CI so code intelligence keeps up with the changes to your repository.
 
 ## Generating and uploading LSIF in CI
 
-1. Install the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) for uploading LSIF data on your CI machines.
-1. Go to https://lsif.dev to find an LSIF indexer for your language and install the command-line tool on your CI machines.
-1. Add a daily step to your CI that:
-  - Runs the LSIF indexer on a project within your repository and generates an LSIF file in the project directory (see docs for your LSIF indexer).
-  - Uploads that generated LSIF file to your Sourcegraph instance using the following command:
+### Setup your CI machines
 
-Make sure the current working directory is somewhere inside your repository, then run:
+Your CI machines will need two command-line tools installed. Depending on your build system setup, you can do this as part of the CI step, or you can add it directly to your CI machines for use by the build.
 
-```
-$ src \
-  -endpoint=https://sourcegraph.example.com \
-  lsif upload \
-  -github-token=abc... (only needed when uploading to Sourcegraph.com) \
-  -file=<LSIF file (e.g. ./cmd/dump.lsif)>
-```
+1. The [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli).
+1. The [LSIF indexer](https://lsif.dev) for your language.
 
-> If you're uploading to Sourcegraph.com, you must authenticate your upload by passing a GitHub access token with [`public_repo` scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) as `-github-token=abc...`. You can create one at https://github.com/settings/tokens
+### Add steps to your CI
 
-If successful, you'll see the following message:
-
-> Upload successful, queued for processing.
-
-If an error occurred, you'll see it in the response.
+1. **Generate the LSIF file** for a project within your repository by running the LSIF indexer in the project directory (see docs for your LSIF indexer).
+1. **[Upload that generated LSIF file](./lsif_quickstart.md#upload-the-data)** to your Sourcegraph instance.
 
 ## Recommended upload frequency
 

--- a/doc/user/code_intelligence/lsif_on_github.md
+++ b/doc/user/code_intelligence/lsif_on_github.md
@@ -1,19 +1,19 @@
 # LSIF on GitHub
 
-You can use [GitHub Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions) to index LSIF data and upload it to your Sourcegraph instance.
+You can use [GitHub Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions) to (1) generate LSIF data and (2) upload it to your Sourcegraph instance.
 
-LSIF indexing actions for each language:
+1. Actions to **Generate LSIF index data** for each language:
 
-- [Go indexer action](https://github.com/marketplace/actions/sourcegraph-go-lsif-indexer)
-- ...and more coming soon!
+    - [Go indexer action](https://github.com/marketplace/actions/sourcegraph-go-lsif-indexer)
+    - ...and more coming soon!
 
-And there is one [LSIF upload action](https://github.com/marketplace/actions/sourcegraph-lsif-uploader).
+2. Action to **[upload LSIF data](https://github.com/marketplace/actions/sourcegraph-lsif-uploader)**.
 
 ## Setup
 
 Create a [workflow file](https://help.github.com/en/github/automating-your-workflow-with-github-actions/configuring-a-workflow#creating-a-workflow-file) `.github/workflows/lsif.yaml` in your repository.
 
-The basic flow is to first generate LSIF data then upload it. Here's an example for generating LSIF data for a Go project:
+You will need configure two actions to (1) generate the LSIF data and (2) upload it to Sourcegraph. Here's an example for generating LSIF data for a Go project:
 
 ```yaml
 name: LSIF

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -1,0 +1,51 @@
+# LSIF quickstart guide
+
+This quickstart guide will walk you through installing and generating LSIF data locally on your machine, and then manually uploading the LSIF data to your Sourcegraph instance for your repository. This will let you experiment with the process locally, and test your generated LSIF data on your repository before changing your CI process.
+
+## 1. Set up your environment
+
+1. Install the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) - used for uploading LSIF data to your Sourcegraph instance.
+1. Install the LSIF indexer for your repository's language:
+     - Go to https://lsif.dev
+     - Find the LSIF indexer for your language
+     - Install the indexer as a command-line tool using the installation instructions in the indexer's README
+
+### What is an LSIF indexer?
+
+An LSIF indexer is a command line tool that analyzes your project's source code and generates a file in LSIF format containing all the definitions, references, and hover documentation in your project. That LSIF file is later uploaded to Sourcegraph to provide code intelligence.
+
+## 2. Generate the data
+
+You now need to generate the LSIF data for your repository. Each language's LSIF is unique to that language, so run the command in the _generate LSIF data_ step found in the README of the installed indexer.
+
+## 3. Upload the data
+
+For all languages, the upload step is the same. Make sure the current working directory is somewhere inside your repository, then use the Sourcegraph CLI to run:
+
+```bash
+$ src \
+  -endpoint=https://sourcegraph.example.com \
+  lsif upload \
+  -github-token=abc... (only needed when uploading to Sourcegraph.com) \
+  -file=<LSIF file (e.g. ./cmd/dump.lsif)>
+```
+
+If successful, you'll see the following message:
+
+> Upload successful, queued for processing.
+
+If an error occurred, you'll see it in the response.
+
+### Authentication
+
+If you're uploading to Sourcegraph.com, you must authenticate your upload by passing a GitHub access token with [`public_repo` scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) as `-github-token=abc...`. You can create one at https://github.com/settings/tokens
+
+## 4. Test out code intelligence
+
+Make sure you have [enabled LSIF code intelligence](lsif.md#enabling-lsif-on-your-sourcegraph-instance) on your Sourcegraph instance.
+
+Once you have successfully uploaded your LSIF data file to your Sourcegraph instance, go to your repository on Sourcegraph. You should now be able to see precise code intelligence hover tooltips on all files of the language you generated an LSIF index of.
+
+## 5. Productionize the process
+
+Now that you're happy with the code intelligence on your repository, you need to make sure that is stays up to date with your repository. This can be done by periodically generating LSIF data, and pushing it to Sourcegraph. You can either [add a step to your CI](./lsif_in_ci.md), or run it as a [GitHub Action](./lsif_on_github.md)

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -32,7 +32,8 @@ $ src \
 
 If successful, you'll see the following message:
 
-> Upload successful, queued for processing.
+> LSIF dump successfully uploaded. It will be converted asynchronously.
+> To check the status, visit <link to your Sourcegraph instance LSIF status>
 
 If an error occurred, you'll see it in the response.
 
@@ -58,4 +59,4 @@ To verify that code intelligence is coming from LSIF:
 
 ## 5. Productionize the process
 
-Now that you're happy with the code intelligence on your repository, you need to make sure that is stays up to date with your repository. This can be done by periodically generating LSIF data, and pushing it to Sourcegraph. You can either [add a step to your CI](./lsif_in_ci.md), or run it as a [GitHub Action](./lsif_on_github.md)
+Now that you're happy with the code intelligence on your repository, you need to make sure that is stays up to date with your repository. This can be done by periodically generating LSIF data, and pushing it to Sourcegraph. You can either [add a step to your CI](lsif_in_ci.md), or run it as a [GitHub Action](lsif_on_github.md)

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -26,7 +26,7 @@ For all languages, the upload step is the same. Make sure the current working di
 $ src \
   -endpoint=https://sourcegraph.example.com \
   lsif upload \
-  -github-token=abc... (only needed when uploading to Sourcegraph.com) \
+  -github-token=<token> \
   -file=<LSIF file (e.g. ./cmd/dump.lsif)>
 ```
 
@@ -44,7 +44,17 @@ If you're uploading to Sourcegraph.com, you must authenticate your upload by pas
 
 Make sure you have [enabled LSIF code intelligence](lsif.md#enabling-lsif-on-your-sourcegraph-instance) on your Sourcegraph instance.
 
-Once you have successfully uploaded your LSIF data file to your Sourcegraph instance, go to your repository on Sourcegraph. You should now be able to see precise code intelligence hover tooltips on all files of the language you generated an LSIF index of.
+Once the LSIF data is uploaded, navigate to a code file for the targeted language in the repository, or repository sub-directory LSIF was generated from. LSIF data should now be the source of hover-tooltip content and definitions for that file (presuming that LSIF data exists for that file).
+
+To verify that code intelligence is coming from LSIF:
+
+1. Open your browser's Developer Tools
+1. Click on the *Network* tab
+1. Reload the page to see all network requests logged
+1. Filter network requests by searching for `lsif`.
+
+> NOTE: We are investigating how to make it easier to verify code intelligence is coming from LSIF
+
 
 ## 5. Productionize the process
 

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -45,7 +45,7 @@ If you're uploading to Sourcegraph.com, you must authenticate your upload by pas
 
 Make sure you have [enabled LSIF code intelligence](lsif.md#enabling-lsif-on-your-sourcegraph-instance) on your Sourcegraph instance.
 
-Once the LSIF data is uploaded, navigate to a code file for the targeted language in the repository, or repository sub-directory LSIF was generated from. LSIF data should now be the source of hover-tooltip content and definitions for that file (presuming that LSIF data exists for that file).
+Once the LSIF data is uploaded, navigate to a code file for the targeted language in the repository, or repository sub-directory LSIF was generated from. LSIF data should now be the source of hover-tooltips, definitions, and references for that file (presuming that LSIF data exists for that file).
 
 To verify that code intelligence is coming from LSIF:
 
@@ -55,7 +55,6 @@ To verify that code intelligence is coming from LSIF:
 1. Filter network requests by searching for `lsif`.
 
 > NOTE: We are investigating how to make it easier to verify code intelligence is coming from LSIF
-
 
 ## 5. Productionize the process
 


### PR DESCRIPTION
I added a quickstart guide, and reorganized the content so nothing was duplicated. 