### PR TITLE
core/a8n: Expose more Search types

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -50,7 +50,7 @@ type codemodResultResolver struct {
 }
 
 func (r *codemodResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
-func (r *codemodResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *codemodResultResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
 func (r *codemodResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }
@@ -144,7 +144,7 @@ func validateQuery(q *query.Query) (*args, error) {
 }
 
 // Calls the codemod backend replacer service for a set of repository revisions.
-func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResolver, *searchResultsCommon, error) {
+func performCodemod(ctx context.Context, args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error) {
 	cmodArgs, err := validateQuery(args.Query)
 	if err != nil {
 		return nil, nil, err
@@ -197,7 +197,7 @@ func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResol
 		return nil, nil, err
 	}
 
-	var results []searchResultResolver
+	var results []SearchResultResolver
 	for _, ur := range unflattened {
 		for _, resolver := range ur {
 			v := resolver

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -222,7 +222,7 @@ func (r *RepositoryResolver) Matches() []*searchResultMatchResolver {
 }
 
 func (r *RepositoryResolver) ToRepository() (*RepositoryResolver, bool) { return r, true }
-func (r *RepositoryResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *RepositoryResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
 func (r *RepositoryResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -51,7 +51,7 @@ func maxReposToSearch() int {
 	}
 }
 
-type searchArgs struct {
+type SearchArgs struct {
 	Version     string
 	PatternType *string
 	Query       string
@@ -59,8 +59,8 @@ type searchArgs struct {
 	First       *int32
 }
 
-type searchImplementer interface {
-	Results(context.Context) (*searchResultsResolver, error)
+type SearchImplementer interface {
+	Results(context.Context) (*SearchResultsResolver, error)
 	Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	Stats(context.Context) (*searchResultsStats, error)
@@ -74,8 +74,8 @@ const (
 	SearchTypeStructural
 )
 
-// Search provides search results and suggestions.
-func (r *schemaResolver) Search(args *searchArgs) (searchImplementer, error) {
+// NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
+func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	tr, _ := trace.New(context.Background(), "graphql.schemaResolver", "Search")
 	defer tr.Finish()
 
@@ -122,6 +122,10 @@ func (r *schemaResolver) Search(args *searchArgs) (searchImplementer, error) {
 		zoekt:         search.Indexed(),
 		searcherURLs:  search.SearcherURLs(),
 	}, nil
+}
+
+func (r *schemaResolver) Search(args *SearchArgs) (SearchImplementer, error) {
+	return NewSearchImplementer(args)
 }
 
 // detectSearchType returns the search type to perfrom ("regexp", or

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -63,7 +63,7 @@ func (r *commitSearchResultResolver) Matches() []*searchResultMatchResolver {
 }
 
 func (r *commitSearchResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
-func (r *commitSearchResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *commitSearchResultResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
 func (r *commitSearchResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return r, true
 }
@@ -438,10 +438,10 @@ func highlightMatches(pattern *regexp.Regexp, data []byte) *highlightedString {
 	return hls
 }
 
-var mockSearchCommitDiffsInRepos func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitDiffsInRepos func(args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error)
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]searchResultResolver, *searchResultsCommon, error) {
+func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitDiffsInRepos != nil {
 		return mockSearchCommitDiffsInRepos(args)
 	}
@@ -499,10 +499,10 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]searchR
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-var mockSearchCommitLogInRepos func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitLogInRepos func(args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]searchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitLogInRepos != nil {
 		return mockSearchCommitLogInRepos(args)
 	}
@@ -560,13 +560,13 @@ func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]searchRes
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-func commitSearchResultsToSearchResults(results []*commitSearchResultResolver) []searchResultResolver {
+func commitSearchResultsToSearchResults(results []*commitSearchResultResolver) []SearchResultResolver {
 	// Show most recent commits first.
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].commit.author.Date() > results[j].commit.author.Date()
 	})
 
-	results2 := make([]searchResultResolver, len(results))
+	results2 := make([]SearchResultResolver, len(results))
 	for i, result := range results {
 		results2[i] = result
 	}

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
@@ -17,13 +17,13 @@ type didYouMeanQuotedResolver struct {
 	err   error
 }
 
-func (r *didYouMeanQuotedResolver) Results(context.Context) (*searchResultsResolver, error) {
+func (r *didYouMeanQuotedResolver) Results(context.Context) (*SearchResultsResolver, error) {
 	sqds := proposedQuotedQueries(r.query)
 	switch e := r.err.(type) {
 	case *types.TypeError:
 		switch e := e.Err.(type) {
 		case *rxsyntax.Error:
-			srr := &searchResultsResolver{
+			srr := &SearchResultsResolver{
 				alert: &searchAlert{
 					title:           capFirst(e.Error()),
 					description:     "Quoting the query may help if you want a literal match instead of a regular expression match.",
@@ -35,7 +35,7 @@ func (r *didYouMeanQuotedResolver) Results(context.Context) (*searchResultsResol
 			return nil, r.err
 		}
 	case *syntax.ParseError:
-		srr := &searchResultsResolver{
+		srr := &SearchResultsResolver{
 			alert: &searchAlert{
 				title:           capFirst(e.Msg),
 				description:     "Quoting the query may help if you want a literal match.",

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -42,8 +42,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path string) *fileMatchResolver {
-		return &fileMatchResolver{JPath: path, repo: repo}
+	result := func(repo *types.Repo, path string) *FileMatchResolver {
+		return &FileMatchResolver{JPath: path, repo: repo}
 	}
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
@@ -61,7 +61,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		fmt.Fprintf(&b, "limitHit: %v\n", r.limitHit)
 		return b.String()
 	}
-	sharedResult := []searchResultResolver{
+	sharedResult := []SearchResultResolver{
 		result(repo("org/repo1"), "a.go"),
 		result(repo("org/repo1"), "b.go"),
 		result(repo("org/repo1"), "c.go"),
@@ -85,19 +85,19 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	}
 	tests := []struct {
 		name          string
-		results       []searchResultResolver
+		results       []SearchResultResolver
 		common        *searchResultsCommon
 		offset, limit int
 		want          slicedSearchResults
 	}{
 		{
 			name:    "empty result set",
-			results: []searchResultResolver{},
+			results: []SearchResultResolver{},
 			common:  &searchResultsCommon{},
 			offset:  0,
 			limit:   3,
 			want: slicedSearchResults{
-				results: []searchResultResolver{},
+				results: []SearchResultResolver{},
 				common: &searchResultsCommon{
 					resultCount: 0,
 					repos:       nil,
@@ -114,7 +114,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset:  0,
 			limit:   3,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo1"), "a.go"),
 					result(repo("org/repo1"), "b.go"),
 					result(repo("org/repo1"), "c.go"),
@@ -135,7 +135,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset:  0,
 			limit:   2,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo1"), "a.go"),
 					result(repo("org/repo1"), "b.go"),
 				},
@@ -155,7 +155,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset:  3,
 			limit:   3,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo2"), "a.go"),
 					result(repo("org/repo2"), "b.go"),
 					result(repo("org/repo3"), "a.go"),
@@ -176,7 +176,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset:  2,
 			limit:   3,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo1"), "c.go"),
 					result(repo("org/repo2"), "a.go"),
 					result(repo("org/repo2"), "b.go"),
@@ -192,7 +192,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		},
 		{
 			name: "offset repo boundary fully consumed",
-			results: []searchResultResolver{
+			results: []SearchResultResolver{
 				result(repo("org/repo1"), "a.go"),
 				result(repo("org/repo1"), "b.go"),
 				result(repo("org/repo1"), "c.go"),
@@ -207,7 +207,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset: 3,
 			limit:  3,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo2"), "a.go"),
 					result(repo("org/repo2"), "b.go"),
 					result(repo("org/repo2"), "c.go"),
@@ -228,7 +228,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			offset:  1,
 			limit:   1,
 			want: slicedSearchResults{
-				results: []searchResultResolver{
+				results: []SearchResultResolver{
 					result(repo("org/repo1"), "b.go"),
 				},
 				common: &searchResultsCommon{
@@ -272,8 +272,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path, rev string) *fileMatchResolver {
-		return &fileMatchResolver{JPath: path, repo: repo, inputRev: &rev}
+	result := func(repo *types.Repo, path, rev string) *FileMatchResolver {
+		return &FileMatchResolver{JPath: path, repo: repo, inputRev: &rev}
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
@@ -289,14 +289,14 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		repoRevs("5", "master"),
 	}
 	var searchedBatches [][]*search.RepositoryRevisions
-	resultsExecutor := func(batch []*search.RepositoryRevisions) (results []searchResultResolver, common *searchResultsCommon, err error) {
+	resultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
 		searchedBatches = append(searchedBatches, batch)
 		common = &searchResultsCommon{}
 		for _, repoRev := range batch {
 			for _, rev := range repoRev.Revs {
 				rev := rev.RevSpec
 				for i := 0; i < 3; i++ {
-					results = append(results, &fileMatchResolver{
+					results = append(results, &FileMatchResolver{
 						JPath:    fmt.Sprintf("some/file%d.go", i),
 						repo:     repoRev.Repo,
 						inputRev: &rev,
@@ -307,7 +307,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		}
 		return
 	}
-	noResultsExecutor := func(batch []*search.RepositoryRevisions) (results []searchResultResolver, common *searchResultsCommon, err error) {
+	noResultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
 		return nil, &searchResultsCommon{}, nil
 	}
 	ctx := context.Background()
@@ -318,7 +318,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		request             *searchPaginationInfo
 		wantSearchedBatches [][]*search.RepositoryRevisions
 		wantCursor          *searchCursor
-		wantResults         []searchResultResolver
+		wantResults         []SearchResultResolver
 		wantCommon          *searchResultsCommon
 		wantErr             error
 	}{
@@ -337,7 +337,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				},
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 2, ResultOffset: 4},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("1"), "some/file0.go", "master"),
 				result(repo("1"), "some/file1.go", "master"),
 				result(repo("1"), "some/file2.go", "master"),
@@ -369,7 +369,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				},
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 5, ResultOffset: 0, Finished: true},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("3"), "some/file1.go", "feature"),
 				result(repo("3"), "some/file2.go", "feature"),
 				result(repo("4"), "some/file0.go", "master"),
@@ -399,7 +399,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				},
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 1},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("1"), "some/file0.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
@@ -423,7 +423,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				},
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 0, ResultOffset: 2},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("1"), "some/file1.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
@@ -490,8 +490,8 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path string) *fileMatchResolver {
-		return &fileMatchResolver{JPath: path, repo: repo}
+	result := func(repo *types.Repo, path string) *FileMatchResolver {
+		return &FileMatchResolver{JPath: path, repo: repo}
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
@@ -499,7 +499,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 			Revs: revs(rev...),
 		}
 	}
-	repoResults := map[string][]searchResultResolver{
+	repoResults := map[string][]SearchResultResolver{
 		"1": {
 			result(repo("1"), "a.go"),
 			result(repo("1"), "b.go"),
@@ -516,7 +516,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		repoRevs("1", "master"),
 		repoRevs("2", "master"),
 	}
-	executor := func(batch []*search.RepositoryRevisions) (results []searchResultResolver, common *searchResultsCommon, err error) {
+	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
 		common = &searchResultsCommon{}
 		for _, repoRev := range batch {
 			results = append(results, repoResults[string(repoRev.Repo.Name)]...)
@@ -530,7 +530,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		name        string
 		request     *searchPaginationInfo
 		wantCursor  *searchCursor
-		wantResults []searchResultResolver
+		wantResults []SearchResultResolver
 		wantErr     error
 	}{
 		{
@@ -540,7 +540,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 				limit:  3,
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 1, ResultOffset: 1},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("1"), "a.go"),
 				result(repo("1"), "b.go"),
 				result(repo("2"), "a.go"),
@@ -553,7 +553,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 				limit:  3,
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 1, ResultOffset: 4},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("2"), "b.go"),
 				result(repo("2"), "c.go"),
 				result(repo("2"), "d.go"),
@@ -566,7 +566,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 				limit:  3,
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 2, ResultOffset: 0, Finished: true},
-			wantResults: []searchResultResolver{
+			wantResults: []SearchResultResolver{
 				result(repo("2"), "e.go"),
 			},
 		},

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -11,14 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
 )
 
-var mockSearchRepositories func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
+var mockSearchRepositories func(args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error)
 var repoIcon = "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K"
 
 // searchRepositories searches for repositories by name.
 //
 // For a repository to match a query, the repository's name must match all of the repo: patterns AND the
 // default patterns (i.e., the patterns that are not prefixed with any search field).
-func searchRepositories(ctx context.Context, args *search.Args, limit int32) (res []searchResultResolver, common *searchResultsCommon, err error) {
+func searchRepositories(ctx context.Context, args *search.Args, limit int32) (res []SearchResultResolver, common *searchResultsCommon, err error) {
 	if mockSearchRepositories != nil {
 		return mockSearchRepositories(args)
 	}
@@ -67,7 +67,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 	}
 
 	// Convert the repos to RepositoryResolvers.
-	results := make([]searchResultResolver, 0, len(repos))
+	results := make([]SearchResultResolver, 0, len(repos))
 	for _, r := range repos {
 		if len(results) == int(limit) {
 			common.limitHit = true

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -20,25 +20,25 @@ func TestSearchRepositories(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
-	mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 		repoName := args.Repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "bar/one":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					repo: &types.Repo{ID: 789},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
-			return []*fileMatchResolver{}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		default:
 			return nil, &searchResultsCommon{}, errors.New("Unexpected repo")
 		}
@@ -121,18 +121,18 @@ func TestSearchRepositories(t *testing.T) {
 }
 
 func TestRepoShouldBeAdded(t *testing.T) {
-	mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 		repoName := args.Repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
 					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
-			return []*fileMatchResolver{}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		default:
 			return nil, &searchResultsCommon{}, errors.New("Unexpected repo")
 		}
@@ -142,8 +142,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
-			return []*fileMatchResolver{
+		mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					repo: &types.Repo{ID: 123},
@@ -162,8 +162,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
-			return []*fileMatchResolver{}, &searchResultsCommon{}, nil
+		mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		}
 		pat := &search.PatternInfo{Pattern: "", FilePatternsReposMustInclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
@@ -177,8 +177,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
-			return []*fileMatchResolver{
+		mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					repo: &types.Repo{ID: 123},
@@ -197,8 +197,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
-			return []*fileMatchResolver{}, &searchResultsCommon{}, nil
+		mockSearchFilesInRepos = func(args *search.Args) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		}
 		pat := &search.PatternInfo{Pattern: "", FilePatternsReposMustExclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -21,7 +21,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 	getSuggestions := func(t *testing.T, query, version string) []string {
 		t.Helper()
-		r, err := (&schemaResolver{}).Search(&searchArgs{Query: query, Version: version})
+		r, err := (&schemaResolver{}).Search(&SearchArgs{Query: query, Version: version})
 		if err != nil {
 			t.Fatal("Search:", err)
 		}
@@ -43,7 +43,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	}
 
-	mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 		// TODO test symbol suggestions
 		return nil, nil, nil
 	}
@@ -88,12 +88,12 @@ func TestSearchSuggestions(t *testing.T) {
 		defer git.ResetMocks()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := "foo"; args.Pattern.Pattern != want {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
 			}
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{uri: "git://repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
 			}, &searchResultsCommon{}, nil
 		}
@@ -114,7 +114,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 	// This test is only valid for Regexp searches. Literal searches won't return suggestions for an invalid regexp.
 	t.Run("single term invalid regex", func(t *testing.T) {
-		sr, err := (&schemaResolver{}).Search(&searchArgs{Query: "[foo", PatternType: nil, Version: "V1"})
+		sr, err := (&schemaResolver{}).Search(&SearchArgs{Query: "[foo", PatternType: nil, Version: "V1"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,14 +154,14 @@ func TestSearchSuggestions(t *testing.T) {
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if args.Pattern.Pattern != "." && args.Pattern.Pattern != "foo" {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, `"foo" or "."`)
 			}
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", repo: &types.Repo{Name: "repo3"}, commitID: "rev"},
 				{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", repo: &types.Repo{Name: "repo1"}, commitID: "rev"},
 				{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
@@ -226,14 +226,14 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
 			}, &searchResultsCommon{}, nil
 		}
@@ -323,14 +323,14 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
 			}, &searchResultsCommon{}, nil
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -47,7 +47,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 
 func Test_limitingSymbolResults(t *testing.T) {
 	t.Run("empty case", func(t *testing.T) {
-		var res []*fileMatchResolver
+		var res []*FileMatchResolver
 
 		t.Run("symbol count is 0", func(t *testing.T) {
 			nsym := symbolCount(res)
@@ -65,7 +65,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
-		res := []*fileMatchResolver{
+		res := []*FileMatchResolver{
 			{
 				symbols: []*searchSymbolResult{
 					{
@@ -100,7 +100,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
-		res := []*fileMatchResolver{
+		res := []*FileMatchResolver{
 			{
 				symbols: []*searchSymbolResult{
 					{
@@ -152,7 +152,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
-		res := []*fileMatchResolver{
+		res := []*FileMatchResolver{
 			{
 				symbols: []*searchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
@@ -177,16 +177,16 @@ func Test_limitingSymbolResults(t *testing.T) {
 		testCases := []struct {
 			name  string
 			limit int
-			want  []*fileMatchResolver
+			want  []*FileMatchResolver
 		}{
 			{
 				name: "limit 0 => no file matches",
-				want: []*fileMatchResolver{},
+				want: []*FileMatchResolver{},
 			},
 			{
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
-				want: []*fileMatchResolver{
+				want: []*FileMatchResolver{
 					{
 						symbols: []*searchSymbolResult{
 							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
@@ -197,7 +197,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
-				want: []*fileMatchResolver{
+				want: []*FileMatchResolver{
 					{
 						symbols: []*searchSymbolResult{
 							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
@@ -209,7 +209,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
-				want: []*fileMatchResolver{
+				want: []*FileMatchResolver{
 					{
 						symbols: []*searchSymbolResult{
 							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
@@ -226,7 +226,7 @@ func Test_limitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
-				want: []*fileMatchResolver{
+				want: []*FileMatchResolver{
 					{
 						symbols: []*searchSymbolResult{
 							{symbol: protocol.Symbol{Name: "symbol-name-1"}},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -60,8 +60,8 @@ var (
 // A light wrapper around the search service. We implement the service here so
 // that we can unmarshal the result directly into graphql resolvers.
 
-// fileMatchResolver is a resolver for the GraphQL type `FileMatch`
-type fileMatchResolver struct {
+// FileMatchResolver is a resolver for the GraphQL type `FileMatch`
+type FileMatchResolver struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`
 	JLimitHit    bool         `json:"LimitHit"`
@@ -75,15 +75,15 @@ type fileMatchResolver struct {
 	inputRev *string
 }
 
-func (fm *fileMatchResolver) Equal(other *fileMatchResolver) bool {
+func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 	return reflect.DeepEqual(fm, other)
 }
 
-func (fm *fileMatchResolver) Key() string {
+func (fm *FileMatchResolver) Key() string {
 	return fm.uri
 }
 
-func (fm *fileMatchResolver) File() *GitTreeEntryResolver {
+func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 	// NOTE(sqs): Omits other commit fields to avoid needing to fetch them
 	// (which would make it slow). This GitCommitResolver will return empty
 	// values for all other fields.
@@ -97,15 +97,15 @@ func (fm *fileMatchResolver) File() *GitTreeEntryResolver {
 	}
 }
 
-func (fm *fileMatchResolver) Repository() *RepositoryResolver {
+func (fm *FileMatchResolver) Repository() *RepositoryResolver {
 	return &RepositoryResolver{repo: fm.repo}
 }
 
-func (fm *fileMatchResolver) Resource() string {
+func (fm *FileMatchResolver) Resource() string {
 	return fm.uri
 }
 
-func (fm *fileMatchResolver) Symbols() []*symbolResolver {
+func (fm *FileMatchResolver) Symbols() []*symbolResolver {
 	symbols := make([]*symbolResolver, len(fm.symbols))
 	for i, s := range fm.symbols {
 		symbols[i] = toSymbolResolver(s.symbol, s.baseURI, s.lang, s.commit)
@@ -113,29 +113,29 @@ func (fm *fileMatchResolver) Symbols() []*symbolResolver {
 	return symbols
 }
 
-func (fm *fileMatchResolver) LineMatches() []*lineMatch {
+func (fm *FileMatchResolver) LineMatches() []*lineMatch {
 	return fm.JLineMatches
 }
 
-func (fm *fileMatchResolver) LimitHit() bool {
+func (fm *FileMatchResolver) LimitHit() bool {
 	return fm.JLimitHit
 }
 
-func (fm *fileMatchResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
-func (fm *fileMatchResolver) ToFileMatch() (*fileMatchResolver, bool)   { return fm, true }
-func (fm *fileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+func (fm *FileMatchResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
+func (fm *FileMatchResolver) ToFileMatch() (*FileMatchResolver, bool)   { return fm, true }
+func (fm *FileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }
 
-func (r *fileMatchResolver) ToCodemodResult() (*codemodResultResolver, bool) {
+func (r *FileMatchResolver) ToCodemodResult() (*codemodResultResolver, bool) {
 	return nil, false
 }
 
-func (fm *fileMatchResolver) searchResultURIs() (string, string) {
+func (fm *FileMatchResolver) searchResultURIs() (string, string) {
 	return string(fm.repo.Name), fm.JPath
 }
 
-func (fm *fileMatchResolver) resultCount() int32 {
+func (fm *FileMatchResolver) resultCount() int32 {
 	rc := len(fm.symbols) + len(fm.LineMatches())
 	if rc > 0 {
 		return int32(rc)
@@ -171,11 +171,11 @@ func (lm *lineMatch) LimitHit() bool {
 	return lm.JLimitHit
 }
 
-var mockTextSearch func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error)
+var mockTextSearch func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
 
 // textSearch searches repo@commit with p.
 // Note: the returned matches do not set fileMatch.uri
-func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
+func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 	if mockTextSearch != nil {
 		return mockTextSearch(ctx, repo, commit, p, fetchTimeout)
 	}
@@ -282,7 +282,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 	}
 }
 
-func textSearchURL(ctx context.Context, url string) ([]*fileMatchResolver, bool, error) {
+func textSearchURL(ctx context.Context, url string) ([]*FileMatchResolver, bool, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, false, err
@@ -316,7 +316,7 @@ func textSearchURL(ctx context.Context, url string) ([]*fileMatchResolver, bool,
 	}
 
 	r := struct {
-		Matches     []*fileMatchResolver
+		Matches     []*FileMatchResolver
 		LimitHit    bool
 		DeadlineHit bool
 	}{}
@@ -347,9 +347,9 @@ func (e *searcherError) Error() string {
 	return e.Message
 }
 
-var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
 
-func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
+func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
 	}
@@ -439,10 +439,10 @@ func fileMatchURI(name api.RepoName, ref, path string) string {
 	return b.String()
 }
 
-var mockSearchFilesInRepos func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error)
+var mockSearchFilesInRepos func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error)
 
 // searchFilesInRepos searches a set of repos for a pattern.
-func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
+func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 	if mockSearchFilesInRepos != nil {
 		return mockSearchFilesInRepos(args)
 	}
@@ -520,13 +520,13 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		wg                sync.WaitGroup
 		mu                sync.Mutex
 		searchErr         error
-		unflattened       [][]*fileMatchResolver
+		unflattened       [][]*FileMatchResolver
 		flattenedSize     int
 		overLimitCanceled bool // canceled because we were over the limit
 	)
 
 	// addMatches assumes the caller holds mu.
-	addMatches := func(matches []*fileMatchResolver) {
+	addMatches := func(matches []*FileMatchResolver) {
 		if len(matches) > 0 {
 			common.resultCount += int32(len(matches))
 			sort.Slice(matches, func(i, j int) bool {
@@ -738,7 +738,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 	return flattened, common, nil
 }
 
-func flattenFileMatches(unflattened [][]*fileMatchResolver, fileMatchLimit int) []*fileMatchResolver {
+func flattenFileMatches(unflattened [][]*FileMatchResolver, fileMatchLimit int) []*FileMatchResolver {
 	// Return early so we don't have to worry about empty lists in later
 	// calculations.
 	if len(unflattened) == 0 {
@@ -754,7 +754,7 @@ func flattenFileMatches(unflattened [][]*fileMatchResolver, fileMatchLimit int) 
 		a, b := unflattened[i][0].uri, unflattened[j][0].uri
 		return a > b
 	})
-	var flattened []*fileMatchResolver
+	var flattened []*FileMatchResolver
 	initialPortion := fileMatchLimit / len(unflattened)
 	for _, matches := range unflattened {
 		if initialPortion < len(matches) {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -322,17 +322,17 @@ func TestQueryToZoektFileOnlyQueries(t *testing.T) {
 }
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		case "foo/two":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
@@ -409,17 +409,17 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestRepoShouldBeSearched(t *testing.T) {
-	mockTextSearch = func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
+	mockTextSearch = func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.PatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*fileMatchResolver{
+			return []*FileMatchResolver{
 				{
 					uri: "git://" + string(repoName) + "?1a2b3c#" + "main.go",
 				},
 			}, false, nil
 		case "foo/no-filematch":
-			return []*fileMatchResolver{}, false, nil
+			return []*FileMatchResolver{}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")
 		}
@@ -513,7 +513,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 	tests := []struct {
 		name              string
 		args              args
-		wantFm            []*fileMatchResolver
+		wantFm            []*FileMatchResolver
 		wantLimitHit      bool
 		wantReposLimitHit map[string]struct{}
 		wantErr           bool

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -74,7 +74,7 @@ func zoektSearchOpts(k int, query *search.PatternInfo) zoekt.SearchOptions {
 	return searchOpts
 }
 
-func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.RepositoryRevisions, isSymbol bool, since func(t time.Time) time.Duration) (fm []*fileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
+func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.RepositoryRevisions, isSymbol bool, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
 	if len(repos) == 0 {
 		return nil, false, nil, nil
 	}
@@ -188,7 +188,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 		limitHit = true
 	}
 
-	matches := make([]*fileMatchResolver, len(resp.Files))
+	matches := make([]*FileMatchResolver, len(resp.Files))
 	for i, file := range resp.Files {
 		fileLimitHit := false
 		if len(file.LineMatches) > maxLineMatches {
@@ -242,7 +242,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 				}
 			}
 		}
-		matches[i] = &fileMatchResolver{
+		matches[i] = &FileMatchResolver{
 			JPath:        file.FileName,
 			JLineMatches: lines,
 			JLimitHit:    fileLimitHit,


### PR DESCRIPTION
This is an extraction from #6893 and most definitely the part of the PR that will stay as it is, because I currently don't see any other way to reach access our search functionality from outside the `graphqlbackend` package.

Merging this would make reviewing and working on #6893 a lot easier.