### PR TITLE
LSIF: Proxy body to backend on upload

### DIFF
--- a/enterprise/internal/codeintel/lsifserver/client/query.go
+++ b/enterprise/internal/codeintel/lsifserver/client/query.go
@@ -57,6 +57,7 @@ func (c *Client) Upload(ctx context.Context, args *struct {
 		path:   "/upload",
 		method: "POST",
 		query:  query,
+		body:   args.Body,
 	}
 
 	payload := struct {


### PR DESCRIPTION
I forgot to add the body to the upload request, meaning that no data actually made it to the lsif-server on upload...

cc @beyang this is critical for the 3.11 release if this does not get merged before branch cut.