### PR TITLE
GLOBAL_SETTINGS_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Language statistics by commit are available via the API. [#6737](https://github.com/sourcegraph/sourcegraph/pull/6737)
+- Global settings can be configured from a local file using the environment variable `GLOBAL_SETTINGS_FILE`.
 
 ### Changed
 

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -90,7 +90,6 @@ func handleConfigOverrides() error {
 			if err != nil {
 				return errors.Wrap(err, "reading GLOBAL_SETTINGS_FILE")
 			}
-			globalSettings := string(globalSettingsBytes)
 			currentSettings, err := db.Settings.GetLatest(ctx, api.SettingsSubject{Site: true})
 			if err != nil {
 				return errors.Wrap(err, "could not fetch current settings")

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/db/confdb"
@@ -53,7 +54,8 @@ func handleConfigOverrides() error {
 	overrideCriticalConfig := os.Getenv("CRITICAL_CONFIG_FILE")
 	overrideSiteConfig := os.Getenv("SITE_CONFIG_FILE")
 	overrideExtSvcConfig := os.Getenv("EXTSVC_CONFIG_FILE")
-	overrideAny := overrideCriticalConfig != "" || overrideSiteConfig != "" || overrideExtSvcConfig != ""
+	overrideGlobalSettings := os.Getenv("GLOBAL_SETTINGS_FILE")
+	overrideAny := overrideCriticalConfig != "" || overrideSiteConfig != "" || overrideExtSvcConfig != "" || overrideGlobalSettings != ""
 	if overrideAny || conf.IsDev(conf.DeployType()) {
 		raw, err := (&configurationSource{}).Read(ctx)
 		if err != nil {
@@ -80,6 +82,30 @@ func handleConfigOverrides() error {
 			err := (&configurationSource{}).Write(ctx, raw)
 			if err != nil {
 				return errors.Wrap(err, "writing critical/site config overrides to database")
+			}
+		}
+
+		if overrideGlobalSettings != "" {
+			globalSettingsBytes, err := ioutil.ReadFile(overrideGlobalSettings)
+			if err != nil {
+				return errors.Wrap(err, "reading GLOBAL_SETTINGS_FILE")
+			}
+			globalSettings := string(globalSettingsBytes)
+			currentSettings, err := db.Settings.GetLatest(ctx, api.SettingsSubject{Site: true})
+			if err != nil {
+				return errors.Wrap(err, "could not fetch current settings")
+			}
+			// Only overwrite the settings if the current settings differ or were created by a human
+			// user to prevent creating unnecessary rows in the DB.
+			if currentSettings.AuthorUserID != nil || currentSettings.Contents != globalSettings {
+				var lastID *int32 = nil
+				if currentSettings != nil {
+					lastID = &currentSettings.ID
+				}
+				_, err = db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{Site: true}, lastID, nil, string(globalSettings))
+				if err != nil {
+					return errors.Wrap(err, "writing global setting override to database")
+				}
 			}
 		}
 

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -102,7 +102,7 @@ func handleConfigOverrides() error {
 				if currentSettings != nil {
 					lastID = &currentSettings.ID
 				}
-				_, err = db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{Site: true}, lastID, nil, string(globalSettings))
+				_, err = db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{Site: true}, lastID, nil, globalSettings)
 				if err != nil {
 					return errors.Wrap(err, "writing global setting override to database")
 				}

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -96,6 +96,7 @@ func handleConfigOverrides() error {
 			}
 			// Only overwrite the settings if the current settings differ or were created by a human
 			// user to prevent creating unnecessary rows in the DB.
+			globalSettings := string(globalSettingsBytes)
 			if currentSettings.AuthorUserID != nil || currentSettings.Contents != globalSettings {
 				var lastID *int32 = nil
 				if currentSettings != nil {

--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,0 +1,3 @@
+{
+  // This is set from an environment variable
+}

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -75,7 +75,9 @@ export WEBPACK_DEV_SERVER=1
 
 export CRITICAL_CONFIG_FILE=${CRITICAL_CONFIG_FILE:-./dev/critical-config.json}
 export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-./dev/site-config.json}
+export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-./dev/global-settings.json}
 export SITE_CONFIG_ALLOW_EDITS=true
+export GLOBAL_SETTINGS_ALLOW_EDITS=true
 
 # WebApp
 export NODE_ENV=development

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -46,6 +46,18 @@ SITE_CONFIG_FILE=site.json
 
 If you want to _allow_ edits to be made through the web UI (which will be overwritten with what is in the file on a subsequent restart), you may additionally set `SITE_CONFIG_ALLOW_EDITS=true`. Note that if you do enable this, it is your responsibility to ensure the configuration on your instance and in the file remain in sync.
 
+#### Global settings
+
+Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
+
+```bash
+GLOBAL_SETTINGS_FILE=global-settings.json
+```
+
+`global-settings.json` contains the global settings, which you would otherwise edit through the in-app global settings editor.
+
+If you want to _allow_ edits to be made through the web UI (which will be overwritten with what is in the file on a subsequent restart), you may additionally set `GLOBAL_SETTINGS_ALLOW_EDITS=true`. Note that if you do enable this, it is your responsibility to ensure the global settings on your instance and in the file remain in sync.
+
 #### External service configuration
 
 Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -21,7 +21,9 @@ source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 export CRITICAL_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json
 export SITE_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json
 export EXTSVC_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json
+export GLOBAL_SETTINGS_FILE=$PWD/../dev/global-settings.json
 export SITE_CONFIG_ALLOW_EDITS=true
+export GLOBAL_SETTINGS_ALLOW_EDITS=true
 export EXTSVC_CONFIG_ALLOW_EDITS=true
 
 export WATCH_ADDITIONAL_GO_DIRS="$PWD/cmd $PWD/dev $PWD/internal"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/5014

Changelog description:
> Global settings can be configured from a local file using the environment variable `GLOBAL_SETTINGS_FILE`.

This is similar to `SITE_CONFIG_FILE` and `CRITICAL_CONFIG_FILE` but for global settings. See the docs ([in the diff](https://github.com/sourcegraph/sourcegraph/pull/7044/files#diff-cc5c4cfecc5a2eabbb0497aeccda1e2c)) for a complete description of what this does.

Please test the following:
- [ ] Setting `GLOBAL_SETTINGS_FILE` is reflected in the value of global settings in the UI.
- [ ] You can't edit the global settings in the UI if `GLOBAL_SETTINGS_FILE` is set.
- [ ] You *can* edit the global settings if `GLOBAL_SETTINGS_FILE` is set *and* `GLOBAL_SETTINGS_ALLOW_EDITS=true`.