### PR TITLE
use lowercase field names for GraphQL LanguageStatistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `NODE_NAME` can be specified instead of `HOSTNAME` for zoekt-indexserver. `HOSTNAME` was a confusing configuration to use in [Pure-Docker Sourcegraph deployments](https://github.com/sourcegraph/deploy-sourcegraph-docker). [#6846](https://github.com/sourcegraph/sourcegraph/issues/6846)
 - The feedback toast now requests feedback every 60 days of usage (was previously only once on the 3rd day of use). [#7165](https://github.com/sourcegraph/sourcegraph/pull/7165)
 - The lsif-server container now only has a dependency on Postgres, whereas before it also relied on Redis. [#6880](https://github.com/sourcegraph/sourcegraph/pull/6880)
+- Renamed the GraphQL API `LanguageStatistics` fields to `name`, `totalBytes`, and `totalLines` (previously the field names started with an uppercase letter, which was inconsistent).
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2344,14 +2344,16 @@ type GitCommitConnection {
     pageInfo: PageInfo!
 }
 
-# Statistics about a specific language
+# Statistics about a language's usage.
 type LanguageStatistics {
-    # The name of the programming language
-    Name: String!
-    # The total bytes of the language
-    TotalBytes: Float!
-    # The total lines of the language
-    TotalLines: Int!
+    # The name of the language.
+    name: String!
+
+    # The total bytes in the language.
+    totalBytes: Float!
+
+    # The total number of lines in the language.
+    totalLines: Int!
 }
 
 # A Git commit.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2351,14 +2351,16 @@ type GitCommitConnection {
     pageInfo: PageInfo!
 }
 
-# Statistics about a specific language
+# Statistics about a language's usage.
 type LanguageStatistics {
-    # The name of the programming language
-    Name: String!
-    # The total bytes of the language
-    TotalBytes: Float!
-    # The total lines of the language
-    TotalLines: Int!
+    # The name of the language.
+    name: String!
+
+    # The total bytes in the language.
+    totalBytes: Float!
+
+    # The total number of lines in the language.
+    totalLines: Int!
 }
 
 # A Git commit.


### PR DESCRIPTION
Lowercase field names are GraphQL standard and are what almost all other GraphQL types use. This breaks backcompat, but it is very easy to fix callers, and the error message they receive will actually suggest the fix (because our GraphQL library does spelled-like suggestions).