### PR TITLE
fix bug where soft-deleted orgs would be returned by list

### DIFF
--- a/cmd/frontend/db/orgs_test.go
+++ b/cmd/frontend/db/orgs_test.go
@@ -68,7 +68,8 @@ func TestOrgs_Delete(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	org, err := Orgs.Create(ctx, "a", nil)
+	displayName := "a"
+	org, err := Orgs.Create(ctx, "a", &displayName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +84,7 @@ func TestOrgs_Delete(t *testing.T) {
 	if _, ok := err.(*OrgNotFoundError); !ok {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
-	orgs, err := Orgs.List(ctx, nil)
+	orgs, err := Orgs.List(ctx, &OrgsListOptions{Query: "a"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If an org was (soft-)deleted, it would still be returned by an org list call if its display name matched the list options query. This is because the `name ILIKE %s OR display_name ILIKE %s` condition was not being wrapped in `(...)` when interpolated into the SQL query, and the `OR` made the first condition `deleted_at IS NULL` ineffective.

This caused a bug where if you deleted an org (in site admin) and then searched for it by display name, you would not see any results and would only see an error `Org not found: id 1234`.