### PR TITLE
search: pass language to structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -754,6 +754,8 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 	includePatterns = append(includePatterns, langIncludePatterns...)
 	excludePatterns = append(excludePatterns, langExcludePatterns...)
 
+	language, _ := r.query.StringValues(query.FieldLang)
+
 	patternInfo := &search.PatternInfo{
 		IsRegExp:                     isRegExp,
 		IsStructuralPat:              isStructuralPat,
@@ -764,6 +766,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 		FilePatternsReposMustInclude: filePatternsReposMustInclude,
 		FilePatternsReposMustExclude: filePatternsReposMustExclude,
 		PathPatternsAreRegExps:       true,
+		Language:                     strings.Join(language, ""),
 		PathPatternsAreCaseSensitive: r.query.IsCaseSensitive(),
 		CombyRule:                    strings.Join(combyRule, ""),
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -754,7 +754,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 	includePatterns = append(includePatterns, langIncludePatterns...)
 	excludePatterns = append(excludePatterns, langExcludePatterns...)
 
-	language, _ := r.query.StringValues(query.FieldLang)
+	languages, _ := r.query.StringValues(query.FieldLang)
 
 	patternInfo := &search.PatternInfo{
 		IsRegExp:                     isRegExp,
@@ -766,7 +766,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Pa
 		FilePatternsReposMustInclude: filePatternsReposMustInclude,
 		FilePatternsReposMustExclude: filePatternsReposMustExclude,
 		PathPatternsAreRegExps:       true,
-		Language:                     strings.Join(language, ""),
+		Languages:                    languages,
 		PathPatternsAreCaseSensitive: r.query.IsCaseSensitive(),
 		CombyRule:                    strings.Join(combyRule, ""),
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -500,12 +500,14 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 			IsRegExp:               true,
 			PathPatternsAreRegExps: true,
 			IncludePatterns:        []string{`\.graphql$|\.gql$|\.graphqls$`},
+			Language:               "graphql",
 		},
 		"p lang:graphql file:f": {
 			Pattern:                "p",
 			IsRegExp:               true,
 			PathPatternsAreRegExps: true,
 			IncludePatterns:        []string{"f", `\.graphql$|\.gql$|\.graphqls$`},
+			Language:               "graphql",
 		},
 		"p -lang:graphql file:f": {
 			Pattern:                "p",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -500,14 +500,14 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 			IsRegExp:               true,
 			PathPatternsAreRegExps: true,
 			IncludePatterns:        []string{`\.graphql$|\.gql$|\.graphqls$`},
-			Language:               "graphql",
+			Languages:              []string{"graphql"},
 		},
 		"p lang:graphql file:f": {
 			Pattern:                "p",
 			IsRegExp:               true,
 			PathPatternsAreRegExps: true,
 			IncludePatterns:        []string{"f", `\.graphql$|\.gql$|\.graphqls$`},
-			Language:               "graphql",
+			Languages:              []string{"graphql"},
 		},
 		"p -lang:graphql file:f": {
 			Pattern:                "p",

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -194,7 +194,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 		"ExcludePattern":  []string{p.ExcludePattern},
 		"IncludePatterns": p.IncludePatterns,
 		"FetchTimeout":    []string{fetchTimeout.String()},
-		"Language":        []string{p.Language},
+		"Language":        p.Languages,
 		"CombyRule":       []string{p.CombyRule},
 	}
 	if deadline, ok := ctx.Deadline(); ok {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -194,6 +194,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 		"ExcludePattern":  []string{p.ExcludePattern},
 		"IncludePatterns": p.IncludePatterns,
 		"FetchTimeout":    []string{fetchTimeout.String()},
+		"Language":        []string{p.Language},
 		"CombyRule":       []string{p.CombyRule},
 	}
 	if deadline, ok := ctx.Deadline(); ok {
@@ -606,7 +607,6 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 					patternCopy := *args.PatternInfo
 					args.PatternInfo = &patternCopy
 					includePatternsCopy := make([]string, len(args.PatternInfo.IncludePatterns))
-					copy(includePatternsCopy, args.PatternInfo.IncludePatterns)
 					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 				}
 			}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -194,7 +194,7 @@ func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.
 		"ExcludePattern":  []string{p.ExcludePattern},
 		"IncludePatterns": p.IncludePatterns,
 		"FetchTimeout":    []string{fetchTimeout.String()},
