### PR TITLE
Use thread-loader in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "style-loader": "^1.0.1",
     "stylelint": "^12.0.0",
     "terser-webpack-plugin": "^2.2.2",
+    "thread-loader": "^2.1.3",
     "ts-node": "^8.5.4",
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -106,6 +106,7 @@ const config = {
         test: /\.[jt]sx?$/,
         include: path.join(__dirname, 'src'),
         use: [
+          'thread-loader',
           {
             loader: 'babel-loader',
             options: {
@@ -128,6 +129,7 @@ const config = {
         test: /\.[jt]sx?$/,
         exclude: path.join(__dirname, 'src'),
         use: [
+          'thread-loader',
           {
             loader: 'babel-loader',
             options: {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -106,7 +106,7 @@ const config = {
         test: /\.[jt]sx?$/,
         include: path.join(__dirname, 'src'),
         use: [
-          'thread-loader',
+          ...(mode === 'production' ? ['thread-loader'] : []),
           {
             loader: 'babel-loader',
             options: {
@@ -129,7 +129,7 @@ const config = {
         test: /\.[jt]sx?$/,
         exclude: path.join(__dirname, 'src'),
         use: [
-          'thread-loader',
+          ...(mode === 'production' ? ['thread-loader'] : []),
           {
             loader: 'babel-loader',
             options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,7 +1766,8 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.0.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.1":
   version "3.0.1"
@@ -11683,7 +11684,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-runner@^2.4.0:
+loader-runner@^2.3.1, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -16754,7 +16755,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "23.0.1"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -17583,6 +17585,15 @@ thenify-all@^1.0.0:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+thread-loader@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz#cbd2c139fc2b2de6e9d28f62286ab770c1acbdda"
+  integrity sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==
+  dependencies:
+    loader-runner "^2.3.1"
+    loader-utils "^1.1.0"
+    neo-async "^2.6.0"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Test plan: 

We ran the pipeline 10 times and came to a conclusion that, compared to the latest 10 master builds, the webapp step takes on average
3:41 compared to 2:55 using `thread-loader`, which is a difference of 46s