### PR TITLE
LSIF: Use client for LSIF uploads (replace reverse proxy)

### DIFF
--- a/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/auth.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -9,45 +10,51 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
 
-func enforceAuth(w http.ResponseWriter, r *http.Request, repoName string) (error, int) {
-	validatorByCodeHost := map[string]func(http.ResponseWriter, *http.Request, string) (error, int){
+func enforceAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) bool {
+	validatorByCodeHost := map[string]func(context.Context, http.ResponseWriter, *http.Request, string) (int, error){
 		"github.com": enforceAuthGithub,
 	}
 
 	for codeHost, validator := range validatorByCodeHost {
 		if strings.HasPrefix(repoName, codeHost) {
-			return validator(w, r, repoName)
+			if status, err := validator(ctx, w, r, repoName); err != nil {
+				http.Error(w, err.Error(), status)
+				return false
+			}
+
+			return true
 		}
 	}
 
-	return errors.New("verification not supported for code host - see https://github.com/sourcegraph/sourcegraph/issues/4967"), http.StatusUnprocessableEntity
+	http.Error(w, "verification not supported for code host - see https://github.com/sourcegraph/sourcegraph/issues/4967", http.StatusUnprocessableEntity)
+	return false
 }
 
 var githubURL = url.URL{Scheme: "https", Host: "api.github.com"}
 
-func enforceAuthGithub(w http.ResponseWriter, r *http.Request, repoName string) (error, int) {
+func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error) {
 	nameWithOwner := strings.TrimPrefix(repoName, "github.com/")
 	owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 	if err != nil {
-		return errors.New("invalid GitHub repository: nameWithOwner=" + nameWithOwner), http.StatusNotFound
+		return http.StatusNotFound, errors.New("invalid GitHub repository: nameWithOwner=" + nameWithOwner)
 	}
 
 	q := r.URL.Query()
 	githubToken := q.Get("github_token")
 	if githubToken == "" {
-		return errors.New("must provide github_token"), http.StatusUnauthorized
+		return http.StatusUnauthorized, errors.New("must provide github_token")
 	}
 
 	client := github.NewClient(&githubURL, githubToken, nil)
-	repo, err := client.GetRepository(r.Context(), owner, name)
+	repo, err := client.GetRepository(ctx, owner, name)
 	if err != nil {
-		return errors.Wrap(err, "unable to get repository permissions"), http.StatusNotFound
+		return http.StatusNotFound, errors.Wrap(err, "unable to get repository permissions")
 	}
 
 	switch repo.ViewerPermission {
 	case "ADMIN", "MAINTAIN", "WRITE":
-		return nil, 0
+		return 0, nil
 	default:
-		return errors.New("you do not have write permission to the repository"), http.StatusUnauthorized
+		return http.StatusUnauthorized, errors.New("you do not have write permission to the repository")
 	}
 }

--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -1,11 +1,14 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/codeintel/lsifserver/client"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -17,40 +20,57 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 		q := r.URL.Query()
 		repoName := q.Get("repository")
 		commit := q.Get("commit")
+		ctx := r.Context()
 
-		repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(repoName))
+		if !ensureRepoAndCommitExist(ctx, w, repoName, commit) {
+			return
+		}
+
+		// 🚨 SECURITY: Ensure we return before proxying to the lsif-server upload
+		// endpoint. This endpoint is unprotected, so we need to make sure the user
+		// provides a valid token proving contributor access to the repository.
+		if conf.Get().LsifEnforceAuth && !enforceAuth(ctx, w, r, repoName) {
+			return
+		}
+
+		resp, err := client.BuildAndTraceRequest(
+			ctx,
+			"POST",
+			"/upload",
+			r.URL.Query(),
+			r.Body,
+		)
 		if err != nil {
-			if errcode.IsNotFound(err) {
-				http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
-				return
-			}
-
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		_, err = backend.Repos.ResolveRev(r.Context(), repo, commit)
-		if err != nil {
-			if gitserver.IsRevisionNotFound(err) {
-				http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
-				return
-			}
-
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if conf.Get().LsifEnforceAuth {
-			// 🚨 SECURITY: Ensure we return before proxying to the lsif-server upload
-			// endpoint. This endpoint is unprotected, so we need to make sure the user
-			// provides a valid token proving contributor access to the repository.
-			if err, status := enforceAuth(w, r, repoName); err != nil {
-				http.Error(w, err.Error(), status)
-				return
-			}
-		}
-
-		r.URL.Path = "upload"
-		p.ServeHTTP(w, r)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
 	}
+}
+
+func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) bool {
+	repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
+			return false
+		}
+
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return false
+	}
+
+	if _, err := backend.Repos.ResolveRev(ctx, repo, commit); err != nil {
+		if gitserver.IsRevisionNotFound(err) {
+			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
+			return false
+		}
+
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return false
+	}
+
+	return true
 }

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -86,7 +86,7 @@ export function createLsifRouter(
             validation.validateOptionalInt('maxWait'),
         ]),
         wrap(
-            async (req: express.Request & { span?: Span }, res: express.Response): Promise<void> => {
+            async (req: express.Request, res: express.Response): Promise<void> => {
                 const { repository, commit, root: rootRaw, blocking, maxWait }: UploadQueryArgs = req.query
                 const root = sanitizeRoot(rootRaw)
                 const ctx = createTracingContext(req, { repository, commit, root })


### PR DESCRIPTION
Using the client will give us a consistent place to get tracing and metrics. This PR:

- replaces reverse proxy with a call to the lsif-server client package
- threads the correct context through enforce auth and gitserver calls