### PR TITLE
a8n: Add tests for campaign type to remove credentials

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -205,7 +205,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	return &SearchResultsResolver{
 		start:               start,
 		searchResultsCommon: common,
-		results:             results,
+		SearchResults:       results,
 		alert:               alert,
 		cursor:              cursor,
 	}, nil

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -43,14 +43,14 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
 	result := func(repo *types.Repo, path string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, repo: repo}
+		return &FileMatchResolver{JPath: path, Repo: repo}
 	}
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
 		fmt.Fprintf(&b, "results:\n")
 		for i, result := range r.results {
 			fm, _ := result.ToFileMatch()
-			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.repo.Name, fm.JPath)
+			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.Repo.Name, fm.JPath)
 		}
 		fmt.Fprintf(&b, "common.repos:\n")
 		for i, r := range r.common.repos {
@@ -273,7 +273,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
 	result := func(repo *types.Repo, path, rev string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, repo: repo, inputRev: &rev}
+		return &FileMatchResolver{JPath: path, Repo: repo, InputRev: &rev}
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
@@ -298,8 +298,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				for i := 0; i < 3; i++ {
 					results = append(results, &FileMatchResolver{
 						JPath:    fmt.Sprintf("some/file%d.go", i),
-						repo:     repoRev.Repo,
-						inputRev: &rev,
+						Repo:     repoRev.Repo,
+						InputRev: &rev,
 					})
 				}
 			}
@@ -491,7 +491,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
 	result := func(repo *types.Repo, path string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, repo: repo}
