### PR TITLE
a8n: Delete ChangesetJobs when Campaign is deleted

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -99,7 +99,7 @@ Foreign-key constraints:
     "campaigns_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     "campaigns_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
-    TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES campaigns(id) DEFERRABLE
+    TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE DEFERRABLE
 Triggers:
     trig_delete_campaign_reference_on_changesets AFTER DELETE ON campaigns FOR EACH ROW EXECUTE PROCEDURE delete_campaign_reference_on_changesets()
     trig_validate_campaign_plan_is_finished BEFORE INSERT OR UPDATE ON campaigns FOR EACH ROW EXECUTE PROCEDURE validate_campaign_plan_is_finished()
@@ -149,7 +149,7 @@ Indexes:
     "changeset_jobs_finished_at" btree (finished_at)
     "changeset_jobs_started_at" btree (started_at)
 Foreign-key constraints:
-    "changeset_jobs_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES campaigns(id) DEFERRABLE
+    "changeset_jobs_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE DEFERRABLE
     "changeset_jobs_campaign_job_id_fkey" FOREIGN KEY (campaign_job_id) REFERENCES campaign_jobs(id) DEFERRABLE
     "changeset_jobs_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) DEFERRABLE
 

--- a/migrations/1528395618_add_delete_cascade_to_changeset_jobs.down.sql
+++ b/migrations/1528395618_add_delete_cascade_to_changeset_jobs.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs DROP CONSTRAINT changeset_jobs_campaign_id_fkey,
+  ADD CONSTRAINT changeset_jobs_campaign_id_fkey
+    FOREIGN KEY (campaign_id)
+    REFERENCES campaigns(id)
+    DEFERRABLE INITIALLY IMMEDIATE;
+
+COMMIT;

