### PR TITLE
LSIF: update workflow to use built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -16,5 +16,5 @@ jobs:
         uses: sourcegraph/lsif-upload-action@master
         continue-on-error: true
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           file: cmd/dump.lsif
-          github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}


### PR DESCRIPTION
Now that the built-in GITHUB_TOKEN is supported sourcegraph/sourcegraph#7114, we can use that instead of the manually-generated token.

Should get merged in tandem with https://github.com/sourcegraph/lsif-upload-action/pull/13