### PR TITLE
LSIF: Split PostgresLocker into its own package.

### DIFF
--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -55,7 +55,7 @@ async function main(logger: Logger): Promise<void> {
 
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const xrepoDatabase = new XrepoDatabase(settings.STORAGE_ROOT, connection)
+    const xrepoDatabase = new XrepoDatabase(connection, settings.STORAGE_ROOT)
     const backend = new Backend(settings.STORAGE_ROOT, xrepoDatabase, fetchConfiguration)
 
     // Temporary migrations

--- a/lsif/src/shared/database/metrics.ts
+++ b/lsif/src/shared/database/metrics.ts
@@ -1,0 +1,15 @@
+import promClient from 'prom-client'
+
+//
+// Query Metrics
+
+export const xrepoQueryDurationHistogram = new promClient.Histogram({
+    name: 'lsif_xrepo_query_duration_seconds',
+    help: 'Total time spent on cross-repo database queries.',
+    buckets: [0.2, 0.5, 1, 2, 5, 10, 30],
+})
+
+export const xrepoQueryErrorsCounter = new promClient.Counter({
+    name: 'lsif_xrepo_query_errors_total',
+    help: 'The number of errors that occurred during a cross-repo database query.',
+})

--- a/lsif/src/shared/database/postgres.ts
+++ b/lsif/src/shared/database/postgres.ts
@@ -166,7 +166,7 @@ async function getMigrationVersion(connection: Connection): Promise<string> {
 }
 
 /**
- * Instrument `callback` with Postgres histogrom and error counter.
+ * Instrument `callback` with Postgres query histogram and error counter.
  *
  * @param callback The function invoke with the connection.
  */

--- a/lsif/src/shared/database/postgres.ts
+++ b/lsif/src/shared/database/postgres.ts
@@ -1,13 +1,13 @@
-import * as metrics from './metrics';
-import * as xrepoModels from '../models/xrepo';
-import pRetry from 'p-retry';
-import { Configuration } from '../config/config';
-import { Connection, createConnection as _createConnection, EntityManager } from 'typeorm';
-import { instrument } from '../metrics';
-import { Logger } from 'winston';
-import { PostgresConnectionCredentialsOptions } from 'typeorm/driver/postgres/PostgresConnectionCredentialsOptions';
-import { readEnvInt } from '../settings';
-import { TlsOptions } from 'tls';
+import * as metrics from './metrics'
+import * as xrepoModels from '../models/xrepo'
+import pRetry from 'p-retry'
+import { Configuration } from '../config/config'
+import { Connection, createConnection as _createConnection, EntityManager } from 'typeorm'
+import { instrument } from '../metrics'
+import { Logger } from 'winston'
+import { PostgresConnectionCredentialsOptions } from 'typeorm/driver/postgres/PostgresConnectionCredentialsOptions'
+import { readEnvInt } from '../settings'
+import { TlsOptions } from 'tls'
 
 /**
  * The minimum migration version required by this instance of the LSIF process.
@@ -168,9 +168,9 @@ async function getMigrationVersion(connection: Connection): Promise<string> {
 /**
  * A wrapper around a Postgres database.
  */
-export abstract class PostgresDataManager {
+export abstract class PostgresManager {
     /**
-     * Create a new `PostgresDataManager` backed by the given database connection.
+     * Create a new `PostgresManager` backed by the given database connection.
      *
      * @param connection The Postgres connection.
      */

--- a/lsif/src/shared/locker/locker.ts
+++ b/lsif/src/shared/locker/locker.ts
@@ -1,0 +1,62 @@
+import * as crc32 from 'crc-32'
+import { ADVISORY_LOCK_ID_SALT } from '../constants'
+import { PostgresManager } from '../database/postgres'
+
+/**
+ * A wrapper around Postgres advisory locks.
+ */
+export class PostgresLocker extends PostgresManager {
+    /**
+     * Hold a Postgres advisory lock while executing the given function.
+     *
+     * @param locker The Postgres locker instance.
+     * @param name The name of the lock.
+     * @param f The function to execute while holding the lock.
+     */
+    public async withLock<T>(name: string, f: () => Promise<T>): Promise<T> {
+        await this.lock(name)
+        try {
+            return await f()
+        } finally {
+            await this.unlock(name)
+        }
+    }
+
+    /**
+     * Acquire an advisory lock with the given name. This will block until the lock can be
+     * acquired.
+     *
+     * See https://www.postgresql.org/docs/9.6/static/explicit-locking.html#ADVISORY-LOCKS.
+     *
+     * @param name The lock name.
+     */
+    private lock(name: string): Promise<void> {
+        return this.withConnection(connection =>
+            connection.query('SELECT pg_advisory_lock($1)', [this.generateLockId(name)])
+        )
+    }
+
+    /**
+     * Release an advisory lock acquired by `lock`.
+     *
+     * @param name The lock name.
+     */
+    private unlock(name: string): Promise<void> {
+        return this.withConnection(connection =>
+            connection.query('SELECT pg_advisory_unlock($1)', [this.generateLockId(name)])
+        )
+    }
+
+    /**
+     * Generate an advisory lock identifier from the given name and application salt. This is
+     * based on golang-migrate's advisory lock identifier generation technique, which is in turn
+     * inspired by rails migrations.
+     *
+     * See https://github.com/golang-migrate/migrate/blob/6c96ef02dfbf9430f7286b58afc15718588f2e13/database/util.go#L12.
+     *
+     * @param name The lock name.
+     */
+    private generateLockId(name: string): number {
+        return crc32.str(name) * ADVISORY_LOCK_ID_SALT
+    }
+}

--- a/lsif/src/shared/locker/locker.ts
+++ b/lsif/src/shared/locker/locker.ts
@@ -1,62 +1,34 @@
 import * as crc32 from 'crc-32'
 import { ADVISORY_LOCK_ID_SALT } from '../constants'
-import { PostgresManager } from '../database/postgres'
+import { Connection } from 'typeorm'
+import { instrumentQuery } from '../database/postgres'
 
 /**
- * A wrapper around Postgres advisory locks.
+ * Hold a Postgres advisory lock while executing the given function. We base our advisory lock
+ * identifier generation technique on golang-migrate. Note that acquiring an advisory lock is
+ * an (indefinitely) blocking operation.
+ *
+ * For more information, see
+ * https://www.postgresql.org/docs/9.6/static/explicit-locking.html#ADVISORY-LOCKS, and
+ * https://github.com/golang-migrate/migrate/blob/6c96ef02dfbf9430f7286b58afc15718588f2e13/database/util.go#L12.
+ *
+ * @param connection The Postgres connection.
+ * @param name The name of the lock.
+ * @param f The function to execute while holding the lock.
  */
-export class PostgresLocker extends PostgresManager {
-    /**
-     * Hold a Postgres advisory lock while executing the given function.
-     *
-     * @param locker The Postgres locker instance.
-     * @param name The name of the lock.
-     * @param f The function to execute while holding the lock.
-     */
-    public async withLock<T>(name: string, f: () => Promise<T>): Promise<T> {
-        await this.lock(name)
-        try {
-            return await f()
-        } finally {
-            await this.unlock(name)
-        }
-    }
+export async function withLock<T>(connection: Connection, name: string, f: () => Promise<T>): Promise<T> {
+    // Create an integer identifier that will be unique to this app, but
+    // will always be the same for this given name within the application.
+    const lockId = crc32.str(name) * ADVISORY_LOCK_ID_SALT
 
-    /**
-     * Acquire an advisory lock with the given name. This will block until the lock can be
-     * acquired.
-     *
-     * See https://www.postgresql.org/docs/9.6/static/explicit-locking.html#ADVISORY-LOCKS.
-     *
-     * @param name The lock name.
-     */
-    private lock(name: string): Promise<void> {
-        return this.withConnection(connection =>
-            connection.query('SELECT pg_advisory_lock($1)', [this.generateLockId(name)])
-        )
-    }
+    // Acquire lock
+    await instrumentQuery(() => connection.query('SELECT pg_advisory_lock($1)', [lockId]))
 
-    /**
-     * Release an advisory lock acquired by `lock`.
-     *
-     * @param name The lock name.
-     */
-    private unlock(name: string): Promise<void> {
-        return this.withConnection(connection =>
-            connection.query('SELECT pg_advisory_unlock($1)', [this.generateLockId(name)])
-        )
-    }
-
-    /**
-     * Generate an advisory lock identifier from the given name and application salt. This is
-     * based on golang-migrate's advisory lock identifier generation technique, which is in turn
-     * inspired by rails migrations.
-     *
-     * See https://github.com/golang-migrate/migrate/blob/6c96ef02dfbf9430f7286b58afc15718588f2e13/database/util.go#L12.
-     *
-     * @param name The lock name.
-     */
-    private generateLockId(name: string): number {
-        return crc32.str(name) * ADVISORY_LOCK_ID_SALT
+    try {
+        // Critical section
+        return await f()
+    } finally {
+        // Release lock
+        await instrumentQuery(() => connection.query('SELECT pg_advisory_unlock($1)', [lockId]))
     }
 }

--- a/lsif/src/shared/xrepo/metrics.ts
+++ b/lsif/src/shared/xrepo/metrics.ts
@@ -1,20 +1,6 @@
 import promClient from 'prom-client'
 
 //
-// Query Metrics
-
-export const xrepoQueryDurationHistogram = new promClient.Histogram({
-    name: 'lsif_xrepo_query_duration_seconds',
-    help: 'Total time spent on cross-repo database queries.',
-    buckets: [0.2, 0.5, 1, 2, 5, 10, 30],
-})
-
-export const xrepoQueryErrorsCounter = new promClient.Counter({
-    name: 'lsif_xrepo_query_errors_total',
-    help: 'The number of errors that occurred during a cross-repo database query.',
-})
-
-//
 // Insertion Metrics
 
 export const xrepoInsertionDurationHistogram = new promClient.Histogram({

--- a/lsif/src/shared/xrepo/xrepo.ts
+++ b/lsif/src/shared/xrepo/xrepo.ts
@@ -9,7 +9,7 @@ import { chunk } from 'lodash'
 import { createFilter, testFilter } from './bloom-filter'
 import { dbFilename, tryDeleteFile } from '../paths'
 import { logAndTraceCall, logSpan, TracingContext } from '../tracing'
-import { PostgresDataManager } from '../database/postgres'
+import { PostgresManager } from '../database/postgres'
 import { TableInserter } from '../database/inserter'
 
 /**
@@ -60,7 +60,7 @@ export interface SymbolReferences {
 /**
  * A wrapper around Postgres advisory locks.
  */
-export class PostgresLocker extends PostgresDataManager {
+export class PostgresLocker extends PostgresManager {
     /**
      * Hold a Postgres advisory lock while executing the given function.
      *
@@ -121,7 +121,7 @@ export class PostgresLocker extends PostgresDataManager {
  * between projects at a specific commit. This is used for cross-repository jump to
  * definition and find references features.
  */
-export class XrepoDatabase extends PostgresDataManager {
+export class XrepoDatabase extends PostgresManager {
     /**
      * Create a new `XrepoDatabase` backed by the given database connection.
      *

--- a/lsif/src/shared/xrepo/xrepo.ts
+++ b/lsif/src/shared/xrepo/xrepo.ts
@@ -125,10 +125,10 @@ export class XrepoDatabase extends PostgresDataManager {
     /**
      * Create a new `XrepoDatabase` backed by the given database connection.
      *
-     * @param storageRoot The path where SQLite databases are stored.
      * @param connection The Postgres connection.
+     * @param storageRoot The path where SQLite databases are stored.
      */
-    constructor(private storageRoot: string, connection: Connection) {
+    constructor(connection: Connection, private storageRoot: string) {
         super(connection)
     }
 

--- a/lsif/src/shared/xrepo/xrepo.ts
+++ b/lsif/src/shared/xrepo/xrepo.ts
@@ -70,7 +70,7 @@ export abstract class PostgresDataManager {
     /**
      * Invoke `callback` with the wrapped Postgres connection.
      *
-     * @param callback The function invoke with the SQLite connection.
+     * @param callback The function invoke with the connection.
      */
     protected withConnection<T>(callback: (connection: Connection) => Promise<T>): Promise<T> {
         return instrument(metrics.xrepoQueryDurationHistogram, metrics.xrepoQueryErrorsCounter, () =>

--- a/lsif/src/shared/xrepo/xrepo.ts
+++ b/lsif/src/shared/xrepo/xrepo.ts
@@ -1,9 +1,8 @@
-import * as crc32 from 'crc-32'
 import * as metrics from './metrics'
 import * as sharedMetrics from '../database/metrics'
 import * as xrepoModels from '../models/xrepo'
 import { addrFor, getCommitsNear, gitserverExecLines } from './commits'
-import { ADVISORY_LOCK_ID_SALT, MAX_CONCURRENT_GITSERVER_REQUESTS, MAX_TRAVERSAL_LIMIT } from '../constants'
+import { MAX_CONCURRENT_GITSERVER_REQUESTS, MAX_TRAVERSAL_LIMIT } from '../constants'
 import { Brackets, Connection, EntityManager } from 'typeorm'
 import { chunk } from 'lodash'
 import { createFilter, testFilter } from './bloom-filter'
@@ -55,65 +54,6 @@ export interface SymbolReferences {
      * The unique identifiers of the symbols imported from the package.
      */
     identifiers: string[]
-}
-
-/**
- * A wrapper around Postgres advisory locks.
- */
-export class PostgresLocker extends PostgresManager {
-    /**
-     * Hold a Postgres advisory lock while executing the given function.
-     *
-     * @param locker The Postgres locker instance.
-     * @param name The name of the lock.
-     * @param f The function to execute while holding the lock.
-     */
-    public async withLock<T>(name: string, f: () => Promise<T>): Promise<T> {
-        await this.lock(name)
-        try {
-            return await f()
-        } finally {
-            await this.unlock(name)
-        }
-    }
-
-    /**
-     * Acquire an advisory lock with the given name. This will block until the lock can be
-     * acquired.
-     *
-     * See https://www.postgresql.org/docs/9.6/static/explicit-locking.html#ADVISORY-LOCKS.
-     *
-     * @param name The lock name.
-     */
-    private lock(name: string): Promise<void> {
-        return this.withConnection(connection =>
-            connection.query('SELECT pg_advisory_lock($1)', [this.generateLockId(name)])
-        )
-    }
-
-    /**
-     * Release an advisory lock acquired by `lock`.
-     *
-     * @param name The lock name.
-     */
-    private unlock(name: string): Promise<void> {
-        return this.withConnection(connection =>
-            connection.query('SELECT pg_advisory_unlock($1)', [this.generateLockId(name)])
-        )
-    }
-
-    /**
-     * Generate an advisory lock identifier from the given name and application salt. This is
-     * based on golang-migrate's advisory lock identifier generation technique, which is in turn
-     * inspired by rails migrations.
-     *
-     * See https://github.com/golang-migrate/migrate/blob/6c96ef02dfbf9430f7286b58afc15718588f2e13/database/util.go#L12.
-     *
-     * @param name The lock name.
-     */
-    private generateLockId(name: string): number {
-        return crc32.str(name) * ADVISORY_LOCK_ID_SALT
-    }
 }
 
 /**

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -204,7 +204,7 @@ export class BackendTestContext {
         this.storageRoot = await createStorageRoot()
         const { connection, cleanup } = await createCleanPostgresDatabase()
         this.cleanup = cleanup
-        this.xrepoDatabase = new XrepoDatabase(this.storageRoot, connection)
+        this.xrepoDatabase = new XrepoDatabase(connection, this.storageRoot)
         this.backend = new Backend(this.storageRoot, this.xrepoDatabase, () => ({ gitServers: [] }))
     }
 

--- a/lsif/src/tests/integration/xrepo/commits.test.ts
+++ b/lsif/src/tests/integration/xrepo/commits.test.ts
@@ -15,7 +15,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase('', connection)
+            const xrepoDatabase = new XrepoDatabase(connection, '')
             await xrepoDatabase.insertDump('test-repo', ca, '')
 
             await xrepoDatabase.discoverAndUpdateCommit({
@@ -40,7 +40,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase('', connection)
+            const xrepoDatabase = new XrepoDatabase(connection, '')
             await xrepoDatabase.insertDump('test-repo', ca, '')
             await xrepoDatabase.updateCommits('test-repo', [[cb, undefined]])
 
@@ -64,7 +64,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase('', connection)
+            const xrepoDatabase = new XrepoDatabase(connection, '')
 
             // This test ensures the following does not make a gitserver request.
             // As we did not register a nock interceptor, any request will result
@@ -96,7 +96,7 @@ describe('discoverAndUpdateTips', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase('', connection)
+            const xrepoDatabase = new XrepoDatabase(connection, '')
             await xrepoDatabase.updateCommits('test-repo', [
                 [ca, undefined],
                 [cb, ca],
@@ -152,7 +152,7 @@ describe('discoverTips', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const xrepoDatabase = new XrepoDatabase('', connection)
+            const xrepoDatabase = new XrepoDatabase(connection, '')
 
             for (let i = 0; i < 15; i++) {
                 await xrepoDatabase.insertDump(`test-repo-${i}`, util.createCommit(), '')

--- a/lsif/src/tests/integration/xrepo/xrepo.test.ts
+++ b/lsif/src/tests/integration/xrepo/xrepo.test.ts
@@ -16,7 +16,7 @@ describe('XrepoDatabase', () => {
     beforeAll(async () => {
         ;({ connection, cleanup } = await util.createCleanPostgresDatabase())
         storageRoot = await util.createStorageRoot()
-        xrepoDatabase = new XrepoDatabase(storageRoot, connection)
+        xrepoDatabase = new XrepoDatabase(connection, storageRoot)
     })
 
     afterAll(async () => {

--- a/lsif/src/worker/processors/convert.ts
+++ b/lsif/src/worker/processors/convert.ts
@@ -2,12 +2,13 @@ import * as constants from '../../shared/constants'
 import * as fs from 'mz/fs'
 import * as path from 'path'
 import * as settings from '../settings'
+import { addTags, TracingContext } from '../../shared/tracing'
 import { convertLsif } from '../importer/importer'
 import { createSilentLogger } from '../../shared/logging'
 import { dbFilename } from '../../shared/paths'
-import { TracingContext, addTags } from '../../shared/tracing'
-import { XrepoDatabase, PostgresLocker } from '../../shared/xrepo/xrepo'
 import { Job } from 'bull'
+import { PostgresLocker } from '../../shared/locker/locker'
+import { XrepoDatabase } from '../../shared/xrepo/xrepo'
 
 /**
  * Create a job that takes a repository, commit, and filename containing the gzipped

--- a/lsif/src/worker/worker.ts
+++ b/lsif/src/worker/worker.ts
@@ -81,7 +81,7 @@ async function main(logger: Logger): Promise<void> {
 
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const xrepoDatabase = new XrepoDatabase(settings.STORAGE_ROOT, connection)
+    const xrepoDatabase = new XrepoDatabase(connection, settings.STORAGE_ROOT)
     const locker = new PostgresLocker(connection)
 
     // Start metrics server

--- a/lsif/src/worker/worker.ts
+++ b/lsif/src/worker/worker.ts
@@ -16,7 +16,6 @@ import { followsFrom, FORMAT_TEXT_MAP, Span, Tracer } from 'opentracing'
 import { instrumentWithLabels } from '../shared/metrics'
 import { Job } from 'bull'
 import { Logger } from 'winston'
-import { PostgresLocker } from '../shared/locker/locker'
 import { startMetricsServer } from './server'
 import { waitForConfiguration } from '../shared/config/config'
 import { XrepoDatabase } from '../shared/xrepo/xrepo'
@@ -83,7 +82,6 @@ async function main(logger: Logger): Promise<void> {
     // Create cross-repo database
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
     const xrepoDatabase = new XrepoDatabase(connection, settings.STORAGE_ROOT)
-    const locker = new PostgresLocker(connection)
 
     // Start metrics server
     startMetricsServer(logger)
@@ -93,7 +91,7 @@ async function main(logger: Logger): Promise<void> {
 
     const convertJobProcessor = wrapJobProcessor(
         'convert',
-        createConvertJobProcessor(xrepoDatabase, locker, fetchConfiguration),
+        createConvertJobProcessor(connection, xrepoDatabase, fetchConfiguration),
         logger,
         tracer
     )

--- a/lsif/src/worker/worker.ts
+++ b/lsif/src/worker/worker.ts
@@ -16,9 +16,10 @@ import { followsFrom, FORMAT_TEXT_MAP, Span, Tracer } from 'opentracing'
 import { instrumentWithLabels } from '../shared/metrics'
 import { Job } from 'bull'
 import { Logger } from 'winston'
+import { PostgresLocker } from '../shared/locker/locker'
 import { startMetricsServer } from './server'
 import { waitForConfiguration } from '../shared/config/config'
-import { XrepoDatabase, PostgresLocker } from '../shared/xrepo/xrepo'
+import { XrepoDatabase } from '../shared/xrepo/xrepo'
 
 /**
  * Wrap a job processor with instrumentation.


### PR DESCRIPTION
This is part of an effort to make the `XrepoDatabase` less of a god-class. It does far too much as currently written.