### PR TITLE
Clean up startup logs in `docker run` quickstart command

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -128,7 +128,7 @@ func Main() {
 		log.Fatal("Failed to setup nginx:", err)
 	}
 
-	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter`, dbutil.PostgresDSN("postgres", os.Getenv))
+	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("postgres", os.Getenv), os.Getenv("SRC_LOG_LEVEL"))
 
 	procfile := []string{
 		nginx,

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -28,6 +28,6 @@ func maybeZoektProcFile() []string {
 
 	return []string{
 		fmt.Sprintf("zoekt-indexserver: env GOGC=50 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
-		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
+		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s | grep -v 'listening on'", defaultHost, indexDir),
 	}
 }


### PR DESCRIPTION
This commit quiets the following log messages when running `cmd/server`:

```
21:41:56  postgres_exporter | time="2019-12-08T21:41:56Z" level=info msg="Established new database connection to \"127.0.0.1:5432\"." source="postgres_exporter.go:814"
21:41:56    zoekt-webserver | 2019/12/08 21:41:56 listening on 127.0.0.1:3070
21:41:57  postgres_exporter | time="2019-12-08T21:41:57Z" level=info msg="Established new database connection to \"127.0.0.1:5432\"." source="postgres_exporter.go:814"
21:41:57  postgres_exporter | time="2019-12-08T21:41:57Z" level=info msg="Semantic Version Changed on \"127.0.0.1:5432\": 0.0.0 -> 11.6.0" source="postgres_exporter.go:1335"
21:41:57  postgres_exporter | time="2019-12-08T21:41:57Z" level=info msg="Starting Server: :9187" source="postgres_exporter.go:1576"
21:41:58 management-console | t=2019-12-08T21:41:58+0000 lvl=info msg="management-console: listening" addr=:2633
21:41:58 management-console | 2019/12/08 21:41:58 Generating and using self-signed TLS cert/key
```

It also makes the management-console log message more easily readable.

Having clean log output for the `docker run` quickstart command is important to create a good first impression. Of course, we don't want to suppress any logs that are helpful, but I don't think any of the ones removed in this PR are actually helpful enough to merit being shown to all users at the default log level.