### PR TITLE
Allow admins past license expiration screen in order to easily update key

### DIFF
--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -3,6 +3,6 @@ package hooks
 
 import "net/http"
 
-// PreAuthMiddleware is an HTTP handler middleware that, if set, runs just before auth-related
-// middleware. The client is not yet authenticated when PreAuthMiddleware is called.
-var PreAuthMiddleware func(http.Handler) http.Handler
+// PostAuthMiddleware is an HTTP handler middleware that, if set, runs just before auth-related
+// middleware. The client is authenticated when PostAuthMiddleware is called.
+var PostAuthMiddleware func(http.Handler) http.Handler

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -37,14 +37,14 @@ func newExternalHTTPHandler(schema *graphql.Schema, githubWebhook http.Handler, 
 	r := router.New(mux.NewRouter().PathPrefix("/.api/").Subrouter())
 	apiHandler := internalhttpapi.NewHandler(r, schema, githubWebhook, lsifServerProxy)
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
-	if hooks.PostAuthMiddleware != nil {
-		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
-		apiHandler = hooks.PostAuthMiddleware(apiHandler)
-	}
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication (except those with the
 	// X-Requested-With header). Doing so would open it up to CSRF attacks.
 	apiHandler = session.CookieMiddlewareWithCSRFSafety(apiHandler, corsAllowHeader, isTrustedOrigin) // API accepts cookies with special header
 	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(apiHandler)                                // API accepts access tokens
+	if hooks.PostAuthMiddleware != nil {
+		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
+		apiHandler = hooks.PostAuthMiddleware(apiHandler)
+	}
 	apiHandler = gziphandler.GzipHandler(apiHandler)
 
 	// App handler (HTML pages).
@@ -52,13 +52,13 @@ func newExternalHTTPHandler(schema *graphql.Schema, githubWebhook http.Handler, 
 	appHandler = handlerutil.CSRFMiddleware(appHandler, func() bool {
 		return globals.ExternalURL().Scheme == "https"
 	}) // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
-	appHandler = authMiddlewares.App(appHandler) // 🚨 SECURITY: auth middleware
+	appHandler = authMiddlewares.App(appHandler)                       // 🚨 SECURITY: auth middleware
+	appHandler = session.CookieMiddleware(appHandler)                  // app accepts cookies
+	appHandler = internalhttpapi.AccessTokenAuthMiddleware(appHandler) // app accepts access tokens
 	if hooks.PostAuthMiddleware != nil {
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		appHandler = hooks.PostAuthMiddleware(appHandler)
 	}
-	appHandler = session.CookieMiddleware(appHandler)                  // app accepts cookies
-	appHandler = internalhttpapi.AccessTokenAuthMiddleware(appHandler) // app accepts access tokens
 
 	// Mount handlers and assets.
 	sm := http.NewServeMux()

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
@@ -76,10 +77,42 @@ func initAuthz() {
 		return nil
 	})
 
+	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
+		// 🚨 SECURITY: Only the site admin should ever see this (all other users will see a hard-block
+		// license expiration screen) about this. Leaking this wouldn't be a security vulnerability, but
+		// just in case this method is changed to return more information, we lock it down.
+		if !args.IsSiteAdmin {
+			return nil
+		}
+
+		info, err := licensing.GetConfiguredProductLicenseInfo()
+		if err != nil {
+			log15.Error("Error reading license key for Sourcegraph subscription.", "err", err)
+			return []*graphqlbackend.Alert{{
+				TypeValue:    graphqlbackend.AlertTypeError,
+				MessageValue: "Error reading Sourcegraph license key. Check the logs for more information, or update the license key in the management console (https://docs.sourcegraph.com/admin/management_console).",
+			}}
+		}
+		if info != nil && info.IsExpiredWithGracePeriod() {
+			return []*graphqlbackend.Alert{{
+				TypeValue:    graphqlbackend.AlertTypeError,
+				MessageValue: "Sourcegraph license expired! All non-admin users are locked out of Sourcegraph! Update the license key in the management console (https://docs.sourcegraph.com/admin/management_console) or downgrade to only using Sourcegraph Core features.",
+			}}
+		}
+		return nil
+	})
+
 	// Enforce the use of a valid license key by preventing all HTTP requests if the license is invalid
 	// (due to a error in parsing or verification, or because the license has expired).
 	hooks.PostAuthMiddleware = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+				// Site admins are exempt from license enforcement screens such that they can
+				// easily update the license key.
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			info, err := licensing.GetConfiguredProductLicenseInfo()
 			if err != nil {
 				log15.Error("Error reading license key for Sourcegraph subscription.", "err", err)

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -96,7 +96,7 @@ func initAuthz() {
 		if info != nil && info.IsExpiredWithGracePeriod() {
 			return []*graphqlbackend.Alert{{
 				TypeValue:    graphqlbackend.AlertTypeError,
-				MessageValue: "Sourcegraph license expired! All non-admin users are locked out of Sourcegraph! Update the license key in the management console (https://docs.sourcegraph.com/admin/management_console) or downgrade to only using Sourcegraph Core features.",
+				MessageValue: "Sourcegraph license expired! All non-admin users are locked out of Sourcegraph. Update the license key in the management console (https://docs.sourcegraph.com/admin/management_console) or downgrade to only using Sourcegraph Core features.",
 			}}
 		}
 		return nil

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -78,7 +78,7 @@ func initAuthz() {
 
 	// Enforce the use of a valid license key by preventing all HTTP requests if the license is invalid
 	// (due to a error in parsing or verification, or because the license has expired).
-	hooks.PreAuthMiddleware = func(next http.Handler) http.Handler {
+	hooks.PostAuthMiddleware = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			info, err := licensing.GetConfiguredProductLicenseInfo()
 			if err != nil {


### PR DESCRIPTION
Prior to this change, if your trial license expired then all users including the site admin would be locked out of Sourcegraph, making it impossible for many site admins to update their license key without resetting their management console password first (see #5559):

![image](https://user-images.githubusercontent.com/3173176/70763124-3a1eca00-1d10-11ea-90d4-8a2fabf17d6c.png)

After this change, site admins bypass this hard-lockout (plain users are still hard-locked) and instead are shown a warning alert informing them all users have been locked out and they need to update their license. This allows them to retrieve their management console password from the site admin area easily:

![image](https://user-images.githubusercontent.com/3173176/70763037-f1671100-1d0f-11ea-8f5b-6f53b8da9d5d.png)

Accepted risk with this approach: A site admin could theoretically promote all users to site admins and use JS to hide the alert, thus bypassing our license lockout mechanism. This seems low-risk and unlikely in practice. If this becomes problematic, we could enforce e.g. only the first 5 admins can bypass into the app.

Fixes #5559