### PR TITLE
docs: self-managed comby dev dependency install

### DIFF
--- a/dev/comby-install-or-upgrade.sh
+++ b/dev/comby-install-or-upgrade.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# This function installs the comby dependency for cmd/searcher and cmd/replacer.
-# The main /dev/start.sh script and CI pipeline call this script to install or
-# upgrade comby for tests or development environments.
+# This function installs the comby dependency for cmd/searcher and
+# cmd/replacer. The CI pipeline calls this script to install or upgrade comby
+# for tests or development environments.
 REQUIRE_VERSION="0.11.3"
 
 RELEASE_VERSION=$REQUIRE_VERSION

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -97,14 +97,6 @@ if ! ./dev/go-install.sh; then
 	exit 1
 fi
 
-# Install or upgrade comby.
-# if ! ./dev/comby-install-or-upgrade.sh; then
-#     # Wait for everything to finish up to here.
-#     wait
-#     echo >&2 "WARNING: comby-install-or-upgrade.sh failed, some builds may have failed."
-#     exit 1
-# fi
-
 # Wait for yarn if it is still running
 if [[ -n "$yarn_pid" ]]; then
     wait "$yarn_pid"

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -37,6 +37,7 @@ Sourcegraph has the following dependencies:
 - [nginx](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/) (v1.14 or higher)
 - [SQLite](https://www.sqlite.org/index.html) tools
 - [Golang Migrate](https://github.com/golang-migrate/migrate/) (v4.7.0 or higher)
+- [Comby](https://github.com/comby-tools/comby/) (v0.11.3 or higher)
 
 The following are two recommendations for installing these dependencies:
 
@@ -51,10 +52,10 @@ The following are two recommendations for installing these dependencies:
     brew cask install docker
     ```
 
-3.  Install Go, Node, PostgreSQL, Redis, Git, nginx, golang-migrate, and SQLite tools with the following command:
+3.  Install Go, Node, PostgreSQL, Redis, Git, nginx, golang-migrate, Comby, and SQLite tools with the following command:
 
     ```bash
-    brew install go node yarn redis postgresql git gnu-sed nginx golang-migrate sqlite pcre FiloSottile/musl-cross/musl-cross
+    brew install go node yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
     ```
 
 4.  Configure PostgreSQL and Redis to start automatically
@@ -110,6 +111,9 @@ The following are two recommendations for installing these dependencies:
 
     # install golang-migrate (you must move the extracted binary into your $PATH)
     curl -L https://github.com/golang-migrate/migrate/releases/download/v4.7.0/migrate.linux-amd64.tar.gz | tar xvz
+
+    # install comby (you must move the extracted binary into your $PATH)
+    curl -L https://github.com/comby-tools/comby/releases/download/0.11.3/comby-0.11.3-x86_64-linux.tar.gz | tar xvz
     ```
 
 4. Configure startup services


### PR DESCRIPTION
This updates documentation for installing `comby` as a dependency. There are constraints that make updating `comby` automatically in the dev scripts hard. These are, roughly: 
- binary distribution for different OSes 
- rapid iteration that require faster distribution than available through OS package managers, and
- effort or extra time required when using toolchains and dependencies for building from source 

If you are interested in more nitty gritty detail, see [the slack thread](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1574793755260000).

Thus, for development, `comby` will now be a self-managed install, and treated as an external  dependency. It is in fact optional unless you work with automation tooling at this point in time. Nothing changes for CI or deployments. There are many options for installing it so that:

- Developers who aren't reliant on `comby` for development are unaffected (i.e., [no broken dev builds](https://sourcegraph.slack.com/archives/C07KZF47K/p1574800216028500), ever, and this is the priority behind this change.)
- Developers who are reliant on `comby` but not the most recent versions can use, e.g., `brew` or grab the binaries from GH and put it on their `PATH`.
- Developers who are reliant on recent versions with bug fixes or feature extensions can grab it directly from GH if it's not available on `brew` yet.

Test plan: N/A, that's part of the objective.