### PR TITLE
Condense parameter types (part 4)

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -35,7 +35,7 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	return matches
 }
 
-func structuralSearch(ctx context.Context, zipPath string, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func structuralSearch(ctx context.Context, zipPath, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	args := comby.Args{

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -28,7 +28,7 @@ var defaultLogger = new()
 // to wait for the frontend to start.
 //
 // Note: This does not block since it creates a new goroutine.
-func LogEvent(userID int32, userEmail string, eventLabel string, eventProperties json.RawMessage) {
+func LogEvent(userID int32, userEmail, eventLabel string, eventProperties json.RawMessage) {
 	go func() {
 		err := defaultLogger.logEvent(userID, userEmail, eventLabel, eventProperties)
 		if err != nil {

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -110,7 +110,7 @@ func canonicalizedURL(apiURL *url.URL) *url.URL {
 // checksum of the access token and API URL are used as a Redis key prefix to prevent collisions
 // with caches for different tokens and API URLs. An optional keyPrefix may also be specified,
 // typically used in tests.
-func NewRepoCache(apiURL *url.URL, token string, keyPrefix string, cacheTTL time.Duration) *rcache.Cache {
+func NewRepoCache(apiURL *url.URL, token, keyPrefix string, cacheTTL time.Duration) *rcache.Cache {
 	if keyPrefix == "" {
 		keyPrefix = "gh_repo:"
 	}


### PR DESCRIPTION
Condenses equal parameter types. Example: `foo(..., bar t, baz t, ...)` -> `foo(..., bar, baz t, ...)`

Created with

```json
{
    "matchTemplate": "func :[[fn]](:[x], :[[p1]] :[t1.], :[[p2]] :[t1.], :[rest])",
    "rewriteTemplate": "func :[[fn]](:[x], :[[p1]], :[[p2]] :[t1.], :[rest])",
    "scopeQuery": "repo:github.com/sourcegraph lang:go"
}
```