### PR TITLE
refactor: pull out commit search types

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -56,12 +56,12 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		Repo: &types.Repo{ID: 1, Name: "repo"},
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}
-	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, commitSearchOp{
-		repoRevs:          repoRevs,
-		info:              &search.PatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
-		query:             query,
-		diff:              true,
-		textSearchOptions: git.TextSearchOptions{Pattern: "p"},
+	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{
+		RepoRevs:          repoRevs,
+		Info:              &search.PatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
+		Query:             query,
+		Diff:              true,
+		TextSearchOptions: git.TextSearchOptions{Pattern: "p"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/frontend/internal/pkg/search/search_types.go
+++ b/cmd/frontend/internal/pkg/search/search_types.go
@@ -1,0 +1,21 @@
+package search
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+type SearchTypeParameters interface {
+	SearchTypeInputValue()
+}
+
+func (c CommitParameters) SearchTypeParametersValue() {}
+
+type CommitParameters struct {
+	RepoRevs           *RepositoryRevisions
+	Info               *PatternInfo
+	Query              *query.Query
+	Diff               bool
+	TextSearchOptions  git.TextSearchOptions
+	ExtraMessageValues []string
+}


### PR DESCRIPTION
This starts internal refactoring related to the principles in [RFC 75](https://docs.google.com/document/d/1iAWIOalYTZLRWmYw0r6_r_uThutLhanyTrxFSFtQAgE/edit#heading=h.5mbm166m15r6). The objective in the current series of PRs is to create explicit Go types for the different 'types' (warning: overloaded term) of search (e.g., `diff`, `commit`, `text`). I'm starting with a file `search_types.go`, and have done some initial passes to get an idea of where this needs to go. Please note the following about how I'm going about this process:

- It is type-directed, meaning I create the type first, and refactor based on the types. This is always safe.
- Naming: I choose verbose names so that it is extremely explicit what is going on, and erring on the side of caution. The names can be changed _later_. It has to get a little 'worse' before it can get better.
- The overall purpose at this stage is to understand where state is bundled, and where it is redundant in the types. The added types will make state explicit, and labeling state according to types will then allow to cut redundant state, which will eventually simplify the logic. There are a lot of nitty gritty details here, but basically there are times when search parameters are separate arguments to functions, and other times when search parameters bundle data that is irrelevant. It all needs to be separated.
- It is very iterative, and I want to minimize:
   - changes to function parameters/return types values
   - moving/renaming/splitting files _and_ changes to file contents at the same time. This is separated where possible.

The above means: this is not a perfect process (things may go back and forth a bit) but it is always:
- structured (the intent is understood)
- safe (because this code is brittle), and 
- incremental (changes are tractable and easy to review, not a single big, heroic refactor).

Next in this diff stack are:
#7245
#7246
#7248