### PR TITLE
search: make it possible to disable structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -84,6 +84,10 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 		return &didYouMeanQuotedResolver{query: args.Query, err: err}, nil
 	}
 
+	if searchType == SearchTypeStructural && !conf.StructuralSearchEnabled() {
+		return nil, errors.New("Structural search is disabled in the site configuration.")
+	}
+
 	var queryString string
 	if searchType == SearchTypeLiteral {
 		queryString = query.ConvertToLiteral(args.Query)

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -266,6 +266,14 @@ func EventLoggingEnabled() bool {
 	return val == "enabled"
 }
 
+func StructuralSearchEnabled() bool {
+	val := Get().ExperimentalFeatures.StructuralSearch
+	if val == "" {
+		return true
+	}
+	return val == "enabled"
+}
+
 func ExperimentalFeatures() schema.ExperimentalFeatures {
 	val := Get().ExperimentalFeatures
 	if val == nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -398,10 +398,10 @@ type ExperimentalFeatures struct {
 	Discussions string `json:"discussions,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
-	// StructuralSearch description: Enables structural search.
-	StructuralSearch string `json:"structuralSearch,omitempty"`
 	// SplitSearchModes description: Enables toggling between the current omni search mode, and experimental interactive search mode.
 	SplitSearchModes string `json:"splitSearchModes,omitempty"`
+	// StructuralSearch description: Enables structural search.
+	StructuralSearch string `json:"structuralSearch,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -398,6 +398,8 @@ type ExperimentalFeatures struct {
 	Discussions string `json:"discussions,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// StructuralSearch description: Enables structural search.
+	StructuralSearch string `json:"structuralSearch,omitempty"`
 	// SplitSearchModes description: Enables toggling between the current omni search mode, and experimental interactive search mode.
 	SplitSearchModes string `json:"splitSearchModes,omitempty"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -67,6 +67,12 @@
           "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
+        "structuralSearch": {
+          "description": "Enables structural search.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
+        },
         "splitSearchModes": {
           "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -72,6 +72,12 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
+        "structuralSearch": {
+          "description": "Enables structural search.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
+        },
         "splitSearchModes": {
           "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
           "type": "string",


### PR DESCRIPTION
Adds this option to site config:

```json
  "experimentalFeatures": {
    "structuralSearch": "disable"
  },
```

I am enabling it by default, with the option to disable. Can someone verify that `"default": "enabled"` in `schema/site.schema.json` is enough to turn this on by default, or whether a additional configuration files need to change?

The notification is red, thoughts on whether this should be a warning (blue) instead?

<img width="542" alt="Screen Shot 2019-12-13 at 1 58 06 PM" src="https://user-images.githubusercontent.com/888624/70831751-9c2f0c00-1db0-11ea-826d-078cb659aed8.png">
