### PR TITLE
ci: run dev/check/all.sh checks in parallel

### DIFF
--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -31,7 +31,7 @@ CHECKS=(
     ./check-owners.sh
 )
 
-echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job log that's printed after 'done'"
+echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"
 
 parallel_run {} ::: "${CHECKS[@]}"
 

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -7,8 +7,8 @@ parallel_run() {
     log_file=$(mktemp)
     trap "rm -rf $log_file" EXIT
 
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
-    echo "--- done"
+    parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
+    echo "--- done - displaying job log:"
     cat $log_file
 }
 
@@ -30,6 +30,8 @@ CHECKS=(
     ./bash-syntax.sh \
     ./check-owners.sh
 )
+
+echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job log that's printed after 'done'"
 
 parallel_run {} ::: "${CHECKS[@]}"
 

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -8,6 +8,7 @@ parallel_run() {
     trap "rm -rf $log_file" EXIT
 
     parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    echo "--- done"
     cat $log_file
 }
 
@@ -36,5 +37,3 @@ parallel_run {} ::: "${CHECKS[@]}"
 # downtime, not from broken URLs.
 #
 # ./broken-urls.bash
-
-echo "--- done"

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -3,21 +3,34 @@
 set -ex
 cd $(dirname "${BASH_SOURCE[0]}")
 
+parallel_run() {
+    log_file=$(mktemp)
+    trap "rm -rf $log_file" EXIT
+
+    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
+    cat $log_file
+}
+
 go version
 go env
-./yarn-deduplicate.sh
-./docsite.sh
-./gofmt.sh
-./template-inlines.sh
-./go-enterprise-import.sh
-./go-dbconn-import.sh
-./mgmt-console-conf-import.sh
-./go-generate.sh
-./go-lint.sh
-./todo-security.sh
-./no-localhost-guard.sh
-./bash-syntax.sh
-./check-owners.sh
+
+CHECKS=(
+    ./yarn-deduplicate.sh \
+    ./docsite.sh \
+    ./gofmt.sh \
+    ./template-inlines.sh \
+    ./go-enterprise-import.sh \
+    ./go-dbconn-import.sh \
+    ./mgmt-console-conf-import.sh \
+    ./go-generate.sh \
+    ./go-lint.sh \
+    ./todo-security.sh \
+    ./no-localhost-guard.sh \
+    ./bash-syntax.sh \
+    ./check-owners.sh
+)
+
+parallel_run {} ::: "${CHECKS[@]}"
 
 # TODO(sqs): Reenable this check when about.sourcegraph.com is reliable. Most failures come from its
 # downtime, not from broken URLs.


### PR DESCRIPTION
All of the steps in /dev/check/all.sh are independent, so we save >2 minutes in CI by running them in [parallel](https://en.wikipedia.org/wiki/GNU_parallel).