### PR TITLE
Start replacer service in server image

### DIFF
--- a/cmd/server/shared/globals.go
+++ b/cmd/server/shared/globals.go
@@ -19,6 +19,7 @@ var SrcProfServices = []map[string]string{
 	{"Name": "query-runner", "Host": "127.0.0.1:6067"},
 	{"Name": "zoekt-indexserver", "Host": "127.0.0.1:6072"},
 	{"Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/"},
+	{"Name": "replacer", "Host": "127.0.0.1:6076"},
 }
 
 // ProcfileAdditions is a list of Procfile lines that should be added to the emitted Procfile that

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -136,6 +136,7 @@ func Main() {
 		`lsif-worker: node /lsif/out/worker/worker.js`,
 		`management-console: management-console`,
 		`searcher: searcher`,
+		`replacer: replacer`,
 		`github-proxy: github-proxy`,
 		`repo-updater: repo-updater`,
 		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,

--- a/dev/prometheus/all/prometheus_targets.yml
+++ b/dev/prometheus/all/prometheus_targets.yml
@@ -49,4 +49,8 @@
   targets:
     # postgres exporter
     - host.docker.internal:9187
-
+- labels:
+    job: replacer
+  targets:
+    # replacer
+    - host.docker.internal:6076

--- a/dev/prometheus/linux/prometheus_targets.yml
+++ b/dev/prometheus/linux/prometheus_targets.yml
@@ -49,3 +49,8 @@
   targets:
     # postgres exporter
     - 127.0.0.1:9187
+- labels:
+    job: replacer
+  targets:
+    # replacer
+    - 127.0.0.1:6076

--- a/dev/src-prof-services.json
+++ b/dev/src-prof-services.json
@@ -6,5 +6,6 @@
   { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
   { "Name": "query-runner", "Host": "127.0.0.1:6067" },
   { "Name": "zoekt-indexserver", "Host": "127.0.0.1:6072" },
-  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" }
+  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" },
+  { "Name": "replacer", "Host": "127.0.0.1:6076" }
 ]

--- a/enterprise/dev/src-prof-services.json
+++ b/enterprise/dev/src-prof-services.json
@@ -5,5 +5,6 @@
   { "Name": "management-console", "Host": "127.0.0.1:6075" },
   { "Name": "symbols", "Host": "127.0.0.1:6071" },
   { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
-  { "Name": "query-runner", "Host": "127.0.0.1:6067" }
+  { "Name": "query-runner", "Host": "127.0.0.1:6067" },
+  { "Name": "replacer", "Host": "127.0.0.1:6076" }
 ]


### PR DESCRIPTION
Tries to address #6711. I don't actually know what changes are needed to run replacer in the Docker built image. Putting this up for visibility. Feel free to commandeer this fix/PR.



Test plan: None, WIP. Should absolutely get an e2e test. I think @eseliger is working on one in #6678. 
