### PR TITLE
remove recommendation for deleted stylelint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "esbenp.prettier-vscode",
     "prisma.vscode-graphql",
     "ms-vscode.Go",
-    "shinnn.stylelint",
     "exiasr.hadolint",
     "bierner.markdown-mermaid",
     "zignd.html-css-class-completion",


### PR DESCRIPTION
According to https://github.com/stylelint/stylelint/pull/4438, the shinnn.stylelint extension was deleted because its creator abandoned it. The fork at https://marketplace.visualstudio.com/items?itemName=hex-ci.stylelint-plus is still maintained, but we can't use it because https://github.com/hex-ci/vscode-stylelint-plus/issues/8 means it would not support the newer version of the underlying stylelint tool and config we use.