### PR TITLE
a8n: Fix ID kind of ExternalChangeset

### DIFF
--- a/enterprise/internal/a8n/resolvers/changesets.go
+++ b/enterprise/internal/a8n/resolvers/changesets.go
@@ -111,7 +111,7 @@ type changesetResolver struct {
 	err  error
 }
 
-const changesetIDKind = "Changeset"
+const changesetIDKind = "ExternalChangeset"
 
 func marshalChangesetID(id int64) graphql.ID {
 	return relay.MarshalID(changesetIDKind, id)


### PR DESCRIPTION
It was not matching the "ExternalChangeset" in the switch case in the root `node` graphql resolver and hence not fetchable returning "Invalid ID" errors