### PR TITLE
use a different redis cache for enhanced lang detection

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -157,11 +157,11 @@ func (s *repos) ListDefault(ctx context.Context) (repos []*types.Repo, err error
 	return db.DefaultRepos.List(ctx)
 }
 
-var inventoryCache = rcache.New("inv:v2")
-
 // Feature flag for enhanced (but much slower) language detection that uses file contents, not just
 // filenames.
 var useEnhancedLanguageDetection, _ = strconv.ParseBool(os.Getenv("USE_ENHANCED_LANGUAGE_DETECTION"))
+
+var inventoryCache = rcache.New(fmt.Sprintf("inv:v2:enhanced_%v", useEnhancedLanguageDetection))
 
 func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *inventory.Inventory, err error) {
 	if Mocks.Repos.GetInventory != nil {


### PR DESCRIPTION
This is necessary because when the server is using USE_ENHANCED_LANGUAGE_DETECTION, the stored results are different from when it's not. When that flag is disabled, all cached results will have line counts of 0. If the flag is later enabled, it will reuse cached results with 0 line counts and the overall result will be partially incorrect.