### PR TITLE
LSIF workflow: fix root

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -9,9 +9,12 @@ jobs:
       - name: Generate LSIF Data
         uses: sourcegraph/lsif-go-action@master
         with:
+          project_root: cmd/
+          file: cmd/dump.lsif
           verbose: "true"
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         continue-on-error: true
         with:
+          file: cmd/dump.lsif
           github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}


### PR DESCRIPTION
Prior to this PR, a Go LSIF dump was uploaded at `/`, breaking TS code intel.

This sets the root to `cmd/`. We might need to delete old dumps after this to clear the upload history for other directories.

```
File: cmd/dump.lsif
Root: cmd
```