### PR TITLE
core: Fix error formatting by getting rid of custom formatting

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -99,16 +98,7 @@ func (e *ExternalServicesStore) ValidateConfig(kind, config string, ps []schema.
 		return errors.Wrap(err, "failed to validate config against schema")
 	}
 
-	errs := &multierror.Error{
-		ErrorFormat: func(errs []error) string {
-			// Markdown bullet list of error messages.
-			var buf bytes.Buffer
-			for _, err := range errs {
-				fmt.Fprintf(&buf, "- %s\n", err)
-			}
-			return buf.String()
-		},
-	}
+	var errs *multierror.Error
 	for _, err := range res.Errors() {
 		e := err.String()
 		// Remove `(root): ` from error formatting since these errors are

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -15,12 +15,12 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 		"1 error": {
 			kind:    "GITHUB",
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": ""}`,
-			wantErr: "- token: String length must be greater than or equal to 1\n",
+			wantErr: "1 error occurred:\n\t* token: String length must be greater than or equal to 1\n\n",
 		},
 		"2 errors": {
 			kind:    "GITHUB",
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "", "x": 123}`,
-			wantErr: "- Additional property x is not allowed\n- token: String length must be greater than or equal to 1\n",
+			wantErr: "2 errors occurred:\n\t* Additional property x is not allowed\n\t* token: String length must be greater than or equal to 1\n\n",
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
After this comment
(https://github.com/sourcegraph/sourcegraph/pull/6916#discussion_r352339241)
I looked into it and it turns out that something broke along the way in
how we display errors and removing the custom formatting makes the error
messages look better.

#### Before

<img width="962" alt="before" src="https://user-images.githubusercontent.com/1185253/69947058-2643be80-14ed-11ea-83a8-c8e89479bfe5.png">

#### After
<img width="955" alt="after" src="https://user-images.githubusercontent.com/1185253/69947086-35c30780-14ed-11ea-95f8-fce09484fb2c.png">
