### PR TITLE
web: Add improved undo/redo to QueryInput

### DIFF
--- a/shared/src/util/UndoRedoHistory.test.ts
+++ b/shared/src/util/UndoRedoHistory.test.ts
@@ -5,9 +5,9 @@ describe('UndoRedoHistory', () => {
         const history = new UndoRedoHistory<string>({
             current: 'undone',
             onChange: () => null,
-        })
-            .push('')
-            .undo()
+        }).push('')
+        expect(history.current).toBe('')
+        history.undo()
         expect(history.current).toBe('undone')
     })
 
@@ -18,7 +18,8 @@ describe('UndoRedoHistory', () => {
         })
             .push('redone')
             .undo()
-            .redo()
+        expect(history.current).toBe('')
+        history.redo()
         expect(history.current).toBe('redone')
     })
 
@@ -34,13 +35,13 @@ describe('UndoRedoHistory', () => {
     it('maintains the correct amount of items in history (historyLength prop)', () => {
         const history = new UndoRedoHistory<string>({
             current: 'a',
-            historyLength: 1,
+            historyLength: 2,
             onChange: () => null,
         })
             .push('b')
             .push('c')
-            .undo()
-            .undo()
+        expect(history.current).toBe('c')
+        history.undo().undo()
         expect(history.current).toBe('b')
     })
 })

--- a/shared/src/util/UndoRedoHistory.test.ts
+++ b/shared/src/util/UndoRedoHistory.test.ts
@@ -1,0 +1,46 @@
+import { UndoRedoHistory } from './UndoRedoHistory'
+
+describe('UndoRedoHistory', () => {
+    test('undo()', () => {
+        const history = new UndoRedoHistory<string>({
+            current: 'undone',
+            onChange: () => null,
+        })
+            .push('')
+            .undo()
+        expect(history.current).toBe('undone')
+    })
+
+    test('redo()', () => {
+        const history = new UndoRedoHistory<string>({
+            current: '',
+            onChange: () => null,
+        })
+            .push('redone')
+            .undo()
+            .redo()
+        expect(history.current).toBe('redone')
+    })
+
+    test('onUpdate()', () => {
+        new UndoRedoHistory<string>({
+            current: 'undone',
+            onChange: value => expect(value).toBe('undone'),
+        })
+            .push('')
+            .undo()
+    })
+
+    it('maintains the correct amount of items in history (historyLength prop)', () => {
+        const history = new UndoRedoHistory<string>({
+            current: 'a',
+            historyLength: 1,
+            onChange: () => null,
+        })
+            .push('b')
+            .push('c')
+            .undo()
+            .undo()
+        expect(history.current).toBe('b')
+    })
+})

--- a/shared/src/util/UndoRedoHistory.ts
+++ b/shared/src/util/UndoRedoHistory.ts
@@ -1,0 +1,104 @@
+import { Unsubscribable } from 'rxjs'
+
+interface Props<T> {
+    /**
+     * Callback that receives value from undo/redo
+     */
+    onChange(currentValue: T): void
+    /**
+     * Current value that the history should start with
+     */
+    current: T
+    /**
+     * Max number of items that should be stored in each history (past, future).
+     * E.g: If given 10, then past + future + current = 21
+     */
+    historyLength?: number
+}
+
+/**
+ * Provides generic undo/redo capabilities
+ */
+export class UndoRedoHistory<T> implements Unsubscribable {
+    public current: T
+    /**
+     * Can be undefined after unsubscribe
+     */
+    private onChange?: Props<T>['onChange']
+
+    private past: T[] = []
+    private future: T[] = []
+    private historyLength = 50
+
+    constructor(props: Props<T>) {
+        this.onChange = value => props.onChange(value)
+        this.current = props.current
+        this.historyLength = props.historyLength ?? this.historyLength
+    }
+
+    /**
+     * Generic function to append items to this.past or this.future
+     */
+    private addToHistoryArray = (history: T[], value: T): T[] =>
+        history.length === this.historyLength ? history.slice(1).concat(value) : history.concat(value)
+
+    /**
+     * (DRY) Function that does the actual undo/redo.
+     * if action === 'undo':
+     *     push current to future
+     *     take from past, set to current
+     * if action === 'redo':
+     *     push current to past
+     *     take from future, set to current
+     */
+    private moveHistory(action: 'undo' | 'redo'): void {
+        const from = action === 'undo' ? 'past' : 'future'
+        const to = action === 'undo' ? 'future' : 'past'
+        const fromValue = this[from]
+        const toValue = this[to]
+
+        // No items to take, exit
+        if (fromValue.length === 0) {
+            return
+        }
+
+        this[from] = fromValue.slice(0, fromValue.length - 1)
+        this[to] = this.addToHistoryArray(toValue, this.current)
+        this.current = fromValue[fromValue.length - 1]
+
+        if (this.onChange) {
+            this.onChange(this.current)
+        }
+    }
+
+    // All public methods should return `this` for method chaining
+
+    /**
+     * Can be used by components and rxjs.Subscription to unsubscribe on unmount
+     */
+    public unsubscribe(): this {
+        this.onChange = undefined
+        return this
+    }
+
+    /**
+     * Standard undo/redo behavior: once a new value is pushed the future
+     * history is erased, and will be populated on the next `undo()`
+     */
+    public push(value: T): this {
+        this.past = this.addToHistoryArray(this.past, this.current)
+        this.current = value
+        this.future = []
+        return this
+    }
+
+    public undo(): this {
+        this.moveHistory('undo')
+        return this
+    }
+
+    public redo(): this {
+        this.moveHistory('redo')
+        return this
+    }
+}


### PR DESCRIPTION
**Issue:** Undo is broken after selecting a suggestions

**Changes:**
- Improve undo/redo after suggestion selection by having a js managed queryState history.
- New class `UndoRedoHistory` provides generic undo/redo capabilities.
- In search input (`QueryInput`): <kbd>ctrl</kbd>+<kbd>z</kbd> for undo, and <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>z</kbd> for redo