### PR TITLE
Fix "No results" banner showing up on every search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,5 +80,4 @@
       "changeProcessCWD": true,
     },
   ],
-  "go.inferGopath": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,4 +80,5 @@
       "changeProcessCWD": true,
     },
   ],
+  "go.inferGopath": false,
 }

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -55,7 +55,7 @@ export function search(
                             results {
                                 __typename
                                 limitHit
-                                resultCount
+                                matchCount
                                 approximateResultCount
                                 missing {
                                     name

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -300,9 +300,9 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         const query = params.get('q') || ''
 
         if (/count:(\d+)/.test(query)) {
-            return Math.max(results.resultCount * 2, 1000)
+            return Math.max(results.matchCount * 2, 1000)
         }
-        return Math.max(results.resultCount * 2 || 0, 1000)
+        return Math.max(results.matchCount * 2 || 0, 1000)
     }
 
     private onExpandAllResultsToggle = (): void => {

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -399,65 +399,63 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                     )}
 
                                     {/* Server-provided help message when there are no results*/}
-                                    {results.matchCount === 0 &&
-                                        (results.alert ? (
-                                            <div className="alert alert-info m-2">
-                                                <h3>
-                                                    <AlertCircleIcon className="icon-inline" /> {results.alert.title}
-                                                </h3>
-                                                <p>{results.alert.description}</p>
-                                                {results.alert.proposedQueries && (
-                                                    <>
-                                                        <h4>Did you mean:</h4>
-                                                        <ul className="list-unstyled">
-                                                            {results.alert.proposedQueries.map(proposedQuery => (
-                                                                <li key={proposedQuery.query}>
-                                                                    <Link
-                                                                        className="btn btn-secondary btn-sm"
-                                                                        to={
-                                                                            '/search?' +
-                                                                            buildSearchURLQuery(
-                                                                                proposedQuery.query,
-                                                                                this.props.patternType
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        {proposedQuery.query ||
-                                                                            proposedQuery.description}
-                                                                    </Link>
-                                                                    {proposedQuery.query &&
-                                                                        proposedQuery.description &&
-                                                                        ` — ${proposedQuery.description}`}
-                                                                </li>
-                                                            ))}
-                                                        </ul>
-                                                    </>
-                                                )}{' '}
-                                                {results.timedout.length === results.repositoriesCount &&
-                                                    /* All repositories timed out. */
-                                                    this.renderRecommendations(
-                                                        window.context.deployType !== 'cluster'
-                                                            ? [
-                                                                  <>
-                                                                      Upgrade to Sourcegraph Enterprise for a highly
-                                                                      scalable Kubernetes cluster deployment option.
-                                                                  </>,
-                                                                  window.context.likelyDockerOnMac
-                                                                      ? 'Use Docker Machine instead of Docker for Mac for better performance on macOS.'
-                                                                      : 'Contact your Sourcegraph administrator if you are seeing timeouts regularly, as more CPU, memory, or disk resources may need to be provisioned.',
-                                                              ]
-                                                            : []
-                                                    )}
-                                            </div>
-                                        ) : (
-                                            <>
-                                                <div className="alert alert-info d-flex m-2">
-                                                    <h3 className="m-0">
-                                                        <SearchIcon className="icon-inline" /> No results
-                                                    </h3>
-                                                </div>
-                                            </>
-                                        ))}
+                                    {results.alert && (
+                                        <div className="alert alert-info m-2">
+                                            <h3>
+                                                <AlertCircleIcon className="icon-inline" /> {results.alert.title}
+                                            </h3>
+                                            <p>{results.alert.description}</p>
+                                            {results.alert.proposedQueries && (
+                                                <>
+                                                    <h4>Did you mean:</h4>
+                                                    <ul className="list-unstyled">
+                                                        {results.alert.proposedQueries.map(proposedQuery => (
+                                                            <li key={proposedQuery.query}>
+                                                                <Link
+                                                                    className="btn btn-secondary btn-sm"
+                                                                    to={
+                                                                        '/search?' +
+                                                                        buildSearchURLQuery(
+                                                                            proposedQuery.query,
+                                                                            this.props.patternType
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {proposedQuery.query || proposedQuery.description}
+                                                                </Link>
+                                                                {proposedQuery.query &&
+                                                                    proposedQuery.description &&
+                                                                    ` — ${proposedQuery.description}`}
+                                                            </li>
+                                                        ))}
+                                                    </ul>
+                                                </>
+                                            )}{' '}
+                                            {results.timedout.length === results.repositoriesCount &&
+                                                /* All repositories timed out. */
+                                                this.renderRecommendations(
+                                                    window.context.deployType !== 'cluster'
+                                                        ? [
+                                                              <>
+                                                                  Upgrade to Sourcegraph Enterprise for a highly
+                                                                  scalable Kubernetes cluster deployment option.
+                                                              </>,
+                                                              window.context.likelyDockerOnMac
+                                                                  ? 'Use Docker Machine instead of Docker for Mac for better performance on macOS.'
+                                                                  : 'Contact your Sourcegraph administrator if you are seeing timeouts regularly, as more CPU, memory, or disk resources may need to be provisioned.',
+                                                          ]
+                                                        : []
+                                                )}
+                                        </div>
+                                    )}
+
+                                    {results.matchCount === 0 && (
+                                        <div className="alert alert-info d-flex m-2">
+                                            <h3 className="m-0">
+                                                <SearchIcon className="icon-inline" /> No results
+                                            </h3>
+                                        </div>
+                                    )}
                                 </>
                             )
                         })()

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -398,64 +398,66 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         </button>
                                     )}
 
