### PR TITLE
web: Fix no undefined filter value

### DIFF
--- a/web/src/search/helpers.test.tsx
+++ b/web/src/search/helpers.test.tsx
@@ -196,6 +196,16 @@ describe('search/helpers', () => {
                 value: 'package.json',
             })
         })
+        it('returns correct values for filter query without a value', () => {
+            const query = '-f'
+            expect(validFilterAndValueBeforeCursor({ query, cursorPosition: query.length })).toEqual({
+                filterIndex: 0,
+                filterAndValue: query,
+                matchedFilter: query,
+                resolvedFilterType: 'file',
+                value: '',
+            })
+        })
     })
 
     describe('isFuzzyWordSearch', () => {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -200,7 +200,7 @@ export const getFilterAndValueBeforeCursor = (queryState: QueryState): FilterAnd
     // get string before ":" char until a space is found or start of string
     const match = firstPart.match(/([^\s:]+)?(:(\S?)+)?$/) || []
     const [filterAndValue, matchedFilter] = match
-    const value = filterAndValue?.split(':')[1]?.trim()
+    const value = filterAndValue?.split(':')[1]?.trim() ?? ''
     return {
         value,
         matchedFilter,


### PR DESCRIPTION
**Fixes:** #6703

**Changes:**
- Return empty string if matched query filter value is undefined.
- Add unit test to cover correctly matching filter without value.
