### PR TITLE
a8n: Use more robust sorting of replacer service JSON lines

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -161,8 +161,10 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 	}
 
 	sort.Slice(diffs, func(i, j int) bool {
-		return diffs[i].diff.OrigName < diffs[j].diff.OrigName &&
-			diffs[i].diff.NewName < diffs[j].diff.NewName
+		if diffs[i].diff.OrigName != diffs[j].diff.OrigName {
+			return diffs[i].diff.OrigName < diffs[j].diff.OrigName
+		}
+		return diffs[i].diff.NewName < diffs[j].diff.NewName
 	})
 
 	var result strings.Builder


### PR DESCRIPTION
This is a follow-up to #6912 that implements the more stable sorting as suggested in this comment: https://github.com/sourcegraph/sourcegraph/pull/6912#discussion_r352142755