-                                    {/* Server-provided help message */}
-                                    {results.alert ? (
-                                        <div className="alert alert-info m-2">
-                                            <h3>
-                                                <AlertCircleIcon className="icon-inline" /> {results.alert.title}
-                                            </h3>
-                                            <p>{results.alert.description}</p>
-                                            {results.alert.proposedQueries && (
-                                                <>
-                                                    <h4>Did you mean:</h4>
-                                                    <ul className="list-unstyled">
-                                                        {results.alert.proposedQueries.map(proposedQuery => (
-                                                            <li key={proposedQuery.query}>
-                                                                <Link
-                                                                    className="btn btn-secondary btn-sm"
-                                                                    to={
-                                                                        '/search?' +
-                                                                        buildSearchURLQuery(
-                                                                            proposedQuery.query,
-                                                                            this.props.patternType
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    {proposedQuery.query || proposedQuery.description}
-                                                                </Link>
-                                                                {proposedQuery.query &&
-                                                                    proposedQuery.description &&
-                                                                    ` — ${proposedQuery.description}`}
-                                                            </li>
-                                                        ))}
-                                                    </ul>
-                                                </>
-                                            )}{' '}
-                                            {results.timedout.length === results.repositoriesCount &&
-                                                /* All repositories timed out. */
-                                                this.renderRecommendations(
-                                                    window.context.deployType !== 'cluster'
-                                                        ? [
-                                                              <>
-                                                                  Upgrade to Sourcegraph Enterprise for a highly
-                                                                  scalable Kubernetes cluster deployment option.
-                                                              </>,
-                                                              window.context.likelyDockerOnMac
-                                                                  ? 'Use Docker Machine instead of Docker for Mac for better performance on macOS.'
-                                                                  : 'Contact your Sourcegraph administrator if you are seeing timeouts regularly, as more CPU, memory, or disk resources may need to be provisioned.',
-                                                          ]
-                                                        : []
-                                                )}
-                                        </div>
-                                    ) : (
-                                        <>
-                                            <div className="alert alert-info d-flex m-2">
-                                                <h3 className="m-0">
-                                                    <SearchIcon className="icon-inline" /> No results
+                                    {/* Server-provided help message when there are no results*/}
+                                    {results.matchCount === 0 &&
+                                        (results.alert ? (
+                                            <div className="alert alert-info m-2">
+                                                <h3>
+                                                    <AlertCircleIcon className="icon-inline" /> {results.alert.title}
                                                 </h3>
+                                                <p>{results.alert.description}</p>
+                                                {results.alert.proposedQueries && (
+                                                    <>
+                                                        <h4>Did you mean:</h4>
+                                                        <ul className="list-unstyled">
+                                                            {results.alert.proposedQueries.map(proposedQuery => (
+                                                                <li key={proposedQuery.query}>
+                                                                    <Link
+                                                                        className="btn btn-secondary btn-sm"
+                                                                        to={
+                                                                            '/search?' +
+                                                                            buildSearchURLQuery(
+                                                                                proposedQuery.query,
+                                                                                this.props.patternType
+                                                                            )
+                                                                        }
+                                                                    >
+                                                                        {proposedQuery.query ||
+                                                                            proposedQuery.description}
+                                                                    </Link>
+                                                                    {proposedQuery.query &&
+                                                                        proposedQuery.description &&
+                                                                        ` — ${proposedQuery.description}`}
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </>
+                                                )}{' '}
+                                                {results.timedout.length === results.repositoriesCount &&
+                                                    /* All repositories timed out. */
+                                                    this.renderRecommendations(
+                                                        window.context.deployType !== 'cluster'
+                                                            ? [
+                                                                  <>
+                                                                      Upgrade to Sourcegraph Enterprise for a highly
+                                                                      scalable Kubernetes cluster deployment option.
+                                                                  </>,
+                                                                  window.context.likelyDockerOnMac
+                                                                      ? 'Use Docker Machine instead of Docker for Mac for better performance on macOS.'
+                                                                      : 'Contact your Sourcegraph administrator if you are seeing timeouts regularly, as more CPU, memory, or disk resources may need to be provisioned.',
+                                                              ]
+                                                            : []
+                                                    )}
                                             </div>
-                                        </>
-                                    )}
+                                        ) : (
+                                            <>
+                                                <div className="alert alert-info d-flex m-2">
+                                                    <h3 className="m-0">
+                                                        <SearchIcon className="icon-inline" /> No results
+                                                    </h3>
+                                                </div>
+                                            </>
+                                        ))}
                                 </>
                             )
                         })()

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -449,7 +449,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         </div>
                                     )}
 
-                                    {results.matchCount === 0 && (
+                                    {results.matchCount === 0 && !results.alert && (
                                         <div className="alert alert-info d-flex m-2">
                                             <h3 className="m-0">
                                                 <SearchIcon className="icon-inline" /> No results

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -398,7 +398,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         </button>
                                     )}
 
-                                    {/* Server-provided help message when there are no results*/}
+                                    {/* Server-provided help message */}
                                     {results.alert && (
                                         <div className="alert alert-info m-2">
                                             <h3>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/7060

Also updates all callsites of the `resultCount` field on search to use `matchCount` as `resultCount` is apparently deprecated: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@531933ca9008089f37bc0af504672718998c3288/-/blob/cmd/frontend/graphqlbackend/schema.graphql#L1378-1379