### PR TITLE
ci: stop building server image twice

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -11,8 +11,9 @@ steps:
   - ./cmd/server/pre-build.sh
   - ./cmd/server/build.sh
   - popd
+  - docker push $IMAGE
   env:
-    IMAGE: sourcegraph/server:e2e_$BUILDKITE_BUILD_NUMBER
+    IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
     VERSION: $BUILDKITE_BUILD_NUMBER
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
   label: ':docker:'
@@ -20,15 +21,17 @@ steps:
 - wait
 
 - artifact_paths: ./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log
-  command: ./dev/ci/e2e.sh
+  command:
+    - docker pull $IMAGE
+    - ./dev/ci/e2e.sh
   concurrency: 1
   concurrency_group: e2e
   env:
-    IMAGE: sourcegraph/server:e2e_$BUILDKITE_BUILD_NUMBER
+    IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
   label: ':chromium:'
 
 - wait
 
-- command: docker image rm -f sourcegraph/server:e2e_$BUILDKITE_BUILD_NUMBER
+- command: docker image rm -f us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
   label: ':sparkles:'
   soft_fail: true

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -4,6 +4,7 @@ env:
   ENTERPRISE: "1"
   FORCE_COLOR: "1"
   GO111MODULE: "on"
+  IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
 
 steps:
 - command:
@@ -11,9 +12,8 @@ steps:
   - ./cmd/server/pre-build.sh
   - ./cmd/server/build.sh
   - popd
-  - docker push $IMAGE
+  - docker push "$IMAGE"
   env:
-    IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
     VERSION: $BUILDKITE_BUILD_NUMBER
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
   label: ':docker:'
@@ -22,16 +22,13 @@ steps:
 
 - artifact_paths: ./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log
   command:
-    - docker pull $IMAGE
     - ./dev/ci/e2e.sh
   concurrency: 1
   concurrency_group: e2e
-  env:
-    IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
   label: ':chromium:'
 
 - wait
 
-- command: docker image rm -f us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
+- command: docker image rm -f "$IMAGE"
   label: ':sparkles:'
   soft_fail: true

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -8,6 +8,7 @@ env:
 
 steps:
 - command:
+  - yes | gcloud auth configure-docker
   - pushd enterprise
   - ./cmd/server/pre-build.sh
   - ./cmd/server/build.sh
@@ -22,6 +23,7 @@ steps:
 
 - artifact_paths: ./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log
   command:
+    - yes | gcloud auth configure-docker
     - ./dev/ci/e2e.sh
   concurrency: 1
   concurrency_group: e2e

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -285,13 +285,13 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 
 		getBuildSteps := func() []bk.StepOpt {
 			buildScriptByApp := map[string][]bk.StepOpt{
-				"symbols": []bk.StepOpt{
+				"symbols": {
 					bk.Env("BUILD_TYPE", "dist"),
 					bk.Cmd("./cmd/symbols/build.sh buildSymbolsDockerImage"),
 				},
 				// The server image was already built for the e2e tests. We can pull the e2e
 				// image instead of building it from scratch.
-				"server": []bk.StepOpt{
+				"server": {
 					bk.Cmd(fmt.Sprintf("docker pull %s:e2e_%s", gcrImage, c.commit)),
 					bk.Cmd(fmt.Sprintf("docker tag %s:e2e_%s %s:%s", gcrImage, c.commit, baseImage, c.version)),
 				},

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -248,9 +248,14 @@ func addDockerImages(c Config) func(*bk.Pipeline) {
 // Build Docker image for the service defined by `app`.
 func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
+		baseImage := "sourcegraph/" + app
+
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
 			bk.Env("DOCKER_BUILDKIT", "1"),
+			bk.Env("IMAGE", baseImage+":"+c.version),
+			bk.Env("VERSION", c.version),
+			bk.Cmd("yes | gcloud auth configure-docker"),
 		}
 
 		cmdDir := func() string {
@@ -267,34 +272,41 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 			return "enterprise/cmd/" + app
 		}()
 
-		preBuildScript := cmdDir + "/pre-build.sh"
-		if _, err := os.Stat(preBuildScript); err == nil {
-			cmds = append(cmds, bk.Cmd(preBuildScript))
+		if app != "server" {
+			// The server image was already built for the e2e tests - it doesn't need to be built again.
+
+			preBuildScript := cmdDir + "/pre-build.sh"
+			if _, err := os.Stat(preBuildScript); err == nil {
+				cmds = append(cmds, bk.Cmd(preBuildScript))
+			}
 		}
 
-		baseImage := "sourcegraph/" + app
+		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
 
-		getBuildScript := func() string {
-			buildScriptByApp := map[string]string{
-				"symbols": "env BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImage",
+		getBuildSteps := func() []bk.StepOpt {
+			buildScriptByApp := map[string][]bk.StepOpt{
+				"symbols": []bk.StepOpt{
+					bk.Env("BUILD_TYPE", "dist"),
+					bk.Cmd("./cmd/symbols/build.sh buildSymbolsDockerImage"),
+				},
+				// The server image was already built for the e2e tests. We can pull the e2e
+				// image instead of building it from scratch.
+				"server": []bk.StepOpt{
+					bk.Cmd(fmt.Sprintf("docker pull %s:e2e_%s", gcrImage, c.commit)),
+					bk.Cmd(fmt.Sprintf("docker tag %s:e2e_%s %s:%s", gcrImage, c.commit, baseImage, c.version)),
+				},
 			}
 			if buildScript, ok := buildScriptByApp[app]; ok {
 				return buildScript
 			}
-			return cmdDir + "/build.sh"
+			return []bk.StepOpt{
+				bk.Cmd(cmdDir + "/build.sh"),
+			}
 		}
 
-		cmds = append(cmds,
-			bk.Env("IMAGE", baseImage+":"+c.version),
-			bk.Env("VERSION", c.version),
-			bk.Cmd(getBuildScript()),
-		)
-
-		cmds = append(cmds, bk.Cmd("yes | gcloud auth configure-docker"))
+		cmds = append(cmds, getBuildSteps()...)
 
 		dockerHubImage := fmt.Sprintf("index.docker.io/%s", baseImage)
-		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
-
 		for _, image := range []string{dockerHubImage, gcrImage} {
 			if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
 				cmds = append(cmds,


### PR DESCRIPTION
We currently build the server image twice in CI: once for the e2e tests, and again after the final docker images are pushed. This PR elimates the second server build by pushing the e2e image to GCR and simply pulling+retagging that image with the final `insiders` tag once the e2e tests pass. 