### PR TITLE
Fix golangci-lint warnings in a8n package

### DIFF
--- a/enterprise/pkg/a8n/resolvers/resolver_test.go
+++ b/enterprise/pkg/a8n/resolvers/resolver_test.go
@@ -886,10 +886,6 @@ func TestCampaignPlanResolver(t *testing.T) {
 		Nodes    []FileDiff
 	}
 
-	type Repository struct {
-		Name string
-	}
-
 	type ChangesetPlan struct {
 		Repository struct{ Name, URL string }
 		FileDiffs  FileDiffs

--- a/enterprise/pkg/a8n/service.go
+++ b/enterprise/pkg/a8n/service.go
@@ -131,8 +131,8 @@ func (s *Service) runChangesetJob(
 				err = multierror.Append(err, e)
 			}
 		}
-		return
 	}()
+
 	job.StartedAt = s.clock()
 
 	campaignJob, err := s.store.GetCampaignJob(ctx, GetCampaignJobOpts{ID: job.CampaignJobID})


### PR DESCRIPTION
@keegancsmith reported these. I must've missed them in PRs or new commits hid them from the CI check.
