### PR TITLE
ci: Build server image

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -234,9 +234,7 @@ func addDockerImages(c Config) func(*bk.Pipeline) {
 	}
 }
 
-// Build Docker image for the service defined by `app`. The Sourcegraph Server Docker image is
-// special-cased, because it is built in another step as a candidate image, so we just need to tag
-// the candidate instead of rebuilding the image.
+// Build Docker image for the service defined by `app`.
 func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		cmds := []bk.StepOpt{
@@ -268,9 +266,6 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 		getBuildScript := func() string {
 			buildScriptByApp := map[string]string{
 				"symbols": "env BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImage",
-
-				// The server image was built prior to e2e tests in a previous step.
-				"server": fmt.Sprintf("docker tag %s:%s_candidate %s:%s", baseImage, c.version, baseImage, c.version),
 			}
 			if buildScript, ok := buildScriptByApp[app]; ok {
 				return buildScript


### PR DESCRIPTION
This was a regression from when we removed E2E from the normal CI
run. Previously we relied on the candidate image being built, now it isn't so
we need to build the server image.

Follow-up from https://github.com/sourcegraph/sourcegraph/pull/7027