### PR TITLE
Remove /lsif-jobs/:id from router.

### DIFF
--- a/web/src/enterprise/site-admin/routes.ts
+++ b/web/src/enterprise/site-admin/routes.ts
@@ -76,8 +76,7 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         render: lazyComponent(() => import('./SiteAdminLsifUploadsPage'), 'SiteAdminLsifUploadsPage'),
     },
     {
-        // Maintain backwards compatibility for outdated src-cli clients
-        path: '/lsif-(uploads|jobs)/:id',
+        path: '/lsif-uploads/:id',
         exact: true,
         render: lazyComponent(() => import('./SiteAdminLsifUploadPage'), 'SiteAdminLsifUploadPage'),
     },


### PR DESCRIPTION
This doesn't work as the ID has the resource name in it, so we had to update src-cli anyway.