### PR TITLE
github: Load PRs in batches

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -172,21 +172,6 @@ func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) error {
 
 // LoadChangesets loads the latest state of the given Changesets from the codehost.
 func (s GithubSource) LoadChangesets(ctx context.Context, cs ...*Changeset) error {
-	const batchSize = 10
-	// We load changesets in batches to avoid hitting Github's GraphQL node limit
-	for i := 0; i < len(cs); i += batchSize {
-		j := i + batchSize
-		if j > len(cs) {
-			j = len(cs)
-		}
-		if err := s.loadChangesets(ctx, cs[i:j]...); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (s GithubSource) loadChangesets(ctx context.Context, cs ...*Changeset) error {
 	prs := make([]*github.PullRequest, len(cs))
 	for i := range cs {
 		repo := cs[i].Repo.Metadata.(*github.Repository)

--- a/enterprise/internal/a8n/syncer.go
+++ b/enterprise/internal/a8n/syncer.go
@@ -16,15 +16,7 @@ type ChangesetSyncer struct {
 	Store       *Store
 	ReposStore  repos.Store
 	HTTPFactory *httpcli.Factory
-
-	// ChangesetBatchSize determines how many changesets to load at a time.
-	// If 0 it falls back to DefaultBatchLoadSize
-	ChangesetBatchSize int
 }
-
-// DefaultChangesetBatchSize is the default number of changesets we should
-// load at a time
-const DefaultChangesetBatchSize = 10
 
 // Sync refreshes the metadata of all changesets and updates them in the
 // database
@@ -122,11 +114,6 @@ func (s *ChangesetSyncer) SyncChangesets(ctx context.Context, cs ...*a8n.Changes
 			Changeset: c,
 			Repo:      repoSet[repoID],
 		})
-	}
-
-	changesetBatchSize := s.ChangesetBatchSize
-	if changesetBatchSize == 0 {
-		changesetBatchSize = DefaultChangesetBatchSize
 	}
 
 	var events []*a8n.ChangesetEvent

--- a/enterprise/internal/a8n/syncer.go
+++ b/enterprise/internal/a8n/syncer.go
@@ -16,7 +16,15 @@ type ChangesetSyncer struct {
 	Store       *Store
 	ReposStore  repos.Store
 	HTTPFactory *httpcli.Factory
+
+	// ChangesetBatchSize determines how many changesets to load at a time.
+	// If 0 it falls back to DefaultBatchLoadSize
+	ChangesetBatchSize int
 }
+
+// DefaultChangesetBatchSize is the default number of changesets we should
+// load at a time
+const DefaultChangesetBatchSize = 10
 
 // Sync refreshes the metadata of all changesets and updates them in the
 // database
@@ -114,6 +122,11 @@ func (s *ChangesetSyncer) SyncChangesets(ctx context.Context, cs ...*a8n.Changes
 			Changeset: c,
 			Repo:      repoSet[repoID],
 		})
+	}
+
+	changesetBatchSize := s.ChangesetBatchSize
+	if changesetBatchSize == 0 {
+		changesetBatchSize = DefaultChangesetBatchSize
 	}
 
 	var events []*a8n.ChangesetEvent

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -396,7 +396,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInp
 
 // LoadPullRequests loads a list of PullRequests from Github.
 func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
-	const batchSize = 10
+	const batchSize = 15
 	// We load prs in batches to avoid hitting Github's GraphQL node limit
 	for i := 0; i < len(prs); i += batchSize {
 		j := i + batchSize

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -396,6 +396,21 @@ func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInp
 
 // LoadPullRequests loads a list of PullRequests from Github.
 func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
+	const batchSize = 10
+	// We load prs in batches to avoid hitting Github's GraphQL node limit
+	for i := 0; i < len(prs); i += batchSize {
+		j := i + batchSize
+		if j > len(prs) {
+			j = len(prs)
+		}
+		if err := c.loadPullRequests(ctx, prs[i:j]...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) loadPullRequests(ctx context.Context, prs ...*PullRequest) error {
 	type repository struct {
 		Owner string
 		Name  string


### PR DESCRIPTION
We now load PRs in batches of 10 to avoid hitting Github's api limits on the number of nodes returned

Issue: https://github.com/sourcegraph/sourcegraph/issues/6658