### PR TITLE
a8n: Bump defaultFetchTimeout from 10s to 30s

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -32,7 +32,7 @@ import (
 
 // defaultFetchTimeout determines how long we wait for the replacer service to fetch
 // zip archives
-const defaultFetchTimeout = 10 * time.Second
+const defaultFetchTimeout = 30 * time.Second
 
 var schemas = map[string]string{
 	"comby":       schema.CombyCampaignTypeSchemaJSON,


### PR DESCRIPTION
After I ran into a few 503 errors returned from `replacer`, I decided to take a closer look.

With a cold cache (`rm -r /tmp/replacer-archives/*`) and running over all ~180 repositories in my Sourcegraph instance, the 10 slowest ZIP-fetch requests take between 2 and 12 seconds:

    $ awk '{print $3}' < ~/work/comby_logs_180_repos.txt | sort -g | tail -n 10
    2.894504976
    3.152952589
    3.920574042
    4.536477702
    4.707850896
    5.56331578
    5.8037550719999995
    6.3973531
    7.639939148
    12.110905126

After bumping the timeout to 30s I haven't run into any timeouts and since I don't see a reason why we shouldn't increase it, let's use 30s.