### PR TITLE
tidy: convert Fprintf to Fprintln when possible

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -47,12 +47,12 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	}
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
-		fmt.Fprintf(&b, "results:\n")
+		fmt.Fprintln(&b, "results:")
 		for i, result := range r.results {
 			fm, _ := result.ToFileMatch()
 			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.Repo.Name, fm.JPath)
 		}
-		fmt.Fprintf(&b, "common.repos:\n")
+		fmt.Fprintln(&b, "common.repos:")
 		for i, r := range r.common.repos {
 			fmt.Fprintf(&b, "	[%d] %s\n", i, r.Name)
 		}

--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -137,8 +137,8 @@ func maybeUpgradePostgres(path, newVersion string) (err error) {
 	hostDataDir, err := hostMountPoint(ctx, cli, id, dataDir)
 	switch {
 	case docker.IsErrConnectionFailed(err):
-		fmt.Fprintf(os.Stderr, "\n    Docker socket must be mounted for the automatic upgrade of the internal database to proceed.\n")
-		fmt.Fprintf(os.Stderr, " 👉 docker run ... -v /var/run/docker.sock:/var/run/docker.sock:ro ...\n\n")
+		fmt.Fprintln(os.Stderr, "\n    Docker socket must be mounted for the automatic upgrade of the internal database to proceed.")
+		fmt.Fprintln(os.Stderr, " 👉 docker run ... -v /var/run/docker.sock:/var/run/docker.sock:ro ...\n")
 		return errors.New("Docker socket volume mount is missing")
 	case err != nil:
 		return errors.Wrap(err, "failed to determine host mount point")

--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -137,8 +137,8 @@ func maybeUpgradePostgres(path, newVersion string) (err error) {
 	hostDataDir, err := hostMountPoint(ctx, cli, id, dataDir)
 	switch {
 	case docker.IsErrConnectionFailed(err):
-		fmt.Fprintln(os.Stderr, "\n    Docker socket must be mounted for the automatic upgrade of the internal database to proceed.")
-		fmt.Fprintln(os.Stderr, " 👉 docker run ... -v /var/run/docker.sock:/var/run/docker.sock:ro ...\n")
+		fmt.Fprint(os.Stderr, "\n    Docker socket must be mounted for the automatic upgrade of the internal database to proceed.\n")
+		fmt.Fprint(os.Stderr, " 👉 docker run ... -v /var/run/docker.sock:/var/run/docker.sock:ro ...\n\n")
 		return errors.New("Docker socket volume mount is missing")
 	case err != nil:
 		return errors.Wrap(err, "failed to determine host mount point")

--- a/internal/debugserver/expvar.go
+++ b/internal/debugserver/expvar.go
@@ -13,16 +13,16 @@ import (
 // can be mounted on any ServeMux, not just http.DefaultServeMux.
 func expvarHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\n")
+	fmt.Fprintln(w, "{")
 	first := true
 	expvar.Do(func(kv expvar.KeyValue) {
 		if !first {
-			fmt.Fprintf(w, ",\n")
+			fmt.Fprintln(w, ",")
 		}
 		first = false
 		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
 	})
-	fmt.Fprintf(w, "\n}\n")
+	fmt.Fprintln(w, "\n}")
 }
 
 func gcHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When the second argument to `Fprintf` contains no format specifiers (AKA "verbs"), use `Fprint` instead.

In our codebase, every pattern that matched the above also contains a `\n` at the end of the string, so we can further simplify the above and say that:

- if the string also ends with `\n`, use `Fprintln` instead.

Created with:

```json
{
    "scopeQuery": "repo:github.com/sourcegraph/sourcegraph$",
    "matchTemplate":   "fmt.Fprintf(:[1], \":[2]\\n\")",
    "rewriteTemplate": "fmt.Fprintln(:[1], \":[2]\")"
}
```