### PR TITLE
ci: parallelize docker build scripts

### DIFF
--- a/cmd/management-console/build-assets.sh
+++ b/cmd/management-console/build-assets.sh
@@ -9,6 +9,6 @@ yarn --mutex network install
 popd
 
 pushd web/
-yarn install
-yarn  --mutex network run build
+yarn --mutex network install
+yarn run build
 popd

--- a/cmd/management-console/build-assets.sh
+++ b/cmd/management-console/build-assets.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 cd $(dirname "${BASH_SOURCE[0]}")
-set -ex
+set -euxo pipefail
 
 # for node_modules/@sourcegraph/tsconfig/tsconfig.json
 pushd ../..
-yarn install
+yarn --mutex network install
 popd
 
 pushd web/
 yarn install
-yarn run build
+yarn  --mutex network run build
 popd

--- a/cmd/management-console/build-assets.sh
+++ b/cmd/management-console/build-assets.sh
@@ -5,10 +5,14 @@ set -euxo pipefail
 
 # for node_modules/@sourcegraph/tsconfig/tsconfig.json
 pushd ../..
+# mutex is necessary since frontend and the management-console can
+# run concurrent "yarn" installs
 yarn --mutex network install
 popd
 
 pushd web/
+# mutex is necessary since frontend and the management-console can
+# run concurrent "yarn" installs
 yarn --mutex network install
 yarn run build
 popd

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -14,7 +14,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -33,7 +33,7 @@ additional_images=${@:-github.com/sourcegraph/sourcegraph/cmd/frontend github.co
 server_pkg=${SERVER_PKG:-github.com/sourcegraph/sourcegraph/cmd/server}
 
 cp -a ./cmd/server/rootfs/. "$OUTPUT"
-bindir="$OUTPUT/usr/local/bin"
+export bindir="$OUTPUT/usr/local/bin"
 mkdir -p "$bindir"
 
 go_build() {
@@ -45,14 +45,14 @@ go_build() {
       -buildmode exe \
       -installsuffix netgo \
       -tags "dist netgo" \
-      -o "$BINDIR/$(basename "$package")" "$package"
+      -o "$bindir/$(basename "$package")" "$package"
 }
 export -f go_build
 
 echo "--- go build"
 
 PACKAGES=(
-    $server_pkg
+    $server_pkg \
     github.com/sourcegraph/sourcegraph/cmd/github-proxy \
     github.com/sourcegraph/sourcegraph/cmd/gitserver \
     github.com/sourcegraph/sourcegraph/cmd/query-runner \

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -14,7 +14,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -52,15 +52,18 @@ export -f go_build
 echo "--- go build"
 
 PACKAGES=(
-    $server_pkg \
     github.com/sourcegraph/sourcegraph/cmd/github-proxy \
     github.com/sourcegraph/sourcegraph/cmd/gitserver \
     github.com/sourcegraph/sourcegraph/cmd/query-runner \
     github.com/sourcegraph/sourcegraph/cmd/replacer \
     github.com/sourcegraph/sourcegraph/cmd/searcher \
+    $additional_images
+    \
     github.com/google/zoekt/cmd/zoekt-archive-index \
     github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver \
-    github.com/google/zoekt/cmd/zoekt-webserver $additional_images
+    github.com/google/zoekt/cmd/zoekt-webserver \
+    \
+    $server_pkg
 )
 
 parallel_run go_build {} ::: "${PACKAGES[@]}"

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -14,7 +14,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -1,16 +1,36 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -ex
-cd $(dirname "${BASH_SOURCE[0]}")/../..
+set -exuo pipefail
+cd $(dirname "${BASH_SOURCE[0]}")/../../..
 
-pushd ..
-echo "--- yarn install"
-yarn --frozen-lockfile --network-timeout 60000
-echo "--- browser: yarn run build (phabricator integration assets)"
-(pushd browser && TARGETS=phabricator yarn build && popd)
-echo "--- web: yarn run build"
-(pushd web && NODE_ENV=production yarn -s run build --color && popd)
-popd
+parallel_run() {
+    log_file=$(mktemp)
+    trap "rm -rf $log_file" EXIT
 
-echo "--- generate"
-dev/generate.sh
+    parallel --keep-order --line-buffer --tag --joblog $log_file "$@"
+    cat $log_file
+}
+
+echo "--- yarn root"
+# --mutex is necessary since frontend and the management-console can
+# run concurrent "yarn" installs
+yarn --mutex network --frozen-lockfile --network-timeout 60000
+
+build_browser() {
+    echo "--- yarn browser"
+    (cd browser && TARGETS=phabricator yarn build)
+}
+
+build_web() {
+    echo "--- yarn web"
+    (cd web && NODE_ENV=production yarn -s run build --color)
+}
+
+export -f build_browser
+export -f build_web
+
+echo "--- (enterprise) build browser and web concurrently"
+parallel_run ::: build_browser build_web
+
+echo "--- (enterprise) generate"
+./enterprise/dev/generate.sh

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -12,7 +12,7 @@ parallel_run() {
 }
 
 echo "--- yarn root"
-# --mutex is necessary since frontend and the management-console can
+# mutex is necessary since frontend and the management-console can
 # run concurrent "yarn" installs
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -12,17 +12,18 @@ parallel_run() {
 }
 
 build_frontend_enterprise() {
-    echo "--- (enterprise) build frontend"
+    echo "--- (enterprise) pre-build frontend"
    ./enterprise/cmd/frontend/pre-build.sh
 }
 export -f build_frontend_enterprise
 
 build_management_console() {
-    echo "--- build management-console"
+    echo "--- pre- build management-console"
     ./cmd/management-console/pre-build.sh
 }
 export -f build_management_console
 
 # We run the the management-console's pre-build script in parallel because it invokes expensive
 # yarn/node commands
+echo "--- (enterprise) pre-build frontend and management console in parallel"
 parallel_run {} ::: build_frontend_enterprise build_management_console

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -7,7 +7,7 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    parallel --jobs 6 --keep-order --line-buffer --tag --joblog $log_file "$@"
     cat $log_file
 }
 

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 
-cd $(dirname "${BASH_SOURCE[0]}")/../..
-set -ex
+cd $(dirname "${BASH_SOURCE[0]}")/../../..
+set -euxo pipefail
 
-./cmd/frontend/pre-build.sh
+parallel_run() {
+    log_file=$(mktemp)
+    trap "rm -rf $log_file" EXIT
+
+    parallel --keep-order --line-buffer --tag --joblog $log_file "$@"
+    cat $log_file
+}
+
+build_frontend_enterprise() {
+    echo "--- (enterprise) build frontend"
+   ./enterprise/cmd/frontend/pre-build.sh
+}
+export -f build_frontend_enterprise
+
+build_management_console() {
+    echo "--- build management-console"
+    ./cmd/management-console/pre-build.sh
+}
+export -f build_management_console
+
+# We run the the management-console's pre-build script in parallel because it invokes expensive
+# yarn/node commands
+parallel_run {} ::: build_frontend_enterprise build_management_console


### PR DESCRIPTION
Some parts of our `docker build` scripts can be sped up by running some independent steps in parallel: 

- server: the frontend and management console pre-build scripts can be run in parallel 
- frontend: the phabricator extension and web assets can be built in parallel
- server: all of the go binaries can be built in parallel 

By using [GNU Parallel](https://en.wikipedia.org/wiki/GNU_parallel) to concurrently run these steps, we can shave ~2-3 minutes off of the server's `docker build` step. 

Notes: 

- This introduces a new dev dependency on [GNU Parallel](https://en.wikipedia.org/wiki/GNU_parallel) (already added to our buildkite agents)
- Buildkite's timestamp UI for certain sections can no longer give you detailed timing information since things are no being run in parallel. However, part of the output of `parallel_run` (utility function that I introduced) can display this same information. Example:

```
build_frontend_enterprise	Seq	Host	Starttime	JobRuntime	Send	Receive	Exitval	Signal	Command
build_frontend_enterprise	1	:	1574719866.609	   117.459	0	1627	0	0	build_browser
build_frontend_enterprise	2	:	1574719866.612	   232.769	0	1475	0	0	build_web
```

