### PR TITLE
LSIF: Do not swallow errors on upload.

### DIFF
--- a/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
@@ -20,7 +20,7 @@ func enforceAuth(w http.ResponseWriter, r *http.Request, repoName string) (error
 		}
 	}
 
-	return errors.New("Verification not supported for code host. See https://github.com/sourcegraph/sourcegraph/issues/4967"), http.StatusUnprocessableEntity
+	return errors.New("verification not supported for code host - see https://github.com/sourcegraph/sourcegraph/issues/4967"), http.StatusUnprocessableEntity
 }
 
 var githubURL = url.URL{Scheme: "https", Host: "api.github.com"}

--- a/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
@@ -29,25 +29,25 @@ func enforceAuthGithub(w http.ResponseWriter, r *http.Request, repoName string) 
 	nameWithOwner := strings.TrimPrefix(repoName, "github.com/")
 	owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 	if err != nil {
-		return errors.New("Invalid GitHub repository: nameWithOwner=" + nameWithOwner), http.StatusNotFound
+		return errors.New("invalid GitHub repository: nameWithOwner=" + nameWithOwner), http.StatusNotFound
 	}
 
 	q := r.URL.Query()
 	githubToken := q.Get("github_token")
 	if githubToken == "" {
-		return errors.New("Must provide github_token."), http.StatusUnauthorized
+		return errors.New("must provide github_token"), http.StatusUnauthorized
 	}
 
 	client := github.NewClient(&githubURL, githubToken, nil)
 	repo, err := client.GetRepository(r.Context(), owner, name)
 	if err != nil {
-		return errors.Wrap(err, "Unable to get repository permissions"), http.StatusNotFound
+		return errors.Wrap(err, "unable to get repository permissions"), http.StatusNotFound
 	}
 
 	switch repo.ViewerPermission {
 	case "ADMIN", "MAINTAIN", "WRITE":
 		return nil, 0
 	default:
-		return errors.New("You do not have write permission to the repository."), http.StatusUnauthorized
+		return errors.New("you do not have write permission to the repository"), http.StatusUnauthorized
 	}
 }

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -42,9 +42,8 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 
 		if conf.Get().LsifEnforceAuth {
 			// 🚨 SECURITY: Ensure we return before proxying to the lsif-server upload
-			// endpoint. When enforce auth is enabled we need to make sure we don't accept
-			// random uploads without verifying ownership of a repository. As this endpoint
-			// is unprotected, this can allow anonymous users to upload questionable content.
+			// endpoint. This endpoint is unprotected, so we need to make sure the user
+			// provides a valid token proving contributor access to the repository.
 			if err, status := enforceAuth(w, r, repoName); err != nil {
 				http.Error(w, err.Error(), status)
 				return

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -31,7 +31,7 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 		_, err = backend.Repos.ResolveRev(r.Context(), repo, commit)
 		if err != nil {
 			if gitserver.IsRevisionNotFound(err) {
-				http.Error(w, "Unknown commit.", http.StatusNotFound)
+				http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
 				return
 			}
 

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -41,8 +41,11 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 		}
 
 		if conf.Get().LsifEnforceAuth {
-			err, status := enforceAuth(w, r, repoName)
-			if err != nil {
+			// 🚨 SECURITY: Ensure we return before proxying to the lsif-server upload
+			// endpoint. When enforce auth is enabled we need to make sure we don't accept
+			// random uploads without verifying ownership of a repository. As this endpoint
+			// is unprotected, this can allow anonymous users to upload questionable content.
+			if err, status := enforceAuth(w, r, repoName); err != nil {
 				http.Error(w, err.Error(), status)
 				return
 			}

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -20,7 +20,7 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 		repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(repoName))
 		if err != nil {
 			if errcode.IsNotFound(err) {
-				http.Error(w, "Unknown repository.", http.StatusNotFound)
+				http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
 				return
 			}
 


### PR DESCRIPTION
We were treating all errors from GetRepo and ResolveRev as not found. This hides errors and does not give us anything to diagnose actual issues (input or backend).