### PR TITLE
LSIF: Reduce duplicate work in location resolution

### DIFF
--- a/enterprise/internal/codeintel/resolvers/location.go
+++ b/enterprise/internal/codeintel/resolvers/location.go
@@ -86,7 +86,7 @@ type resolversByPathMap map[string]*graphqlbackend.GitTreeEntryResolver
 // empty structs in the path set are replaced by git tree resolvers. This ensures that each repository,
 // commit, and path are each resolved only once.
 //
-// This method resolves repositories. See `resolveGitCommitsForRepository` and `resolveGitTreeForPath`
+// This method resolves repositories. See `resolveGitCommitsForRepositories` and `resolveGitTreeForPaths`
 // (which are called from here) for the resolution of commits and git trees, respectively.
 func resolveGitTrees(ctx context.Context, pathsByCommitByRepository pathsByCommitByRepositoryMap) (resolversByPathByCommitByRepostioryMap, error) {
 	resolversByRepositories := resolversByPathByCommitByRepostioryMap{}
@@ -98,7 +98,7 @@ func resolveGitTrees(ctx context.Context, pathsByCommitByRepository pathsByCommi
 		}
 		repositoryResolver := graphqlbackend.NewRepositoryResolver(repo)
 
-		resolvers, err := resolveGitCommitsForRepository(ctx, repositoryResolver, commits)
+		resolvers, err := resolveGitCommitsForRepositories(ctx, repositoryResolver, commits)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func resolveGitTrees(ctx context.Context, pathsByCommitByRepository pathsByCommi
 	return resolversByRepositories, nil
 }
 
-func resolveGitCommitsForRepository(ctx context.Context, repositoryResolver *graphqlbackend.RepositoryResolver, pathsByCommit pathsByCommitMap) (resolversByPathByCommitMap, error) {
+func resolveGitCommitsForRepositories(ctx context.Context, repositoryResolver *graphqlbackend.RepositoryResolver, pathsByCommit pathsByCommitMap) (resolversByPathByCommitMap, error) {
 	resolversByCommit := resolversByPathByCommitMap{}
 
 	for commit, paths := range pathsByCommit {
@@ -117,7 +117,7 @@ func resolveGitCommitsForRepository(ctx context.Context, repositoryResolver *gra
 			return nil, err
 		}
 
-		resolvers, err := resolveGitTreeForPath(ctx, commitResolver, paths)
+		resolvers, err := resolveGitTreeForPaths(ctx, commitResolver, paths)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,7 @@ func resolveGitCommitsForRepository(ctx context.Context, repositoryResolver *gra
 	return resolversByCommit, nil
 }
 
-func resolveGitTreeForPath(ctx context.Context, commitResolver *graphqlbackend.GitCommitResolver, paths pathsSet) (resolversByPathMap, error) {
+func resolveGitTreeForPaths(ctx context.Context, commitResolver *graphqlbackend.GitCommitResolver, paths pathsSet) (resolversByPathMap, error) {
 	resolversByPath := resolversByPathMap{}
 
 	for path := range paths {

--- a/enterprise/internal/codeintel/resolvers/location.go
+++ b/enterprise/internal/codeintel/resolvers/location.go
@@ -31,15 +31,19 @@ type locationConnectionResolver struct {
 var _ graphqlbackend.LocationConnectionResolver = &locationConnectionResolver{}
 
 func (r *locationConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.LocationResolver, error) {
+	gitTreeResolvers, err := resolveGitTrees(ctx, partitionPathsByCommitByRepository(r.locations))
+	if err != nil {
+		return nil, err
+	}
+
 	var l []graphqlbackend.LocationResolver
 	for _, location := range r.locations {
-		resolver, err := rangeToLocationResolver(ctx, location)
-		if err != nil {
-			return nil, err
-		}
-
-		l = append(l, resolver)
+		l = append(l, graphqlbackend.NewLocationResolver(
+			gitTreeResolvers[location.Repository][location.Commit][location.Path],
+			&location.Range,
+		))
 	}
+
 	return l, nil
 }
 
@@ -50,28 +54,89 @@ func (r *locationConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func rangeToLocationResolver(ctx context.Context, location *lsif.LSIFLocation) (graphqlbackend.LocationResolver, error) {
-	repo, err := backend.Repos.GetByName(ctx, api.RepoName(location.Repository))
-	if err != nil {
-		return nil, err
+type pathsByCommitByRepositoryMap map[string]pathsByCommitMap
+type pathsByCommitMap map[string]pathsSet
+type pathsSet map[string]struct{}
+
+// partitionPathsByCommitByRepository partitions locations as returned by a definitions or references
+// query from the LSIF server into a nested map of the form `{repository} -> {commit} -> {set of paths}`.
+// The set of paths are encoded as a map from the path name to an empty struct.
+func partitionPathsByCommitByRepository(locations []*lsif.LSIFLocation) pathsByCommitByRepositoryMap {
+	pathsByCommitByRepository := pathsByCommitByRepositoryMap{}
+	for _, location := range locations {
+		if _, ok := pathsByCommitByRepository[location.Repository]; !ok {
+			pathsByCommitByRepository[location.Repository] = pathsByCommitMap{}
+		}
+
+		if _, ok := pathsByCommitByRepository[location.Repository][location.Commit]; !ok {
+			pathsByCommitByRepository[location.Repository][location.Commit] = pathsSet{}
+		}
+
+		pathsByCommitByRepository[location.Repository][location.Commit][location.Path] = struct{}{}
 	}
 
-	commitResolver, err := graphqlbackend.NewRepositoryResolver(repo).Commit(
-		ctx,
-		&graphqlbackend.RepositoryCommitArgs{Rev: location.Commit},
-	)
-	if err != nil {
-		return nil, err
+	return pathsByCommitByRepository
+}
+
+type resolversByPathByCommitByRepostioryMap map[string]resolversByPathByCommitMap
+type resolversByPathByCommitMap map[string]resolversByPathMap
+type resolversByPathMap map[string]*graphqlbackend.GitTreeEntryResolver
+
+// resolveGitTrees takes the map produced by `resolveGitTrees` and returns a symmetric map, where the
+// empty structs in the path set are replaced by git tree resolvers. This ensures that each repository,
+// commit, and path are each resolved only once.
+//
+// This method resolves repositories. See `resolveGitCommitsForRepository` and `resolveGitTreeForPath`
+// (which are called from here) for the resolution of commits and git trees, respectively.
+func resolveGitTrees(ctx context.Context, pathsByCommitByRepository pathsByCommitByRepositoryMap) (resolversByPathByCommitByRepostioryMap, error) {
+	resolversByRepositories := resolversByPathByCommitByRepostioryMap{}
+
+	for repoName, commits := range pathsByCommitByRepository {
+		repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
+		if err != nil {
+			return nil, err
+		}
+		repositoryResolver := graphqlbackend.NewRepositoryResolver(repo)
+
+		resolvers, err := resolveGitCommitsForRepository(ctx, repositoryResolver, commits)
+		if err != nil {
+			return nil, err
+		}
+		resolversByRepositories[repoName] = resolvers
 	}
 
-	gitTreeResolver, err := commitResolver.Blob(ctx, &struct {
-		Path string
-	}{
-		Path: location.Path,
-	})
-	if err != nil {
-		return nil, err
+	return resolversByRepositories, nil
+}
+
+func resolveGitCommitsForRepository(ctx context.Context, repositoryResolver *graphqlbackend.RepositoryResolver, pathsByCommit pathsByCommitMap) (resolversByPathByCommitMap, error) {
+	resolversByCommit := resolversByPathByCommitMap{}
+
+	for commit, paths := range pathsByCommit {
+		commitResolver, err := repositoryResolver.Commit(ctx, &graphqlbackend.RepositoryCommitArgs{Rev: commit})
+		if err != nil {
+			return nil, err
+		}
+
+		resolvers, err := resolveGitTreeForPath(ctx, commitResolver, paths)
+		if err != nil {
+			return nil, err
+		}
+		resolversByCommit[commit] = resolvers
 	}
 
-	return graphqlbackend.NewLocationResolver(gitTreeResolver, &location.Range), nil
+	return resolversByCommit, nil
+}
+
+func resolveGitTreeForPath(ctx context.Context, commitResolver *graphqlbackend.GitCommitResolver, paths pathsSet) (resolversByPathMap, error) {
+	resolversByPath := resolversByPathMap{}
+
+	for path := range paths {
+		gitTreeResolver, err := commitResolver.Blob(ctx, &struct{ Path string }{Path: path})
+		if err != nil {
+			return nil, err
+		}
+		resolversByPath[path] = gitTreeResolver
+	}
+
+	return resolversByPath, nil
 }


### PR DESCRIPTION
LSIF server returns a list of locations for references and definitions. This requires a repository, commit, and git-tree lookup for each result. The previous code did this in the naive way, looping through each location and resolving the repository, commit, and git tree in sequence.

This PR discovers each distinct repository, commit, and git-tree, and reuses the results. Everything is still sequential (no goroutines added), but reduces the duplicate work in re-resolving the same repo and commit multiple times.