### PR TITLE
LSIF: Update missing use of lsifserver/client.DefaultClient.

### DIFF
--- a/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/pkg/codeintel/lsifserver/proxy/upload.go
@@ -33,7 +33,7 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 			return
 		}
 
-		resp, err := client.BuildAndTraceRequest(
+		resp, err := client.DefaultClient.BuildAndTraceRequest(
 			ctx,
 			"POST",
 			"/upload",


### PR DESCRIPTION
Somehow a one usage change did not make it through a previous merge....