### PR TITLE
a8n: Add CampaignTypes description of diff in Markdown & return description in NPM credentials campaign

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -36,6 +36,7 @@ Foreign-key constraints:
  created_at       | timestamp with time zone | not null default now()
  updated_at       | timestamp with time zone | not null default now()
  base_ref         | text                     | not null
+ description      | text                     | 
 Indexes:
     "campaign_jobs_pkey" PRIMARY KEY, btree (id)
     "campaign_jobs_campaign_plan_repo_rev_unique" UNIQUE CONSTRAINT, btree (campaign_plan_id, repo_id, rev) DEFERRABLE

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -279,6 +279,7 @@ func TestCampaignType_Credentials(t *testing.T) {
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
 +//npm.fontawesome.com/:_authToken=
 `,
+			wantDescription: "Tokens found:\n\n- [ ] `12345678-2323-1111-1111-12345670B312`\n",
 		},
 		{
 			name: "multiple NPM tokens",
@@ -289,17 +290,24 @@ func TestCampaignType_Credentials(t *testing.T) {
 			searchResultsContents: map[string]string{
 				".npmrc": `//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 //npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+:_authToken=ANOTHER_TOKEN
+_authToken=YET_ANOTHER_TOKEN_LEAKED
 `,
 			},
 			wantDiff: `diff .npmrc .npmrc
 --- .npmrc
 +++ .npmrc
-@@ -1,2 +1,2 @@
+@@ -1,4 +1,4 @@
 -//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+-:_authToken=ANOTHER_TOKEN
+-_authToken=YET_ANOTHER_TOKEN_LEAKED
 +//registry.npmjs.org/:_authToken=
 +//npm.fontawesome.com/:_authToken=
++:_authToken=
++_authToken=
 `,
+			wantDescription: "Tokens found:\n\n- [ ] `${NPM_TOKEN}`\n- [ ] `12345678-2323-1111-1111-12345670B312`\n- [ ] `ANOTHER_TOKEN`\n- [ ] `YET_ANOTHER_TOKEN_LEAKED`\n",
 		},
 		{
 			name: "single NPM token and replaceWith",
@@ -318,6 +326,7 @@ func TestCampaignType_Credentials(t *testing.T) {
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
 +//npm.fontawesome.com/:_authToken=REMOVED_TOKEN
 `,
+			wantDescription: "Tokens found:\n\n- [ ] `12345678-2323-1111-1111-12345670B312`\n",
 		},
 	}
 

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -125,8 +125,9 @@ func TestCampaignType_Comby(t *testing.T) {
 
 		handler func(w http.ResponseWriter, r *http.Request)
 
-		wantDiff string
-		wantErr  string
+		wantDiff        string
+		wantDescription string
+		wantErr         string
 	}{
 		{
 			name:     "success single file diff",
@@ -216,13 +217,17 @@ func TestCampaignType_Comby(t *testing.T) {
 				tc.wantErr = "<nil>"
 			}
 
-			haveDiff, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
+			haveDiff, haveDescription, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
 			if have, want := fmt.Sprint(err), tc.wantErr; have != want {
 				t.Fatalf("have error: %q\nwant error: %q", have, want)
 			}
 
 			if haveDiff != tc.wantDiff {
 				t.Fatalf("wrong diff.\nhave=%q\nwant=%q", haveDiff, tc.wantDiff)
+			}
+
+			if haveDescription != tc.wantDescription {
+				t.Fatalf("wrong description.\nhave=%q\nwant=%q", haveDescription, tc.wantDescription)
 			}
 		})
 	}
@@ -244,8 +249,9 @@ func TestCampaignType_Credentials(t *testing.T) {
 
 		searchResultsContents map[string]string
 
-		wantDiff string
-		wantErr  string
+		wantDiff        string
+		wantDescription string
+		wantErr         string
 	}{
 		{
 			name: "no NPM tokens",
@@ -362,13 +368,17 @@ func TestCampaignType_Credentials(t *testing.T) {
 
 			ct := &credentials{args: tc.args, newSearch: testSearch}
 
-			haveDiff, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
+			haveDiff, haveDescription, err := ct.generateDiff(ctx, api.RepoName(tc.repoName), api.CommitID(tc.commitID))
 			if have, want := fmt.Sprint(err), tc.wantErr; have != want {
 				t.Fatalf("have error: %q\nwant error: %q", have, want)
 			}
 
 			if haveDiff != tc.wantDiff {
 				t.Fatalf("wrong diff.\nhave=%q\nwant=%q", haveDiff, tc.wantDiff)
+			}
+
+			if haveDescription != tc.wantDescription {
+				t.Fatalf("wrong description.\nhave=%q\nwant=%q", haveDescription, tc.wantDescription)
 			}
 		})
 	}

