### PR TITLE
search: structural search rule support

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -740,6 +740,11 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 		}
 	}
 
+	var combyRule []string
+	for _, v := range r.query.Values(query.FieldCombyRule) {
+		combyRule = append(combyRule, asString(v))
+	}
+
 	// Handle lang: and -lang: filters.
 	langIncludePatterns, langExcludePatterns, err := langIncludeExcludePatterns(r.query.StringValues(query.FieldLang))
 	if err != nil {
@@ -759,6 +764,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 		FilePatternsReposMustExclude: filePatternsReposMustExclude,
 		PathPatternsAreRegExps:       true,
 		PathPatternsAreCaseSensitive: r.query.IsCaseSensitive(),
+		CombyRule:                    strings.Join(combyRule, ""),
 	}
 	if len(excludePatterns) > 0 {
 		patternInfo.ExcludePattern = unionRegExps(excludePatterns)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -194,6 +194,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 		"ExcludePattern":  []string{p.ExcludePattern},
 		"IncludePatterns": p.IncludePatterns,
 		"FetchTimeout":    []string{fetchTimeout.String()},
+		"CombyRule":       []string{p.CombyRule},
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		t, err := deadline.MarshalText()

--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -32,11 +32,12 @@ const (
 	FieldMessage   = "message"
 
 	// Temporary experimental fields:
-	FieldIndex   = "index"
-	FieldCount   = "count" // Searches that specify `count:` will fetch at least that number of results, or the full result set
-	FieldMax     = "max"   // Deprecated alias for count
-	FieldTimeout = "timeout"
-	FieldReplace = "replace"
+	FieldIndex     = "index"
+	FieldCount     = "count" // Searches that specify `count:` will fetch at least that number of results, or the full result set
+	FieldMax       = "max"   // Deprecated alias for count
+	FieldTimeout   = "timeout"
+	FieldReplace   = "replace"
+	FieldCombyRule = "rule"
 )
 
 var (
@@ -66,11 +67,12 @@ var (
 			FieldMessage:   regexpNegatableFieldType,
 
 			// Experimental fields:
-			FieldIndex:   {Literal: types.StringType, Quoted: types.StringType, Singular: true},
-			FieldCount:   {Literal: types.StringType, Quoted: types.StringType, Singular: true},
-			FieldMax:     {Literal: types.StringType, Quoted: types.StringType, Singular: true},
-			FieldTimeout: {Literal: types.StringType, Quoted: types.StringType, Singular: true},
-			FieldReplace: {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldIndex:     {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldCount:     {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldMax:       {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldTimeout:   {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldReplace:   {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldCombyRule: {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 		},
 		FieldAliases: map[string]string{
 			"r":        FieldRepo,

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -15,6 +15,7 @@ type PatternInfo struct {
 	Pattern         string
 	IsRegExp        bool
 	IsStructuralPat bool
+	CombyRule       string
 	IsWordMatch     bool
 	IsCaseSensitive bool
 	FileMatchLimit  int32

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -99,6 +99,9 @@ type PatternInfo struct {
 	// PatternMatchesPath is whether a file whose path matches Pattern (but whose contents don't) should be
 	// considered a match.
 	PatternMatchesPath bool
+
+	// CombyRule is a rule that constrains matching for structural search. It only applies when IsStructuralPat is true.
+	CombyRule string
 }
 
 func (p *PatternInfo) String() string {

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -227,7 +227,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.IncludePatterns, p.Repo)
+		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.IncludePatterns, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath)
 	}

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -78,7 +78,7 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	return matches
 }
 
-func structuralSearch(ctx context.Context, zipPath, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func structuralSearch(ctx context.Context, zipPath, pattern string, rule string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	args := comby.Args{
@@ -86,6 +86,7 @@ func structuralSearch(ctx context.Context, zipPath, pattern string, includePatte
 		MatchTemplate: pattern,
 		MatchOnly:     true,
 		FilePatterns:  includePatterns,
+		Rule:          rule,
 		NumWorkers:    numWorkers,
 	}
 

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -25,6 +25,11 @@ func exists() bool {
 
 func rawArgs(args Args) (rawArgs []string) {
 	rawArgs = append(rawArgs, args.MatchTemplate, args.RewriteTemplate)
+
+	if args.Rule != "" {
+		rawArgs = append(rawArgs, "-rule", args.Rule)
+	}
+
 	if len(args.FilePatterns) > 0 {
 		rawArgs = append(rawArgs, "-f", strings.Join(args.FilePatterns, ","))
 	}

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -17,6 +17,9 @@ type Args struct {
 	// A template pattern that expresses what to match
 	MatchTemplate string
 
+	// A rule that places constraints on matching or rewriting
+	Rule string
+
 	// A template pattern that expresses how matches should be rewritten
 	RewriteTemplate string
 


### PR DESCRIPTION
This PR adds an experimental `rule:` keyword that accepts `comby` where rules. It is not intended that `rule` should be a permanent keyword since it is so specific to structural search. Unfortunately, there isn't currently a way to separate this input in the UI--when we have that, this will disappear.

Similarly, our implementation doesn't allow to separate this data type cleanly. I wanted to bundle this `rule` information with the rest of structural search, but ran into problems where the types need to be refactored first (which is what prompted #7182 and #7183).

Example:

<img width="1173" alt="Screen Shot 2019-12-12 at 5 29 29 PM" src="https://user-images.githubusercontent.com/888624/70759851-fa061a00-1d04-11ea-87fb-6e0064b52794.png">


