### PR TITLE
docs: update Digital Ocean installation instructions

### DIFF
--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -30,7 +30,7 @@ After initial setup, we recommend you do the following:
   should secure port `2633`, because this serves the Sourcegraph management console. We recommend
   you use [SSH port forwarding](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding) to
   access the management console after restricting it.
-* Set up [TLS/SSL](../../nginx#nginx-ssl-https-configuration) in the NGINX configuration.
+* Set up [TLS/SSL](../../nginx.md#nginx-ssl-https-configuration) in the NGINX configuration.
 
 ---
 

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -6,28 +6,31 @@ If you're just starting out, we recommend [installing Sourcegraph locally](index
 
 ---
 
-## Use the "Create Droplets" wizard
+## Run Sourcegraph on a Digital Ocean Droplet
 
-[Open your DigitalOcean dashboard](https://cloud.digitalocean.com/droplets/new) to create a new droplet
+1. [Create a new Digital Ocean Droplet](https://cloud.digitalocean.com/droplets/new). Set the
+   operating system to be Ubuntu 18.04. For droplet size, we recommend at least 4GB RAM and 2 CPU,
+   but you may need more depending on team size and number of repositories. We recommend you set up
+   SSH access (Authentication > SSH keys) for convenient access to the droplet.
+1. SSH into the droplet, and install Docker: `snap install docker`
+1. Run the Sourcegraph Docker image as a daemon:
 
-- **Choose an image -** Select the **One-click apps** tab and then choose Docker
-- **Choose a size -** We recommend at least 4GB RAM and 2 CPU, more depending on team size and number of repositories/languages enabled.
-- **Select additional options -** Check "User data" and paste in the following:
+   ```
+   docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.10.2
+   ```
+1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
+   DNS entry for the IP, configure `externalURL` to reflect that.
 
-  ```
-  #cloud-config
-  repo_update: true
-  repo_upgrade: all
+### After initialization
 
-  runcmd:
-  - mkdir -p /root/.sourcegraph/config
-  - mkdir -p /root/.sourcegraph/data
-  - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.10.4' ]
-  ```
+After initial setup, we recommend you do the following:
 
-- Launch your instance, then navigate to its IP address.
-
-- If you have configured a DNS entry for the IP, configure `externalURL` to reflect that. (Note: `externalURL` was called `appURL` in Sourcegraph 2.13 and earlier.)
+* Restrict the accessibility of ports other than `80` and `443` via [Cloud
+  Firewalls](https://www.digitalocean.com/docs/networking/firewalls/quickstart/). In particular, you
+  should secure port `2633`, because this serves the Sourcegraph management console. We recommend
+  you use [SSH port forwarding](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding) to
+  access the management console after restricting it.
+* Set up [TLS/SSL](../../nginx#nginx-ssl-https-configuration) in the NGINX configuration.
 
 ---
 

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -16,7 +16,7 @@ If you're just starting out, we recommend [installing Sourcegraph locally](index
 1. Run the Sourcegraph Docker image as a daemon:
 
    ```
-   docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.10.2
+   docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.10.4
    ```
 1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
    DNS entry for the IP, configure `externalURL` to reflect that.

--- a/doc/admin/nginx.md
+++ b/doc/admin/nginx.md
@@ -62,15 +62,12 @@ http {
 
 There are a few options:
 
-**[1. Generate a self-signed certificate](ssl_https_self_signed_cert_nginx.md)**<br />
-For instances that don't yet have certificate from a [globally trusted Certificate Authority (CA) provider](https://en.wikipedia.org/wiki/Certificate_authority#Providers).
-
-**[2. Generate a browser trusted certificate using Let's Encrypt (Certbot)](https://certbot.eff.org/)**<br />
+**[1. Generate a browser-trusted certificate using Let's Encrypt (Certbot)](https://certbot.eff.org/)**<br />
 
 1. On the Certbot homepage, select "Nginx" and the operating system of the machine hosting Sourcegraph.
 1. Follow the instructions to install and run Certbot.
-  1. If there is currently a process (e.g., Sourcegraph via Docker) listening on port 80, you'll
-     need to stop it before running Certbot. E.g.,
+  1. If there is currently a process (e.g., Sourcegraph) listening on port 80, you'll
+     need to stop it before running Certbot:
 
      ```
      docker rm -f $(docker ps | grep sourcegraph/server | awk '{ print $1 }')
@@ -80,8 +77,17 @@ For instances that don't yet have certificate from a [globally trusted Certifica
      `fullchain.pem`. These should be renamed to `sourcegraph.crt` and `sourcegraph.key` if you are
      using the `nginx.conf` template mentioned in this doc.
 
-**3. Proxy as a service**<br />
-Services such as [Cloudflare](https://www.cloudflare.com/ssl/) can handle the SSL connection from the browser/client, proxying requests to your Sourcegraph instance.
+**[2. Generate a self-signed certificate](ssl_https_self_signed_cert_nginx.md)**<br />
+
+For instances that don't yet have a certificate from a [globally trusted Certificate Authority (CA) provider](https://en.wikipedia.org/wiki/Certificate_authority#Providers).
+
+**3. Use your CDN's HTTPS proxy feature**<br />
+
+Some CDNs such as
+[Cloudflare](https://support.cloudflare.com/hc/en-us/articles/200170416-End-to-end-HTTPS-with-Cloudflare-Part-3-SSL-options)
+can handle the HTTPS connection from the user's browser while allowing the underlying service to
+continue serving HTTP (or HTTPS with a self-signed certificate). View your CDN's documentation for
+more details.
 
 ## Redirect to external HTTPS URL
 

--- a/doc/admin/nginx.md
+++ b/doc/admin/nginx.md
@@ -80,8 +80,8 @@ There are a few options:
      ```
   1. When you get to the step describing how to run Certbot, use the "certonly" command: `sudo certbot certonly --nginx`.
   1. When Certbot runs successfully, it will emit the key file `privkey.pem` and cert file
-     `fullchain.pem`. These should be renamed to `sourcegraph.crt` and `sourcegraph.key` if you are
-     using the `nginx.conf` template mentioned in this doc.
+     `fullchain.pem`. These should be renamed to `sourcegraph.key` and `sourcegraph.crt`,
+     respectively, if you are using the `nginx.conf` template mentioned in this doc.
   1. Kill the NGINX server that Certbot started: `killall nginx`. Restart Sourcegraph:
 
      ```

--- a/doc/admin/nginx.md
+++ b/doc/admin/nginx.md
@@ -48,12 +48,18 @@ http {
     }
 
     server {
-       ...
+        # Do not remove. The contents of sourcegraph_server.conf can change
+        # between versions and may include improvements to the configuration.
+        include nginx/sourcegraph_server.conf;
+
         listen 7443 ssl;
-        server_name sourcegraph.example.com;
+        server_name sourcegraph.example.com;  # change to your URL
         ssl_certificate         sourcegraph.crt;
         ssl_certificate_key     sourcegraph.key;
-        ...
+
+        location / {
+            ...
+        }
     }
 }
 ```
@@ -70,12 +76,22 @@ There are a few options:
      need to stop it before running Certbot:
 
      ```
-     docker rm -f $(docker ps | grep sourcegraph/server | awk '{ print $1 }')
+     docker stop $(docker ps | grep sourcegraph/server | awk '{ print $1 }')
      ```
-  1. When you get to the step describing how to run Certbot, use the "certonly" command.
+  1. When you get to the step describing how to run Certbot, use the "certonly" command: `sudo certbot certonly --nginx`.
   1. When Certbot runs successfully, it will emit the key file `privkey.pem` and cert file
      `fullchain.pem`. These should be renamed to `sourcegraph.crt` and `sourcegraph.key` if you are
      using the `nginx.conf` template mentioned in this doc.
+  1. Kill the NGINX server that Certbot started: `killall nginx`. Restart Sourcegraph:
+
+     ```
+     docker start $(docker ps -a | grep sourcegraph/server | awk '{ print $1 }')
+     ```
+  1. Now visit your Sourcegraph instance at `https://${YOUR_URL}`. If there are issues, debug by examining the Docker logs:
+
+     ```
+     docker logs $(docker ps | grep sourcegraph/server | awk '{ print $1 }')
+     ```
 
 **[2. Generate a self-signed certificate](ssl_https_self_signed_cert_nginx.md)**<br />
 

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -44,26 +44,23 @@ Run `sudo ls -la ~/.sourcegraph/config` and you should see the CA and SSL certif
 
 ## 3. Adding SSL support to NGINX
 
-Change the [default `~/.sourcegraph/config/nginx.conf`](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx.conf) by:
-
-**1.** Replacing `listen 7080;` with `listen 7080 ssl;`.
-
-**2.** Adding the following two lines below the `listen 7080 ssl;` statement.
-
-```nginx
-ssl_certificate         sourcegraph.crt;
-ssl_certificate_key     sourcegraph.key;
-```
-
-The `nginx.conf` should now look like:
+Edit the [default
+`~/.sourcegraph/config/nginx.conf`](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx.conf),
+so that port `7080` redirects to `7443` and `7443` is served with SSL. It should look like this:
 
 ```nginx
 ...
 http {
     ...
     server {
+        listen 7080;
+        return 301 https://$host:7433$request_uri;
+    }
+
+    server {
        ...
-        listen 7080 ssl;
+        listen 7443 ssl;
+        server_name sourcegraph.example.com;
         ssl_certificate         sourcegraph.crt;
         ssl_certificate_key     sourcegraph.key;
         ...
@@ -75,14 +72,15 @@ http {
 
 > NOTE: If the Sourcegraph container is still running, stop it before reading on.
 
-Now that NGINX is listening on port 443, we need the Sourcegraph container to listen on port 443 by adding `--publish 443:7080` to the `docker run` command:
+Now that NGINX is listening on port 7443, we need to configure the Sourcegraph container to forward
+443 to 7443 by adding `--publish 443:7443` to the `docker run` command:
 
 ```bash
 docker container run \
   --rm  \
   --publish 7080:7080 \
   --publish 2633:2633 \
-  --publish 443:7080 \
+  --publish 443:7443 \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -58,12 +58,18 @@ http {
     }
 
     server {
-       ...
+        # Do not remove. The contents of sourcegraph_server.conf can change
+        # between versions and may include improvements to the configuration.
+        include nginx/sourcegraph_server.conf;
+
         listen 7443 ssl;
-        server_name sourcegraph.example.com;
+        server_name sourcegraph.example.com;  # change to your URL
         ssl_certificate         sourcegraph.crt;
         ssl_certificate_key     sourcegraph.key;
-        ...
+
+        location / {
+            ...
+        }
     }
 }
 ```


### PR DESCRIPTION
Partially address https://github.com/sourcegraph/sourcegraph/issues/6652. Previously, the instructions did not yield a functioning instance.

This also changes docs to server HTTPS on port 433 (standard) rather than 80 (non-standard).

What remains to be done for #6652 is to test out the path for enabling IPv6.