### PR TITLE
Fix GitHub getCodeCellFromTarget()

### DIFF
--- a/browser/src/libs/github/dom_functions.ts
+++ b/browser/src/libs/github/dom_functions.ts
@@ -58,9 +58,9 @@ const getLineNumberFromCodeElement = (codeElement: HTMLElement): number => {
  * Gets the `<td>` element for a target that contains the code
  */
 const getCodeCellFromTarget = (target: HTMLElement): HTMLTableCellElement | null => {
-    const cell = target.closest('td.blob-code') as HTMLTableCellElement
+    const cell = target.closest<HTMLTableCellElement>('td.blob-code')
     // Handle rows with the [ ↕ ] button that expands collapsed unchanged lines
-    if (!cell?.parentElement?.classList.contains('js-expandable-line')) {
+    if (!cell || cell.parentElement?.classList.contains('js-expandable-line')) {
         return null
     }
     return cell


### PR DESCRIPTION
I noticed that hovers were not showing on a browser extension built from `master`. This fixes it.

This was introduced by the optional chaining refactor in https://github.com/sourcegraph/sourcegraph/commit/765884306e2f11508e1be94fe8ea942ccfa9fbc0#diff-eea808a113c86d3273f7a5271213f632, which in this case actually changed the semantics.