### PR TITLE
a8n: Allow listing all CampaignJobs/ChangesetJobs and avoid Year 10000 Looming Pagination Bug

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -110,7 +110,7 @@ func (s *Service) RunChangesetJobs(ctx context.Context, c *a8n.Campaign) error {
 	}()
 	jobs, _, err := s.store.ListChangesetJobs(ctx, ListChangesetJobsOpts{
 		CampaignID: c.ID,
-		Limit:      10000,
+		Limit:      -1,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -77,7 +77,7 @@ func (s *Service) CreateCampaign(ctx context.Context, c *a8n.Campaign) error {
 
 	jobs, _, err := tx.ListCampaignJobs(ctx, ListCampaignJobsOpts{
 		CampaignPlanID: c.CampaignPlanID,
-		Limit:          10000,
+		Limit:          -1,
 		OnlyFinished:   true,
 		OnlyWithDiff:   true,
 	})

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1779,7 +1779,7 @@ func (s *Store) ListCampaignJobs(ctx context.Context, opts ListCampaignJobsOpts)
 		return int64(c.ID), 1, err
 	})
 
-	if len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.Limit {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}
@@ -1805,7 +1805,6 @@ SELECT
 FROM campaign_jobs
 WHERE %s
 ORDER BY id ASC
-LIMIT %s
 `
 
 func listCampaignJobsQuery(opts *ListCampaignJobsOpts) *sqlf.Query {
@@ -1813,6 +1812,11 @@ func listCampaignJobsQuery(opts *ListCampaignJobsOpts) *sqlf.Query {
 		opts.Limit = defaultListLimit
 	}
 	opts.Limit++
+
+	var limitClause string
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+	}
 
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
@@ -1831,9 +1835,8 @@ func listCampaignJobsQuery(opts *ListCampaignJobsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listCampaignJobsQueryFmtstr,
+		listCampaignJobsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
-		opts.Limit,
 	)
 }
 

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1729,10 +1729,85 @@ func testStore(db *sql.DB) func(*testing.T) {
 			})
 
 			t.Run("List", func(t *testing.T) {
-				for i := 1; i <= len(changesetJobs); i++ {
-					opts := ListChangesetJobsOpts{CampaignID: int64(i)}
+				t.Run("WithCampaignID", func(t *testing.T) {
+					for i := 1; i <= len(changesetJobs); i++ {
+						opts := ListChangesetJobsOpts{CampaignID: int64(i)}
 
-					ts, next, err := s.ListChangesetJobs(ctx, opts)
+						ts, next, err := s.ListChangesetJobs(ctx, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						if have, want := next, int64(0); have != want {
+							t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+						}
+
+						have, want := ts, changesetJobs[i-1:i]
+						if len(have) != len(want) {
+							t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
+						}
+
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatalf("opts: %+v, diff: %s", opts, diff)
+						}
+					}
+				})
+
+				t.Run("WithPositiveLimit", func(t *testing.T) {
+					for i := 1; i <= len(changesetJobs); i++ {
+						cs, next, err := s.ListChangesetJobs(ctx, ListChangesetJobsOpts{Limit: i})
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						{
+							have, want := next, int64(0)
+							if i < len(changesetJobs) {
+								want = changesetJobs[i].ID
+							}
+
+							if have != want {
+								t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+							}
+						}
+
+						{
+							have, want := cs, changesetJobs[:i]
+							if len(have) != len(want) {
+								t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
+							}
+
+							if diff := cmp.Diff(have, want); diff != "" {
+								t.Fatal(diff)
+							}
+						}
+					}
+				})
+
+				t.Run("WithNegativeLimitToListAll", func(t *testing.T) {
+					cs, next, err := s.ListChangesetJobs(ctx, ListChangesetJobsOpts{Limit: -1})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if have, want := next, int64(0); have != want {
+						t.Fatalf("have next %v, want %v", have, want)
+					}
+
+					have, want := cs, changesetJobs
+					if len(have) != len(want) {
+						t.Fatalf("listed %d campaignJobs, want: %d", len(have), len(want))
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
+				t.Run("EmptyResultListingAll", func(t *testing.T) {
+					opts := ListChangesetJobsOpts{CampaignID: 99999, Limit: -1}
+
+					cs, next, err := s.ListChangesetJobs(ctx, opts)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1741,46 +1816,12 @@ func testStore(db *sql.DB) func(*testing.T) {
 						t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
 					}
 
-					have, want := ts, changesetJobs[i-1:i]
-					if len(have) != len(want) {
-						t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
+					if len(cs) != 0 {
+						t.Fatalf("listed %d jobs, want: %d", len(cs), 0)
 					}
+				})
 
-					if diff := cmp.Diff(have, want); diff != "" {
-						t.Fatalf("opts: %+v, diff: %s", opts, diff)
-					}
-				}
-
-				for i := 1; i <= len(changesetJobs); i++ {
-					cs, next, err := s.ListChangesetJobs(ctx, ListChangesetJobsOpts{Limit: i})
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					{
-						have, want := next, int64(0)
-						if i < len(changesetJobs) {
-							want = changesetJobs[i].ID
-						}
-
-						if have != want {
-							t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
-						}
-					}
-
-					{
-						have, want := cs, changesetJobs[:i]
-						if len(have) != len(want) {
-							t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
-						}
-
-						if diff := cmp.Diff(have, want); diff != "" {
-							t.Fatal(diff)
-						}
-					}
-				}
-
-				{
+				t.Run("WithCursor", func(t *testing.T) {
 					var cursor int64
 					for i := 1; i <= len(changesetJobs); i++ {
 						opts := ListChangesetJobsOpts{Cursor: cursor, Limit: 1}
@@ -1796,7 +1837,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 						cursor = next
 					}
-				}
+				})
 			})
 
 			t.Run("Update", func(t *testing.T) {


### PR DESCRIPTION
This fixes the [Year 10000 Looming Pagination Bug](https://github.com/sourcegraph/sourcegraph/pull/7127#discussion_r355986213) and removes another thing from our #6572 list.
