### PR TITLE
ci: Order steps such that slower steps run sooner

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -79,20 +79,23 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 
 	default:
-		// Otherwise, run the CI steps for the Sourcegraph web app. Specific steps may be modified
-		// or skipped for certain branches; these variations are defined in the functions
-		// parameterized by the config.
+		// Otherwise, run the CI steps for the Sourcegraph web app. Specific
+		// steps may be modified or skipped for certain branches; these
+		// variations are defined in the functions parameterized by the
+		// config.
+		//
+		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			addServerDockerImageCandidate(c),
-			addCheck,
-			addLint,
+			addLint,    // ~5m
+			addWebApp,  // ~3m
+			addGoTests, // ~2m
+			addGoBuild, // ~2m
+			addCheck,   // ~2m
 			addBrowserExt,
-			addWebApp,
 			addLSIFServer,
 			addSharedTests,
 			addPostgresBackcompat,
-			addGoTests,
-			addGoBuild,
 			addDockerfileLint,
 			wait,
 			addE2E(c),


### PR DESCRIPTION
The effective time taken for a step is the waiting time + run time. The earlier a step is in the pipeline the lower its waiting time should be => ordering steps by run time should help minimise total effective time => faster CI results.