### PR TITLE
search: Do not highlight trailing newline in multiline structural search

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -41,7 +41,7 @@ func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 		} else if i == (lineSpan - 1) {
 			// Last line.
 			columnStart = 0
-			columnEnd = r.Range.End.Column - 1 /* don't include trailing newline */
+			columnEnd = r.Range.End.Column - 1 // don't include trailing newline
 		} else {
 			// In between line.
 			columnStart = 0

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -32,20 +32,20 @@ func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 	}
 
 	contentLines := strings.Split(r.Matched, "\n")
-	for i, lines := range contentLines {
+	for i, line := range contentLines {
 		var columnStart, columnEnd int
 		if i == 0 {
 			// First line.
 			columnStart = r.Range.Start.Column - 1
-			columnEnd = len(lines) + 1
+			columnEnd = len(line)
 		} else if i == (lineSpan - 1) {
 			// Last line.
 			columnStart = 0
-			columnEnd = r.Range.End.Column
+			columnEnd = r.Range.End.Column - 1 /* don't include trailing newline */
 		} else {
 			// In between line.
 			columnStart = 0
-			columnEnd = len(lines) + 1
+			columnEnd = len(line)
 		}
 
 		matches = append(matches, protocol.LineMatch{
@@ -56,7 +56,7 @@ func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
 					columnEnd,
 				},
 			},
-			Preview: lines,
+			Preview: line,
 		})
 	}
 	return matches

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -174,7 +174,7 @@ func TestHighlightMultipleLines(t *testing.T) {
 					OffsetAndLengths: [][2]int{
 						{
 							0,
-							23,
+							22,
 						},
 					},
 					Preview: "this is a match across",
@@ -184,7 +184,7 @@ func TestHighlightMultipleLines(t *testing.T) {
 					OffsetAndLengths: [][2]int{
 						{
 							0,
-							6,
+							5,
 						},
 					},
 					Preview: "three",
@@ -194,7 +194,7 @@ func TestHighlightMultipleLines(t *testing.T) {
 					OffsetAndLengths: [][2]int{
 						{
 							0,
-							5,
+							4, /* don't include trailing newline */
 						},
 					},
 					Preview: "lines",

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -194,7 +194,7 @@ func TestHighlightMultipleLines(t *testing.T) {
 					OffsetAndLengths: [][2]int{
 						{
 							0,
-							4, /* don't include trailing newline */
+							4, // don't include trailing newline
 						},
 					},
 					Preview: "lines",


### PR DESCRIPTION
Previous to this change, multiline structural search highlights included the trailing newline of the last line, which would highlight the character in the 0th column on the next line. This change updates the line lengths to exclude the trailing newlines.

Test plan: Validated visually, updated the tests.
