### PR TITLE
Condense parameter types

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -211,7 +211,7 @@ lines
 	}
 }
 
-func queryEqual(a zoektquery.Q, b zoektquery.Q) bool {
+func queryEqual(a, b zoektquery.Q) bool {
 	sortChildren := func(q zoektquery.Q) zoektquery.Q {
 		switch s := q.(type) {
 		case *zoektquery.And:

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -23,7 +23,7 @@ type test struct {
 	want *lsp.Location
 }
 
-func mkLocation(uri string, line int, character int) *lsp.Location {
+func mkLocation(uri string, line, character int) *lsp.Location {
 	return &lsp.Location{
 		URI: "https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#/mux.go",
 		Range: lsp.Range{

--- a/cmd/frontend/internal/app/tracking/tracking.go
+++ b/cmd/frontend/internal/app/tracking/tracking.go
@@ -15,7 +15,7 @@ import (
 
 // SyncUser handles creating or syncing a user profile in HubSpot, and if provided,
 // logs a user event.
-func SyncUser(email string, eventID string, contactParams *hubspot.ContactProperties) {
+func SyncUser(email, eventID string, contactParams *hubspot.ContactProperties) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Printf("panic in tracking.SyncUser: %s", err)

--- a/cmd/frontend/internal/inventory/inventory_test.go
+++ b/cmd/frontend/internal/inventory/inventory_test.go
@@ -72,7 +72,7 @@ func TestGetLang_language(t *testing.T) {
 	}
 }
 
-func makeFileReader(ctx context.Context, path string, contents string) func(context.Context, string) (io.ReadCloser, error) {
+func makeFileReader(ctx context.Context, path, contents string) func(context.Context, string) (io.ReadCloser, error) {
 	return func(ctx context.Context, path string) (io.ReadCloser, error) {
 		return ioutil.NopCloser(strings.NewReader(contents)), nil
 	}

--- a/cmd/frontend/internal/pkg/usagestats/action_handlers.go
+++ b/cmd/frontend/internal/pkg/usagestats/action_handlers.go
@@ -17,7 +17,7 @@ var (
 
 // LogActivity logs any user activity (page view, integration usage, etc) to their "last active" time, and
 // adds their unique ID to the set of active users
-func LogActivity(isAuthenticated bool, userID int32, userCookieID string, event string) error {
+func LogActivity(isAuthenticated bool, userID int32, userCookieID, event string) error {
 	// Setup our GC of active key goroutine
 	gcOnce.Do(func() {
 		go gc()

--- a/cmd/gitserver/server/gitolite-phabricator.go
+++ b/cmd/gitserver/server/gitolite-phabricator.go
@@ -70,7 +70,7 @@ func (s *Server) handleGetGitolitePhabricatorMetadata(w http.ResponseWriter, r *
 
 var callSignPattern = lazyregexp.New("^[A-Z]+$")
 
-func getGitolitePhabCallsign(ctx context.Context, gconf *schema.GitoliteConnection, repo string, command string) (string, error) {
+func getGitolitePhabCallsign(ctx context.Context, gconf *schema.GitoliteConnection, repo, command string) (string, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Env = append(os.Environ(), "REPO="+repo)
 	stdout, err := cmd.Output()

--- a/cmd/management-console/shared/main.go
+++ b/cmd/management-console/shared/main.go
@@ -185,7 +185,7 @@ func serveGet(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func httpError(w http.ResponseWriter, message string, code string) {
+func httpError(w http.ResponseWriter, message, code string) {
 	_ = json.NewEncoder(w).Encode(struct {
 		Error string `json:"error"`
 		Code  string `json:"code"`

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -35,7 +35,7 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	return matches
 }
 
-func structuralSearch(ctx context.Context, zipPath string, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func structuralSearch(ctx context.Context, zipPath, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	args := comby.Args{

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func serveRepos(logger *log.Logger, addr string, repoDir string) error {
+func serveRepos(logger *log.Logger, addr, repoDir string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return errors.Wrap(err, "listen")

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,7 +78,7 @@ func init() {
 //
 // This should be used for only *internal* environment values. User-visible configuration should be
 // added to the Config struct in the github.com/sourcegraph/sourcegraph/config package.
-func Get(name, defaultValue string, description string) string {
+func Get(name, defaultValue, description string) string {
 	if locked {
 		panic("env.Get has to be called on package initialization")
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,7 +78,7 @@ func init() {
 //
 // This should be used for only *internal* environment values. User-visible configuration should be
 // added to the Config struct in the github.com/sourcegraph/sourcegraph/config package.
-func Get(name string, defaultValue string, description string) string {
+func Get(name, defaultValue string, description string) string {
 	if locked {
 		panic("env.Get has to be called on package initialization")
 	}

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -28,7 +28,7 @@ var defaultLogger = new()
 // to wait for the frontend to start.
 //
 // Note: This does not block since it creates a new goroutine.
-func LogEvent(userID int32, userEmail string, eventLabel string, eventProperties json.RawMessage) {
+func LogEvent(userID int32, userEmail, eventLabel string, eventProperties json.RawMessage) {
 	go func() {
 		err := defaultLogger.logEvent(userID, userEmail, eventLabel, eventProperties)
 		if err != nil {

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -110,7 +110,7 @@ func canonicalizedURL(apiURL *url.URL) *url.URL {
 // checksum of the access token and API URL are used as a Redis key prefix to prevent collisions
 // with caches for different tokens and API URLs. An optional keyPrefix may also be specified,
 // typically used in tests.
-func NewRepoCache(apiURL *url.URL, token string, keyPrefix string, cacheTTL time.Duration) *rcache.Cache {
+func NewRepoCache(apiURL *url.URL, token, keyPrefix string, cacheTTL time.Duration) *rcache.Cache {
 	if keyPrefix == "" {
 		keyPrefix = "gh_repo:"
 	}

--- a/internal/hubspot/hubspot.go
+++ b/internal/hubspot/hubspot.go
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // New returns a new HubSpot client using the given Portal ID.
-func New(portalID string, hapiKey string) *Client {
+func New(portalID, hapiKey string) *Client {
 	return &Client{
 		portalID: portalID,
 		hapiKey:  hapiKey,


### PR DESCRIPTION
Condenses equal parameter types. Example: `foo(bar t, baz t)` -> `foo(bar, baz t)`

Example
```
{
    "matchTemplate": "func :[[fn]](:[[p1]] :[t1.], :[[p2]] :[t1.])",
    "rewriteTemplate": "func :[[fn]](:[[p1]], :[[p2]] :[t1.])",
    "scopeQuery": "repo:github.com/sourcegraph lang:go"
}
```

See merge history for this PR for the other parts.