### PR TITLE
Show SurveyToast every 60 active days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - `repohascommitafter:` search filter uses a more efficient git command to determine inclusion. [#6739](https://github.com/sourcegraph/sourcegraph/pull/6739)
 - `NODE_NAME` can be specified instead of `HOSTNAME` for zoekt-indexserver. `HOSTNAME` was a confusing configuration to use in [Pure-Docker Sourcegraph deployments](https://github.com/sourcegraph/deploy-sourcegraph-docker). [#6846](https://github.com/sourcegraph/sourcegraph/issues/6846)
+- The feedback toast now requests feedback every 60 days of usage (was previously only once on the 3rd day of use). [#7165](https://github.com/sourcegraph/sourcegraph/pull/7165)
 
 ### Fixed
 

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -41,6 +41,7 @@ import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
 import { parseBrowserRepoURL } from './util/url'
 import LiteralSearchToast from './marketing/LiteralSearchToast'
+import { SurveyToast } from './marketing/SurveyToast'
 import { ThemeProps } from '../../shared/src/theme'
 import { ThemePreferenceProps } from './search/theme'
 import { KeyboardShortcutsProps, KEYBOARD_SHORTCUT_SHOW_HELP } from './keyboardShortcuts/keyboardShortcuts'
@@ -130,6 +131,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             {!needsSiteInit && !isSiteInit && !!props.authenticatedUser && (
                 <IntegrationsToast history={props.history} />
             )}
+            {!isSiteInit && <SurveyToast authenticatedUser={props.authenticatedUser} />}
             {!isSiteInit && <LiteralSearchToast isSourcegraphDotCom={props.isSourcegraphDotCom} />}
             {!isSiteInit && <GlobalNavbar {...props} lowProfile={isSearchHomepage} />}
             {needsSiteInit && !isSiteInit && <Redirect to="/site-admin/init" />}

--- a/web/src/marketing/SurveyToast.tsx
+++ b/web/src/marketing/SurveyToast.tsx
@@ -62,10 +62,13 @@ export class SurveyToast extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
         this.state = {
-            visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount === 3,
+            visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 60 === 3,
         }
         if (this.state.visible) {
             eventLogger.log('SurveyReminderViewed', { marketing: { sessionCount: daysActiveCount } })
+        } else if (daysActiveCount % 60 === 0) {
+            // Reset toast dismissal 3 days before it will be shown
+            localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'false')
         }
     }
 

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -16,7 +16,6 @@ import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { HeroPage } from '../components/HeroPage'
 import { ChromeExtensionToast } from '../marketing/BrowserExtensionToast'
-import { SurveyToast } from '../marketing/SurveyToast'
 import { IS_CHROME } from '../marketing/util'
 import { ThemeProps } from '../../../shared/src/theme'
 import { EventLoggerProps } from '../tracking/eventLogger'
@@ -229,7 +228,6 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
         return (
             <div className="repo-rev-container">
                 {IS_CHROME && <ChromeExtensionToast />}
-                <SurveyToast authenticatedUser={this.props.authenticatedUser} />
                 <RepoHeaderContributionPortal
                     position="nav"
                     priority={100}


### PR DESCRIPTION
We would like to get more frequent feedback from our users. Currently, we only show the survey toast on the third day of using the product. This means that we're asking for feedback early in their usage, but aren't following up to see if that changes over time. We don't want to bother users too frequently, so only showing each 60 days of usage will make sure it is not happening too frequently and will likely be a frequency of ~1x/quarter. 

- Show survey toast on all pages (not just a code view page) to avoid users missing it by not going to the right page that day
- Show survey toast every 60 days of activity

There are longer term improvements that I would like to make here, but this is a quick win to allow users to share feedback with us more regularly.