### PR TITLE
Regression: Extract codenav utils

### DIFF
--- a/web/src/regression/codenav.test.ts
+++ b/web/src/regression/codenav.test.ts
@@ -11,7 +11,7 @@ import { ensureLoggedInOrCreateTestUser } from './util/helpers'
 import { ScreenshotVerifier } from './util/ScreenshotVerifier'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { ensureTestExternalService } from './util/api'
-import { TestCase, testCodeIntel } from './util/codeintel'
+import { testCodeIntel } from './util/codeintel'
 
 describe('Code navigation regression test suite', () => {
     const testUsername = 'test-codenav'

--- a/web/src/regression/codenav.test.ts
+++ b/web/src/regression/codenav.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Driver } from '../../../shared/src/e2e/driver'
-import { getConfig } from '../../../shared/src/e2e/config'
+import { getConfig, Config } from '../../../shared/src/e2e/config'
 import { getTestTools } from './util/init'
 import { TestResourceManager } from './util/TestResourceManager'
 import { GraphQLClient } from './util/GraphQLClient'
@@ -91,20 +91,6 @@ describe('Code navigation regression test suite', () => {
     test(
         'Basic code intel',
         async () => {
-            interface TestCase {
-                repoRev: string
-                files: {
-                    path: string
-                    locations: {
-                        line: number
-                        token: string
-                        expectedHoverContains: string
-                        expectedDefinition: string | string[]
-                        expectedReferences?: string[]
-                    }[]
-                }[]
-            }
-
             const testCases: TestCase[] = [
                 {
                     repoRev: 'github.com/sourcegraph/sourcegraph@7d557b9cbcaa5d4f612016bddd2f4ef0a7efed25',
@@ -213,98 +199,8 @@ describe('Code navigation regression test suite', () => {
                     ],
                 },
             ]
-            const getTooltip = () =>
-                driver.page.evaluate(() => (document.querySelector('.e2e-tooltip-content') as HTMLElement).innerText)
-            const collectLinks = (selector: string) =>
-                driver.page.evaluate(selector => {
-                    const links: string[] = []
-                    document.querySelectorAll<HTMLElement>(selector).forEach(e => {
-                        e.querySelectorAll<HTMLElement>('a[href]').forEach(a => {
-                            const href = a.getAttribute('href')
-                            if (href) {
-                                links.push(href)
-                            }
-                        })
-                    })
-                    return links
-                }, selector)
-            const clickOnEmptyPartOfCodeView = () =>
-                driver.page.$x('//*[contains(@class, "e2e-blob")]//tr[1]//*[text() = ""]')
-            const findTokenElement = async (line: number, token: string) => {
-                const xpathQuery = `//*[contains(@class, "e2e-blob")]//tr[${line}]//*[normalize-space(text()) = ${JSON.stringify(
-                    token
-                )}]`
-                return {
-                    tokenEl: await driver.page.$x(xpathQuery),
-                    xpathQuery,
-                }
-            }
-            const normalizeWhitespace = (s: string) => s.replace(/\s+/g, ' ')
-            const waitForHover = async (expectedHoverContains: string) => {
-                await driver.page.waitForSelector('.e2e-tooltip-go-to-definition')
-                await driver.page.waitForSelector('.e2e-tooltip-content')
-                expect(normalizeWhitespace(await getTooltip())).toContain(normalizeWhitespace(expectedHoverContains))
-            }
 
-            for (const { repoRev, files } of testCases) {
-                for (const { path, locations } of files) {
-                    await driver.page.goto(config.sourcegraphBaseUrl + `/${repoRev}/-/blob${path}`)
-                    await driver.page.waitForSelector('.e2e-blob')
-                    for (const {
-                        line,
-                        token,
-                        expectedHoverContains,
-                        expectedDefinition,
-                        expectedReferences,
-                    } of locations) {
-                        const { tokenEl, xpathQuery } = await findTokenElement(line, token)
-                        if (tokenEl.length === 0) {
-                            throw new Error(
-                                `did not find token ${JSON.stringify(token)} on page. XPath query was: ${xpathQuery}`
-                            )
-                        }
-
-                        // Check hover and click
-                        await tokenEl[0].hover()
-                        await waitForHover(expectedHoverContains)
-                        const { tokenEl: emptyTokenEl } = await findTokenElement(line, '')
-                        await emptyTokenEl[0].hover()
-                        await driver.page.waitForFunction(
-                            () => document.querySelectorAll('.e2e-tooltip-go-to-definition').length === 0
-                        )
-                        await tokenEl[0].click()
-                        await waitForHover(expectedHoverContains)
-
-                        // Find-references
-                        if (expectedReferences) {
-                            await (await driver.findElementWithText('Find references')).click()
-                            await driver.page.waitForSelector('.e2e-search-result')
-                            const refLinks = await collectLinks('.e2e-search-result')
-                            for (const expectedReference of expectedReferences) {
-                                expect(refLinks.includes(expectedReference)).toBeTruthy()
-                            }
-                            await clickOnEmptyPartOfCodeView()
-                        }
-
-                        // Go-to-definition
-                        await (await driver.findElementWithText('Go to definition')).click()
-                        if (Array.isArray(expectedDefinition)) {
-                            await driver.page.waitForSelector('.e2e-search-result')
-                            const defLinks = await collectLinks('.e2e-search-result')
-                            expect(expectedDefinition.every(l => defLinks.includes(l))).toBeTruthy()
-                        } else {
-                            await driver.page.waitForFunction(
-                                defURL => document.location.href.endsWith(defURL),
-                                { timeout: 2000 },
-                                expectedDefinition
-                            )
-                            await driver.page.goBack()
-                        }
-
-                        await driver.page.keyboard.press('Escape')
-                    }
-                }
-            }
+            return testCodeIntel(driver, config, testCases)
         },
         30 * 1000
     )
@@ -373,3 +269,105 @@ describe('Code navigation regression test suite', () => {
         )
     })
 })
+
+interface TestCase {
+    repoRev: string
+    files: {
+        path: string
+        locations: {
+            line: number
+            token: string
+            expectedHoverContains: string
+            expectedDefinition: string | string[]
+            expectedReferences?: string[]
+        }[]
+    }[]
+}
+
+async function testCodeIntel(driver: Driver, config: Pick<Config, 'sourcegraphBaseUrl'>, testCases: TestCase[]) {
+    const getTooltip = () =>
+        driver.page.evaluate(() => (document.querySelector('.e2e-tooltip-content') as HTMLElement).innerText)
+    const collectLinks = (selector: string) =>
+        driver.page.evaluate(selector => {
+            const links: string[] = []
+            document.querySelectorAll<HTMLElement>(selector).forEach(e => {
+                e.querySelectorAll<HTMLElement>('a[href]').forEach(a => {
+                    const href = a.getAttribute('href')
+                    if (href) {
+                        links.push(href)
+                    }
+                })
+            })
+            return links
+        }, selector)
+    const clickOnEmptyPartOfCodeView = () => driver.page.$x('//*[contains(@class, "e2e-blob")]//tr[1]//*[text() = ""]')
+    const findTokenElement = async (line: number, token: string) => {
+        const xpathQuery = `//*[contains(@class, "e2e-blob")]//tr[${line}]//*[normalize-space(text()) = ${JSON.stringify(
+            token
+        )}]`
+        return {
+            tokenEl: await driver.page.$x(xpathQuery),
+            xpathQuery,
+        }
+    }
+    const normalizeWhitespace = (s: string) => s.replace(/\s+/g, ' ')
+    const waitForHover = async (expectedHoverContains: string) => {
+        await driver.page.waitForSelector('.e2e-tooltip-go-to-definition')
+        await driver.page.waitForSelector('.e2e-tooltip-content')
+        expect(normalizeWhitespace(await getTooltip())).toContain(normalizeWhitespace(expectedHoverContains))
+    }
+
+    for (const { repoRev, files } of testCases) {
+        for (const { path, locations } of files) {
+            await driver.page.goto(config.sourcegraphBaseUrl + `/${repoRev}/-/blob${path}`)
+            await driver.page.waitForSelector('.e2e-blob')
+            for (const { line, token, expectedHoverContains, expectedDefinition, expectedReferences } of locations) {
+                const { tokenEl, xpathQuery } = await findTokenElement(line, token)
+                if (tokenEl.length === 0) {
+                    throw new Error(
+                        `did not find token ${JSON.stringify(token)} on page. XPath query was: ${xpathQuery}`
+                    )
+                }
+
+                // Check hover and click
+                await tokenEl[0].hover()
+                await waitForHover(expectedHoverContains)
+                const { tokenEl: emptyTokenEl } = await findTokenElement(line, '')
+                await emptyTokenEl[0].hover()
+                await driver.page.waitForFunction(
+                    () => document.querySelectorAll('.e2e-tooltip-go-to-definition').length === 0
+                )
+                await tokenEl[0].click()
+                await waitForHover(expectedHoverContains)
+
+                // Find-references
+                if (expectedReferences) {
+                    await (await driver.findElementWithText('Find references')).click()
+                    await driver.page.waitForSelector('.e2e-search-result')
+                    const refLinks = await collectLinks('.e2e-search-result')
+                    for (const expectedReference of expectedReferences) {
+                        expect(refLinks.includes(expectedReference)).toBeTruthy()
+                    }
+                    await clickOnEmptyPartOfCodeView()
+                }
+
+                // Go-to-definition
+                await (await driver.findElementWithText('Go to definition')).click()
+                if (Array.isArray(expectedDefinition)) {
+                    await driver.page.waitForSelector('.e2e-search-result')
+                    const defLinks = await collectLinks('.e2e-search-result')
+                    expect(expectedDefinition.every(l => defLinks.includes(l))).toBeTruthy()
+                } else {
+                    await driver.page.waitForFunction(
+                        defURL => document.location.href.endsWith(defURL),
+                        { timeout: 2000 },
+                        expectedDefinition
+                    )
+                    await driver.page.goBack()
+                }
+
+                await driver.page.keyboard.press('Escape')
+            }
+        }
+    }
+}

--- a/web/src/regression/codenav.test.ts
+++ b/web/src/regression/codenav.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Driver } from '../../../shared/src/e2e/driver'
-import { getConfig, Config } from '../../../shared/src/e2e/config'
+import { getConfig } from '../../../shared/src/e2e/config'
 import { getTestTools } from './util/init'
 import { TestResourceManager } from './util/TestResourceManager'
 import { GraphQLClient } from './util/GraphQLClient'
