### PR TITLE
ci: use buildkit to parallelize separate stages

### DIFF
--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -23,6 +23,7 @@ done
 
 echo "--- docker build $IMAGE"
 docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/github-proxy; do
 done
 
 docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/gitserver; do
 done
 
 docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/loadtest; do
 done
 
 docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/management-console/build.sh
+++ b/cmd/management-console/build.sh
@@ -22,6 +22,7 @@ for pkg in $path_to_package; do
 done
 
 docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/query-runner; do
 done
 
 docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/replacer/build.sh
+++ b/cmd/replacer/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/replacer; do
 done
 
 docker build -f cmd/replacer/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -22,6 +22,7 @@ for pkg in $path_to_package; do
 done
 
 docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/searcher; do
 done
 
 docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -65,6 +65,7 @@ cp -r dev/grafana/linux "$OUTPUT/sg_config_grafana/provisioning/datasources"
 
 echo "--- docker build"
 docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -131,7 +131,7 @@ function buildLibsqlite3PcreDockerImage() {
     trap "rm -rf $EMPTY_DIRECTORY" EXIT
 
     echo "Building the libsqlite3-pcre Docker image..."
-    docker build --quiet -f cmd/symbols/libsqlite3-pcre/Dockerfile -t "libsqlite3-pcre" "$EMPTY_DIRECTORY"
+    docker build --progress=plain --quiet -f cmd/symbols/libsqlite3-pcre/Dockerfile -t "libsqlite3-pcre" "$EMPTY_DIRECTORY"
     echo "Building the libsqlite3-pcre Docker image... done"
 }
 
@@ -172,7 +172,7 @@ function buildSymbolsDockerImage() {
     buildSymbolsDockerImageDependencies
 
     echo "Building the $IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" \
+    docker build --progress=plain --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" \
         --build-arg COMMIT_SHA \
         --build-arg DATE \
         --build-arg VERSION
@@ -187,7 +187,7 @@ function buildCtagsDockerImage() {
     cp -R cmd/symbols/.ctags.d "$ctagsDockerBuildContext"
 
     echo "Building the $CTAGS_IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/internal/pkg/ctags/Dockerfile -t "$CTAGS_IMAGE" "$ctagsDockerBuildContext"
+    docker build --progress=plain --quiet -f cmd/symbols/internal/pkg/ctags/Dockerfile -t "$CTAGS_IMAGE" "$ctagsDockerBuildContext"
     echo "Building the $CTAGS_IMAGE Docker image... done"
 }
 

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -21,6 +21,7 @@ for pkg in github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend; do
 done
 
 docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -209,6 +209,7 @@ func addServerDockerImageCandidate(c Config) func(*bk.Pipeline) {
 			bk.Cmd("./cmd/server/pre-build.sh"),
 			bk.Env("IMAGE", "sourcegraph/server:"+c.version+"_candidate"),
 			bk.Env("VERSION", c.version),
+			bk.Env("DOCKER_BUILDKIT", "1"),
 			bk.Cmd("./cmd/server/build.sh"),
 			bk.Cmd("popd"))
 	}
@@ -258,6 +259,7 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
+			bk.Env("DOCKER_BUILDKIT", "1"),
 		}
 
 		cmdDir := func() string {

--- a/lsif/build.sh
+++ b/lsif/build.sh
@@ -4,6 +4,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -ex
 
 docker build -f lsif/Dockerfile -t "$IMAGE" lsif \
+    --progress=plain \
     --build-arg COMMIT_SHA \
     --build-arg DATE \
     --build-arg VERSION


### PR DESCRIPTION
This PR enables https://github.com/moby/buildkit which speeds up our `docker build`'s by running non-dependent steps in parallel (amongst other things). 