### PR TITLE
search: repohascommitafter includes repo after finding first commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- `repohascommitafter:` search filter uses a more efficient git command to determine inclusion. [#6739](https://github.com/sourcegraph/sourcegraph/pull/6739)
+
 ### Fixed
 
 - The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -122,6 +122,7 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 	}
 
 	n, err := CommitCount(ctx, repo, CommitsOptions{
+		N:     1,
 		After: date,
 		Range: string(commitid),
 	})


### PR DESCRIPTION
HasCommitAfter uses "git rev-list" under the hood. It will return true if
there is atleast one commit returned by rev-list. Previously we would return
all such commits matching the filters. This commit will tell git to stop
looking for commits after finding 1. This should result in git doing much less
work in the case of repositories which match the filter.