### PR TITLE
search: rename query to patternInfo

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
-func TestQueryToZoektQuery(t *testing.T) {
+func TestPatternInfoToZoektQuery(t *testing.T) {
 	cases := []struct {
 		Name    string
 		Pattern *search.PatternInfo
@@ -117,9 +117,9 @@ func TestQueryToZoektQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse %q: %v", tt.Query, err)
 			}
-			got, err := queryToZoektQuery(tt.Pattern, false)
+			got, err := patternInfoToZoektQuery(tt.Pattern, false)
 			if err != nil {
-				t.Fatal("queryToZoektQuery failed:", err)
+				t.Fatal("patternInfoToZoektQuery failed:", err)
 			}
 			if !queryEqual(got, q) {
 				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), q.String())
@@ -228,7 +228,7 @@ func queryEqual(a, b zoektquery.Q) bool {
 	return zoektquery.Map(a, sortChildren).String() == zoektquery.Map(b, sortChildren).String()
 }
 
-func TestQueryToZoektFileOnlyQueries(t *testing.T) {
+func TestPatternInfoToZoektFileOnlyQueries(t *testing.T) {
 	cases := []struct {
 		Name    string
 		Pattern *search.PatternInfo
@@ -308,9 +308,9 @@ func TestQueryToZoektFileOnlyQueries(t *testing.T) {
 				queries = append(queries, q)
 			}
 
-			got, err := queryToZoektFileOnlyQueries(tt.Pattern, tt.ListOfFilePaths)
+			got, err := patternInfoToZoektFileOnlyQueries(tt.Pattern, tt.ListOfFilePaths)
 			if err != nil {
-				t.Fatal("queryToZoektQuery failed:", err)
+				t.Fatal("patternInfoToZoektQuery failed:", err)
 			}
 			for i, gotQuery := range got {
 				if !queryEqual(gotQuery, queries[i]) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -537,7 +537,7 @@ func patternInfoToZoektQuery(patternInfo *search.PatternInfo, isSymbol bool) (zo
 	return zoektquery.Simplify(zoektquery.NewAnd(and...)), nil
 }
 
-// queryToZoektFileOnlyQueries constructs a list of Zoekt queries that search for a file pattern(s).
+// patternInfoToZoektFileOnlyQueries constructs a list of Zoekt queries that search for a file pattern(s).
 // `listOfFilePaths` specifies which field on `query` should be the list of file patterns to look for.
 //  A separate zoekt query is created for each file path that should be searched.
 func patternInfoToZoektFileOnlyQueries(patternInfo *search.PatternInfo, listOfFilePaths []string) ([]zoektquery.Q, error) {


### PR DESCRIPTION
This is stacked on top of #7182. 

The Zoekt code names the `PatternInfo` type `query` everywhere. Let's name it `patternInfo` for now--it doesn't have to stay this way, but it will make refactoring things easier later. The aim later is to refactor the `PatternInfo` type to separate things instead of bundling all of the Zoekt/Searcher/Regex/Structural/Commit/Diff/Repo parameters all in a mostly flat struct.

Semantics preserving, tests pass.
