### PR TITLE
Update comby in Dockerfiles to 0.11.1

### DIFF
--- a/cmd/replacer/Dockerfile
+++ b/cmd/replacer/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add pcre
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.11.0@sha256:839ba09b1e23e5d1688aa6e43fc69c5d3df79f08fe6cf2a3acbe484c94eab986 /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.11.1@sha256:03c6aa9621d176c5efbcf1128fbc95e721b219c89750a2c6bcd151deaac79d6b /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add pcre
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.11.0@sha256:839ba09b1e23e5d1688aa6e43fc69c5d3df79f08fe6cf2a3acbe484c94eab986 /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.11.1@sha256:03c6aa9621d176c5efbcf1128fbc95e721b219c89750a2c6bcd151deaac79d6b /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -50,7 +50,7 @@ RUN apk update && apk add --no-cache \
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
 # have been appropriately set in cmd/server/shared/shared.go.
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.11.0@sha256:839ba09b1e23e5d1688aa6e43fc69c5d3df79f08fe6cf2a3acbe484c94eab986 /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.11.1@sha256:03c6aa9621d176c5efbcf1128fbc95e721b219c89750a2c6bcd151deaac79d6b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88 /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/


### PR DESCRIPTION
This is the follow-up to bbd72479 and updates Comby from 0.11.0 to 0.11.1 in the Dockerfiles. This fixes large parts of #6625 for Automation features in 3.10.

More context [in this Slack thread](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1573830311154300).

@beyang It would be great if https://github.com/sourcegraph/sourcegraph/commit/bbd724791ed8e1ed88c8544cbb2b126dd496b6a6 along with *this PR* could be cherry-picked into the release branch.
