### PR TITLE
ci: Move most multi-line commands into own script

### DIFF
--- a/dev/ci/docker-lint.sh
+++ b/dev/ci/docker-lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "--- install hadolint"
+curl -sL -o hadolint "https://github.com/hadolint/hadolint/releases/download/v1.15.0/hadolint-$(uname -s)-$(uname -m)"
+chmod 700 hadolint
+
+echo "--- hadolint"
+git ls-files | grep Dockerfile | xargs ./hadolint

--- a/dev/ci/go-build.sh
+++ b/dev/ci/go-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Seperate out time for go mod from go install
+echo "--- go mod download"
+go mod download
+
+echo "--- go generate"
+go generate ./...
+
+echo "--- go install"
+go install -tags dist ./cmd/... ./enterprise/cmd/...

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# For symbol tests
+echo "--- build libsqlite"
+./cmd/symbols/build.sh buildLibsqlite3Pcre
+
+# For searcher and replacer tests
+echo "--- comby install"
+./dev/comby-install-or-upgrade.sh
+
+# Seperate out time for go mod from go test
+echo "--- go mod download"
+go mod download
+
+echo "--- go test"
+go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -100,25 +100,21 @@ func addPostgresBackcompat(pipeline *bk.Pipeline) {
 // Adds the Go test step.
 func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go:",
-		bk.Cmd("./cmd/symbols/build.sh buildLibsqlite3Pcre"), // for symbols tests
-		bk.Cmd("./dev/comby-install-or-upgrade.sh"),          // for searcher and replacer tests
-		bk.Cmd("go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./..."),
+		bk.Cmd("./dev/ci/go-test.sh"),
 		bk.ArtifactPaths("coverage.txt"))
 }
 
 // Builds the OSS and Enterprise Go commands.
 func addGoBuild(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go:",
-		bk.Cmd("go generate ./..."),
-		bk.Cmd("go install -tags dist ./cmd/... ./enterprise/cmd/..."),
+		bk.Cmd("./dev/ci/go-build.sh"),
 	)
 }
 
 // Lints the Dockerfiles.
 func addDockerfileLint(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":docker:",
-		bk.Cmd("curl -sL -o hadolint \"https://github.com/hadolint/hadolint/releases/download/v1.15.0/hadolint-$(uname -s)-$(uname -m)\" && chmod 700 hadolint"),
-		bk.Cmd("git ls-files | grep Dockerfile | xargs ./hadolint"))
+		bk.Cmd("./dev/ci/docker-lint.sh"))
 }
 
 // Code coverage.


### PR DESCRIPTION
This will give us some timings in the logs per command run in the
step. Additionally this makes it easier for us to experiment with other CI
systems (if we choose to).