### PR TITLE
a8n: Allow specifying custom replacement for removed credentials

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -245,6 +245,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 
 type credentialsMatcher struct {
 	MatcherType string `json:"type"`
+	ReplaceWith string `json:"replaceWith"`
 }
 
 type credentialsArgs struct {
@@ -302,7 +303,9 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 		if err != nil {
 			return "", err
 		}
-		newContent := npmTokenRegexpMultiline.ReplaceAllString(content, `${1}REMOVED_TOKEN`)
+
+		replacement := fmt.Sprintf("${1}%s", c.args.Matchers[0].ReplaceWith)
+		newContent := npmTokenRegexpMultiline.ReplaceAllString(content, replacement)
 
 		diff, err := tmpfileDiff(path, content, newContent)
 		if err != nil {

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -248,7 +248,7 @@ func TestCampaignType_Credentials(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name: "success no NPM tokens",
+			name: "no NPM tokens",
 			args: credentialsArgs{
 				ScopeQuery: "repo:github",
 				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
@@ -257,7 +257,7 @@ func TestCampaignType_Credentials(t *testing.T) {
 			wantDiff:              ``,
 		},
 		{
-			name: "success single NPM token",
+			name: "single NPM token",
 			args: credentialsArgs{
 				ScopeQuery: "repo:github",
 				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
@@ -271,11 +271,11 @@ func TestCampaignType_Credentials(t *testing.T) {
 +++ .npmrc
 @@ -1 +1 @@
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
-+//npm.fontawesome.com/:_authToken=REMOVED_TOKEN
++//npm.fontawesome.com/:_authToken=
 `,
 		},
 		{
-			name: "success multiple NPM tokens",
+			name: "multiple NPM tokens",
 			args: credentialsArgs{
 				ScopeQuery: "repo:github",
 				Matchers:   []credentialsMatcher{{MatcherType: "npm"}},
@@ -291,7 +291,25 @@ func TestCampaignType_Credentials(t *testing.T) {
 @@ -1,2 +1,2 @@
 -//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
-+//registry.npmjs.org/:_authToken=REMOVED_TOKEN
++//registry.npmjs.org/:_authToken=
++//npm.fontawesome.com/:_authToken=
+`,
+		},
+		{
+			name: "single NPM token and replaceWith",
+			args: credentialsArgs{
+				ScopeQuery: "repo:github",
+				Matchers:   []credentialsMatcher{{MatcherType: "npm", ReplaceWith: "REMOVED_TOKEN"}},
+			},
+			searchResultsContents: map[string]string{
+				".npmrc": `//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+`,
+			},
+			wantDiff: `diff .npmrc .npmrc
+--- .npmrc
++++ .npmrc
+@@ -1 +1 @@
+-//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
 +//npm.fontawesome.com/:_authToken=REMOVED_TOKEN
 `,
 		},


### PR DESCRIPTION
This is the first enhancement described in [RFC 73](https://docs.google.com/document/d/143FIe1Tak4_YPPuOuEzuobTQW09ZU85WfOCdZkNwIVQ/edit#) and allows the user to specify a custom "replacement" for a found NPM token/credential.