### PR TITLE
LSIF: Update batch sizes for non-sqlite models.

### DIFF
--- a/lsif/src/shared/constants.ts
+++ b/lsif/src/shared/constants.ts
@@ -14,6 +14,11 @@ export const TEMP_DIR = 'temp'
 export const UPLOADS_DIR = 'uploads'
 
 /**
+ * The maximum number of rows to bulk insert in Postgres.
+ */
+export const MAX_POSTGRES_BATCH_SIZE = 5000
+
+/**
  * The maximum number of commits to visit breadth-first style when when finding
  * the closest commit.
  */

--- a/lsif/src/shared/models/dump.ts
+++ b/lsif/src/shared/models/dump.ts
@@ -1,6 +1,6 @@
 import * as lsif from 'lsif-protocol'
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm'
-import { getBatchSize } from './util'
+import { MAX_POSTGRES_BATCH_SIZE } from '../constants'
 
 export type DocumentId = lsif.Id
 export type DocumentPath = string
@@ -33,7 +33,7 @@ export class MetaModel {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(4)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * A unique ID required by typeorm entities: always zero here.
@@ -73,7 +73,7 @@ export class DocumentModel {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(2)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * The root-relative path of the document.
@@ -98,7 +98,7 @@ export class ResultChunkModel {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(2)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * The identifier of the chunk. This is also the index of the chunk during its
@@ -123,7 +123,7 @@ class Symbols {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(7)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * A unique ID required by typeorm entities.

--- a/lsif/src/shared/models/util.ts
+++ b/lsif/src/shared/models/util.ts
@@ -1,12 +1,12 @@
 /**
  * Determine the table inserter batch size for an entity given the number of
- * fields inserted for that entity. We cannot perform an insert operation with
- * more than 999 placeholder variables, so we need to flush our batch before
- * we reach that amount. If fields are added to the models, the argument to
- * this function also needs to change.
+ * fields inserted for that entity. We cannot perform an insert operation in
+ * SQLite with more than 999 placeholder variables, so we need to flush our
+ * batch before we reach that amount. If fields are added to the models, the
+ * argument to this function also needs to change.
  *
  * @param numFields The number of fields for an entity.
  */
-export function getBatchSize(numFields: number): number {
+export function calcSqliteBatchSize(numFields: number): number {
     return Math.floor(999 / numFields)
 }

--- a/lsif/src/shared/models/xrepo.ts
+++ b/lsif/src/shared/models/xrepo.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { EncodedBloomFilter } from '../xrepo/bloom-filter'
-import { getBatchSize } from './util'
+import { MAX_POSTGRES_BATCH_SIZE } from '../constants'
 
 /**
  * An entity within the cross-repo database. This tracks commit parentage and branch
@@ -11,7 +11,7 @@ export class Commit {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(3)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * A unique ID required by typeorm entities.
@@ -99,7 +99,7 @@ export class LsifDump {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(7)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 }
 
 /**
@@ -155,7 +155,7 @@ export class PackageModel extends Package {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(4)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 }
 
 /**
@@ -167,7 +167,7 @@ export class ReferenceModel extends Package {
     /**
      * The number of model instances that can be inserted at once.
      */
-    public static BatchSize = getBatchSize(6)
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 
     /**
      * A serialized bloom filter that encodes the set of symbols that this repository


### PR DESCRIPTION
Postgres does not have the limit SQLite does on insertion variables. Hard-code this to something that's not dependent on the model size.