### PR TITLE
a8n: Merge `a8n` and `run` packages

### DIFF
--- a/dev/check/go-dbconn-import.sh
+++ b/dev/check/go-dbconn-import.sh
@@ -7,7 +7,7 @@ echo "--- go dbconn import"
 
 set -euf -o pipefail
 
-allowed='^github.com/sourcegraph/sourcegraph/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend|github.com/sourcegraph/sourcegraph/cmd/management-console|github.com/sourcegraph/sourcegraph/enterprise/cmd/management-console'
+allowed='^github.com/sourcegraph/sourcegraph/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend|github.com/sourcegraph/sourcegraph/cmd/management-console|github.com/sourcegraph/sourcegraph/enterprise/cmd/management-console|github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater'
 template='{{with $pkg := .}}{{ range $pkg.Deps }}{{ printf "%s imports %s\n" $pkg.ImportPath .}}{{end}}{{end}}'
 
 if go list ./../../cmd/... ../../enterprise/cmd/... \

--- a/enterprise/pkg/a8n/campaign_type.go
+++ b/enterprise/pkg/a8n/campaign_type.go
@@ -1,4 +1,4 @@
-package run
+package a8n
 
 import (
 	"bufio"

--- a/enterprise/pkg/a8n/campaign_type_test.go
+++ b/enterprise/pkg/a8n/campaign_type_test.go
@@ -1,4 +1,4 @@
-package run
+package a8n
 
 import (
 	"context"

--- a/enterprise/pkg/a8n/resolvers/resolver.go
+++ b/enterprise/pkg/a8n/resolvers/resolver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
-	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n/run"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -424,14 +423,14 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 		return nil, errors.New("cannot create CampaignPlan without Type")
 	}
 
-	campaignType, err := run.NewCampaignType(typeName, specArgs, r.httpFactory)
+	campaignType, err := ee.NewCampaignType(typeName, specArgs, r.httpFactory)
 	if err != nil {
 		return nil, err
 	}
 
 	plan := &a8n.CampaignPlan{CampaignType: typeName, Arguments: specArgs}
 
-	runner := run.New(r.store, campaignType, graphqlbackend.SearchRepos, nil)
+	runner := ee.NewRunner(r.store, campaignType, graphqlbackend.SearchRepos, nil)
 
 	if args.Wait {
 		err := runner.Run(ctx, plan)

--- a/enterprise/pkg/a8n/runner.go
+++ b/enterprise/pkg/a8n/runner.go
@@ -1,4 +1,4 @@
-package run
+package a8n
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
-	ee "github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -37,7 +36,7 @@ var ErrTooManyResults = errors.New("search yielded too many results")
 // A Runner executes a CampaignPlan by creating and running CampaignJobs
 // according to the CampaignPlan's Arguments and CampaignType.
 type Runner struct {
-	store         *ee.Store
+	store         *Store
 	search        repoSearch
 	defaultBranch repoDefaultBranch
 	clock         func() time.Time
@@ -85,16 +84,16 @@ var defaultRepoDefaultBranch = func(ctx context.Context, repo *graphqlbackend.Re
 	return branch, commitID, nil
 }
 
-// New returns a Runner for a given CampaignType.
-func New(store *ee.Store, ct CampaignType, search repoSearch, defaultBranch repoDefaultBranch) *Runner {
-	return NewWithClock(store, ct, search, defaultBranch, func() time.Time {
+// NewRunner returns a Runner for a given CampaignType.
+func NewRunner(store *Store, ct CampaignType, search repoSearch, defaultBranch repoDefaultBranch) *Runner {
+	return NewRunnerWithClock(store, ct, search, defaultBranch, func() time.Time {
 		return time.Now().UTC().Truncate(time.Microsecond)
 	})
 }
 
-// NewWithClock returns a Runner for a given CampaignType with the given clock used
+// NewRunnerWithClock returns a Runner for a given CampaignType with the given clock used
 // to generate timestamps
-func NewWithClock(store *ee.Store, ct CampaignType, search repoSearch, defaultBranch repoDefaultBranch, clock func() time.Time) *Runner {
+func NewRunnerWithClock(store *Store, ct CampaignType, search repoSearch, defaultBranch repoDefaultBranch, clock func() time.Time) *Runner {
 	runner := &Runner{
 		store:         store,
 		search:        search,
@@ -225,7 +224,7 @@ func (r *Runner) createPlanAndJobs(
 ) ([]*a8n.CampaignJob, error) {
 	var (
 		err error
-		tx  *ee.Store
+		tx  *Store
 	)
 	tx, err = r.store.Transact(ctx)
 	if err != nil {

--- a/enterprise/pkg/a8n/service_test.go
+++ b/enterprise/pkg/a8n/service_test.go
@@ -3,7 +3,6 @@ package a8n
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -11,9 +10,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
@@ -50,7 +49,7 @@ func TestService(t *testing.T) {
 
 	var rs []*repos.Repo
 	for i := 0; i < 3; i++ {
-		rs = append(rs, testRepo(i))
+		rs = append(rs, testRepo(i, github.ServiceType))
 	}
 
 	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
@@ -113,25 +112,6 @@ func TestService(t *testing.T) {
 
 	if len(haveJobs) != len(campaignJobs) {
 		t.Errorf("wrong number of ChangesetJobs: %d. want=%d", len(haveJobs), len(campaignJobs))
-	}
-}
-
-func testRepo(num int) *repos.Repo {
-	return &repos.Repo{
-		Name:    fmt.Sprintf("repo-%d", num),
-		URI:     fmt.Sprintf("repo-%d", num),
-		Enabled: true,
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          fmt.Sprintf("external-id-%d", num),
-			ServiceType: "github",
-			ServiceID:   "https://github.com/",
-		},
-		Sources: map[string]*repos.SourceInfo{
-			"extsvc:github:4": {
-				ID:       "extsvc:github:4",
-				CloneURL: "https://secrettoken@github.com/sourcegraph/sourcegraph",
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
This is part of #6572 and the first step before possibly merging `a8n.Service` and `Runner`.

Decided to create a separate PR for easier reviewability. This PR here only

1. Moves the files
2. Renames `run.New`/`run.NewWithClock` to `a8n.NewRunner`/`a8n.NewRunnerWithClock`
3. Removes the now duplicate `testRepo` test helper function

---

Update: After merging the `run` and `a8n` packages in 9ab8f4f the `dev/check/go-dbconn-import.sh` failed. I discussed this with @keegancsmit and added e51e6f9d22 to whitelist the enterprise/repo-updater package in the test. See the commit message for more details.