-		"Language":        p.Languages,
+		"Languages":       p.Languages,
 		"CombyRule":       []string{p.CombyRule},
 	}
 	if deadline, ok := ctx.Deadline(); ok {
@@ -603,10 +603,10 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			args := *args
 			if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
 				// Modify the search query to only run for the filtered files
+				var includePatternsCopy []string
 				if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
 					patternCopy := *args.PatternInfo
 					args.PatternInfo = &patternCopy
-					includePatternsCopy := make([]string, len(args.PatternInfo.IncludePatterns))
 					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 				}
 			}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -603,10 +603,10 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*FileMatc
 			args := *args
 			if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
 				// Modify the search query to only run for the filtered files
-				var includePatternsCopy []string
 				if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
 					patternCopy := *args.PatternInfo
 					args.PatternInfo = &patternCopy
+					includePatternsCopy := []string{}
 					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 				}
 			}

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -34,7 +34,7 @@ type PatternInfo struct {
 	PatternMatchesContent bool
 	PatternMatchesPath    bool
 
-	Language string
+	Languages []string
 }
 
 func (p *PatternInfo) IsEmpty() bool {

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -33,6 +33,8 @@ type PatternInfo struct {
 
 	PatternMatchesContent bool
 	PatternMatchesPath    bool
+
+	Language string
 }
 
 func (p *PatternInfo) IsEmpty() bool {

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -100,6 +100,9 @@ type PatternInfo struct {
 	// considered a match.
 	PatternMatchesPath bool
 
+	// Language is the language passed via the lang filter (e.g., "lang:c")
+	Language string
+
 	// CombyRule is a rule that constrains matching for structural search. It only applies when IsStructuralPat is true.
 	CombyRule string
 }

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -100,8 +100,8 @@ type PatternInfo struct {
 	// considered a match.
 	PatternMatchesPath bool
 
-	// Language is the language passed via the lang filter (e.g., "lang:c")
-	Language string
+	// Languages is the languages passed via the lang filters (e.g., "lang:c")
+	Languages []string
 
 	// CombyRule is a rule that constrains matching for structural search. It only applies when IsStructuralPat is true.
 	CombyRule string

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -142,7 +142,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	span.SetTag("pattern", p.Pattern)
 	span.SetTag("isRegExp", strconv.FormatBool(p.IsRegExp))
 	span.SetTag("isStructuralPat", strconv.FormatBool(p.IsStructuralPat))
-	span.SetTag("language", p.Languages)
+	span.SetTag("languages", p.Languages)
 	span.SetTag("isWordMatch", strconv.FormatBool(p.IsWordMatch))
 	span.SetTag("isCaseSensitive", strconv.FormatBool(p.IsCaseSensitive))
 	span.SetTag("pathPatternsAreRegExps", strconv.FormatBool(p.PathPatternsAreRegExps))
@@ -184,7 +184,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		span.SetTag("deadlineHit", deadlineHit)
 		span.Finish()
 		if s.Log != nil {
-			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "language", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
+			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "languages", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
 		}
 	}(time.Now())
 

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -142,7 +142,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	span.SetTag("pattern", p.Pattern)
 	span.SetTag("isRegExp", strconv.FormatBool(p.IsRegExp))
 	span.SetTag("isStructuralPat", strconv.FormatBool(p.IsStructuralPat))
-	span.SetTag("language", p.Language)
+	span.SetTag("language", p.Languages)
 	span.SetTag("isWordMatch", strconv.FormatBool(p.IsWordMatch))
 	span.SetTag("isCaseSensitive", strconv.FormatBool(p.IsCaseSensitive))
 	span.SetTag("pathPatternsAreRegExps", strconv.FormatBool(p.PathPatternsAreRegExps))
@@ -184,7 +184,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		span.SetTag("deadlineHit", deadlineHit)
 		span.Finish()
 		if s.Log != nil {
-			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "language", p.Language, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
+			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "language", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
 		}
 	}(time.Now())
 
@@ -228,7 +228,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, p.Repo)
+		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath)
 	}

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -142,6 +142,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	span.SetTag("pattern", p.Pattern)
 	span.SetTag("isRegExp", strconv.FormatBool(p.IsRegExp))
 	span.SetTag("isStructuralPat", strconv.FormatBool(p.IsStructuralPat))
