### PR TITLE
LSIF: Convert to LSP location later in request

### DIFF
--- a/lsif/src/server/backend/backend.test.ts
+++ b/lsif/src/server/backend/backend.test.ts
@@ -1,0 +1,42 @@
+import * as lsp from 'vscode-languageserver-protocol'
+import { internalLocationToLocation } from './backend'
+
+describe('internalLocationToLocation', () => {
+    const dump = {
+        id: 0,
+        repository: 'github.com/sourcegraph/codeintellify',
+        commit: 'deadbeef',
+        root: '',
+        visibleAtTip: false,
+        uploadedAt: new Date(),
+        processedAt: new Date(),
+    }
+
+    const range: lsp.Range = {
+        start: {
+            line: 1,
+            character: 1,
+        },
+        end: {
+            line: 2,
+            character: 3,
+        },
+    }
+
+    it('should generate a relative URI to the same repo', () => {
+        const input = { dump, path: 'src/position.ts', range }
+        const location = internalLocationToLocation('github.com/sourcegraph/codeintellify', input)
+        const expected = lsp.Location.create('src/position.ts', range)
+        expect(location).toEqual(expected)
+    })
+
+    it('should generate an absolute URI to another project', () => {
+        const input = { dump, path: 'src/position.ts', range }
+        const location = internalLocationToLocation('github.com/sourcegraph/lsif-go', input)
+        const expected = lsp.Location.create(
+            'git://github.com/sourcegraph/codeintellify?deadbeef#src/position.ts',
+            range
+        )
+        expect(location).toEqual(expected)
+    })
+})

--- a/lsif/src/shared/models/xrepo.ts
+++ b/lsif/src/shared/models/xrepo.ts
@@ -52,6 +52,11 @@ export type DumpId = number
 @Entity({ name: 'lsif_dumps' })
 export class LsifDump {
     /**
+     * The number of model instances that can be inserted at once.
+     */
+    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
+
+    /**
      * A unique ID required by typeorm entities.
      */
     @PrimaryGeneratedColumn('increment', { type: 'int' })
@@ -95,11 +100,6 @@ export class LsifDump {
      */
     @Column('timestamp with time zone', { name: 'processed_at' })
     public processedAt!: Date
-
-    /**
-     * The number of model instances that can be inserted at once.
-     */
-    public static BatchSize = MAX_POSTGRES_BATCH_SIZE
 }
 
 /**


### PR DESCRIPTION
This is a small behavior-preserving refactor that splits the backend definition/references method into a pair of public and internal methods. The internal method returns a wrapped lsp.Location that also carries the associated dump object. This will allow us to get definitions for a token interally without having to re-parse the lsp.Location object to determine the target repo and commit.