### PR TITLE
ci: refactor foreach-ts-project to run in parallel

### DIFF
--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -4,7 +4,34 @@ set -e
 unset CDPATH
 cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 
-for dir in web shared browser packages/sourcegraph-extension-api packages/@sourcegraph/extension-api-types lsif dev/release; do
-    echo "--- $dir: $@"
-    (set -x; cd "$dir" && "$@")
-done
+parallel_run() {
+    log_file=$(mktemp)
+    trap "rm -rf $log_file" EXIT
+
+    parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
+    echo "--- done - displaying job log:"
+    cat $log_file
+}
+
+export ARGS="$@"
+
+DIRS=(
+   web \
+   shared \
+   browser \
+   packages/sourcegraph-extension-api \
+   packages/@sourcegraph/extension-api-types \
+   lsif \
+   dev/release
+)
+
+run_command() {
+    dir=$1
+    echo "--- $dir: $ARGS"
+    (set -x; cd "$dir" && $ARGS)
+}
+export -f run_command
+
+echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"
+
+parallel_run run_command {} ::: "${DIRS[@]}"


### PR DESCRIPTION
This changes dev/foreach-ts-project.sh to run the commands it's given in parallel instead of sequentially. This seems to save ~1 minute for the build steps that use it (eslint, stylelint)