### PR TITLE
search: infer file extensions from lang scope

### DIFF
--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -213,3 +213,25 @@ func TestHighlightMultipleLines(t *testing.T) {
 		})
 	}
 }
+
+func TestInferExtensions(t *testing.T) {
+	cases := []struct {
+		Name    string
+		Pattern []string
+		Want    []string
+	}{
+		{
+			Name:    "C language extensions",
+			Pattern: []string{`\.c$|\.cats$|\.h$|\.idc$`},
+			Want:    []string{".c", ".cats", ".h", ".idc"},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			got := inferExtensions(tt.Pattern)
+			if !reflect.DeepEqual(got, tt.Want) {
+				t.Errorf("got: %s, want: %s", got, tt.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When `lang:c` or such is specified, a regex pattern like `\.c$|\.cats$|\.h$|\.idc$` populates `includePatterns`. This PR heuristically converts the patterns to file extensions like `.c` and `.h`, which `comby` can use to infer the language.

Note that _without_ the `lang` specifier, `comby` will infer the language based on the first file to search as returned by Zoekt, so this PR is just a heuristic that ensures that the `lang` keyword is honored.