### PR TITLE
search: surface alert when diff or commit search happens over more than 50 repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -462,6 +462,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]searchR
 		unflattened [][]*commitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
+
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -462,7 +462,6 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]searchR
 		unflattened [][]*commitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
-
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -825,7 +825,7 @@ func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *sea
 				resultTypes = []string{}
 				alert = &searchAlert{
 					title:       "Too many repositories need to be searched",
-					description: fmt.Sprintf(`Your search for %ss would run on more than %d repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`, resultType, repoLimit),
+					description: fmt.Sprintf(`Your search for %ss would run on more than %d repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`, resultType, repoLimit),
 				}
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -812,6 +812,27 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 	return repos, missingRepoRevs, nil, nil
 }
 
+// Surface an alert if a query exceeds limits that we place on search. Currently limits
+// diff and commit searches where more than repoLimit repos need to be searched.
+func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *searchAlert) {
+	var alert *searchAlert
+	repoLimit := 50
+	if len(args.Repos) > repoLimit {
+		if len(resultTypes) == 1 {
+			resultType := resultTypes[0]
+			switch resultType {
+			case "commit", "diff":
+				resultTypes = []string{}
+				alert = &searchAlert{
+					title:       "Too many repositories need to be searched",
+					description: fmt.Sprintf(`Your search for %ss would run on more than %d repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`, resultType, repoLimit),
+				}
+			}
+		}
+	}
+	return resultTypes, alert
+}
+
 func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType string) (res *searchResultsResolver, err error) {
 	tr, ctx := trace.New(ctx, "graphql.SearchResults", r.rawQuery())
 	defer func() {
@@ -877,6 +898,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		// to merge multiple results of different types for the same file
 		fileMatches   = make(map[string]*fileMatchResolver)
 		fileMatchesMu sync.Mutex
+		// Alert is a potential alert shown to the user.
+		alert *searchAlert
 	)
 
 	waitGroup := func(required bool) *sync.WaitGroup {
@@ -889,6 +912,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		}
 		return &optionalWg
 	}
