### PR TITLE
graphqlbackend: Optimize repo query for lang suggestions

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -367,7 +367,7 @@ func parsePattern(p string) ([]*sqlf.Query, error) {
 		conds = append(conds, sqlf.Sprintf("(%s)", sqlf.Join(likeConds, " OR ")))
 	}
 	if pattern != "" {
-		conds = append(conds, sqlf.Sprintf("lower(name) ~* %s", pattern))
+		conds = append(conds, sqlf.Sprintf("lower(name) ~ %s", strings.ToLower(pattern)))
 	}
 	return conds, nil
 }

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -367,7 +367,7 @@ func parsePattern(p string) ([]*sqlf.Query, error) {
 		conds = append(conds, sqlf.Sprintf("(%s)", sqlf.Join(likeConds, " OR ")))
 	}
 	if pattern != "" {
-		conds = append(conds, sqlf.Sprintf("lower(name) ~ %s", strings.ToLower(pattern)))
+		conds = append(conds, sqlf.Sprintf("lower(name) ~ lower(%s)", pattern))
 	}
 	return conds, nil
 }

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -136,6 +136,12 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 
 		validValues := effectiveRepoFieldValues[:0]
 		for _, v := range effectiveRepoFieldValues {
+			if i := strings.LastIndexByte(v, '@'); i > -1 {
+				// Strip off the @revision suffix so that we can use
+				// the trigram index on the name column in Postgres.
+				v = v[:i]
+			}
+
 			if _, err := regexp.Compile(v); err == nil {
 				validValues = append(validValues, v)
 			}


### PR DESCRIPTION
This commit optimizes the SQL query used to find a repo for language
suggestions.

- It removes everything from the last `@` in the repo name,
since it prevented Postgres from using its trigram index on the name column
of the repo table.
- It changes the operator we use to perform regex matching on the name
column from `~*` (case insenstive) to `~` case senstive.

Fixes #6760