@@ -11,6 +11,7 @@ import { ensureLoggedInOrCreateTestUser } from './util/helpers'
 import { ScreenshotVerifier } from './util/ScreenshotVerifier'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { ensureTestExternalService } from './util/api'
+import { TestCase, testCodeIntel } from './util/codeintel'
 
 describe('Code navigation regression test suite', () => {
     const testUsername = 'test-codenav'
@@ -269,105 +270,3 @@ describe('Code navigation regression test suite', () => {
         )
     })
 })
-
-interface TestCase {
-    repoRev: string
-    files: {
-        path: string
-        locations: {
-            line: number
-            token: string
-            expectedHoverContains: string
-            expectedDefinition: string | string[]
-            expectedReferences?: string[]
-        }[]
-    }[]
-}
-
-async function testCodeIntel(driver: Driver, config: Pick<Config, 'sourcegraphBaseUrl'>, testCases: TestCase[]) {
-    const getTooltip = () =>
-        driver.page.evaluate(() => (document.querySelector('.e2e-tooltip-content') as HTMLElement).innerText)
-    const collectLinks = (selector: string) =>
-        driver.page.evaluate(selector => {
-            const links: string[] = []
-            document.querySelectorAll<HTMLElement>(selector).forEach(e => {
-                e.querySelectorAll<HTMLElement>('a[href]').forEach(a => {
-                    const href = a.getAttribute('href')
-                    if (href) {
-                        links.push(href)
-                    }
-                })
-            })
-            return links
-        }, selector)
-    const clickOnEmptyPartOfCodeView = () => driver.page.$x('//*[contains(@class, "e2e-blob")]//tr[1]//*[text() = ""]')
-    const findTokenElement = async (line: number, token: string) => {
-        const xpathQuery = `//*[contains(@class, "e2e-blob")]//tr[${line}]//*[normalize-space(text()) = ${JSON.stringify(
-            token
-        )}]`
-        return {
-            tokenEl: await driver.page.$x(xpathQuery),
-            xpathQuery,
-        }
-    }
-    const normalizeWhitespace = (s: string) => s.replace(/\s+/g, ' ')
-    const waitForHover = async (expectedHoverContains: string) => {
-        await driver.page.waitForSelector('.e2e-tooltip-go-to-definition')
-        await driver.page.waitForSelector('.e2e-tooltip-content')
-        expect(normalizeWhitespace(await getTooltip())).toContain(normalizeWhitespace(expectedHoverContains))
-    }
-
-    for (const { repoRev, files } of testCases) {
-        for (const { path, locations } of files) {
-            await driver.page.goto(config.sourcegraphBaseUrl + `/${repoRev}/-/blob${path}`)
-            await driver.page.waitForSelector('.e2e-blob')
-            for (const { line, token, expectedHoverContains, expectedDefinition, expectedReferences } of locations) {
-                const { tokenEl, xpathQuery } = await findTokenElement(line, token)
-                if (tokenEl.length === 0) {
-                    throw new Error(
-                        `did not find token ${JSON.stringify(token)} on page. XPath query was: ${xpathQuery}`
-                    )
-                }
-
-                // Check hover and click
-                await tokenEl[0].hover()
-                await waitForHover(expectedHoverContains)
-                const { tokenEl: emptyTokenEl } = await findTokenElement(line, '')
-                await emptyTokenEl[0].hover()
-                await driver.page.waitForFunction(
-                    () => document.querySelectorAll('.e2e-tooltip-go-to-definition').length === 0
-                )
-                await tokenEl[0].click()
-                await waitForHover(expectedHoverContains)
-
-                // Find-references
-                if (expectedReferences) {
-                    await (await driver.findElementWithText('Find references')).click()
-                    await driver.page.waitForSelector('.e2e-search-result')
-                    const refLinks = await collectLinks('.e2e-search-result')
-                    for (const expectedReference of expectedReferences) {
-                        expect(refLinks.includes(expectedReference)).toBeTruthy()
-                    }
-                    await clickOnEmptyPartOfCodeView()
-                }
-
-                // Go-to-definition
-                await (await driver.findElementWithText('Go to definition')).click()
-                if (Array.isArray(expectedDefinition)) {
-                    await driver.page.waitForSelector('.e2e-search-result')
-                    const defLinks = await collectLinks('.e2e-search-result')
-                    expect(expectedDefinition.every(l => defLinks.includes(l))).toBeTruthy()
-                } else {
-                    await driver.page.waitForFunction(
-                        defURL => document.location.href.endsWith(defURL),
-                        { timeout: 2000 },
-                        expectedDefinition
-                    )
-                    await driver.page.goBack()
-                }
-
-                await driver.page.keyboard.press('Escape')
-            }
-        }
-    }
-}

