### PR TITLE
replace select element with connection on dotcom create subscription page

### DIFF
--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -48,7 +48,7 @@ class UserCreateSubscriptionNode extends React.PureComponent<UserCreateSubscript
                             className="btn btn-sm btn-secondary"
                             onClick={this.createProductSubscription}
                         >
-                            <AddIcon className="icon-inline" /> Create new Subscription
+                            <AddIcon className="icon-inline" /> Create new subscription
                         </button>
                     </div>
                 </div>

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -1,46 +1,66 @@
+import * as H from 'history'
+import AddIcon from 'mdi-react/AddIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
-import { Observable, Subject, Subscription } from 'rxjs'
-import { catchError, map, startWith, switchMap, tap } from 'rxjs/operators'
-import { gql } from '../../../../../../shared/src/graphql/graphql'
+import { Link } from 'react-router-dom'
+import { Observable } from 'rxjs'
+import { map, tap } from 'rxjs/operators'
+import { dataOrThrowErrors, gql } from '../../../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../../../shared/src/graphql/schema'
-import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../../shared/src/util/errors'
-import { pluralize } from '../../../../../../shared/src/util/strings'
 import { mutateGraphQL, queryGraphQL } from '../../../../backend/graphql'
-import { Form } from '../../../../components/Form'
+import { FilteredConnection } from '../../../../components/FilteredConnection'
 import { PageTitle } from '../../../../components/PageTitle'
 import { eventLogger } from '../../../../tracking/eventLogger'
-import { AccountEmailAddresses } from '../../../dotcom/productSubscriptions/AccountEmailAddresses'
-import { ErrorAlert } from '../../../../components/alerts'
+
+interface UserCreateSubscriptionNodeProps {
+    /**
+     * The user to display in this list item.
+     */
+    node: GQL.IUser
+
+    /**
+     * Browser history, used to redirect the user to the new subscription after one is successfully created.
+     */
+    history: H.History
+}
+
+class UserCreateSubscriptionNode extends React.PureComponent<UserCreateSubscriptionNodeProps> {
+    private createProductSubscription = (): Observable<
+        Pick<GQL.IProductSubscription, 'id' | 'name' | 'url' | 'urlForSiteAdmin'>
+    > =>
+        createProductSubscription({ accountID: this.props.node.id }).pipe(
+            tap(({ url, urlForSiteAdmin }) => this.props.history.push(urlForSiteAdmin || url))
+        )
+
+    public render(): JSX.Element | null {
+        return (
+            <li className="list-group-item py-2">
+                <div className="d-flex align-items-center justify-content-between">
+                    <div>
+                        <Link to={`/users/${this.props.node.username}`}>{this.props.node.username}</Link>{' '}
+                        <span className="text-muted">
+                            ({this.props.node.emails.filter(email => email.isPrimary).map(email => email.email)})
+                        </span>
+                    </div>
+                    <div>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-secondary"
+                            onClick={this.createProductSubscription}
+                        >
+                            <AddIcon className="icon-inline" /> Create new Subscription
+                        </button>
+                    </div>
+                </div>
+            </li>
+        )
+    }
+}
+
+class FilteredUserConnection extends FilteredConnection<GQL.IUser, Pick<UserCreateSubscriptionNodeProps, 'history'>> {}
 
 interface Props extends RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
-}
-
-/** A customer account. */
-interface Account extends Pick<GQL.IUser, 'id' | 'username' | 'displayName'> {
-    emails: Pick<GQL.IUserEmail, 'email' | 'verified'>[]
-}
-
-const LOADING: 'loading' = 'loading'
-
-interface State {
-    accountID: GQL.ID
-
-    /**
-     * The list of all possible accounts.
-     */
-    accountsOrError: Account[] | typeof LOADING | ErrorLike
-
-    /**
-     * The result of creating the product subscription, or null when not pending or complete, or loading, or an
-     * error.
-     */
-    creationOrError:
-        | null
-        | Pick<GQL.IProductSubscription, 'id' | 'name' | 'url' | 'urlForSiteAdmin'>
-        | typeof LOADING
-        | ErrorLike
 }
 
 /**
@@ -48,172 +68,55 @@ interface State {
  *
  * For use on Sourcegraph.com by Sourcegraph teammates only.
  */
