### PR TITLE
tidy: remove redundant Sprintf

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -79,8 +79,8 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 	}
 	if len(repoFilters) == 0 && len(repoGroupFilters) > 1 {
 		return &searchAlert{
-			title:       fmt.Sprintf("Repository groups have no repositories in common"),
-			description: fmt.Sprintf("No repository exists in all of the specified repository groups."),
+			title:       "Repository groups have no repositories in common",
+			description: "No repository exists in all of the specified repository groups.",
 		}, nil
 	}
 

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -72,7 +72,7 @@ func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend
 }
 
 func (r *lsifQueryResolver) Hover(ctx context.Context, args *graphqlbackend.LSIFQueryPositionArgs) (graphqlbackend.HoverResolver, error) {
-	path := fmt.Sprintf("/hover")
+	path := "/hover"
 	values := url.Values{}
 	values.Set("repository", r.repoName)
 	values.Set("commit", string(r.commit))

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"strconv"
 


### PR DESCRIPTION
If the argument to `Sprintf` is just a constant string, we can remove the call.

Created wit

```json
{
    "scopeQuery": "repo:github.com/sourcegraph/sourcegraph",
    "matchTemplate": "fmt.Sprintf(\":[args]\")",
    "rewriteTemplate": "\":[args]\""
}
```