### PR TITLE
ci: add --mutex network to all yarn installs

### DIFF
--- a/cmd/frontend/pre-build.sh
+++ b/cmd/frontend/pre-build.sh
@@ -4,7 +4,8 @@ cd $(dirname "${BASH_SOURCE[0]}")/../..
 
 # Build the webapp typescript code.
 echo "--- yarn"
-[[ -z "${CI}" ]] && yarn || yarn --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+[[ -z "${CI}" ]] && yarn --mutex network || yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 pushd web
 echo "--- yarn run build"

--- a/dev/check/yarn-deduplicate.sh
+++ b/dev/check/yarn-deduplicate.sh
@@ -5,7 +5,8 @@ echo "--- check yarn.lock for duplicates"
 
 # Prevent duplicates in yarn.lock/node_modules that lead to errors and bloated bundle sizes
 
-yarn --frozen-lockfile --ignore-scripts
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --ignore-scripts
 
 echo "Checking for duplicate dependencies in yarn.lock"
 yarn run -s yarn-deduplicate --fail --list --strategy fewer ./yarn.lock || {

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -58,7 +58,8 @@ set -e
 echo "Waiting for $URL... done"
 
 echo "--- yarn"
-yarn
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network
 
 echo "--- yarn run test-e2e"
 pushd web

--- a/dev/ci/yarn-build.sh
+++ b/dev/ci/yarn-build.sh
@@ -7,7 +7,8 @@ echo 'NODE_ENV='$NODE_ENV
 echo "# Note: NODE_ENV only used for build command"
 
 echo "--- yarn in root"
-NODE_ENV= yarn --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+NODE_ENV= yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 cd $1
 echo "--- browserslist"

--- a/dev/ci/yarn-run.sh
+++ b/dev/ci/yarn-run.sh
@@ -3,9 +3,10 @@
 set -e
 
 echo "--- yarn"
-yarn --frozen-lockfile --network-timeout 60000
-yarn --cwd lsif --frozen-lockfile --network-timeout 60000
-yarn --cwd dev/release --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --network-timeout 60000
+yarn --mutex network --cwd lsif --frozen-lockfile --network-timeout 60000
+yarn --mutex network --cwd dev/release --frozen-lockfile --network-timeout 60000
 
 for cmd in "$@"
 do

--- a/dev/ci/yarn-test-separate.sh
+++ b/dev/ci/yarn-test-separate.sh
@@ -3,11 +3,13 @@
 set -e
 
 echo "--- yarn in root"
-yarn --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 cd $1
 echo "--- yarn"
-yarn --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 echo "--- test"
 

--- a/dev/ci/yarn-test.sh
+++ b/dev/ci/yarn-test.sh
@@ -3,7 +3,8 @@
 set -e
 
 echo "--- yarn in root"
-yarn --frozen-lockfile --network-timeout 60000
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 cd $1
 echo "--- test"


### PR DESCRIPTION
We've made some recent improvements to CI so that it can run certain commands/scripts in parallel. Some of these parallelized scripts run `yarn` installs.

However, since then I've noticed some flaky `yarn` CI steps: https://buildkite.com/sourcegraph/sourcegraph/builds/50480#b996b624-73ef-4fa3-a0a3-6c5b96e700f4

This flakiness occurs because [`yarn`'s global cache isn't threadsafe](https://github.com/yarnpkg/yarn/issues/683). Using the [`yarn --mutex network`](https://yarnpkg.com/lang/en/docs/cli/#toc-concurrency-and-mutex) flag ensures that only one `yarn` install can run at a time - which should fix this issue. We already used this flag in our docker image build scripts, but this PR adds this flag to **all** the `yarn` installs that CI runs.