--- a/enterprise/internal/a8n/runner.go
+++ b/enterprise/internal/a8n/runner.go
@@ -225,12 +225,13 @@ func (r *Runner) runJob(pctx context.Context, job *a8n.CampaignJob) {
 		return
 	}
 
-	diff, err := r.ct.generateDiff(ctx, api.RepoName(rs[0].Name), api.CommitID(job.Rev))
+	diff, desc, err := r.ct.generateDiff(ctx, api.RepoName(rs[0].Name), api.CommitID(job.Rev))
 	if err != nil {
 		job.Error = err.Error()
 	}
 
 	job.Diff = diff
+	job.Description = desc
 }
 
 func (r *Runner) createPlanAndJobs(

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -247,9 +247,14 @@ func (s *Service) runChangesetJob(
 		baseRef = campaignJob.BaseRef
 	}
 
+	body := c.Description
+	if campaignJob.Description != "" {
+		body += "\n\n---\n\n" + campaignJob.Description
+	}
+
 	cs := repos.Changeset{
 		Title:   c.Name,
-		Body:    c.Description,
+		Body:    body,
 		BaseRef: baseRef,
 		HeadRef: git.EnsureRefPrefix(headRefName),
 		Repo:    repo,

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1504,13 +1504,14 @@ INSERT INTO campaign_jobs (
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
   created_at,
   updated_at
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   campaign_plan_id,
@@ -1518,6 +1519,7 @@ RETURNING
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
@@ -1541,6 +1543,7 @@ func (s *Store) createCampaignJobQuery(c *a8n.CampaignJob) (*sqlf.Query, error) 
 		c.Rev,
 		c.BaseRef,
 		c.Diff,
+		c.Description,
 		c.Error,
 		nullTimeColumn(c.StartedAt),
 		nullTimeColumn(c.FinishedAt),
@@ -1571,11 +1574,12 @@ SET (
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
   updated_at
-) = (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -1584,6 +1588,7 @@ RETURNING
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
@@ -1601,6 +1606,7 @@ func (s *Store) updateCampaignJobQuery(c *a8n.CampaignJob) (*sqlf.Query, error) 
 		c.Rev,
 		c.BaseRef,
 		c.Diff,
+		c.Description,
 		c.Error,
 		c.StartedAt,
 		c.FinishedAt,
@@ -1703,6 +1709,7 @@ SELECT
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
@@ -1767,6 +1774,7 @@ SELECT
   rev,
   base_ref,
   diff,
+  description,
   error,
   started_at,
   finished_at,
@@ -2242,6 +2250,7 @@ func scanCampaignJob(c *a8n.CampaignJob, s scanner) error {
 		&c.Rev,
 		&c.BaseRef,
 		&c.Diff,
+		&c.Description,
 		&c.Error,
 		&dbutil.NullTime{Time: &c.StartedAt},
 		&dbutil.NullTime{Time: &c.FinishedAt},

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1047,7 +1047,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 						Rev:            api.CommitID("deadbeef"),
 						BaseRef:        "master",
 						Diff:           "+ foobar - barfoo",
-						Description:  "- Removed 3 instances of foobar\n",
+						Description:    "- Removed 3 instances of foobar\n",
 						Error:          "only set on error",
 					}
 

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1047,6 +1047,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 						Rev:            api.CommitID("deadbeef"),
 						BaseRef:        "master",
 						Diff:           "+ foobar - barfoo",
+						Description:  "- Removed 3 instances of foobar\n",
 						Error:          "only set on error",
 					}
 
@@ -1281,6 +1282,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					c.StartedAt = now
 					c.FinishedAt = now
 					c.Diff += "-updated"
+					c.Description += "-updated"
 					c.Error += "-updated"
 
 					want := c

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -56,7 +56,8 @@ type CampaignJob struct {
 	Rev     api.CommitID
 	BaseRef string
 
-	Diff string
+	Diff        string
+	Description string
 
 	StartedAt  time.Time
 	FinishedAt time.Time

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -419,9 +419,14 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *PullRequest) error {
 		Locked      bool   `json:"locked"`
 	}
 
+	// Bitbucket Server doesn't support GFM taskitems. But since we might add
+	// those to a PR description for certain Automation Campaigns, we have to
+	// "downgrade" here and for now, removing taskitems is enough.
+	description := strings.ReplaceAll(pr.Description, "- [ ] ", "- ")
+
 	payload := requestBody{
 		Title:       pr.Title,
-		Description: pr.Description,
+		Description: description,
 		State:       "OPEN",
 		Open:        true,
 		Closed:      false,

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -514,6 +514,15 @@ func TestClient_CreatePullRequest(t *testing.T) {
 			},
 			err: ErrAlreadyExists.Error(),
 		},
+		{
+			name: "description includes GFM tasklist items",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.ID = "refs/heads/test-pr-bbs-17"
+				pr.Description = "- [ ] One\n- [ ] Two\n"
+				return &pr
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-description-includes-GFM-tasklist-items
+++ b/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-description-includes-GFM-tasklist-items
@@ -1,0 +1,53 @@
+{
+  "id": 30,
+  "version": 0,
+  "title": "This is a test PR",
+  "description": "- One\n- Two",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1575369047926,
+  "updatedDate": 1575369047926,
+  "fromRef": {
+   "id": "refs/heads/test-pr-bbs-17",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "milton",
+    "emailAddress": "dev@sourcegraph.com",
+    "id": 1,
+    "displayName": "milton woof",
+    "active": true,
+    "slug": "milton",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/30"
+    }
+   ]
+  }
+ }

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-description-includes-GFM-tasklist-items.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-description-includes-GFM-tasklist-items.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"title":"This is a test PR","description":"- One\n- Two\n","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-17","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
+    method: POST
+  response:
+    body: '{"id":30,"version":0,"title":"This is a test PR","description":"- One\n-
+      Two","state":"OPEN","open":true,"closed":false,"createdDate":1575369047926,"updatedDate":1575369047926,"fromRef":{"id":"refs/heads/test-pr-bbs-17","displayId":"test-pr-bbs-17","latestCommit":"91d3c74b68e068e0d19fbff2f6171ec71f2ecfab","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"97f8a75319760990c187710c50a957358f663366","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
+      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/30"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 03 Dec 2019 10:30:47 GMT
+      Location:
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/30
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@1IK17DGx630x3350668x0'
+      X-Asen:
+      - SEN-L13789548
+      X-Asessionid:
+      - brwuvl
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/migrations/1528395620_add_description_to_campaign_jobs.down.sql
+++ b/migrations/1528395620_add_description_to_campaign_jobs.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaign_jobs DROP COLUMN description;
+
+COMMIT;

--- a/migrations/1528395620_add_description_to_campaign_jobs.up.sql
+++ b/migrations/1528395620_add_description_to_campaign_jobs.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaign_jobs ADD COLUMN description text;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -76,6 +76,8 @@
 // 1528395618_add_delete_cascade_to_changeset_jobs.up.sql (255B)
 // 1528395619_remove_unused_indexes.down.sql (82B)
 // 1528395619_remove_unused_indexes.up.sql (179B)
+// 1528395620_add_description_to_campaign_jobs.down.sql (68B)
+// 1528395620_add_description_to_campaign_jobs.up.sql (72B)
 
 package migrations
 
@@ -1664,6 +1666,46 @@ func _1528395619_remove_unused_indexesUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395620_add_description_to_campaign_jobsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x8b\xcf\xca\x4f\x2a\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x49\x2d\x4e\x2e\xca\x2c\x28\xc9\xcc\xcf\xb3\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xe3\x89\x3a\xc0\x44\x00\x00\x00")
+
+func _1528395620_add_description_to_campaign_jobsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395620_add_description_to_campaign_jobsDownSql,
+		"1528395620_add_description_to_campaign_jobs.down.sql",
+	)
+}
+
+func _1528395620_add_description_to_campaign_jobsDownSql() (*asset, error) {
+	bytes, err := _1528395620_add_description_to_campaign_jobsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395620_add_description_to_campaign_jobs.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x64, 0xb1, 0x8c, 0x41, 0xe6, 0xcc, 0xc2, 0x7a, 0x99, 0xd1, 0xad, 0xc, 0x51, 0xe0, 0x2, 0x83, 0xbd, 0x0, 0xbe, 0xf6, 0x32, 0xba, 0x39, 0x10, 0x6f, 0xb6, 0xcc, 0x25, 0x66, 0xf0, 0x85, 0xad}}
+	return a, nil
+}
+
+var __1528395620_add_description_to_campaign_jobsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x8b\xcf\xca\x4f\x2a\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x49\x2d\x4e\x2e\xca\x2c\x28\xc9\xcc\xcf\x53\x28\x49\xad\x28\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x2f\x85\x9b\x51\x48\x00\x00\x00")
+
+func _1528395620_add_description_to_campaign_jobsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395620_add_description_to_campaign_jobsUpSql,
+		"1528395620_add_description_to_campaign_jobs.up.sql",
+	)
+}
+
+func _1528395620_add_description_to_campaign_jobsUpSql() (*asset, error) {
+	bytes, err := _1528395620_add_description_to_campaign_jobsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395620_add_description_to_campaign_jobs.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe9, 0xa, 0x6c, 0x65, 0x84, 0x9a, 0x7c, 0x4e, 0xd6, 0x58, 0x63, 0xd3, 0x2a, 0x62, 0xca, 0x6d, 0xd5, 0x7f, 0x23, 0x62, 0xb6, 0x43, 0xb7, 0xc1, 0x40, 0xeb, 0x66, 0xe3, 0x1a, 0x89, 0xc1, 0xf1}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1831,6 +1873,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395618_add_delete_cascade_to_changeset_jobs.up.sql":                   _1528395618_add_delete_cascade_to_changeset_jobsUpSql,
 	"1528395619_remove_unused_indexes.down.sql":                                _1528395619_remove_unused_indexesDownSql,
 	"1528395619_remove_unused_indexes.up.sql":                                  _1528395619_remove_unused_indexesUpSql,
