### PR TITLE
a8n: allow campaign creation from locally computed diffs

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -44,6 +44,16 @@ type PreviewCampaignPlanArgs struct {
 	Wait bool
 }
 
+type CreateCampaignPlanFromPatchesArgs struct {
+	Patches []CampaignPlanPatch
+}
+
+type CampaignPlanPatch struct {
+	Repository   graphql.ID
+	BaseRevision string
+	Patch        string
+}
+
 type CancelCampaignPlanArgs struct {
 	Plan graphql.ID
 }
@@ -85,6 +95,7 @@ type A8NResolver interface {
 	AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error)
 
 	PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error)
+	CreateCampaignPlanFromPatches(ctx context.Context, args CreateCampaignPlanFromPatchesArgs) (CampaignPlanResolver, error)
 	CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error)
 	CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error)
 }
@@ -103,6 +114,13 @@ func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCa
 		return nil, a8nOnlyInEnterprise
 	}
 	return EnterpriseResolvers.a8nResolver.PreviewCampaignPlan(ctx, args)
+}
+
+func (r *schemaResolver) CreateCampaignPlanFromPatches(ctx context.Context, args CreateCampaignPlanFromPatchesArgs) (CampaignPlanResolver, error) {
+	if EnterpriseResolvers.a8nResolver == nil {
+		return nil, a8nOnlyInEnterprise
+	}
+	return EnterpriseResolvers.a8nResolver.CreateCampaignPlanFromPatches(ctx, args)
 }
 
 func (r *schemaResolver) CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error) {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -360,7 +360,7 @@ func (r *schemaResolver) DeleteRepository(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	id, err := unmarshalRepositoryID(args.Repository)
+	id, err := UnmarshalRepositoryID(args.Repository)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -60,12 +60,12 @@ func RepositoryByIDInt32(ctx context.Context, repoID api.RepoID) (*RepositoryRes
 }
 
 func (r *RepositoryResolver) ID() graphql.ID {
-	return marshalRepositoryID(r.repo.ID)
+	return MarshalRepositoryID(r.repo.ID)
 }
 
-func marshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
+func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
 
-func unmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {
+func UnmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {
 	err = relay.UnmarshalSpec(id, &repo)
 	return
 }

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -189,7 +189,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 	var repo *types.Repo
 	switch {
 	case args.Repository != nil:
-		repoID, err := unmarshalRepositoryID(*args.Repository)
+		repoID, err := UnmarshalRepositoryID(*args.Repository)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -454,8 +454,8 @@ input CampaignPlanPatch {
     # The base revision in the repository that this patch is applied to.
     baseRevision: String!
 
-    # The patch (in unified diff format) to apply. The filenames must not be prefixed (e.g., with
-    # 'a/' and 'b/').
+    # The patch (in unified diff format) to apply. The filenames must be prefixed (with 'a/' and
+    # 'b/' for the old and new filenames, respectively).
     patch: String!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -454,8 +454,10 @@ input CampaignPlanPatch {
     # The base revision in the repository that this patch is applied to.
     baseRevision: String!
 
-    # The patch (in unified diff format) to apply. The filenames must be prefixed (with 'a/' and
-    # 'b/' for the old and new filenames, respectively).
+    # The patch (in unified diff format) to apply.
+    #
+    # The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
+    # to omit the prefix.
     patch: String!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -57,8 +57,8 @@ type Mutation {
     # To create the campaign, call createCampaign with the returned CampaignPlan.id in the
     # CreateCampaignInput.plan field.
     createCampaignPlanFromPatches(
-        # A list of patches (diffs) to apply to repositories (to create new branches) when a campaign is created
-        # from this campaign plan.
+        # A list of patches (diffs) to apply to repositories (in new branches) when a campaign is
+        # created from this campaign plan.
         patches: [CampaignPlanPatch!]!
     ): CampaignPlan!
     # Cancel a campaign plan that is being generated.
@@ -445,8 +445,8 @@ input CampaignPlanSpecification {
     arguments: JSONCString!
 }
 
-# A patch to apply to a repository branch (to create a new branch) when a campaign is created from
-# the parent campaign plan.
+# A patch to apply to a repository (in a new branch) when a campaign is created from the parent
+# campaign plan.
 input CampaignPlanPatch {
     # The repository that this patch is applied to.
     repository: ID!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -52,6 +52,15 @@ type Mutation {
         # the query will return anyway, so the caller must check the result's CampaignPlan.status.
         wait: Boolean = false
     ): CampaignPlan!
+    # Create a campaign plan from patches (in unified diff format) that are computed by the caller.
+    #
+    # To create the campaign, call createCampaign with the returned CampaignPlan.id in the
+    # CreateCampaignInput.plan field.
+    createCampaignPlanFromPatches(
+        # A list of patches (diffs) to apply to repositories (to create new branches) when a campaign is created
+        # from this campaign plan.
+        patches: [CampaignPlanPatch!]!
+    ): CampaignPlan!
     # Cancel a campaign plan that is being generated.
     # Cancellation expresses a desinterest in the campaign plan and is best-effort.
     # It may not be relied upon.
@@ -434,6 +443,20 @@ input CampaignPlanSpecification {
     # Schema for comby:
     # { scopeQuery: string, matchTemplate: string, rewriteTemplate: string }
     arguments: JSONCString!
+}
+
+# A patch to apply to a repository branch (to create a new branch) when a campaign is created from
+# the parent campaign plan.
+input CampaignPlanPatch {
+    # The repository that this patch is applied to.
+    repository: ID!
+
+    # The base revision in the repository that this patch is applied to.
+    baseRevision: String!
+
+    # The patch (in unified diff format) to apply. The filenames must not be prefixed (e.g., with
+    # 'a/' and 'b/').
+    patch: String!
 }
 
 # Input arguments for creating a campaign.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -54,6 +54,15 @@ type Mutation {
         # the query will return anyway, so the caller must check the result's CampaignPlan.status.
         wait: Boolean = false
     ): CampaignPlan!
+    # Create a campaign plan from patches (in unified diff format) that are computed by the caller.
+    #
+    # To create the campaign, call createCampaign with the returned CampaignPlan.id in the
+    # CreateCampaignInput.plan field.
+    createCampaignPlanFromPatches(
+        # A list of patches (diffs) to apply to repositories (to create new branches) when a campaign is created
+        # from this campaign plan.
+        patches: [CampaignPlanPatch!]!
+    ): CampaignPlan!
     # Cancel a campaign plan that is being generated.
     # Cancellation expresses a desinterest in the campaign plan and is best-effort.
     # It may not be relied upon.
@@ -441,6 +450,20 @@ input CampaignPlanSpecification {
     # Schema for comby:
     # { scopeQuery: string, matchTemplate: string, rewriteTemplate: string }
     arguments: JSONCString!
+}
+
+# A patch to apply to a repository branch (to create a new branch) when a campaign is created from
+# the parent campaign plan.
+input CampaignPlanPatch {
+    # The repository that this patch is applied to.
+    repository: ID!
+
+    # The base revision in the repository that this patch is applied to.
+    baseRevision: String!
+
+    # The patch (in unified diff format) to apply. The filenames must not be prefixed (e.g., with
+    # 'a/' and 'b/').
+    patch: String!
 }
 
 # Input arguments for creating a campaign.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -461,8 +461,8 @@ input CampaignPlanPatch {
     # The base revision in the repository that this patch is applied to.
     baseRevision: String!
 
-    # The patch (in unified diff format) to apply. The filenames must not be prefixed (e.g., with
-    # 'a/' and 'b/').
+    # The patch (in unified diff format) to apply. The filenames must be prefixed (with 'a/' and
+    # 'b/' for the old and new filenames, respectively).
     patch: String!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -59,8 +59,8 @@ type Mutation {
     # To create the campaign, call createCampaign with the returned CampaignPlan.id in the
     # CreateCampaignInput.plan field.
     createCampaignPlanFromPatches(
-        # A list of patches (diffs) to apply to repositories (to create new branches) when a campaign is created
-        # from this campaign plan.
+        # A list of patches (diffs) to apply to repositories (in new branches) when a campaign is
+        # created from this campaign plan.
         patches: [CampaignPlanPatch!]!
     ): CampaignPlan!
     # Cancel a campaign plan that is being generated.
@@ -452,8 +452,8 @@ input CampaignPlanSpecification {
     arguments: JSONCString!
 }
 
-# A patch to apply to a repository branch (to create a new branch) when a campaign is created from
-# the parent campaign plan.
+# A patch to apply to a repository (in a new branch) when a campaign is created from the parent
+# campaign plan.
 input CampaignPlanPatch {
     # The repository that this patch is applied to.
     repository: ID!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -461,8 +461,10 @@ input CampaignPlanPatch {
     # The base revision in the repository that this patch is applied to.
     baseRevision: String!
 
-    # The patch (in unified diff format) to apply. The filenames must be prefixed (with 'a/' and
-    # 'b/' for the old and new filenames, respectively).
+    # The patch (in unified diff format) to apply.
+    #
+    # The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
+    # to omit the prefix.
     patch: String!
 }
 

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -87,6 +87,11 @@ func NewCampaignType(campaignTypeName, args string, cf *httpcli.Factory) (Campai
 
 		ct = c
 
+	case patchCampaignType:
+		// Prefer the more specific createCampaignPlanFromPatches GraphQL API for creating campaigns
+		// from patches computed by the caller, to avoid having multiple ways to do the same thing.
+		return nil, errors.New("use createCampaignPlanFromPatches for patch campaign types")
+
 	default:
 		return nil, fmt.Errorf("unknown campaign type: %s", campaignTypeName)
 	}
@@ -383,4 +388,12 @@ func tmpfileDiff(filename, a, b string) (string, error) {
 		}
 	}
 	return string(out), nil
+}
+
+const patchCampaignType = "patch"
+
+type CampaignPlanPatch struct {
+	Repo         api.RepoID
+	BaseRevision string
+	Patch        string
 }

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -39,6 +39,8 @@ var schemas = map[string]string{
 	"credentials": schema.CredentialsCampaignTypeSchemaJSON,
 }
 
+const patchCampaignType = "patch"
+
 // NewCampaignType returns a new CampaignType for the given campaign type name
 // and arguments.
 func NewCampaignType(campaignTypeName, args string, cf *httpcli.Factory) (CampaignType, error) {
@@ -388,12 +390,4 @@ func tmpfileDiff(filename, a, b string) (string, error) {
 		}
 	}
 	return string(out), nil
-}
-
-const patchCampaignType = "patch"
-
-type CampaignPlanPatch struct {
-	Repo         api.RepoID
-	BaseRevision string
-	Patch        string
 }

--- a/enterprise/internal/a8n/resolvers/changeset_events.go
+++ b/enterprise/internal/a8n/resolvers/changeset_events.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 type changesetEventsConnectionResolver struct {
@@ -80,12 +79,6 @@ func (r *changesetEventResolver) CreatedAt() graphqlbackend.DateTime {
 
 func (r *changesetEventResolver) Changeset(ctx context.Context) (graphqlbackend.ExternalChangesetResolver, error) {
 	return &changesetResolver{store: r.store, Changeset: r.changeset}, nil
-}
-
-func marshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
-func unmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {
-	err = relay.UnmarshalSpec(id, &repo)
-	return
 }
 
 type changesetCountsResolver struct {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -207,7 +207,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
 	err = svc.CreateCampaign(ctx, campaign)
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
 	err = svc.DeleteCampaign(ctx, campaignID, args.CloseChangesets)
 	return &graphqlbackend.EmptyResponse{}, err
 }
@@ -312,7 +312,7 @@ func (r *Resolver) RetryCampaign(ctx context.Context, args *graphqlbackend.Retry
 		return nil, errors.Wrap(err, "resetting failed changeset jobs")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
 	go func() {
 		ctx := trace.ContextWithTrace(context.Background(), tr)
 		err := svc.RunChangesetJobs(ctx, campaign)
@@ -534,8 +534,8 @@ func (r *Resolver) CreateCampaignPlanFromPatches(ctx context.Context, args graph
 		}
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
-	plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches, nil)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches)
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +603,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
 
 	campaign, err := svc.CloseCampaign(ctx, campaignID, args.CloseChangesets)
 	if err != nil {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -347,7 +347,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	cs := make([]*a8n.Changeset, 0, len(args.Input))
 
 	for _, c := range args.Input {
-		repoID, err := unmarshalRepositoryID(c.Repository)
+		repoID, err := graphqlbackend.UnmarshalRepositoryID(c.Repository)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 
 	for id, r := range repoSet {
 		if r == nil {
-			return nil, errors.Errorf("repo %v not found", marshalRepositoryID(api.RepoID(id)))
+			return nil, errors.Errorf("repo %v not found", graphqlbackend.MarshalRepositoryID(api.RepoID(id)))
 		}
 	}
 

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -508,7 +508,7 @@ func (r *Resolver) CreateCampaignPlanFromPatches(ctx context.Context, args graph
 		return nil, err
 	}
 
-	patches := make([]ee.CampaignPlanPatch, len(args.Patches))
+	patches := make([]a8n.CampaignPlanPatch, len(args.Patches))
 	for i, patch := range args.Patches {
 		repo, err := graphqlbackend.UnmarshalRepositoryID(patch.Repository)
 		if err != nil {
@@ -527,7 +527,7 @@ func (r *Resolver) CreateCampaignPlanFromPatches(ctx context.Context, args graph
 			}
 		}
 
-		patches[i] = ee.CampaignPlanPatch{
+		patches[i] = a8n.CampaignPlanPatch{
 			Repo:         repo,
 			BaseRevision: patch.BaseRevision,
 			Patch:        patch.Patch,

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -852,19 +852,18 @@ func TestChangesetCountsOverTime(t *testing.T) {
 	}
 }
 
-const testDiff = `diff --git a/README.md b/README.md
+const testDiff = `diff README.md README.md
 index 671e50a..851b23a 100644
---- a/README.md
-+++ b/README.md
-@@ -1,3 +1,3 @@
+--- README.md
++++ README.md
+@@ -1,2 +1,2 @@
  # README
- 
 -This file is hosted at example.com and is a test file.
 +This file is hosted at sourcegraph.com and is a test file.
-diff --git a/urls.txt b/urls.txt
+diff --git urls.txt urls.txt
 index 6f8b5d9..17400bc 100644
---- a/urls.txt
-+++ b/urls.txt
+--- urls.txt
++++ urls.txt
 @@ -1,3 +1,3 @@
  another-url.com
 -example.com
@@ -878,21 +877,21 @@ var wantFileDiffs = FileDiffs{
 	DiffStat: DiffStat{Changed: 2},
 	Nodes: []FileDiff{
 		{
-			OldPath: "a/README.md",
-			NewPath: "b/README.md",
+			OldPath: "README.md",
+			NewPath: "README.md",
 			OldFile: File{Name: "README.md"},
 			Hunks: []FileDiffHunk{
 				{
-					Body:     " # README\n \n-This file is hosted at example.com and is a test file.\n+This file is hosted at sourcegraph.com and is a test file.\n",
-					OldRange: DiffRange{StartLine: 1, Lines: 3},
-					NewRange: DiffRange{StartLine: 1, Lines: 3},
+					Body:     " # README\n-This file is hosted at example.com and is a test file.\n+This file is hosted at sourcegraph.com and is a test file.\n",
+					OldRange: DiffRange{StartLine: 1, Lines: 2},
+					NewRange: DiffRange{StartLine: 1, Lines: 2},
 				},
 			},
 			Stat: DiffStat{Changed: 1},
 		},
 		{
-			OldPath: "a/urls.txt",
-			NewPath: "b/urls.txt",
+			OldPath: "urls.txt",
+			NewPath: "urls.txt",
 			OldFile: File{Name: "urls.txt"},
 			Hunks: []FileDiffHunk{
 				{

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -964,9 +964,9 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 			}
 		}
 
-		const patch = `diff --git a b
---- a
-+++ b
+		const patch = `diff --git a/f b/f
+--- a/f
++++ b/f
 @@ -1,1 +1,2 @@
 +x
  y

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -368,8 +368,8 @@ func TestCampaigns(t *testing.T) {
 		Changesets []Changeset
 	}
 
-	graphqlGithubRepoID := string(marshalRepositoryID(api.RepoID(githubRepo.ID)))
-	graphqlBBSRepoID := string(marshalRepositoryID(api.RepoID(bbsRepo.ID)))
+	graphqlGithubRepoID := string(graphqlbackend.MarshalRepositoryID(api.RepoID(githubRepo.ID)))
+	graphqlBBSRepoID := string(graphqlbackend.MarshalRepositoryID(api.RepoID(bbsRepo.ID)))
 
 	in := fmt.Sprintf(
 		`[{repository: %q, externalID: %q}, {repository: %q, externalID: %q}]`,

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -858,7 +858,7 @@ index 671e50a..851b23a 100644
 +++ b/README.md
 @@ -1,3 +1,3 @@
  # README
- 
+
 -This file is hosted at example.com and is a test file.
 +This file is hosted at sourcegraph.com and is a test file.
 diff --git a/urls.txt b/urls.txt
@@ -880,7 +880,7 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 			Patches: []graphqlbackend.CampaignPlanPatch{
 				{
 					Repository:   graphqlbackend.MarshalRepositoryID(1),
-					BaseRevision: "b",
+					BaseRevision: "master",
 					Patch:        "!!! this is not a valid unified diff !!!\n--- x\n+++ y\n@@ 1,1 2,2\na",
 				},
 			},
@@ -973,7 +973,7 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 `
 		mustExec(ctx, t, s, nil, &response, fmt.Sprintf(`
       mutation {
-        createCampaignPlanFromPatches(patches: [{repository: %q, baseRevision: "b", patch: %q}]) {
+        createCampaignPlanFromPatches(patches: [{repository: %q, baseRevision: "master", patch: %q}]) {
           ... on CampaignPlan {
             id
             type

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -70,7 +70,7 @@ var defaultRepoResolveRevision = func(ctx context.Context, repo *repos.Repo, rev
 // specification).
 //
 // If resolveRevision is nil, a default implementation is used.
-func (s *Service) CreateCampaignPlanFromPatches(ctx context.Context, patches []CampaignPlanPatch, repoResolveRevision repoResolveRevision) (*a8n.CampaignPlan, error) {
+func (s *Service) CreateCampaignPlanFromPatches(ctx context.Context, patches []a8n.CampaignPlanPatch, repoResolveRevision repoResolveRevision) (*a8n.CampaignPlan, error) {
 	if repoResolveRevision == nil {
 		repoResolveRevision = defaultRepoResolveRevision
 	}

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -48,6 +50,91 @@ type Service struct {
 	cf    *httpcli.Factory
 
 	clock func() time.Time
+}
+
+// repoResolveRevision resolves a Git revspec in a repository and returns the resolved commit ID.
+type repoResolveRevision func(context.Context, *repos.Repo, string) (api.CommitID, error)
+
+// defaultRepoResolveRevision is an implementation of repoResolveRevision that talks to gitserver to
+// resolve a Git revspec.
+var defaultRepoResolveRevision = func(ctx context.Context, repo *repos.Repo, revspec string) (api.CommitID, error) {
+	return backend.Repos.ResolveRev(ctx,
+		&types.Repo{Name: api.RepoName(repo.Name), ExternalRepo: repo.ExternalRepo},
+		revspec,
+	)
+}
+
+// CreateCampaignPlanFromPatches creates a CampaignPlan and its associated CampaignJobs from patches
+// computed by the caller. There is no diff execution or computation performed during creation of
+// the CampaignJobs in this case (unlike when using Runner to create a CampaignPlan from a
+// specification).
+//
+// If resolveRevision is nil, a default implementation is used.
+func (s *Service) CreateCampaignPlanFromPatches(ctx context.Context, patches []CampaignPlanPatch, repoResolveRevision repoResolveRevision) (*a8n.CampaignPlan, error) {
+	if repoResolveRevision == nil {
+		repoResolveRevision = defaultRepoResolveRevision
+	}
+
+	// Look up all repositories.
+	reposStore := repos.NewDBStore(s.store.DB(), sql.TxOptions{})
+	repoIDs := make([]uint32, len(patches))
+	for i, patch := range patches {
+		repoIDs[i] = uint32(patch.Repo)
+	}
+	allRepos, err := reposStore.ListRepos(ctx, repos.StoreListReposArgs{IDs: repoIDs})
+	if err != nil {
+		return nil, err
+	}
+	reposByID := make(map[uint32]*repos.Repo, len(patches))
+	for _, repo := range allRepos {
+		reposByID[repo.ID] = repo
+	}
+
+	tx, err := s.store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Done(&err)
+
+	plan := &a8n.CampaignPlan{
+		CampaignType: patchCampaignType,
+		Arguments:    "", // intentionally empty to avoid needless duplication with CampaignJob diffs
+	}
+
+	err = tx.CreateCampaignPlan(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, patch := range patches {
+		repo := reposByID[uint32(patch.Repo)]
+		if repo == nil {
+			return nil, fmt.Errorf("repository ID %d not found", patch.Repo)
+		}
+		if !a8n.IsRepoSupported(&repo.ExternalRepo) {
+			continue
+		}
+
+		commit, err := repoResolveRevision(ctx, repo, patch.BaseRevision)
+		if err != nil {
+			return nil, errors.Wrapf(err, "repository %q", repo.Name)
+		}
+
+		job := &a8n.CampaignJob{
+			CampaignPlanID: plan.ID,
+			RepoID:         int32(patch.Repo),
+			BaseRef:        patch.BaseRevision,
+			Rev:            commit,
+			Diff:           patch.Patch,
+			StartedAt:      s.clock(),
+			FinishedAt:     s.clock(),
+		}
+		if err := tx.CreateCampaignJob(ctx, job); err != nil {
+			return nil, err
+		}
+	}
+
+	return plan, nil
 }
 
 // CreateCampaign creates the Campaign. When a CampaignPlanID is set, it also

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -66,7 +66,7 @@ func TestService(t *testing.T) {
 			return commit, nil
 		}
 
-		svc := NewServiceWithClock(store, nil, nil, clock)
+		svc := NewServiceWithClock(store, nil, repoResolveRevision, nil, clock)
 
 		const patch = `diff --git a/f b/f
 --- a/f
@@ -80,7 +80,7 @@ func TestService(t *testing.T) {
 			{Repo: api.RepoID(rs[1].ID), BaseRevision: "b1", Patch: patch},
 		}
 
-		plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches, repoResolveRevision)
+		plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -150,7 +150,7 @@ func TestService(t *testing.T) {
 		gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
 
 		cf := httpcli.NewHTTPClientFactory()
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
 		err = svc.CreateCampaign(ctx, campaign)
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -68,9 +68,9 @@ func TestService(t *testing.T) {
 
 		svc := NewServiceWithClock(store, nil, nil, clock)
 
-		const patch = `diff --git a b
---- a
-+++ b
+		const patch = `diff --git a/f b/f
+--- a/f
++++ b/f
 @@ -1,1 +1,2 @@
 +x
  y

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -68,9 +68,9 @@ func TestService(t *testing.T) {
 
 		svc := NewServiceWithClock(store, nil, repoResolveRevision, nil, clock)
 
-		const patch = `diff --git a/f b/f
---- a/f
-+++ b/f
+		const patch = `diff f f
+--- f
++++ f
 @@ -1,1 +1,2 @@
 +x
  y

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -75,7 +75,7 @@ func TestService(t *testing.T) {
 +x
  y
 `
-		patches := []CampaignPlanPatch{
+		patches := []a8n.CampaignPlanPatch{
 			{Repo: api.RepoID(rs[0].ID), BaseRevision: "b0", Patch: patch},
 			{Repo: api.RepoID(rs[1].ID), BaseRevision: "b1", Patch: patch},
 		}

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -26,6 +26,13 @@ func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
 	return ok
 }
 
+// CampaignPlanPatch is a patch applied to a repository (to create a new branch).
+type CampaignPlanPatch struct {
+	Repo         api.RepoID
+	BaseRevision string
+	Patch        string
+}
+
 // A CampaignPlan represents the application of a CampaignType to the Arguments
 // over multiple repositories.
 type CampaignPlan struct {


### PR DESCRIPTION
Adds a new `createCampaignPlanFromPatches` GraphQL API mutation that accepts a list of repository-branches and corresponding patches (which are expected to be computed by the caller). From this, a campaign plan is created. Previously, you could only create a campaign plan from a specification (such as of a Comby rewrite), which was simpler in many ways but less powerful. This new API lets you perform arbitrary mass changes across repositories, assuming you're able to compute the diffs locally.

(Proposed in [this Slack thread](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1576504701016400).)