### PR TITLE
ci: optimistically build docker images alongside e2e tests

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -4,7 +4,7 @@ env:
   ENTERPRISE: "1"
   FORCE_COLOR: "1"
   GO111MODULE: "on"
-  IMAGE: us.gcr.io/sourcegraph-dev/server:e2e_$BUILDKITE_COMMIT
+  IMAGE: us.gcr.io/sourcegraph-dev/server:"$BUILDKITE_COMMIT"_candidate
 
 steps:
 - command:

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -4,7 +4,7 @@ env:
   ENTERPRISE: "1"
   FORCE_COLOR: "1"
   GO111MODULE: "on"
-  IMAGE: us.gcr.io/sourcegraph-dev/server:"$BUILDKITE_COMMIT"_candidate
+  IMAGE: us.gcr.io/sourcegraph-dev/server:candidate_$BUILDKITE_COMMIT
 
 steps:
 - command:

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -4,7 +4,7 @@ env:
   ENTERPRISE: "1"
   FORCE_COLOR: "1"
   GO111MODULE: "on"
-  IMAGE: us.gcr.io/sourcegraph-dev/server:candidate_$BUILDKITE_COMMIT
+  IMAGE: us.gcr.io/sourcegraph-dev/server:$TAG
 
 steps:
 - command:
@@ -15,7 +15,6 @@ steps:
   - popd
   - docker push "$IMAGE"
   env:
-    VERSION: $BUILDKITE_BUILD_NUMBER
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
   label: ':docker:'
 

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -17,20 +17,12 @@ if curl --output /dev/null --silent --head --fail $URL; then
 fi
 
 # Switch the default Docker host to the dedicated e2e testing host
-BUILD_DOCKER_HOST="$DOCKER_HOST"
-BUILD_DOCKER_PASSWORD="$DOCKER_PASSWORD"
-BUILD_DOCKER_USERNAME="$DOCKER_USERNAME"
 export DOCKER_HOST="$E2E_DOCKER_HOST"
 export DOCKER_PASSWORD="$E2E_DOCKER_PASSWORD"
 export DOCKER_USERNAME="$E2E_DOCKER_USERNAME"
 
 echo "--- Copying $IMAGE to the dedicated e2e testing node..."
-env \
-    DOCKER_HOST="$BUILD_DOCKER_HOST" \
-    DOCKER_PASSWORD="$BUILD_DOCKER_PASSWORD" \
-    DOCKER_USERNAME="$BUILD_DOCKER_USERNAME" \
-    docker save "$IMAGE" \
-    | docker load
+docker pull $IMAGE
 echo "Copying $IMAGE to the dedicated e2e testing node... done"
 
 echo "--- Running a daemonized $IMAGE as the test subject..."

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -31,6 +31,7 @@ type Config struct {
 	patch               bool
 	patchNoTest         bool
 	isQuick             bool
+	isMasterDryRun      bool
 }
 
 func ComputeConfig() Config {
@@ -59,6 +60,8 @@ func ComputeConfig() Config {
 		version = version + "_patch"
 	}
 
+	isMasterDryRun := strings.HasPrefix(branch, "master-dry-run/")
+
 	isQuick := strings.HasPrefix(branch, "quick/")
 
 	var mustIncludeCommits []string
@@ -82,6 +85,7 @@ func ComputeConfig() Config {
 		patch:               patch,
 		patchNoTest:         patchNoTest,
 		isQuick:             isQuick,
+		isMasterDryRun:      isMasterDryRun,
 	}
 }
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -237,10 +237,7 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 			addDockerImage(c, "server", false)(pipeline)
 			pipeline.AddWait()
 		case strings.HasPrefix(c.branch, "master-dry-run/"): // replicates `master` build but does not deploy
