### PR TITLE
doc: update pricing docs to reflect active user model

### DIFF
--- a/doc/admin/subscriptions/index.md
+++ b/doc/admin/subscriptions/index.md
@@ -2,23 +2,34 @@
 
 > NOTE: Sourcegraph is [open source](https://github.com/sourcegraph/sourcegraph). Pricing documentation below applies to [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).
 
-Organizations using Sourcegraph can [upgrade to Sourcegraph Enterprise](https://about.sourcegraph.com/pricing) to get the features that large organizations need (single sign-on, backups and recovery, cluster deployment, etc.). These additional features in Sourcegraph Enterprise are paid and not open source.
+Organizations using Sourcegraph can [upgrade to Sourcegraph Enterprise](https://about.sourcegraph.com/pricing) to get the features that large organizations need (single sign-on, backups and recovery, cluster deployment, access to code navigation and intelligence and other Sourcegraph extensions, etc.). These additional features in Sourcegraph Enterprise are paid and not open source.
 
-You can [buy a subscription](https://sourcegraph.com/subscriptions/new) on Sourcegraph.com. This entitles you to a license key (immediately generated after purchase), which activates Enterprise features on your Sourcegraph instance.
+You can [contact Sourcegraph](https://about.sourcegraph.com/contact/sales) to purchase a subscription. This entitles you to a license key (provided immediately after your purchase), which activates Enterprise features on your Sourcegraph instance.
 
 ## Volume discounts
 
 [Contact us](https://about.sourcegraph.com/contact) to ask about volume discounts for Sourcegraph Enterprise. 
 
-## True-up pricing
+## How active users are counted
 
-When you purchase a new Sourcegraph Enterprise license, you select and pay for a number of users. [Like GitLab, Sourcegraph offers true-up pricing](https://about.gitlab.com/handbook/product/pricing/#true-up-pricing), which means the license is never blocking user growth.
+[Sourcegraph's pricing](https://about.sourcegraph.com/pricing) is based on **monthly active users**. This count is maintained on your Sourcegraph instance, viewable and auditable on the **Site admin > Usage statistics** page, and is reported back in aggregate to Sourcegraph.com via [pings](https://docs.sourcegraph.com/admin/pings).
 
-Instead, if you exceed the number of users on the license, Sourcegraph will true up your license at your next renewal. This means a retroactive charge for the full yearly cost of a user will be applied for the difference between the maximum number of user accounts at any given time on your instance, and the number of users on the license.
+A Sourcegraph active user is a user who visits or uses your Sourcegraph while signed in over the course of the month.
 
-If you want to prevent the retroactive charge, you can upgrade your license to cover a larger number of users at any time. This will allow you only pay for new users as they start using Sourcegraph, and not for the full previous license term.
+This includes:
+- Successfully signing in to your instance (via https://sourcegraph.example.com/sign-in).
+- Running a search on your instance.
+- Clicking a link to a page on your instance.
+- Using a Sourcegraph integration connected to your Sourcegraph instance (such as a browser extension or native code host integration) while signed in.
+- Receiving a saved search notification from your Sourcegraph instance.
 
-See your license status any time on the **Site admin > License** page. (The URL is `https://sourcegraph.example.com/site-admin/license`.)
+This does not include:
+- Viewing the sign-up page (at https://sourcegraph.example.com/sign-up) without signing up
+- Viewing the sign-in page (at https://sourcegraph.example.com/sign-in) without signing in.
+- Viewing and submitting a forgotten password form.
 
-Example Sourcegraph Enterprise license status:
-![True up pricing summary example](img/true-up-pricing-summary.png.md)
+## How user accounts are counted
+
+Some customers have contracts based on **total user accounts**, rather than on monthly active users. This count is maintained on your Sourcegraph instance, viewable and auditable on the **Site admin > Users** page, and is reported back in aggregate to Sourcegraph.com via [pings](https://docs.sourcegraph.com/admin/pings).
+
+A Sourcegraph user account is created when a user signs up or signs in for the first time. Sourcegraph user accounts can be deleted by administrators via the **Site admin > Users** page, or using the GraphQL API (including with the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli), if needed).

--- a/doc/index.md
+++ b/doc/index.md
@@ -80,7 +80,7 @@ You can use Sourcegraph in 2 ways:
 - [Self-hosted Sourcegraph](admin/install/index.md): Deploy and manage your own Sourcegraph instance.
 - [Sourcegraph.com](https://sourcegraph.com): For public code only. No signup or installation required.
 
-For self-hosted Sourcegraph instances, you run a Docker image or Kubernetes cluster on-premises or on your preferred cloud provider. There are [2 tiers](https://about.sourcegraph.com/pricing): Core (free) and Enterprise. Enterprise features require a [Sourcegraph subscription](https://sourcegraph.com/subscriptions/new).
+For self-hosted Sourcegraph instances, you run a Docker image or Kubernetes cluster on-premises or on your preferred cloud provider. There are [2 tiers](https://about.sourcegraph.com/pricing): Core (free) and Enterprise. Enterprise features require a [Sourcegraph subscription](https://about.sourcegraph.com/contact/sales).
 
 ## Other links
 

--- a/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -120,7 +120,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                                     </div>
                                     <div className="text-nowrap flex-wrap-reverse">
                                         <a
-                                            href="http://sourcegraph.com/subscriptions/new"
+                                            href="http://about.sourcegraph.com/contact/sales"
                                             className="btn btn-primary btn-sm"
                                             // eslint-disable-next-line react/jsx-no-target-blank
                                             target="_blank"


### PR DESCRIPTION
Updates our pricing documentation page to reflect the active user model. Also removes links to to the purchase online page (which is fine to leave up for now, but metered billing needs to be implemented for us to switch it to the MAU pricing model).