+		return &FileMatchResolver{JPath: path, Repo: repo}
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -103,7 +103,7 @@ func reposToAdd(ctx context.Context, args *search.Args, repos []*search.Reposito
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.repo.ID] = true
+				matchingIDs[m.Repo.ID] = true
 			}
 		}
 	} else {
@@ -130,7 +130,7 @@ func reposToAdd(ctx context.Context, args *search.Args, repos []*search.Reposito
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.repo.ID] = false
+				matchingIDs[m.Repo.ID] = false
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -27,14 +27,14 @@ func TestSearchRepositories(t *testing.T) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
-					repo: &types.Repo{ID: 123},
+					Repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
-					repo: &types.Repo{ID: 789},
+					Repo: &types.Repo{ID: 789},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
@@ -128,7 +128,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
-					repo: &types.Repo{ID: 123},
+					Repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
@@ -146,7 +146,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
-					repo: &types.Repo{ID: 123},
+					Repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		}
@@ -181,7 +181,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
-					repo: &types.Repo{ID: 123},
+					Repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -145,7 +145,7 @@ func dedupSort(repos *types.Repos) {
 
 // SearchResultsResolver is a resolver for the GraphQL type `SearchResults`
 type SearchResultsResolver struct {
-	results []SearchResultResolver
+	SearchResults []SearchResultResolver
 	searchResultsCommon
 	alert *searchAlert
 	start time.Time // when the results started being computed
@@ -156,12 +156,12 @@ type SearchResultsResolver struct {
 }
 
 func (sr *SearchResultsResolver) Results() []SearchResultResolver {
-	return sr.results
+	return sr.SearchResults
 }
 
 func (sr *SearchResultsResolver) MatchCount() int32 {
 	var totalResults int32
-	for _, result := range sr.results {
+	for _, result := range sr.SearchResults {
 		totalResults += result.resultCount()
 	}
 	return totalResults
@@ -260,13 +260,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 		}
 	}
 
-	for _, result := range sr.results {
+	for _, result := range sr.SearchResults {
 		if fm, ok := result.ToFileMatch(); ok {
 			rev := ""
-			if fm.inputRev != nil {
-				rev = *fm.inputRev
+			if fm.InputRev != nil {
+				rev = *fm.InputRev
 			}
-			addRepoFilter(string(fm.repo.Name), rev, len(fm.LineMatches()))
+			addRepoFilter(string(fm.Repo.Name), rev, len(fm.LineMatches()))
 			addLangFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
 			addFileFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
 
@@ -368,8 +368,8 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *FileMat
 		return time.Time{}, nil
 	}
 	lm := fm.LineMatches()[0]
-	hunks, err := git.BlameFile(ctx, gitserver.Repo{Name: fm.repo.Name}, fm.JPath, &git.BlameOptions{
-		NewestCommit: fm.commitID,
+	hunks, err := git.BlameFile(ctx, gitserver.Repo{Name: fm.Repo.Name}, fm.JPath, &git.BlameOptions{
+		NewestCommit: fm.CommitID,
 		StartLine:    int(lm.LineNumber()),
 		EndLine:      int(lm.LineNumber()),
 	})
@@ -414,7 +414,7 @@ func (sr *SearchResultsResolver) Sparkline(ctx context.Context) (sparkline []int
 	// Consider all of our search results as a potential data point in our
 	// sparkline.
 loop:
-	for _, r := range sr.results {
+	for _, r := range sr.SearchResults {
 		r := r // shadow so it doesn't change in the goroutine
 		switch m := r.(type) {
 		case *RepositoryResolver:
@@ -1133,7 +1133,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	resultsResolver := SearchResultsResolver{
 		start:               start,
 		searchResultsCommon: common,
-		results:             results,
+		SearchResults:       results,
 		alert:               alert,
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -39,8 +39,8 @@ func TestSearchResults(t *testing.T) {
 		if err != nil {
 			t.Fatal("Results:", err)
 		}
-		resultDescriptions := make([]string, len(results.results))
-		for i, result := range results.results {
+		resultDescriptions := make([]string, len(results.SearchResults))
+		for i, result := range results.SearchResults {
 			// NOTE: Only supports one match per line. If we need to test other cases,
 			// just remove that assumption in the following line of code.
 			switch m := result.(type) {
@@ -147,7 +147,7 @@ func TestSearchResults(t *testing.T) {
 					uri:          "git://repo?rev#dir/file",
 					JPath:        "dir/file",
 					JLineMatches: []*lineMatch{{JLineNumber: 123}},
-					repo:         &types.Repo{ID: 1},
+					Repo:         &types.Repo{ID: 1},
 				},
 			}, &searchResultsCommon{}, nil
 		}
@@ -218,7 +218,7 @@ func TestSearchResults(t *testing.T) {
 					uri:          "git://repo?rev#dir/file",
 					JPath:        "dir/file",
 					JLineMatches: []*lineMatch{{JLineNumber: 123}},
-					repo:         &types.Repo{ID: 1},
+					Repo:         &types.Repo{ID: 1},
 				},
 			}, &searchResultsCommon{}, nil
 		}
@@ -548,24 +548,24 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 
 	fileMatch := &FileMatchResolver{
 		JPath: "/testFile.md",
-		repo:  repo,
+		Repo:  repo,
 	}
 
 	tsFileMatch := &FileMatchResolver{
 		JPath: "/testFile.ts",
-		repo:  repo,
+		Repo:  repo,
 	}
 
 	tsxFileMatch := &FileMatchResolver{
 		JPath: "/testFile.tsx",
-		repo:  repo,
+		Repo:  repo,
 	}
 
 	rev := "develop"
 	fileMatchRev := &FileMatchResolver{
 		JPath:    "/testFile.md",
-		repo:     repo,
-		inputRev: &rev,
+		Repo:     repo,
+		InputRev: &rev,
 	}
 
 	type testCase struct {
@@ -633,7 +633,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.descr, func(t *testing.T) {
-			actualDynamicFilters := (&SearchResultsResolver{results: test.searchResults}).DynamicFilters()
+			actualDynamicFilters := (&SearchResultsResolver{SearchResults: test.searchResults}).DynamicFilters()
 			actualDynamicFilterStrs := make(map[string]struct{})
 
 			for _, filter := range actualDynamicFilters {
@@ -773,7 +773,7 @@ func TestCompareSearchResults(t *testing.T) {
 	}, {
 		// Repo match vs file match in same repo
 		a: &FileMatchResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
+			Repo: &types.Repo{Name: api.RepoName("a")},
 
 			JPath: "a",
 		},
@@ -784,12 +784,12 @@ func TestCompareSearchResults(t *testing.T) {
 	}, {
 		// Same repo, different files
 		a: &FileMatchResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
+			Repo: &types.Repo{Name: api.RepoName("a")},
 
 			JPath: "a",
 		},
 		b: &FileMatchResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
+			Repo: &types.Repo{Name: api.RepoName("a")},
 
 			JPath: "b",
 		},
@@ -797,12 +797,12 @@ func TestCompareSearchResults(t *testing.T) {
 	}, {
 		// different repo, same file name
 		a: &FileMatchResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
+			Repo: &types.Repo{Name: api.RepoName("a")},
 
 			JPath: "a",
 		},
 		b: &FileMatchResolver{
-			repo: &types.Repo{Name: api.RepoName("b")},
+			Repo: &types.Repo{Name: api.RepoName("b")},
 
 			JPath: "a",
 		},
@@ -1243,7 +1243,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
-				results:             tt.fields.results,
+				SearchResults:       tt.fields.results,
 				searchResultsCommon: tt.fields.searchResultsCommon,
 				alert:               tt.fields.alert,
 				start:               tt.fields.start,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -269,14 +269,14 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			}
 			var suggestions []*searchSuggestionResolver
 			if results != nil {
-				if len(results.results) > int(*args.First) {
-					results.results = results.results[:*args.First]
+				if len(results.SearchResults) > int(*args.First) {
+					results.SearchResults = results.SearchResults[:*args.First]
 				}
-				suggestions = make([]*searchSuggestionResolver, 0, len(results.results))
-				for i, res := range results.results {
+				suggestions = make([]*searchSuggestionResolver, 0, len(results.SearchResults))
+				for i, res := range results.SearchResults {
 					if fm, ok := res.ToFileMatch(); ok {
 						entryResolver := fm.File()
-						suggestions = append(suggestions, newSearchResultResolver(entryResolver, len(results.results)-i))
+						suggestions = append(suggestions, newSearchResultResolver(entryResolver, len(results.SearchResults)-i))
 					}
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -94,7 +94,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
+				{uri: "git://repo?rev#dir/file", JPath: "dir/file", Repo: &types.Repo{Name: "repo"}, CommitID: "rev"},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -162,9 +162,9 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, `"foo" or "."`)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", repo: &types.Repo{Name: "repo3"}, commitID: "rev"},
-				{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", repo: &types.Repo{Name: "repo1"}, commitID: "rev"},
-				{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
+				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", Repo: &types.Repo{Name: "repo3"}, CommitID: "rev"},
+				{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", Repo: &types.Repo{Name: "repo1"}, CommitID: "rev"},
+				{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", Repo: &types.Repo{Name: "repo"}, CommitID: "rev"},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -234,7 +234,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
+				{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", Repo: &types.Repo{Name: "foo-repo"}, CommitID: ""},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -331,7 +331,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
+				{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", Repo: &types.Repo{Name: "foo-repo"}, CommitID: ""},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -305,10 +305,10 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 				JPath:   symbolRes.symbol.Path,
 				symbols: []*searchSymbolResult{symbolRes},
 				uri:     uri,
-				repo:    symbolRes.commit.repo.repo,
+				Repo:    symbolRes.commit.repo.repo,
 				// Don't get commit from GitCommitResolver.OID() because we don't want to
 				// slow search results down when they are coming from zoekt.
-				commitID: api.CommitID(symbolRes.commit.oid),
+				CommitID: api.CommitID(symbolRes.commit.oid),
 			}
 			fileMatchesByURI[uri] = fileMatch
 			fileMatches = append(fileMatches, fileMatch)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -67,12 +67,12 @@ type FileMatchResolver struct {
 	JLimitHit    bool         `json:"LimitHit"`
 	symbols      []*searchSymbolResult
 	uri          string
-	repo         *types.Repo
-	commitID     api.CommitID
-	// inputRev is the Git revspec that the user originally requested to search. It is used to
+	Repo         *types.Repo
+	CommitID     api.CommitID
+	// InputRev is the Git revspec that the user originally requested to search. It is used to
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
-	inputRev *string
+	InputRev *string
 }
 
 func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
@@ -89,16 +89,16 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 	// values for all other fields.
 	return &GitTreeEntryResolver{
 		commit: &GitCommitResolver{
-			repo:     &RepositoryResolver{repo: fm.repo},
-			oid:      GitObjectID(fm.commitID),
-			inputRev: fm.inputRev,
+			repo:     &RepositoryResolver{repo: fm.Repo},
+			oid:      GitObjectID(fm.CommitID),
+			inputRev: fm.InputRev,
 		},
 		stat: CreateFileInfo(fm.JPath, false),
 	}
 }
 
 func (fm *FileMatchResolver) Repository() *RepositoryResolver {
-	return &RepositoryResolver{repo: fm.repo}
+	return &RepositoryResolver{repo: fm.Repo}
 }
 
 func (fm *FileMatchResolver) Resource() string {
@@ -132,7 +132,7 @@ func (r *FileMatchResolver) ToCodemodResult() (*codemodResultResolver, bool) {
 }
 
 func (fm *FileMatchResolver) searchResultURIs() (string, string) {
-	return string(fm.repo.Name), fm.JPath
+	return string(fm.Repo.Name), fm.JPath
 }
 
 func (fm *FileMatchResolver) resultCount() int32 {
@@ -143,7 +143,7 @@ func (fm *FileMatchResolver) resultCount() int32 {
 	return 1 // 1 to count "empty" results like type:path results
 }
 
-// LineMatch is the struct used by vscode to receive search results for a line
+// lineMatch is the struct used by vscode to receive search results for a line
 type lineMatch struct {
 	JPreview          string     `json:"Preview"`
 	JOffsetAndLengths [][2]int32 `json:"OffsetAndLengths"`
@@ -376,9 +376,9 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 	workspace := fileMatchURI(repo.Name, rev, "")
 	for _, fm := range matches {
 		fm.uri = workspace + fm.JPath
-		fm.repo = repo
-		fm.commitID = commit
-		fm.inputRev = &rev
+		fm.Repo = repo
+		fm.CommitID = commit
+		fm.InputRev = &rev
 	}
 
 	return matches, limitHit, err
@@ -688,7 +688,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			var repos []*search.RepositoryRevisions
 
 			for _, m := range matches {
-				name := string(m.repo.Name)
+				name := string(m.Repo.Name)
 				partition[name] = append(partition[name], m.JPath)
 			}
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -248,8 +248,8 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 			JLimitHit:    fileLimitHit,
 			uri:          fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			symbols:      symbols,
-			repo:         repoRev.Repo,
-			commitID:     repoRev.IndexedHEADCommit(),
+			Repo:         repoRev.Repo,
+			CommitID:     repoRev.IndexedHEADCommit(),
 		}
 	}
 

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -79,7 +79,7 @@ func NewCampaignType(campaignTypeName, args string, cf *httpcli.Factory) (Campai
 		ct = c
 
 	case "credentials":
-		c := &credentials{}
+		c := &credentials{newSearch: graphqlbackend.NewSearchImplementer}
 
 		if err := json.Unmarshal(normalizedArgs, &c.args); err != nil {
 			return nil, err
@@ -252,6 +252,8 @@ var npmTokenRegexpMultiline = regexp.MustCompile(`(?m)((?:^|:)_(?:auth|authToken
 
 type credentials struct {
 	args credentialsArgs
+
+	newSearch func(*graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error)
 }
 
 func (c *credentials) searchQuery() string {
@@ -268,7 +270,7 @@ func (c *credentials) searchQueryForRepo(n api.RepoName) string {
 
 func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, error) {
 	t := "regexp"
-	search, err := graphqlbackend.NewSearchImplementer(&graphqlbackend.SearchArgs{
+	search, err := c.newSearch(&graphqlbackend.SearchArgs{
 		Version:     "V2",
 		PatternType: &t,
 		Query:       c.searchQueryForRepo(repo),

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -10,7 +10,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestNewCampaignType_ArgsValidation(t *testing.T) {
@@ -224,6 +228,128 @@ func TestCampaignType_Comby(t *testing.T) {
 	}
 }
 
+func TestCampaignType_Credentials(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+
+		repoName string
+		commitID string
+		args     credentialsArgs
+
+		newSearch func(*graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error)
+
+		gitFileContent string
+
+		searchResultsContents map[string]string
+
+		wantDiff string
+		wantErr  string
+	}{
+		{
+			name:     "success no NPM tokens",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: credentialsArgs{
+				ScopeQuery: "repo:github",
+				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
+			},
+			searchResultsContents: map[string]string{},
+			wantDiff:              ``,
+		},
+		{
+			name:     "success single NPM token",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: credentialsArgs{
+				ScopeQuery: "repo:github",
+				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
+			},
+			searchResultsContents: map[string]string{
+				".npmrc": `//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+`,
+			},
+			wantDiff: `diff .npmrc .npmrc
+--- .npmrc
++++ .npmrc
+@@ -1 +1 @@
+-//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
++//npm.fontawesome.com/:_authToken=REMOVED_TOKEN
+`,
+		},
+		{
+			name:     "success multiple NPM tokens",
+			repoName: "github.com/sourcegraph/sourcegraph",
+			commitID: "deadbeef",
+			args: credentialsArgs{
+				ScopeQuery: "repo:github",
+				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
+			},
+			searchResultsContents: map[string]string{
+				".npmrc": `//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+`,
+			},
+			wantDiff: `diff .npmrc .npmrc
+--- .npmrc
++++ .npmrc
+@@ -1,2 +1,2 @@
+-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+-//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
++//registry.npmjs.org/:_authToken=REMOVED_TOKEN
++//npm.fontawesome.com/:_authToken=REMOVED_TOKEN
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			git.Mocks.ReadFile = func(_ api.CommitID, name string) ([]byte, error) {
+				content, ok := tc.searchResultsContents[name]
+				if !ok {
+					return nil, fmt.Errorf("no fake file content for %s set up", name)
+				}
+
+				return []byte(content), nil
+			}
+			defer func() { git.Mocks.ReadFile = nil }()
+
+			testSearch := func(*graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
+				results := make([]graphqlbackend.SearchResultResolver, 0, len(tc.searchResultsContents))
+
+				for path := range tc.searchResultsContents {
+					results = append(results, &fakeSearchResultResolver{
+						commitID: api.CommitID(tc.commitID),
+						repo: &types.Repo{
+							ExternalRepo: api.ExternalRepoSpec{ServiceType: github.ServiceType},
+						},
+						path: path,
+					})
+				}
+
+				return &fakeSearch{results: results}, nil
+			}
+
+			ct := &credentials{args: tc.args, newSearch: testSearch}
+
+			if tc.wantErr == "" {
+				tc.wantErr = "<nil>"
+			}
+
+			haveDiff, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
+			if have, want := fmt.Sprint(err), tc.wantErr; have != want {
+				t.Fatalf("have error: %q\nwant error: %q", have, want)
+			}
+
+			if haveDiff != tc.wantDiff {
+				t.Fatalf("wrong diff.\nhave=%q\nwant=%q", haveDiff, tc.wantDiff)
+			}
+		})
+	}
+}
+
 func validateReplacerQuery(t *testing.T, vals url.Values, repo, commit string, args combyArgs) {
 	t.Helper()
 
@@ -246,4 +372,31 @@ func validateReplacerQuery(t *testing.T, vals url.Values, repo, commit string, a
 			t.Errorf("wrong %q param: %s (want=%s)", tc.name, have[0], tc.want)
 		}
 	}
+}
+
+type fakeSearchResultResolver struct {
+	graphqlbackend.SearchResultResolver
+
+	commitID api.CommitID
+	repo     *types.Repo
+	path     string
+}
+
+func (r *fakeSearchResultResolver) ToFileMatch() (*graphqlbackend.FileMatchResolver, bool) {
+	fm := &graphqlbackend.FileMatchResolver{
+		JPath:    r.path,
+		Repo:     r.repo,
+		CommitID: r.commitID,
+	}
+
+	return fm, true
+}
+
+type fakeSearch struct {
+	graphqlbackend.SearchImplementer
+	results []graphqlbackend.SearchResultResolver
+}
+
+func (s *fakeSearch) Results(ctx context.Context) (*graphqlbackend.SearchResultsResolver, error) {
+	return &graphqlbackend.SearchResultsResolver{SearchResults: s.results}, nil
 }


### PR DESCRIPTION
I decided before I add support for `replaceWith` and the optional-changeset-body-additions-per-campaign-type that are part of RFC 73, I'll add some tests.

Don't be scared of the diff here and look at it commit wise: the first commit exposes fields on `graphqlbackend` types so that I can fake the search from the outside, the second commit adds the tests.

I'm actually pretty now that I've invested the time to fake the search. Took a lot of fiddling and digging around. I predict (since I already had that locally) that next we need to expose the `graphqalbackend.lineMatches`, once we need the specific search result locations. And that should be easy with this setup. We'd only need to expose `lineMatches`.