### PR TITLE
ci: Remove init-pipeline.yaml

### DIFF
--- a/enterprise/dev/ci/README.md
+++ b/enterprise/dev/ci/README.md
@@ -1,0 +1,15 @@
+# Buildkite Pipeline for sourcegraph/sourcegraph
+
+We dynamically generate our CI pipeline for https://buildkite.com/sourcegraph/sourcegraph based on the output of [gen-pipeline.go](./gen-pipeline.go).
+
+## Setup
+
+In the [pipeline settings](https://buildkite.com/sourcegraph/sourcegraph/settings) ensure there is the following step:
+
+```shell
+go run ./enterprise/dev/ci/gen-pipeline.go | buildkite-agent pipeline upload
+```
+
+## Testing
+
+To test this you can run `env BUILDKITE_BRANCH=TESTBRANCH go run ./enterprise/dev/ci/gen-pipeline.go` and inspect the YAML output. To change the behaviour set the relevant `BUILDKITE_` environment variables.

--- a/enterprise/dev/ci/init-pipeline.yml
+++ b/enterprise/dev/ci/init-pipeline.yml
@@ -1,8 +1,0 @@
-steps:
-  - command: |
-      GO111MODULE=on go run ./enterprise/dev/ci/gen-pipeline.go | tee ./pipeline.yml
-      buildkite-agent pipeline upload ./pipeline.yml
-    label: ':pipeline:'
-    plugins:
-      gopath-checkout#v1.0.1:
-        import: github.com/sourcegraph/sourcegraph


### PR DESCRIPTION
We now directly specify the generation step in the pipeline settings. This
removes a step from the critical path which had varying runtimes. For example
in the last buildkite build I looked at it took 21s and waited 2s.

Additionally we introduce a README lightly explaining how this script fits in.

Here is the example:

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/187831/70041065-2a430f80-15c5-11ea-9399-265c6b678a5f.png">

That first step took 23s total (with wait time), and all it does is run our actual generation logic. This is on the critical path, so moving to this shaves of 10s of seconds on CI time.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