-			for _, dockerImage := range allDockerImages {
-				addDockerImage(c, dockerImage, false)(pipeline)
-			}
-			pipeline.AddWait()
+			fallthrough
 		case c.branch == "master":
 			for _, dockerImage := range allDockerImages {
 				addDockerImage(c, dockerImage, true)(pipeline)

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -263,7 +263,7 @@ func addCanidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 		baseImage := "sourcegraph/" + app
 
 		cmds := []bk.StepOpt{
-			bk.Cmd(fmt.Sprintf(`echo "Building candidte %s image..."`, app)),
+			bk.Cmd(fmt.Sprintf(`echo "Building candidate %s image..."`, app)),
 			bk.Env("DOCKER_BUILDKIT", "1"),
 			bk.Env("IMAGE", baseImage+":"+c.version),
 			bk.Env("VERSION", c.version),

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -188,7 +188,7 @@ func wait(pipeline *bk.Pipeline) {
 
 func triggerE2E(c Config) func(*bk.Pipeline) {
 	// hardFail if we publish docker images
-	hardFail := c.branch == "master" || c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+	hardFail := c.branch == "master" || strings.HasPrefix(c.branch, "master-dry-run/") || c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":chromium:",

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -237,7 +237,10 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 			addDockerImage(c, "server", false)(pipeline)
 			pipeline.AddWait()
 		case strings.HasPrefix(c.branch, "master-dry-run/"): // replicates `master` build but does not deploy
-			fallthrough
+			for _, dockerImage := range allDockerImages {
+				addDockerImage(c, dockerImage, false)(pipeline)
+			}
+			pipeline.AddWait()
 		case c.branch == "master":
 			for _, dockerImage := range allDockerImages {
 				addDockerImage(c, dockerImage, true)(pipeline)

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -311,8 +311,8 @@ func addCanidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 		)
 
 		cmds = append(cmds,
-			bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s_candidate", baseImage, c.version, gcrImage, c.commit)),
-			bk.Cmd(fmt.Sprintf("docker push %s:%s_candidate", gcrImage, c.commit)),
+			bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:candidate_%s", baseImage, c.version, gcrImage, c.commit)),
+			bk.Cmd(fmt.Sprintf("docker push %s:candidate_%s", gcrImage, c.commit)),
 		)
 
 		pipeline.AddStep(":docker: :construction:", cmds...)
@@ -332,7 +332,7 @@ func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline)
 
 		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
 
-		candidateImage := fmt.Sprintf("%s:%s_candidate", gcrImage, c.commit)
+		candidateImage := fmt.Sprintf("%s:candidate_%s", gcrImage, c.commit)
 		cmds = append(cmds,
 			bk.Cmd(fmt.Sprintf("docker pull %s", candidateImage)),
 			bk.Cmd(fmt.Sprintf("docker tag %s %s:%s", candidateImage, baseImage, c.version)),

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -36,7 +36,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]
-		pipelineOperations = append(pipelineOperations, addDockerImage(c, app, false))
+		pipelineOperations = append(pipelineOperations,
+			addCanidateDockerImage(c, app),
+			addFinalDockerImage(c, app, false),
+		)
 
 	case c.isBextReleaseBranch:
 		// If this is a browser extension release branch, run the browser-extension tests and
@@ -85,9 +88,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addSharedTests,
 			addPostgresBackcompat,
 			addDockerfileLint,
+			addDockerImages(c, false),
 			wait,
 			addCodeCov,
-			addDockerImages(c),
+			addDockerImages(c, true),
 		}
 	}
 


### PR DESCRIPTION
<img width="1167" alt="Screen Shot 2019-12-16 at 12 18 22 PM" src="https://user-images.githubusercontent.com/9022011/70928147-6a12e980-1ffe-11ea-9c0a-523720b5653b.png">

---

Ultimately, the purpose of our e2e tests is to prevent bad commits from making their way into the final `sourcegraph/*` `insiders`/`semver` docker images. Currently, we wait for all of the e2e tests to pass before we even start the process of building our docker images. 

If all we care about is making sure only the commits that pass e2e test are the ones with the vetted `insiders` or `semver` tags, we can recover a lot of previously wasted time by building `candidate` versions of our docker images while the e2e tests are running. Once we know that e2e tests have passed, we can re-tag those `candidate` images with the final `insiders/semver` tag. 

Removing the e2e tests from the critical path can potentially shave off **~5 minutes** from our `master` branch CI pipeline.


---

The best buildkite builds to review for this PR are the ones for the [master-dry-run/ggilmore branch](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=master-dry-run%2Fggilmore ) which includes all of the `docker build` steps that the `master` branch has. 

---
Note: https://github.com/sourcegraph/infrastructure/pull/1754/ would be nice to get working since this will introduce a lot more steps per build into our CI pipeline.  

---