### PR TITLE
LSIF: Add commit to LSIF query resolver. 

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -88,6 +88,7 @@ type LSIFJobConnectionResolver interface {
 }
 
 type LSIFQueryResolver interface {
+	Commit(ctx context.Context) (*GitCommitResolver, error)
 	Definitions(ctx context.Context, args *LSIFQueryPositionArgs) (LocationConnectionResolver, error)
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2668,6 +2668,14 @@ type LSIFQueryResolver {
     # (experimental) The LSIF API may change substantially in the near future as we
     # continue to adjust it for our use cases. Changes will not be documented in the
     # CHANGELOG during this time.
+    # The commit that is being used to power code intelligence. This may be distinct from
+    # the commit of the git blob from which this query resolver came when there is no
+    # LSIF data available for that commit.
+    commit: GitCommit!
+
+    # (experimental) The LSIF API may change substantially in the near future as we
+    # continue to adjust it for our use cases. Changes will not be documented in the
+    # CHANGELOG during this time.
     # A list of definitions of the symbol under the given document position.
     definitions(
         # The line on which the symbol occurs (zero-based, inclusive).

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2675,6 +2675,14 @@ type LSIFQueryResolver {
     # (experimental) The LSIF API may change substantially in the near future as we
     # continue to adjust it for our use cases. Changes will not be documented in the
     # CHANGELOG during this time.
+    # The commit that is being used to power code intelligence. This may be distinct from
+    # the commit of the git blob from which this query resolver came when there is no
+    # LSIF data available for that commit.
+    commit: GitCommit!
+
+    # (experimental) The LSIF API may change substantially in the near future as we
+    # continue to adjust it for our use cases. Changes will not be documented in the
+    # CHANGELOG during this time.
     # A list of definitions of the symbol under the given document position.
     definitions(
         # The line on which the symbol occurs (zero-based, inclusive).

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -8,8 +8,10 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/go-lsp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/lsifserver/client"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lsif"
 )
 
@@ -21,6 +23,18 @@ type lsifQueryResolver struct {
 }
 
 var _ graphqlbackend.LSIFQueryResolver = &lsifQueryResolver{}
+
+func (r *lsifQueryResolver) Commit(ctx context.Context) (*graphqlbackend.GitCommitResolver, error) {
+	repo, err := backend.Repos.GetByName(ctx, api.RepoName(r.repoName))
+	if err != nil {
+		return nil, err
+	}
+
+	return graphqlbackend.NewRepositoryResolver(repo).Commit(
+		ctx,
+		&graphqlbackend.RepositoryCommitArgs{Rev: string(r.dump.Commit)},
+	)
+}
 
 func (r *lsifQueryResolver) Definitions(ctx context.Context, args *graphqlbackend.LSIFQueryPositionArgs) (graphqlbackend.LocationConnectionResolver, error) {
 	opt := LocationsQueryOptions{


### PR DESCRIPTION
Add a commit resolver to the LSIF query resolver under GitBlob.