### PR TITLE
Proposal: Reduce duplicate tasks being run

### DIFF
--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -8,8 +8,10 @@ echo "--- yarn install"
 yarn --frozen-lockfile --network-timeout 60000
 echo "--- browser: yarn run build (phabricator integration assets)"
 (pushd browser && TARGETS=phabricator yarn build && popd)
-echo "--- web: yarn run build"
-(pushd web && NODE_ENV=production yarn -s run build --color && popd)
+if [[ "{$SKIP_WEB_BUILD}" != "1" ]]; then
+    echo "--- web: yarn run build"
+    (pushd web && NODE_ENV=production yarn -s run build --color && popd)
+fi
 popd
 
 echo "--- generate"


### PR DESCRIPTION
Part of #6770

Description: We built the webapp 4 times,
- the actual build enterprise CI step
- within the build step of generating the server candidate
(master, release only)
- building the server docker image
- building the frontend docker image


do you have an idea how we would be able to extract the build enterprise web app into it's own step again and then pull it in to the serverCandidate step? 