### PR TITLE
a8n: Add Head/Base to ExternalChangeset in GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -200,6 +200,8 @@ type ExternalChangesetResolver interface {
 	Campaigns(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (CampaignsConnectionResolver, error)
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
 	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
+	Head(ctx context.Context) (*GitRefResolver, error)
+	Base(ctx context.Context) (*GitRefResolver, error)
 }
 
 type ChangesetPlansConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -654,6 +654,12 @@ type ExternalChangeset implements Node {
     # The review state of this changeset.
     reviewState: ChangesetReviewState!
 
+    # The head of the diff ("new" or "right-hand side").
+    head: GitRef!
+
+    # The base of the diff ("old" or "left-hand side").
+    base: GitRef!
+
     # The diff of this changeset.
     # Only returned if the changeset has not been merged or closed.
     diff: RepositoryComparison

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -661,6 +661,12 @@ type ExternalChangeset implements Node {
     # The review state of this changeset.
     reviewState: ChangesetReviewState!
 
+    # The head of the diff ("new" or "right-hand side").
+    head: GitRef!
+
+    # The base of the diff ("old" or "left-hand side").
+    base: GitRef!
+
     # The diff of this changeset.
     # Only returned if the changeset has not been merged or closed.
     diff: RepositoryComparison

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -389,9 +389,9 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	csr := make([]graphqlbackend.ExternalChangesetResolver, len(cs))
 	for i := range cs {
 		csr[i] = &changesetResolver{
-			store:     r.store,
-			Changeset: cs[i],
-			repo:      repoSet[uint32(cs[i].RepoID)],
+			store:         r.store,
+			Changeset:     cs[i],
+			preloadedRepo: repoSet[uint32(cs[i].RepoID)],
 		}
 	}
 

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -350,11 +350,25 @@ func (t *Changeset) Events() (events []*ChangesetEvent) {
 }
 
 // HeadRefOid returns the git ObjectID of the HEAD reference associated with
-// the Changeset on the codehost.
+// Changeset on the codehost. If the codehost doesn't include the ObjectID, an
+// empty string is returned.
 func (t *Changeset) HeadRefOid() (string, error) {
 	switch m := t.Metadata.(type) {
 	case *github.PullRequest:
 		return m.HeadRefOid, nil
+	case *bitbucketserver.PullRequest:
+		return "", nil
+	default:
+		return "", errors.New("unknown changeset type")
+	}
+}
+
+// HeadRefName returns the full ref name (e.g. `refs/heads/my-branch`) of the
+// HEAD reference associated with the Changeset on the codehost.
+func (t *Changeset) HeadRefName() (string, error) {
+	switch m := t.Metadata.(type) {
+	case *github.PullRequest:
+		return "refs/heads/" + m.HeadRefName, nil
 	case *bitbucketserver.PullRequest:
 		return m.FromRef.ID, nil
 	default:
@@ -363,11 +377,25 @@ func (t *Changeset) HeadRefOid() (string, error) {
 }
 
 // BaseRefOid returns the git ObjectID of the base reference associated with the
-// Changeset on the codehost.
+// Changeset on the codehost. If the codehost doesn't include the ObjectID, an
+// empty string is returned.
 func (t *Changeset) BaseRefOid() (string, error) {
 	switch m := t.Metadata.(type) {
 	case *github.PullRequest:
 		return m.BaseRefOid, nil
+	case *bitbucketserver.PullRequest:
+		return "", nil
+	default:
+		return "", errors.New("unknown changeset type")
+	}
+}
+
+// BaseRefName returns the full ref name (e.g. `refs/heads/my-branch`) of the
+// base reference associated with the Changeset on the codehost.
+func (t *Changeset) BaseRefName() (string, error) {
+	switch m := t.Metadata.(type) {
+	case *github.PullRequest:
+		return "refs/heads/" + m.BaseRefName, nil
 	case *bitbucketserver.PullRequest:
 		return m.ToRef.ID, nil
 	default:


### PR DESCRIPTION
This fixes the backend part of #6749 by implementing the schema as suggested in #6750.