### PR TITLE
a8n: Allow closing of changesets on codehosts when deleting campaign

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -49,7 +49,8 @@ type CancelCampaignPlanArgs struct {
 }
 
 type DeleteCampaignArgs struct {
-	Campaign graphql.ID
+	Campaign        graphql.ID
+	CloseChangesets bool
 }
 
 type RetryCampaignArgs struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -66,7 +66,13 @@ type Mutation {
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.
     retryCampaign(campaign: ID!): Campaign!
     # Deletes a campaign.
-    deleteCampaign(campaign: ID!): EmptyResponse
+    deleteCampaign(
+        campaign: ID!
+        # Whether to close the changesets associated with this campaign on their
+        # respective codehosts, where "close" means the appropriate final state
+        # on the codehost (e.g. "declined" on Bitbucket Server).
+        closeChangesets: Boolean = false
+    ): EmptyResponse
     # Closes a campaign.
     # Closing a campaign sets the Campaign's ClosedAt timestamp to the current
     # time and, if closeChangesets = true, closes associated changesets on the

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -68,7 +68,13 @@ type Mutation {
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.
     retryCampaign(campaign: ID!): Campaign!
     # Deletes a campaign.
-    deleteCampaign(campaign: ID!): EmptyResponse
+    deleteCampaign(
+        campaign: ID!
+        # Whether to close the changesets associated with this campaign on their
+        # respective codehosts, where "close" means the appropriate final state
+        # on the codehost (e.g. "declined" on Bitbucket Server).
+        closeChangesets: Boolean = false
+    ): EmptyResponse
     # Closes a campaign.
     # Closing a campaign sets the Campaign's ClosedAt timestamp to the current
     # time and, if closeChangesets = true, closes associated changesets on the

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -277,46 +277,9 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	// If we don't have to close the changesets, we can simply delete the
-	// Campaign and return. The triggers in the database will remove the
-	// campaign's ID from the changesets' CampaignIDs.
-	if args.CloseChangesets {
-		err := r.store.DeleteCampaign(ctx, campaignID)
-		return &graphqlbackend.EmptyResponse{}, err
-	}
-
-	// First load the Changesets with the given campaignID, before deleting
-	// the campaign would remove the association.
-	cs, _, err := r.store.ListChangesets(ctx, ee.ListChangesetsOpts{
-		CampaignID: campaignID,
-		Limit:      -1,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Remove the association manually, since we'll update the Changesets in
-	// the database, after closing them and we can't update them with an
-	// invalid CampaignID.
-	for _, c := range cs {
-		c.RemoveCampaignID(campaignID)
-	}
-
-	err = r.store.DeleteCampaign(ctx, campaignID)
-	if err != nil {
-		return nil, err
-	}
-
 	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
-	go func() {
-		ctx := trace.ContextWithTrace(context.Background(), tr)
-		err := svc.CloseOpenChangesets(ctx, cs)
-		if err != nil {
-			log15.Error("CloseCampaignChangesets", "err", err)
-		}
-	}()
-
-	return &graphqlbackend.EmptyResponse{}, nil
+	err = svc.DeleteCampaign(ctx, campaignID, args.CloseChangesets)
+	return &graphqlbackend.EmptyResponse{}, err
 }
 
 func (r *Resolver) RetryCampaign(ctx context.Context, args *graphqlbackend.RetryCampaignArgs) (graphqlbackend.CampaignResolver, error) {

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -335,7 +335,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64) (campaign *a8n.Ca
 // Campaign will be closed on the codehosts.
 func (s *Service) DeleteCampaign(ctx context.Context, id int64, closeChangesets bool) (err error) {
 	traceTitle := fmt.Sprintf("campaign: %d, closeChangesets: %t", id, closeChangesets)
-	tr, ctx := trace.New(ctx, "service.runChangeSetJob", traceTitle)
+	tr, ctx := trace.New(ctx, "service.DeleteCampaign", traceTitle)
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -352,7 +352,7 @@ func (s *Service) DeleteCampaign(ctx context.Context, id int64, closeChangesets 
 	// the campaign would remove the association.
 	cs, _, err := s.store.ListChangesets(ctx, ListChangesetsOpts{
 		CampaignID: id,
-		Limit:      10000,
+		Limit:      -1,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -408,7 +408,7 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs []*a8n.Changeset) 
 		return err
 	}
 
-	var errs *multierror.Error
+	errs := &multierror.Error{}
 	for _, s := range bySource {
 		for _, c := range s.Changesets {
 			if err := s.CloseChangeset(ctx, c); err != nil {

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -330,15 +330,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64) (campaign *a8n.Ca
 	return campaign, nil
 }
 
-func (s *Service) CloseOpenCampaignChangesets(ctx context.Context, c *a8n.Campaign) (err error) {
-	cs, _, err := s.store.ListChangesets(ctx, ListChangesetsOpts{
-		CampaignID: c.ID,
-		Limit:      10000,
-	})
-	if err != nil {
-		return err
-	}
-
+func (s *Service) CloseOpenChangesets(ctx context.Context, cs []*a8n.Changeset) (err error) {
 	cs = selectChangesets(cs, func(c *a8n.Changeset) bool {
 		s, err := c.State()
 		if err != nil {

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -227,6 +227,16 @@ func (t *Changeset) Clone() *Changeset {
 	return &tt
 }
 
+// RemoveCampaignID removes the given id from the Changesets CampaignIDs slice.
+// If the id is not in CampaignIDs calling this method doesn't have an effect.
+func (t *Changeset) RemoveCampaignID(id int64) {
+	for i := len(t.CampaignIDs) - 1; i >= 0; i-- {
+		if t.CampaignIDs[i] == id {
+			t.CampaignIDs = append(t.CampaignIDs[:i], t.CampaignIDs[i+1:]...)
+		}
+	}
+}
+
 // Title of the Changeset.
 func (t *Changeset) Title() (string, error) {
 	switch m := t.Metadata.(type) {


### PR DESCRIPTION
This PR contains the mirror implementation of #7127 for the `deleteCampaign` mutation. When specifying `closeChangesets` the mutation will close the changesets on the codehost after deleting the Campaign on Sourcegraph.

It also contains a refactoring of the `closeCampaign` mutation: I moved the logic into the `a8n.Service.CloseCampaign` method so that it's closer to the implementation of `DeleteCampaign` and we don't have more business logic lying around in the resolver.