### PR TITLE
Add help page, reroute help to documentation

### DIFF
--- a/cmd/frontend/internal/app/ui/documentation.go
+++ b/cmd/frontend/internal/app/ui/documentation.go
@@ -10,12 +10,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-// serveHelp redirects to documentation pages on https://docs.sourcegraph.com for the current
+// serveDocumentation redirects to documentation pages on https://docs.sourcegraph.com for the current
 // product version, i.e., /help/PATH -> https://docs.sourcegraph.com/@VERSION/PATH. In unreleased
 // development builds (whose docs aren't necessarily available on https://docs.sourcegraph.com, it
 // shows a message with instructions on how to see the docs.)
-func serveHelp(w http.ResponseWriter, r *http.Request) {
-	page := strings.TrimPrefix(r.URL.Path, "/help")
+func serveDocumentation(w http.ResponseWriter, r *http.Request) {
+	page := strings.TrimPrefix(r.URL.Path, "/documentation")
 	versionStr := version.Version()
 
 	// For release builds, use the version string. Otherwise, don't use any version string because:

--- a/cmd/frontend/internal/app/ui/documentation_test.go
+++ b/cmd/frontend/internal/app/ui/documentation_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-func TestServeHelp(t *testing.T) {
+func TestServeDocumentation(t *testing.T) {
 	t.Run("unreleased dev version", func(t *testing.T) {
 		{
 			orig := envvar.SourcegraphDotComMode()
@@ -25,8 +25,8 @@ func TestServeHelp(t *testing.T) {
 
 		rw := httptest.NewRecorder()
 		rw.Body = new(bytes.Buffer)
-		req, _ := http.NewRequest("GET", "/help/foo/bar", nil)
-		serveHelp(rw, req)
+		req, _ := http.NewRequest("GET", "/documentation/foo/bar", nil)
+		serveDocumentation(rw, req)
 
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
@@ -49,8 +49,8 @@ func TestServeHelp(t *testing.T) {
 		}
 
 		rw := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/help/foo/bar", nil)
-		serveHelp(rw, req)
+		req, _ := http.NewRequest("GET", "/documentation/foo/bar", nil)
+		serveDocumentation(rw, req)
 
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
@@ -66,8 +66,8 @@ func TestServeHelp(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 
 		rw := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/help/foo/bar", nil)
-		serveHelp(rw, req)
+		req, _ := http.NewRequest("GET", "/documentation/foo/bar", nil)
+		serveDocumentation(rw, req)
 
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -65,6 +65,7 @@ const (
 	routeRegistry       = "registry"
 	routeExtensions     = "extensions"
 	routeHelp           = "help"
+	routeDocumentation  = "documentation"
 	routeExplore        = "explore"
 	routeWelcome        = "welcome"
 	routeSnippets       = "snippets"
@@ -140,6 +141,7 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/registry").Methods("GET").Name(routeRegistry)
 	r.PathPrefix("/extensions").Methods("GET").Name(routeExtensions)
 	r.PathPrefix("/help").Methods("GET").Name(routeHelp)
+	r.PathPrefix("/documentation").Methods("GET").Name(routeDocumentation)
 	r.PathPrefix("/explore").Methods("GET").Name(routeExplore)
 	r.PathPrefix("/snippets").Methods("GET").Name(routeSnippets)
 	r.PathPrefix("/subscriptions").Methods("GET").Name(routeSubscriptions)
@@ -225,7 +227,8 @@ func initRouter() {
 	router.Get(routeRegistry).Handler(handler(serveBrandedPageString("Registry")))
 	router.Get(routeExtensions).Handler(handler(serveBrandedPageString("Extensions")))
 	router.Get(routeExplore).Handler(handler(serveBrandedPageString("Explore")))
-	router.Get(routeHelp).HandlerFunc(serveHelp)
+	router.Get(routeHelp).Handler(handler(serveBrandedPageString("Help")))
+	router.Get(routeDocumentation).HandlerFunc(serveDocumentation)
 	router.Get(routeSnippets).Handler(handler(serveBrandedPageString("Snippets")))
 	router.Get(routeSubscriptions).Handler(handler(serveBrandedPageString("Subscriptions")))
 

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -252,6 +252,7 @@ body,
 @import './components/AnimatedAlert';
 @import './components/DismissibleAlert';
 @import './marketing/SurveyPage';
+@import './marketing/HelpPage';
 @import './components/SingleValueCard';
 @import './repo/blob/discussions/DiscussionsTree';
 @import './components/SearchResult';

--- a/web/src/marketing/HelpPage.scss
+++ b/web/src/marketing/HelpPage.scss
@@ -1,0 +1,14 @@
+.help-content {
+    max-width: calc(100vw - 2rem);
+    padding-top: 2rem;
+    text-align: left;
+    width: 30rem;
+
+    h3 {
+        padding-top: 2rem;
+    }
+}
+
+.help-page {
+    width: 100%;
+}

--- a/web/src/marketing/HelpPage.tsx
+++ b/web/src/marketing/HelpPage.tsx
@@ -1,40 +1,77 @@
 import * as React from 'react'
-import { RouteComponentProps } from 'react-router'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { ThemeProps } from '../../../shared/src/theme'
 import HelpCircleIcon from 'mdi-react/HelpCircleIcon'
+import { Link } from '../../../shared/src/components/Link'
 
-interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
+interface Props extends ThemeProps {
     authenticatedUser: GQL.IUser | null
+    showDotComMarketing: boolean
 }
 
-export class HelpPage extends React.Component<SurveyPageProps> {
+export class HelpPage extends React.Component<Props> {
     public componentDidMount(): void {
         eventLogger.logViewEvent('Help')
     }
 
     public render(): JSX.Element | null {
         return (
-            <div className="survey-page">
+            <div className="help-page">
                 <PageTitle title="Help" />
                 <HeroPage
                     icon={HelpCircleIcon}
-                    title="Need Help?"
+                    title="Looking for answers?"
                     body={
-                        <div>
+                        <div className="help-content">
                             <div>
-                                <p>Reach out to support if you have a question.</p>
+                                We have many different resources available to help answer any questions you may have:
+                            </div>
+                            {!this.props.showDotComMarketing && (
+                                <div>
+                                    <h3>Email support</h3>
+                                    Have a question about your custom setup? Need help scaling your instance? File a
+                                    support ticket by emailing us at{' '}
+                                    <Link to="mailto:support@sourcegraph.com">support@sourcegraph.com</Link>
+                                </div>
+                            )}
+                            <div>
+                                <h3>File a GitHub issue</h3>
+                                We are an{' '}
+                                <a href="https://about.sourcegraph.com/company/open_source_open_company">
+                                    open company
+                                </a>
+                                , so our{' '}
+                                <a href="https://github.com/sourcegraph/sourcegraph/issues">issue tracker on GitHub</a>{' '}
+                                is available to the public. Look to see if there is already an issue filed, or feel free
+                                to{' '}
+                                <a href="https://github.com/sourcegraph/sourcegraph/issues/new/choose">file an issue</a>{' '}
+                                with feature requests, bug reports, or product enhancements!
                             </div>
                             <div>
+                                <h3>Search our documentation</h3>
+                                Our <Link to="/documentation">documentation</Link> has information that can help you
+                                with any questions you have about using the product, setup, and configuration. If you
+                                notice that something is missing in our docs please let us know or even submit a pull
+                                request with an update!
+                            </div>
+                            <div>
+                                <h3>Submit product feedback</h3>
                                 <p>
-                                    Take a look at our <a href="/documentation">documentation</a>.
+                                    We love hearing from our users! Send us your product feedback, ideas, and feature
+                                    requests. This form is especially useful for anyone wishing to stay anonymous to the
+                                    public with any requests.
                                 </p>
-                            </div>
-                            <div>
-                                <p>Send us your product feedback, ideas, and feature requests.</p>
+                                <Link
+                                    to={`https://share.hsforms.com/1kZm78wx9QiGpjRRrHEcapA1n7ku?site_id=${window.context.siteID}&email=${this.props.authenticatedUser.email}`}
+                                    className="btn btn-secondary"
+                                    // eslint-disable-next-line react/jsx-no-target-blank
+                                    target="_blank"
+                                >
+                                    Share feedback
+                                </Link>
                             </div>
                         </div>
                     }

--- a/web/src/marketing/HelpPage.tsx
+++ b/web/src/marketing/HelpPage.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { RouteComponentProps } from 'react-router'
+import * as GQL from '../../../shared/src/graphql/schema'
+import { HeroPage } from '../components/HeroPage'
+import { PageTitle } from '../components/PageTitle'
+import { eventLogger } from '../tracking/eventLogger'
+import { ThemeProps } from '../../../shared/src/theme'
+import HelpCircleIcon from 'mdi-react/HelpCircleIcon'
+
+interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
+    authenticatedUser: GQL.IUser | null
+}
+
+export class HelpPage extends React.Component<SurveyPageProps> {
+    public componentDidMount(): void {
+        eventLogger.logViewEvent('Help')
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <div className="survey-page">
+                <PageTitle title="Help" />
+                <HeroPage
+                    icon={HelpCircleIcon}
+                    title="Need Help?"
+                    body={
+                        <div>
+                            <div>
+                                <p>Reach out to support if you have a question.</p>
+                            </div>
+                            <div>
+                                <p>
+                                    Take a look at our <a href="/documentation">documentation</a>.
+                                </p>
+                            </div>
+                            <div>
+                                <p>Send us your product feedback, ideas, and feature requests.</p>
+                            </div>
+                        </div>
+                    }
+                />
+            </div>
+        )
+    }
+}

--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -131,13 +131,16 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                     {this.props.showDotComMarketing ? (
                         // eslint-disable-next-line react/jsx-no-target-blank
                         <a href="https://docs.sourcegraph.com" target="_blank" className="dropdown-item">
-                            Help
+                            Documentation
                         </a>
                     ) : (
-                        <Link to="/help" className="dropdown-item">
-                            Help
+                        <Link to="/documentation" className="dropdown-item">
+                            Documentation
                         </Link>
                     )}
+                    <Link to="/help" className="dropdown-item">
+                        Help
+                    </Link>
                     {this.props.authenticatedUser.session && this.props.authenticatedUser.session.canSignOut && (
                         <a href="/-/sign-out" className="dropdown-item">
                             Sign out

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -168,6 +168,21 @@ export const routes: readonly LayoutRouteProps[] = [
         render: lazyComponent(() => import('./marketing/HelpPage'), 'HelpPage'),
     },
     {
+        path: '/documentation',
+        render: () => {
+            // Force a hard reload so that we delegate to the HTTP handler for /documentation, which handles
+            // redirecting /documentation to https://docs.sourcegraph.com. That logic is not duplicated in
+            // the web app because that would add complexity with no user benefit.
+            //
+            // TODO(sqs): This currently has a bug in dev mode where you can't go back to the app
+            // after following the redirect. This will be fixed when we run docsite on
+            // http://localhost:5080 in Procfile because then the redirect will be cross-domain and
+            // won't reuse the same history stack.
+            window.location.reload()
+            return null
+        },
+    },
+    {
         path: '/snippets',
         render: lazyComponent(() => import('./snippets/SnippetsPage'), 'SnippetsPage'),
     },

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -165,18 +165,7 @@ export const routes: readonly LayoutRouteProps[] = [
     },
     {
         path: '/help',
-        render: () => {
-            // Force a hard reload so that we delegate to the HTTP handler for /help, which handles
-            // redirecting /help to https://docs.sourcegraph.com. That logic is not duplicated in
-            // the web app because that would add complexity with no user benefit.
-            //
-            // TODO(sqs): This currently has a bug in dev mode where you can't go back to the app
-            // after following the redirect. This will be fixed when we run docsite on
-            // http://localhost:5080 in Procfile because then the redirect will be cross-domain and
-            // won't reuse the same history stack.
-            window.location.reload()
-            return null
-        },
+        render: lazyComponent(() => import('./marketing/HelpPage'), 'HelpPage'),
     },
     {
         path: '/snippets',


### PR DESCRIPTION
We would like to surface more information to our users who are having trouble finding information. This change introduces a help page that has information for them to figure out the best place to go for help. It also includes a new link to a [product feedback form](https://share.hsforms.com/1kZm78wx9QiGpjRRrHEcapA1n7ku) in Hubspot. For now, this form will just be an external url and open a new tab, we will eventually build this into the product in a more thorough way (like the NPS forms).

![image](https://user-images.githubusercontent.com/1559622/70672461-2e5dd580-1c34-11ea-9055-88232e2db59f.png)

This change also moves the functionality that used to occur with the `/help` path and changes this to `/documentation` which is a more accurate representation of where you will end up.

I would love feedback on the copy/messaging. One idea I was considering was making the primary action for each section to be a secondary button (like the form submission). 

Question for the @sourcegraph/web team - I couldn't figure out when we're supposed to use a `<Link>` object vs. an a tag `<a href="">` for the links. Let me know what is best practice so I can update consistently!