### PR TITLE
gitserver: Handle and ignore filepath.Walk error

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -533,6 +533,10 @@ func (s *Server) cleanTmpFiles(dir GitDir) {
 	now := time.Now()
 	packdir := dir.Path("objects", "pack")
 	err := filepath.Walk(packdir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// ignore
+			return nil
+		}
 		if path != packdir && info.IsDir() {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
filepath.Walk can return errors if we run into permission errors or a file
disappears between `readdir` and the `stat` of the file. In either case this
error isn't important for our cleanup, so we just ignore it. This is what we
typically do in the rest of the gitserver uses of filepath.Walk

Previously we ignored the error completely, which would lead to `info` being
nil => panic. This bug has existed for a long time, but is a hard to trip
panic.

Fixes https://github.com/sourcegraph/sourcegraph/issues/6710