### PR TITLE
Condense parameter types (part 2)

### DIFF
--- a/cmd/frontend/internal/app/tracking/tracking.go
+++ b/cmd/frontend/internal/app/tracking/tracking.go
@@ -15,7 +15,7 @@ import (
 
 // SyncUser handles creating or syncing a user profile in HubSpot, and if provided,
 // logs a user event.
-func SyncUser(email string, eventID string, contactParams *hubspot.ContactProperties) {
+func SyncUser(email, eventID string, contactParams *hubspot.ContactProperties) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Printf("panic in tracking.SyncUser: %s", err)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,7 +78,7 @@ func init() {
 //
 // This should be used for only *internal* environment values. User-visible configuration should be
 // added to the Config struct in the github.com/sourcegraph/sourcegraph/config package.
-func Get(name string, defaultValue string, description string) string {
+func Get(name, defaultValue string, description string) string {
 	if locked {
 		panic("env.Get has to be called on package initialization")
 	}


### PR DESCRIPTION
Condenses equal parameter types. Example: `foo(bar t, baz t, ...)` -> `foo(bar, baz t, ...)`

Created with
```json
{
    "matchTemplate": "func :[[fn]](:[[p1]] :[t1.], :[[p2]] :[t1.], :[rest])",
    "rewriteTemplate": "func :[[fn]](:[[p1]], :[[p2]] :[t1.], :[rest])",
    "scopeQuery": "repo:github.com/sourcegraph lang:go"
}
```