+
+	// Apply search limits and generate warnings before firing off workers.
+	// This currently limits diff and commit search to a set number of
+	// repos, and removes the diff and commit resultTypes if it is breached.
+	resultTypes, alert = alertOnSearchLimit(resultTypes, &args)
 
 	searchedFileContentsOrPaths := false
 	for _, resultType := range resultTypes {
@@ -1084,9 +1112,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	timer.Stop()
 
 	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d timedout=%d", len(results), common.limitHit, len(common.cloning), len(common.missing), len(common.timedout))
-
-	// Alert is a potential alert shown to the user.
-	var alert *searchAlert
 
 	if len(missingRepoRevs) > 0 {
 		alert = r.alertForMissingRepoRevs(missingRepoRevs)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -825,7 +825,7 @@ func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *sea
 				resultTypes = []string{}
 				alert = &searchAlert{
 					title:       "Too many repositories need to be searched",
-					description: fmt.Sprintf(`Your search for %ss would run on more than %d repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`, resultType, repoLimit),
+					description: fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
 				}
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -824,7 +824,7 @@ func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *sea
 			case "commit", "diff":
 				resultTypes = []string{}
 				alert = &searchAlert{
-					title:       "Too many repositories need to be searched",
+					title:       fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
 					description: fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1106,14 +1106,14 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 			resultTypes:          []string{"diff"},
 			numRepoRevs:          51,
 			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Your search for diffs would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`,
+			wantAlertDescription: `Your search for diffs would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
 			resultTypes:          []string{"commit"},
 			numRepoRevs:          51,
 			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Your search for commits would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`,
+			wantAlertDescription: `Your search for commits would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`,
 		},
 		{
 			name:                 "no_warning_when_commit_search_within_search_limit",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1093,6 +1093,76 @@ func Test_dedupSort(t *testing.T) {
 	}
 }
 
+func Test_commitAndDiffSearchLimits(t *testing.T) {
+	cases := []struct {
+		name                 string
+		resultTypes          []string
+		numRepoRevs          int
+		wantResultTypes      []string
+		wantAlertDescription string
+	}{
+		{
+			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
+			resultTypes:          []string{"diff"},
+			numRepoRevs:          51,
+			wantResultTypes:      []string{}, // diff is removed from the resultTypes
+			wantAlertDescription: `Your search for diffs would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`,
+		},
+		{
+			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
+			resultTypes:          []string{"commit"},
+			numRepoRevs:          51,
+			wantResultTypes:      []string{}, // diff is removed from the resultTypes
+			wantAlertDescription: `Your search for commits would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repos to search.`,
+		},
+		{
+			name:                 "no_warning_when_commit_search_within_search_limit",
+			resultTypes:          []string{"commit"},
+			numRepoRevs:          50,
+			wantResultTypes:      []string{"commit"}, // commit is preserved in resultTypes
+			wantAlertDescription: "",
+		},
+		{
+			name:                 "no_search_limit_on_repos_for_file_search",
+			resultTypes:          []string{"file"},
+			numRepoRevs:          200,
+			wantResultTypes:      []string{"file"},
+			wantAlertDescription: "",
+		},
+	}
+
+	for _, test := range cases {
+		repoRevs := make([]*search.RepositoryRevisions, test.numRepoRevs)
+		for i := range repoRevs {
+			repoRevs[i] = &search.RepositoryRevisions{
+				Repo: &types.Repo{ID: api.RepoID(i)},
+			}
+		}
+
+		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.Args{Repos: repoRevs})
+
+		haveAlertDescription := ""
+		if alert != nil {
+			haveAlertDescription = *alert.Description()
+		}
+
+		if haveAlertDescription != test.wantAlertDescription {
+			t.Fatalf("test %s, have alert %q, want: %q", test.name, haveAlertDescription, test.wantAlertDescription)
+		}
+		if !reflect.DeepEqual(haveResultTypes, test.wantResultTypes) {
+			haveResultType := "is empty"
+			wantResultType := "is empty"
+			if len(haveResultTypes) > 0 {
+				haveResultType = haveResultTypes[0]
+			}
+			if len(test.wantResultTypes) > 0 {
+				wantResultType = test.wantResultTypes[0]
+			}
+			t.Fatalf("test %s, have result type: %q, want result type: %q", test.name, haveResultType, wantResultType)
+		}
+	}
+}
+
 func Test_searchResultsResolver_ApproximateResultCount(t *testing.T) {
 	type fields struct {
 		results             []searchResultResolver

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1106,14 +1106,14 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 			resultTypes:          []string{"diff"},
 			numRepoRevs:          51,
 			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Your search for diffs would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`,
+			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
 			resultTypes:          []string{"commit"},
 			numRepoRevs:          51,
 			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Your search for commits would run on more than 50 repositories. That's a bit much to process at once. Instead, try using the "repo:" filter to narrow down which repositories to search.`,
+			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "no_warning_when_commit_search_within_search_limit",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1129,6 +1129,13 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 			wantResultTypes:      []string{"file"},
 			wantAlertDescription: "",
 		},
+		{
+			name:                 "multiple_result_type_search_is_unaffected",
+			resultTypes:          []string{"file", "commit"},
+			numRepoRevs:          200,
+			wantResultTypes:      []string{"file", "commit"},
+			wantAlertDescription: "",
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Addresses #5519 via https://github.com/sourcegraph/sourcegraph/issues/5519#issuecomment-555226517

Test plan: Added tests. Confirmed working:

<img width="1133" alt="Screen Shot 2019-11-22 at 9 38 49 PM" src="https://user-images.githubusercontent.com/888624/69473366-cc1a5f00-0d70-11ea-918b-86ebd00ea45b.png">

<img width="1126" alt="Screen Shot 2019-11-22 at 9 38 39 PM" src="https://user-images.githubusercontent.com/888624/69473369-cde42280-0d70-11ea-8dd0-6f110a4c1ffd.png">

