### PR TITLE
Use `--silent` in npm script prettier-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prettier": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
-    "prettier-check": "npm run prettier --silent -- --write=false",
+    "prettier-check": "yarn -s run prettier --write=false",
     "all:eslint": "dev/foreach-ts-project.sh yarn -s run eslint",
     "all:tslint": "dev/foreach-ts-project.sh yarn -s run tslint",
     "all:stylelint": "yarn --cwd web run stylelint && yarn --cwd shared run stylelint && yarn --cwd browser run stylelint",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prettier": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
-    "prettier-check": "npm run prettier -- --write=false",
+    "prettier-check": "npm run prettier --silent -- --write=false",
     "all:eslint": "dev/foreach-ts-project.sh yarn -s run eslint",
     "all:tslint": "dev/foreach-ts-project.sh yarn -s run tslint",
     "all:stylelint": "yarn --cwd web run stylelint && yarn --cwd shared run stylelint && yarn --cwd browser run stylelint",


### PR DESCRIPTION
Without `--silent` the output of the command is incredibly noisy on CI:

<img width="1153" alt="prettier_check" src="https://user-images.githubusercontent.com/1185253/70524742-1a3baa80-1b46-11ea-9185-3e77249241ff.png">

And since it's a "check" command to make sure that everything's been formatted properly, we only want to know:

1. did it succeed or fail?
2. if it failed, which fails were not formatted?

With `--silent` we get all of that and can more easily spot which files  are wrongly formatted.

Before:

<img width="955" alt="prettier_check_before" src="https://user-images.githubusercontent.com/1185253/70524760-24f63f80-1b46-11ea-962e-a33fdfee053a.png">

After:

<img width="957" alt="prettier_check_after" src="https://user-images.githubusercontent.com/1185253/70524764-2889c680-1b46-11ea-8f0b-e4aff12310ff.png">