### PR TITLE
metrics: fix an issue where search alerts were incorrectly counted as timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Remove potential panic in gitserver if heavily loaded. [#6710](https://github.com/sourcegraph/sourcegraph/issues/6710)
 - Multiple fixes to make the preview and creation of Automation campaigns more robust and a smoother user experience. [#6682](https://github.com/sourcegraph/sourcegraph/pull/6682) [#6625](https://github.com/sourcegraph/sourcegraph/issues/6625) [#6658](https://github.com/sourcegraph/sourcegraph/issues/6658) [#7088](https://github.com/sourcegraph/sourcegraph/issues/7088) [#6766](https://github.com/sourcegraph/sourcegraph/issues/6766) [#6717](https://github.com/sourcegraph/sourcegraph/issues/6717) [#6659](https://github.com/sourcegraph/sourcegraph/issues/6659)
 - Repositories referenced in Automation campaigns that are removed in an external service configuration change won't lead to problems with the syncing process anymore. [#7015](https://github.com/sourcegraph/sourcegraph/pull/7015)
+- The Searcher dashboard (and the `src_graphql_search_response` Prometheus metric) now properly account for search alerts instead of them being incorrectly added to the `timeout` category. [#7214](https://github.com/sourcegraph/sourcegraph/issues/7214)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -18,6 +18,7 @@ import (
 )
 
 type searchAlert struct {
+	prometheusType  string
 	title           string
 	description     string
 	patternType     SearchType
@@ -58,8 +59,9 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 
 func (r *searchResolver) alertForQuotesInQueryInLiteralMode(ctx context.Context) (*searchAlert, error) {
 	return &searchAlert{
-		title:       "No results. Did you mean to use quotes?",
-		description: "Your search is interpreted literally and contains quotes. Did you mean to search for quotes?",
+		prometheusType: "no_results__suggest_quotes",
+		title:          "No results. Did you mean to use quotes?",
+		description:    "Your search is interpreted literally and contains quotes. Did you mean to search for quotes?",
 		proposedQueries: []*searchQueryDescription{{
 			description: "Remove quotes",
 			query:       syntax.ExprString(omitQuotes(r.query)),
@@ -76,23 +78,26 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 	// Handle repogroup-only scenarios.
 	if len(repoFilters) == 0 && len(repoGroupFilters) == 0 {
 		return &searchAlert{
-			title:       "Add repositories or connect repository hosts",
-			description: "There are no repositories to search. Add an external service connection to your code host.",
-			patternType: r.patternType,
+			prometheusType: "no_resolved_repos__no_repositories",
+			title:          "Add repositories or connect repository hosts",
+			description:    "There are no repositories to search. Add an external service connection to your code host.",
+			patternType:    r.patternType,
 		}, nil
 	}
 	if len(repoFilters) == 0 && len(repoGroupFilters) == 1 {
 		return &searchAlert{
-			title:       fmt.Sprintf("Add repositories to repogroup:%s to see results", repoGroupFilters[0]),
-			description: fmt.Sprintf("The repository group %q is empty. See the documentation for configuration and troubleshooting.", repoGroupFilters[0]),
-			patternType: r.patternType,
+			prometheusType: "no_resolved_repos__repogroup_empty",
+			title:          fmt.Sprintf("Add repositories to repogroup:%s to see results", repoGroupFilters[0]),
+			description:    fmt.Sprintf("The repository group %q is empty. See the documentation for configuration and troubleshooting.", repoGroupFilters[0]),
+			patternType:    r.patternType,
 		}, nil
 	}
 	if len(repoFilters) == 0 && len(repoGroupFilters) > 1 {
 		return &searchAlert{
-			title:       "Repository groups have no repositories in common",
-			description: "No repository exists in all of the specified repository groups.",
-			patternType: r.patternType,
+			prometheusType: "no_resolved_repos__repogroup_none_in_common",
+			title:          "Repository groups have no repositories in common",
+			description:    "No repository exists in all of the specified repository groups.",
+			patternType:    r.patternType,
 		}, nil
 	}
 
@@ -238,8 +243,9 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 
 func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert, error) {
 	alert := &searchAlert{
-		title:       "Too many matching repositories",
-		patternType: r.patternType,
+		prometheusType: "over_repo_limit",
+		title:          "Too many matching repositories",
+		patternType:    r.patternType,
 	}
 
 	if envvar.SourcegraphDotComMode() {
@@ -359,9 +365,10 @@ func (r *searchResolver) alertForMissingRepoRevs(missingRepoRevs []*search.Repos
 		description = fmt.Sprintf("%d repositories matched by your repo: filter could not be searched because the following revisions do not exist, or differ but were specified for the same repository: %s.", len(missingRepoRevs), strings.Join(repoRevs, ", "))
 	}
 	return &searchAlert{
-		title:       "Some repositories could not be searched",
-		description: description,
-		patternType: r.patternType,
+		prometheusType: "missing_repo_revs",
+		title:          "Some repositories could not be searched",
+		description:    description,
+		patternType:    r.patternType,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
@@ -25,6 +25,7 @@ func (r *didYouMeanQuotedResolver) Results(context.Context) (*SearchResultsResol
 		case *rxsyntax.Error:
 			srr := &SearchResultsResolver{
 				alert: &searchAlert{
+					prometheusType:  "regex_syntax_error",
 					title:           capFirst(e.Error()),
 					description:     "Quoting the query may help if you want a literal match instead of a regular expression match.",
 					proposedQueries: sqds,
@@ -37,6 +38,7 @@ func (r *didYouMeanQuotedResolver) Results(context.Context) (*SearchResultsResol
 	case *syntax.ParseError:
 		srr := &SearchResultsResolver{
 			alert: &searchAlert{
+				prometheusType:  "parse_syntax_error",
 				title:           capFirst(e.Msg),
 				description:     "Quoting the query may help if you want a literal match.",
 				proposedQueries: sqds,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -486,9 +486,9 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 		status = "timeout"
 	case err == nil && len(rr.searchResultsCommon.timedout) > 0:
 		status = "partial_timeout"
-	case err == nil && rr.alert != nil {
+	case err == nil && rr.alert != nil:
 		status = "alert"
-		alertType = rr.alert
+		alertType = rr.alert.prometheusType
 	case err != nil:
 		status = "error"
 	case err == nil:
@@ -524,9 +524,9 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 		rr = &SearchResultsResolver{
 			alert: &searchAlert{
 				prometheusType: "timed_out",
-				title:       "Timed out while searching",
-				description: fmt.Sprintf("We weren't able to find any results in %s.", roundStr(dt.String())),
-				patternType: r.patternType,
+				title:          "Timed out while searching",
+				description:    fmt.Sprintf("We weren't able to find any results in %s.", roundStr(dt.String())),
+				patternType:    r.patternType,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "query with longer timeout",
@@ -872,8 +872,8 @@ func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *sea
 				resultTypes = []string{}
 				alert = &searchAlert{
 					prometheusType: "exceeded_diff_commit_search_limit",
-					title:       fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
-					description: fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
+					title:          fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
+					description:    fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
 				}
 			}
 		}
@@ -890,14 +890,14 @@ func alertOnError(multiErr *multierror.Error) (newMultiErr *multierror.Error, al
 			if strings.Contains(err.Error(), "Assert_failure zip") {
 				alert = &searchAlert{
 					prometheusType: "structural_search_repo_too_large",
-					title:       "Repository too large for structural search",
-					description: "One repository is too large to perform structural search. Use the `repo:` filter to run on a specific repository. This is a temporary restriction that will be removed in the future. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/7133",
+					title:          "Repository too large for structural search",
+					description:    "One repository is too large to perform structural search. Use the `repo:` filter to run on a specific repository. This is a temporary restriction that will be removed in the future. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/7133",
 				}
 			} else if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
 				alert = &searchAlert{
 					prometheusType: "structural_search_needs_more_memory",
-					title:       "Structural search needs more memory",
-					description: "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
+					title:          "Structural search needs more memory",
+					description:    "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
 				}
 			} else {
 				newMultiErr = multierror.Append(newMultiErr, err)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -468,7 +468,7 @@ var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "graphql",
 	Name:      "search_response",
 	Help:      "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
-}, []string{"status"})
+}, []string{"status", "alert_type"})
 
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	// If the request is a paginated one, we handle it separately. See
@@ -480,12 +480,15 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	rr, err := r.resultsWithTimeoutSuggestion(ctx)
 
 	// Record what type of response we sent back via Prometheus.
-	var status string
+	var status, alertType string
 	switch {
-	case err == context.DeadlineExceeded || (err == nil && len(rr.searchResultsCommon.timedout) == len(rr.searchResultsCommon.repos)):
+	case err == context.DeadlineExceeded || (err == nil && len(rr.searchResultsCommon.timedout) > 0 && len(rr.searchResultsCommon.timedout) == len(rr.searchResultsCommon.repos)):
 		status = "timeout"
 	case err == nil && len(rr.searchResultsCommon.timedout) > 0:
 		status = "partial_timeout"
+	case err == nil && rr.alert != nil {
+		status = "alert"
+		alertType = rr.alert
 	case err != nil:
 		status = "error"
 	case err == nil:
@@ -493,7 +496,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	default:
 		status = "unknown"
 	}
-	searchResponseCounter.WithLabelValues(status).Inc()
+	searchResponseCounter.WithLabelValues(status, alertType).Inc()
 
 	return rr, err
 }
@@ -520,6 +523,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 		dt2 := longer(2, dt)
 		rr = &SearchResultsResolver{
 			alert: &searchAlert{
+				prometheusType: "timed_out",
 				title:       "Timed out while searching",
 				description: fmt.Sprintf("We weren't able to find any results in %s.", roundStr(dt.String())),
 				patternType: r.patternType,
@@ -867,6 +871,7 @@ func alertOnSearchLimit(resultTypes []string, args *search.Args) ([]string, *sea
 			case "commit", "diff":
 				resultTypes = []string{}
 				alert = &searchAlert{
+					prometheusType: "exceeded_diff_commit_search_limit",
 					title:       fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
 					description: fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
 				}
@@ -884,11 +889,13 @@ func alertOnError(multiErr *multierror.Error) (newMultiErr *multierror.Error, al
 		for _, err := range multiErr.Errors {
 			if strings.Contains(err.Error(), "Assert_failure zip") {
 				alert = &searchAlert{
+					prometheusType: "structural_search_repo_too_large",
 					title:       "Repository too large for structural search",
 					description: "One repository is too large to perform structural search. Use the `repo:` filter to run on a specific repository. This is a temporary restriction that will be removed in the future. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/7133",
 				}
 			} else if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
 				alert = &searchAlert{
+					prometheusType: "structural_search_needs_more_memory",
 					title:       "Structural search needs more memory",
 					description: "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
 				}


### PR DESCRIPTION
Fixes #7214

The added `prometheusType` allows us to account for the type of search alert, such as for tracking the amount of search queries that result in `structural_search_repo_too_large` and `structural_search_needs_more_memory` alerts (cc @rvantonder )