### PR TITLE
comby: less verbose file path logging

### DIFF
--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -9,10 +9,12 @@ import (
 )
 
 func (args Args) String() string {
-	var s []string
-	s = append(s, args.MatchTemplate, args.RewriteTemplate)
-	s = append(s, fmt.Sprintf("-f (%d file patterns)", len(args.FilePatterns)))
-	s = append(s, "-json-lines")
+	s := []string{
+		args.MatchTemplate,
+		args.RewriteTemplate,
+		fmt.Sprintf("-f (%d file patterns)", len(args.FilePatterns)),
+		"-json-lines",
+	}
 	if args.MatchOnly {
 		s = append(s, "-match-only")
 	} else {

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -1,0 +1,43 @@
+package comby
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+func (args Args) String() string {
+	var s []string
+	s = append(s, args.MatchTemplate, args.RewriteTemplate)
+	s = append(s, fmt.Sprintf("-f (%d file patterns)", len(args.FilePatterns)))
+	s = append(s, "-json-lines")
+	if args.MatchOnly {
+		s = append(s, "-match-only")
+	} else {
+		s = append(s, "-json-only-diff")
+	}
+
+	if args.NumWorkers == 0 {
+		s = append(s, "-sequential")
+	} else {
+		s = append(s, "-jobs", strconv.Itoa(args.NumWorkers))
+	}
+
+	if args.Matcher != "" {
+		s = append(s, "-matcher", args.Matcher)
+	}
+
+	switch i := args.Input.(type) {
+	case ZipPath:
+		s = append(s, "-zip", string(i))
+	case DirPath:
+		s = append(s, "-directory", string(i))
+	default:
+		log15.Error("unrecognized input type: %T", i)
+		panic("unreachable")
+	}
+
+	return strings.Join(s, " ")
+}

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -69,7 +69,7 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 	defer cancel()
 
 	rawArgs := rawArgs(args)
-	log15.Info("running comby", "args", strings.Join(rawArgs, " "))
+	log15.Info("running comby", "args", args.String())
 
 	cmd := exec.CommandContext(ctx, combyPath, rawArgs...)
 


### PR DESCRIPTION
This PR just adds a `String()` method for comby args that truncates the file patterns / file paths that are logged, printing the length instead of the full path names.

No test here, this is just a utility/logging function.