### PR TITLE
a8n: Make campaign branch names globally unique

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -177,8 +176,7 @@ func (s *Service) runChangesetJob(
 	}
 	repo := rs[0]
 
-	// TODO: This should be globally unique
-	headRefName := "sourcegraph/campaign-" + strconv.FormatInt(c.ID, 10)
+	headRefName := fmt.Sprintf("sourcegraph/%s-%d", git.HumanReadableBranchName(c.Name), c.CreatedAt.Unix())
 
 	_, err = s.git.CreateCommitFromPatch(ctx, protocol.CreateCommitFromPatchRequest{
 		Repo:       api.RepoName(repo.Name),

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/RoaringBitmap/roaring v0.4.21
+	github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774
 	github.com/aws/aws-sdk-go-v2 v0.17.0
 	github.com/beevik/etree v1.1.0
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
@@ -126,6 +127,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/procfs v0.0.7 // indirect
+	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be
 	github.com/russellhaering/gosaml2 v0.3.2-0.20190403162508-649841e7f48a
 	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774 h1:HrMVYtly2IVqg9EBooHsakQ256ueojP7QuG32K71X/U=
+github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774/go.mod h1:5wi5YYOpfuAKwL5XLFYopbgIl/v7NZxaJpa/4X6yFKE=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.17.0 h1:b/9gp0SD6doAWv72f3ZwzFJSsWmUw9dM8wMNmf6OBws=
 github.com/aws/aws-sdk-go-v2 v0.17.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
@@ -689,6 +691,8 @@ github.com/prometheus/procfs v0.0.7 h1:RS5GAlMbnkWkhs4+bPocMTmGjYkuCY5djjqEDdXOh
 github.com/prometheus/procfs v0.0.7/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
+github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=
+github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -9,12 +9,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avelino/slugify"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/rainycape/unidecode"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
+
+// HumanReadableBranchName returns a human readable branch name from the
+// given text. It replaces unicode characters with their ASCII equivalent
+// or similar and connects each component with a dash.
+//
+// Example: "Change coördination mechanism" -> "change-coordination-mechanism"
+func HumanReadableBranchName(text string) string {
+	return slugify.Slugify(unidecode.Unidecode(text))
+}
 
 // EnsureRefPrefix checks whether the ref is a full ref and contains the
 // "refs/heads" prefix (i.e. "refs/heads/master") or just an abbreviated ref

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -25,7 +25,22 @@ import (
 //
 // Example: "Change coördination mechanism" -> "change-coordination-mechanism"
 func HumanReadableBranchName(text string) string {
-	return slugify.Slugify(unidecode.Unidecode(text))
+	name := slugify.Slugify(unidecode.Unidecode(text))
+
+	const length = 60
+	if len(name) <= length {
+		return name
+	}
+
+	// Find the last word separator so we don't cut in the middle of a word.
+	// If the word separator is found in the very first part of the name we don't
+	// cut there because it'd leave out too much of it.
+	sep := strings.LastIndexByte(name[:length], '-')
+	if sep >= 0 && float32(sep)/float32(length) >= 0.2 {
+		return name[:sep]
+	}
+
+	return name[:length]
 }
 
 // EnsureRefPrefix checks whether the ref is a full ref and contains the

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -13,12 +13,26 @@ import (
 )
 
 func TestHumanReadableBranchName(t *testing.T) {
-	text := "Change coördination mechanism"
-	have := git.HumanReadableBranchName(text)
-	want := "change-coordination-mechanism"
-
-	if have != want {
-		t.Fatalf("HumanReadableBranchName(%q): have %q, want %q", text, have, want)
+	for _, tc := range []struct {
+		text string
+		want string
+	}{{
+		// Respect word boundaries when cutting length
+		text: "Change coördination mechanisms of fungible automation processes in place",
+		want: "change-coordination-mechanisms-of-fungible-automation",
+	}, {
+		// Length smaller than maximum
+		text: "Change coördination mechanisms",
+		want: "change-coordination-mechanisms",
+	}, {
+		// Respecting word boundary would result in cutting too much,
+		// so we don't.
+		text: "Change alongwordmadeofmanylettersandnumbersandsymbolsandwhatnotisthisalreadymorethansixtyrunes",
+		want: "change-alongwordmadeofmanylettersandnumbersandsymbolsandwhat",
+	}} {
+		if have := git.HumanReadableBranchName(tc.text); have != tc.want {
+			t.Fatalf("HumanReadableBranchName(%q):\nhave %q\nwant %q", tc.text, have, tc.want)
+		}
 	}
 }
 

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
+func TestHumanReadableBranchName(t *testing.T) {
+	text := "Change coördination mechanism"
+	have := git.HumanReadableBranchName(text)
+	want := "change-coordination-mechanism"
+
+	if have != want {
+		t.Fatalf("HumanReadableBranchName(%q): have %q, want %q", text, have, want)
+	}
+}
+
 func TestRepository_ListBranches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This commit makes campaign branch names globally unique and human
friendly at the same time. We convert the campaign name to an ASCII slug
and append the created at timestamp in unix seconds.

Using randomness in the name would prevent the retry mechanism to work
since we'd end up with a different headRefName in each attempt.

Fixes #7088
