### PR TITLE
graphqlbackend: Test all To* graphql resolvers

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -37,16 +37,30 @@ func TestRepository(t *testing.T) {
 	})
 }
 
-func TestNodeResolverTo(t *testing.T) {
+func TestResolverTo(t *testing.T) {
 	// This test exists purely to remove some non determinism in our tests
 	// run. The To* resolvers are stored in a map in our graphql
 	// implementation => the order we call them is non deterministic =>
 	// codecov coverage reports are noisy.
-	r := &NodeResolver{}
-	typ := reflect.TypeOf(r)
-	for i := 0; i < typ.NumMethod(); i++ {
-		if name := typ.Method(i).Name; strings.HasPrefix(name, "To") {
-			reflect.ValueOf(r).MethodByName(name).Call(nil)
+	resolvers := []interface{}{
+		&FileMatchResolver{},
+		&GitTreeEntryResolver{},
+		&NamespaceResolver{},
+		&NodeResolver{},
+		&RepositoryResolver{},
+		&codemodResultResolver{},
+		&commitSearchResultResolver{},
+		&gitRevSpec{},
+		&searchSuggestionResolver{},
+		&settingsSubject{},
+		&statusMessageResolver{},
+	}
+	for _, r := range resolvers {
+		typ := reflect.TypeOf(r)
+		for i := 0; i < typ.NumMethod(); i++ {
+			if name := typ.Method(i).Name; strings.HasPrefix(name, "To") {
+				reflect.ValueOf(r).MethodByName(name).Call(nil)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is another attempt to remove code coverage non-determinism. I have seen
it popping up for the RepositoryResolver recently. So decided to just include
all resolvers which have To methods.

Previous PRs in this vein:
- graphqlbackend: Use reflection in TestNodeResolverTo (#6325)
- graphqlbackend: Call new Node.To* methods to remove non-determinism in coverage (#5949)
- ci: Test node resolvers to remove non-deterministic coverage (#4961)