### PR TITLE
release: fix sed command on macOS

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -18,6 +18,8 @@ import commandExists from 'command-exists'
 import { PullsCreateParams } from '@octokit/rest'
 import execa from 'execa'
 
+const sed = process.platform === 'linux' ? 'sed' : 'gsed'
+
 interface Config {
     teamEmail: string
 
@@ -312,7 +314,7 @@ Key dates:
                     head: `publish-${parsedVersion.version}`,
                     commitMessage: `Update latest release to ${parsedVersion.version}`,
                     bashEditCommands: [
-                        `find . -type f -name '*.md' -exec sed -i -E 's/sourcegraph\\/server:[0-9]+\\.[0-9]+\\.[0-9]+/sourcegraph\\/server:${parsedVersion.version}/g' {} +`,
+                        `find . -type f -name '*.md' -exec ${sed} -i -E 's/sourcegraph\\/server:[0-9]+\\.[0-9]+\\.[0-9]+/sourcegraph\\/server:${parsedVersion.version}/g' {} +`,
                         parsedVersion.patch === 0
                             ? `comby -in-place '{{$previousReleaseRevspec := ":[1]"}} {{$previousReleaseVersion := ":[2]"}} {{$currentReleaseRevspec := ":[3]"}} {{$currentReleaseVersion := ":[4]"}}' '{{$previousReleaseRevspec := ":[3]"}} {{$previousReleaseVersion := ":[4]"}} {{$currentReleaseRevspec := "v${parsedVersion.version}"}} {{$currentReleaseVersion := "${parsedVersion.major}.${parsedVersion.minor}"}}' doc/_resources/templates/document.html`
                             : `comby -in-place 'currentReleaseRevspec := ":[1]"' 'currentReleaseRevspec := "v${parsedVersion.version}"' doc/_resources/templates/document.html`,


### PR DESCRIPTION
Fix #7075

Tried to use comby, but it doesn't have a matcher for Markdown and I could not get it to match even simple strings. @rvantonder this may be by design, but cc'ing you in case you would like to support his use case.