### PR TITLE
remove rarely used "Test plan:" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
 
 
 <!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
-
-Test plan: <!-- Required: What is the test plan for this change? -->


### PR DESCRIPTION
I've noticed that the `Test plan:` item in the PR template is rarely used. I would like to remove unused things to (1) reduce friction in common tasks and (2) make sure our *actual* practices are documented, not our *ideal* practices.

Only 5 of the last 33 merged PRs (excluding Renovate PRs) had test plans. Of those, only 1 actually had a true test plan, but it didn't use this template.

- https://github.com/sourcegraph/sourcegraph/pull/7103 (`Test plan:Manually tested`)
- https://github.com/sourcegraph/sourcegraph/pull/7098
- https://github.com/sourcegraph/sourcegraph/pull/7091 (`Test plan:`, i.e., it is empty, therefore not counted)
- https://github.com/sourcegraph/sourcegraph/pull/7053 (`Test plan: Manually tested`)
- https://github.com/sourcegraph/sourcegraph/pull/7044 (`Please test the following:`)
- https://github.com/sourcegraph/sourcegraph/pull/7039 (`Test plan: e2e tests`)