### PR TITLE
tidy: simplify int conversions

### DIFF
--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -208,7 +208,7 @@ func (r *settingsMutation) getCurrentSettings(ctx context.Context) (string, erro
 			if v == nil {
 				return "null"
 			}
-			return strconv.FormatInt(int64(*v), 10)
+			return strconv.Itoa(*v)
 		}
 		var lastID *int32
 		if settings != nil {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -202,7 +202,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 		}
 		q.Set("Deadline", string(t))
 	}
-	q.Set("FileMatchLimit", strconv.FormatInt(int64(p.FileMatchLimit), 10))
+	q.Set("FileMatchLimit", strconv.Itoa(p.FileMatchLimit))
 	if p.IsRegExp {
 		q.Set("IsRegExp", "true")
 	}

--- a/cmd/frontend/internal/pkg/search/query/syntax/tokentype_string.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/tokentype_string.go
@@ -24,7 +24,7 @@ var _TokenType_index = [...]uint8{0, 8, 18, 30, 41, 53, 63, 73, 81}
 
 func (i TokenType) String() string {
 	if i < 0 || i >= TokenType(len(_TokenType_index)-1) {
-		return "TokenType(" + strconv.FormatInt(int64(i), 10) + ")"
+		return "TokenType(" + strconv.Itoa(i) + ")"
 	}
 	return _TokenType_name[_TokenType_index[i]:_TokenType_index[i+1]]
 }

--- a/cmd/frontend/internal/pkg/search/query/syntax/tokentype_string.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/tokentype_string.go
@@ -24,7 +24,7 @@ var _TokenType_index = [...]uint8{0, 8, 18, 30, 41, 53, 63, 73, 81}
 
 func (i TokenType) String() string {
 	if i < 0 || i >= TokenType(len(_TokenType_index)-1) {
-		return "TokenType(" + strconv.Itoa(i) + ")"
+		return "TokenType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _TokenType_name[_TokenType_index[i]:_TokenType_index[i+1]]
 }

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -124,7 +124,7 @@ func (s BitbucketServerSource) CreateChangeset(ctx context.Context, c *Changeset
 	}
 
 	c.Changeset.Metadata = pr
-	c.Changeset.ExternalID = strconv.FormatInt(int64(pr.ID), 10)
+	c.Changeset.ExternalID = strconv.Itoa(pr.ID)
 	c.Changeset.ExternalServiceType = bitbucketserver.ServiceType
 
 	return nil

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -53,7 +53,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			ServiceType: s.ServiceType,
 			ServiceID:   s.ServiceID,
 			ClientID:    s.clientID,
-			AccountID:   strconv.FormatInt(int64(gUser.ID), 10),
+			AccountID:   strconv.Itoa(gUser.ID),
 		},
 		ExternalAccountData: data,
 		CreateIfNotExist:    true,

--- a/enterprise/internal/codeintel/resolvers/dump.go
+++ b/enterprise/internal/codeintel/resolvers/dump.go
@@ -137,7 +137,7 @@ func (r *lsifDumpConnectionResolver) compute(ctx context.Context) ([]*lsif.LSIFD
 			query.Set("visibleAtTip", "true")
 		}
 		if r.opt.Limit != nil {
-			query.Set("limit", strconv.FormatInt(int64(*r.opt.Limit), 10))
+			query.Set("limit", strconv.Itoa(*r.opt.Limit))
 		}
 
 		resp, err := client.DefaultClient.BuildAndTraceRequest(ctx, "GET", path, query, nil)

--- a/enterprise/internal/codeintel/resolvers/job.go
+++ b/enterprise/internal/codeintel/resolvers/job.go
@@ -153,7 +153,7 @@ func (r *lsifJobConnectionResolver) compute(ctx context.Context) ([]*lsif.LSIFJo
 			query.Set("query", *r.opt.Query)
 		}
 		if r.opt.Limit != nil {
-			query.Set("limit", strconv.FormatInt(int64(*r.opt.Limit), 10))
+			query.Set("limit", strconv.Itoa(*r.opt.Limit))
 		}
 
 		resp, err := client.DefaultClient.BuildAndTraceRequest(ctx, "GET", path, query, nil)


### PR DESCRIPTION
`strconv.Itoa(:[var])` is equivalent to `FormatInt(int64(:[var]), 10)`. [Reference](https://golang.org/pkg/strconv/#Itoa).

Created with

```json
{
    "matchTemplate": "strconv.FormatInt(int64(:[v]), 10)",
    "rewriteTemplate": "strconv.Itoa(:[v])",
    "scopeQuery": "repo:github.com/sourcegraph/sourcegraph$ lang:go"
}
```