### PR TITLE
tidy: frivolous Sprintf

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -537,7 +537,7 @@ func roundStr(s string) string {
 			return s
 		}
 		f = math.Round(f)
-		return fmt.Sprintf("%d", int(f))
+		return strconv.Itoa(int(f))
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -174,7 +174,7 @@ func (sr *SearchResultsResolver) ApproximateResultCount() string {
 	if sr.LimitHit() || len(sr.cloning) > 0 || len(sr.timedout) > 0 {
 		return fmt.Sprintf("%d+", count)
 	}
-	return strconv.FormatInt(int64(int(count)), 10)
+	return strconv.Itoa(int(count))
 }
 
 func (sr *SearchResultsResolver) Alert() *searchAlert { return sr.alert }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -174,7 +174,7 @@ func (sr *SearchResultsResolver) ApproximateResultCount() string {
 	if sr.LimitHit() || len(sr.cloning) > 0 || len(sr.timedout) > 0 {
 		return fmt.Sprintf("%d+", count)
 	}
-	return strconv.Itoa(int(count))
+	return strconv.FormatInt(int64(int(count)), 10)
 }
 
 func (sr *SearchResultsResolver) Alert() *searchAlert { return sr.alert }

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -2,8 +2,8 @@ package httpapi
 
 import (
 	"context"
-	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -21,7 +21,7 @@ func TestRepoShieldFmt(t *testing.T) {
 		15410: " 15.4k projects",
 	}
 	for input, want := range want {
-		t.Run(strconv.Itoa(input), func(t *testing.T) {
+		t.Run(strconv.FormatInt(int64(input), 10), func(t *testing.T) {
 			got := badgeValueFmt(input)
 			if got != want {
 				t.Fatalf("input %d got %q want %q", input, got, want)

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -21,7 +21,7 @@ func TestRepoShieldFmt(t *testing.T) {
 		15410: " 15.4k projects",
 	}
 	for input, want := range want {
-		t.Run(strconv.FormatInt(int64(input), 10), func(t *testing.T) {
+		t.Run(strconv.Itoa(input), func(t *testing.T) {
 			got := badgeValueFmt(input)
 			if got != want {
 				t.Fatalf("input %d got %q want %q", input, got, want)

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -21,7 +21,7 @@ func TestRepoShieldFmt(t *testing.T) {
 		15410: " 15.4k projects",
 	}
 	for input, want := range want {
-		t.Run(fmt.Sprintf("%d", input), func(t *testing.T) {
+		t.Run(strconv.Itoa(input), func(t *testing.T) {
 			got := badgeValueFmt(input)
 			if got != want {
 				t.Fatalf("input %d got %q want %q", input, got, want)

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -191,7 +191,7 @@ main.go:7:}
 	defer ts.Close()
 
 	for i, test := range cases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			test.arg.PatternMatchesContent = true
 			req := protocol.Request{
 				Repo:         "foo",

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -191,7 +191,7 @@ main.go:7:}
 	defer ts.Close()
 
 	for i, test := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
 			test.arg.PatternMatchesContent = true
 			req := protocol.Request{
 				Repo:         "foo",

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -191,7 +191,7 @@ main.go:7:}
 	defer ts.Close()
 
 	for i, test := range cases {
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			test.arg.PatternMatchesContent = true
 			req := protocol.Request{
 				Repo:         "foo",

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -137,7 +137,7 @@ func Matches(args Args) (matches []FileMatch, err error) {
 	}
 
 	if len(matches) > 0 {
-		log15.Info("comby invocation", "num_matches", fmt.Sprintf("%d", len(matches)))
+		log15.Info("comby invocation", "num_matches", strconv.Itoa(len(matches)))
 	}
 	return matches, nil
 }

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -38,7 +38,7 @@ func rawArgs(args Args) (rawArgs []string) {
 	if args.NumWorkers == 0 {
 		rawArgs = append(rawArgs, "-sequential")
 	} else {
-		rawArgs = append(rawArgs, "-jobs", strconv.Itoa(args.NumWorkers))
+		rawArgs = append(rawArgs, "-jobs", strconv.FormatInt(int64(args.NumWorkers), 10))
 	}
 
 	if args.Matcher != "" {

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -38,7 +38,7 @@ func rawArgs(args Args) (rawArgs []string) {
 	if args.NumWorkers == 0 {
 		rawArgs = append(rawArgs, "-sequential")
 	} else {
-		rawArgs = append(rawArgs, "-jobs", strconv.FormatInt(int64(args.NumWorkers), 10))
+		rawArgs = append(rawArgs, "-jobs", strconv.Itoa(args.NumWorkers))
 	}
 
 	if args.Matcher != "" {

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -2,7 +2,7 @@ package eventlogger
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 	"time"
 
 	log15 "gopkg.in/inconshreveable/log15.v2"
@@ -81,7 +81,7 @@ func (logger *eventLogger) newPayload(userEmail string, event *Event) *Payload {
 		BatchInfo: &BatchInfo{
 			BatchID:     uuid.New().String(),
 			TotalEvents: 1,
-			ServerTime:  strconv.Itoa(time.Now().UTC().Unix() * 1000),
+			ServerTime:  strconv.FormatInt(int64(time.Now().UTC().Unix()*1000), 10),
 		},
 		UserInfo: userInfo,
 	}

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -81,7 +81,7 @@ func (logger *eventLogger) newPayload(userEmail string, event *Event) *Payload {
 		BatchInfo: &BatchInfo{
 			BatchID:     uuid.New().String(),
 			TotalEvents: 1,
-			ServerTime:  strconv.Itoa(time.Now().UTC().Unix()*1000),
+			ServerTime:  strconv.Itoa(time.Now().UTC().Unix() * 1000),
 		},
 		UserInfo: userInfo,
 	}

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -81,7 +81,7 @@ func (logger *eventLogger) newPayload(userEmail string, event *Event) *Payload {
 		BatchInfo: &BatchInfo{
 			BatchID:     uuid.New().String(),
 			TotalEvents: 1,
-			ServerTime:  fmt.Sprintf("%d", time.Now().UTC().Unix()*1000),
+			ServerTime:  strconv.Itoa(time.Now().UTC().Unix()*1000),
 		},
 		UserInfo: userInfo,
 	}


### PR DESCRIPTION
Remove frivolous uses of `Sprintf`. See this [reference article](https://medium.com/swlh/bad-go-frivolous-sprintf-2ad28fedf1a0).

Created with

```json
{
    "matchTemplate": "fmt.Sprintf(\"%d\", :[v])",
    "rewriteTemplate": "strconv.Itoa(:[v])",
    "scopeQuery": "repo:github.com/sourcegraph/sourcegraph$ lang:go"
}
```