+	"1528395620_add_description_to_campaign_jobs.down.sql":                     _1528395620_add_description_to_campaign_jobsDownSql,
+	"1528395620_add_description_to_campaign_jobs.up.sql":                       _1528395620_add_description_to_campaign_jobsUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1950,6 +1994,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395618_add_delete_cascade_to_changeset_jobs.up.sql":                   {_1528395618_add_delete_cascade_to_changeset_jobsUpSql, map[string]*bintree{}},
 	"1528395619_remove_unused_indexes.down.sql":                                {_1528395619_remove_unused_indexesDownSql, map[string]*bintree{}},
 	"1528395619_remove_unused_indexes.up.sql":                                  {_1528395619_remove_unused_indexesUpSql, map[string]*bintree{}},
+	"1528395620_add_description_to_campaign_jobs.down.sql":                     {_1528395620_add_description_to_campaign_jobsDownSql, map[string]*bintree{}},
+	"1528395620_add_description_to_campaign_jobs.up.sql":                       {_1528395620_add_description_to_campaign_jobsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This implements the second and last part of the "Enhanced Workflow" described in https://github.com/sourcegraph/sourcegraph/issues/6852#issuecomment-560329073 and thus fixes #6852 (leaving aside the stretch goals, see #7010).

What this PR does:

* Add a `Description` field to `CampaignJobs` that gets optionally populated by `CampaignTypes` to describe the `diff` the `generateDiff` method returned for a specific repository.
* Change the `credentials` `CampaignType` to return a `description` that includes a list of tokens that were removed
* Add the `CampaignJob.Description` to the `Body` of a pull request on GitHub and Bitbucket Server
* Downgrade from GFM when creating a PR on BBS by turning `- [ ]` taskitems into normal list items