-export class SiteAdminCreateProductSubscriptionPage extends React.Component<Props, State> {
-    private get emptyState(): Pick<State, 'accountID' | 'creationOrError'> {
-        return {
-            accountID: this.props.authenticatedUser.id,
-            creationOrError: null,
-        }
-    }
-
-    public state: State = {
-        ...this.emptyState,
-        accountsOrError: LOADING,
-    }
-
-    private submits = new Subject<void>()
-    private subscriptions = new Subscription()
-
+export class SiteAdminCreateProductSubscriptionPage extends React.Component<Props> {
     public componentDidMount(): void {
         eventLogger.logViewEvent('SiteAdminCreateProductSubscription')
-
-        this.subscriptions.add(
-            queryAccounts()
-                .pipe(
-                    catchError(err => [asError(err)]),
-                    startWith(LOADING),
-                    map(c => ({ accountsOrError: c }))
-                )
-                .subscribe(stateUpdate => this.setState(stateUpdate))
-        )
-
-        this.subscriptions.add(
-            this.submits
-                .pipe(
-                    switchMap(() =>
-                        createProductSubscription({ accountID: this.state.accountID }).pipe(
-                            tap(({ url, urlForSiteAdmin }) => this.props.history.push(urlForSiteAdmin || url)),
-                            catchError(err => [asError(err)]),
-                            startWith(LOADING),
-                            map(c => ({ creationOrError: c }))
-                        )
-                    )
-                )
-                .subscribe(stateUpdate => this.setState(stateUpdate))
-        )
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
     }
 
     public render(): JSX.Element | null {
-        const disableForm = Boolean(
-            this.state.creationOrError === LOADING ||
-                (this.state.creationOrError && !isErrorLike(this.state.creationOrError)) ||
-                isErrorLike(this.state.accountsOrError)
-        )
-
-        const selectedAccount: Account | undefined =
-            this.state.accountsOrError !== LOADING && !isErrorLike(this.state.accountsOrError)
-                ? this.state.accountsOrError.find(({ id }) => this.state.accountID === id)
-                : undefined
-
+        const nodeProps: Pick<UserCreateSubscriptionNodeProps, 'history'> = {
+            history: this.props.history,
+        }
         return (
             <div className="site-admin-create-product-subscription-page">
                 <PageTitle title="Create product subscription" />
                 <h2>Create product subscription</h2>
-                <Form onSubmit={this.onSubmit}>
-                    <div className="form-group">
-                        <label htmlFor="site-admin-create-product-subscription-page__account">Account (customer)</label>
-                        <select
-                            id="site-admin-create-product-subscription-page__account"
-                            className="form-control"
-                            required={true}
-                            disabled={
-                                disableForm ||
-                                this.state.accountsOrError === LOADING ||
-                                isErrorLike(this.state.accountsOrError)
-                            }
-                            value={this.state.accountID}
-                            onChange={this.onAccountIDChange}
-                        >
-                            {this.state.accountsOrError === LOADING ? (
-                                <option value={this.state.accountID}>Loading...</option>
-                            ) : (
-                                !isErrorLike(this.state.accountsOrError) &&
-                                this.state.accountsOrError.map(({ id, username, displayName }, i) => (
-                                    <option key={i} value={id}>
-                                        {username} {displayName && `(${displayName})`}
-                                    </option>
-                                ))
-                            )}
-                        </select>
-                        {isErrorLike(this.state.accountsOrError) ? (
-                            <ErrorAlert
-                                className="mt-2"
-                                error={this.state.accountsOrError}
-                                prefix="Error loading accounts"
-                            />
-                        ) : selectedAccount ? (
-                            <small className="form-text text-muted">
-                                Email {pluralize('address', selectedAccount.emails.length, 'addresses')}:{' '}
-                                <AccountEmailAddresses emails={selectedAccount.emails} />
-                            </small>
-                        ) : (
-                            <small className="form-text text-muted">
-                                The user associated with the customer account will be able to view this license key by
-                                signing into Sourcegraph.com.
-                            </small>
-                        )}
-                    </div>
-                    <div className="form-group">
-                        <button
-                            type="submit"
-                            disabled={
-                                disableForm ||
-                                this.state.accountsOrError === LOADING ||
-                                isErrorLike(this.state.accountsOrError)
-                            }
-                            className={`btn btn-${disableForm ? 'secondary' : 'primary'}`}
-                        >
-                            Create product subscription
-                        </button>
-                        <small className="form-text text-muted">
-                            You can generate a product license after creation.
-                        </small>
-                    </div>
-                </Form>
-                {isErrorLike(this.state.creationOrError) && (
-                    <ErrorAlert className="mt-3" error={this.state.creationOrError} />
-                )}
+                <FilteredUserConnection
+                    className="list-group list-group-flush mt-3"
+                    noun="user"
+                    pluralNoun="users"
+                    queryConnection={queryAccounts}
+                    nodeComponent={UserCreateSubscriptionNode}
+                    nodeComponentProps={nodeProps}
+                    history={this.props.history}
+                    location={this.props.location}
+                />
             </div>
         )
     }
-
-    private onAccountIDChange: React.ChangeEventHandler<HTMLSelectElement> = e =>
-        this.setState({ accountID: e.currentTarget.value })
-
-    private onSubmit: React.FormEventHandler = e => {
-        e.preventDefault()
-        this.submits.next()
-    }
 }
 
-function queryAccounts(): Observable<Account[]> {
+function queryAccounts(args: { first?: number; query?: string }): Observable<GQL.IUserConnection> {
     return queryGraphQL(
         gql`
-            query ProductSubscriptionAccounts {
-                users {
+            query ProductSubscriptionAccounts($first: Int, $query: String) {
+                users(first: $first, query: $query) {
                     nodes {
                         id
                         username
-                        displayName
                         emails {
                             email
                             verified
+                            isPrimary
                         }
                     }
                 }
             }
-        `
+        `,
+        args
     ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.users || (errors && errors.length > 0)) {
-                throw createAggregateError(errors)
-            }
-            return data.users.nodes
-        })
+        map(dataOrThrowErrors),
+        map(data => data.users)
     )
 }
 
@@ -234,11 +137,7 @@ function createProductSubscription(
         `,
         args
     ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.dotcom || !data.dotcom.createProductSubscription || (errors && errors.length > 0)) {
-                throw createAggregateError(errors)
-            }
-            return data.dotcom.createProductSubscription
-        })
+        map(dataOrThrowErrors),
+        map(data => data.dotcom.createProductSubscription)
     )
 }

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -29,8 +29,8 @@ interface UserCreateSubscriptionNodeProps {
 
 const createProductSubscription = (
     args: GQL.ICreateProductSubscriptionOnDotcomMutationArguments
-): Observable<Pick<GQL.IProductSubscription, 'urlForSiteAdmin'>> => {
-    return mutateGraphQL(
+): Observable<Pick<GQL.IProductSubscription, 'urlForSiteAdmin'>> =>
+    mutateGraphQL(
         gql`
             mutation CreateProductSubscription($accountID: ID!) {
                 dotcom {
@@ -45,7 +45,7 @@ const createProductSubscription = (
         map(dataOrThrowErrors),
         map(data => data.dotcom.createProductSubscription)
     )
-}
+
 const UserCreateSubscriptionNode: React.FunctionComponent<UserCreateSubscriptionNodeProps> = (
     props: UserCreateSubscriptionNodeProps
 ) => {


### PR DESCRIPTION
Replaces 
![image](https://user-images.githubusercontent.com/5589410/69700781-2df40500-10a0-11ea-9b42-ca1ff27769d8.png)

with
![image](https://user-images.githubusercontent.com/5589410/69700798-38160380-10a0-11ea-98bf-0b361469927e.png)

(key addition here: the ability to search)

~@felixfbecker curious if I can ask for your thoughts here -- when I click a "Create new subscription' button, nothing happens... No network requests at all. Do you see any obvious issues where I call the GraphQL mutation (https://github.com/sourcegraph/sourcegraph/pull/6885/files#diff-fac646feb1d687f629663865b214f912R28)?~