### PR TITLE
LSIF: Remove isTracked methods from xrepo class.

### DIFF
--- a/lsif/src/tests/integration/xrepo/commits.test.ts
+++ b/lsif/src/tests/integration/xrepo/commits.test.ts
@@ -1,4 +1,5 @@
 import * as util from '../integration-test-util'
+import * as xrepoModels from '../../../shared/models/xrepo'
 import nock from 'nock'
 import { XrepoDatabase } from '../../../shared/xrepo/xrepo'
 
@@ -28,9 +29,11 @@ describe('discoverAndUpdateCommit', () => {
             )
 
             // Ensure all commits are now tracked
-            expect(await xrepoDatabase.isCommitTracked('test-repo', ca)).toBeTruthy()
-            expect(await xrepoDatabase.isCommitTracked('test-repo', cb)).toBeTruthy()
-            expect(await xrepoDatabase.isCommitTracked('test-repo', cc)).toBeTruthy()
+            expect((await connection.getRepository(xrepoModels.Commit).find()).map(c => c.commit).sort()).toEqual([
+                ca,
+                cb,
+                cc,
+            ])
         } finally {
             await cleanup()
         }


### PR DESCRIPTION
Inline methods used only once in xrepo implementation.