### PR TITLE
a8n: Tiny follow up to #6903 and make base ref more explicit

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -219,7 +219,7 @@ func (s *Service) runChangesetJob(
 		return err
 	}
 
-	baseRef := "master"
+	baseRef := "refs/heads/master"
 	if campaignJob.BaseRef != "" {
 		baseRef = campaignJob.BaseRef
 	}


### PR DESCRIPTION
This is a tiny follow up to #6903 and makes it more explicit that the
refs we persist on CampaignJob also include the `refs/heads/` prefix.