### PR TITLE
a8n: Increase default fetch timeout from 2s to 10s

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -32,7 +32,7 @@ import (
 
 // defaultFetchTimeout determines how long we wait for the replacer service to fetch
 // zip archives
-const defaultFetchTimeout = 2 * time.Second
+const defaultFetchTimeout = 10 * time.Second
 
 var schemas = map[string]string{
 	"comby":       schema.CombyCampaignTypeSchemaJSON,


### PR DESCRIPTION
Relevant Slack thread: https://sourcegraph.slack.com/archives/CMMTWQQ49/p1575934344362800

@christinaforney reported 503 errors when previewing a new campaign. We suspect that this is most probably due to `replacer`'s cache being empty and fetching the ZIPs from `gitserver` taking more than 2s.

2s was already pretty optimistic. So let's try 10s which should give us a lot more headroom without being problematic.
