### PR TITLE
tests: bump 500ms fetch timeout to 2s

### DIFF
--- a/cmd/replacer/replace/replace_test.go
+++ b/cmd/replacer/replace/replace_test.go
@@ -64,7 +64,7 @@ func main() {
 			URL:                  "u",
 			Commit:               "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			RewriteSpecification: test.arg,
-			FetchTimeout:         "500ms",
+			FetchTimeout:         "2000ms",
 		}
 		got, err := doReplace(ts.URL, &req)
 		if err != nil {

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -198,7 +198,7 @@ main.go:7:}
 				URL:          "u",
 				Commit:       "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				PatternInfo:  test.arg,
-				FetchTimeout: "500ms",
+				FetchTimeout: "2000ms",
 			}
 			m, err := doSearch(ts.URL, &req)
 			if err != nil {


### PR DESCRIPTION
Bumping a fetch timeout causing replacer tests to fail: https://github.com/sourcegraph/sourcegraph/issues/5721#issuecomment-563959437

Adding a personal note: this test code has not been flaky for the last 6 months, so it's unclear why this is happening now.
