### PR TITLE
use new stylelint extension for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "esbenp.prettier-vscode",
     "prisma.vscode-graphql",
     "ms-vscode.Go",
-    "shinnn.stylelint",
+    "hex-ci.stylelint-plus",
     "exiasr.hadolint",
     "bierner.markdown-mermaid",
     "zignd.html-css-class-completion",


### PR DESCRIPTION
According to https://github.com/stylelint/stylelint/pull/4438, the shinnn.stylelint extension was deleted because its creator abandoned it. The fork at https://marketplace.visualstudio.com/items?itemName=hex-ci.stylelint-plus is still maintained.

Fixes an issue where VS Code reports that one of the recommended workspace extensions does not exist in the VS Code extension marketplace.

- [ ] Blocked on https://github.com/hex-ci/vscode-stylelint-plus/issues/8