### PR TITLE
a8n: Fix flaky test by sorting validation errors

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -116,8 +116,13 @@ func validateArgs(campaignType, args string) ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to validate specification against schema")
 	}
 
+	validationErrs := res.Errors()
+	sort.Slice(validationErrs, func(i, j int) bool {
+		return validationErrs[i].Field() < validationErrs[j].Field()
+	})
+
 	var errs *multierror.Error
-	for _, err := range res.Errors() {
+	for _, err := range validationErrs {
 		e := err.String()
 		// Remove `(root): ` from error formatting since these errors are
 		// presented to users.


### PR DESCRIPTION
This fixes #6969 by sorting the validation by their fields. The sort order itself is not important, it's important _that_ we sort.