### PR TITLE
a8n: Implement `cancelCampaignPlan` mutation

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -61,6 +61,7 @@ Referenced by:
  created_at    | timestamp with time zone | not null default now()
  updated_at    | timestamp with time zone | not null default now()
  arguments     | text                     | not null
+ canceled_at   | timestamp with time zone | 
 Indexes:
     "campaign_plans_pkey" PRIMARY KEY, btree (id)
 Check constraints:

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -488,6 +488,8 @@ enum BackgroundProcessState {
     ERRORED
     # The background process completed processing all items successfully.
     COMPLETED
+    # The background process was canceled.
+    CANCELED
 }
 
 # Reusable type to report progress of a background process.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -495,6 +495,8 @@ enum BackgroundProcessState {
     ERRORED
     # The background process completed processing all items successfully.
     COMPLETED
+    # The background process was canceled.
+    CANCELED
 }
 
 # Reusable type to report progress of a background process.

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -494,7 +494,16 @@ func (r *Resolver) CancelCampaignPlan(ctx context.Context, args graphqlbackend.C
 	}
 
 	if !plan.CanceledAt.IsZero() {
-		return nil, errors.New("execution has already been canceled")
+		return &graphqlbackend.EmptyResponse{}, nil
+	}
+
+	status, err := tx.GetCampaignPlanStatus(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if status.Finished() {
+		return &graphqlbackend.EmptyResponse{}, nil
 	}
 
 	plan.CanceledAt = time.Now().UTC()

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"strings"
+	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -469,7 +470,7 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 	return &campaignPlanResolver{store: r.store, campaignPlan: plan}, nil
 }
 
-func (r *Resolver) CancelCampaignPlan(ctx context.Context, args graphqlbackend.CancelCampaignPlanArgs) (*graphqlbackend.EmptyResponse, error) {
+func (r *Resolver) CancelCampaignPlan(ctx context.Context, args graphqlbackend.CancelCampaignPlanArgs) (res *graphqlbackend.EmptyResponse, err error) {
 	// 🚨 SECURITY: Only site admins may update campaigns for now
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -480,11 +481,25 @@ func (r *Resolver) CancelCampaignPlan(ctx context.Context, args graphqlbackend.C
 		return nil, err
 	}
 
-	_, err = r.store.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: id})
+	tx, err := r.store.Transact(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(a8n): Implement this. We need to cancel plan so that all jobs are stopped.
-	return &graphqlbackend.EmptyResponse{}, nil
+	defer tx.Done(&err)
+
+	plan, err := tx.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: id})
+	if err != nil {
+		return nil, err
+	}
+
+	if !plan.CanceledAt.IsZero() {
+		return nil, errors.New("execution has already been canceled")
+	}
+
+	plan.CanceledAt = time.Now().UTC()
+
+	err = tx.UpdateCampaignPlan(ctx, plan)
+
+	return &graphqlbackend.EmptyResponse{}, err
 }

--- a/enterprise/internal/a8n/runner.go
+++ b/enterprise/internal/a8n/runner.go
@@ -209,6 +209,17 @@ func (r *Runner) runJob(pctx context.Context, job *a8n.CampaignJob) {
 		}
 	}()
 
+	// Check whether CampaignPlan has been canceled.
+	p, err := r.store.GetCampaignPlan(ctx, GetCampaignPlanOpts{ID: job.CampaignPlanID})
+	if err != nil {
+		job.Error = err.Error()
+		return
+	}
+	if !p.CanceledAt.IsZero() {
+		job.Error = "Campaign execution canceled."
+		return
+	}
+
 	job.StartedAt = r.clock()
 
 	// We load the repository here again so that we decouple the

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1156,14 +1156,16 @@ var createCampaignPlanQueryFmtstr = `
 INSERT INTO campaign_plans (
   campaign_type,
   arguments,
+  canceled_at,
   created_at,
   updated_at
 )
-VALUES (%s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s)
 RETURNING
   id,
   campaign_type,
   arguments,
+  canceled_at,
   created_at,
   updated_at
 `
@@ -1186,6 +1188,7 @@ func (s *Store) createCampaignPlanQuery(c *a8n.CampaignPlan) (*sqlf.Query, error
 		createCampaignPlanQueryFmtstr,
 		c.CampaignType,
 		arguments,
+		nullTimeColumn(c.CanceledAt),
 		c.CreatedAt,
 		c.UpdatedAt,
 	), nil
