### PR TITLE
replacer: Send FetchTimeout in tests

### DIFF
--- a/cmd/replacer/replace/replace_test.go
+++ b/cmd/replacer/replace/replace_test.go
@@ -123,6 +123,7 @@ func doReplace(u string, p *protocol.Request) (string, error) {
 		"Repo":            []string{string(p.Repo)},
 		"URL":             []string{string(p.URL)},
 		"Commit":          []string{string(p.Commit)},
+		"FetchTimeout":    []string{p.FetchTimeout},
 		"MatchTemplate":   []string{p.RewriteSpecification.MatchTemplate},
 		"RewriteTemplate": []string{p.RewriteSpecification.RewriteTemplate},
 		"FileExtension":   []string{p.RewriteSpecification.FileExtension},


### PR DESCRIPTION
The previous adjustment to FetchTimeout was a noop since we didn't send it.