### PR TITLE
refactor: add symbols search parameter type

### DIFF
--- a/cmd/frontend/backend/symbols.go
+++ b/cmd/frontend/backend/symbols.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/search/search"
 	symbolsclient "github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
@@ -13,7 +14,7 @@ var Symbols = &symbols{}
 type symbols struct{}
 
 // ListTags returns symbols in a repository from ctags.
-func (symbols) ListTags(ctx context.Context, args protocol.SearchArgs) ([]protocol.Symbol, error) {
+func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) ([]protocol.Symbol, error) {
 	result, err := symbolsclient.DefaultClient.Search(ctx, args)
 	if result == nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -271,7 +271,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		return nil, err
 	}
 
-	symbols, err := backend.Symbols.ListTags(ctx, protocol.SearchArgs{
+	symbols, err := backend.Symbols.ListTags(ctx, search.SymbolsParameters{
 		Repo:            repoRevs.Repo.Name,
 		CommitID:        commitID,
 		Query:           patternInfo.Pattern,

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
+	"github.com/sourcegraph/sourcegraph/internal/search/search"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
 
@@ -59,7 +60,7 @@ func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *strin
 	if includePatterns != nil {
 		includePatternsSlice = *includePatterns
 	}
-	searchArgs := protocol.SearchArgs{
+	searchArgs := search.SymbolsParameters{
 		CommitID:        api.CommitID(commit.oid),
 		First:           limitOrDefault(first) + 1, // add 1 so we can determine PageInfo.hasNextPage
 		Repo:            commit.repo.repo.Name,

--- a/cmd/symbols/internal/symbols/service_test.go
+++ b/cmd/symbols/internal/symbols/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/pkg/ctags"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/search/search"
 	symbolsclient "github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
@@ -102,47 +103,47 @@ func TestService(t *testing.T) {
 	y := protocol.Symbol{Name: "y", Path: "a.js"}
 
 	tests := map[string]struct {
-		args protocol.SearchArgs
+		args search.SymbolsParameters
 		want protocol.SearchResult
 	}{
 		"simple": {
-			args: protocol.SearchArgs{First: 10},
+			args: search.SymbolsParameters{First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
 		},
 		"onematch": {
-			args: protocol.SearchArgs{Query: "x", First: 10},
+			args: search.SymbolsParameters{Query: "x", First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
 		},
 		"nomatches": {
-			args: protocol.SearchArgs{Query: "foo", First: 10},
+			args: search.SymbolsParameters{Query: "foo", First: 10},
 			want: protocol.SearchResult{},
 		},
 		"caseinsensitiveexactmatch": {
-			args: protocol.SearchArgs{Query: "^X$", First: 10},
+			args: search.SymbolsParameters{Query: "^X$", First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
 		},
 		"casesensitiveexactmatch": {
-			args: protocol.SearchArgs{Query: "^x$", IsCaseSensitive: true, First: 10},
+			args: search.SymbolsParameters{Query: "^x$", IsCaseSensitive: true, First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
 		},
 		"casesensitivenoexactmatch": {
-			args: protocol.SearchArgs{Query: "^X$", IsCaseSensitive: true, First: 10},
+			args: search.SymbolsParameters{Query: "^X$", IsCaseSensitive: true, First: 10},
 			want: protocol.SearchResult{},
 		},
 		"caseinsensitiveexactpathmatch": {
-			args: protocol.SearchArgs{IncludePatterns: []string{"^A.js$"}, First: 10},
+			args: search.SymbolsParameters{IncludePatterns: []string{"^A.js$"}, First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
 		},
 		"casesensitiveexactpathmatch": {
-			args: protocol.SearchArgs{IncludePatterns: []string{"^a.js$"}, IsCaseSensitive: true, First: 10},
+			args: search.SymbolsParameters{IncludePatterns: []string{"^a.js$"}, IsCaseSensitive: true, First: 10},
 			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
 		},
 		"casesensitivenoexactpathmatch": {
-			args: protocol.SearchArgs{IncludePatterns: []string{"^A.js$"}, IsCaseSensitive: true, First: 10},
+			args: search.SymbolsParameters{IncludePatterns: []string{"^A.js$"}, IsCaseSensitive: true, First: 10},
 			want: protocol.SearchResult{},
 		},
 		"exclude": {
-			args: protocol.SearchArgs{ExcludePattern: "a.js", IsCaseSensitive: true, First: 10},
+			args: search.SymbolsParameters{ExcludePattern: "a.js", IsCaseSensitive: true, First: 10},
 			want: protocol.SearchResult{},
 		},
 	}

--- a/internal/search/search/search_types.go
+++ b/internal/search/search/search_types.go
@@ -3,6 +3,7 @@ package search
 import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -10,8 +11,9 @@ type SearchTypeParameters interface {
 	SearchTypeInputValue()
 }
 
-func (c CommitParameters) SearchTypeParametersValue() {}
-func (d DiffParameters) SearchTypeParametersValue()   {}
+func (c CommitParameters) SearchTypeParametersValue()  {}
+func (d DiffParameters) SearchTypeParametersValue()    {}
+func (s SymbolsParameters) SearchTypeParametersValue() {}
 
 type CommitParameters struct {
 	RepoRevs           *RepositoryRevisions
@@ -26,3 +28,5 @@ type DiffParameters struct {
 	Repo    gitserver.Repo
 	Options git.RawLogDiffSearchOptions
 }
+
+type SymbolsParameters protocol.SearchArgs

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/search/search"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -73,7 +74,7 @@ func (c *Client) url(key key) (string, error) {
 }
 
 // Search performs a symbol search on the symbols service.
-func (c *Client) Search(ctx context.Context, args protocol.SearchArgs) (result *protocol.SearchResult, err error) {
+func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (result *protocol.SearchResult, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "symbols.Client.Search")
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
Stacked on top of #7246. This adds a dedicated type for symbols search parameters. The key addition is:

 `type SymbolsParameters protocol.SearchArgs`

which aliases the dedicated `SymbolsParameters` type to `protocol.SearchArgs` _for now_. The type is propagated through. This will be important later when we clean up the types and state.