### PR TITLE
LSIF: Fix use of p-retry for LSIF uploads

### DIFF
--- a/lsif/src/server/routes/dumps.ts
+++ b/lsif/src/server/routes/dumps.ts
@@ -16,7 +16,7 @@ export function createDumpRouter(backend: Backend): express.Router {
 
     interface DumpsQueryArgs {
         query: string
-        visibleAtTip: boolean
+        visibleAtTip?: boolean
     }
 
     router.get(
@@ -35,7 +35,7 @@ export function createDumpRouter(backend: Backend): express.Router {
                 const { dumps, totalCount } = await backend.dumps(
                     decodeURIComponent(req.params.repository),
                     query,
-                    visibleAtTip,
+                    !!visibleAtTip,
                     limit,
                     offset
                 )

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -70,9 +70,9 @@ export function createLsifRouter(
     interface UploadQueryArgs {
         repository: string
         commit: string
-        root: string
-        blocking: boolean
-        maxWait: number
+        root?: string
+        blocking?: boolean
+        maxWait?: number
     }
 
     router.post(


### PR DESCRIPTION
The old behavior always returned after the first attempt. This actually polls the upload for a change in status.