### PR TITLE
tidy: condense variable declarations

### DIFF
--- a/cmd/frontend/db/survey_responses.go
+++ b/cmd/frontend/db/survey_responses.go
@@ -90,8 +90,7 @@ func (s *surveyResponses) Last30DaysNetPromoterScore(ctx context.Context) (int, 
 		return 0, err
 	}
 
-	var promoters int
-	var detractors int
+	var promoters, detractors int
 	err = dbconn.Global.QueryRowContext(ctx, promotersQ.Query(sqlf.PostgresBindVar), promotersQ.Args()...).Scan(&promoters)
 	if err != nil {
 		return 0, err

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -149,8 +149,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 	OrgID       *graphql.ID
 	UserID      *graphql.ID
 }) (*savedSearchResolver, error) {
-	var userID *int32
-	var orgID *int32
+	var userID, orgID *int32
 	// 🚨 SECURITY: Make sure the current user has permission to create a saved search for the specified user or org.
 	if args.UserID != nil {
 		u, err := unmarshalSavedSearchID(*args.UserID)


### PR DESCRIPTION
Condenses consecutive variable declarations with the same type. Example:

```
var x int
var y int
```

becomes

`var x, y int`

Created with

```json
{
    "matchTemplate": "var :[[x]] :[t.] var :[[y]] :[t.]",
    "rewriteTemplate": "var :[[x]], :[[y]] :[[t]]",
    "scopeQuery": "repo:github.com/sourcegraph/sourcegraph$ lang:go"
}
```
