### PR TITLE
minversion: Lower to any go1.13

### DIFF
--- a/internal/version/minversion/minversion.go
+++ b/internal/version/minversion/minversion.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	minimumVersion := "1.13.5"
+	minimumVersion := "1.13"
 	rawVersion := runtime.Version()
 	versionNumber := strings.TrimPrefix(rawVersion, "go")
 	minimumVersionMet := version.Compare(minimumVersion, versionNumber, "<=")


### PR DESCRIPTION
minversion is for ensuring developers are on a version of go which doesn't
introduce problems locally. It doesn't need to match the version we use in
CI. Currently minversion is higher than what is available from brew. So this
PR just lowers it to the actual minversion required for development purposes.
