### PR TITLE
a8n: Correctly use `git apply` with prefix-less unified diffs

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -87,7 +87,8 @@ func (s *Server) handleCreateCommitFromPatch(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "apply", "--cached")
+	applyArgs := append([]string{"apply", "--cached"}, req.GitApplyArgs...)
+	cmd = exec.CommandContext(ctx, "git", applyArgs...)
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(cmd.Env, tmpGitPathEnv, altObjectsEnv)
 	cmd.Stdin = strings.NewReader(req.Patch)

--- a/enterprise/pkg/a8n/run/campaign_type.go
+++ b/enterprise/pkg/a8n/run/campaign_type.go
@@ -143,7 +143,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 			result.WriteRune('\n')
 		}
 
-		header := fmt.Sprintf("diff a/%s b/%s\n", parsed.OrigName, parsed.NewName)
+		header := fmt.Sprintf("diff %s %s\n", parsed.OrigName, parsed.NewName)
 		result.WriteString(header)
 		result.WriteString(raw.Diff)
 	}

--- a/enterprise/pkg/a8n/run/campaign_type_test.go
+++ b/enterprise/pkg/a8n/run/campaign_type_test.go
@@ -46,7 +46,7 @@ func TestCampaignType_Comby(t *testing.T) {
 
 				fmt.Fprintln(w, combyJsonLineDiffs[0])
 			},
-			wantDiff: `diff a/file1.txt b/file1.txt
+			wantDiff: `diff file1.txt file1.txt
 --- file1.txt
 +++ file1.txt
 @@ -1,3 +1,3 @@
@@ -71,7 +71,7 @@ func TestCampaignType_Comby(t *testing.T) {
 				fmt.Fprintln(w, combyJsonLineDiffs[0])
 				fmt.Fprintln(w, combyJsonLineDiffs[1])
 			},
-			wantDiff: `diff a/file1.txt b/file1.txt
+			wantDiff: `diff file1.txt file1.txt
 --- file1.txt
 +++ file1.txt
 @@ -1,3 +1,3 @@
@@ -79,7 +79,7 @@ func TestCampaignType_Comby(t *testing.T) {
 -file1-line2
 +file1-lineFOO
  file1-line3
-diff a/file2.txt b/file2.txt
+diff file2.txt file2.txt
 --- file2.txt
 +++ file2.txt
 @@ -1,3 +1,3 @@

--- a/enterprise/pkg/a8n/service.go
+++ b/enterprise/pkg/a8n/service.go
@@ -165,7 +165,11 @@ func (s *Service) runChangesetJob(
 			AuthorEmail: "automation@sourcegraph.com",
 			Date:        job.StartedAt,
 		},
-		Push: true,
+		// We use unified diffs, not git diffs, which means they're missing the
+		// `a/` and `/b` filename prefixes. `-p0` tells `git apply` to not
+		// expect and strip prefixes.
+		GitApplyArgs: []string{"-p0"},
+		Push:         true,
 	})
 
 	if err != nil {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -142,6 +142,9 @@ type CreateCommitFromPatchRequest struct {
 	CommitInfo PatchCommitInfo
 	// Push specifies whether the target ref will be pushed to the code host
 	Push bool
+	// GitApplyArgs are the arguments that will be passed to `git apply` along
+	// with `--cached`.
+	GitApplyArgs []string
 }
 
 // PatchCommitInfo will be used for commit information when creating a commit from a patch


### PR DESCRIPTION
Related issue: #6625. This fixes the problem for _some_ repositories.

When using `-p0` with `git apply` a lot of the diffs that previously couldn't be applied can now be applied. (There are still some diffs that can't be applied that I'll investigate next.)

It does this by allowing clients to pass arbitrary arguments to `git apply`, since I didn't want to hardcode `-p0` and break existing behavior.

To keep things consistent I also removed the manually added `a/` and `/b` prefixes from the "extended header" line that we inject when constructing the multi-file diffs.