### PR TITLE
LSIF: Add method and body to lsif-server client.

### DIFF
--- a/enterprise/pkg/codeintel/lsifserver/client/client.go
+++ b/enterprise/pkg/codeintel/lsifserver/client/client.go
@@ -24,20 +24,20 @@ var httpClient = &http.Client{
 
 // BuildAndTraceRequest builds a URL and performs a request. This is a convenience wrapper
 // around BuildURL and TraceRequest.
-func BuildAndTraceRequest(ctx context.Context, path string, query url.Values) (*http.Response, error) {
+func BuildAndTraceRequest(ctx context.Context, method, path string, query url.Values, body io.ReadCloser) (*http.Response, error) {
 	url, err := buildURL(path, query)
 	if err != nil {
 		return nil, err
 	}
 
-	return traceRequest(ctx, url)
+	return traceRequest(ctx, method, url, body)
 }
 
 // TraceRequestAndUnmarshalPayload builds a URL, performs a request, and populates
 // the given payload with the response body. This is a convenience wrapper around
 // BuildURL, TraceRequest, and UnmarshalPayload.
-func TraceRequestAndUnmarshalPayload(ctx context.Context, path string, query url.Values, payload interface{}) error {
-	resp, err := BuildAndTraceRequest(ctx, path, query)
+func TraceRequestAndUnmarshalPayload(ctx context.Context, method, path string, query url.Values, body io.ReadCloser, payload interface{}) error {
+	resp, err := BuildAndTraceRequest(ctx, method, path, query, body)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func traceRequest(ctx context.Context, url string) (resp *http.Response, err err
 		tr.Finish()
 	}()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return
 	}

--- a/enterprise/pkg/codeintel/lsifserver/client/client.go
+++ b/enterprise/pkg/codeintel/lsifserver/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -85,7 +86,7 @@ func buildURL(path string, query url.Values) (string, error) {
 // traceRequest performs a GET request to the given URL with the given context. The
 // response is expected to have a 200-level status code. If an error is returned, the
 // HTTP response body has been closed.
-func traceRequest(ctx context.Context, url string) (resp *http.Response, err error) {
+func traceRequest(ctx context.Context, method, url string, body io.ReadCloser) (resp *http.Response, err error) {
 	tr, ctx := trace.New(ctx, "lsifRequest", fmt.Sprintf("url: %s", url))
 	defer func() {
 		tr.SetError(err)
@@ -120,12 +121,12 @@ func traceRequest(ctx context.Context, url string) (resp *http.Response, err err
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}
 
-	err = errors.WithStack(&lsifError{StatusCode: resp.StatusCode, Message: string(body)})
+	err = errors.WithStack(&lsifError{StatusCode: resp.StatusCode, Message: string(content)})
 	return
 }
 

--- a/enterprise/pkg/codeintel/resolvers/dump.go
+++ b/enterprise/pkg/codeintel/resolvers/dump.go
@@ -140,7 +140,7 @@ func (r *lsifDumpConnectionResolver) compute(ctx context.Context) ([]*lsif.LSIFD
 			query.Set("limit", strconv.FormatInt(int64(*r.opt.Limit), 10))
 		}
 
-		resp, err := client.BuildAndTraceRequest(ctx, path, query)
+		resp, err := client.BuildAndTraceRequest(ctx, "GET", path, query, nil)
 		if err != nil {
 			r.err = err
 			return

--- a/enterprise/pkg/codeintel/resolvers/job.go
+++ b/enterprise/pkg/codeintel/resolvers/job.go
@@ -156,7 +156,7 @@ func (r *lsifJobConnectionResolver) compute(ctx context.Context) ([]*lsif.LSIFJo
 			query.Set("limit", strconv.FormatInt(int64(*r.opt.Limit), 10))
 		}
 
-		resp, err := client.BuildAndTraceRequest(ctx, path, query)
+		resp, err := client.BuildAndTraceRequest(ctx, "GET", path, query, nil)
 		if err != nil {
 			r.err = err
 			return

--- a/enterprise/pkg/codeintel/resolvers/resolver.go
+++ b/enterprise/pkg/codeintel/resolvers/resolver.go
@@ -39,7 +39,7 @@ func (r *Resolver) LSIFDumpByGQLID(ctx context.Context, id graphql.ID) (graphqlb
 	path := fmt.Sprintf("/dumps/%s/%d", url.PathEscape(repoName), dumpID)
 
 	var lsifDump *lsif.LSIFDump
-	if err := client.TraceRequestAndUnmarshalPayload(ctx, path, nil, &lsifDump); err != nil {
+	if err := client.TraceRequestAndUnmarshalPayload(ctx, "GET", path, nil, nil, &lsifDump); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func (r *Resolver) LSIFJobByGQLID(ctx context.Context, id graphql.ID) (graphqlba
 	path := fmt.Sprintf("/jobs/%s", url.PathEscape(jobID))
 
 	var lsifJob *lsif.LSIFJob
-	if err := client.TraceRequestAndUnmarshalPayload(ctx, path, nil, &lsifJob); err != nil {
+	if err := client.TraceRequestAndUnmarshalPayload(ctx, "GET", path, nil, nil, &lsifJob); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func (r *Resolver) LSIFJobStatsByGQLID(ctx context.Context, id graphql.ID) (grap
 	}
 
 	var stats *lsif.LSIFJobStats
-	if err := client.TraceRequestAndUnmarshalPayload(ctx, "/jobs/stats", nil, &stats); err != nil {
+	if err := client.TraceRequestAndUnmarshalPayload(ctx, "GET", "/jobs/stats", nil, nil, &stats); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
All HTTP methods for the lsif-server were previously GET requests. We will need to expand this in the future to handle upload and LSP-request requests.