### PR TITLE
tests: factor out diff function

### DIFF
--- a/cmd/replacer/replace/replace_test.go
+++ b/cmd/replacer/replace/replace_test.go
@@ -78,7 +78,7 @@ func main() {
 		}
 
 		if got != test.want {
-			d, err := diff(test.want, got)
+			d, err := testutil.Diff(test.want, got)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -141,35 +141,4 @@ func doReplace(u string, p *protocol.Request) (string, error) {
 	}
 
 	return string(body), err
-}
-
-func diff(b1, b2 string) (string, error) {
-	f1, err := ioutil.TempFile("", "search_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f1.Name())
-	defer f1.Close()
-
-	f2, err := ioutil.TempFile("", "search_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f2.Name())
-	defer f2.Close()
-
-	_, err = f1.WriteString(b1)
-	if err != nil {
-		return "", err
-	}
-	_, err = f2.WriteString(b2)
-	if err != nil {
-		return "", err
-	}
-
-	data, err := exec.Command("diff", "-u", "--label=want", f1.Name(), "--label=got", f2.Name()).CombinedOutput()
-	if len(data) > 0 {
-		err = nil
-	}
-	return string(data), err
 }

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -169,7 +170,7 @@ func TestBitbucketCloudSource_MakeRepo(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(actual, expect) {
-				d, err := diff(actual, expect)
+				d, err := testutil.Diff(string(actual), string(expect))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -270,7 +271,7 @@ func TestBitbucketCloudSource_Exclude(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(actual, expect) {
-				d, err := diff(actual, expect)
+				d, err := testutil.Diff(string(actual), string(expect))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -84,7 +84,7 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(actual, expect) {
-				d, err := diff(actual, expect)
+				d, err := testutil.Diff(string(actual), string(expect))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -190,7 +190,7 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(actual, expect) {
-				d, err := diff(actual, expect)
+				d, err := testutil.Diff(string(actual), string(expect))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -418,29 +418,4 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 			}
 		})
 	}
-}
-
-func diff(b1, b2 []byte) (string, error) {
-	f1, err := ioutil.TempFile("", "repos_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f1.Name())
-	defer f1.Close()
-
-	f2, err := ioutil.TempFile("", "repos_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f2.Name())
-	defer f2.Close()
-
-	_, _ = f1.Write(b1)
-	_, _ = f2.Write(b2)
-
-	data, err := exec.Command("diff", "-u", f1.Name(), f2.Name()).CombinedOutput()
-	if len(data) > 0 {
-		err = nil
-	}
-	return string(data), err
 }

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestSearch(t *testing.T) {
@@ -215,7 +215,7 @@ main.go:7:}
 				test.want = test.want[1:]
 			}
 			if got != test.want {
-				d, err := diff(test.want, got)
+				d, err := testutil.Diff(test.want, got)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -476,35 +476,6 @@ func sanityCheckSorted(m []protocol.FileMatch) error {
 		}
 	}
 	return nil
-}
-
-func diff(b1, b2 string) (string, error) {
-	f1, err := ioutil.TempFile("", "search_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f1.Name())
-	defer f1.Close()
-
-	f2, err := ioutil.TempFile("", "search_test")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f2.Name())
-	defer f2.Close()
-
-	if _, err := f1.WriteString(b1); err != nil {
-		return "", err
-	}
-	if _, err := f2.WriteString(b2); err != nil {
-		return "", err
-	}
-
-	data, err := exec.Command("diff", "-u", "--label=want", f1.Name(), "--label=got", f2.Name()).CombinedOutput()
-	if len(data) > 0 {
-		err = nil
-	}
-	return string(data), err
 }
 
 type sortByPath []protocol.FileMatch

--- a/internal/testutil/diff.go
+++ b/internal/testutil/diff.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+func Diff(b1, b2 string) (string, error) {
+	f1, err := ioutil.TempFile("", "diff_test")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(f1.Name())
+	defer f1.Close()
+
+	f2, err := ioutil.TempFile("", "diff_test")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(f2.Name())
+	defer f2.Close()
+
+	_, err = f1.WriteString(b1)
+	if err != nil {
+		return "", err
+	}
+	_, err = f2.WriteString(b2)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := exec.Command("diff", "-u", "--label=want", f1.Name(), "--label=got", f2.Name()).CombinedOutput()
+	if len(data) > 0 {
+		err = nil
+	}
+	return string(data), err
+}


### PR DESCRIPTION
Factors out a common `diff` test function in replace, search, and bitbucket tests.

Test plan: Semantics preserving, tests pass.
