### PR TITLE
search: Make search/backend package codecov deterministic

### DIFF
--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -104,7 +104,7 @@ func TestHorizontalSearcher(t *testing.T) {
 func TestSyncSearchers(t *testing.T) {
 	// This test exists to ensure we test the fast path returns in
 	// syncSearchers. TestHorizontalSearcher tests the same code paths, but
-	// isn't gaurenteed to trigger the fast-path returns.
+	// isn't guaranteed to trigger the fast-path returns.
 	var endpoints atomicMap
 	endpoints.Store(prefixMap{"a"})
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -101,6 +101,47 @@ func TestHorizontalSearcher(t *testing.T) {
 	searcher.Close()
 }
 
+func TestSyncSearchers(t *testing.T) {
+	// This test exists to ensure we test the fast path returns in
+	// syncSearchers. TestHorizontalSearcher tests the same code paths, but
+	// isn't gaurenteed to trigger the fast-path returns.
+	var endpoints atomicMap
+	endpoints.Store(prefixMap{"a"})
+
+	type mock struct {
+		mockSearcher
+		dialNum int
+	}
+
+	dialNumCounter := 0
+	searcher := &HorizontalSearcher{
+		Map: &endpoints,
+		Dial: func(endpoint string) zoekt.Searcher {
+			dialNumCounter++
+			return &mock{
+				dialNum: dialNumCounter,
+			}
+		},
+	}
+	defer searcher.Close()
+
+	// First call initializes the list, second should use the fast-path so
+	// should have the same dialNum.
+	for i := 0; i < 2; i++ {
+		t.Log("gen", i)
+		m, err := searcher.syncSearchers()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 1 {
+			t.Fatal(err)
+		}
+		if got, want := m["a"].(*mock).dialNum, 1; got != want {
+			t.Fatalf("expected immutable dail num %d, got %d", want, got)
+		}
+	}
+}
+
 func TestDedupper(t *testing.T) {
 	parse := func(s string) []zoekt.FileMatch {
 		t.Helper()


### PR DESCRIPTION
This bit of code has given false signal too many times on a PR, so this commit ensures we always run the slow and fast path for syncing the set of endpoints with the set of clients.

Previously hese lines of code sometimes run and sometimes do not in our tests: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.10.0/-/blob/internal/search/backend/horizontal.go#L158-160

We already have a test which quickly has 5 background goroutines running which try to trigger this case, but it wasn't sufficient: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.10.0/-/blob/internal/search/backend/horizontal_test.go#L38-43

Slack context: https://sourcegraph.slack.com/archives/C07KZF47K/p1574865065040100