### PR TITLE
Extension API: make configuration a Subscribable

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -835,6 +835,16 @@ declare module 'sourcegraph' {
         readonly value: Readonly<C>
     }
 
+    interface ConfigurationService extends Subscribable<void> {
+        /**
+         * Returns the full configuration object.
+         *
+         * @template C The configuration schema.
+         * @returns The full configuration object.
+         */
+        get<C extends object = { [key: string]: any }>(): Configuration<C>
+    }
+
     /**
      * The configuration settings.
      *
@@ -850,24 +860,7 @@ declare module 'sourcegraph' {
      * @todo Add a way to get/update configuration for a specific scope or subject.
      * @todo Support applying defaults to the configuration values.
      */
-    export namespace configuration {
-        /**
-         * Returns the full configuration object.
-         *
-         * @template C The configuration schema.
-         * @returns The full configuration object.
-         */
-        export function get<C extends object = { [key: string]: any }>(): Configuration<C>
-
-        /**
-         * Subscribe to changes to the configuration. The {@link next} callback is called when any configuration
-         * value changes (and synchronously immediately). Call {@link get} in the callback to obtain the new
-         * configuration values.
-         *
-         * @returns An unsubscribable to stop calling the callback for configuration changes.
-         */
-        export const subscribe: Subscribable<void>['subscribe']
-    }
+    export const configuration: ConfigurationService
 
     /**
      * A provider result represents the values that a provider, such as the {@link HoverProvider}, may return. The

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -867,7 +867,7 @@ declare module 'sourcegraph' {
          * @template C The configuration schema.
          * @returns An unsubscribable to stop calling the callback for configuration changes.
          */
-        export function subscribe(next: () => void): Unsubscribable
+        export const subscribe: Subscribable<void>['subscribe']
     }
 
     /**

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -864,7 +864,6 @@ declare module 'sourcegraph' {
          * value changes (and synchronously immediately). Call {@link get} in the callback to obtain the new
          * configuration values.
          *
-         * @template C The configuration schema.
          * @returns An unsubscribable to stop calling the callback for configuration changes.
          */
         export const subscribe: Subscribable<void>['subscribe']

--- a/shared/src/api/extension/api/configuration.ts
+++ b/shared/src/api/extension/api/configuration.ts
@@ -73,8 +73,23 @@ export class ExtConfiguration<C extends object> implements ExtConfigurationAPI<C
         return Object.freeze(new ExtConfigurationSection<C>(this.proxy, this.getData().value.final))
     }
 
-    public subscribe(observer?: PartialObserver<C>): Unsubscribable
-    public subscribe(next?: (value: C) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable
+    public subscribe(observer?: PartialObserver<void>): Unsubscribable
+    /** @deprecated Use an observer instead of a complete callback */
+    public subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable
+    /** @deprecated Use an observer instead of an error callback */
+    public subscribe(
+        next: null | undefined,
+        error: (error: any) => void,
+        complete?: (() => void) | null
+    ): Unsubscribable
+    /** @deprecated Use an observer instead of a complete callback */
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
+    public subscribe(next: (value: void) => void, error: null | undefined, complete: () => void): Unsubscribable
+    public subscribe(
+        next?: ((value: void) => void) | null,
+        error?: ((error: any) => void) | null,
+        complete?: (() => void) | null
+    ): Unsubscribable
     public subscribe(...args: any[]): sourcegraph.Unsubscribable {
         return this.getData().subscribe(...args)
     }

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -197,7 +197,7 @@ function createExtensionAPI(
 
         configuration: {
             get: () => configuration.get(),
-            subscribe: (next: () => void) => configuration.subscribe(next),
+            subscribe: configuration.subscribe.bind(configuration),
         },
 
         languages: {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/3557

In the extension API, `Sourcegraph.configuration` did not conform to the `Subscribable` interface, which led to [ugly workarounds](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-git-extras/-/blob/src/extension.ts#L13-16) when composing it with RxJS operators in Sourcegraph extensions. This fixes that.
