### PR TITLE
search: rename Pattern to PatternInfo where applicable

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -746,14 +746,14 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, err
 	}
 	args := search.Args{
-		Pattern:         p,
+		PatternInfo:     p,
 		Repos:           repos,
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}
-	if err := args.Pattern.Validate(); err != nil {
+	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -448,7 +448,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]SearchR
 	}
 
 	var err error
-	tr, ctx := trace.New(ctx, "searchCommitDiffsInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.Pattern, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "searchCommitDiffsInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -471,7 +471,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]SearchR
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.Pattern, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo, args.Query)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.
@@ -513,7 +513,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]SearchRes
 	}
 
 	var err error
-	tr, ctx := trace.New(ctx, "searchCommitLogInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.Pattern, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "searchCommitLogInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -536,7 +536,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]SearchRes
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.Pattern, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -145,14 +145,14 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, err
 	}
 	args := search.Args{
-		Pattern:         p,
+		PatternInfo:     p,
 		Repos:           repos,
 		Query:           r.query,
 		UseFullDeadline: false,
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}
-	if err := args.Pattern.Validate(); err != nil {
+	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, &badRequestError{err}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -45,7 +45,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 		}
 	}
 
-	pattern, err := regexp.Compile(args.Pattern.Pattern)
+	pattern, err := regexp.Compile(args.PatternInfo.Pattern)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 	}
 
 	// Filter the repos if there is a repohasfile: or -repohasfile field.
