### PR TITLE
LSIF: allow auth via GITHUB_TOKEN from GitHub Actions

### DIFF
--- a/doc/user/code_intelligence/lsif_on_github.md
+++ b/doc/user/code_intelligence/lsif_on_github.md
@@ -30,8 +30,6 @@ jobs:
           verbose: "true"
       - name: Upload LSIF Data
         uses: sourcegraph/lsif-upload-action@master
-        with:
-          public_repo_github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}
 ```
 
 Once that workflow is committed to your repository, you will start to see LSIF workflows in the Actions tab of your repository (e.g. https://github.com/sourcegraph/sourcegraph/actions).

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -53,7 +53,7 @@ Possible errors include:
 
 ### Proving ownership of a GitHub repository
 
-If you're uploading to Sourcegraph.com or another Sourcegraph instance with [`lsifEnforceAuth`](https://docs.sourcegraph.com/admin/config/site_config#lsifEnforceAuth) enabled, you must prove that you own the GitHub repository in order to upload LSIF data for it. To do so, authenticate your upload by passing a GitHub access token with [`public_repo` scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) as `-github-token=abc...`. You can create' one at https://github.com/settings/tokens.
+If you're uploading to Sourcegraph.com or another Sourcegraph instance with [`lsifEnforceAuth`](https://docs.sourcegraph.com/admin/config/site_config#lsifEnforceAuth) enabled, you must prove that you own the GitHub repository in order to upload LSIF data for it. To do so, authenticate your upload by passing a GitHub App installation access token or a GitHub access token with [`public_repo` scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) as `-github-token=abc...`. You can create one at https://github.com/settings/tokens.
 
 ## 4. Test out code intelligence
 

--- a/enterprise/internal/codeintel/lsifserver/proxy/auth.go
+++ b/enterprise/internal/codeintel/lsifserver/proxy/auth.go
@@ -2,10 +2,12 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
@@ -46,15 +48,72 @@ func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Reque
 	}
 
 	client := github.NewClient(&githubURL, githubToken, nil)
-	repo, err := client.GetRepository(ctx, owner, name)
-	if err != nil {
-		return http.StatusNotFound, errors.Wrap(err, "unable to get repository permissions")
+
+	// There are 2 supported ways to authenticate the upload:
+	//
+	// 1. If the given token is a GitHub App installation token, then we use the
+	//
+	//    https://developer.github.com/v3/apps/installations/#list-repositories
+	//
+	//    endpoint to see if the associated GitHub App has been installed on the given repository.
+	//
+	//    One example of this is the built-in GITHUB_TOKEN in GitHub Actions:
+	//
+	//    https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret
+	//
+	// 2. If the given token is a personal access token, then we use the
+	//
+	//    https://developer.github.com/v3/repos/#get
+	//
+	//    endpoint to see if the user has write access to the given repository.
+	//
+	// We don't know which kind of token was provided, so we try authenticating
+	// the user via each in turn.
+
+	authViaGithubApp := func() error {
+		repos, err := client.ListInstallationRepositories(ctx)
+		if err != nil {
+			return err
+		}
+		for _, repo := range repos {
+			if repo.NameWithOwner == nameWithOwner {
+				return nil
+			}
+		}
+		return fmt.Errorf("given repository %s not listed in installed repositories", nameWithOwner)
 	}
 
-	switch repo.ViewerPermission {
-	case "ADMIN", "MAINTAIN", "WRITE":
-		return 0, nil
-	default:
-		return http.StatusUnauthorized, errors.New("you do not have write permission to the repository")
+	authViaReposEndpoint := func() error {
+		repo, err := client.GetRepository(ctx, owner, name)
+		if err != nil {
+			return errors.Wrap(err, "unable to get repository permissions")
+		}
+
+		switch repo.ViewerPermission {
+		case "ADMIN", "MAINTAIN", "WRITE":
+			return nil
+		default:
+			return errors.New("you do not have write permission to the repository")
+		}
 	}
+
+	err = nil
+	var authErr error
+
+	// Must try authenticating via GitHub App before the repos endpoint because
+	// the repos endpoint always reports no permissions with a GitHub App
+	// installation token.
+	authErr = authViaGithubApp()
+	if authErr == nil {
+		return 0, nil
+	}
+	err = multierror.Append(err, authErr)
+
+	authErr = authViaReposEndpoint()
+	if authErr == nil {
+		return 0, nil
+	}
+	err = multierror.Append(err, authErr)
+
+	return http.StatusUnauthorized, err
 }


### PR DESCRIPTION
This allows LSIF upload authentication via the built-in `GITHUB_TOKEN` in GitHub actions, which eliminates one more manual step from uploading LSIF through a GitHub action.

Unfortunately, this also allows uploads from **any** GitHub app installed on the given repository, **even ones with read-only access**. I haven't found a way to determine that the given token is associated with GitHub Actions and not some other random GitHub App. I also haven't found a zero-impact way to determine that the given token has write access to the repository. @sqs Is this acceptable?