### PR TITLE
ci: Use same buildkite message for e2e as PR

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -185,7 +185,7 @@ func triggerE2E(c Config) func(*bk.Pipeline) {
 			bk.Trigger("sourcegraph-e2e"),
 			bk.Async(!hardFail),
 			bk.Build(bk.BuildOptions{
-				Message: fmt.Sprintf("Test"),
+				Message: os.Getenv("BUILDKITE_MESSAGE"),
 				Commit:  c.commit,
 				Branch:  c.branch,
 				Env: copyEnv(


### PR DESCRIPTION
We are currently setting the title to "test" always. This will use the same title we use in the rest of buildkite, which is usually the commit title.