### PR TITLE
LSIF: update workflow

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -12,6 +12,6 @@ jobs:
           verbose: "true"
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          ignore_failure: "true"

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -14,4 +14,4 @@ jobs:
         uses: sourcegraph/lsif-upload-action@master
         continue-on-error: true
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -13,4 +13,5 @@ jobs:
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:
-          public_repo_github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          ignore_failure: "true"


### PR DESCRIPTION
- Set `ignore_failure: "true"` now that the default has been flipped in https://github.com/sourcegraph/lsif-upload-action/pull/7
- Replace `public_repo_github_token` with `github_token` https://github.com/sourcegraph/lsif-upload-action/pull/6

Test plan: CI
