### PR TITLE
structural search: alert on large zip

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/zoekt"
 	zoektrpc "github.com/google/zoekt/rpc"
+	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
@@ -1168,6 +1169,51 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 			}
 			t.Fatalf("test %s, have result type: %q, want result type: %q", test.name, haveResultType, wantResultType)
 		}
+	}
+}
+
+func Test_ErrorToAlertConversion(t *testing.T) {
+	cases := []struct {
+		name           string
+		errors         []error
+		wantErrors     []error
+		wantAlertTitle string
+	}{
+		{
+			name:           "multierr_is_unaffected",
+			errors:         []error{errors.New("some error")},
+			wantErrors:     []error{errors.New("some error")},
+			wantAlertTitle: "",
+		},
+		{
+			name: "multierr_converts_zip_error",
+			errors: []error{
+				errors.New("some error"),
+				errors.New("Assert_failure zip"),
+				errors.New("some other error"),
+			},
+			wantErrors: []error{
+				errors.New("some error"),
+				errors.New("some other error"),
+			},
+			wantAlertTitle: "Repository too large for structural search",
+		},
+	}
+	for _, test := range cases {
+		multiErr := &multierror.Error{
+			Errors:      test.errors,
+			ErrorFormat: multierror.ListFormatFunc,
+		}
+		haveMultiErr, haveAlert := alertOnError(multiErr)
+
+		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
+			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
+		}
+
+		if haveAlert != nil && haveAlert.title != test.wantAlertTitle {
+			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
+		}
+
 	}
 }
 


### PR DESCRIPTION
Previously:
<img width="1016" alt="Screen Shot 2019-12-09 at 7 37 00 PM" src="https://user-images.githubusercontent.com/888624/70494583-0867f200-1ac9-11ea-8ea7-583362b7cf39.png">

This PR:

<img width="1227" alt="Screen Shot 2019-12-09 at 9 15 46 PM" src="https://user-images.githubusercontent.com/888624/70494594-1584e100-1ac9-11ea-9b5c-c9b8305d1806.png">

- The underlying issue is described and tracked in #7133.
- I added tests for the function that performs the conversion of error -> alert. A follow on PR can simplify this by having `searcher` send back a `searchAlert` directly. [See comment](https://github.com/sourcegraph/sourcegraph/pull/7134#discussion_r355848300).
