### PR TITLE
frontend: Add GraphQL resolvers for LanguageStatistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Language statistics by commit are available via the API. [#6737](https://github.com/sourcegraph/sourcegraph/pull/6737)
+
 ### Changed
 
 ### Removed

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -182,6 +182,20 @@ func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*languageStatisticsResolver, error) {
+	inventory, err := backend.Repos.GetInventory(ctx, r.repo.repo, api.CommitID(r.oid))
+	if err != nil {
+		return nil, err
+	}
+	stats := make([]*languageStatisticsResolver, 0, len(inventory.Languages))
+	for _, lang := range inventory.Languages {
+		stats = append(stats, &languageStatisticsResolver{
+			l: lang,
+		})
+	}
+	return stats, nil
+}
+
 func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query *string

--- a/cmd/frontend/graphqlbackend/language_statistics.go
+++ b/cmd/frontend/graphqlbackend/language_statistics.go
@@ -10,8 +10,8 @@ func (l *languageStatisticsResolver) Name() string {
 	return l.l.Name
 }
 
-func (l *languageStatisticsResolver) TotalBytes() int32 {
-	return int32(l.l.TotalBytes)
+func (l *languageStatisticsResolver) TotalBytes() float64 {
+	return float64(l.l.TotalBytes)
 }
 
 func (l *languageStatisticsResolver) TotalLines() int32 {

--- a/cmd/frontend/graphqlbackend/language_statistics.go
+++ b/cmd/frontend/graphqlbackend/language_statistics.go
@@ -1,0 +1,19 @@
+package graphqlbackend
+
+import "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
+
+type languageStatisticsResolver struct {
+	l inventory.Lang
+}
+
+func (l *languageStatisticsResolver) Name() string {
+	return l.l.Name
+}
+
+func (l *languageStatisticsResolver) TotalBytes() int32 {
+	return int32(l.l.TotalBytes)
+}
+
+func (l *languageStatisticsResolver) TotalLines() int32 {
+	return int32(l.l.TotalLines)
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2306,6 +2306,16 @@ type GitCommitConnection {
     pageInfo: PageInfo!
 }
 
+# Statistics about a specific language
+type LanguageStatistics {
+    # The name of the programming language
+    Name: String!
+    # The total bytes of the language
+    TotalBytes: Float!
+    # The total lines of the language
+    TotalLines: Int!
+}
+
 # A Git commit.
 type GitCommit implements Node {
     # The globally addressable ID for this commit.
@@ -2352,6 +2362,8 @@ type GitCommit implements Node {
     file(path: String!): File2
     # Lists the programming languages present in the tree at this commit.
     languages: [String!]!
+    # List statistics for each language present in the repository
+    languageStatistics: [LanguageStatistics!]!
     # The log of commits consisting of this commit and its ancestors.
     ancestors(
         # Returns the first n commits from the list.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2362,7 +2362,7 @@ type GitCommit implements Node {
     file(path: String!): File2
     # Lists the programming languages present in the tree at this commit.
     languages: [String!]!
-    # List statistics for each language present in the repository
+    # List statistics for each language present in the repository.
     languageStatistics: [LanguageStatistics!]!
     # The log of commits consisting of this commit and its ancestors.
     ancestors(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2313,6 +2313,16 @@ type GitCommitConnection {
     pageInfo: PageInfo!
 }
 
+# Statistics about a specific language
+type LanguageStatistics {
+    # The name of the programming language
+    Name: String!
+    # The total bytes of the language
+    TotalBytes: Int!
+    # The total lines of the language
+    TotalLines: Int!
+}
+
 # A Git commit.
 type GitCommit implements Node {
     # The globally addressable ID for this commit.
@@ -2359,6 +2369,8 @@ type GitCommit implements Node {
     file(path: String!): File2
     # Lists the programming languages present in the tree at this commit.
     languages: [String!]!
+    # List statistics for each language present in the repository
+    languageStatistics: [LanguageStatistics!]!
     # The log of commits consisting of this commit and its ancestors.
     ancestors(
         # Returns the first n commits from the list.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2369,7 +2369,7 @@ type GitCommit implements Node {
     file(path: String!): File2
     # Lists the programming languages present in the tree at this commit.
     languages: [String!]!
-    # List statistics for each language present in the repository
+    # List statistics for each language present in the repository.
     languageStatistics: [LanguageStatistics!]!
     # The log of commits consisting of this commit and its ancestors.
     ancestors(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2318,7 +2318,7 @@ type LanguageStatistics {
     # The name of the programming language
     Name: String!
     # The total bytes of the language
-    TotalBytes: Int!
+    TotalBytes: Float!
     # The total lines of the language
     TotalLines: Int!
 }


### PR DESCRIPTION
This change exposes line counts under a new node called `LanguageStatistics` under `GitCommit`