+	span.SetTag("language", p.Language)
 	span.SetTag("isWordMatch", strconv.FormatBool(p.IsWordMatch))
 	span.SetTag("isCaseSensitive", strconv.FormatBool(p.IsCaseSensitive))
 	span.SetTag("pathPatternsAreRegExps", strconv.FormatBool(p.PathPatternsAreRegExps))
@@ -183,7 +184,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		span.SetTag("deadlineHit", deadlineHit)
 		span.Finish()
 		if s.Log != nil {
-			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
+			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "language", p.Language, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", len(matches), "code", code, "duration", time.Since(start), "err", err)
 		}
 	}(time.Now())
 
@@ -227,7 +228,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.IncludePatterns, p.Repo)
+		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath)
 	}

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -156,14 +156,19 @@ func lookupMatcher(language string) string {
 	return ""
 }
 
-func structuralSearch(ctx context.Context, zipPath, pattern, rule, language string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func structuralSearch(ctx context.Context, zipPath, pattern, rule string, languages, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
 	numWorkers := 4
 
-	matcher := lookupMatcher(language)
-	log15.Info("structural search", "language", language, "matcher", matcher)
+	var matcher string
+	if languages != nil {
+		// Pick the first language, there is no support for applying
+		// multiple language matchers in a single search query.
+		matcher = lookupMatcher(languages[0])
+		log15.Info("structural search", "language", languages[0], "matcher", matcher)
+	}
 
 	args := comby.Args{
 		Input:         comby.ZipPath(zipPath),

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -78,14 +78,96 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	return matches
 }
 
-func structuralSearch(ctx context.Context, zipPath, pattern string, rule string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
+func lookupMatcher(language string) string {
+	switch strings.ToLower(language) {
+	case "assembly, asm":
+		return ".s"
+	case "bash":
+		return ".sh"
+	case "c":
+		return ".c"
+	case "c#,csharp":
+		return ".cs"
+	case "css":
+		return ".css"
+	case "dart":
+		return ".dart"
+	case "clojure":
+		return ".clj"
+	case "elm":
+		return ".elm"
+	case "erlang":
+		return ".erl"
+	case "elixir":
+		return ".ex"
+	case "fortran":
+		return ".f"
+	case "f#, fsharp":
+		return ".fsx"
+	case "go":
+		return ".go"
+	case "html":
+		return ".html"
+	case "haskell":
+		return ".hs"
+	case "java":
+		return ".java"
+	case "javascript":
+		return ".js"
+	case "json":
+		return ".json"
+	case "julia":
+		return ".jl"
+	case "kotlin":
+		return ".kt"
+	case "laTeX":
+		return ".tex"
+	case "lisp":
+		return ".lisp"
+	case "nim":
+		return ".nim"
+	case "ocaml":
+		return ".ml"
+	case "pascal":
+		return ".pas"
+	case "php":
+		return ".php"
+	case "python":
+		return ".py"
+	case "reason":
+		return ".re"
+	case "ruby":
+		return ".rb"
+	case "rust":
+		return ".rs"
+	case "scala":
+		return ".scala"
+	case "sql":
+		return ".sql"
+	case "swift":
+		return ".swift"
+	case " text":
+		return ".txt"
+	case "typescript", "ts":
+		return ".ts"
+	case "xml":
+		return ".xml"
+	}
+	return ""
+}
+
+func structuralSearch(ctx context.Context, zipPath, pattern, rule, language string, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
 	log15.Info("structural search", "repo", string(repo))
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
 	numWorkers := 4
 
+	matcher := lookupMatcher(language)
+	log15.Info("structural search", "language", language, "matcher", matcher)
+
 	args := comby.Args{
 		Input:         comby.ZipPath(zipPath),
+		Matcher:       matcher,
 		MatchTemplate: pattern,
 		MatchOnly:     true,
 		FilePatterns:  includePatterns,

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -78,15 +78,19 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 	return matches
 }
 
+// lookupMatcher looks up a key for specifying -matcher in comby. Comby accepts
+// a representative file extension to set a language, so this lookup does not
+// need to consider all possible file extensions for a language. There is a generic
+// fallback language, so this lookup does not need to be exhaustive either.
 func lookupMatcher(language string) string {
 	switch strings.ToLower(language) {
-	case "assembly, asm":
+	case "assembly", "asm":
 		return ".s"
 	case "bash":
 		return ".sh"
 	case "c":
 		return ".c"
-	case "c#,csharp":
+	case "c#, csharp":
 		return ".cs"
 	case "css":
 		return ".css"
@@ -102,7 +106,7 @@ func lookupMatcher(language string) string {
 		return ".ex"
 	case "fortran":
 		return ".f"
-	case "f#, fsharp":
+	case "f#", "fsharp":
 		return ".fsx"
 	case "go":
 		return ".go"
@@ -146,7 +150,7 @@ func lookupMatcher(language string) string {
 		return ".sql"
 	case "swift":
 		return ".swift"
-	case " text":
+	case "text":
 		return ".txt"
 	case "typescript", "ts":
 		return ".ts"
@@ -163,11 +167,11 @@ func structuralSearch(ctx context.Context, zipPath, pattern, rule string, langua
 	numWorkers := 4
 
 	var matcher string
-	if languages != nil {
+	if len(languages) > 0 {
 		// Pick the first language, there is no support for applying
 		// multiple language matchers in a single search query.
 		matcher = lookupMatcher(languages[0])
-		log15.Info("structural search", "language", languages[0], "matcher", matcher)
+		log15.Debug("structural search", "language", languages[0], "matcher", matcher)
 	}
 
 	args := comby.Args{

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -13,6 +13,75 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
+func TestMatcherLookupByLanguage(t *testing.T) {
+	// If we are not on CI skip the test.
+	if os.Getenv("CI") == "" {
+		t.Skip("Not on CI, skipping comby-dependent test")
+	}
+
+	input := map[string]string{
+		"file_without_extension": `
+/* This foo(plain string) {} is in a Go comment should not match in Go, but should match in plaintext */
+func foo(go string) {}
+`,
+	}
+
+	p := &protocol.PatternInfo{
+		Pattern:         "foo(:[args])",
+		IncludePatterns: []string{"file_without_extension"},
+	}
+
+	cases := []struct {
+		Name     string
+		Language string
+		Want     []string
+	}{
+		{
+			Name:     "Language test for Go",
+			Language: "go",
+			Want:     []string{"foo(go string)"},
+		},
+		{
+			Name:     "Language test for plaintext",
+			Language: "text",
+			Want:     []string{"foo(plain string)", "foo(go string)"},
+		},
+	}
+
+	zipData, err := testutil.CreateZip(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zf, cleanup, err := testutil.TempZipFileOnDisk(zipData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			p.Language = tt.Language
+			matches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "repo_foo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			for _, fileMatches := range matches {
+				for _, m := range fileMatches.LineMatches {
+					got = append(got, m.Preview)
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(got, tt.Want) {
+				t.Fatalf("got file matches %v, want %v", got, tt.Want)
+			}
+		})
+	}
+}
+
 // Tests that structural search correctly infers the Go matcher from the .go
 // file extension.
 func TestInferredMatcher(t *testing.T) {
@@ -47,7 +116,7 @@ func foo(real string) {}
 		Pattern:         pattern,
 		IncludePatterns: includePatterns,
 	}
-	m, _, err := structuralSearch(context.Background(), zf, p.Pattern, "", p.IncludePatterns, "foo")
+	m, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +173,7 @@ func TestIncludePatterns(t *testing.T) {
 		Pattern:         "",
 		IncludePatterns: includePatterns,
 	}
-	fileMatches, _, err := structuralSearch(context.Background(), zf, p.Pattern, "", p.IncludePatterns, "foo")
+	fileMatches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,11 +208,13 @@ func TestRule(t *testing.T) {
 	}
 	defer cleanup()
 
-	pattern := "func :[[fn]](:[args])"
-	rule := `where :[args] == "success"`
-	includePatterns := []string{".go"}
+	p := &protocol.PatternInfo{
+		Pattern:         "func :[[fn]](:[args])",
+		IncludePatterns: []string{".go"},
+		CombyRule:       `where :[args] == "success"`,
+	}
 
-	got, _, err := structuralSearch(context.Background(), zf, pattern, rule, includePatterns, "repo")
+	got, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "repo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -71,9 +71,6 @@ func foo(go string) {}
 					got = append(got, m.Preview)
 				}
 			}
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			if !reflect.DeepEqual(got, tt.Want) {
 				t.Fatalf("got file matches %v, want %v", got, tt.Want)

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -32,19 +32,19 @@ func foo(go string) {}
 	}
 
 	cases := []struct {
-		Name     string
-		Language string
-		Want     []string
+		Name      string
+		Languages []string
+		Want      []string
 	}{
 		{
-			Name:     "Language test for Go",
-			Language: "go",
-			Want:     []string{"foo(go string)"},
+			Name:      "Language test for Go",
+			Languages: []string{"go"},
+			Want:      []string{"foo(go string)"},
 		},
 		{
-			Name:     "Language test for plaintext",
-			Language: "text",
-			Want:     []string{"foo(plain string)", "foo(go string)"},
+			Name:      "Language test for plaintext",
+			Languages: []string{"text"},
+			Want:      []string{"foo(plain string)", "foo(go string)"},
 		},
 	}
 
@@ -60,8 +60,8 @@ func foo(go string) {}
 
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			p.Language = tt.Language
-			matches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "repo_foo")
+			p.Languages = tt.Languages
+			matches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, "repo_foo")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -116,7 +116,7 @@ func foo(real string) {}
 		Pattern:         pattern,
 		IncludePatterns: includePatterns,
 	}
-	m, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "foo")
+	m, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestIncludePatterns(t *testing.T) {
 		Pattern:         "",
 		IncludePatterns: includePatterns,
 	}
-	fileMatches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "foo")
+	fileMatches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestRule(t *testing.T) {
 		CombyRule:       `where :[args] == "success"`,
 	}
 
-	got, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Language, p.IncludePatterns, "repo")
+	got, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, "repo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -37,6 +37,11 @@ func foo(go string) {}
 		Want      []string
 	}{
 		{
+			Name:      "Language test for no language",
+			Languages: []string{},
+			Want:      []string{"foo(plain string)", "foo(go string)"},
+		},
+		{
 			Name:      "Language test for Go",
 			Languages: []string{"go"},
 			Want:      []string{"foo(go string)"},


### PR DESCRIPTION
Pass the values of `lang` to searcher so that structural search can pick a matcher. The `lang` parameter is traditionally used by Zoekt/literal/regex searcher to only filter files by extension. By passing the lang parameter to `searcher`, `comby` can use the lang parameter in a semantically meaningful way to force language-aware parsing. 

Architecture note:

Structural search only works when indexing is active. This means that `lang` and `file` parameters in the query are honored and processed by Zoekt code first, always. For structural search, Zoekt returns files matching parts of the search pattern we care about, and these files are the only thing we are interested in (we no longer care about performing filtering on files using regular expressions, like `\.c$|\.h$`, etc.). Thus: `includePatterns` is wiped when `isStructuralPat` is true, and we populate the `includePatterns` with the file paths returned by Zoekt for structural search to process.

If and when structural search is activated for _unindexed_ search (not currently supported), the logic will need to process regex file patterns. For now we don't need to worry about this because the Zoekt code is a required passthrough.

