### PR TITLE
a8n: Validate campaign plan arguments with JSON schema

### DIFF
--- a/schema/campaign-types/comby.schema.json
+++ b/schema/campaign-types/comby.schema.json
@@ -6,14 +6,17 @@
   "properties": {
     "scopeQuery": {
       "type": "string",
+      "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     },
     "matchTemplate": {
       "type": "string",
+      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     },
     "rewriteTemplate": {
       "type": "string",
+      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     }
   },

--- a/schema/campaign-types/comby_stringdata.go
+++ b/schema/campaign-types/comby_stringdata.go
@@ -11,14 +11,17 @@ const CombyCampaignTypeSchemaJSON = `{
   "properties": {
     "scopeQuery": {
       "type": "string",
+      "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     },
     "matchTemplate": {
       "type": "string",
+      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     },
     "rewriteTemplate": {
       "type": "string",
+      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     }
   },

--- a/schema/campaign-types/credentials.schema.json
+++ b/schema/campaign-types/credentials.schema.json
@@ -28,6 +28,7 @@
     },
     "scopeQuery": {
       "type": "string",
+      "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     }
   },

--- a/schema/campaign-types/credentials_stringdata.go
+++ b/schema/campaign-types/credentials_stringdata.go
@@ -33,6 +33,7 @@ const CredentialsCampaignTypeSchemaJSON = `{
     },
     "scopeQuery": {
       "type": "string",
+      "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     }
   },


### PR DESCRIPTION
This changes the existing validation of campaign type arguments to use the JSON schemas we defined.

The errors it returns are in Markdown. I use the same functions to generate these errors that we use in the external services.

---

@sourcegraph/core-services What would be a good place to put these tiny helper functions to turn JSON schema validation errors into markdown? I copied them from here: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a5be7367ce89de5c316eae084492e014e4ad84f1/-/blob/cmd/frontend/db/external_services.go#L102-118