### PR TITLE
Add replacer to dev goreman monitoring

### DIFF
--- a/internal/processrestart/goreman_dev.go
+++ b/internal/processrestart/goreman_dev.go
@@ -31,6 +31,7 @@ func restartGoremanDev() error {
 		"query-runner",
 		"repo-updater",
 		"searcher",
+		"replacer",
 		"symbols",
 		"github-proxy",
 		"management-console",


### PR DESCRIPTION
I checked and `replacer` _is_ restarted without this change (not sure why), but the [comment above](https://github.com/sourcegraph/sourcegraph/compare/rvt/monitor-replacer-goreman?expand=1#diff-c7b3e92ee0613030aa453f9a8d47b266R19-R22) suggests other things are at play, and this list should be kept up to date with `Procfile`

Test plan: Checked that `replacer` is rebuilt on file change.
