### PR TITLE
Fix copying integration assets

### DIFF
--- a/browser/gulpfile.js
+++ b/browser/gulpfile.js
@@ -20,21 +20,4 @@ function watch() {
   })
 }
 
-const INTEGRATION_FILES = path.join(__dirname, './build/integration/**')
-const INTEGRATION_ASSETS_DIRECTORY = path.join(__dirname, '../ui/assets/extension')
-
-/**
- * Copies the phabricator extension over to the ui/assets folder so they can be served by the webapp. The package
- * is published from ./browser.
- */
-function copyIntegrationAssets() {
-  return gulp.src(INTEGRATION_FILES).pipe(gulp.dest(INTEGRATION_ASSETS_DIRECTORY))
-}
-
-const watchIntegrationAssets = gulp.series(copyIntegrationAssets, async function watchIntegrationAssets() {
-  await new Promise((_, reject) => {
-    gulp.watch(INTEGRATION_FILES, copyIntegrationAssets).on('error', reject)
-  })
-})
-
-module.exports = { watchIntegrationAssets, copyIntegrationAssets, build, watch }
+module.exports = { build, watch }

--- a/browser/scripts/tasks.ts
+++ b/browser/scripts/tasks.ts
@@ -69,6 +69,9 @@ export function copyIntegrationAssets(): void {
     shelljs.cp('build/dist/js/extensionHostWorker.bundle.js', 'build/integration/scripts')
     shelljs.cp('build/dist/css/style.bundle.css', 'build/integration/css')
     shelljs.cp('src/phabricator/extensionHostFrame.html', 'build/integration')
+    // Copy to the ui/assets directory so that these files can be served by the webapp.
+    shelljs.mkdir('-p', '../ui/assets/extension')
+    shelljs.cp('-r', 'build/integration/*', '../ui/assets/extension')
 }
 
 const BROWSER_TITLES = {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 const gulp = require('gulp')
-const { copyIntegrationAssets, watchIntegrationAssets } = require('./browser/gulpfile')
 const { graphQLTypes, schema, watchGraphQLTypes, watchSchema } = require('./shared/gulpfile')
 const { webpack: webWebpack, webpackDevServer: webWebpackDevServer } = require('./web/gulpfile')
 
@@ -13,14 +12,11 @@ const generate = gulp.parallel(schema, graphQLTypes)
 /**
  * Builds everything.
  */
-const build = gulp.parallel(gulp.series(generate, gulp.parallel(webWebpack, copyIntegrationAssets)))
+const build = gulp.series(generate, webWebpack)
 
 /**
  * Watches everything and rebuilds on file changes.
  */
-const watch = gulp.series(
-  generate,
-  gulp.parallel(watchSchema, watchGraphQLTypes, webWebpackDevServer, watchIntegrationAssets)
-)
+const watch = gulp.series(generate, gulp.parallel(watchSchema, watchGraphQLTypes, webWebpackDevServer))
 
 module.exports = { generate, build, watch, schema, graphQLTypes }

--- a/web/src/regression/integrations.test.ts
+++ b/web/src/regression/integrations.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+
+import { getConfig } from '../../../shared/src/e2e/config'
+import { fromFetch } from 'rxjs/fetch'
+import { map, catchError } from 'rxjs/operators'
+import { checkOk } from '../../../shared/src/backend/fetch'
+import { merge } from 'rxjs'
+
+describe('Native integrations regression test suite', () => {
+    const { sourcegraphBaseUrl } = getConfig('sourcegraphBaseUrl')
+    test('Native integration assets are served by the instance', async () => {
+        const assets = [
+            '/.assets/extension/scripts/integration.bundle.js',
+            '/.assets/extension/scripts/phabricator.bundle.js',
+            '/.assets/extension/scripts/extensionHostWorker.bundle.js',
+            '/.assets/extension/css/style.bundle.css',
+            '/.assets/extension/extensionHostFrame.html',
+        ]
+        await merge(
+            ...assets.map(asset =>
+                fromFetch(new URL(asset, sourcegraphBaseUrl).href).pipe(
+                    map(checkOk),
+                    catchError(() => {
+                        throw new Error('Error fetching native integration asset: ' + asset)
+                    })
+                )
+            )
+        ).toPromise()
+    })
+})


### PR DESCRIPTION
Copying of native code host integration assets to `/ui/assets` (which
allows them to be served by the Sourcegraph instance) was broken in
https://github.com/sourcegraph/sourcegraph/commit/d5bb53fb4db4ecb9b1b81724df314983ad6da1ee

Reported in https://sourcegraph.slack.com/archives/CNC4YAL1E/p1576263875005300?thread_ts=1576262866.004000&cid=CNC4YAL1E

This fixes it by removing the gulp tasks for copying the integration assets,
and instead doing the copy directly in `browser/scripts/tasks.ts`.
Having separate copy tasks in the build script and in a gulpfile was awkward,
and has led to this same bug happening before.

Also adds a regression test to verify that all native integration assets
are indeed served by the Sourcegraph instance.
