### PR TITLE
search: multiline highlighting for structural search

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -9,11 +10,15 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) {
-	for _, m := range combyMatches {
-		var lineMatches []protocol.LineMatch
-		for _, r := range m.Matches {
-			lineMatch := protocol.LineMatch{
+// Our current highlighting doesn't allow specifying a line and column range
+// spanning multiple lines. This function chops up potentially multiline matches into
+// multiple LineMatches.
+func highlightMultipleLines(r comby.Match) (matches []protocol.LineMatch) {
+	lineSpan := r.Range.End.Line - r.Range.Start.Line + 1
+	log15.Info("structural search", "line span", lineSpan)
+	if lineSpan == 1 {
+		return []protocol.LineMatch{
+			{
 				LineNumber: r.Range.Start.Line - 1,
 				OffsetAndLengths: [][2]int{
 					{
@@ -22,8 +27,46 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 					},
 				},
 				Preview: r.Matched,
-			}
-			lineMatches = append(lineMatches, lineMatch)
+			},
+		}
+	}
+
+	contentLines := strings.Split(r.Matched, "\n")
+	for i, lines := range contentLines {
+		var columnStart, columnEnd int
+		if i == 0 {
+			// First line.
+			columnStart = r.Range.Start.Column - 1
+			columnEnd = len(lines) + 1
+		} else if i == (lineSpan - 1) {
+			// In between line.
+			columnStart = 0
+			columnEnd = r.Range.End.Column
+		} else {
+			// Last line.
+			columnStart = 0
+			columnEnd = len(lines) + 1
+		}
+
+		matches = append(matches, protocol.LineMatch{
+			LineNumber: r.Range.Start.Line + i - 1,
+			OffsetAndLengths: [][2]int{
+				{
+					columnStart,
+					columnEnd,
+				},
+			},
+			Preview: lines,
+		})
+	}
+	return matches
+}
+
+func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) {
+	for _, m := range combyMatches {
+		var lineMatches []protocol.LineMatch
+		for _, r := range m.Matches {
+			lineMatches = append(lineMatches, highlightMultipleLines(r)...)
 		}
 		matches = append(matches,
 			protocol.FileMatch{

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -10,9 +10,10 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// Our current highlighting doesn't allow specifying a line and column range
-// spanning multiple lines. This function chops up potentially multiline matches into
-// multiple LineMatches.
+// The Sourcegraph frontend and interface only allow LineMatches (matches on a
+// single line) and it isn't possible to specify a line and column range
+// spanning multiple lines for highlighting. This function chops up potentially
+// multiline matches into multiple LineMatches.
 func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 	lineSpan := r.Range.End.Line - r.Range.Start.Line + 1
 	if lineSpan == 1 {
@@ -38,11 +39,11 @@ func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 			columnStart = r.Range.Start.Column - 1
 			columnEnd = len(lines) + 1
 		} else if i == (lineSpan - 1) {
-			// In between line.
+			// Last line.
 			columnStart = 0
 			columnEnd = r.Range.End.Column
 		} else {
-			// Last line.
+			// In between line.
 			columnStart = 0
 			columnEnd = len(lines) + 1
 		}

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -13,9 +13,8 @@ import (
 // Our current highlighting doesn't allow specifying a line and column range
 // spanning multiple lines. This function chops up potentially multiline matches into
 // multiple LineMatches.
-func highlightMultipleLines(r comby.Match) (matches []protocol.LineMatch) {
+func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 	lineSpan := r.Range.End.Line - r.Range.Start.Line + 1
-	log15.Info("structural search", "line span", lineSpan)
 	if lineSpan == 1 {
 		return []protocol.LineMatch{
 			{
@@ -66,7 +65,7 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	for _, m := range combyMatches {
 		var lineMatches []protocol.LineMatch
 		for _, r := range m.Matches {
-			lineMatches = append(lineMatches, highlightMultipleLines(r)...)
+			lineMatches = append(lineMatches, highlightMultipleLines(&r)...)
 		}
 		matches = append(matches,
 			protocol.FileMatch{


### PR DESCRIPTION
Adds multiline highlighting for structural search results.

<img width="427" alt="Screen Shot 2019-11-27 at 8 29 45 PM" src="https://user-images.githubusercontent.com/888624/69775077-e11e3600-1154-11ea-904c-1d4090656843.png">


Test plan: Unit tests added.
