### PR TITLE
all: improve GraphQL logging (fixes #5706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Language statistics by commit are available via the API. [#6737](https://github.com/sourcegraph/sourcegraph/pull/6737)
 - Global settings can be configured from a local file using the environment variable `GLOBAL_SETTINGS_FILE`.
-- Logging around GraphQL requests, and especially around unnamed GraphQL requests (ones without a `/.api/graphql?Name`) is now much more verbose, allowing for easier debugging of problematic queries and where they originate from. [#5706](https://github.com/sourcegraph/sourcegraph/issues/5706)
+- Logging for GraphQL API requests not issued by Sourcegraph is now much more verbose, allowing for easier debugging of problematic queries and where they originate from. [#5706](https://github.com/sourcegraph/sourcegraph/issues/5706)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Language statistics by commit are available via the API. [#6737](https://github.com/sourcegraph/sourcegraph/pull/6737)
 - Global settings can be configured from a local file using the environment variable `GLOBAL_SETTINGS_FILE`.
+- Logging around GraphQL requests, and especially around unnamed GraphQL requests (ones without a `/.api/graphql?Name`) is now much more verbose, allowing for easier debugging of problematic queries and where they originate from. [#5706](https://github.com/sourcegraph/sourcegraph/issues/5706)
 
 ### Changed
 

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -568,6 +568,9 @@ func (u *users) GetByCurrentAuthUser(ctx context.Context) (*types.User, error) {
 	if !actor.IsAuthenticated() {
 		return nil, ErrNoCurrentUser
 	}
+	if dbconn.Global == nil {
+		return nil, ErrNoCurrentUser
+	}
 
 	return u.getOneBySQL(ctx, "WHERE id=$1 AND deleted_at IS NULL LIMIT 1", actor.UID)
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -3,11 +3,13 @@ package graphqlbackend
 import (
 	"context"
 	"errors"
+	"log"
 	"strconv"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/introspection"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/graph-gophers/graphql-go/trace"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,6 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 var graphqlFieldHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -33,6 +37,41 @@ func init() {
 
 type prometheusTracer struct {
 	trace.OpenTracingTracer
+}
+
+func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
+	traceCtx, finish := trace.OpenTracingTracer{}.TraceQuery(ctx, queryString, operationName, variables, varTypes)
+
+	currentUser, _ := CurrentUser(ctx)
+	var currentUserName string
+	if currentUser != nil {
+		currentUserName = currentUser.Username()
+	}
+
+	// Requests made by our JS frontend and other internal things will have a concrete name attached to the
+	// request which allows us to (softly) differentiate it from end-user API requests. For example,
+	// /.api/graphql?Foobar where Foobar is the name of the request we make. If there is not a request name,
+	// then it is an interesting query to log in the event it is harmful and a site admin needs to identify
+	// it and the user issuing it.
+	requestName := sgtrace.GraphQLRequestName(ctx)
+	lvl := log15.Debug
+	if requestName == "unknown" {
+		lvl = log15.Info
+	}
+	lvl("serving GraphQL request", "name", requestName, "user", currentUserName)
+	if requestName == "unknown" {
+		log.Printf(`logging complete query for unnamed GraphQL request above name=%s user=%s:
+QUERY
+-----
+%s
+
+VARIABLES
+---------
+%v
+
+`, requestName, currentUserName, queryString, variables)
+	}
+	return traceCtx, finish
 }
 
 func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldName string, trivial bool, args map[string]interface{}) (context.Context, trace.TraceFieldFinishFunc) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -42,7 +42,7 @@ type prometheusTracer struct {
 func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	traceCtx, finish := trace.OpenTracingTracer{}.TraceQuery(ctx, queryString, operationName, variables, varTypes)
 
-	// Note: We don't care about the error here, we just extrat the username if
+	// Note: We don't care about the error here, we just extract the username if
 	// we get a non-nil user object.
 	currentUser, _ := CurrentUser(ctx)
 	var currentUserName string

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -42,6 +42,8 @@ type prometheusTracer struct {
 func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	traceCtx, finish := trace.OpenTracingTracer{}.TraceQuery(ctx, queryString, operationName, variables, varTypes)
 
+	// Note: We don't care about the error here, we just extrat the username if
+	// we get a non-nil user object.
 	currentUser, _ := CurrentUser(ctx)
 	var currentUserName string
 	if currentUser != nil {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -30,6 +30,7 @@ const (
 	routeNameKey key = iota
 	userKey
 	requestErrorCauseKey
+	graphQLRequestNameKey
 )
 
 var metricLabels = []string{"route", "method", "code", "repo"}
@@ -77,6 +78,22 @@ func init() {
 			}
 		})
 	}()
+}
+
+// GraphQLRequestName returns the GraphQL request name for a request context. For example,
+// a request to /.api/graphql?Foobar would have the name `Foobar`. If the request had no
+// name, or the context is not a GraphQL request, "unknown" is returned.
+func GraphQLRequestName(ctx context.Context) string {
+	v := ctx.Value(graphQLRequestNameKey)
+	if v == nil {
+		return "unknown"
+	}
+	return v.(string)
+}
+
+// WithGraphQLRequestName sets the GraphQL request name in the context.
+func WithGraphQLRequestName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, graphQLRequestNameKey, name)
 }
 
 // Middleware captures and exports metrics to Prometheus, etc.

--- a/web/src/tracking/withActivation.tsx
+++ b/web/src/tracking/withActivation.tsx
@@ -20,7 +20,7 @@ const fetchActivationStatus = (isSiteAdmin: boolean): Observable<ActivationCompl
     queryGraphQL(
         isSiteAdmin
             ? gql`
-                  query {
+                  query ActivationStatus {
                       externalServices {
                           totalCount
                       }
@@ -43,7 +43,7 @@ const fetchActivationStatus = (isSiteAdmin: boolean): Observable<ActivationCompl
                   }
               `
             : gql`
-                  query {
+                  query ActivationStatus {
                       currentUser {
                           usageStatistics {
                               searchQueries


### PR DESCRIPTION
Fixes #5706 by ensuring we always log verbose information for unnamed GraphQL requests (i.e. ones not coming from known clients like the frontend or src CLI).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
