### PR TITLE
tests: factor out zip and store helper functions

### DIFF
--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -481,7 +481,7 @@ func TestMaxMatches(t *testing.T) {
 // - A path must match all (not any) of the IncludePatterns
 // - An empty pattern is allowed
 func TestPathMatches(t *testing.T) {
-	zipData, err := createZip(map[string]string{
+	zipData, err := testutil.CreateZip(map[string]string{
 		"a":   "",
 		"a/b": "",
 		"a/c": "",
@@ -520,27 +520,6 @@ func TestPathMatches(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got file matches %v, want %v", got, want)
 	}
-}
-
-func createZip(files map[string]string) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	zw := zip.NewWriter(buf)
-	for name, body := range files {
-		w, err := zw.CreateHeader(&zip.FileHeader{
-			Name:   name,
-			Method: zip.Store,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if _, err := w.Write([]byte(body)); err != nil {
-			return nil, err
-		}
-	}
-	if err := zw.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }
 
 // githubStore fetches from github and caches across test runs.

--- a/internal/store/zipcache.go
+++ b/internal/store/zipcache.go
@@ -121,7 +121,7 @@ func readZipFile(path string) (*ZipFile, error) {
 
 	// Create at populate ZipFile from contents.
 	zf := &ZipFile{f: f}
-	if err := zf.populateFiles(r); err != nil {
+	if err := zf.PopulateFiles(r); err != nil {
 		return nil, err
 	}
 
@@ -138,7 +138,7 @@ func readZipFile(path string) (*ZipFile, error) {
 	return zf, nil
 }
 
-func (f *ZipFile) populateFiles(r *zip.Reader) error {
+func (f *ZipFile) PopulateFiles(r *zip.Reader) error {
 	f.Files = make([]SrcFile, len(r.File))
 	for i, file := range r.File {
 		if file.Method != zip.Store {
@@ -180,7 +180,7 @@ func MockZipFile(data []byte) (*ZipFile, error) {
 		return nil, err
 	}
 	zf := new(ZipFile)
-	if err := zf.populateFiles(r); err != nil {
+	if err := zf.PopulateFiles(r); err != nil {
 		return nil, err
 	}
 	// Make a copy of data to avoid accidental alias/re-use bugs.

--- a/internal/testutil/store.go
+++ b/internal/testutil/store.go
@@ -1,0 +1,62 @@
+package testutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/store"
+)
+
+func NewStore(files map[string]string) (*store.Store, func(), error) {
+	buf := new(bytes.Buffer)
+	w := tar.NewWriter(buf)
+	for name, body := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0600,
+			Size: int64(len(body)),
+		}
+		if err := w.WriteHeader(hdr); err != nil {
+			return nil, nil, err
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			return nil, nil, err
+		}
+	}
+	// git-archive usually includes a pax header we should ignore.
+	// use a body which matches a test case. Ensures we don't return this
+	// false entry as a result.
+	if err := addpaxheader(w, "Hello world\n"); err != nil {
+		return nil, nil, err
+	}
+
+	err := w.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+	d, err := ioutil.TempDir("", "search_test")
+	if err != nil {
+		return nil, nil, err
+	}
+	return &store.Store{
+		FetchTar: func(ctx context.Context, repo gitserver.Repo, commit api.CommitID) (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		},
+		Path: d,
+	}, func() { os.RemoveAll(d) }, nil
+}
+
+func addpaxheader(w *tar.Writer, body string) error {
+	hdr := &tar.Header{
+		Name:       "pax_global_header",
+		Typeflag:   tar.TypeXGlobalHeader,
+		PAXRecords: map[string]string{"somekey": body},
+	}
+	return w.WriteHeader(hdr)
+}

--- a/internal/testutil/zip.go
+++ b/internal/testutil/zip.go
@@ -1,0 +1,88 @@
+package testutil
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/store"
+)
+
+func CreateZip(files map[string]string) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+	for name, body := range files {
+		w, err := zw.CreateHeader(&zip.FileHeader{
+			Name:   name,
+			Method: zip.Store,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			return nil, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func MockZipFile(data []byte) (*store.ZipFile, error) {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	zf := new(store.ZipFile)
+	if err := zf.PopulateFiles(r); err != nil {
+		return nil, err
+	}
+	// Make a copy of data to avoid accidental alias/re-use bugs.
+	// This method is only for testing, so don't sweat the performance.
+	zf.Data = make([]byte, len(data))
+	copy(zf.Data, data)
+	// zf.f is intentionally left nil;
+	// this is an indicator that this is a mock ZipFile.
+	return zf, nil
+}
+
+func TempZipFromFiles(files map[string]string) (path string, cleanup func(), err error) {
+	s, cleanup, err := NewStore(files)
+	if err != nil {
+		return "", cleanup, err
+	}
+
+	ctx := context.Background()
+	repo := gitserver.Repo{Name: "foo", URL: "u"}
+	var commit api.CommitID = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	path, err = s.PrepareZip(ctx, repo, commit)
+	if err != nil {
+		return "", cleanup, err
+	}
+	return path, cleanup, nil
+}
+
+func TempZipFileOnDisk(data []byte) (string, func(), error) {
+	z, err := MockZipFile(data)
+	if err != nil {
+		return "", nil, err
+	}
+	d, err := ioutil.TempDir("", "temp_zip_dir")
+	if err != nil {
+		return "", nil, err
+	}
+	f, err := ioutil.TempFile(d, "temp_zip")
+	if err != nil {
+		return "", nil, err
+	}
+	_, err = f.Write(z.Data)
+	if err != nil {
+		return "", nil, err
+	}
+	return f.Name(), func() { os.RemoveAll(d) }, nil
+}


### PR DESCRIPTION
Searcher, replacer, and comby code use zip file / store functions that are duplicated. This PR factors out the functions and puts them in `testutil/zip.go` and `testutil/store.go` respectively. None of the functions are changed, they are only moved. Callers are updated.

Note: I don't want `testutil` to be a dumping ground for test functions; they only go here if they are shared by > 1 packages. Perhaps we can call this the `testing` package instead of `testutil`

Test plan: Semantics preserving. Affects only tests. Tests pass.
