### PR TITLE
Condense parameter types (part 3)

### DIFF
--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -23,7 +23,7 @@ type test struct {
 	want *lsp.Location
 }
 
-func mkLocation(uri string, line int, character int) *lsp.Location {
+func mkLocation(uri string, line, character int) *lsp.Location {
 	return &lsp.Location{
 		URI: "https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#/mux.go",
 		Range: lsp.Range{

--- a/cmd/frontend/internal/inventory/inventory_test.go
+++ b/cmd/frontend/internal/inventory/inventory_test.go
@@ -72,7 +72,7 @@ func TestGetLang_language(t *testing.T) {
 	}
 }
 
-func makeFileReader(ctx context.Context, path string, contents string) func(context.Context, string) (io.ReadCloser, error) {
+func makeFileReader(ctx context.Context, path, contents string) func(context.Context, string) (io.ReadCloser, error) {
 	return func(ctx context.Context, path string) (io.ReadCloser, error) {
 		return ioutil.NopCloser(strings.NewReader(contents)), nil
 	}

--- a/cmd/frontend/internal/pkg/usagestats/action_handlers.go
+++ b/cmd/frontend/internal/pkg/usagestats/action_handlers.go
@@ -17,7 +17,7 @@ var (
 
 // LogActivity logs any user activity (page view, integration usage, etc) to their "last active" time, and
 // adds their unique ID to the set of active users
-func LogActivity(isAuthenticated bool, userID int32, userCookieID string, event string) error {
+func LogActivity(isAuthenticated bool, userID int32, userCookieID, event string) error {
 	// Setup our GC of active key goroutine
 	gcOnce.Do(func() {
 		go gc()

--- a/cmd/gitserver/server/gitolite-phabricator.go
+++ b/cmd/gitserver/server/gitolite-phabricator.go
@@ -70,7 +70,7 @@ func (s *Server) handleGetGitolitePhabricatorMetadata(w http.ResponseWriter, r *
 
 var callSignPattern = lazyregexp.New("^[A-Z]+$")
 
-func getGitolitePhabCallsign(ctx context.Context, gconf *schema.GitoliteConnection, repo string, command string) (string, error) {
+func getGitolitePhabCallsign(ctx context.Context, gconf *schema.GitoliteConnection, repo, command string) (string, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Env = append(os.Environ(), "REPO="+repo)
 	stdout, err := cmd.Output()

--- a/cmd/management-console/shared/main.go
+++ b/cmd/management-console/shared/main.go
@@ -185,7 +185,7 @@ func serveGet(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func httpError(w http.ResponseWriter, message string, code string) {
+func httpError(w http.ResponseWriter, message, code string) {
 	_ = json.NewEncoder(w).Encode(struct {
 		Error string `json:"error"`
 		Code  string `json:"code"`

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func serveRepos(logger *log.Logger, addr string, repoDir string) error {
+func serveRepos(logger *log.Logger, addr, repoDir string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return errors.Wrap(err, "listen")

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,7 +78,7 @@ func init() {
 //
 // This should be used for only *internal* environment values. User-visible configuration should be
 // added to the Config struct in the github.com/sourcegraph/sourcegraph/config package.
-func Get(name string, defaultValue string, description string) string {
+func Get(name string, defaultValue, description string) string {
 	if locked {
 		panic("env.Get has to be called on package initialization")
 	}


### PR DESCRIPTION
Condenses equal parameter types. Example: `foo(..., bar t, baz t)` -> `foo(..., bar, baz t)`

Created with
```json
{
    "matchTemplate": "func :[[fn]](:[x], :[[p1]] :[t1.], :[[p2]] :[t1.])",
    "rewriteTemplate": "func :[[fn]](:[x], :[[p1]], :[[p2]] :[t1.])",
    "scopeQuery": "repo:github.com/sourcegraph lang:go"
}
```