-	if len(args.Pattern.FilePatternsReposMustExclude) > 0 || len(args.Pattern.FilePatternsReposMustInclude) > 0 {
+	if len(args.PatternInfo.FilePatternsReposMustExclude) > 0 || len(args.PatternInfo.FilePatternsReposMustInclude) > 0 {
 		repos, err = reposToAdd(ctx, args, repos)
 		if err != nil {
 			return nil, nil, err
@@ -86,8 +86,8 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
 func reposToAdd(ctx context.Context, args *search.Args, repos []*search.RepositoryRevisions) ([]*search.RepositoryRevisions, error) {
 	matchingIDs := make(map[api.RepoID]bool)
-	if len(args.Pattern.FilePatternsReposMustInclude) > 0 {
-		for _, pattern := range args.Pattern.FilePatternsReposMustInclude {
+	if len(args.PatternInfo.FilePatternsReposMustInclude) > 0 {
+		for _, pattern := range args.PatternInfo.FilePatternsReposMustInclude {
 			// The high FileMatchLimit here is to make sure we get all the repo matches we can. Setting it to
 			// len(repos) could mean we miss some repos since there could be for example len(repos) file matches in
 			// the first repo and some more in other repos.
@@ -97,7 +97,7 @@ func reposToAdd(ctx context.Context, args *search.Args, repos []*search.Reposito
 				return nil, err
 			}
 			newArgs := *args
-			newArgs.Pattern = &p
+			newArgs.PatternInfo = &p
 			newArgs.Repos = repos
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
@@ -116,15 +116,15 @@ func reposToAdd(ctx context.Context, args *search.Args, repos []*search.Reposito
 		}
 	}
 
-	if len(args.Pattern.FilePatternsReposMustExclude) > 0 {
-		for _, pattern := range args.Pattern.FilePatternsReposMustExclude {
+	if len(args.PatternInfo.FilePatternsReposMustExclude) > 0 {
+		for _, pattern := range args.PatternInfo.FilePatternsReposMustExclude {
 			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err
 			}
 			newArgs := *args
-			newArgs.Pattern = &p
+			newArgs.PatternInfo = &p
 			newArgs.Repos = repos
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -50,10 +50,10 @@ func TestSearchRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 		args := search.Args{
-			Pattern: &search.PatternInfo{Pattern: "", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
-			Repos:   repositories,
-			Query:   q,
-			Zoekt:   zoekt,
+			PatternInfo: &search.PatternInfo{Pattern: "", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
+			Repos:       repositories,
+			Query:       q,
+			Zoekt:       zoekt,
 		}
 		res, _, err := searchRepositories(context.Background(), &args, int32(100))
 		if err != nil {
@@ -71,10 +71,10 @@ func TestSearchRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 		args := search.Args{
-			Pattern: &search.PatternInfo{Pattern: "foo/one", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
-			Repos:   repositories,
-			Query:   q,
-			Zoekt:   zoekt,
+			PatternInfo: &search.PatternInfo{Pattern: "foo/one", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
+			Repos:       repositories,
+			Query:       q,
+			Zoekt:       zoekt,
 		}
 		res, _, err := searchRepositories(context.Background(), &args, int32(100))
 		if err != nil {
@@ -98,10 +98,10 @@ func TestSearchRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 		args := search.Args{
-			Pattern: &search.PatternInfo{Pattern: "foo", IsRegExp: true, FileMatchLimit: 1, FilePatternsReposMustInclude: []string{"f.go"}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
-			Repos:   repositories,
-			Query:   q,
-			Zoekt:   zoekt,
+			PatternInfo: &search.PatternInfo{Pattern: "foo", IsRegExp: true, FileMatchLimit: 1, FilePatternsReposMustInclude: []string{"f.go"}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
+			Repos:       repositories,
+			Query:       q,
+			Zoekt:       zoekt,
 		}
 		res, _, err := searchRepositories(context.Background(), &args, int32(100))
 		if err != nil {
@@ -216,8 +216,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 func repoShouldBeAdded(ctx context.Context, zoekt *searchbackend.Zoekt, repo *search.RepositoryRevisions, pattern *search.PatternInfo) (bool, error) {
 	repos := []*search.RepositoryRevisions{repo}
 	args := search.Args{
-		Pattern: pattern,
-		Zoekt:   zoekt,
+		PatternInfo: pattern,
+		Zoekt:       zoekt,
 	}
 	rsta, err := reposToAdd(ctx, &args, repos)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -814,9 +814,9 @@ func (r *searchResolver) determineResultTypes(args search.Args, forceOnlyResultT
 	seenResultTypes = make(map[string]struct{}, len(resultTypes))
 	for _, resultType := range resultTypes {
 		if resultType == "file" {
-			args.Pattern.PatternMatchesContent = true
+			args.PatternInfo.PatternMatchesContent = true
 		} else if resultType == "path" {
-			args.Pattern.PatternMatchesPath = true
+			args.PatternInfo.PatternMatchesPath = true
 		}
 	}
 	return resultTypes, seenResultTypes
@@ -924,14 +924,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, err
 	}
 	args := search.Args{
-		Pattern:         p,
+		PatternInfo:     p,
 		Repos:           repos,
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
 	}
-	if err := args.Pattern.Validate(); err != nil {
+	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, &badRequestError{err}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -129,8 +129,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchSymbols := false
 		mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 			calledSearchSymbols = true
-			if want := `(foo\d).*?(bar\*)`; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			// TODO return mock results here and assert that they are output as results
 			return nil, nil, nil
@@ -140,8 +140,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchFilesInRepos := false
 		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
-			if want := `(foo\d).*?(bar\*)`; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			return []*FileMatchResolver{
 				{
@@ -201,8 +201,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchSymbols := false
 		mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 			calledSearchSymbols = true
-			if want := `"foo\\d \"bar*\""`; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if want := `"foo\\d \"bar*\""`; args.PatternInfo.Pattern != want {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			// TODO return mock results here and assert that they are output as results
 			return nil, nil, nil
@@ -212,8 +212,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchFilesInRepos := false
 		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
-			if want := `foo\\d "bar\*"`; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			return []*FileMatchResolver{
 				{

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -208,7 +208,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		defer cancel()
 
 		fileMatches, _, err := searchSymbols(ctx, &search.Args{
-			Pattern:      p,
+			PatternInfo:  p,
 			Repos:        repoRevs,
 			Query:        r.query,
 			Zoekt:        r.zoekt,

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -90,8 +90,8 @@ func TestSearchSuggestions(t *testing.T) {
 		calledSearchFilesInRepos := false
 		mockSearchFilesInRepos = func(args *search.Args) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
-			if want := "foo"; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if want := "foo"; args.PatternInfo.Pattern != want {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			return []*FileMatchResolver{
 				{uri: "git://repo?rev#dir/file", JPath: "dir/file", Repo: &types.Repo{Name: "repo"}, CommitID: "rev"},
@@ -158,8 +158,8 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if args.Pattern.Pattern != "." && args.Pattern.Pattern != "foo" {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, `"foo" or "."`)
+			if args.PatternInfo.Pattern != "." && args.PatternInfo.Pattern != "foo" {
+				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, `"foo" or "."`)
 			}
 			return []*FileMatchResolver{
 				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", Repo: &types.Repo{Name: "repo3"}, CommitID: "rev"},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -447,7 +447,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 		return mockSearchFilesInRepos(args)
 	}
 
-	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.Pattern, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -481,7 +481,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 		common.repos[i] = repo.Repo
 	}
 
-	if args.Pattern.IsEmpty() {
+	if args.PatternInfo.IsEmpty() {
 		// Empty query isn't an error, but it has no results.
 		return nil, common, nil
 	}
@@ -539,8 +539,8 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			// Stop searching once we have found enough matches. This does
 			// lead to potentially unstable result ordering, but is worth
 			// it for the performance benefit.
-			if flattenedSize > int(args.Pattern.FileMatchLimit) {
-				tr.LazyPrintf("cancel due to result size: %d > %d", flattenedSize, args.Pattern.FileMatchLimit)
+			if flattenedSize > int(args.PatternInfo.FileMatchLimit) {
+				tr.LazyPrintf("cancel due to result size: %d > %d", flattenedSize, args.PatternInfo.FileMatchLimit)
 				overLimitCanceled = true
 				common.limitHit = true
 				cancel()
@@ -599,14 +599,14 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			}
 
 			args := *args
-			if args.Pattern.IsStructuralPat && searcherReposFilteredFiles != nil {
+			if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
 				// Modify the search query to only run for the filtered files
 				if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
-					patternCopy := *args.Pattern
-					args.Pattern = &patternCopy
-					includePatternsCopy := make([]string, len(args.Pattern.IncludePatterns))
-					copy(includePatternsCopy, args.Pattern.IncludePatterns)
-					args.Pattern.IncludePatterns = append(includePatternsCopy, v...)
+					patternCopy := *args.PatternInfo
+					args.PatternInfo = &patternCopy
+					includePatternsCopy := make([]string, len(args.PatternInfo.IncludePatterns))
+					copy(includePatternsCopy, args.PatternInfo.IncludePatterns)
+					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 				}
 			}
 
@@ -616,7 +616,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 				defer done()
 
 				rev := repoRev.RevSpecs()[0] // TODO(sqs): search multiple revs
-				matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.Pattern, fetchTimeout)
+				matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.PatternInfo, fetchTimeout)
 				if err != nil {
 					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 					log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
@@ -688,7 +688,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			cancel()
 		}
 
-		if args.Pattern.IsStructuralPat {
+		if args.PatternInfo.IsStructuralPat {
 			// A partition of {repo name => file list} that we will build from Zoekt matches
 			partition := make(map[string][]string)
 			var repos []*search.RepositoryRevisions
@@ -727,7 +727,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 	}()
 
 	// This guard disables unindexed structural search for now.
-	if !args.Pattern.IsStructuralPat {
+	if !args.PatternInfo.IsStructuralPat {
 		if err := callSearcherOverRepos(searcherRepos, nil); err != nil {
 			mu.Lock()
 			searchErr = err
@@ -740,7 +740,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 		return nil, common, searchErr
 	}
 
-	flattened := flattenFileMatches(unflattened, int(args.Pattern.FileMatchLimit))
+	flattened := flattenFileMatches(unflattened, int(args.PatternInfo.FileMatchLimit))
 	return flattened, common, nil
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -362,7 +362,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 	args := &search.Args{
-		Pattern: &search.PatternInfo{
+		PatternInfo: &search.PatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
@@ -392,7 +392,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	// If we specify a rev and it isn't found, we fail the whole search since
 	// that should be checked earlier.
 	args = &search.Args{
-		Pattern: &search.PatternInfo{
+		PatternInfo: &search.PatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
@@ -582,7 +582,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			args := &search.Args{
-				Pattern:         tt.args.query,
+				PatternInfo:     tt.args.query,
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt:           &searchbackend.Zoekt{Client: tt.args.searcher},
 			}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -94,7 +94,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 		repoMap[api.RepoName(strings.ToLower(string(repoRev.Repo.Name)))] = repoRev
 	}
 
-	queryExceptRepos, err := queryToZoektQuery(args.Pattern, isSymbol)
+	queryExceptRepos, err := queryToZoektQuery(args.PatternInfo, isSymbol)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -109,8 +109,8 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 		tr.Finish()
 	}()
 
-	k := zoektResultCountFactor(len(repos), args.Pattern)
-	searchOpts := zoektSearchOpts(k, args.Pattern)
+	k := zoektResultCountFactor(len(repos), args.PatternInfo)
+	searchOpts := zoektSearchOpts(k, args.PatternInfo)
 
 	if args.UseFullDeadline {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
@@ -137,7 +137,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 
 	// If the query has a `repohasfile` or `-repohasfile` flag, we want to construct a new reposet based
 	// on the values passed in to the flag.
-	newRepoSet, err := createNewRepoSetWithRepoHasFileInputs(ctx, args.Pattern, args.Zoekt.Client, *repoSet)
+	newRepoSet, err := createNewRepoSetWithRepoHasFileInputs(ctx, args.PatternInfo, args.Zoekt.Client, *repoSet)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -172,7 +172,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.Args, repos []*search.Rep
 
 	maxLineMatches := 25 + k
 	maxLineFragmentMatches := 3 + k
-	if limit := int(args.Pattern.FileMatchLimit); len(resp.Files) > limit {
+	if limit := int(args.PatternInfo.FileMatchLimit); len(resp.Files) > limit {
 		// List of files we cut out from the Zoekt response because they exceed the file match limit on the Sourcegraph end.
 		// We use this to get a list of repositories that do not have complete results.
 		fileMatchesInSkippedRepos := resp.Files[limit:]

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -66,8 +66,8 @@ func (p *PatternInfo) Validate() error {
 // to search for, as well as the hydrated list of repository revisions to
 // search.
 type Args struct {
-	Pattern *PatternInfo
-	Repos   []*RepositoryRevisions
+	PatternInfo *PatternInfo
+	Repos       []*RepositoryRevisions
 
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and


### PR DESCRIPTION
`Pattern` is both a member of `search.Args` (of type `PatternInfo`) and a member of `PatternInfo`. Let's stop the madness and call it `PatternInfo`. This will make it easier to refactor parts of this later (which I started doing, but then got sidetracked by this naming).

Semantics preserving rename, tests pass.