### PR TITLE
search: fix critical regression which broke diff, commit, and repo search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -462,6 +463,10 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]SearchR
 		unflattened [][]*commitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
+	common.repos = make([]*types.Repo, len(args.Repos))
+	for i, repo := range args.Repos {
+		common.repos[i] = repo.Repo
+	}
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
@@ -523,6 +528,10 @@ func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]SearchRes
 		unflattened [][]*commitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
+	common.repos = make([]*types.Repo, len(args.Repos))
+	for i, repo := range args.Repos {
+		common.repos[i] = repo.Repo
+	}
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
 var mockSearchRepositories func(args *search.Args) ([]SearchResultResolver, *searchResultsCommon, error)
@@ -51,8 +52,10 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 
 	// Filter args.Repos by matching their names against the query pattern.
 	common = &searchResultsCommon{}
+	common.repos = make([]*types.Repo, len(args.Repos))
 	var repos []*search.RepositoryRevisions
-	for _, r := range args.Repos {
+	for i, r := range args.Repos {
+		common.repos[i] = r.Repo
 		if pattern.MatchString(string(r.Repo.Name)) {
 			repos = append(repos, r)
 		}


### PR DESCRIPTION
In #7020 I failed to properly test that my change did not affect other
search types sufficiently. I tested text and symbol search, but failed to
manually test that commit/diff/repo search were not negatively affected.

Our end-to-end tests, regeression tests, and release process failed here
which I have filed at #7102 for us to address so this does not happen
again.

The cause of this issue was that diff/commit/repo search all were incorrectly
implemented in such a way that they did not properly fill out in `searchResultsCommon`
exactly which repositories they searched. Before my change, this would've
been a bug in our GraphQL API but after my change we were relying on
this to identify when timeouts ocurred.

This PR fixes the true root cause by correcting the search functions so
that they properly indicate which repositories they searched in accordance
with the searchResultsCommon and GraphQL API spec.

A patch release 3.10.3 with this change will be released ASAP.

Fixes #7060

Test plan:Manually tested