--- a/web/src/regression/codenav.test.ts
+++ b/web/src/regression/codenav.test.ts
@@ -91,8 +91,8 @@ describe('Code navigation regression test suite', () => {
 
     test(
         'Basic code intel',
-        async () => {
-            const testCases: TestCase[] = [
+        async () =>
+            testCodeIntel(driver, config, [
                 {
                     repoRev: 'github.com/sourcegraph/sourcegraph@7d557b9cbcaa5d4f612016bddd2f4ef0a7efed25',
                     files: [
@@ -199,10 +199,7 @@ describe('Code navigation regression test suite', () => {
                         },
                     ],
                 },
-            ]
-
-            return testCodeIntel(driver, config, testCases)
-        },
+            ]),
         30 * 1000
     )
 

--- a/web/src/regression/util/codeintel.ts
+++ b/web/src/regression/util/codeintel.ts
@@ -1,0 +1,104 @@
+import { Driver } from '../../../../shared/src/e2e/driver'
+import { Config } from '../../../../shared/src/e2e/config'
+
+export interface TestCase {
+    repoRev: string
+    files: {
+        path: string
+        locations: {
+            line: number
+            token: string
+            expectedHoverContains: string
+            expectedDefinition: string | string[]
+            expectedReferences?: string[]
+        }[]
+    }[]
+}
+
+export async function testCodeIntel(driver: Driver, config: Pick<Config, 'sourcegraphBaseUrl'>, testCases: TestCase[]) {
+    const getTooltip = () =>
+        driver.page.evaluate(() => (document.querySelector('.e2e-tooltip-content') as HTMLElement).innerText)
+    const collectLinks = (selector: string) =>
+        driver.page.evaluate(selector => {
+            const links: string[] = []
+            document.querySelectorAll<HTMLElement>(selector).forEach(e => {
+                e.querySelectorAll<HTMLElement>('a[href]').forEach(a => {
+                    const href = a.getAttribute('href')
+                    if (href) {
+                        links.push(href)
+                    }
+                })
+            })
+            return links
+        }, selector)
+    const clickOnEmptyPartOfCodeView = () => driver.page.$x('//*[contains(@class, "e2e-blob")]//tr[1]//*[text() = ""]')
+    const findTokenElement = async (line: number, token: string) => {
+        const xpathQuery = `//*[contains(@class, "e2e-blob")]//tr[${line}]//*[normalize-space(text()) = ${JSON.stringify(
+            token
+        )}]`
+        return {
+            tokenEl: await driver.page.$x(xpathQuery),
+            xpathQuery,
+        }
+    }
+    const normalizeWhitespace = (s: string) => s.replace(/\s+/g, ' ')
+    const waitForHover = async (expectedHoverContains: string) => {
+        await driver.page.waitForSelector('.e2e-tooltip-go-to-definition')
+        await driver.page.waitForSelector('.e2e-tooltip-content')
+        expect(normalizeWhitespace(await getTooltip())).toContain(normalizeWhitespace(expectedHoverContains))
+    }
+
+    for (const { repoRev, files } of testCases) {
+        for (const { path, locations } of files) {
+            await driver.page.goto(config.sourcegraphBaseUrl + `/${repoRev}/-/blob${path}`)
+            await driver.page.waitForSelector('.e2e-blob')
+            for (const { line, token, expectedHoverContains, expectedDefinition, expectedReferences } of locations) {
+                const { tokenEl, xpathQuery } = await findTokenElement(line, token)
+                if (tokenEl.length === 0) {
+                    throw new Error(
+                        `did not find token ${JSON.stringify(token)} on page. XPath query was: ${xpathQuery}`
+                    )
+                }
+
+                // Check hover and click
+                await tokenEl[0].hover()
+                await waitForHover(expectedHoverContains)
+                const { tokenEl: emptyTokenEl } = await findTokenElement(line, '')
+                await emptyTokenEl[0].hover()
+                await driver.page.waitForFunction(
+                    () => document.querySelectorAll('.e2e-tooltip-go-to-definition').length === 0
+                )
+                await tokenEl[0].click()
+                await waitForHover(expectedHoverContains)
+
+                // Find-references
+                if (expectedReferences) {
+                    await (await driver.findElementWithText('Find references')).click()
+                    await driver.page.waitForSelector('.e2e-search-result')
+                    const refLinks = await collectLinks('.e2e-search-result')
+                    for (const expectedReference of expectedReferences) {
+                        expect(refLinks.includes(expectedReference)).toBeTruthy()
+                    }
+                    await clickOnEmptyPartOfCodeView()
+                }
+
+                // Go-to-definition
+                await (await driver.findElementWithText('Go to definition')).click()
+                if (Array.isArray(expectedDefinition)) {
+                    await driver.page.waitForSelector('.e2e-search-result')
+                    const defLinks = await collectLinks('.e2e-search-result')
+                    expect(expectedDefinition.every(l => defLinks.includes(l))).toBeTruthy()
+                } else {
+                    await driver.page.waitForFunction(
+                        defURL => document.location.href.endsWith(defURL),
+                        { timeout: 2000 },
+                        expectedDefinition
+                    )
+                    await driver.page.goBack()
+                }
+
+                await driver.page.keyboard.press('Escape')
+            }
+        }
+    }
+}


### PR DESCRIPTION
We will want the same functionality from the Basic Code Intel test for the precise code intelligence tests. This moves some of the code to make it available to a second suite.