### PR TITLE
search: convert structural search patterns to match newlines in index

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -128,7 +128,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 	}
 }
 
-func TestStructuralPatToQuery(t *testing.T) {
+func TestStructuralPatToZoektQuery(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Pattern  string

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -128,36 +128,42 @@ func TestQueryToZoektQuery(t *testing.T) {
 	}
 }
 
-func TestStructuralPatToZoektQuery(t *testing.T) {
+func TestStructuralPatToQuery(t *testing.T) {
 	cases := []struct {
-		Name    string
-		Pattern string
-		Want    string
+		Name     string
+		Pattern  string
+		Function func(string) (zoektquery.Q, error)
+		Want     string
 	}{
 		{
-			Name:    "Just a hole",
-			Pattern: ":[1]",
-			Want:    `TRUE`,
+			Name:     "Just a hole",
+			Pattern:  ":[1]",
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `TRUE`,
 		},
 		{
-			Name:    "Adjacent holes",
-			Pattern: ":[1]:[2]:[3]",
-			Want:    `TRUE`,
+			Name:     "Adjacent holes",
+			Pattern:  ":[1]:[2]:[3]",
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `TRUE`,
 		},
 		{
-			Name:    "Substring between holes",
-			Pattern: ":[1] substring :[2]",
-			Want:    `(and case_content_substr:" substring ")`,
+			Name:     "Substring between holes",
+			Pattern:  ":[1] substring :[2]",
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `(and case_content_substr:" substring ")`,
 		},
 		{
-			Name:    "Substring before and after different hole kinds",
-			Pattern: "prefix :[[1]] :[2.] suffix",
-			Want:    `(and case_content_substr:"prefix " case_content_substr:" " case_content_substr:" suffix")`,
+			Name:     "Substring before and after different hole kinds",
+			Pattern:  "prefix :[[1]] :[2.] suffix",
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `(and case_content_substr:"prefix " case_content_substr:" " case_content_substr:" suffix")`,
 		},
 		{
-			Name:    "Substrings covering all hole kinds.",
-			Pattern: `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
-			Want:    `(and case_content_substr:"1. " case_content_substr:" 2. " case_content_substr:" 3. " case_content_substr:" 4. " case_content_substr:" 5. " case_content_substr:" 6. " case_content_substr:" done.")`,
+			Name:     "Substrings covering all hole kinds.",
+			Pattern:  `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `(and case_content_substr:"1. " case_content_substr:" 2. " case_content_substr:" 3. " case_content_substr:" 4. " case_content_substr:" 5. " case_content_substr:" 6. " case_content_substr:" done.")`,
 		},
 		{
 			Name: "Substrings across multiple lines.",
@@ -165,17 +171,32 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 multiple
 lines
  :[2]`,
-			Want: `(and case_content_substr:" spans\nmultiple\nlines\n ")`,
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `(and case_content_substr:" spans\nmultiple\nlines\n ")`,
 		},
 		{
-			Name:    "Allow alphanumeric identifiers in holes",
-			Pattern: "sub :[alphanum_ident_123] string",
-			Want:    `(and case_content_substr:"sub " case_content_substr:" string")`,
+			Name:     "Allow alphanumeric identifiers in holes",
+			Pattern:  "sub :[alphanum_ident_123] string",
+			Function: StructuralPatToConjunctedLiteralsQuery,
+			Want:     `(and case_content_substr:"sub " case_content_substr:" string")`,
+		},
+
+		{
+			Name:     "Whitespace separated holes",
+			Pattern:  ":[1] :[2]",
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"(?:)" case_regex:"[\\t-\\n\\f-\\r ]+" case_regex:"(?:)")`,
+		},
+		{
+			Name:     "Expect newline separated pattern",
+			Pattern:  "ParseInt(:[stuff], :[x]) if err ",
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_content_substr:"ParseInt(" case_regex:",[\\t-\\n\\f-\\r ]+" case_regex:"\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+")`,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			got := StructuralPatToQuery(tt.Pattern)
+			got, _ := tt.Function(tt.Pattern)
 			if got.String() != tt.Want {
 				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), tt.Want)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -193,6 +193,13 @@ lines
 			Function: StructuralPatToRegexpQuery,
 			Want:     `(and case_content_substr:"ParseInt(" case_regex:",[\\t-\\n\\f-\\r ]+" case_regex:"\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+")`,
 		},
+		{
+			Name: "Contiguous whitespace is replaced by regex",
+			Pattern: `ParseInt(:[stuff],    :[x])
+             if err `,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_content_substr:"ParseInt(" case_regex:",[\\t-\\n\\f-\\r ]+" case_regex:"\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+")`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"regexp/syntax"
 	"strings"
 	"time"
@@ -397,7 +398,7 @@ var matchHoleRegexp = lazyregexp.New(splitOnHolesPattern())
 // "foo(:[args])"          -> "foo(" AND ")"
 // ":[fn](:[[1]], :[[2]])" -> "(" AND ", " AND ")"
 // ":[1\n] :[ whitespace]" -> " "
-func StructuralPatToQuery(pattern string) zoektquery.Q {
+func StructuralPatToConjunctedLiteralsQuery(pattern string) (zoektquery.Q, error) {
 	var children []zoektquery.Q
 	substrings := matchHoleRegexp.Split(pattern, -1)
 	for _, s := range substrings {
@@ -410,24 +411,84 @@ func StructuralPatToQuery(pattern string) zoektquery.Q {
 		}
 	}
 	if len(children) == 0 {
-		return &zoektquery.Const{Value: true}
+		return &zoektquery.Const{Value: true}, nil
 	}
-	return &zoektquery.And{Children: children}
+	return &zoektquery.And{Children: children}, nil
+}
+
+// Converts comby a structural pattern to a Zoekt regular expression query. This
+// conversion conceptually performs the same conversion as
+// StructuralPatToConjunctedLiteralsQuery, except that whitespace in the pattern
+// is converted so that content across newlines can be matched in the index. The
+// function produces a conjunction of regular expressions where whitespace is
+// converted to \s+, rather than a conjunction of literal strings.
+// Example:
+// "ParseInt(:[args]) if err != nil" -> "ParseInt(" AND ")\s+if\s+err!=\s+nil"
+func StructuralPatToRegexpQuery(pattern string) (zoektquery.Q, error) {
+	substrings := matchHoleRegexp.Split(pattern, -1)
+	var children []zoektquery.Q
+	for _, s := range substrings {
+		rs := regexp.QuoteMeta(s)
+		rs = strings.ReplaceAll(rs, " ", "[\\s]+")
+		re, err := syntax.Parse(rs, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
+		if err != nil {
+			return nil, err
+		}
+		// zoekt decides to use its literal optimization at the query parser
+		// level, so we check if our regex can just be a literal.
+		if re.Op == syntax.OpLiteral {
+			children = append(children, &zoektquery.Substring{
+				Pattern:       s,
+				CaseSensitive: true,
+				Content:       true,
+			})
+		} else {
+			children = append(children, &zoektquery.Regexp{
+				Regexp:        re,
+				CaseSensitive: true,
+				Content:       true,
+			})
+		}
+	}
+	if len(children) == 0 {
+		return &zoektquery.Const{Value: true}, nil
+	}
+	return &zoektquery.And{Children: children}, nil
+}
+
+func StructuralPatToQuery(pattern string) (zoektquery.Q, error) {
+	// ToConjunctedLiteralsQuery cannot return an error. @rvantonder added
+	// an error type so that the function signatures below are equal,
+	// resulting in cleaner test code.
+	conjunctedLiteralsQuery, _ := StructuralPatToConjunctedLiteralsQuery(pattern)
+	regexpQuery, err := StructuralPatToRegexpQuery(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return &zoektquery.Or{
+		Children: []zoektquery.Q{
+			conjunctedLiteralsQuery,
+			regexpQuery,
+		},
+	}, nil
 }
 
 func queryToZoektQuery(query *search.PatternInfo, isSymbol bool) (zoektquery.Q, error) {
 	var and []zoektquery.Q
 
 	var q zoektquery.Q
+	var err error
 	if query.IsRegExp {
-		var err error
 		fileNameOnly := query.PatternMatchesPath && !query.PatternMatchesContent
 		q, err = parseRe(query.Pattern, fileNameOnly, query.IsCaseSensitive)
 		if err != nil {
 			return nil, err
 		}
 	} else if query.IsStructuralPat {
-		q = StructuralPatToQuery(query.Pattern)
+		q, err = StructuralPatToQuery(query.Pattern)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		q = &zoektquery.Substring{
 			Pattern:       query.Pattern,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -429,7 +429,8 @@ func StructuralPatToRegexpQuery(pattern string) (zoektquery.Q, error) {
 	var children []zoektquery.Q
 	for _, s := range substrings {
 		rs := regexp.QuoteMeta(s)
-		rs = strings.ReplaceAll(rs, " ", "[\\s]+")
+		onMatchWhitespace := lazyregexp.New(`[\s]+`)
+		rs = onMatchWhitespace.ReplaceAllLiteralString(rs, `[\s]+`)
 		re, err := syntax.Parse(rs, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Summary is the same as the comment for the added `StructuralPatToRegexpQuery` function:

```
Converts comby a structural pattern to a Zoekt regular expression query. This
conversion conceptually performs the same conversion as
StructuralPatToConjunctedLiteralsQuery, except that whitespace in the pattern
is converted so that content across newlines can be matched in the index. The
function produces a conjunction of regular expressions where whitespace is
converted to \s+, rather than a conjunction of literal strings.

Example:
"ParseInt(:[args]) if err != nil" -> "ParseInt(" AND ")\s+if\s+err!=\s+nil"
```

The regex-zoekt query is combined with the existing substring query using an `OR` clause. I don't want to combine the regex-zoekt queries and substring query generation even though it's possible, because (a) keeping the functionality isolated may help for reusing this in unindexed search and (b) the existing tests do not need to change (the internal query representation would change otherwise, meaning the output would change).

Test plan: Tests added.
