### PR TITLE
simplify shared Link component

### DIFF
--- a/browser/config/webpack/base.config.ts
+++ b/browser/config/webpack/base.config.ts
@@ -15,9 +15,9 @@ const config: webpack.Configuration = {
     entry: {
         background: buildEntry(extEntry, backgroundEntry, '../../src/extension/scripts/background.tsx'),
         options: buildEntry(extEntry, optionsEntry, '../../src/extension/scripts/options.tsx'),
-        inject: buildEntry(extEntry, contentEntry, '../../src/extension/scripts/inject.tsx'),
-        phabricator: buildEntry(pageEntry, '../../src/libs/phabricator/extension.tsx'),
-        integration: buildEntry(pageEntry, '../../src/integration/integration.tsx'),
+        inject: buildEntry(extEntry, contentEntry, '../../src/extension/scripts/inject.ts'),
+        phabricator: buildEntry(pageEntry, '../../src/libs/phabricator/extension.ts'),
+        integration: buildEntry(pageEntry, '../../src/integration/integration.ts'),
 
         style: path.join(__dirname, '../../src/app.scss'),
         'options-style': path.join(__dirname, '../../src/options.scss'),

--- a/browser/src/extension/scripts/inject.ts
+++ b/browser/src/extension/scripts/inject.ts
@@ -1,10 +1,8 @@
 import '../polyfills'
 
-import * as H from 'history'
-import React from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { first } from 'rxjs/operators'
-import { setLinkComponent } from '../../../../shared/src/components/Link'
+import { setLinkComponent, AnchorLink } from '../../../../shared/src/components/Link'
 import { storage } from '../../browser/storage'
 import { determineCodeHost } from '../../libs/code_intelligence'
 import { injectCodeIntelligence } from '../../libs/code_intelligence/inject'
@@ -28,11 +26,7 @@ assertEnv('CONTENT')
 const codeHost = determineCodeHost()
 initSentry('content', codeHost?.type)
 
-setLinkComponent(({ to, children, ...props }) => (
-    <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
-        {children}
-    </a>
-))
+setLinkComponent(AnchorLink)
 
 const IS_EXTENSION = true
 

--- a/browser/src/integration/integration.ts
+++ b/browser/src/integration/integration.ts
@@ -1,19 +1,13 @@
 import '../../../shared/src/polyfills'
 
-import * as H from 'history'
-import React from 'react'
-import { setLinkComponent } from '../../../shared/src/components/Link'
+import { setLinkComponent, AnchorLink } from '../../../shared/src/components/Link'
 import { injectCodeIntelligence } from '../libs/code_intelligence/inject'
 import { EXTENSION_MARKER_ID, injectExtensionMarker, NATIVE_INTEGRATION_ACTIVATED } from '../libs/sourcegraph/inject'
 import { getAssetsURL } from '../shared/util/context'
 
 const IS_EXTENSION = false
 
-setLinkComponent(({ to, children, ...props }) => (
-    <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
-        {children}
-    </a>
-))
+setLinkComponent(AnchorLink)
 
 async function init(): Promise<void> {
     console.log('Sourcegraph native integration is running')

--- a/browser/src/libs/phabricator/extension.ts
+++ b/browser/src/libs/phabricator/extension.ts
@@ -1,8 +1,6 @@
 import '../../../../shared/src/polyfills'
 
-import * as H from 'history'
-import React from 'react'
-import { setLinkComponent } from '../../../../shared/src/components/Link'
+import { setLinkComponent, AnchorLink } from '../../../../shared/src/components/Link'
 import { injectCodeIntelligence } from '../code_intelligence/inject'
 import { injectExtensionMarker } from '../sourcegraph/inject'
 import { getPhabricatorCSS, getSourcegraphURLFromConduit } from './backend'
@@ -14,11 +12,7 @@ window.SOURCEGRAPH_PHABRICATOR_EXTENSION = true
 
 const IS_EXTENSION = false
 
-setLinkComponent(({ to, children, ...props }) => (
-    <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
-        {children}
-    </a>
-))
+setLinkComponent(AnchorLink)
 
 async function init(): Promise<void> {
     /**

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -36,6 +36,7 @@ const config = {
     // Neither NodeJS nor JSDOM have fetch + AbortController yet
     require.resolve('abort-controller/polyfill'),
     path.join(__dirname, 'shared/dev/fetch'),
+    path.join(__dirname, 'shared/dev/setLinkComponentForTest.ts'),
   ],
 }
 

--- a/shared/dev/setLinkComponentForTest.ts
+++ b/shared/dev/setLinkComponentForTest.ts
@@ -1,0 +1,3 @@
+import { setLinkComponent, AnchorLink } from '../src/components/Link'
+
+setLinkComponent(AnchorLink)

--- a/shared/src/actions/ActionItem.story.tsx
+++ b/shared/src/actions/ActionItem.story.tsx
@@ -2,16 +2,9 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as H from 'history'
 import React from 'react'
-import { setLinkComponent } from '../components/Link'
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { ActionItem, ActionItemComponentProps } from './ActionItem'
 import './ActionItem.scss'
-
-setLinkComponent(({ to, children, ...props }) => (
-    <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
-        {children}
-    </a>
-))
 
 const EXTENSIONS_CONTROLLER: ActionItemComponentProps['extensionsController'] = {
     executeCommand: () => new Promise(resolve => setTimeout(resolve, 750)),

--- a/shared/src/actions/ActionItem.test.tsx
+++ b/shared/src/actions/ActionItem.test.tsx
@@ -2,7 +2,6 @@ import * as H from 'history'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { createBarrier } from '../api/integration-test/testHelpers'
-import { setLinkComponent } from '../components/Link'
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { ActionItem } from './ActionItem'
 
@@ -204,8 +203,6 @@ describe('ActionItem', () => {
 
     test('render as link for "open" command', () => {
         jsdom.reconfigure({ url: 'https://example.com/foo' })
-        setLinkComponent((props: any) => <a {...props} />)
-        afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
 
         const component = renderer.create(
             <ActionItem
@@ -221,8 +218,6 @@ describe('ActionItem', () => {
 
     test('render as link with icon for "open" command with different origin', () => {
         jsdom.reconfigure({ url: 'https://example.com/foo' })
-        setLinkComponent((props: any) => <a {...props} />)
-        afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
 
         const component = renderer.create(
             <ActionItem

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -90,10 +90,10 @@ exports[`ActionItem pressed toggle actionItem 1`] = `
 exports[`ActionItem render as link for "open" command 1`] = `
 <a
   className="action-item "
+  href="https://example.com/bar"
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
-  to="https://example.com/bar"
 >
   
   t
@@ -104,10 +104,10 @@ exports[`ActionItem render as link for "open" command 1`] = `
 exports[`ActionItem render as link with icon for "open" command with different origin 1`] = `
 <a
   className="action-item "
+  href="https://other.com/foo"
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
-  to="https://other.com/foo"
 >
   
   t

--- a/shared/src/components/FileMatch.test.tsx
+++ b/shared/src/components/FileMatch.test.tsx
@@ -6,7 +6,6 @@ import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
 import { MockVisibilitySensor } from './CodeExcerpt.test'
 import { FileMatch, IFileMatch } from './FileMatch'
-import { setLinkComponent } from './Link'
 import { HIGHLIGHTED_FILE_LINES_REQUEST, NOOP_SETTINGS_CASCADE, RESULT } from '../util/searchTestHelpers'
 
 jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children, onChange }) => (
@@ -16,12 +15,7 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
 ))
 
 describe('FileMatch', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-
-    afterAll(() => {
-        setLinkComponent(null as any)
-        cleanup()
-    })
+    afterAll(cleanup)
     const history = createBrowserHistory()
     const defaultProps = {
         location: history.location,

--- a/shared/src/components/FileMatchChildren.test.tsx
+++ b/shared/src/components/FileMatchChildren.test.tsx
@@ -13,7 +13,6 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
 import sinon from 'sinon'
 
 import { FileMatchChildren } from './FileMatchChildren'
-import { setLinkComponent } from './Link'
 import { RESULT, HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST, NOOP_SETTINGS_CASCADE } from '../util/searchTestHelpers'
 
 const history = H.createBrowserHistory()
@@ -40,11 +39,7 @@ const defaultProps = {
 }
 
 describe('FileMatchChildren', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => {
-        setLinkComponent(null as any)
-        cleanup()
-    })
+    afterAll(cleanup)
 
     it('calls onSelect callback when an item is clicked', () => {
         const { container } = render(<FileMatchChildren {...defaultProps} onSelect={onSelect} />)

--- a/shared/src/components/Link.tsx
+++ b/shared/src/components/Link.tsx
@@ -38,7 +38,20 @@ if (process.env.NODE_ENV !== 'production') {
  * Sets (globally) the component to use for links. This must be set at initialization time.
  *
  * @see Link
+ * @see AnchorLink
  */
 export function setLinkComponent(component: typeof Link): void {
     Link = component
 }
+
+/**
+ * A link component (to be passed to {@link setLinkComponent}) that renders a normal <a>. This
+ * should be used everywhere except when a HTML5 history API router is in use (e.g., react-router).
+ *
+ * @see setLinkComponent
+ */
+export const AnchorLink: React.FunctionComponent<LinkProps> = ({ to, children, ...props }) => (
+    <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
+        {children}
+    </a>
+)

--- a/shared/src/components/LinkOrButton.test.tsx
+++ b/shared/src/components/LinkOrButton.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from './Link'
 import { LinkOrButton } from './LinkOrButton'
 
 describe('LinkOrButton', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     test('render a link when "to" is set', () => {
         const component = renderer.create(<LinkOrButton to="http://example.com">foo</LinkOrButton>)
         expect(component.toJSON()).toMatchSnapshot()

--- a/shared/src/components/LinkOrSpan.test.tsx
+++ b/shared/src/components/LinkOrSpan.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from './Link'
 import { LinkOrSpan } from './LinkOrSpan'
 
 describe('LinkOrSpan', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     test('render a link when "to" is set', () => {
         const component = renderer.create(<LinkOrSpan to="http://example.com">foo</LinkOrSpan>)
         expect(component.toJSON()).toMatchSnapshot()

--- a/shared/src/components/RepoFileLink.test.tsx
+++ b/shared/src/components/RepoFileLink.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from './Link'
 import { RepoFileLink } from './RepoFileLink'
 
 describe('RepoFileLink', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     test('renders', () => {
         const component = renderer.create(
             <RepoFileLink

--- a/shared/src/components/RepoLink.test.tsx
+++ b/shared/src/components/RepoLink.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from './Link'
 import { RepoLink } from './RepoLink'
 
 describe('RepoLink', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     test('renders a link when "to" is set', () => {
         const component = renderer.create(<RepoLink repoName="my/repo" to="http://example.com" />)
         expect(component.toJSON()).toMatchSnapshot()

--- a/shared/src/components/ResultContainer.test.tsx
+++ b/shared/src/components/ResultContainer.test.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { cleanup, fireEvent, getByTestId, getByText, render } from '@testing-library/react'
 import sinon from 'sinon'
 import { FileMatchChildren } from './FileMatchChildren'
-import { setLinkComponent } from './Link'
 import { RepoFileLink } from './RepoFileLink'
 import { ResultContainer } from './ResultContainer'
 import {
@@ -14,11 +13,7 @@ import {
 } from '../util/searchTestHelpers'
 
 describe('ResultContainer', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => {
-        setLinkComponent(() => null as any)
-        cleanup()
-    })
+    afterAll(cleanup)
 
     const history = H.createBrowserHistory()
     history.replace({ pathname: '/search' })

--- a/shared/src/components/__snapshots__/LinkOrButton.test.tsx.snap
+++ b/shared/src/components/__snapshots__/LinkOrButton.test.tsx.snap
@@ -15,10 +15,10 @@ exports[`LinkOrButton render a button when "to" is undefined 1`] = `
 exports[`LinkOrButton render a link when "to" is set 1`] = `
 <a
   className="nav-link "
+  href="http://example.com"
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
-  to="http://example.com"
 >
   foo
 </a>

--- a/shared/src/components/__snapshots__/LinkOrSpan.test.tsx.snap
+++ b/shared/src/components/__snapshots__/LinkOrSpan.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`LinkOrSpan render a link when "to" is set 1`] = `
 <a
   className=""
-  to="http://example.com"
+  href="http://example.com"
 >
   foo
 </a>

--- a/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`RepoFileLink renders 1`] = `
 Array [
   <a
-    to="https://example.com"
+    href="https://example.com"
   >
     my/repo
   </a>,
   " ›",
   " ",
   <a
-    to="https://example.com/file"
+    href="https://example.com/file"
   >
     my/
     <strong>

--- a/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
@@ -13,7 +13,7 @@ Array [
 exports[`RepoLink renders a link when "to" is set 1`] = `
 <a
   className=""
-  to="http://example.com"
+  href="http://example.com"
 >
    
   my/

--- a/shared/src/components/activation/ActivationDropdown.test.tsx
+++ b/shared/src/components/activation/ActivationDropdown.test.tsx
@@ -2,14 +2,10 @@ import * as H from 'history'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { noop } from 'rxjs'
-import { setLinkComponent } from '../Link'
 import { Activation } from './Activation'
 import { ActivationDropdown } from './ActivationDropdown'
 
 describe('ActivationDropdown', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     const baseActivation: Activation = {
         steps: [
             {

--- a/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`ActivationDropdown render 0/2 completed 1`] = `
         onClick={[Function]}
       >
         <a
-          to="/some/url"
+          href="/some/url"
         >
           <div
             className="d-flex justify-content-between"
@@ -301,7 +301,7 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
         onClick={[Function]}
       >
         <a
-          to="/some/url"
+          href="/some/url"
         >
           <div
             className="d-flex justify-content-between"

--- a/shared/src/panel/views/HierarchicalLocationsView.test.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.test.tsx
@@ -13,15 +13,11 @@ import * as sinon from 'sinon'
 import { createContextService } from '../../api/client/context/contextService'
 import { parseTemplate } from '../../api/client/context/expr/evaluator'
 import { ContributionsEntry, ContributionUnsubscribable } from '../../api/client/services/contribution'
-import { setLinkComponent } from '../../components/Link'
 import { Controller } from '../../extensions/controller'
 import { SettingsCascadeOrError } from '../../settings/settings'
 import { HierarchicalLocationsView, HierarchicalLocationsViewProps } from './HierarchicalLocationsView'
 
 describe('<HierarchicalLocationsView />', () => {
-    beforeAll(() => {
-        setLinkComponent((props: any) => <a {...props} />)
-    })
     const getProps = () => {
         const services = {
             context: createContextService({ clientApplication: 'other' }),
@@ -205,9 +201,5 @@ describe('<HierarchicalLocationsView />', () => {
             locations: of(locations),
         }
         expect(renderer.create(<HierarchicalLocationsView {...props} />).toJSON()).toMatchSnapshot()
-    })
-
-    afterAll(() => {
-        setLinkComponent(null as any)
     })
 })

--- a/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -39,14 +39,14 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 onClick={[Function]}
               >
                 <a
-                  to="/github.com/foo/bar"
+                  href="/github.com/foo/bar"
                 >
                   foo/bar
                 </a>
                  ›
                  
                 <a
-                  to="/github.com/foo/bar/-/blob/undefined"
+                  href="/github.com/foo/bar/-/blob/undefined"
                 >
                   <strong>
                     
@@ -75,8 +75,8 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
           >
             <a
               className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
+              href="/github.com/foo/bar/-/blob/undefined#L2:1"
               onClick={[Function]}
-              to="/github.com/foo/bar/-/blob/undefined#L2:1"
             >
               <VisibilitySensor
                 offset={
@@ -236,14 +236,14 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 onClick={[Function]}
               >
                 <a
-                  to="/github.com/foo/bar"
+                  href="/github.com/foo/bar"
                 >
                   foo/bar
                 </a>
                  ›
                  
                 <a
-                  to="/github.com/foo/bar/-/blob/file1.txt"
+                  href="/github.com/foo/bar/-/blob/file1.txt"
                 >
                   <strong>
                     file1.txt
@@ -272,8 +272,8 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
           >
             <a
               className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
+              href="/github.com/foo/bar/-/blob/file1.txt#L2:1"
               onClick={[Function]}
-              to="/github.com/foo/bar/-/blob/file1.txt#L2:1"
             >
               <VisibilitySensor
                 offset={
@@ -389,14 +389,14 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                 onClick={[Function]}
               >
                 <a
-                  to="/github.com/foo/bar"
+                  href="/github.com/foo/bar"
                 >
                   foo/bar
                 </a>
                  ›
                  
                 <a
-                  to="/github.com/foo/bar/-/blob/undefined"
+                  href="/github.com/foo/bar/-/blob/undefined"
                 >
                   <strong>
                     
@@ -425,8 +425,8 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
           >
             <a
               className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
+              href="/github.com/foo/bar/-/blob/undefined#L2:1"
               onClick={[Function]}
-              to="/github.com/foo/bar/-/blob/undefined#L2:1"
             >
               <VisibilitySensor
                 offset={

--- a/web/src/enterprise/campaigns/detail/FileDiffTab.test.tsx
+++ b/web/src/enterprise/campaigns/detail/FileDiffTab.test.tsx
@@ -3,13 +3,8 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { FileDiffTab } from './FileDiffTab'
 import * as GQL from '../../../../../shared/src/graphql/schema'
-import { setLinkComponent } from '../../../../../shared/src/components/Link'
 
 describe('FileDiffTab', () => {
-    beforeEach(() => {
-        setLinkComponent((props: any) => <a {...props} />)
-        afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-    })
     test('renders the form', () => {
         const history = H.createMemoryHistory({ keyLength: 0 })
         const location = H.createLocation('/campaigns/new')

--- a/web/src/enterprise/campaigns/detail/__snapshots__/FileDiffTab.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/FileDiffTab.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`FileDiffTab renders the form 1`] = `
      
     <a
       className=""
-      to="github.com/sourcegraph/sourcegraph"
+      href="github.com/sourcegraph/sourcegraph"
     >
       sourcegraph/sourcegraph
     </a>

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.test.tsx
@@ -8,15 +8,10 @@ import {
     ChangesetState,
     IExternalChangeset,
 } from '../../../../../../shared/src/graphql/schema'
-import { setLinkComponent } from '../../../../../../shared/src/components/Link'
 
 describe('ChangesetNode', () => {
     const history = H.createMemoryHistory({ keyLength: 0 })
     const location = H.createLocation('/campaigns')
-    beforeEach(() => {
-        setLinkComponent((props: any) => <a {...props} />)
-        afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-    })
     test('renders a changesetplan', () => {
         expect(
             renderer

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
@@ -40,9 +40,9 @@ exports[`ChangesetNode renders a changesetplan 1`] = `
             >
               <a
                 className="text-muted"
+                href="github.com/sourcegraph/sourcegraph"
                 rel="noopener noreferrer"
                 target="_blank"
-                to="github.com/sourcegraph/sourcegraph"
               >
                 sourcegraph
               </a>
@@ -181,9 +181,9 @@ exports[`ChangesetNode renders an externalchangeset 1`] = `
             >
               <a
                 className="text-muted"
+                href="github.com/sourcegraph/sourcegraph"
                 rel="noopener noreferrer"
                 target="_blank"
-                to="github.com/sourcegraph/sourcegraph"
               >
                 sourcegraph
               </a>
@@ -194,9 +194,9 @@ exports[`ChangesetNode renders an externalchangeset 1`] = `
                
               <a
                 className=""
+                href="https://github.com/sourcegraph/sourcegraph/pull/111111"
                 rel="noopener noreferrer"
                 target="_blank"
-                to="https://github.com/sourcegraph/sourcegraph/pull/111111"
               >
                 Remove lodash
               </a>

--- a/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -2,14 +2,8 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { CampaignNode } from './CampaignNode'
 import * as GQL from '../../../../../shared/src/graphql/schema'
-import { setLinkComponent } from '../../../../../shared/src/components/Link'
 
 describe('CampaignNode', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => {
-        setLinkComponent(null as any)
-    })
-
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const node = {
         __typename: 'Campaign',

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`CampaignNode renders a campaign node 1`] = `
       >
         <a
           className="d-flex align-items-center text-decoration-none"
-          to="/campaigns/123"
+          href="/campaigns/123"
         >
           Upgrade lodash to v4
         </a>

--- a/web/src/extensions/ExtensionCard.test.tsx
+++ b/web/src/extensions/ExtensionCard.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from '../../../shared/src/components/Link'
 import { PlatformContext } from '../../../shared/src/platform/context'
 import { ExtensionCard } from './ExtensionCard'
 
 describe('ExtensionCard', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     const NOOP_PLATFORM_CONTEXT: PlatformContext = {} as any
 
     test('renders', () => {

--- a/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`ExtensionCard renders 1`] = `
             >
               <a
                 className="stretched-link"
-                to="extensions/x/y"
+                href="extensions/x/y"
               >
                 <span
                   className="text-muted"

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -2,13 +2,9 @@ import { noop } from 'lodash'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from '../../../../shared/src/components/Link'
 import { RegistryExtensionOverviewPage } from './RegistryExtensionOverviewPage'
 
 describe('RegistryExtensionOverviewPage', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     test('renders', () =>
         expect(
             renderer

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -2,7 +2,6 @@ import * as H from 'history'
 import { flatten, noop } from 'lodash'
 import React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow'
-import { setLinkComponent } from '../../../shared/src/components/Link'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
@@ -40,8 +39,6 @@ const renderShallow = (element: React.ReactElement<NavLinks['props']>): any => {
 }
 
 describe('NavLinks', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
     const NOOP_EXTENSIONS_CONTROLLER: ExtensionsControllerProps<
         'executeCommand' | 'services'
     >['extensionsController'] = { executeCommand: () => Promise.resolve(), services: {} as any }

--- a/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { of, queueScheduler, Observable } from 'rxjs'
-import { setLinkComponent } from '../../../shared/src/components/Link'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
 
 describe('StatusMessagesNavItem', () => {
-    setLinkComponent(props => <a {...props} />)
-    afterAll(() => setLinkComponent(() => null)) // reset global env for other tests
-
     test('no messages', () => {
         const fetchMessages = (): Observable<GQL.StatusMessage[]> => of([])
         expect(

--- a/web/src/nav/UserNavItem.test.tsx
+++ b/web/src/nav/UserNavItem.test.tsx
@@ -2,15 +2,11 @@ import * as H from 'history'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
-import { setLinkComponent } from '../../../shared/src/components/Link'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { UserNavItem } from './UserNavItem'
 import { ThemePreference } from '../search/theme'
 
 describe('UserNavItem', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-    afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
-
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const ORG_CONNECTION = {
         __typename: 'OrgConnection',

--- a/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -176,8 +176,8 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
         className="status-messages-nav-item__entry-link"
       >
         <a
+          href="/site-admin/external-services"
           onClick={[Function]}
-          to="/site-admin/external-services"
         >
           Configure external services
         </a>
@@ -304,8 +304,8 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
         className="status-messages-nav-item__entry-link"
       >
         <a
+          href="/site-admin/external-services/abcd"
           onClick={[Function]}
-          to="/site-admin/external-services/abcd"
         >
           Edit "GitHub.com"
         </a>
@@ -432,8 +432,8 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
         className="status-messages-nav-item__entry-link"
       >
         <a
+          href="/site-admin/external-services"
           onClick={[Function]}
-          to="/site-admin/external-services"
         >
           Configure external services
         </a>

--- a/web/src/search/results/SearchResults.test.tsx
+++ b/web/src/search/results/SearchResults.test.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter } from 'react-router-dom'
 import { cleanup, getAllByTestId, getByTestId, render, waitForElement } from '@testing-library/react'
 import { noop } from 'rxjs'
 import sinon from 'sinon'
-import { setLinkComponent } from '../../../../shared/src/components/Link'
 import {
     extensionsController,
     HIGHLIGHTED_FILE_LINES_REQUEST,
@@ -15,12 +14,7 @@ import { SearchResults, SearchResultsProps } from './SearchResults'
 import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 
 describe('SearchResults', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-
-    afterAll(() => {
-        setLinkComponent(null as any)
-        cleanup()
-    })
+    afterAll(cleanup)
 
     const history = createBrowserHistory()
     history.replace({ search: 'q=r:golang/oauth2+test+f:travis&patternType=regexp' })

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -5,7 +5,6 @@ import { BrowserRouter } from 'react-router-dom'
 import { cleanup, getAllByTestId, getByTestId, queryByTestId, render } from '@testing-library/react'
 import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
-import { setLinkComponent } from '../../../../shared/src/components/Link'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemetryService'
 import {
@@ -43,8 +42,6 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
 ))
 
 describe('SearchResultsList', () => {
-    setLinkComponent((props: any) => <a {...props} />)
-
     /**
      * Simulates "scrolling" to the end of the search results,
      * by triggering all the visibility changed callbacks with
@@ -80,10 +77,7 @@ describe('SearchResultsList', () => {
         VISIBILITY_CHANGED_CALLBACKS = []
     })
 
-    afterAll(() => {
-        setLinkComponent(null as any)
-        cleanup()
-    })
+    afterAll(cleanup)
 
     const history = createBrowserHistory()
     history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })


### PR DESCRIPTION
- In tests, call setLinkComponent with the AnchorLink (which uses `<a>`) to avoid each test needing to do so. Update test snapshots to reflect this (mostly `to` prop to `href`).
- Export the `AnchorLink`, which was defined duplicatively in several places, which renders an `<a href>` given `LinkProps`.