### PR TITLE
dev/release: properly use gsed on mac OS

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -297,7 +297,7 @@ Key dates:
             if (parsedVersion.prerelease.length > 0) {
                 throw new Error(`version ${version} is pre-release`)
             }
-            const requiredCommands = ['comby', 'sed', 'find']
+            const requiredCommands = ['comby', sed, 'find']
             for (const cmd of requiredCommands) {
                 try {
                     await commandExists(cmd)
@@ -330,7 +330,7 @@ Key dates:
                     head: `publish-${parsedVersion.version}`,
                     commitMessage: `Update latest release to ${parsedVersion.version}`,
                     bashEditCommands: [
-                        `sed -i -E 's/export SOURCEGRAPH_VERSION=[0-9]+\\.[0-9]+\\.[0-9]+/export SOURCEGRAPH_VERSION=${parsedVersion.version}/g' resources/user-data.sh`,
+                        `${sed} -i -E 's/export SOURCEGRAPH_VERSION=[0-9]+\\.[0-9]+\\.[0-9]+/export SOURCEGRAPH_VERSION=${parsedVersion.version}/g' resources/user-data.sh`,
                     ],
                     title: `Update latest release to ${parsedVersion.version}`,
                 },
@@ -341,7 +341,7 @@ Key dates:
                     head: `publish-${parsedVersion.version}`,
                     commitMessage: `Update latest release to ${parsedVersion.version}`,
                     bashEditCommands: [
-                        `sed -i -E 's/export SOURCEGRAPH_VERSION=[0-9]+\\.[0-9]+\\.[0-9]+/export SOURCEGRAPH_VERSION=${parsedVersion.version}/g' resources/user-data.sh`,
+                        `${sed} -i -E 's/export SOURCEGRAPH_VERSION=[0-9]+\\.[0-9]+\\.[0-9]+/export SOURCEGRAPH_VERSION=${parsedVersion.version}/g' resources/user-data.sh`,
                     ],
                     title: `Update latest release to ${parsedVersion.version}`,
                 },


### PR DESCRIPTION
This was broken before, so I finally fixed it.

I had to `yarn run build` the scripts again, it doesn't happen automatically and was easy to forget to do. I don't know how to solve this. Maybe there should be a wrapper script around the yarn script which invokes `yarn run build` first? I defer this to you.