@@ -1210,13 +1213,15 @@ UPDATE campaign_plans
 SET (
   campaign_type,
   arguments,
+  canceled_at,
   updated_at
-) = (%s, %s, %s)
+) = (%s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
   campaign_type,
   arguments,
+  canceled_at,
   created_at,
   updated_at
 `
@@ -1233,6 +1238,7 @@ func (s *Store) updateCampaignPlanQuery(c *a8n.CampaignPlan) (*sqlf.Query, error
 		updateCampaignPlanQueryFmtstr,
 		c.CampaignType,
 		arguments,
+		nullTimeColumn(c.CanceledAt),
 		c.UpdatedAt,
 		c.ID,
 	), nil
@@ -1342,6 +1348,7 @@ SELECT
   id,
   campaign_type,
   arguments,
+  canceled_at,
   created_at,
   updated_at
 FROM campaign_plans
@@ -1458,6 +1465,7 @@ SELECT
   id,
   campaign_type,
   arguments,
+  canceled_at,
   created_at,
   updated_at
 FROM campaign_plans
@@ -2237,6 +2245,7 @@ func scanCampaignPlan(c *a8n.CampaignPlan, s scanner) error {
 		&c.ID,
 		&c.CampaignType,
 		&c.Arguments,
+		&dbutil.NullTime{Time: &c.CanceledAt},
 		&c.CreatedAt,
 		&c.UpdatedAt,
 	)

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -861,6 +861,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					c := &a8n.CampaignPlan{
 						CampaignType: "COMBY",
 						Arguments:    `{"scopeQuery": "file:README.md"}`,
+						CanceledAt:   now,
 					}
 
 					want := c.Clone()
@@ -971,6 +972,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 				for _, c := range campaignPlans {
 					c.CampaignType += "-updated"
 					c.Arguments = `{"updated": true}`
+					c.CanceledAt = now.Add(5 * time.Second)
 
 					now = now.Add(time.Second)
 					want := c

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1352,8 +1352,9 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 		t.Run("CampaignPlan BackgroundProcessStatus", func(t *testing.T) {
 			tests := []struct {
-				jobs []*a8n.CampaignJob
-				want *a8n.BackgroundProcessStatus
+				planCanceledAt time.Time
+				jobs           []*a8n.CampaignJob
+				want           *a8n.BackgroundProcessStatus
 			}{
 				{
 					jobs: []*a8n.CampaignJob{}, // no jobs
@@ -1431,12 +1432,69 @@ func testStore(db *sql.DB) func(*testing.T) {
 						ProcessErrors: []string{"error1", "error2"},
 					},
 				},
+				{
+					planCanceledAt: now,
+					jobs: []*a8n.CampaignJob{
+						// not started (pending)
+						{},
+						// started (pending)
+						{StartedAt: now},
+					},
+					want: &a8n.BackgroundProcessStatus{
+						// Instead of "Processing" it's "Canceled"
+						ProcessState:  a8n.BackgroundProcessStateCanceled,
+						Canceled:      true,
+						Total:         2,
+						Completed:     0,
+						Pending:       2,
+						ProcessErrors: nil,
+					},
+				},
+				{
+					planCanceledAt: now,
+					jobs: []*a8n.CampaignJob{
+						// completed, error
+						{StartedAt: now, FinishedAt: now, Error: "error1"},
+					},
+					want: &a8n.BackgroundProcessStatus{
+						// Instead of "Errored" it's "Canceled"
+						ProcessState:  a8n.BackgroundProcessStateCanceled,
+						Canceled:      true,
+						Total:         1,
+						Completed:     1,
+						Pending:       0,
+						ProcessErrors: []string{"error1"},
+					},
+				},
+				{
+					planCanceledAt: now,
+					jobs: []*a8n.CampaignJob{
+						// completed, no errors
+						{StartedAt: now, FinishedAt: now, Diff: "+foobar\n-foobar"},
+					},
+					want: &a8n.BackgroundProcessStatus{
+						// Instead of "Completed" it's "Canceled"
+						ProcessState:  a8n.BackgroundProcessStateCanceled,
+						Canceled:      true,
+						Total:         1,
+						Completed:     1,
+						Pending:       0,
+						ProcessErrors: nil,
+					},
+				},
 			}
-			for num, tc := range tests {
-				campaignPlanID := int64(num + 1)
+			for _, tc := range tests {
+				plan := &a8n.CampaignPlan{
+					CampaignType: "comby",
+					CanceledAt:   tc.planCanceledAt,
+				}
+				err := s.CreateCampaignPlan(ctx, plan)
+				if err != nil {
+					t.Fatal(err)
+				}
 
 				for i, j := range tc.jobs {
-					j.CampaignPlanID = campaignPlanID
+					j.CampaignPlanID = plan.ID
 					j.RepoID = int32(i)
 					j.Rev = api.CommitID(fmt.Sprintf("deadbeef-%d", i))
 					j.BaseRef = "master"
@@ -1447,7 +1505,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					}
 				}
 
-				status, err := s.GetCampaignPlanStatus(ctx, campaignPlanID)
+				status, err := s.GetCampaignPlanStatus(ctx, plan.ID)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -121,6 +121,7 @@ func (s ChangesetState) Valid() bool {
 
 // BackgroundProcessStatus defines the status of a background process.
 type BackgroundProcessStatus struct {
+	Canceled      bool
 	Total         int32
 	Completed     int32
 	Pending       int32

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -141,6 +141,7 @@ const (
 	BackgroundProcessStateProcessing BackgroundProcessState = "PROCESSING"
 	BackgroundProcessStateErrored    BackgroundProcessState = "ERRORED"
 	BackgroundProcessStateCompleted  BackgroundProcessState = "COMPLETED"
+	BackgroundProcessStateCanceled   BackgroundProcessState = "CANCELED"
 )
 
 // ChangesetReviewState defines the possible states of a Changeset's review.

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -36,6 +36,8 @@ type CampaignPlan struct {
 	// Arguments is a JSONC string
 	Arguments string
 
+	CanceledAt time.Time
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -133,6 +133,13 @@ func (b BackgroundProcessStatus) CompletedCount() int32         { return b.Compl
 func (b BackgroundProcessStatus) PendingCount() int32           { return b.Pending }
 func (b BackgroundProcessStatus) State() BackgroundProcessState { return b.ProcessState }
 func (b BackgroundProcessStatus) Errors() []string              { return b.ProcessErrors }
+func (b BackgroundProcessStatus) Finished() bool {
+	if b.ProcessState == BackgroundProcessStateCompleted ||
+		b.ProcessState == BackgroundProcessStateErrored {
+		return true
+	}
+	return false
+}
 
 // BackgroundProcessState defines the possible states of a background process.
 type BackgroundProcessState string

--- a/migrations/1528395623_add_canceled_at_to_campaign_plan.down.sql
+++ b/migrations/1528395623_add_canceled_at_to_campaign_plan.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaign_plans DROP COLUMN canceled_at;
+
+COMMIT;

--- a/migrations/1528395623_add_canceled_at_to_campaign_plan.up.sql
+++ b/migrations/1528395623_add_canceled_at_to_campaign_plan.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaign_plans ADD COLUMN canceled_at timestamptz;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -82,6 +82,8 @@
 // 1528395621_add_delete_cascade_to_campaign_jobs.up.sql (235B)
 // 1528395622_add_more_delete_cascades_to_changeset_jobs.down.sql (478B)
 // 1528395622_add_more_delete_cascades_to_changeset_jobs.up.sql (514B)
+// 1528395623_add_canceled_at_to_campaign_plan.down.sql (69B)
+// 1528395623_add_canceled_at_to_campaign_plan.up.sql (80B)
 
 package migrations
 
@@ -1790,6 +1792,46 @@ func _1528395622_add_more_delete_cascades_to_changeset_jobsUpSql() (*asset, erro
 	return a, nil
 }
 
+var __1528395623_add_canceled_at_to_campaign_planDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x8b\x2f\xc8\x49\xcc\x2b\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x4e\xcc\x4b\x4e\xcd\x49\x4d\x89\x4f\x2c\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xb2\x7c\xc9\x8e\x45\x00\x00\x00")
+
+func _1528395623_add_canceled_at_to_campaign_planDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395623_add_canceled_at_to_campaign_planDownSql,
+		"1528395623_add_canceled_at_to_campaign_plan.down.sql",
+	)
+}
+
+func _1528395623_add_canceled_at_to_campaign_planDownSql() (*asset, error) {
+	bytes, err := _1528395623_add_canceled_at_to_campaign_planDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395623_add_canceled_at_to_campaign_plan.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x25, 0x6e, 0x0, 0x97, 0xbb, 0xac, 0x70, 0xe0, 0xa7, 0x48, 0x98, 0x91, 0x60, 0x15, 0xdb, 0x9a, 0xdb, 0x67, 0x43, 0xb0, 0xea, 0xdb, 0x19, 0xf6, 0x91, 0xb3, 0x78, 0xd2, 0x62, 0x24, 0x50, 0xab}}
+	return a, nil
+}
+
+var __1528395623_add_canceled_at_to_campaign_planUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x04\xc0\x39\x0a\xc5\x20\x10\x00\xd0\x7e\x4e\x31\xf7\xb0\x72\xe3\x23\xb8\xc0\xc7\xd4\x32\x18\x09\x82\x8a\xe0\x54\x39\x7d\x9e\xb2\x3f\x17\x05\x80\xf4\xd9\xfe\x31\x4b\xe5\x2d\x56\x9a\x9b\xfa\xb3\xca\x1e\xb4\x0e\x4a\x63\x50\x27\x7f\x85\x88\x95\x56\x6d\xa3\xdd\x85\x18\xb9\xcf\x76\x98\xe6\xe6\x57\x00\xe8\x14\x82\xcb\x02\xbe\x00\x00\x00\xff\xff\x9f\x9f\xa5\xae\x50\x00\x00\x00")
+
+func _1528395623_add_canceled_at_to_campaign_planUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395623_add_canceled_at_to_campaign_planUpSql,
+		"1528395623_add_canceled_at_to_campaign_plan.up.sql",
+	)
+}
+
+func _1528395623_add_canceled_at_to_campaign_planUpSql() (*asset, error) {
+	bytes, err := _1528395623_add_canceled_at_to_campaign_planUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395623_add_canceled_at_to_campaign_plan.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3, 0x80, 0xa9, 0x5, 0xa, 0xfb, 0x55, 0xe9, 0x7a, 0xc5, 0x4b, 0x1c, 0xff, 0x81, 0xda, 0x93, 0xa0, 0x21, 0x18, 0xee, 0x14, 0x18, 0xab, 0xd9, 0xcd, 0x5b, 0xe1, 0xee, 0x89, 0x51, 0x2d, 0x4e}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1963,6 +2005,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395621_add_delete_cascade_to_campaign_jobs.up.sql":                    _1528395621_add_delete_cascade_to_campaign_jobsUpSql,
 	"1528395622_add_more_delete_cascades_to_changeset_jobs.down.sql":           _1528395622_add_more_delete_cascades_to_changeset_jobsDownSql,
 	"1528395622_add_more_delete_cascades_to_changeset_jobs.up.sql":             _1528395622_add_more_delete_cascades_to_changeset_jobsUpSql,
+	"1528395623_add_canceled_at_to_campaign_plan.down.sql":                     _1528395623_add_canceled_at_to_campaign_planDownSql,
+	"1528395623_add_canceled_at_to_campaign_plan.up.sql":                       _1528395623_add_canceled_at_to_campaign_planUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -2088,6 +2132,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395621_add_delete_cascade_to_campaign_jobs.up.sql":                    {_1528395621_add_delete_cascade_to_campaign_jobsUpSql, map[string]*bintree{}},
 	"1528395622_add_more_delete_cascades_to_changeset_jobs.down.sql":           {_1528395622_add_more_delete_cascades_to_changeset_jobsDownSql, map[string]*bintree{}},
 	"1528395622_add_more_delete_cascades_to_changeset_jobs.up.sql":             {_1528395622_add_more_delete_cascades_to_changeset_jobsUpSql, map[string]*bintree{}},
+	"1528395623_add_canceled_at_to_campaign_plan.down.sql":                     {_1528395623_add_canceled_at_to_campaign_planDownSql, map[string]*bintree{}},
+	"1528395623_add_canceled_at_to_campaign_plan.up.sql":                       {_1528395623_add_canceled_at_to_campaign_planUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This implements the `cancelCampaignPlan` mutation that marks a `CampaignPlan` as cancelled in its `BackgroundProcessStatus` and stops all enqueued `CampaignJob`s from running.

It does this by
- adding a `canceled_at` field on `campaign_plans` and setting that in `cancelCampaignPlan` in case it hasn't been set.
- checking whether the the `CampaignPlan` has been canceled before executing a single `CampaignJob`. If it has, it marks the `CampaignJob` as errored.
- extending the `BackgroundProcessStatus` (in the GraphQL API and in the backend) with a new `CANCELED` state that's returned when a `CampaignPlan` has been executed.

 **Note**: this is not the most performant solution since we still do a `SELECT` and `UPDATE` for every `CampaignJob` if the `CampaignPlan` has been cancelled. But it's by far the most straightforward and easiest to debug solution.

Alternatives:
1. stop the workers in `Runner` once the plan has been executed. But in that case we'd need to do some concurrency foo to mark the `WaitGroup` as done.
2. add a `canceled_at` on `campaign_jobs`, set it along with `campaign_plan.canceled_at` and then do a `SELECT` (no `UPDATE`) to check whether it's been set before executing a job.

I think it's fine as it is and the `SELECT/UPDATEs` won't be a problem for a long time, but happy about suggestions :) 