--- a/migrations/1528395618_add_delete_cascade_to_changeset_jobs.up.sql
+++ b/migrations/1528395618_add_delete_cascade_to_changeset_jobs.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs DROP CONSTRAINT changeset_jobs_campaign_id_fkey,
+  ADD CONSTRAINT changeset_jobs_campaign_id_fkey
+    FOREIGN KEY (campaign_id)
+    REFERENCES campaigns(id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -72,6 +72,8 @@
 // 1528395616_lsif_processed_at.up.sql (359B)
 // 1528395617_add_base_ref_to_campaign_jobs.down.sql (65B)
 // 1528395617_add_base_ref_to_campaign_jobs.up.sql (271B)
+// 1528395618_add_delete_cascade_to_changeset_jobs.down.sql (237B)
+// 1528395618_add_delete_cascade_to_changeset_jobs.up.sql (255B)
 
 package migrations
 
@@ -1580,6 +1582,46 @@ func _1528395617_add_base_ref_to_campaign_jobsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395618_add_delete_cascade_to_changeset_jobsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xce\xbd\x8a\x83\x40\x14\xc5\xf1\x7e\x9e\xe2\x94\x2e\xec\x1b\x58\x8d\xce\x55\x2e\x3b\x1f\xcb\x78\x1b\xab\xc1\x18\x63\x4c\x88\x09\x98\x26\x6f\x1f\x22\x08\x21\x5d\xea\xdf\x39\xf0\x2f\xa8\x66\x9f\x2b\xa5\xad\x50\x84\xe8\xc2\x12\xfa\x63\x37\x8f\xc3\x32\xdc\xd3\xe9\xba\x5b\x60\x62\xf8\x47\x19\x7c\x23\x51\xb3\x97\x0f\x4e\x7d\x77\xb9\x75\xd3\x38\xa7\x69\x9f\x0e\xe7\xe1\xf1\xab\x00\x6d\xcc\x17\x0f\x05\x00\x55\x88\xc4\xb5\xc7\x1f\xb5\xc8\xde\x16\x3f\xab\x46\xaa\x28\x92\x2f\xa9\xc1\x66\x4b\xb6\xa1\x79\x61\x5c\xd3\xd9\xb3\xb0\xb6\xb6\x05\x3b\x47\x86\xb5\x50\xae\x54\x19\x9c\x63\xc9\xd5\x33\x00\x00\xff\xff\xa5\x7f\x5f\x26\xed\x00\x00\x00")
+
+func _1528395618_add_delete_cascade_to_changeset_jobsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395618_add_delete_cascade_to_changeset_jobsDownSql,
+		"1528395618_add_delete_cascade_to_changeset_jobs.down.sql",
+	)
+}
+
+func _1528395618_add_delete_cascade_to_changeset_jobsDownSql() (*asset, error) {
+	bytes, err := _1528395618_add_delete_cascade_to_changeset_jobsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395618_add_delete_cascade_to_changeset_jobs.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3b, 0x4e, 0x6d, 0x44, 0x8e, 0x36, 0xf1, 0xe4, 0x7b, 0x15, 0xa2, 0x4c, 0xec, 0x6, 0xb8, 0x92, 0xcc, 0x47, 0xe2, 0x48, 0xae, 0xb6, 0x64, 0x6d, 0xd4, 0xb, 0x20, 0x46, 0xad, 0x99, 0x7a, 0x1}}
+	return a, nil
+}
+
+var __1528395618_add_delete_cascade_to_changeset_jobsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xcf\xbd\x4e\x84\x40\x14\xc5\xf1\x7e\x9e\xe2\x94\x98\xf8\x06\x54\x97\x99\x0b\xb9\x71\x3e\xcc\x70\x1b\xaa\x09\x22\x22\x1a\xd1\x04\x1b\xdf\xde\x2c\x09\xc9\x66\xbb\xad\x7f\xff\x53\x9c\x86\x3b\x89\xb5\x31\xe4\x95\x33\x94\x1a\xcf\x98\xde\xc7\x6d\x99\xf7\xf9\xb7\x7c\x7c\xbf\xec\x70\x39\x3d\xc3\xa6\xd8\x6b\x26\x89\x7a\xc3\x65\x1a\xbf\x7e\xc6\x75\xd9\xca\xfa\x5a\xde\x3e\xe7\xbf\x47\x03\x90\x73\x77\x2c\x0c\x00\xb4\x29\xb3\x74\x11\x4f\x3c\xa0\xba\x2a\x1e\x0e\xcd\xdc\x72\xe6\x68\xb9\xc7\x69\x7b\x75\x62\x8a\x70\xec\x59\x19\x96\x7a\x4b\x8e\xe1\x2e\x79\x3e\xce\x48\x14\x15\xf2\x7e\x80\x84\xc0\x4e\x48\xb9\x36\xc6\xa6\x10\x44\x6b\xf3\x1f\x00\x00\xff\xff\x70\x06\xad\x71\xff\x00\x00\x00")
+
+func _1528395618_add_delete_cascade_to_changeset_jobsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395618_add_delete_cascade_to_changeset_jobsUpSql,
+		"1528395618_add_delete_cascade_to_changeset_jobs.up.sql",
+	)
+}
+
+func _1528395618_add_delete_cascade_to_changeset_jobsUpSql() (*asset, error) {
+	bytes, err := _1528395618_add_delete_cascade_to_changeset_jobsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395618_add_delete_cascade_to_changeset_jobs.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x78, 0x39, 0x77, 0xce, 0x45, 0x80, 0xa8, 0xc1, 0xd6, 0xb0, 0xb1, 0x46, 0x2a, 0xa8, 0xc8, 0x74, 0xd4, 0xaa, 0x28, 0xfb, 0x64, 0xf2, 0x44, 0x3, 0x3e, 0xab, 0x16, 0x8a, 0xa, 0xf5, 0xaf, 0x86}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1743,6 +1785,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395616_lsif_processed_at.up.sql":                                      _1528395616_lsif_processed_atUpSql,
 	"1528395617_add_base_ref_to_campaign_jobs.down.sql":                        _1528395617_add_base_ref_to_campaign_jobsDownSql,
 	"1528395617_add_base_ref_to_campaign_jobs.up.sql":                          _1528395617_add_base_ref_to_campaign_jobsUpSql,
+	"1528395618_add_delete_cascade_to_changeset_jobs.down.sql":                 _1528395618_add_delete_cascade_to_changeset_jobsDownSql,
+	"1528395618_add_delete_cascade_to_changeset_jobs.up.sql":                   _1528395618_add_delete_cascade_to_changeset_jobsUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1858,6 +1902,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395616_lsif_processed_at.up.sql":                                      {_1528395616_lsif_processed_atUpSql, map[string]*bintree{}},
 	"1528395617_add_base_ref_to_campaign_jobs.down.sql":                        {_1528395617_add_base_ref_to_campaign_jobsDownSql, map[string]*bintree{}},
 	"1528395617_add_base_ref_to_campaign_jobs.up.sql":                          {_1528395617_add_base_ref_to_campaign_jobsUpSql, map[string]*bintree{}},
+	"1528395618_add_delete_cascade_to_changeset_jobs.down.sql":                 {_1528395618_add_delete_cascade_to_changeset_jobsDownSql, map[string]*bintree{}},
+	"1528395618_add_delete_cascade_to_changeset_jobs.up.sql":                   {_1528395618_add_delete_cascade_to_changeset_jobsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This fixes #6659 by changing foreign key constraint on `changeset_jobs.campaign_id` to have a `ON DELETE CASCADE`.

I know this is a good "first issue", but I run into this repeatedly and want to fix it rather soon.

