### PR TITLE
enable the new enhanced language detection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The feedback toast now requests feedback every 60 days of usage (was previously only once on the 3rd day of use). [#7165](https://github.com/sourcegraph/sourcegraph/pull/7165)
 - The lsif-server container now only has a dependency on Postgres, whereas before it also relied on Redis. [#6880](https://github.com/sourcegraph/sourcegraph/pull/6880)
 - Renamed the GraphQL API `LanguageStatistics` fields to `name`, `totalBytes`, and `totalLines` (previously the field names started with an uppercase letter, which was inconsistent).
+- Detecting a file's language uses a more accurate but slower algorithm. To revert to the old (faster and less accurate) algorithm, set the `USE_ENHANCED_LANGUAGE_DETECTION` env var to the string `false` (on the `sourcegraph/server` container, or if using the cluster deployment, on the `sourcegraph-frontend` pod).
 
 ### Fixed
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -158,8 +158,15 @@ func (s *repos) ListDefault(ctx context.Context) (repos []*types.Repo, err error
 }
 
 // Feature flag for enhanced (but much slower) language detection that uses file contents, not just
-// filenames.
-var useEnhancedLanguageDetection, _ = strconv.ParseBool(os.Getenv("USE_ENHANCED_LANGUAGE_DETECTION"))
+// filenames. Enabled by default.
+var useEnhancedLanguageDetection = func() bool {
+	v := os.Getenv("USE_ENHANCED_LANGUAGE_DETECTION")
+	if v == "" {
+		return true
+	}
+	b, _ := strconv.ParseBool(v)
+	return b
+}()
 
 var inventoryCache = rcache.New(fmt.Sprintf("inv:v2:enhanced_%v", useEnhancedLanguageDetection))
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -159,14 +160,7 @@ func (s *repos) ListDefault(ctx context.Context) (repos []*types.Repo, err error
 
 // Feature flag for enhanced (but much slower) language detection that uses file contents, not just
 // filenames. Enabled by default.
-var useEnhancedLanguageDetection = func() bool {
-	v := os.Getenv("USE_ENHANCED_LANGUAGE_DETECTION")
-	if v == "" {
-		return true
-	}
-	b, _ := strconv.ParseBool(v)
-	return b
-}()
+var useEnhancedLanguageDetection, _ = strconv.ParseBool(env.Get("USE_ENHANCED_LANGUAGE_DETECTION", "true", "Enable more accurate but slower language detection that uses file contents"))
 
 var inventoryCache = rcache.New(fmt.Sprintf("inv:v2:enhanced_%v", useEnhancedLanguageDetection))
 


### PR DESCRIPTION
Tested on Sourcegraph.com and performance is acceptable.

For example, running this query:

```
query {
  repository(name:"github.com/microsoft/vscode") {
    commit(rev: "HEAD") {
      languageStatistics {
        name
        totalBytes
        totalLines
      }
    }
  }
}
```

without a cache took 6.1s. Because of how the results are cached (per-git object), recomputing the stats after subsequent commits is usually cheap (only changed git trees need to be recomputed).

There are currently no operations (other than manual API queries) that would cause this to be run across all repositories on an instance, or a large subset of all repositories, so the downsides of unexpectedly bad performance are low.

Closes #2587 