### PR TITLE
search: use an alert and suggestion when OOM-like behavior surfaces

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -875,7 +875,12 @@ func alertOnError(multiErr *multierror.Error) (newMultiErr *multierror.Error, al
 			if strings.Contains(err.Error(), "Assert_failure zip") {
 				alert = &searchAlert{
 					title:       "Repository too large for structural search",
-					description: "One repository is too large to perform structural search. This is a temporary restriction that will be removed in the future. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/7133",
+					description: "One repository is too large to perform structural search. Use the `repo:` filter to run on a specific repository. This is a temporary restriction that will be removed in the future. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/7133",
+				}
+			} else if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
+				alert = &searchAlert{
+					title:       "Structural search needs more memory",
+					description: "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
 				}
 			} else {
 				newMultiErr = multierror.Append(newMultiErr, err)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1198,6 +1198,19 @@ func Test_ErrorToAlertConversion(t *testing.T) {
 			},
 			wantAlertTitle: "Repository too large for structural search",
 		},
+		{
+			name: "surface_friendly_alert_on_oom_err_message",
+			errors: []error{
+				errors.New("some error"),
+				errors.New("Worker_oomed"),
+				errors.New("some other error"),
+			},
+			wantErrors: []error{
+				errors.New("some error"),
+				errors.New("some other error"),
+			},
+			wantAlertTitle: "Structural search needs more memory",
+		},
 	}
 	for _, test := range cases {
 		multiErr := &multierror.Error{

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -81,6 +81,9 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 func structuralSearch(ctx context.Context, zipPath, pattern string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
+	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
+	numWorkers := 4
+
 	args := comby.Args{
 		Input:         comby.ZipPath(zipPath),
 		MatchTemplate: pattern,


### PR DESCRIPTION
It's not currently possible to surface an `alert` in `searcher` since it can't be propagated back. That would be the preferred solution. 

Instead, I'm relying on the error string here to promote it to an alert instead, as before. It's either this, or I can completely suppress the error and only log it, and return "no results".


