### PR TITLE
Add regression test for repohascommitafter search filter

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -698,10 +698,6 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 						continue
 					}
 
-					if ctx.Err() != nil {
-						err = errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)")
-					}
-
 					run.Error(err)
 					continue
 				}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -116,24 +116,6 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 		revspec = "HEAD"
 	}
 
-	// We resolve the revision first because some repositories unfortunately have *both* a HEAD branch
-	// and remotes/origin/HEAD -> master reference. We've only encountered this on k8s.sgdev.org (see
-	// https://github.com/sourcegraph/sourcegraph/issues/4619)
-	// and CommitCount below would fail to take into account the first line that is output:
-	//
-	//  warning: refname 'HEAD' is ambiguous.
-	//
-	// While this could theoretically be handled in CommitCount by handling the above output, it is tricky
-	// to do there because the placement of the message can come before or after the normal output and
-	// we are worried it could even be interleaved in some situations.
-	//
-	// We can remove this and pass revspec directly into CommitCount in the future if the following hold
-	// true:
-	//
-	//  - k8s.sgdev.org is fixed
-	//  - CommitCount handles the case of opt.Range == "" by treating it as "HEAD"
-	//  - We are OK with not handling these bad repositories that contain HEAD branches.
-	//
 	commitid, err := ResolveRevision(ctx, repo, nil, revspec, &ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return false, err

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -112,9 +112,36 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 	span.SetTag("RevSpec", revspec)
 	defer span.Finish()
 
+	if revspec == "" {
+		revspec = "HEAD"
+	}
+
+	// We resolve the revision first because some repositories unfortunately have *both* a HEAD branch
+	// and remotes/origin/HEAD -> master reference. We've only encountered this on k8s.sgdev.org (see
+	// https://github.com/sourcegraph/sourcegraph/issues/4619)
+	// and CommitCount below would fail to take into account the first line that is output:
+	//
+	//  warning: refname 'HEAD' is ambiguous.
+	//
+	// While this could theoretically be handled in CommitCount by handling the above output, it is tricky
+	// to do there because the placement of the message can come before or after the normal output and
+	// we are worried it could even be interleaved in some situations.
+	//
+	// We can remove this and pass revspec directly into CommitCount in the future if the following hold
+	// true:
+	//
+	//  - k8s.sgdev.org is fixed
+	//  - CommitCount handles the case of opt.Range == "" by treating it as "HEAD"
+	//  - We are OK with not handling these bad repositories that contain HEAD branches.
+	//
+	commitid, err := ResolveRevision(ctx, repo, nil, revspec, &ResolveRevisionOptions{NoEnsureRevision: true})
+	if err != nil {
+		return false, err
+	}
+
 	n, err := CommitCount(ctx, repo, CommitsOptions{
 		After: date,
-		Range: revspec,
+		Range: string(commitid),
 	})
 	return n > 0, err
 }
@@ -218,10 +245,6 @@ func CommitCount(ctx context.Context, repo gitserver.Repo, opt CommitsOptions) (
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Git: CommitCount")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
-
-	if opt.Range == "" {
-		opt.Range = "HEAD"
-	}
 
 	args, err := commitLogArgs([]string{"rev-list", "--count"}, opt)
 	if err != nil {

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -227,6 +227,10 @@ describe('Search regression test suite', () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=repohasfile:copying')
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length >= 2)
         })
+        test('Global text search (repohascommitafter:"5 years ago")', async () => {
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=repohascommitafter:"5+months+ago"+test&patternType=literal')
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length >= 10)
+        })
         test('Global text search for something with more than 1000 results and use "count:1000".', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=.+count:1000')
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -228,7 +228,9 @@ describe('Search regression test suite', () => {
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length >= 2)
         })
         test('Global text search (repohascommitafter:"5 years ago")', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=repohascommitafter:"5+months+ago"+test&patternType=literal')
+            await driver.page.goto(
+                config.sourcegraphBaseUrl + '/search?q=repohascommitafter:"5+months+ago"+test&patternType=literal'
+            )
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length >= 10)
         })
         test('Global text search for something with more than 1000 results and use "count:1000".', async () => {


### PR DESCRIPTION
This PR adds a regression test for the repohascommitafter search filter. The case for ignoring all errors is that whenever there is one, the repository is likely unaccessible/damaged. This implies the filter should skip this repository anyways. Perhaps, these errors should bubble up elsewhere or explored more in depth during 3.11.

This closes #6475.