### PR TITLE
LSIF: Add additional LSIF intelligence endpoints

### DIFF
--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -73,6 +73,162 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EnqueueResponse'
+  /definitions:
+    get:
+      description: Get definitions for the symbol at a source position.
+      tags:
+        - LSIF
+      parameters:
+        - name: repository
+          in: query
+          description: The url-encoded repository name.
+          required: true
+          example: github.com%2Fsourcegraph%2Flsif-go
+          schema:
+            type: string
+        - name: commit
+          in: query
+          description: The 40-character commit hash.
+          required: true
+          schema:
+            type: number
+        - name: path
+          in: query
+          description: The file path within the repository (relative to the repository root).
+          required: true
+          schema:
+            type: string
+        - name: line
+          in: query
+          description: The line index (zero-indexed).
+          required: true
+          schema:
+            type: number
+        - name: character
+          in: query
+          description: The character index (zero-indexed).
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Locations2'
+        '404':
+          description: Not found
+  /references:
+    get:
+      description: Get references for the symbol at a source position.
+      tags:
+        - LSIF
+      parameters:
+        - name: repository
+          in: query
+          description: The url-encoded repository name.
+          required: true
+          example: github.com%2Fsourcegraph%2Flsif-go
+          schema:
+            type: string
+        - name: commit
+          in: query
+          description: The 40-character commit hash.
+          required: true
+          schema:
+            type: number
+        - name: path
+          in: query
+          description: The file path within the repository (relative to the repository root).
+          required: true
+          schema:
+            type: string
+        - name: line
+          in: query
+          description: The line index (zero-indexed).
+          required: true
+          schema:
+            type: number
+        - name: character
+          in: query
+          description: The character index (zero-indexed).
+          required: true
+          schema:
+            type: number
+        - name: limit
+          in: query
+          description: The maximum number of remote dumps to search for remote references per page. This parameter is only read on references request.
+          required: false
+          schema:
+            type: number
+            default: 10
+        - name: cursor
+          in: query
+          description: The end cursor given in the response of a previous page.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Locations2'
+          headers:
+            Link:
+              description: If there are more results, this header includes the URL of the next page with relation type *next*. See [RFC 5988](https://tools.ietf.org/html/rfc5988).
+              schema:
+                type: string
+        '404':
+          description: Not found
+  /hover:
+    get:
+      description: Get hover data for the symbol at a source position.
+      tags:
+        - LSIF
+      parameters:
+        - name: repository
+          in: query
+          description: The url-encoded repository name.
+          required: true
+          example: github.com%2Fsourcegraph%2Flsif-go
+          schema:
+            type: string
+        - name: commit
+          in: query
+          description: The 40-character commit hash.
+          required: true
+          schema:
+            type: number
+        - name: path
+          in: query
+          description: The file path within the repository (relative to the repository root).
+          required: true
+          schema:
+            type: string
+        - name: line
+          in: query
+          description: The line index (zero-indexed).
+          required: true
+          schema:
+            type: number
+        - name: character
+          in: query
+          description: The character index (zero-indexed).
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Hover2'
+        '404':
+          description: Not found
   /exists:
     get:
       description: Determine if LSIF data exists for a file within a particular commit. This endpoint will return true if there is a nearby commit (direct ancestor or descendant) with LSIF data for the same file if the exact commit does not have available LSIF data.
@@ -431,6 +587,27 @@ components:
         - uri
         - range
       additionalProperties: false
+    Location2:
+      type: object
+      description: A position in a file of a code base.
+      properties:
+        repository:
+          type: string
+          description: The repository in which the location occurs.
+        commit:
+          type: string
+          description: The commit in which the location occurs.
+        path:
+          type: string
+          description: The root-relative path to the file.
+        range:
+          $ref: '#/components/schemas/Range'
+      required:
+        - repository
+        - commit
+        - path
+        - range
+      additionalProperties: false
     LSPRequest:
       type: object
       description: A payload indicating the type of requested LSP data.
@@ -456,6 +633,21 @@ components:
       description: A list of definition or reference locations.
       items:
         $ref: '#/components/schemas/Location'
+    Locations2:
+      type: array
+      description: A list of definition or reference locations.
+      items:
+        $ref: '#/components/schemas/Location2'
+    Hover2:
+      type: object
+      description: The text associated with a position in a source file.
+      properties:
+        text:
+          type: string
+          description: The raw hover text.
+      required:
+        - text
+      additionalProperties: false
     Hover:
       type: object
       description: The text associated with a position in a source file.

--- a/lsif/src/server/backend/database.ts
+++ b/lsif/src/server/backend/database.ts
@@ -148,7 +148,7 @@ export class Database {
      * @param position The current hover position.
      * @param ctx The tracing context.
      */
-    public async hover(path: string, position: lsp.Position, ctx: TracingContext = {}): Promise<lsp.Hover | null> {
+    public async hover(path: string, position: lsp.Position, ctx: TracingContext = {}): Promise<string | null> {
         return this.logAndTraceCall(ctx, 'Fetching hover', async ctx => {
             const { document, ranges } = await this.getRangeByPosition(path, position, ctx)
             if (!document || ranges.length === 0) {
@@ -162,13 +162,8 @@ export class Database {
 
                 this.logSpan(ctx, 'hover_result', { hoverResultId: range.hoverResultId })
 
-                const contents = {
-                    kind: lsp.MarkupKind.Markdown,
-                    value: mustGet(document.hoverResults, range.hoverResultId, 'hoverResult'),
-                }
-
                 // Return first defined hover result for the inner-most range
-                return { contents, range: createRange(range) }
+                return mustGet(document.hoverResults, range.hoverResultId, 'hoverResult')
             }
 
             return null

--- a/lsif/src/server/middleware/validation.ts
+++ b/lsif/src/server/middleware/validation.ts
@@ -35,6 +35,16 @@ export const validateOptionalBoolean = (key: string): ValidationChain =>
         .toBoolean()
 
 /**
+ * Create a query string validator for an integer value.
+ *
+ * @param key The query string key.
+ */
+export const validateInt = (key: string): ValidationChain =>
+    query(key)
+        .isInt()
+        .toInt()
+
+/**
  * Create a query string validator for a possibly empty integer value.
  *
  * @param key The query string key.

--- a/lsif/src/server/routes/lsif.test.ts
+++ b/lsif/src/server/routes/lsif.test.ts
@@ -1,5 +1,5 @@
 import * as lsp from 'vscode-languageserver-protocol'
-import { internalLocationToLocation } from './backend'
+import { internalLocationToLocation } from './lsif'
 
 describe('internalLocationToLocation', () => {
     const dump = {

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -21,6 +21,7 @@ import { Span, Tracer } from 'opentracing'
 import { waitForJob } from '../jobs/blocking'
 import { wrap } from 'async-middleware'
 import { extractLimitOffset } from '../pagination/limit-offset'
+import { InternalLocation } from '../backend/database'
 
 const pipeline = promisify(_pipeline)
 
@@ -113,6 +114,124 @@ export function createLsifRouter(
         )
     )
 
+    interface FilePositionArgs {
+        repository: string
+        commit: string
+        path: string
+        line: number
+        character: number
+    }
+
+    router.get(
+        '/definitions',
+        validation.validationMiddleware([
+            validation.validateNonEmptyString('repository'),
+            validation.validateNonEmptyString('commit'),
+            validation.validateNonEmptyString('path'),
+            validation.validateInt('line'),
+            validation.validateInt('character'),
+        ]),
+        wrap(
+            async (req: express.Request, res: express.Response): Promise<void> => {
+                const { repository, commit, path, line, character }: FilePositionArgs = req.query
+                const ctx = createTracingContext(req, { repository, commit, path })
+
+                const locations = await backend.definitions(repository, commit, path, { line, character }, ctx)
+                if (locations === undefined) {
+                    throw Object.assign(new Error('LSIF dump not found'), { status: 404 })
+                }
+
+                res.send({
+                    locations: locations.map(l => ({
+                        repository: l.dump.repository,
+                        commit: l.dump.commit,
+                        path: l.path,
+                        range: l.range,
+                    })),
+                })
+            }
+        )
+    )
+
+    interface ReferencesQueryArgs extends FilePositionArgs {
+        commit: string
+        cursor: ReferencePaginationCursor | undefined
+    }
+
+    router.get(
+        '/references',
+        validation.validationMiddleware([
+            validation.validateNonEmptyString('repository'),
+            validation.validateNonEmptyString('commit'),
+            validation.validateNonEmptyString('path'),
+            validation.validateInt('line'),
+            validation.validateInt('character'),
+            validation.validateLimit,
+            validation.validateCursor<ReferencePaginationCursor>(),
+        ]),
+        wrap(
+            async (req: express.Request, res: express.Response): Promise<void> => {
+                const { repository, commit, path, line, character, cursor }: ReferencesQueryArgs = req.query
+                const { limit } = extractLimitOffset(req.query, settings.DEFAULT_REFERENCES_NUM_REMOTE_DUMPS)
+                const ctx = createTracingContext(req, { repository, commit, path })
+
+                const result = await backend.references(
+                    repository,
+                    commit,
+                    path,
+                    { line, character },
+                    { limit, cursor },
+                    ctx
+                )
+                if (result === undefined) {
+                    throw Object.assign(new Error('LSIF dump not found'), { status: 404 })
+                }
+
+                const { locations, cursor: endCursor } = result
+                const encodedCursor = encodeCursor<ReferencePaginationCursor>(endCursor)
+                if (encodedCursor) {
+                    res.set('Link', nextLink(req, { limit, cursor: encodedCursor }))
+                }
+
+                res.json({
+                    locations: locations.map(l => ({
+                        repository: l.dump.repository,
+                        commit: l.dump.commit,
+                        path: l.path,
+                        range: l.range,
+                    })),
+                })
+            }
+        )
+    )
+
+    router.get(
+        '/hover',
+        validation.validationMiddleware([
+            validation.validateNonEmptyString('repository'),
+            validation.validateNonEmptyString('commit'),
+            validation.validateNonEmptyString('path'),
+            validation.validateInt('line'),
+            validation.validateInt('character'),
+        ]),
+        wrap(
+            async (req: express.Request, res: express.Response): Promise<void> => {
+                const { repository, commit, path, line, character }: FilePositionArgs = req.query
+                const ctx = createTracingContext(req, { repository, commit, path })
+
+                const text = await backend.hover(repository, commit, path, { line, character }, ctx)
+                if (text === undefined) {
+                    throw Object.assign(new Error('LSIF dump not found'), { status: 404 })
+                }
+
+                res.json({ text })
+            }
+        )
+    )
+
+    //
+    // Legacy Endpoints
+
     interface ExistsQueryArgs {
         repository: string
         commit: string
@@ -179,7 +298,7 @@ export function createLsifRouter(
                             return
                         }
 
-                        res.json(result)
+                        res.json(result.map(loc => internalLocationToLocation(repository, loc)))
                         break
                     }
 
@@ -190,7 +309,7 @@ export function createLsifRouter(
                             return
                         }
 
-                        res.json(result)
+                        res.json(result && { contents: result })
                         break
                     }
 
@@ -211,11 +330,11 @@ export function createLsifRouter(
 
                         const { locations, cursor: endCursor } = result
                         const encodedCursor = encodeCursor<ReferencePaginationCursor>(endCursor)
-                        if (!encodedCursor) {
+                        if (encodedCursor) {
                             res.set('Link', nextLink(req, { limit, cursor: encodedCursor }))
                         }
 
-                        res.json(locations)
+                        res.json(locations.map(loc => internalLocationToLocation(repository, loc)))
                         break
                     }
                 }
@@ -224,4 +343,26 @@ export function createLsifRouter(
     )
 
     return router
+}
+
+/**
+ * Convert an `InternalLocation` to an LSP location object. The URI of the resulting
+ * location object will be a relative if the dump describes a location in the source
+ * repository and wil be an absolute URI otherwise.
+ *
+ * @param repository The source repository.
+ * @param location The location object.
+ */
+export const internalLocationToLocation = (
+    repository: string,
+    { dump, path, range }: InternalLocation
+): lsp.Location => {
+    if (dump.repository !== repository) {
+        const url = new URL(`git://${dump.repository}`)
+        url.search = dump.commit
+        url.hash = path
+        path = url.href
+    }
+
+    return lsp.Location.create(path, range)
 }

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -1,6 +1,6 @@
 import * as constants from '../../shared/constants'
 import * as fs from 'mz/fs'
-import * as path from 'path'
+import * as nodepath from 'path'
 import * as settings from '../settings'
 import * as validation from '../middleware/validation'
 import bodyParser from 'body-parser'
@@ -91,7 +91,7 @@ export function createLsifRouter(
                 const { repository, commit, root: rootRaw, blocking, maxWait }: UploadQueryArgs = req.query
                 const root = sanitizeRoot(rootRaw)
                 const ctx = createTracingContext(req, { repository, commit, root })
-                const filename = path.join(settings.STORAGE_ROOT, constants.UPLOADS_DIR, uuid.v4())
+                const filename = nodepath.join(settings.STORAGE_ROOT, constants.UPLOADS_DIR, uuid.v4())
                 const output = fs.createWriteStream(filename)
                 await logAndTraceCall(ctx, 'Uploading dump', () => pipeline(req, output))
 
@@ -353,10 +353,7 @@ export function createLsifRouter(
  * @param repository The source repository.
  * @param location The location object.
  */
-export const internalLocationToLocation = (
-    repository: string,
-    { dump, path, range }: InternalLocation
-): lsp.Location => {
+export function internalLocationToLocation(repository: string, { dump, path, range }: InternalLocation): lsp.Location {
     if (dump.repository !== repository) {
         const url = new URL(`git://${dump.repository}`)
         url.search = dump.commit

--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -92,7 +92,7 @@ async function main(logger: Logger): Promise<void> {
             winstonInstance: logger,
             level: 'debug',
             ignoredRoutes: ['/ping', '/healthz', '/metrics'],
-            requestWhitelist: ['method', 'url', 'query'],
+            requestWhitelist: ['method', 'url'],
             msg: 'Handled request',
         })
     )

--- a/lsif/src/tests/integration/backend/linked-reference-results.test.ts
+++ b/lsif/src/tests/integration/backend/linked-reference-results.test.ts
@@ -29,7 +29,10 @@ describe('Backend', () => {
 
         for (const position of positions) {
             const { locations } = util.filterNodeModules(
-                (await ctx.backend.references(repository, commit, 'src/index.ts', position)) || { locations: [] }
+                util.mapInternalLocations(
+                    repository,
+                    (await ctx.backend.references(repository, commit, 'src/index.ts', position)) || { locations: [] }
+                )
             )
 
             expect(locations).toContainEqual(util.createLocation('src/index.ts', 1, 4, 1, 7)) // abstract def in I

--- a/lsif/src/tests/integration/backend/reference-pagination-monorepo.test.ts
+++ b/lsif/src/tests/integration/backend/reference-pagination-monorepo.test.ts
@@ -104,18 +104,15 @@ describe('Backend', () => {
         ]
 
         for (const { commit, refs } of testCases) {
-            const fetch = async (paginationContext?: ReferencePaginationContext) =>
+            const fetch = async () =>
                 util.filterNodeModules(
-                    (await backend.references(
+                    util.mapInternalLocations(
                         repository,
-                        commit,
-                        'a/src/index.ts',
-                        {
+                        (await backend.references(repository, commit, 'a/src/index.ts', {
                             line: 0,
                             character: 17,
-                        },
-                        paginationContext
-                    )) || { locations: [] }
+                        })) || { locations: [] }
+                    )
                 )
 
             const { locations, cursor } = await fetch()
@@ -142,16 +139,19 @@ describe('Backend', () => {
 
         const fetch = async (paginationContext?: ReferencePaginationContext) =>
             util.filterNodeModules(
-                (await backend.references(
+                util.mapInternalLocations(
                     repository,
-                    c3,
-                    'a/src/index.ts',
-                    {
-                        line: 0,
-                        character: 17,
-                    },
-                    paginationContext
-                )) || { locations: [] }
+                    (await backend.references(
+                        repository,
+                        c3,
+                        'a/src/index.ts',
+                        {
+                            line: 0,
+                            character: 17,
+                        },
+                        paginationContext
+                    )) || { locations: [] }
+                )
             )
 
         const { locations: locations0, cursor: cursor0 } = await fetch({ limit: 50 }) // all local

--- a/lsif/src/tests/integration/backend/reference-pagination.test.ts
+++ b/lsif/src/tests/integration/backend/reference-pagination.test.ts
@@ -27,16 +27,19 @@ describe('Backend', () => {
 
         const fetch = async (paginationContext?: ReferencePaginationContext) =>
             util.filterNodeModules(
-                (await backend.references(
+                util.mapInternalLocations(
                     'a',
-                    commit,
-                    'src/index.ts',
-                    {
-                        line: 0,
-                        character: 17,
-                    },
-                    paginationContext
-                )) || { locations: [] }
+                    (await backend.references(
+                        'a',
+                        commit,
+                        'src/index.ts',
+                        {
+                            line: 0,
+                            character: 17,
+                        },
+                        paginationContext
+                    )) || { locations: [] }
+                )
             )
 
         const { locations: locations0, cursor: cursor0 } = await fetch() // everything

--- a/lsif/src/tests/integration/backend/xrepo.test.ts
+++ b/lsif/src/tests/integration/backend/xrepo.test.ts
@@ -1,4 +1,5 @@
 import * as util from '../integration-test-util'
+import { internalLocationToLocation } from '../../../server/routes/lsif'
 
 describe('Backend', () => {
     const ctx = new util.BackendTestContext()
@@ -26,7 +27,9 @@ describe('Backend', () => {
             line: 11,
             character: 18,
         })
-        expect(definitions).toEqual([util.createLocation('src/index.ts', 0, 16, 0, 19)])
+        expect(definitions?.map(l => internalLocationToLocation('a', l))).toEqual([
+            util.createLocation('src/index.ts', 0, 16, 0, 19),
+        ])
     })
 
     it('should find all cross-repo defs of `add` from repo b1', async () => {
@@ -38,7 +41,9 @@ describe('Backend', () => {
             line: 3,
             character: 12,
         })
-        expect(definitions).toEqual([util.createRemoteLocation('a', commit, 'src/index.ts', 0, 16, 0, 19)])
+        expect(definitions?.map(l => internalLocationToLocation('b1', l))).toEqual([
+            util.createRemoteLocation('a', commit, 'src/index.ts', 0, 16, 0, 19),
+        ])
     })
 
     it('should find all cross-repo defs of `mul` from repo b1', async () => {
@@ -50,7 +55,9 @@ describe('Backend', () => {
             line: 3,
             character: 16,
         })
-        expect(definitions).toEqual([util.createRemoteLocation('a', commit, 'src/index.ts', 4, 16, 4, 19)])
+        expect(definitions?.map(l => internalLocationToLocation('b1', l))).toEqual([
+            util.createRemoteLocation('a', commit, 'src/index.ts', 4, 16, 4, 19),
+        ])
     })
 
     it('should find all cross-repo refs of `mul` from repo a', async () => {
@@ -59,10 +66,13 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
-                line: 4,
-                character: 19,
-            })) || { locations: [] }
+            util.mapInternalLocations(
+                'a',
+                (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
+                    line: 4,
+                    character: 19,
+                })) || { locations: [] }
+            )
         )
 
         expect(locations).toContainEqual(util.createLocation('src/index.ts', 4, 16, 4, 19)) // def
@@ -86,10 +96,13 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            (await ctx.backend.references('b1', util.createCommit(0), 'src/index.ts', {
-                line: 3,
-                character: 16,
-            })) || { locations: [] }
+            util.mapInternalLocations(
+                'b1',
+                (await ctx.backend.references('b1', util.createCommit(0), 'src/index.ts', {
+                    line: 3,
+                    character: 16,
+                })) || { locations: [] }
+            )
         )
 
         expect(locations).toContainEqual(util.createRemoteLocation('a', commit, 'src/index.ts', 4, 16, 4, 19)) // def
@@ -113,10 +126,13 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
-                line: 0,
-                character: 17,
-            })) || { locations: [] }
+            util.mapInternalLocations(
+                'a',
+                (await ctx.backend.references('a', util.createCommit(0), 'src/index.ts', {
+                    line: 0,
+                    character: 17,
+                })) || { locations: [] }
+            )
         )
 
         expect(locations).toContainEqual(util.createLocation('src/index.ts', 0, 16, 0, 19)) // def
@@ -150,10 +166,13 @@ describe('Backend', () => {
         }
 
         const { locations } = util.filterNodeModules(
-            (await ctx.backend.references('c1', util.createCommit(0), 'src/index.ts', {
-                line: 3,
-                character: 16,
-            })) || { locations: [] }
+            util.mapInternalLocations(
+                'c1',
+                (await ctx.backend.references('c1', util.createCommit(0), 'src/index.ts', {
+                    line: 3,
+                    character: 16,
+                })) || { locations: [] }
+            )
         )
 
         expect(locations).toContainEqual(util.createRemoteLocation('a', commit, 'src/index.ts', 0, 16, 0, 19)) // def

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -12,6 +12,8 @@ import { dbFilename, ensureDirectory } from '../../shared/paths'
 import { lsp } from 'lsif-protocol'
 import { userInfo } from 'os'
 import { XrepoDatabase } from '../../shared/xrepo/xrepo'
+import { internalLocationToLocation } from '../../server/routes/lsif'
+import { InternalLocation } from '../../server/backend/database'
 
 /**
  * Create a temporary directory with a subdirectory for dbs.
@@ -332,4 +334,15 @@ export function filterNodeModules<T>({
     cursor?: ReferencePaginationCursor
 }): { locations: lsp.Location[]; cursor?: ReferencePaginationCursor } {
     return { locations: locations.filter(l => !l.uri.includes('node_modules')), cursor }
+}
+
+// TODO
+export function mapInternalLocations<T extends { locations: InternalLocation[] }>(
+    repository: string,
+    resp: T
+): Omit<T, 'locations'> & { locations: lsp.Location[] } {
+    return {
+        ...resp,
+        locations: resp.locations.map(l => internalLocationToLocation(repository, l)),
+    }
 }

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -336,7 +336,14 @@ export function filterNodeModules<T>({
     return { locations: locations.filter(l => !l.uri.includes('node_modules')), cursor }
 }
 
-// TODO
+/**
+ * Map locations into the 'legacy' shape. Tests will need to be updated do that
+ * the assertions work against internal locations rather than the lsp.Location
+ * object (it does not hold enough data).
+ *
+ * @param repository The source repository.
+ * @param resp The input containing a locations array.
+ */
 export function mapInternalLocations<T extends { locations: InternalLocation[] }>(
     repository: string,
     resp: T


### PR DESCRIPTION
This PR adds additional endpoints that will aid queries from the frontend to support the LSIF GraphQL API resolvers as described in [RFC 74](https://docs.google.com/document/d/1Vw7kF-BrTGMvdAaVVADIMzfv-wzlurMx6oP5DTmbpcc).

The new endpoints are:

- GET `/definitions?repository,commit,path,line,character`
- GET `/references?repository,commit,path,line,character,limit,cursor`
- GET `/hover?repository,commit,path,line,character`

These are basically the same responses from the `/request` endpoint, but returns a more "exploded" view of the data. Instead of a single URI for locations, it returns the repository, commit, path, and range as a JSON object.