### PR TITLE
web: Update repo and file suggestions to include regex boundaries

### DIFF
--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -468,13 +468,8 @@ export class QueryInput extends React.Component<Props, State> {
                 return { suggestions: noSuggestions }
             }
 
-            // Add "regex end of string boundary" to limit future suggestion results
-            const selectedSuggestion = !suggestion.fromFuzzySearch
-                ? suggestion
-                : { ...suggestion, value: suggestion.value + '$' }
-
             this.inputValues.next({
-                ...insertSuggestionInQuery(value.query, selectedSuggestion, suggestions.cursorPosition),
+                ...insertSuggestionInQuery(value.query, suggestion, suggestions.cursorPosition),
                 fromUserInput: true,
             })
 

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -59,6 +59,11 @@ export interface Suggestion {
     type: SuggestionTypes
     /** The value to be suggested and that will be added to queries */
     value: string
+    /**
+     * Optional value to use when suggestion is displayed to the user.
+     * Useful for displaying a "human-readable" suggestion value
+     */
+    displayValue?: string
     /** Description that will be displayed together with suggestion value */
     description?: string
     /** Fuzzy-search suggestions may have a url for redirect when selected */
@@ -81,7 +86,10 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
         case 'Repository': {
             return {
                 type: SuggestionTypes.repo,
-                value: item.name,
+                // Add "regex start and end boundaries" to
+                // correctly scope additional suggestions
+                value: '^' + item.name + '$',
+                displayValue: item.name,
                 url: `/${item.name}`,
                 label: 'go to repository',
             }
@@ -104,7 +112,8 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             }
             return {
                 type: SuggestionTypes.file,
-                value: item.name,
+                value: item.name + '$',
+                displayValue: item.name,
                 description: descriptionParts.join(' — '),
                 url: `${item.url}?suggestion`,
                 label: 'go to file',
@@ -166,7 +175,7 @@ export const SuggestionItem: React.FunctionComponent<SuggestionProps> = ({
 }) => (
     <li className={'suggestion' + (isSelected ? ' suggestion--selected' : '')} {...props}>
         <SuggestionIcon className="icon-inline suggestion__icon" suggestion={suggestion} />
-        <div className="suggestion__title">{suggestion.value}</div>
+        <div className="suggestion__title">{suggestion.displayValue ?? suggestion.value}</div>
         <div className="suggestion__description">{suggestion.description}</div>
         {(showUrlLabel || defaultLabel) && (
             <div className="suggestion__action" hidden={!isSelected}>

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -108,9 +108,10 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             }
             descriptionParts.push(basename(item.repository.name))
             if (item.isDirectory) {
+                console.log('YES ', item)
                 return {
                     type: SuggestionTypes.dir,
-                    value: formatRegExp(item.path),
+                    value: '^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
                     url: `${item.url}?suggestion`,
                     label: 'go to dir',

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -6,6 +6,7 @@ import FilterIcon from 'mdi-react/FilterIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import { SymbolIcon } from '../../../../shared/src/symbols/SymbolIcon'
+import { escapeRegExp } from 'lodash'
 
 export enum SuggestionTypes {
     filters = 'filters',
@@ -81,6 +82,11 @@ interface SuggestionIconProps {
     className?: string
 }
 
+/**
+ * @returns The given string with escaped special characters and wrapped with regex boundaries
+ */
+const formatRegExp = (value: string): string => '^' + escapeRegExp(value) + '$'
+
 export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undefined {
     switch (item.__typename) {
         case 'Repository': {
@@ -88,7 +94,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                 type: SuggestionTypes.repo,
                 // Add "regex start and end boundaries" to
                 // correctly scope additional suggestions
-                value: '^' + item.name + '$',
+                value: formatRegExp(item.name),
                 displayValue: item.name,
                 url: `/${item.name}`,
                 label: 'go to repository',
@@ -104,7 +110,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             if (item.isDirectory) {
                 return {
                     type: SuggestionTypes.dir,
-                    value: item.name,
+                    value: formatRegExp(item.path),
                     description: descriptionParts.join(' — '),
                     url: `${item.url}?suggestion`,
                     label: 'go to dir',
@@ -112,7 +118,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             }
             return {
                 type: SuggestionTypes.file,
-                value: item.name + '$',
+                value: formatRegExp(item.path),
                 displayValue: item.name,
                 description: descriptionParts.join(' — '),
                 url: `${item.url}?suggestion`,

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -108,7 +108,6 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
             }
             descriptionParts.push(basename(item.repository.name))
             if (item.isDirectory) {
-                console.log('YES ', item)
                 return {
                     type: SuggestionTypes.dir,
                     value: '^' + escapeRegExp(item.path),


### PR DESCRIPTION
- Update repo and file suggestions to include regex boundaries
  - Add `displayValue` property to `Suggestion` type for rendering "human-readable" values
  - Move suggestion value formatting from `QueryInput.onSuggestionSelect()` to `Suggestion.tsx/createSuggestion()`

Fix #6747
Fix #6997