### PR TITLE
repo-updater: Do not try to source deleted external services

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -144,9 +144,11 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err = syncExternalService(ctx, externalService); err != nil {
-		return nil, errors.Wrap(err, "warning: external service deleted, but sync request failed")
-	}
+	// The user doesn't care triggering syncing failed when deleting a
+	// service, so kick off in the background.
+	go func() {
+		_ = syncExternalService(context.Background(), externalService)
+	}()
 
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -144,7 +144,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	// The user doesn't care triggering syncing failed when deleting a
+	// The user doesn't care if triggering syncing failed when deleting a
 	// service, so kick off in the background.
 	go func() {
 		_ = syncExternalService(context.Background(), externalService)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -306,6 +306,12 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 
 	errch := make(chan error, 1)
 	go func() {
+		if req.ExternalService.DeletedAt != nil {
+			// We don't need to check deleted services.
+			errch <- nil
+			return
+		}
+
 		src, err := repos.NewSource(&repos.ExternalService{
 			ID:          req.ExternalService.ID,
 			Kind:        req.ExternalService.Kind,


### PR DESCRIPTION
This PR introduces two changes:
- Do not block deletion on triggering repo-updater syncs. We don't need to give the user any feedback from repo-updater, so no need to wait for the trigger to happen.
- Do not try source deleted external services. We source for validation purposes, but no point validating a deleted external service.

The second point in particular lead to the reported bug report where we would present a warning that we failed to sync when deleting an external service. However, this was expected since the external service upstream code host was down, which is why the service was deleted.

Test plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/5617
