### PR TITLE
all: rename ExternalService to CodeHost in go files

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -96,7 +96,7 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType stri
 // hasGitHubDotComToken reports whether there are any personal access tokens configured for
 // github.com.
 func hasGitHubDotComToken(ctx context.Context) (bool, error) {
-	conns, err := db.ExternalServices.ListGitHubConnections(ctx)
+	conns, err := db.CodeHosts.ListGitHubConnections(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -116,7 +116,7 @@ func hasGitHubDotComToken(ctx context.Context) (bool, error) {
 // hasGitLabDotComToken reports whether there are any personal access tokens configured for
 // github.com.
 func hasGitLabDotComToken(ctx context.Context) (bool, error) {
-	conns, err := db.ExternalServices.ListGitLabConnections(ctx)
+	conns, err := db.CodeHosts.ListGitLabConnections(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -22,19 +22,19 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// An ExternalServicesStore stores external services and their configuration.
+// An CodeHostsStore stores external services and their configuration.
 // Before updating or creating a new external service, validation is performed.
 // The enterprise code registers additional validators at run-time and sets the
 // global instance in stores.go
-type ExternalServicesStore struct {
+type CodeHostsStore struct {
 	GitHubValidators          []func(*schema.GitHubConnection) error
 	GitLabValidators          []func(*schema.GitLabConnection, []schema.AuthProviders) error
 	BitbucketServerValidators []func(*schema.BitbucketServerConnection) error
 }
 
-// ExternalServiceKinds contains a map of all supported kinds of
+// CodeHostKinds contains a map of all supported kinds of
 // external services.
-var ExternalServiceKinds = map[string]ExternalServiceKind{
+var CodeHostKinds = map[string]CodeHostKind{
 	"AWSCODECOMMIT":   {CodeHost: true, JSONSchema: schema.AWSCodeCommitSchemaJSON},
 	"BITBUCKETCLOUD":  {CodeHost: true, JSONSchema: schema.BitbucketCloudSchemaJSON},
 	"BITBUCKETSERVER": {CodeHost: true, JSONSchema: schema.BitbucketServerSchemaJSON},
@@ -42,24 +42,24 @@ var ExternalServiceKinds = map[string]ExternalServiceKind{
 	"GITLAB":          {CodeHost: true, JSONSchema: schema.GitLabSchemaJSON},
 	"GITOLITE":        {CodeHost: true, JSONSchema: schema.GitoliteSchemaJSON},
 	"PHABRICATOR":     {CodeHost: true, JSONSchema: schema.PhabricatorSchemaJSON},
-	"OTHER":           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
+	"OTHER":           {CodeHost: true, JSONSchema: schema.OtherCodeHostSchemaJSON},
 }
 
-// ExternalServiceKind describes a kind of external service.
-type ExternalServiceKind struct {
+// CodeHostKind describes a kind of external service.
+type CodeHostKind struct {
 	// True if the external service can host repositories.
 	CodeHost bool
 
 	JSONSchema string // JSON Schema for the external service's configuration
 }
 
-// ExternalServicesListOptions contains options for listing external services.
-type ExternalServicesListOptions struct {
+// CodeHostsListOptions contains options for listing external services.
+type CodeHostsListOptions struct {
 	Kinds []string
 	*LimitOffset
 }
 
-func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
+func (o CodeHostsListOptions) sqlConditions() []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
 	if len(o.Kinds) > 0 {
 		kinds := []*sqlf.Query{}
@@ -72,15 +72,15 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 }
 
 // ValidateConfig validates the given external service configuration.
-func (e *ExternalServicesStore) ValidateConfig(kind, config string, ps []schema.AuthProviders) error {
-	ext, ok := ExternalServiceKinds[kind]
+func (e *CodeHostsStore) ValidateConfig(kind, config string, ps []schema.AuthProviders) error {
+	ext, ok := CodeHostKinds[kind]
 	if !ok {
 		return fmt.Errorf("invalid external service kind: %s", kind)
 	}
 
 	// All configs must be valid JSON.
 	// If this requirement is ever changed, you will need to update
-	// serveExternalServiceConfigs to handle this case.
+	// serveCodeHostConfigs to handle this case.
 
 	sl := gojsonschema.NewSchemaLoader()
 	sc, err := sl.Compile(gojsonschema.NewStringLoader(ext.JSONSchema))
@@ -131,11 +131,11 @@ func (e *ExternalServicesStore) ValidateConfig(kind, config string, ps []schema.
 		err = e.validateBitbucketServerConnection(&c)
 
 	case "OTHER":
-		var c schema.OtherExternalServiceConnection
+		var c schema.OtherCodeHostConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = validateOtherExternalServiceConnection(&c)
+		err = validateOtherCodeHostConnection(&c)
 	}
 
 	return multierror.Append(errs, err).ErrorOrNil()
@@ -145,7 +145,7 @@ func (e *ExternalServicesStore) ValidateConfig(kind, config string, ps []schema.
 // object dependencies well, so we must validate here that repo items
 // match the uri-reference format when url is set, instead of uri when
 // it isn't.
-func validateOtherExternalServiceConnection(c *schema.OtherExternalServiceConnection) error {
+func validateOtherCodeHostConnection(c *schema.OtherCodeHostConnection) error {
 	parseRepo := url.Parse
 	if c.Url != "" {
 		// We ignore the error because this already validated by JSON Schema.
@@ -170,7 +170,7 @@ func validateOtherExternalServiceConnection(c *schema.OtherExternalServiceConnec
 	return nil
 }
 
-func (e *ExternalServicesStore) validateGithubConnection(c *schema.GitHubConnection) error {
+func (e *CodeHostsStore) validateGithubConnection(c *schema.GitHubConnection) error {
 	err := new(multierror.Error)
 	for _, validate := range e.GitHubValidators {
 		err = multierror.Append(err, validate(c))
@@ -183,7 +183,7 @@ func (e *ExternalServicesStore) validateGithubConnection(c *schema.GitHubConnect
 	return err.ErrorOrNil()
 }
 
-func (e *ExternalServicesStore) validateGitlabConnection(c *schema.GitLabConnection, ps []schema.AuthProviders) error {
+func (e *CodeHostsStore) validateGitlabConnection(c *schema.GitLabConnection, ps []schema.AuthProviders) error {
 	err := new(multierror.Error)
 	for _, validate := range e.GitLabValidators {
 		err = multierror.Append(err, validate(c, ps))
@@ -191,7 +191,7 @@ func (e *ExternalServicesStore) validateGitlabConnection(c *schema.GitLabConnect
 	return err.ErrorOrNil()
 }
 
-func (e *ExternalServicesStore) validateBitbucketServerConnection(c *schema.BitbucketServerConnection) error {
+func (e *CodeHostsStore) validateBitbucketServerConnection(c *schema.BitbucketServerConnection) error {
 	err := new(multierror.Error)
 	for _, validate := range e.BitbucketServerValidators {
 		err = multierror.Append(err, validate(c))
@@ -213,24 +213,24 @@ func (e *ExternalServicesStore) validateBitbucketServerConnection(c *schema.Bitb
 // determines a deadlock occurred.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
+func (c *CodeHostsStore) Create(ctx context.Context, confGet func() *conf.Unified, codeHost *types.CodeHost) error {
 	ps := confGet().AuthProviders
-	if err := c.ValidateConfig(externalService.Kind, externalService.Config, ps); err != nil {
+	if err := c.ValidateConfig(codeHost.Kind, codeHost.Config, ps); err != nil {
 		return err
 	}
 
-	externalService.CreatedAt = time.Now()
-	externalService.UpdatedAt = externalService.CreatedAt
+	codeHost.CreatedAt = time.Now()
+	codeHost.UpdatedAt = codeHost.CreatedAt
 
 	return dbconn.Global.QueryRowContext(
 		ctx,
 		"INSERT INTO external_services(kind, display_name, config, created_at, updated_at) VALUES($1, $2, $3, $4, $5) RETURNING id",
-		externalService.Kind, externalService.DisplayName, externalService.Config, externalService.CreatedAt, externalService.UpdatedAt,
-	).Scan(&externalService.ID)
+		codeHost.Kind, codeHost.DisplayName, codeHost.Config, codeHost.CreatedAt, codeHost.UpdatedAt,
+	).Scan(&codeHost.ID)
 }
 
-// ExternalServiceUpdate contains optional fields to update.
-type ExternalServiceUpdate struct {
+// CodeHostUpdate contains optional fields to update.
+type CodeHostUpdate struct {
 	DisplayName *string
 	Config      *string
 }
@@ -238,15 +238,15 @@ type ExternalServiceUpdate struct {
 // Update updates a external service.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error {
+func (c *CodeHostsStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *CodeHostUpdate) error {
 	if update.Config != nil {
 		// Query to get the kind (which is immutable) so we can validate the new config.
-		externalService, err := c.GetByID(ctx, id)
+		codeHost, err := c.GetByID(ctx, id)
 		if err != nil {
 			return err
 		}
 
-		if err := c.ValidateConfig(externalService.Kind, *update.Config, ps); err != nil {
+		if err := c.ValidateConfig(codeHost.Kind, *update.Config, ps); err != nil {
 			return err
 		}
 	}
@@ -262,7 +262,7 @@ func (c *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProv
 			return err
 		}
 		if affected == 0 {
-			return externalServiceNotFoundError{id: id}
+			return codeHostNotFoundError{id: id}
 		}
 		return nil
 	}
@@ -281,22 +281,22 @@ func (c *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProv
 	})
 }
 
-type externalServiceNotFoundError struct {
+type codeHostNotFoundError struct {
 	id int64
 }
 
-func (e externalServiceNotFoundError) Error() string {
+func (e codeHostNotFoundError) Error() string {
 	return fmt.Sprintf("external service not found: %v", e.id)
 }
 
-func (e externalServiceNotFoundError) NotFound() bool {
+func (e codeHostNotFoundError) NotFound() bool {
 	return true
 }
 
 // Delete deletes an external service.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (*ExternalServicesStore) Delete(ctx context.Context, id int64) error {
+func (*CodeHostsStore) Delete(ctx context.Context, id int64) error {
 	res, err := dbconn.Global.ExecContext(ctx, "UPDATE external_services SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
@@ -306,7 +306,7 @@ func (*ExternalServicesStore) Delete(ctx context.Context, id int64) error {
 		return err
 	}
 	if nrows == 0 {
-		return externalServiceNotFoundError{id: id}
+		return codeHostNotFoundError{id: id}
 	}
 	return nil
 }
@@ -314,28 +314,28 @@ func (*ExternalServicesStore) Delete(ctx context.Context, id int64) error {
 // GetByID returns the external service for id.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
-	if Mocks.ExternalServices.GetByID != nil {
-		return Mocks.ExternalServices.GetByID(id)
+func (c *CodeHostsStore) GetByID(ctx context.Context, id int64) (*types.CodeHost, error) {
+	if Mocks.CodeHosts.GetByID != nil {
+		return Mocks.CodeHosts.GetByID(id)
 	}
 
 	conds := []*sqlf.Query{sqlf.Sprintf("id=%d", id)}
-	ExternalServicesStore, err := c.list(ctx, conds, nil)
+	CodeHostsStore, err := c.list(ctx, conds, nil)
 	if err != nil {
 		return nil, err
 	}
-	if len(ExternalServicesStore) == 0 {
+	if len(CodeHostsStore) == 0 {
 		return nil, fmt.Errorf("external service not found: id=%d", id)
 	}
-	return ExternalServicesStore[0], nil
+	return CodeHostsStore[0], nil
 }
 
 // List returns all external services.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-	if Mocks.ExternalServices.List != nil {
-		return Mocks.ExternalServices.List(opt)
+func (c *CodeHostsStore) List(ctx context.Context, opt CodeHostsListOptions) ([]*types.CodeHost, error) {
+	if Mocks.CodeHosts.List != nil {
+		return Mocks.CodeHosts.List(opt)
 	}
 	return c.list(ctx, opt.sqlConditions(), opt.LimitOffset)
 }
@@ -343,8 +343,8 @@ func (c *ExternalServicesStore) List(ctx context.Context, opt ExternalServicesLi
 // listConfigs decodes the list configs into result.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) listConfigs(ctx context.Context, kind string, result interface{}) error {
-	services, err := c.List(ctx, ExternalServicesListOptions{Kinds: []string{kind}})
+func (c *CodeHostsStore) listConfigs(ctx context.Context, kind string, result interface{}) error {
+	services, err := c.List(ctx, CodeHostsListOptions{Kinds: []string{kind}})
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (c *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 // ListAWSCodeCommitConnections returns a list of AWSCodeCommit configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
+func (c *CodeHostsStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
 	var connections []*schema.AWSCodeCommitConnection
 	if err := c.listConfigs(ctx, "AWSCODECOMMIT", &connections); err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (c *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context
 // ListBitbucketCloudConnections returns a list of BitbucketCloud configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Context) ([]*schema.BitbucketCloudConnection, error) {
+func (c *CodeHostsStore) ListBitbucketCloudConnections(ctx context.Context) ([]*schema.BitbucketCloudConnection, error) {
 	var connections []*schema.BitbucketCloudConnection
 	if err := c.listConfigs(ctx, "BITBUCKETCLOUD", &connections); err != nil {
 		return nil, err
@@ -395,7 +395,7 @@ func (c *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Contex
 // ListBitbucketServerConnections returns a list of BitbucketServer configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
+func (c *CodeHostsStore) ListBitbucketServerConnections(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
 	var connections []*schema.BitbucketServerConnection
 	if err := c.listConfigs(ctx, "BITBUCKETSERVER", &connections); err != nil {
 		return nil, err
@@ -406,7 +406,7 @@ func (c *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Conte
 // ListGitHubConnections returns a list of GitHubConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*schema.GitHubConnection, error) {
+func (c *CodeHostsStore) ListGitHubConnections(ctx context.Context) ([]*schema.GitHubConnection, error) {
 	var connections []*schema.GitHubConnection
 	if err := c.listConfigs(ctx, "GITHUB", &connections); err != nil {
 		return nil, err
@@ -417,7 +417,7 @@ func (c *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*s
 // ListGitLabConnections returns a list of GitLabConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*schema.GitLabConnection, error) {
+func (c *CodeHostsStore) ListGitLabConnections(ctx context.Context) ([]*schema.GitLabConnection, error) {
 	var connections []*schema.GitLabConnection
 	if err := c.listConfigs(ctx, "GITLAB", &connections); err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func (c *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*s
 // ListGitoliteConnections returns a list of GitoliteConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]*schema.GitoliteConnection, error) {
+func (c *CodeHostsStore) ListGitoliteConnections(ctx context.Context) ([]*schema.GitoliteConnection, error) {
 	var connections []*schema.GitoliteConnection
 	if err := c.listConfigs(ctx, "GITOLITE", &connections); err != nil {
 		return nil, err
@@ -439,7 +439,7 @@ func (c *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]
 // ListPhabricatorConnections returns a list of PhabricatorConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
+func (c *CodeHostsStore) ListPhabricatorConnections(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
 	var connections []*schema.PhabricatorConnection
 	if err := c.listConfigs(ctx, "PHABRICATOR", &connections); err != nil {
 		return nil, err
@@ -447,18 +447,18 @@ func (c *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) 
 	return connections, nil
 }
 
-// ListOtherExternalServicesConnections returns a list of OtherExternalServiceConnection configs.
+// ListOtherCodeHostsConnections returns a list of OtherCodeHostConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListOtherExternalServicesConnections(ctx context.Context) ([]*schema.OtherExternalServiceConnection, error) {
-	var connections []*schema.OtherExternalServiceConnection
+func (c *CodeHostsStore) ListOtherCodeHostsConnections(ctx context.Context) ([]*schema.OtherCodeHostConnection, error) {
+	var connections []*schema.OtherCodeHostConnection
 	if err := c.listConfigs(ctx, "OTHER", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
 }
 
-func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.ExternalService, error) {
+func (c *CodeHostsStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.CodeHost, error) {
 	q := sqlf.Sprintf(`
 		SELECT id, kind, display_name, config, created_at, updated_at
 		FROM external_services
@@ -475,9 +475,9 @@ func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, l
 	}
 	defer rows.Close()
 
-	var results []*types.ExternalService
+	var results []*types.CodeHost
 	for rows.Next() {
-		var h types.ExternalService
+		var h types.CodeHost
 		if err := rows.Scan(&h.ID, &h.Kind, &h.DisplayName, &h.Config, &h.CreatedAt, &h.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -489,7 +489,7 @@ func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, l
 // Count counts all external services that satisfy the options (ignoring limit and offset).
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Count(ctx context.Context, opt ExternalServicesListOptions) (int, error) {
+func (c *CodeHostsStore) Count(ctx context.Context, opt CodeHostsListOptions) (int, error) {
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_services WHERE (%s)", sqlf.Join(opt.sqlConditions(), ") AND ("))
 	var count int
 	if err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
@@ -498,8 +498,8 @@ func (c *ExternalServicesStore) Count(ctx context.Context, opt ExternalServicesL
 	return count, nil
 }
 
-// MockExternalServices mocks the external services store.
-type MockExternalServices struct {
-	GetByID func(id int64) (*types.ExternalService, error)
-	List    func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
+// MockCodeHosts mocks the external services store.
+type MockCodeHosts struct {
+	GetByID func(id int64) (*types.CodeHost, error)
+	List    func(opt CodeHostsListOptions) ([]*types.CodeHost, error)
 }

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -2,7 +2,7 @@ package db
 
 import "testing"
 
-func TestExternalServicesStore_ValidateConfig(t *testing.T) {
+func TestCodeHostsStore_ValidateConfig(t *testing.T) {
 	tests := map[string]struct {
 		kind, config string
 		wantErr      string
@@ -25,7 +25,7 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := (&ExternalServicesStore{}).ValidateConfig(test.kind, test.config, nil)
+			err := (&CodeHostsStore{}).ValidateConfig(test.kind, test.config, nil)
 			var errStr string
 			if err != nil {
 				errStr = err.Error()

--- a/cmd/frontend/db/mockstores.go
+++ b/cmd/frontend/db/mockstores.go
@@ -24,5 +24,5 @@ type MockStores struct {
 
 	OrgInvitations MockOrgInvitations
 
-	ExternalServices MockExternalServices
+	CodeHosts MockCodeHosts
 }

--- a/cmd/frontend/db/phabricator.go
+++ b/cmd/frontend/db/phabricator.go
@@ -106,7 +106,7 @@ func (p *phabricator) GetByName(ctx context.Context, name api.RepoName) (*types.
 		return Mocks.Phabricator.GetByName(name)
 	}
 
-	connections, err := ExternalServices.ListPhabricatorConnections(ctx)
+	connections, err := CodeHosts.ListPhabricatorConnections(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/db/stores.go
+++ b/cmd/frontend/db/stores.go
@@ -2,7 +2,7 @@ package db
 
 var (
 	AccessTokens              = &accessTokens{}
-	ExternalServices          = &ExternalServicesStore{}
+	CodeHosts                 = &CodeHostsStore{}
 	DefaultRepos              = &defaultRepos{}
 	DiscussionThreads         = &discussionThreads{}
 	DiscussionComments        = &discussionComments{}

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -11,70 +11,70 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
-type externalServiceResolver struct {
-	externalService *types.ExternalService
+type codeHostResolver struct {
+	codeHost *types.CodeHost
 	warning         string
 }
 
-const externalServiceIDKind = "ExternalService"
+const codeHostIDKind = "CodeHost"
 
-func externalServiceByID(ctx context.Context, id graphql.ID) (*externalServiceResolver, error) {
+func codeHostByID(ctx context.Context, id graphql.ID) (*codeHostResolver, error) {
 	// 🚨 SECURITY: Only site admins are allowed to read external services.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
 	}
 
-	externalServiceID, err := unmarshalExternalServiceID(id)
+	codeHostID, err := unmarshalCodeHostID(id)
 	if err != nil {
 		return nil, err
 	}
 
-	externalService, err := db.ExternalServices.GetByID(ctx, externalServiceID)
+	codeHost, err := db.CodeHosts.GetByID(ctx, codeHostID)
 	if err != nil {
 		return nil, err
 	}
 
-	return &externalServiceResolver{externalService: externalService}, nil
+	return &codeHostResolver{codeHost: codeHost}, nil
 }
 
-func marshalExternalServiceID(id int64) graphql.ID {
-	return relay.MarshalID(externalServiceIDKind, id)
+func marshalCodeHostID(id int64) graphql.ID {
+	return relay.MarshalID(codeHostIDKind, id)
 }
 
-func unmarshalExternalServiceID(id graphql.ID) (externalServiceID int64, err error) {
-	if kind := relay.UnmarshalKind(id); kind != externalServiceIDKind {
-		err = fmt.Errorf("expected graphql ID to have kind %q; got %q", externalServiceIDKind, kind)
+func unmarshalCodeHostID(id graphql.ID) (codeHostID int64, err error) {
+	if kind := relay.UnmarshalKind(id); kind != codeHostIDKind {
+		err = fmt.Errorf("expected graphql ID to have kind %q; got %q", codeHostIDKind, kind)
 		return
 	}
-	err = relay.UnmarshalSpec(id, &externalServiceID)
+	err = relay.UnmarshalSpec(id, &codeHostID)
 	return
 }
 
-func (r *externalServiceResolver) ID() graphql.ID {
-	return marshalExternalServiceID(r.externalService.ID)
+func (r *codeHostResolver) ID() graphql.ID {
+	return marshalCodeHostID(r.codeHost.ID)
 }
 
-func (r *externalServiceResolver) Kind() string {
-	return r.externalService.Kind
+func (r *codeHostResolver) Kind() string {
+	return r.codeHost.Kind
 }
 
-func (r *externalServiceResolver) DisplayName() string {
-	return r.externalService.DisplayName
+func (r *codeHostResolver) DisplayName() string {
+	return r.codeHost.DisplayName
 }
 
-func (r *externalServiceResolver) Config() JSONCString {
-	return JSONCString(r.externalService.Config)
+func (r *codeHostResolver) Config() JSONCString {
+	return JSONCString(r.codeHost.Config)
 }
 
-func (r *externalServiceResolver) CreatedAt() DateTime {
-	return DateTime{Time: r.externalService.CreatedAt}
+func (r *codeHostResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.codeHost.CreatedAt}
 }
 
-func (r *externalServiceResolver) UpdatedAt() DateTime {
-	return DateTime{Time: r.externalService.UpdatedAt}
+func (r *codeHostResolver) UpdatedAt() DateTime {
+	return DateTime{Time: r.codeHost.UpdatedAt}
 }
 
-func (r *externalServiceResolver) Warning() *string {
+func (r *codeHostResolver) Warning() *string {
 	if r.warning == "" {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -132,7 +132,7 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 	// It is also unclear to me if deterministic order is important here (it seems like it might be),
 	// so if this is parallalized in the future, consider whether order is important.
 
-	githubs, err := db.ExternalServices.ListGitHubConnections(ctx)
+	githubs, err := db.CodeHosts.ListGitHubConnections(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -140,7 +140,7 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		repoSources = append(repoSources, reposource.GitHub{GitHubConnection: c})
 	}
 
-	gitlabs, err := db.ExternalServices.ListGitLabConnections(ctx)
+	gitlabs, err := db.CodeHosts.ListGitLabConnections(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		repoSources = append(repoSources, reposource.GitLab{GitLabConnection: c})
 	}
 
-	bitbuckets, err := db.ExternalServices.ListBitbucketServerConnections(ctx)
+	bitbuckets, err := db.CodeHosts.ListBitbucketServerConnections(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +156,7 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		repoSources = append(repoSources, reposource.BitbucketServer{BitbucketServerConnection: c})
 	}
 
-	awscodecommits, err := db.ExternalServices.ListAWSCodeCommitConnections(ctx)
+	awscodecommits, err := db.CodeHosts.ListAWSCodeCommitConnections(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -164,7 +164,7 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		repoSources = append(repoSources, reposource.AWS{AWSCodeCommitConnection: c})
 	}
 
-	gitolites, err := db.ExternalServices.ListGitoliteConnections(ctx)
+	gitolites, err := db.CodeHosts.ListGitoliteConnections(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGitTree(t *testing.T) {
 	resetMocks()
-	db.Mocks.ExternalServices.List = func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+	db.Mocks.CodeHosts.List = func(opt db.CodeHostsListOptions) ([]*types.CodeHost, error) {
 		return nil, nil
 	}
 	db.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -123,8 +123,8 @@ func (r *NodeResolver) ToExternalAccount() (*externalAccountResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToExternalService() (*externalServiceResolver, bool) {
-	n, ok := r.Node.(*externalServiceResolver)
+func (r *NodeResolver) ToCodeHost() (*codeHostResolver, bool) {
+	n, ok := r.Node.(*codeHostResolver)
 	return n, ok
 }
 
@@ -250,8 +250,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return nil, errors.New("not implemented")
 	case "ExternalAccount":
 		return externalAccountByID(ctx, id)
-	case externalServiceIDKind:
-		return externalServiceByID(ctx, id)
+	case codeHostIDKind:
+		return codeHostByID(ctx, id)
 	case "GitRef":
 		return gitRefByID(ctx, id)
 	case "Repository":

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -296,7 +296,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 		}
 
 		// Have any external services been updated to exclude the given repo?
-		done = len(resp.ExternalServices) > 0
+		done = len(resp.CodeHosts) > 0
 	}
 
 	if !done {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -404,7 +404,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 }
 
 func makePhabClientForOrigin(ctx context.Context, origin string) (*phabricator.Client, error) {
-	phabs, err := db.ExternalServices.ListPhabricatorConnections(ctx)
+	phabs, err := db.CodeHosts.ListPhabricatorConnections(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -27,30 +27,30 @@ func (r *externalRepositoryResolver) ServiceID() string {
 	return r.repository.repo.ExternalRepo.ServiceID
 }
 
-func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct {
+func (r *RepositoryResolver) CodeHosts(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
-}) (*computedExternalServiceConnectionResolver, error) {
+}) (*computedCodeHostConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins may read external services (they have secrets).
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
 	}
 
-	svcs, err := repoupdater.DefaultClient.RepoExternalServices(ctx, uint32(r.repo.ID))
+	svcs, err := repoupdater.DefaultClient.RepoCodeHosts(ctx, uint32(r.repo.ID))
 	if err != nil {
 		return nil, err
 	}
 
-	return &computedExternalServiceConnectionResolver{
+	return &computedCodeHostConnectionResolver{
 		args:             args.ConnectionArgs,
-		externalServices: newExternalServices(svcs...),
+		codeHosts: newCodeHosts(svcs...),
 	}, nil
 }
 
-func newExternalServices(es ...api.ExternalService) []*types.ExternalService {
-	svcs := make([]*types.ExternalService, 0, len(es))
+func newCodeHosts(es ...api.CodeHost) []*types.CodeHost {
+	svcs := make([]*types.CodeHost, 0, len(es))
 
 	for _, e := range es {
-		svc := &types.ExternalService{
+		svc := &types.CodeHost{
 			ID:          e.ID,
 			Kind:        e.Kind,
 			DisplayName: e.DisplayName,

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -109,11 +109,11 @@ type Mutation {
     # Deletes an organization. Only site admins may perform this mutation.
     deleteOrganization(organization: ID!): EmptyResponse
     # Adds a external service. Only site admins may perform this mutation.
-    addExternalService(input: AddExternalServiceInput!): ExternalService!
+    addCodeHost(input: AddCodeHostInput!): CodeHost!
     # Updates a external service. Only site admins may perform this mutation.
-    updateExternalService(input: UpdateExternalServiceInput!): ExternalService!
+    updateCodeHost(input: UpdateCodeHostInput!): CodeHost!
     # Delete an external service. Only site admins may perform this mutation.
-    deleteExternalService(externalService: ID!): EmptyResponse!
+    deleteCodeHost(codeHost: ID!): EmptyResponse!
     # DEPRECATED: All repositories are accessible or deleted. To prevent a
     # repository from being accessed on Sourcegraph add it to the external
     # service exclude configuration. This mutation will be removed in 3.6.
@@ -764,9 +764,9 @@ type ChangesetEventConnection {
 }
 
 # A new external service.
-input AddExternalServiceInput {
+input AddCodeHostInput {
     # The kind of the external service.
-    kind: ExternalServiceKind!
+    kind: CodeHostKind!
     # The display name of the external service.
     displayName: String!
     # The JSON configuration of the external service.
@@ -774,7 +774,7 @@ input AddExternalServiceInput {
 }
 
 # Fields to update for an existing external service.
-input UpdateExternalServiceInput {
+input UpdateCodeHostInput {
     # The id of the external service to update.
     id: ID!
     # The updated display name, if provided.
@@ -1106,10 +1106,10 @@ type Query {
         uri: String
     ): Repository
     # Lists all external services.
-    externalServices(
+    codeHosts(
         # Returns the first n external services from the list.
         first: Int
-    ): ExternalServiceConnection!
+    ): CodeHostConnection!
     # List all repositories.
     repositories(
         # Returns the first n repositories from the list.
@@ -1625,9 +1625,9 @@ type Highlight {
 }
 
 # A list of external services.
-type ExternalServiceConnection {
+type CodeHostConnection {
     # A list of external services.
-    nodes: [ExternalService!]!
+    nodes: [CodeHost!]!
 
     # The total number of external services in the connection.
     totalCount: Int!
@@ -1637,7 +1637,7 @@ type ExternalServiceConnection {
 }
 
 # A specific kind of external service.
-enum ExternalServiceKind {
+enum CodeHostKind {
     AWSCODECOMMIT
     BITBUCKETCLOUD
     BITBUCKETSERVER
@@ -1649,11 +1649,11 @@ enum ExternalServiceKind {
 }
 
 # A configured external service.
-type ExternalService implements Node {
+type CodeHost implements Node {
     # The external service's unique ID.
     id: ID!
     # The kind of external service.
-    kind: ExternalServiceKind!
+    kind: CodeHostKind!
     # The display name of the external service.
     displayName: String!
     # The JSON configuration of the external service.
@@ -1663,9 +1663,9 @@ type ExternalService implements Node {
     # When the external service was last updated.
     updatedAt: DateTime!
     # This is an optional field that's populated when we ran into errors on the
-    # backend side when trying to create/update an ExternalService, but the
+    # backend side when trying to create/update an CodeHost, but the
     # create/update still succeeded.
-    # It is a field on ExternalService instead of a separate thing in order to
+    # It is a field on CodeHost instead of a separate thing in order to
     # not break the API and stay backwards compatible.
     warning: String
 }
@@ -1736,10 +1736,10 @@ type Repository implements Node & GenericSearchResultInterface {
     # Phabricator, etc.).
     externalRepository: ExternalRepository
     # Lists all external services which yield this repository.
-    externalServices(
+    codeHosts(
         # Returns the first n external services from the list.
         first: Int
-    ): ExternalServiceConnection!
+    ): CodeHostConnection!
     # Whether the repository is currently being cloned.
     cloneInProgress: Boolean! @deprecated(reason: "use Repository.mirrorInfo.cloneInProgress instead")
     # Information about the text search index for this repository, or null if text search indexing
@@ -4542,11 +4542,11 @@ type CloningProgress {
 
 # FOR INTERNAL USE ONLY: A status message produced when repositories could not
 # be synced from an external service
-type ExternalServiceSyncError {
+type CodeHostSyncError {
     # The message of this status message
     message: String!
     # The external service that failed to sync
-    externalService: ExternalService!
+    codeHost: CodeHost!
 }
 
 # FOR INTERNAL USE ONLY: A status message produced when repositories could not
@@ -4557,7 +4557,7 @@ type SyncError {
 }
 
 # FOR INTERNAL USE ONLY: A status message
-union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
+union StatusMessage = CloningProgress | CodeHostSyncError | SyncError
 
 # An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
 # JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -27,7 +27,7 @@ func TestSearch(t *testing.T) {
 		searchVersion                string
 		reposListMock                func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
 		repoRevsMock                 func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error)
-		externalServicesListMock     func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error)
+		codeHostsListMock     func(opt db.CodeHostsListOptions) ([]*types.CodeHost, error)
 		phabricatorGetRepoByNameMock func(repo api.RepoName) (*types.PhabricatorRepo, error)
 		wantResults                  Results
 	}{
@@ -40,7 +40,7 @@ func TestSearch(t *testing.T) {
 			repoRevsMock: func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
 				return api.CommitID(""), nil
 			},
-			externalServicesListMock: func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+			codeHostsListMock: func(opt db.CodeHostsListOptions) ([]*types.CodeHost, error) {
 				return nil, nil
 			},
 			phabricatorGetRepoByNameMock: func(repo api.RepoName) (*types.PhabricatorRepo, error) {
@@ -63,7 +63,7 @@ func TestSearch(t *testing.T) {
 			repoRevsMock: func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
 				return api.CommitID(""), nil
 			},
-			externalServicesListMock: func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+			codeHostsListMock: func(opt db.CodeHostsListOptions) ([]*types.CodeHost, error) {
 				return nil, nil
 			},
 			phabricatorGetRepoByNameMock: func(repo api.RepoName) (*types.PhabricatorRepo, error) {
@@ -87,7 +87,7 @@ func TestSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			db.Mocks.ExternalServices.List = tc.externalServicesListMock
+			db.Mocks.CodeHosts.List = tc.codeHostsListMock
 			db.Mocks.Phabricator.GetByName = tc.phabricatorGetRepoByNameMock
 			git.Mocks.ResolveRevision = tc.repoRevsMock
 			result := schema.Exec(context.Background(), testSearchGQLQuery, "", vars)

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -122,12 +122,12 @@ func init() {
 			})
 		}
 
-		externalServiceProblems := problems.ExternalService()
-		if len(externalServiceProblems) > 0 {
+		codeHostProblems := problems.CodeHost()
+		if len(codeHostProblems) > 0 {
 			alerts = append(alerts, &Alert{
 				TypeValue: AlertTypeWarning,
 				MessageValue: `[**Update external service configuration**](/site-admin/external-services) to resolve problems:` +
-					"\n* " + strings.Join(externalServiceProblems.Messages(), "\n* "),
+					"\n* " + strings.Join(codeHostProblems.Messages(), "\n* "),
 			})
 		}
 		return alerts

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -25,14 +25,14 @@ func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, 
 }
 
 func needsRepositoryConfiguration(ctx context.Context) (bool, error) {
-	kinds := make([]string, 0, len(db.ExternalServiceKinds))
-	for kind, config := range db.ExternalServiceKinds {
+	kinds := make([]string, 0, len(db.CodeHostKinds))
+	for kind, config := range db.CodeHostKinds {
 		if config.CodeHost {
 			kinds = append(kinds, kind)
 		}
 	}
 
-	count, err := db.ExternalServices.Count(ctx, db.ExternalServicesListOptions{
+	count, err := db.CodeHosts.Count(ctx, db.CodeHostsListOptions{
 		Kinds: kinds,
 	})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -38,8 +38,8 @@ func (r *statusMessageResolver) ToCloningProgress() (*statusMessageResolver, boo
 	return r, r.message.Cloning != nil
 }
 
-func (r *statusMessageResolver) ToExternalServiceSyncError() (*statusMessageResolver, bool) {
-	return r, r.message.ExternalServiceSyncError != nil
+func (r *statusMessageResolver) ToCodeHostSyncError() (*statusMessageResolver, bool) {
+	return r, r.message.CodeHostSyncError != nil
 }
 
 func (r *statusMessageResolver) ToSyncError() (*statusMessageResolver, bool) {
@@ -50,8 +50,8 @@ func (r *statusMessageResolver) Message() (string, error) {
 	if r.message.Cloning != nil {
 		return r.message.Cloning.Message, nil
 	}
-	if r.message.ExternalServiceSyncError != nil {
-		return r.message.ExternalServiceSyncError.Message, nil
+	if r.message.CodeHostSyncError != nil {
+		return r.message.CodeHostSyncError.Message, nil
 	}
 	if r.message.SyncError != nil {
 		return r.message.SyncError.Message, nil
@@ -59,12 +59,12 @@ func (r *statusMessageResolver) Message() (string, error) {
 	return "", errors.New("status message is of unknown type")
 }
 
-func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
-	id := r.message.ExternalServiceSyncError.ExternalServiceId
-	externalService, err := db.ExternalServices.GetByID(ctx, id)
+func (r *statusMessageResolver) CodeHost(ctx context.Context) (*codeHostResolver, error) {
+	id := r.message.CodeHostSyncError.CodeHostId
+	codeHost, err := db.CodeHosts.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	return &externalServiceResolver{externalService: externalService}, nil
+	return &codeHostResolver{codeHost: codeHost}, nil
 }

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -26,10 +26,9 @@ func TestStatusMessages(t *testing.T) {
 					message
 				}
 
-				... on ExternalServiceSyncError {
+				... on CodeHostSyncError {
 					message
-					externalService {
-						id
+					codeHost {
 						displayName
 					}
 				}
@@ -94,10 +93,10 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { db.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		db.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
-			return &types.ExternalService{ID: 1, DisplayName: "GitHub.com testing"}, nil
+		db.Mocks.CodeHosts.GetByID = func(id int64) (*types.CodeHost, error) {
+			return &types.CodeHost{ID: 1, DisplayName: "GitHub.com testing"}, nil
 		}
-		defer func() { db.Mocks.ExternalServices.GetByID = nil }()
+		defer func() { db.Mocks.CodeHosts.GetByID = nil }()
 
 		repoupdater.MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
 			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{
@@ -107,9 +106,9 @@ func TestStatusMessages(t *testing.T) {
 					},
 				},
 				{
-					ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-						Message:           "Authentication failed. Please check credentials.",
-						ExternalServiceId: 1,
+					CodeHostSyncError: &protocol.CodeHostSyncError{
+						Message:    "Authentication failed. Please check credentials.",
+						CodeHostId: 1,
 					},
 				},
 				{
@@ -134,10 +133,9 @@ func TestStatusMessages(t *testing.T) {
 								"message": "Currently cloning 5 repositories in parallel..."
 							},
 							{
-								"__typename": "ExternalServiceSyncError",
-								"externalService": {
-									"displayName": "GitHub.com testing",
-									"id": "RXh0ZXJuYWxTZXJ2aWNlOjE="
+								"__typename": "CodeHostSyncError",
+								"codeHost": {
+									"displayName": "GitHub.com testing"
 								},
 								"message": "Authentication failed. Please check credentials."
 							},

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -130,9 +130,9 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.UserEmails.GetInitialSiteAdminEmail failed", "error", err)
 	}
 	q.Set("initAdmin", initAdminEmail)
-	svcs, err := externalServiceKinds(ctx)
+	svcs, err := codeHostKinds(ctx)
 	if err != nil {
-		logFunc("externalServicesKinds failed", "error", err)
+		logFunc("codeHostsKinds failed", "error", err)
 	}
 	q.Set("extsvcs", strings.Join(svcs, ","))
 	return baseURL.ResolveReference(&url.URL{RawQuery: q.Encode()}).String()
@@ -147,8 +147,8 @@ func authProviderTypes() []string {
 	return types
 }
 
-func externalServiceKinds(ctx context.Context) ([]string, error) {
-	services, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
+func codeHostKinds(ctx context.Context) ([]string, error) {
+	services, err := db.CodeHosts.List(ctx, db.CodeHostsListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -147,7 +147,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	q := r.URL.Query()
 	clientSiteID := q.Get("site")
 	authProviders := q.Get("auth")
-	externalServices := q.Get("extsvcs")
+	codeHosts := q.Get("extsvcs")
 	builtinSignupAllowed := q.Get("signup")
 	hasExtURL := q.Get("hasExtURL")
 	uniqueUsers := q.Get("u")
@@ -200,7 +200,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		activity,
 		initialAdminEmail,
 		authProviders,
-		externalServices,
+		codeHosts,
 		builtinSignupAllowed,
 		deployType,
 		totalUsers,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -100,8 +100,8 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 		WriteErrBody: true,
 	})
 
-	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.TraceRoute(handler(serveExternalServiceConfigs)))
-	m.Get(apirouter.ExternalServicesList).Handler(trace.TraceRoute(handler(serveExternalServicesList)))
+	m.Get(apirouter.CodeHostConfigs).Handler(trace.TraceRoute(handler(serveCodeHostConfigs)))
+	m.Get(apirouter.CodeHostsList).Handler(trace.TraceRoute(handler(serveCodeHostsList)))
 	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.TraceRoute(handler(servePhabricatorRepoCreate)))
 	m.Get(apirouter.ReposCreateIfNotExists).Handler(trace.TraceRoute(handler(serveReposCreateIfNotExists)))
 	m.Get(apirouter.ReposUpdateMetadata).Handler(trace.TraceRoute(handler(serveReposUpdateMetadata)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -96,15 +96,15 @@ func servePhabricatorRepoCreate(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// serveExternalServiceConfigs serves a JSON response that is an array of all
+// serveCodeHostConfigs serves a JSON response that is an array of all
 // external service configs that match the requested kind.
-func serveExternalServiceConfigs(w http.ResponseWriter, r *http.Request) error {
-	var req api.ExternalServiceConfigsRequest
+func serveCodeHostConfigs(w http.ResponseWriter, r *http.Request) error {
+	var req api.CodeHostConfigsRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return err
 	}
-	services, err := db.ExternalServices.List(r.Context(), db.ExternalServicesListOptions{
+	services, err := db.CodeHosts.List(r.Context(), db.CodeHostsListOptions{
 		Kinds: []string{req.Kind},
 	})
 	if err != nil {
@@ -135,10 +135,10 @@ func serveExternalServiceConfigs(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(configs)
 }
 
-// serveExternalServicesList serves a JSON response that is an array of all external services
+// serveCodeHostsList serves a JSON response that is an array of all external services
 // of the given kind
-func serveExternalServicesList(w http.ResponseWriter, r *http.Request) error {
-	var req api.ExternalServicesListRequest
+func serveCodeHostsList(w http.ResponseWriter, r *http.Request) error {
+	var req api.CodeHostsListRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func serveExternalServicesList(w http.ResponseWriter, r *http.Request) error {
 		req.Kinds = append(req.Kinds, req.Kind)
 	}
 
-	services, err := db.ExternalServices.List(r.Context(), db.ExternalServicesListOptions{
+	services, err := db.CodeHosts.List(r.Context(), db.CodeHostsListOptions{
 		Kinds: req.Kinds,
 	})
 	if err != nil {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -45,8 +45,8 @@ const (
 	ReposUpdateMetadata    = "internal.repos.update-metadata"
 	Configuration          = "internal.configuration"
 	SearchConfiguration    = "internal.search-configuration"
-	ExternalServiceConfigs = "internal.external-services.configs"
-	ExternalServicesList   = "internal.external-services.list"
+	CodeHostConfigs        = "internal.external-services.configs"
+	CodeHostsList          = "internal.external-services.list"
 )
 
 // New creates a new API router with route URL pattern definitions but
@@ -101,8 +101,8 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/git/{RepoName:.*}/resolve-revision/{Spec}").Methods("GET").Name(GitResolveRevision)
 	base.Path("/git/{RepoName:.*}/tar/{Commit}").Methods("GET").Name(GitTar)
 	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
-	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)
-	base.Path("/external-services/list").Methods("POST").Name(ExternalServicesList)
+	base.Path("/external-services/configs").Methods("POST").Name(CodeHostConfigs)
+	base.Path("/external-services/list").Methods("POST").Name(CodeHostsList)
 	base.Path("/repos/create-if-not-exists").Methods("POST").Name(ReposCreateIfNotExists)
 	base.Path("/repos/inventory-uncached").Methods("POST").Name(ReposInventoryUncached)
 	base.Path("/repos/inventory").Methods("POST").Name(ReposInventory)

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -52,8 +52,8 @@ func (rs Repos) Len() int           { return len(rs) }
 func (rs Repos) Less(i, j int) bool { return rs[i].ID < rs[j].ID }
 func (rs Repos) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
 
-// ExternalService is a connection to an external service.
-type ExternalService struct {
+// CodeHost is a connection to an external service.
+type CodeHost struct {
 	ID          int64
 	Kind        string
 	DisplayName string

--- a/cmd/gitserver/server/gitolite_phabricator_test.go
+++ b/cmd/gitserver/server/gitolite_phabricator_test.go
@@ -20,14 +20,14 @@ func TestServer_handleGet(t *testing.T) {
 			Url:             "https://phab.mycompany.com",
 		},
 	}}
-	api.MockExternalServiceConfigs = func(kind string, result interface{}) error {
+	api.MockCodeHostConfigs = func(kind string, result interface{}) error {
 		buf, err := json.Marshal(conn)
 		if err != nil {
 			return err
 		}
 		return json.Unmarshal(buf, result)
 	}
-	defer func() { api.MockExternalServiceConfigs = nil }()
+	defer func() { api.MockCodeHostConfigs = nil }()
 
 	s := &Server{ReposDir: "/testroot"}
 	h := s.Handler()
@@ -64,14 +64,14 @@ func TestServer_handleGet_invalid(t *testing.T) {
 			CallsignCommand: `echo "Something went wrong this is not a valid callsign"`,
 		},
 	}}
-	api.MockExternalServiceConfigs = func(kind string, result interface{}) error {
+	api.MockCodeHostConfigs = func(kind string, result interface{}) error {
 		buf, err := json.Marshal(conn)
 		if err != nil {
 			return err
 		}
 		return json.Unmarshal(buf, result)
 	}
-	defer func() { api.MockExternalServiceConfigs = nil }()
+	defer func() { api.MockCodeHostConfigs = nil }()
 
 	s := &Server{ReposDir: "/testroot"}
 	h := s.Handler()

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -22,7 +22,7 @@ import (
 // connection configured in Sourcegraph via the external services
 // configuration.
 type AWSCodeCommitSource struct {
-	svc    *ExternalService
+	svc    *CodeHost
 	config *schema.AWSCodeCommitConnection
 
 	awsConfig    aws.Config
@@ -34,7 +34,7 @@ type AWSCodeCommitSource struct {
 }
 
 // NewAWSCodeCommitSource returns a new AWSCodeCommitSource from the given external service.
-func NewAWSCodeCommitSource(svc *ExternalService, cf *httpcli.Factory) (*AWSCodeCommitSource, error) {
+func NewAWSCodeCommitSource(svc *CodeHost, cf *httpcli.Factory) (*AWSCodeCommitSource, error) {
 	var c schema.AWSCodeCommitConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -42,7 +42,7 @@ func NewAWSCodeCommitSource(svc *ExternalService, cf *httpcli.Factory) (*AWSCode
 	return newAWSCodeCommitSource(svc, &c, cf)
 }
 
-func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnection, cf *httpcli.Factory) (*AWSCodeCommitSource, error) {
+func newAWSCodeCommitSource(svc *CodeHost, c *schema.AWSCodeCommitConnection, cf *httpcli.Factory) (*AWSCodeCommitSource, error) {
 	awsConfig := defaults.Config()
 	awsConfig.Region = c.Region
 	awsConfig.Credentials = aws.StaticCredentialsProvider{
@@ -110,9 +110,9 @@ func (s *AWSCodeCommitSource) ListRepos(ctx context.Context, results chan Source
 	s.listAllRepositories(ctx, results)
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s *AWSCodeCommitSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s *AWSCodeCommitSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s *AWSCodeCommitSource) makeRepo(r *awscodecommit.Repository) (*Repo, error) {

--- a/cmd/repo-updater/repos/awscodecommit_test.go
+++ b/cmd/repo-updater/repos/awscodecommit_test.go
@@ -21,7 +21,7 @@ func TestAWSCodeCommitSource_Exclude(t *testing.T) {
 	}
 
 	fact := httpcli.NewFactory(httpcli.NewMiddleware())
-	svc := ExternalService{Kind: "AWSCODECOMMIT"}
+	svc := CodeHost{Kind: "AWSCODECOMMIT"}
 	conn, err := newAWSCodeCommitSource(&svc, config, fact)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -22,7 +22,7 @@ import (
 // A BitbucketCloudSource yields repositories from a single BitbucketCloud connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketCloudSource struct {
-	svc             *ExternalService
+	svc             *CodeHost
 	config          *schema.BitbucketCloudConnection
 	exclude         map[string]bool
 	excludePatterns []*regexp.Regexp
@@ -30,7 +30,7 @@ type BitbucketCloudSource struct {
 }
 
 // NewBitbucketCloudSource returns a new BitbucketCloudSource from the given external service.
-func NewBitbucketCloudSource(svc *ExternalService, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
+func NewBitbucketCloudSource(svc *CodeHost, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	var c schema.BitbucketCloudConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -38,7 +38,7 @@ func NewBitbucketCloudSource(svc *ExternalService, cf *httpcli.Factory) (*Bitbuc
 	return newBitbucketCloudSource(svc, &c, cf)
 }
 
-func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
+func newBitbucketCloudSource(svc *CodeHost, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	if cf == nil {
 		cf = httpcli.NewHTTPClientFactory()
 	}
@@ -87,9 +87,9 @@ func (s BitbucketCloudSource) ListRepos(ctx context.Context, results chan Source
 	s.listAllRepos(ctx, results)
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s BitbucketCloudSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s BitbucketCloudSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s BitbucketCloudSource) makeRepo(r *bitbucketcloud.Repo) *Repo {

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -86,7 +86,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind:   "BITBUCKETCLOUD",
 				Config: marshalJSON(t, tc.conf),
 			}
@@ -139,7 +139,7 @@ func TestBitbucketCloudSource_MakeRepo(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETCLOUD"}
+	svc := CodeHost{ID: 1, Kind: "BITBUCKETCLOUD"}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestBitbucketCloudSource_Exclude(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETCLOUD"}
+	svc := CodeHost{ID: 1, Kind: "BITBUCKETCLOUD"}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -23,7 +23,7 @@ import (
 // A BitbucketServerSource yields repositories from a single BitbucketServer connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketServerSource struct {
-	svc             *ExternalService
+	svc             *CodeHost
 	config          *schema.BitbucketServerConnection
 	exclude         map[string]bool
 	excludePatterns []*regexp.Regexp
@@ -31,7 +31,7 @@ type BitbucketServerSource struct {
 }
 
 // NewBitbucketServerSource returns a new BitbucketServerSource from the given external service.
-func NewBitbucketServerSource(svc *ExternalService, cf *httpcli.Factory) (*BitbucketServerSource, error) {
+func NewBitbucketServerSource(svc *CodeHost, cf *httpcli.Factory) (*BitbucketServerSource, error) {
 	var c schema.BitbucketServerConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -39,7 +39,7 @@ func NewBitbucketServerSource(svc *ExternalService, cf *httpcli.Factory) (*Bitbu
 	return newBitbucketServerSource(svc, &c, cf)
 }
 
-func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerConnection, cf *httpcli.Factory) (*BitbucketServerSource, error) {
+func newBitbucketServerSource(svc *CodeHost, c *schema.BitbucketServerConnection, cf *httpcli.Factory) (*BitbucketServerSource, error) {
 	baseURL, err := url.Parse(c.Url)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func (s BitbucketServerSource) CreateChangeset(ctx context.Context, c *Changeset
 
 	c.Changeset.Metadata = pr
 	c.Changeset.ExternalID = strconv.FormatInt(int64(pr.ID), 10)
-	c.Changeset.ExternalServiceType = bitbucketserver.ServiceType
+	c.Changeset.CodeHostType = bitbucketserver.ServiceType
 
 	return nil
 }
@@ -185,9 +185,9 @@ func (s BitbucketServerSource) LoadChangesets(ctx context.Context, cs ...*Change
 	return nil
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s BitbucketServerSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s BitbucketServerSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s BitbucketServerSource) makeRepo(repo *bitbucketserver.Repo) *Repo {

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -53,7 +53,7 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETSERVER"}
+	svc := CodeHost{ID: 1, Kind: "BITBUCKETSERVER"}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -147,7 +147,7 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETSERVER"}
+	svc := CodeHost{ID: 1, Kind: "BITBUCKETSERVER"}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -248,7 +248,7 @@ func TestBitbucketServerSource_LoadChangesets(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "BITBUCKETSERVER",
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
@@ -377,7 +377,7 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "BITBUCKETSERVER",
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
@@ -467,7 +467,7 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "BITBUCKETSERVER",
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -25,7 +25,7 @@ import (
 // A GithubSource yields repositories from a single Github connection configured
 // in Sourcegraph via the external services configuration.
 type GithubSource struct {
-	svc             *ExternalService
+	svc             *CodeHost
 	config          *schema.GitHubConnection
 	exclude         map[string]bool
 	excludePatterns []*regexp.Regexp
@@ -42,7 +42,7 @@ type GithubSource struct {
 }
 
 // NewGithubSource returns a new GithubSource from the given external service.
-func NewGithubSource(svc *ExternalService, cf *httpcli.Factory) (*GithubSource, error) {
+func NewGithubSource(svc *CodeHost, cf *httpcli.Factory) (*GithubSource, error) {
 	var c schema.GitHubConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -50,7 +50,7 @@ func NewGithubSource(svc *ExternalService, cf *httpcli.Factory) (*GithubSource, 
 	return newGithubSource(svc, &c, cf)
 }
 
-func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error) {
+func newGithubSource(svc *CodeHost, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error) {
 	baseURL, err := url.Parse(c.Url)
 	if err != nil {
 		return nil, err
@@ -143,9 +143,9 @@ func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult) 
 	}
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s GithubSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s GithubSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 // CreateChangeset creates the given *Changeset in the code host.
@@ -176,7 +176,7 @@ func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) error {
 
 	c.Changeset.Metadata = pr
 	c.Changeset.ExternalID = strconv.FormatInt(pr.Number, 10)
-	c.Changeset.ExternalServiceType = github.ServiceType
+	c.Changeset.CodeHostType = github.ServiceType
 
 	return nil
 }

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -88,7 +88,7 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
@@ -179,7 +179,7 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
@@ -274,7 +274,7 @@ func TestGithubSource_LoadChangesets(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
@@ -404,7 +404,7 @@ func TestGithubSource_GetRepo(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url: "https://github.com",
@@ -608,7 +608,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind:   "GITHUB",
 				Config: marshalJSON(t, tc.conf),
 			}

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -21,7 +21,7 @@ import (
 // A GitLabSource yields repositories from a single GitLab connection configured
 // in Sourcegraph via the external services configuration.
 type GitLabSource struct {
-	svc                 *ExternalService
+	svc                 *CodeHost
 	config              *schema.GitLabConnection
 	exclude             map[string]bool
 	baseURL             *url.URL // URL with path /api/v4 (no trailing slash)
@@ -30,7 +30,7 @@ type GitLabSource struct {
 }
 
 // NewGitLabSource returns a new GitLabSource from the given external service.
-func NewGitLabSource(svc *ExternalService, cf *httpcli.Factory) (*GitLabSource, error) {
+func NewGitLabSource(svc *CodeHost, cf *httpcli.Factory) (*GitLabSource, error) {
 	var c schema.GitLabConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -38,7 +38,7 @@ func NewGitLabSource(svc *ExternalService, cf *httpcli.Factory) (*GitLabSource, 
 	return newGitLabSource(svc, &c, cf)
 }
 
-func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpcli.Factory) (*GitLabSource, error) {
+func newGitLabSource(svc *CodeHost, c *schema.GitLabConnection, cf *httpcli.Factory) (*GitLabSource, error) {
 	baseURL, err := url.Parse(c.Url)
 	if err != nil {
 		return nil, err
@@ -110,9 +110,9 @@ func (s GitLabSource) GetRepo(ctx context.Context, pathWithNamespace string) (*R
 	return s.makeRepo(proj), nil
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s GitLabSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s GitLabSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s GitLabSource) makeRepo(proj *gitlab.Project) *Repo {

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -130,7 +130,7 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			svc := &ExternalService{
+			svc := &CodeHost{
 				Kind: "GITLAB",
 				Config: marshalJSON(t, &schema.GitLabConnection{
 					Url: "https://gitlab.com",

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -21,7 +21,7 @@ import (
 // A GitoliteSource yields repositories from a single Gitolite connection configured
 // in Sourcegraph via the external services configuration.
 type GitoliteSource struct {
-	svc  *ExternalService
+	svc  *CodeHost
 	conn *schema.GitoliteConnection
 	// We ask gitserver to talk to gitolite because it holds the ssh keys
 	// required for authentication.
@@ -31,7 +31,7 @@ type GitoliteSource struct {
 }
 
 // NewGitoliteSource returns a new GitoliteSource from the given external service.
-func NewGitoliteSource(svc *ExternalService, cf *httpcli.Factory) (*GitoliteSource, error) {
+func NewGitoliteSource(svc *CodeHost, cf *httpcli.Factory) (*GitoliteSource, error) {
 	var c schema.GitoliteConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
@@ -87,9 +87,9 @@ func (s *GitoliteSource) ListRepos(ctx context.Context, results chan SourceResul
 	}
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s GitoliteSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s GitoliteSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s GitoliteSource) excludes(gr *gitolite.Repo, r *Repo) bool {
@@ -167,7 +167,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*R
 			continue
 		}
 
-		for _, id := range r.ExternalServiceIDs() {
+		for _, id := range r.CodeHostIDs() {
 			ids = append(ids, id)
 			grouped[id] = append(grouped[id], r)
 		}
@@ -178,7 +178,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*R
 		return nil
 	}
 
-	es, err := s.store.ListExternalServices(ctx, StoreListExternalServicesArgs{IDs: ids})
+	es, err := s.store.ListCodeHosts(ctx, StoreListCodeHostsArgs{IDs: ids})
 	if err != nil {
 		return errors.Wrap(err, "gitolite-phabricator-metadata-syncer.store.list-external-services")
 	}

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -49,9 +49,9 @@ func TestIntegration(t *testing.T) {
 		test func(*testing.T)
 	}{
 		{"DBStore/Transact", testDBStoreTransact(dbstore)},
-		{"DBStore/ListExternalServices", testStoreListExternalServices(store)},
-		{"DBStore/ListExternalServices/ByRepo", testStoreListExternalServicesByRepos(store)},
-		{"DBStore/UpsertExternalServices", testStoreUpsertExternalServices(store)},
+		{"DBStore/ListCodeHosts", testStoreListCodeHosts(store)},
+		{"DBStore/ListCodeHosts/ByRepo", testStoreListCodeHostsByRepos(store)},
+		{"DBStore/UpsertCodeHosts", testStoreUpsertCodeHosts(store)},
 		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -156,13 +156,13 @@ type ObservedStore struct {
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.
 type StoreMetrics struct {
-	Transact               *OperationMetrics
-	Done                   *OperationMetrics
-	UpsertRepos            *OperationMetrics
-	ListRepos              *OperationMetrics
-	UpsertExternalServices *OperationMetrics
-	ListExternalServices   *OperationMetrics
-	ListAllRepoNames       *OperationMetrics
+	Transact         *OperationMetrics
+	Done             *OperationMetrics
+	UpsertRepos      *OperationMetrics
+	ListRepos        *OperationMetrics
+	UpsertCodeHosts  *OperationMetrics
+	ListCodeHosts    *OperationMetrics
+	ListAllRepoNames *OperationMetrics
 }
 
 // NewStoreMetrics returns StoreMetrics that need to be registered
@@ -249,7 +249,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when listing repos",
 			}, []string{}),
 		},
-		UpsertExternalServices: &OperationMetrics{
+		UpsertCodeHosts: &OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "external_serviceupdater",
@@ -269,7 +269,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when upserting external_services",
 			}, []string{}),
 		},
-		ListExternalServices: &OperationMetrics{
+		ListCodeHosts: &OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -371,9 +371,9 @@ func (o *ObservedStore) Done(errs ...*error) {
 	o.store.(TxStore).Done(errs...)
 }
 
-// ListExternalServices calls into the inner Store and registers the observed results.
-func (o *ObservedStore) ListExternalServices(ctx context.Context, args StoreListExternalServicesArgs) (es []*ExternalService, err error) {
-	tr, ctx := o.trace(ctx, "Store.ListExternalServices")
+// ListCodeHosts calls into the inner Store and registers the observed results.
+func (o *ObservedStore) ListCodeHosts(ctx context.Context, args StoreListCodeHostsArgs) (es []*CodeHost, err error) {
+	tr, ctx := o.trace(ctx, "Store.ListCodeHosts")
 	tr.LogFields(
 		otlog.Object("args.ids", args.IDs),
 		otlog.Object("args.kinds", args.Kinds),
@@ -383,7 +383,7 @@ func (o *ObservedStore) ListExternalServices(ctx context.Context, args StoreList
 		secs := time.Since(began).Seconds()
 		count := float64(len(es))
 
-		o.metrics.ListExternalServices.Observe(secs, count, &err)
+		o.metrics.ListCodeHosts.Observe(secs, count, &err)
 		log(o.log, "store.list-external-services", &err,
 			"args", fmt.Sprintf("%+v", args),
 			"count", len(es),
@@ -391,40 +391,40 @@ func (o *ObservedStore) ListExternalServices(ctx context.Context, args StoreList
 
 		tr.LogFields(
 			otlog.Int("count", len(es)),
-			otlog.Object("names", ExternalServices(es).DisplayNames()),
-			otlog.Object("urns", ExternalServices(es).URNs()),
+			otlog.Object("names", CodeHosts(es).DisplayNames()),
+			otlog.Object("urns", CodeHosts(es).URNs()),
 		)
 		tr.SetError(err)
 		tr.Finish()
 	}(time.Now())
 
-	return o.store.ListExternalServices(ctx, args)
+	return o.store.ListCodeHosts(ctx, args)
 }
 
-// UpsertExternalServices calls into the inner Store and registers the observed results.
-func (o *ObservedStore) UpsertExternalServices(ctx context.Context, svcs ...*ExternalService) (err error) {
-	tr, ctx := o.trace(ctx, "Store.UpsertExternalServices")
+// UpsertCodeHosts calls into the inner Store and registers the observed results.
+func (o *ObservedStore) UpsertCodeHosts(ctx context.Context, svcs ...*CodeHost) (err error) {
+	tr, ctx := o.trace(ctx, "Store.UpsertCodeHosts")
 	tr.LogFields(
 		otlog.Int("count", len(svcs)),
-		otlog.Object("names", ExternalServices(svcs).DisplayNames()),
-		otlog.Object("urns", ExternalServices(svcs).URNs()),
+		otlog.Object("names", CodeHosts(svcs).DisplayNames()),
+		otlog.Object("urns", CodeHosts(svcs).URNs()),
 	)
 
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		count := float64(len(svcs))
 
-		o.metrics.UpsertExternalServices.Observe(secs, count, &err)
+		o.metrics.UpsertCodeHosts.Observe(secs, count, &err)
 		log(o.log, "store.upsert-external-services", &err,
 			"count", len(svcs),
-			"names", ExternalServices(svcs).DisplayNames(),
+			"names", CodeHosts(svcs).DisplayNames(),
 		)
 
 		tr.SetError(err)
 		tr.Finish()
 	}(time.Now())
 
-	return o.store.UpsertExternalServices(ctx, svcs...)
+	return o.store.UpsertCodeHosts(ctx, svcs...)
 }
 
 // ListRepos calls into the inner Store and registers the observed results.

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -19,14 +19,14 @@ import (
 // A OtherSource yields repositories from a single Other connection configured
 // in Sourcegraph via the external services configuration.
 type OtherSource struct {
-	svc    *ExternalService
-	conn   *schema.OtherExternalServiceConnection
+	svc    *CodeHost
+	conn   *schema.OtherCodeHostConnection
 	client httpcli.Doer
 }
 
 // NewOtherSource returns a new OtherSource from the given external service.
-func NewOtherSource(svc *ExternalService, cf *httpcli.Factory) (*OtherSource, error) {
-	var c schema.OtherExternalServiceConnection
+func NewOtherSource(svc *CodeHost, cf *httpcli.Factory) (*OtherSource, error) {
+	var c schema.OtherCodeHostConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
 	}
@@ -74,9 +74,9 @@ func (s OtherSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	}
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s OtherSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s OtherSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s OtherSource) cloneURLs() ([]*url.URL, error) {
@@ -113,7 +113,7 @@ func otherRepoCloneURL(base *url.URL, repo string) (*url.URL, error) {
 
 func (s OtherSource) otherRepoFromCloneURL(urn string, u *url.URL) (*Repo, error) {
 	repoURL := u.String()
-	repoSource := reposource.Other{OtherExternalServiceConnection: s.conn}
+	repoSource := reposource.Other{OtherCodeHostConnection: s.conn}
 	repoName, err := repoSource.CloneURLToRepoName(u.String())
 	if err != nil {
 		return nil, err

--- a/cmd/repo-updater/repos/other_test.go
+++ b/cmd/repo-updater/repos/other_test.go
@@ -116,7 +116,7 @@ func TestSrcExpose(t *testing.T) {
 		}},
 	}}
 
-	source, err := NewOtherSource(&ExternalService{
+	source, err := NewOtherSource(&CodeHost{
 		ID:     1,
 		Kind:   "OTHER",
 		Config: fmt.Sprintf(`{"url": %q}`, s.URL),

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -18,7 +18,7 @@ import (
 // A PhabricatorSource yields repositories from a single Phabricator connection configured
 // in Sourcegraph via the external services configuration.
 type PhabricatorSource struct {
-	svc  *ExternalService
+	svc  *CodeHost
 	conn *schema.PhabricatorConnection
 	cf   *httpcli.Factory
 
@@ -27,7 +27,7 @@ type PhabricatorSource struct {
 }
 
 // NewPhabricatorSource returns a new PhabricatorSource from the given external service.
-func NewPhabricatorSource(svc *ExternalService, cf *httpcli.Factory) (*PhabricatorSource, error) {
+func NewPhabricatorSource(svc *CodeHost, cf *httpcli.Factory) (*PhabricatorSource, error) {
 	var c schema.PhabricatorConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
@@ -72,9 +72,9 @@ func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan SourceRe
 	}
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s *PhabricatorSource) ExternalServices() ExternalServices {
-	return ExternalServices{s.svc}
+// CodeHosts returns a singleton slice containing the external service.
+func (s *PhabricatorSource) CodeHosts() CodeHosts {
+	return CodeHosts{s.svc}
 }
 
 func (s *PhabricatorSource) makeRepo(repo *phabricator.Repo) (*Repo, error) {
@@ -184,7 +184,7 @@ func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
 	cf := httpcli.NewHTTPClientFactory()
 
 	for {
-		phabs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+		phabs, err := s.ListCodeHosts(ctx, StoreListCodeHostsArgs{
 			Kinds: []string{"PHABRICATOR"},
 		})
 		if err != nil {

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -32,7 +32,7 @@ import (
 func TestNewSourcer(t *testing.T) {
 	now := time.Now()
 
-	github := ExternalService{
+	github := CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "Github - Test",
 		Config:      `{"url": "https://github.com"}`,
@@ -40,7 +40,7 @@ func TestNewSourcer(t *testing.T) {
 		UpdatedAt:   now,
 	}
 
-	gitlab := ExternalService{
+	gitlab := CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "Github - Test",
 		Config:      `{"url": "https://github.com"}`,
@@ -49,7 +49,7 @@ func TestNewSourcer(t *testing.T) {
 		DeletedAt:   now,
 	}
 
-	sources := func(es ...*ExternalService) (srcs []Source) {
+	sources := func(es ...*CodeHost) (srcs []Source) {
 		t.Helper()
 
 		for _, e := range es {
@@ -65,13 +65,13 @@ func TestNewSourcer(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		svcs ExternalServices
+		svcs CodeHosts
 		srcs Sources
 		err  string
 	}{
 		{
 			name: "deleted external services are excluded",
-			svcs: ExternalServices{&github, &gitlab},
+			svcs: CodeHosts{&github, &gitlab},
 			srcs: sources(&github),
 			err:  "<nil>",
 		},
@@ -84,8 +84,8 @@ func TestNewSourcer(t *testing.T) {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}
 
-			have := srcs.ExternalServices()
-			want := tc.srcs.ExternalServices()
+			have := srcs.CodeHosts()
+			want := tc.srcs.CodeHosts()
 
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("sources:\n%s", cmp.Diff(have, want))
@@ -113,14 +113,14 @@ func TestSources_ListRepos(t *testing.T) {
 	type testCase struct {
 		name   string
 		ctx    context.Context
-		svcs   ExternalServices
-		assert func(*ExternalService) ReposAssertion
+		svcs   CodeHosts
+		assert func(*CodeHost) ReposAssertion
 		err    string
 	}
 
 	var testCases []testCase
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
@@ -180,7 +180,7 @@ func TestSources_ListRepos(t *testing.T) {
 			},
 			{
 				Kind: "OTHER",
-				Config: marshalJSON(t, &schema.OtherExternalServiceConnection{
+				Config: marshalJSON(t, &schema.OtherCodeHostConnection{
 					Url: "https://github.com",
 					Repos: []string{
 						"google/go-cmp",
@@ -192,7 +192,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "yielded repos are always enabled",
 			svcs: svcs,
-			assert: func(e *ExternalService) ReposAssertion {
+			assert: func(e *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -214,7 +214,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
@@ -302,7 +302,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "excluded repos are never yielded",
 			svcs: svcs,
-			assert: func(s *ExternalService) ReposAssertion {
+			assert: func(s *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -380,7 +380,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
@@ -421,7 +421,7 @@ func TestSources_ListRepos(t *testing.T) {
 			},
 			{
 				Kind: "OTHER",
-				Config: marshalJSON(t, &schema.OtherExternalServiceConnection{
+				Config: marshalJSON(t, &schema.OtherCodeHostConnection{
 					Url: "https://github.com",
 					Repos: []string{
 						"google/go-cmp",
@@ -445,7 +445,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "included repos that exist are yielded",
 			svcs: svcs,
-			assert: func(s *ExternalService) ReposAssertion {
+			assert: func(s *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -494,7 +494,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "GITHUB",
 				Config: marshalJSON(t, &schema.GitHubConnection{
@@ -553,7 +553,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "repositoryPathPattern determines the repo name",
 			svcs: svcs,
-			assert: func(s *ExternalService) ReposAssertion {
+			assert: func(s *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -625,7 +625,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "GITLAB",
 				Config: marshalJSON(t, &schema.GitLabConnection{
@@ -654,7 +654,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "nameTransformations updates the repo name",
 			svcs: svcs,
-			assert: func(s *ExternalService) ReposAssertion {
+			assert: func(s *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -680,7 +680,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "AWSCODECOMMIT",
 				Config: marshalJSON(t, &schema.AWSCodeCommitConnection{
@@ -698,7 +698,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "yielded repos have authenticated CloneURLs",
 			svcs: svcs,
-			assert: func(s *ExternalService) ReposAssertion {
+			assert: func(s *CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 
@@ -728,7 +728,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 
 	{
-		svcs := ExternalServices{
+		svcs := CodeHosts{
 			{
 				Kind: "PHABRICATOR",
 				Config: marshalJSON(t, &schema.PhabricatorConnection{
@@ -741,7 +741,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "phabricator",
 			svcs: svcs,
-			assert: func(*ExternalService) ReposAssertion {
+			assert: func(*CodeHost) ReposAssertion {
 				return func(t testing.TB, rs Repos) {
 					t.Helper()
 

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -33,8 +33,8 @@ func TestFakeStore(t *testing.T) {
 		name string
 		test func(repos.Store) func(*testing.T)
 	}{
-		{"ListExternalServices", testStoreListExternalServices},
-		{"UpsertExternalServices", testStoreUpsertExternalServices},
+		{"ListCodeHosts", testStoreListCodeHosts},
+		{"UpsertCodeHosts", testStoreUpsertCodeHosts},
 		{"ListRepos", testStoreListRepos},
 		{"ListRepos_Pagination", testStoreListReposPagination},
 		{"UpsertRepos", testStoreUpsertRepos},
@@ -48,7 +48,7 @@ func TestFakeStore(t *testing.T) {
 	}
 }
 
-func testStoreListExternalServicesByRepos(store repos.Store) func(*testing.T) {
+func testStoreListCodeHostsByRepos(store repos.Store) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
@@ -57,7 +57,7 @@ func testStoreListExternalServicesByRepos(store repos.Store) func(*testing.T) {
 		now := clock.Now()
 
 		t.Run("", transact(ctx, store, func(t testing.TB, tx repos.Store) {
-			github := repos.ExternalService{
+			github := repos.CodeHost{
 				Kind:        "GITHUB",
 				DisplayName: "Github - Test",
 				Config:      `{"url": "https://github.com"}`,
@@ -65,7 +65,7 @@ func testStoreListExternalServicesByRepos(store repos.Store) func(*testing.T) {
 				UpdatedAt:   now,
 			}
 
-			gitlab := repos.ExternalService{
+			gitlab := repos.CodeHost{
 				Kind:        "GITLAB",
 				DisplayName: "GitLab - Test",
 				Config:      `{"url": "https://gitlab.com"}`,
@@ -73,9 +73,9 @@ func testStoreListExternalServicesByRepos(store repos.Store) func(*testing.T) {
 				UpdatedAt:   now,
 			}
 
-			svcs := repos.ExternalServices{&github, &gitlab}
+			svcs := repos.CodeHosts{&github, &gitlab}
 
-			if err := tx.UpsertExternalServices(ctx, svcs...); err != nil {
+			if err := tx.UpsertCodeHosts(ctx, svcs...); err != nil {
 				t.Fatalf("failed to setup store: %v", err)
 			}
 
@@ -119,25 +119,25 @@ func testStoreListExternalServicesByRepos(store repos.Store) func(*testing.T) {
 				t.Fatalf("failed to setup store: %v", err)
 			}
 
-			opts := repos.StoreListExternalServicesArgs{
+			opts := repos.StoreListCodeHostsArgs{
 				RepoIDs: repositories.IDs(),
 			}
 
-			have, err := tx.ListExternalServices(ctx, opts)
+			have, err := tx.ListCodeHosts(ctx, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			repos.Assert.ExternalServicesEqual(svcs...)(t, have)
+			repos.Assert.CodeHostsEqual(svcs...)(t, have)
 		}))
 	}
 }
 
-func testStoreListExternalServices(store repos.Store) func(*testing.T) {
+func testStoreListCodeHosts(store repos.Store) func(*testing.T) {
 	clock := repos.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
-	github := repos.ExternalService{
+	github := repos.CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "Github - Test",
 		Config:      `{"url": "https://github.com"}`,
@@ -145,7 +145,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	gitlab := repos.ExternalService{
+	gitlab := repos.CodeHost{
 		Kind:        "GITLAB",
 		DisplayName: "GitLab - Test",
 		Config:      `{"url": "https://gitlab.com"}`,
@@ -153,7 +153,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	bitbucketServer := repos.ExternalService{
+	bitbucketServer := repos.CodeHost{
 		Kind:        "BITBUCKETSERVER",
 		DisplayName: "Bitbucket Server - Test",
 		Config:      `{"url": "https://bitbucketserver.mycorp.com"}`,
@@ -161,7 +161,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	awsCodeCommit := repos.ExternalService{
+	awsCodeCommit := repos.CodeHost{
 		Kind:        "AWSCODECOMMIT",
 		DisplayName: "AWS CodeCommit - Test",
 		Config:      `{"region": "us-west-1"}`,
@@ -169,7 +169,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	otherService := repos.ExternalService{
+	otherService := repos.CodeHost{
 		Kind:        "OTHER",
 		DisplayName: "Other code hosts",
 		Config:      `{"url": "https://git-host.mycorp.com"}`,
@@ -177,7 +177,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	gitoliteService := repos.ExternalService{
+	gitoliteService := repos.CodeHost{
 		Kind:        "GITOLITE",
 		DisplayName: "Gitolite Server - Test",
 		Config:      `{"prefix": "/", "host": "git@gitolite.mycorp.com"}`,
@@ -185,7 +185,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	phabricatorService := repos.ExternalService{
+	phabricatorService := repos.CodeHost{
 		Kind:        "PHABRICATOR",
 		DisplayName: "Phabricator - Test",
 		Config:      `{"url": "https://phab.org", "token": "foo"}`,
@@ -193,7 +193,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		UpdatedAt:   now,
 	}
 
-	svcs := repos.ExternalServices{
+	svcs := repos.CodeHosts{
 		&github,
 		&gitlab,
 		&bitbucketServer,
@@ -205,9 +205,9 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 
 	type testCase struct {
 		name   string
-		args   func(stored repos.ExternalServices) repos.StoreListExternalServicesArgs
-		stored repos.ExternalServices
-		assert repos.ExternalServicesAssertion
+		args   func(stored repos.CodeHosts) repos.StoreListCodeHostsArgs
+		stored repos.CodeHosts
+		assert repos.CodeHostsAssertion
 		err    error
 	}
 
@@ -215,35 +215,35 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 	testCases = append(testCases,
 		testCase{
 			name: "returned kind is uppercase",
-			args: func(repos.ExternalServices) repos.StoreListExternalServicesArgs {
-				return repos.StoreListExternalServicesArgs{
+			args: func(repos.CodeHosts) repos.StoreListCodeHostsArgs {
+				return repos.StoreListCodeHostsArgs{
 					Kinds: svcs.Kinds(),
 				}
 			},
 			stored: svcs,
-			assert: repos.Assert.ExternalServicesEqual(svcs...),
+			assert: repos.Assert.CodeHostsEqual(svcs...),
 		},
 		testCase{
 			name: "case-insensitive kinds",
-			args: func(repos.ExternalServices) (args repos.StoreListExternalServicesArgs) {
+			args: func(repos.CodeHosts) (args repos.StoreListCodeHostsArgs) {
 				for _, kind := range svcs.Kinds() {
 					args.Kinds = append(args.Kinds, strings.ToLower(kind))
 				}
 				return args
 			},
 			stored: svcs,
-			assert: repos.Assert.ExternalServicesEqual(svcs...),
+			assert: repos.Assert.CodeHostsEqual(svcs...),
 		},
 		testCase{
 			name:   "excludes soft deleted external services by default",
-			stored: svcs.With(repos.Opt.ExternalServiceDeletedAt(now)),
-			assert: repos.Assert.ExternalServicesEqual(),
+			stored: svcs.With(repos.Opt.CodeHostDeletedAt(now)),
+			assert: repos.Assert.CodeHostsEqual(),
 		},
 		testCase{
 			name:   "results are in ascending order by id",
-			stored: mkExternalServices(7, svcs...),
-			assert: repos.Assert.ExternalServicesOrderedBy(
-				func(a, b *repos.ExternalService) bool {
+			stored: mkCodeHosts(7, svcs...),
+			assert: repos.Assert.CodeHostsOrderedBy(
+				func(a, b *repos.CodeHost) bool {
 					return a.ID < b.ID
 				},
 			),
@@ -251,7 +251,7 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		testCase{
 			name:   "excludes phabricator by default",
 			stored: svcs,
-			assert: repos.Assert.ExternalServicesEqual(func() (es repos.ExternalServices) {
+			assert: repos.Assert.CodeHostsEqual(func() (es repos.CodeHosts) {
 				for _, e := range svcs {
 					if e.Kind != "PHABRICATOR" {
 						es = append(es, e)
@@ -263,23 +263,23 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		testCase{
 			name:   "includes phabricator if specified in Kinds",
 			stored: svcs,
-			args: func(repos.ExternalServices) (args repos.StoreListExternalServicesArgs) {
+			args: func(repos.CodeHosts) (args repos.StoreListCodeHostsArgs) {
 				args.Kinds = []string{"PHABRICATOR"}
 				return args
 			},
-			assert: repos.Assert.ExternalServicesEqual(&phabricatorService),
+			assert: repos.Assert.CodeHostsEqual(&phabricatorService),
 		},
 	)
 
 	testCases = append(testCases, testCase{
 		name:   "returns svcs by their ids",
 		stored: svcs,
-		args: func(stored repos.ExternalServices) repos.StoreListExternalServicesArgs {
-			return repos.StoreListExternalServicesArgs{
+		args: func(stored repos.CodeHosts) repos.StoreListCodeHostsArgs {
+			return repos.StoreListCodeHostsArgs{
 				IDs: []int64{stored[0].ID, stored[1].ID},
 			}
 		},
-		assert: repos.Assert.ExternalServicesEqual(svcs[:2].Clone()...),
+		assert: repos.Assert.CodeHostsEqual(svcs[:2].Clone()...),
 	})
 
 	return func(t *testing.T) {
@@ -291,16 +291,16 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 
 			t.Run(tc.name, transact(ctx, store, func(t testing.TB, tx repos.Store) {
 				stored := tc.stored.Clone()
-				if err := tx.UpsertExternalServices(ctx, stored...); err != nil {
+				if err := tx.UpsertCodeHosts(ctx, stored...); err != nil {
 					t.Fatalf("failed to setup store: %v", err)
 				}
 
-				var args repos.StoreListExternalServicesArgs
+				var args repos.StoreListCodeHostsArgs
 				if tc.args != nil {
 					args = tc.args(stored)
 				}
 
-				es, err := tx.ListExternalServices(ctx, args)
+				es, err := tx.ListCodeHosts(ctx, args)
 				if have, want := fmt.Sprint(err), fmt.Sprint(tc.err); have != want {
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
@@ -313,14 +313,14 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 	}
 }
 
-func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
+func testStoreUpsertCodeHosts(store repos.Store) func(*testing.T) {
 	clock := repos.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	return func(t *testing.T) {
 		t.Helper()
 
-		github := repos.ExternalService{
+		github := repos.CodeHost{
 			Kind:        "GITHUB",
 			DisplayName: "Github - Test",
 			Config:      `{"url": "https://github.com"}`,
@@ -328,7 +328,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		gitlab := repos.ExternalService{
+		gitlab := repos.CodeHost{
 			Kind:        "GITLAB",
 			DisplayName: "GitLab - Test",
 			Config:      `{"url": "https://gitlab.com"}`,
@@ -336,7 +336,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		bitbucketServer := repos.ExternalService{
+		bitbucketServer := repos.CodeHost{
 			Kind:        "BITBUCKETSERVER",
 			DisplayName: "Bitbucket Server - Test",
 			Config:      `{"url": "https://bitbucketserver.mycorp.com"}`,
@@ -344,7 +344,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		awsCodeCommit := repos.ExternalService{
+		awsCodeCommit := repos.CodeHost{
 			Kind:        "AWSCODECOMMIT",
 			DisplayName: "AWS CodeCommit - Test",
 			Config:      `{"region": "us-west-1"}`,
@@ -352,7 +352,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		otherService := repos.ExternalService{
+		otherService := repos.CodeHost{
 			Kind:        "OTHER",
 			DisplayName: "Other code hosts",
 			Config:      `{"url": "https://git-host.mycorp.com"}`,
@@ -360,7 +360,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		gitoliteService := repos.ExternalService{
+		gitoliteService := repos.CodeHost{
 			Kind:        "GITOLITE",
 			DisplayName: "Gitolite Server - Test",
 			Config:      `{"prefix": "/", "host": "git@gitolite.mycorp.com"}`,
@@ -368,7 +368,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			UpdatedAt:   now,
 		}
 
-		svcs := repos.ExternalServices{
+		svcs := repos.CodeHosts{
 			&github,
 			&gitlab,
 			&bitbucketServer,
@@ -380,16 +380,16 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 		ctx := context.Background()
 
 		t.Run("no external services", func(t *testing.T) {
-			if err := store.UpsertExternalServices(ctx); err != nil {
-				t.Fatalf("UpsertExternalServices error: %s", err)
+			if err := store.UpsertCodeHosts(ctx); err != nil {
+				t.Fatalf("UpsertCodeHosts error: %s", err)
 			}
 		})
 
 		t.Run("many external services", transact(ctx, store, func(t testing.TB, tx repos.Store) {
-			want := mkExternalServices(7, svcs...)
+			want := mkCodeHosts(7, svcs...)
 
-			if err := tx.UpsertExternalServices(ctx, want...); err != nil {
-				t.Fatalf("UpsertExternalServices error: %s", err)
+			if err := tx.UpsertCodeHosts(ctx, want...); err != nil {
+				t.Fatalf("UpsertCodeHosts error: %s", err)
 			}
 
 			for _, e := range want {
@@ -401,15 +401,15 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 
 			sort.Sort(want)
 
-			have, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+			have, err := tx.ListCodeHosts(ctx, repos.StoreListCodeHostsArgs{
 				Kinds: svcs.Kinds(),
 			})
 			if err != nil {
-				t.Fatalf("ListExternalServices error: %s", err)
+				t.Fatalf("ListCodeHosts error: %s", err)
 			}
 
 			if diff := pretty.Compare(have, want); diff != "" {
-				t.Fatalf("ListExternalServices:\n%s", diff)
+				t.Fatalf("ListCodeHosts:\n%s", diff)
 			}
 
 			now := clock.Now()
@@ -422,23 +422,23 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 				r.CreatedAt = now
 			}
 
-			if err = tx.UpsertExternalServices(ctx, want...); err != nil {
-				t.Errorf("UpsertExternalServices error: %s", err)
-			} else if have, err = tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{}); err != nil {
-				t.Errorf("ListExternalServices error: %s", err)
+			if err = tx.UpsertCodeHosts(ctx, want...); err != nil {
+				t.Errorf("UpsertCodeHosts error: %s", err)
+			} else if have, err = tx.ListCodeHosts(ctx, repos.StoreListCodeHostsArgs{}); err != nil {
+				t.Errorf("ListCodeHosts error: %s", err)
 			} else if diff := pretty.Compare(have, want); diff != "" {
-				t.Errorf("ListExternalServices:\n%s", diff)
+				t.Errorf("ListCodeHosts:\n%s", diff)
 			}
 
-			want.Apply(repos.Opt.ExternalServiceDeletedAt(now))
-			args := repos.StoreListExternalServicesArgs{}
+			want.Apply(repos.Opt.CodeHostDeletedAt(now))
+			args := repos.StoreListCodeHostsArgs{}
 
-			if err = tx.UpsertExternalServices(ctx, want.Clone()...); err != nil {
-				t.Errorf("UpsertExternalServices error: %s", err)
-			} else if have, err = tx.ListExternalServices(ctx, args); err != nil {
-				t.Errorf("ListExternalServices error: %s", err)
-			} else if diff := pretty.Compare(have, repos.ExternalServices{}); diff != "" {
-				t.Errorf("ListExternalServices:\n%s", diff)
+			if err = tx.UpsertCodeHosts(ctx, want.Clone()...); err != nil {
+				t.Errorf("UpsertCodeHosts error: %s", err)
+			} else if have, err = tx.ListCodeHosts(ctx, args); err != nil {
+				t.Errorf("ListCodeHosts error: %s", err)
+			} else if diff := pretty.Compare(have, repos.CodeHosts{}); diff != "" {
+				t.Errorf("ListCodeHosts:\n%s", diff)
 			}
 		}))
 	}
@@ -1030,11 +1030,11 @@ func mkRepos(n int, base ...*repos.Repo) repos.Repos {
 	return rs
 }
 
-func mkExternalServices(n int, base ...*repos.ExternalService) repos.ExternalServices {
+func mkCodeHosts(n int, base ...*repos.CodeHost) repos.CodeHosts {
 	if len(base) == 0 {
 		return nil
 	}
-	es := make(repos.ExternalServices, 0, n)
+	es := make(repos.CodeHosts, 0, n)
 	for i := 0; i < n; i++ {
 		id := strconv.Itoa(i)
 		r := base[i%len(base)].Clone()

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -384,7 +384,7 @@ func merge(o, n *Repo) {
 }
 
 func (s *Syncer) sourced(ctx context.Context, observe ...func(*Repo)) ([]*Repo, error) {
-	svcs, err := s.Store.ListExternalServices(ctx, StoreListExternalServicesArgs{})
+	svcs, err := s.Store.ListCodeHosts(ctx, StoreListCodeHostsArgs{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -26,8 +26,8 @@ func TestSyncer_Sync(t *testing.T) {
 
 	testSyncerSync(new(repos.FakeStore))(t)
 
-	github := repos.ExternalService{ID: 1, Kind: "github"}
-	gitlab := repos.ExternalService{ID: 2, Kind: "gitlab"}
+	github := repos.CodeHost{ID: 1, Kind: "github"}
+	gitlab := repos.CodeHost{ID: 2, Kind: "gitlab"}
 
 	for _, tc := range []struct {
 		name    string
@@ -88,7 +88,7 @@ func TestSyncer_Sync(t *testing.T) {
 }
 
 func testSyncerSync(s repos.Store) func(*testing.T) {
-	githubService := &repos.ExternalService{
+	githubService := &repos.CodeHost{
 		ID:   1,
 		Kind: "GITHUB",
 	}
@@ -106,7 +106,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(githubService.URN()),
 	)
 
-	gitlabService := &repos.ExternalService{
+	gitlabService := &repos.CodeHost{
 		ID:   10,
 		Kind: "GITLAB",
 	}
@@ -124,7 +124,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(gitlabService.URN()),
 	)
 
-	bitbucketServerService := &repos.ExternalService{
+	bitbucketServerService := &repos.CodeHost{
 		ID:   20,
 		Kind: "BITBUCKETSERVER",
 	}
@@ -142,7 +142,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(bitbucketServerService.URN()),
 	)
 
-	awsCodeCommitService := &repos.ExternalService{
+	awsCodeCommitService := &repos.CodeHost{
 		ID:   30,
 		Kind: "AWSCODECOMMIT",
 	}
@@ -160,7 +160,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(awsCodeCommitService.URN()),
 	)
 
-	otherService := &repos.ExternalService{
+	otherService := &repos.CodeHost{
 		ID:   40,
 		Kind: "OTHER",
 	}
@@ -177,7 +177,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(otherService.URN()),
 	)
 
-	gitoliteService := &repos.ExternalService{
+	gitoliteService := &repos.CodeHost{
 		ID:   50,
 		Kind: "GITOLITE",
 	}
@@ -195,7 +195,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		repos.Opt.RepoSources(gitoliteService.URN()),
 	)
 
-	bitbucketCloudService := &repos.ExternalService{
+	bitbucketCloudService := &repos.CodeHost{
 		ID:   60,
 		Kind: "BITBUCKETCLOUD",
 	}
@@ -229,7 +229,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 	var testCases []testCase
 	for _, tc := range []struct {
 		repo *repos.Repo
-		svc  *repos.ExternalService
+		svc  *repos.CodeHost
 	}{
 		{repo: githubRepo, svc: githubService},
 		{repo: gitlabRepo, svc: gitlabService},
@@ -239,7 +239,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		{repo: gitoliteRepo, svc: gitoliteService},
 		{repo: bitbucketCloudRepo, svc: bitbucketCloudService},
 	} {
-		svcdup := tc.svc.With(repos.Opt.ExternalServiceID(tc.svc.ID + 1))
+		svcdup := tc.svc.With(repos.Opt.CodeHostID(tc.svc.ID + 1))
 		testCases = append(testCases,
 			testCase{
 				name: "new repo",

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -35,8 +35,8 @@ type Changeset struct {
 	*Repo
 }
 
-// An ExternalService is defines a Source that yields Repos.
-type ExternalService struct {
+// An CodeHost is defines a Source that yields Repos.
+type CodeHost struct {
 	ID          int64
 	Kind        string
 	DisplayName string
@@ -48,16 +48,16 @@ type ExternalService struct {
 
 // URN returns a unique resource identifier of this external service,
 // used as the key in a repo's Sources map as well as the SourceInfo ID.
-func (e *ExternalService) URN() string {
+func (e *CodeHost) URN() string {
 	return "extsvc:" + strings.ToLower(e.Kind) + ":" + strconv.FormatInt(e.ID, 10)
 }
 
 // IsDeleted returns true if the external service is deleted.
-func (e *ExternalService) IsDeleted() bool { return !e.DeletedAt.IsZero() }
+func (e *CodeHost) IsDeleted() bool { return !e.DeletedAt.IsZero() }
 
-// Update updates ExternalService r with the fields from the given newer ExternalService n,
+// Update updates CodeHost r with the fields from the given newer CodeHost n,
 // returning true if modified.
-func (e *ExternalService) Update(n *ExternalService) (modified bool) {
+func (e *CodeHost) Update(n *CodeHost) (modified bool) {
 	if e.ID != n.ID {
 		return false
 	}
@@ -86,7 +86,7 @@ func (e *ExternalService) Update(n *ExternalService) (modified bool) {
 }
 
 // Configuration returns the external service config.
-func (e ExternalService) Configuration() (cfg interface{}, _ error) {
+func (e CodeHost) Configuration() (cfg interface{}, _ error) {
 	switch strings.ToLower(e.Kind) {
 	case "awscodecommit":
 		cfg = &schema.AWSCodeCommitConnection{}
@@ -101,7 +101,7 @@ func (e ExternalService) Configuration() (cfg interface{}, _ error) {
 	case "phabricator":
 		cfg = &schema.PhabricatorConnection{}
 	case "other":
-		cfg = &schema.OtherExternalServiceConnection{}
+		cfg = &schema.OtherCodeHostConnection{}
 	default:
 		return nil, fmt.Errorf("unknown external service kind %q", e.Kind)
 	}
@@ -110,7 +110,7 @@ func (e ExternalService) Configuration() (cfg interface{}, _ error) {
 
 // Exclude changes the configuration of an external service to exclude the given
 // repos from being synced.
-func (e *ExternalService) Exclude(rs ...*Repo) error {
+func (e *CodeHost) Exclude(rs ...*Repo) error {
 	switch strings.ToLower(e.Kind) {
 	case "github":
 		return e.excludeGithubRepos(rs...)
@@ -131,13 +131,13 @@ func (e *ExternalService) Exclude(rs ...*Repo) error {
 
 // excludeOtherRepos changes the configuration of an OTHER external service to exclude
 // the given repos.
-func (e *ExternalService) excludeOtherRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeOtherRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
 
 	return e.config("other", func(v interface{}) (string, interface{}, error) {
-		c := v.(*schema.OtherExternalServiceConnection)
+		c := v.(*schema.OtherCodeHostConnection)
 
 		var base *url.URL
 		if c.Url != "" {
@@ -194,7 +194,7 @@ func (e *ExternalService) excludeOtherRepos(rs ...*Repo) error {
 
 // excludeGitLabRepos changes the configuration of a GitLab external service to exclude the
 // given repos from being synced.
-func (e *ExternalService) excludeGitLabRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeGitLabRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -243,7 +243,7 @@ func (e *ExternalService) excludeGitLabRepos(rs ...*Repo) error {
 
 // excludeBitbucketServerRepos changes the configuration of a BitbucketServer external service to exclude the
 // given repos from being synced.
-func (e *ExternalService) excludeBitbucketServerRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeBitbucketServerRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -298,7 +298,7 @@ func (e *ExternalService) excludeBitbucketServerRepos(rs ...*Repo) error {
 
 // excludeGitoliteRepos changes the configuration of a Gitolite external service to exclude the
 // given repos from being synced.
-func (e *ExternalService) excludeGitoliteRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeGitoliteRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -326,7 +326,7 @@ func (e *ExternalService) excludeGitoliteRepos(rs ...*Repo) error {
 
 // excludeGithubRepos changes the configuration of a Github external service to exclude the
 // given repos from being synced.
-func (e *ExternalService) excludeGithubRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeGithubRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -375,7 +375,7 @@ func (e *ExternalService) excludeGithubRepos(rs ...*Repo) error {
 
 // excludeAWSCodeCommitRepos changes the configuration of a AWS CodeCommit
 // external service to exclude the given repos from being synced.
-func (e *ExternalService) excludeAWSCodeCommitRepos(rs ...*Repo) error {
+func (e *CodeHost) excludeAWSCodeCommitRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -430,7 +430,7 @@ func nameWithOwner(name string) string {
 	return strings.ToLower(name)
 }
 
-func (e *ExternalService) config(kind string, opt func(c interface{}) (string, interface{}, error)) error {
+func (e *CodeHost) config(kind string, opt func(c interface{}) (string, interface{}, error)) error {
 	if strings.ToLower(e.Kind) != kind {
 		return fmt.Errorf("config: unexpected external service kind %q", e.Kind)
 	}
@@ -456,7 +456,7 @@ func (e *ExternalService) config(kind string, opt func(c interface{}) (string, i
 	return e.validateConfig()
 }
 
-func (e ExternalService) schema() string {
+func (e CodeHost) schema() string {
 	switch strings.ToLower(e.Kind) {
 	case "awscodecommit":
 		return schema.AWSCodeCommitSchemaJSON
@@ -471,7 +471,7 @@ func (e ExternalService) schema() string {
 	case "phabricator":
 		return schema.PhabricatorSchemaJSON
 	case "other":
-		return schema.OtherExternalServiceSchemaJSON
+		return schema.OtherCodeHostSchemaJSON
 	default:
 		return ""
 	}
@@ -479,7 +479,7 @@ func (e ExternalService) schema() string {
 
 // validateConfig validates the config of an external service
 // against its JSON schema.
-func (e ExternalService) validateConfig() error {
+func (e CodeHost) validateConfig() error {
 	sl := gojsonschema.NewSchemaLoader()
 	sc, err := sl.Compile(gojsonschema.NewStringLoader(e.schema()))
 	if err != nil {
@@ -505,13 +505,13 @@ func (e ExternalService) validateConfig() error {
 }
 
 // Clone returns a clone of the given external service.
-func (e *ExternalService) Clone() *ExternalService {
+func (e *CodeHost) Clone() *CodeHost {
 	clone := *e
 	return &clone
 }
 
-// Apply applies the given functional options to the ExternalService.
-func (e *ExternalService) Apply(opts ...func(*ExternalService)) {
+// Apply applies the given functional options to the CodeHost.
+func (e *CodeHost) Apply(opts ...func(*CodeHost)) {
 	if e == nil {
 		return
 	}
@@ -522,7 +522,7 @@ func (e *ExternalService) Apply(opts ...func(*ExternalService)) {
 }
 
 // With returns a clone of the given repo with the given functional options applied.
-func (e *ExternalService) With(opts ...func(*ExternalService)) *ExternalService {
+func (e *CodeHost) With(opts ...func(*CodeHost)) *CodeHost {
 	clone := e.Clone()
 	clone.Apply(opts...)
 	return clone
@@ -573,9 +573,9 @@ type SourceInfo struct {
 	CloneURL string
 }
 
-// ExternalServiceID returns the ID of the external service this
+// CodeHostID returns the ID of the external service this
 // SourceInfo refers to.
-func (i SourceInfo) ExternalServiceID() int64 {
+func (i SourceInfo) CodeHostID() int64 {
 	ps := strings.SplitN(i.ID, ":", 3)
 	if len(ps) != 3 {
 		return -1
@@ -600,12 +600,12 @@ func (r *Repo) CloneURLs() []string {
 	return urls
 }
 
-// ExternalServiceIDs returns the IDs of the external services this
+// CodeHostIDs returns the IDs of the external services this
 // repo belongs to.
-func (r *Repo) ExternalServiceIDs() []int64 {
+func (r *Repo) CodeHostIDs() []int64 {
 	ids := make([]int64, 0, len(r.Sources))
 	for _, src := range r.Sources {
-		ids = append(ids, src.ExternalServiceID())
+		ids = append(ids, src.CodeHostID())
 	}
 	return ids
 }
@@ -845,12 +845,12 @@ func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
 	return fs
 }
 
-// ExternalServices is an utility type with
-// convenience methods for operating on lists of ExternalServices.
-type ExternalServices []*ExternalService
+// CodeHosts is an utility type with
+// convenience methods for operating on lists of CodeHosts.
+type CodeHosts []*CodeHost
 
-// DisplayNames returns the list of display names from all ExternalServices.
-func (es ExternalServices) DisplayNames() []string {
+// DisplayNames returns the list of display names from all CodeHosts.
+func (es CodeHosts) DisplayNames() []string {
 	names := make([]string, len(es))
 	for i := range es {
 		names[i] = es[i].DisplayName
@@ -859,7 +859,7 @@ func (es ExternalServices) DisplayNames() []string {
 }
 
 // Kinds returns the unique set of Kinds in the given external services list.
-func (es ExternalServices) Kinds() (kinds []string) {
+func (es CodeHosts) Kinds() (kinds []string) {
 	set := make(map[string]bool, len(es))
 	for _, e := range es {
 		if !set[e.Kind] {
@@ -870,8 +870,8 @@ func (es ExternalServices) Kinds() (kinds []string) {
 	return kinds
 }
 
-// URNs returns the list of URNs from all ExternalServices.
-func (es ExternalServices) URNs() []string {
+// URNs returns the list of URNs from all CodeHosts.
+func (es CodeHosts) URNs() []string {
 	urns := make([]string, len(es))
 	for i := range es {
 		urns[i] = es[i].URN()
@@ -879,36 +879,36 @@ func (es ExternalServices) URNs() []string {
 	return urns
 }
 
-func (es ExternalServices) Len() int {
+func (es CodeHosts) Len() int {
 	return len(es)
 }
 
-func (es ExternalServices) Swap(i, j int) {
+func (es CodeHosts) Swap(i, j int) {
 	es[i], es[j] = es[j], es[i]
 }
 
-func (es ExternalServices) Less(i, j int) bool {
+func (es CodeHosts) Less(i, j int) bool {
 	return es[i].ID < es[j].ID
 }
 
 // Clone returns a clone of the given external services.
-func (es ExternalServices) Clone() ExternalServices {
-	o := make(ExternalServices, 0, len(es))
+func (es CodeHosts) Clone() CodeHosts {
+	o := make(CodeHosts, 0, len(es))
 	for _, r := range es {
 		o = append(o, r.Clone())
 	}
 	return o
 }
 
-// Apply applies the given functional options to the ExternalService.
-func (es ExternalServices) Apply(opts ...func(*ExternalService)) {
+// Apply applies the given functional options to the CodeHost.
+func (es CodeHosts) Apply(opts ...func(*CodeHost)) {
 	for _, r := range es {
 		r.Apply(opts...)
 	}
 }
 
 // With returns a clone of the given external services with the given functional options applied.
-func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices {
+func (es CodeHosts) With(opts ...func(*CodeHost)) CodeHosts {
 	clone := es.Clone()
 	clone.Apply(opts...)
 	return clone

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -13,17 +13,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
-func TestExternalService_Exclude(t *testing.T) {
+func TestCodeHost_Exclude(t *testing.T) {
 	now := time.Now()
 
 	type testCase struct {
 		name   string
-		svcs   ExternalServices
+		svcs   CodeHosts
 		repos  Repos
-		assert ExternalServicesAssertion
+		assert CodeHostsAssertion
 	}
 
-	githubService := ExternalService{
+	githubService := CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "Github",
 		Config: `{
@@ -36,7 +36,7 @@ func TestExternalService_Exclude(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	gitlabService := ExternalService{
+	gitlabService := CodeHost{
 		Kind:        "GITLAB",
 		DisplayName: "GitLab",
 		Config: `{
@@ -49,7 +49,7 @@ func TestExternalService_Exclude(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	bitbucketServerService := ExternalService{
+	bitbucketServerService := CodeHost{
 		Kind:        "BITBUCKETSERVER",
 		DisplayName: "Bitbucket Server",
 		Config: `{
@@ -63,7 +63,7 @@ func TestExternalService_Exclude(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	awsCodeCommitService := ExternalService{
+	awsCodeCommitService := CodeHost{
 		ID:          9,
 		Kind:        "AWSCODECOMMIT",
 		DisplayName: "AWS CodeCommit",
@@ -77,7 +77,7 @@ func TestExternalService_Exclude(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	gitoliteService := ExternalService{
+	gitoliteService := CodeHost{
 		Kind:        "GITOLITE",
 		DisplayName: "Gitolite",
 		Config: `{
@@ -89,7 +89,7 @@ func TestExternalService_Exclude(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	otherService := ExternalService{
+	otherService := CodeHost{
 		Kind:        "OTHER",
 		DisplayName: "Other code hosts",
 		Config: formatJSON(t, `{
@@ -178,8 +178,8 @@ func TestExternalService_Exclude(t *testing.T) {
 
 	var testCases []testCase
 	{
-		svcs := ExternalServices{
-			githubService.With(func(e *ExternalService) {
+		svcs := CodeHosts{
+			githubService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -192,7 +192,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			gitlabService.With(func(e *ExternalService) {
+			gitlabService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -205,7 +205,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			bitbucketServerService.With(func(e *ExternalService) {
+			bitbucketServerService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -219,7 +219,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			awsCodeCommitService.With(func(e *ExternalService) {
+			awsCodeCommitService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -233,7 +233,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			gitoliteService.With(func(e *ExternalService) {
+			gitoliteService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -251,12 +251,12 @@ func TestExternalService_Exclude(t *testing.T) {
 			name:   "already excluded repos are ignored",
 			svcs:   svcs,
 			repos:  repos,
-			assert: Assert.ExternalServicesEqual(svcs...),
+			assert: Assert.CodeHostsEqual(svcs...),
 		})
 	}
 	{
-		svcs := ExternalServices{
-			githubService.With(func(e *ExternalService) {
+		svcs := CodeHosts{
+			githubService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -268,7 +268,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			gitlabService.With(func(e *ExternalService) {
+			gitlabService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -280,7 +280,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			bitbucketServerService.With(func(e *ExternalService) {
+			bitbucketServerService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -293,7 +293,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			awsCodeCommitService.With(func(e *ExternalService) {
+			awsCodeCommitService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -306,7 +306,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			gitoliteService.With(func(e *ExternalService) {
+			gitoliteService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					// Some comment
@@ -317,7 +317,7 @@ func TestExternalService_Exclude(t *testing.T) {
 					]
 				}`)
 			}),
-			otherService.With(func(e *ExternalService) {
+			otherService.With(func(e *CodeHost) {
 				e.Config = formatJSON(t, `
 				{
 					"url": "https://git-host.mycorp.com",
@@ -334,8 +334,8 @@ func TestExternalService_Exclude(t *testing.T) {
 			name:  "repos are excluded",
 			svcs:  svcs,
 			repos: repos,
-			assert: Assert.ExternalServicesEqual(
-				githubService.With(func(e *ExternalService) {
+			assert: Assert.CodeHostsEqual(
+				githubService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						// Some comment
@@ -349,7 +349,7 @@ func TestExternalService_Exclude(t *testing.T) {
 						]
 					}`)
 				}),
-				gitlabService.With(func(e *ExternalService) {
+				gitlabService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						// Some comment
@@ -363,7 +363,7 @@ func TestExternalService_Exclude(t *testing.T) {
 						]
 					}`)
 				}),
-				bitbucketServerService.With(func(e *ExternalService) {
+				bitbucketServerService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						// Some comment
@@ -378,7 +378,7 @@ func TestExternalService_Exclude(t *testing.T) {
 						]
 					}`)
 				}),
-				awsCodeCommitService.With(func(e *ExternalService) {
+				awsCodeCommitService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						// Some comment
@@ -393,7 +393,7 @@ func TestExternalService_Exclude(t *testing.T) {
 						]
 					}`)
 				}),
-				gitoliteService.With(func(e *ExternalService) {
+				gitoliteService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						// Some comment
@@ -405,7 +405,7 @@ func TestExternalService_Exclude(t *testing.T) {
 						]
 					}`)
 				}),
-				otherService.With(func(e *ExternalService) {
+				otherService.With(func(e *CodeHost) {
 					e.Config = formatJSON(t, `
 					{
 						"url": "https://git-host.mycorp.com",

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -54,16 +54,16 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repo-update-scheduler-info", s.handleRepoUpdateSchedulerInfo)
 	mux.HandleFunc("/repo-lookup", s.handleRepoLookup)
-	mux.HandleFunc("/repo-external-services", s.handleRepoExternalServices)
+	mux.HandleFunc("/repo-external-services", s.handleRepoCodeHosts)
 	mux.HandleFunc("/enqueue-repo-update", s.handleEnqueueRepoUpdate)
 	mux.HandleFunc("/exclude-repo", s.handleExcludeRepo)
-	mux.HandleFunc("/sync-external-service", s.handleExternalServiceSync)
+	mux.HandleFunc("/sync-external-service", s.handleCodeHostSync)
 	mux.HandleFunc("/status-messages", s.handleStatusMessages)
 	return mux
 }
 
-func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Request) {
-	var req protocol.RepoExternalServicesRequest
+func (s *Server) handleRepoCodeHosts(w http.ResponseWriter, r *http.Request) {
+	var req protocol.RepoCodeHostsRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respond(w, http.StatusInternalServerError, err)
@@ -83,25 +83,25 @@ func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var resp protocol.RepoExternalServicesResponse
+	var resp protocol.RepoCodeHostsResponse
 
-	svcIDs := rs[0].ExternalServiceIDs()
+	svcIDs := rs[0].CodeHostIDs()
 	if len(svcIDs) == 0 {
 		respond(w, http.StatusOK, resp)
 		return
 	}
 
-	args := repos.StoreListExternalServicesArgs{
+	args := repos.StoreListCodeHostsArgs{
 		IDs: svcIDs,
 	}
 
-	es, err := s.Store.ListExternalServices(r.Context(), args)
+	es, err := s.Store.ListCodeHosts(r.Context(), args)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	resp.ExternalServices = newExternalServices(es...)
+	resp.CodeHosts = newCodeHosts(es...)
 
 	respond(w, http.StatusOK, resp)
 }
@@ -128,11 +128,11 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	args := repos.StoreListExternalServicesArgs{
+	args := repos.StoreListCodeHostsArgs{
 		Kinds: repos.Repos(rs).Kinds(),
 	}
 
-	es, err := s.Store.ListExternalServices(r.Context(), args)
+	es, err := s.Store.ListCodeHosts(r.Context(), args)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
@@ -145,13 +145,13 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err = s.Store.UpsertExternalServices(r.Context(), es...)
+	err = s.Store.UpsertCodeHosts(r.Context(), es...)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	resp.ExternalServices = newExternalServices(es...)
+	resp.CodeHosts = newCodeHosts(es...)
 
 	respond(w, http.StatusOK, resp)
 }
@@ -181,11 +181,11 @@ func respond(w http.ResponseWriter, code int, v interface{}) {
 	}
 }
 
-func newExternalServices(es ...*repos.ExternalService) []api.ExternalService {
-	svcs := make([]api.ExternalService, 0, len(es))
+func newCodeHosts(es ...*repos.CodeHost) []api.CodeHost {
+	svcs := make([]api.CodeHost, 0, len(es))
 
 	for _, e := range es {
-		svc := api.ExternalService{
+		svc := api.CodeHost{
 			ID:          e.ID,
 			Kind:        e.Kind,
 			DisplayName: e.DisplayName,
@@ -292,11 +292,11 @@ func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdate
 	}, http.StatusOK, nil
 }
 
-func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleCodeHostSync(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	var req protocol.ExternalServiceSyncRequest
+	var req protocol.CodeHostSyncRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -306,17 +306,17 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 
 	errch := make(chan error, 1)
 	go func() {
-		if req.ExternalService.DeletedAt != nil {
+		if req.CodeHost.DeletedAt != nil {
 			// We don't need to check deleted services.
 			errch <- nil
 			return
 		}
 
-		src, err := repos.NewSource(&repos.ExternalService{
-			ID:          req.ExternalService.ID,
-			Kind:        req.ExternalService.Kind,
-			DisplayName: req.ExternalService.DisplayName,
-			Config:      req.ExternalService.Config,
+		src, err := repos.NewSource(&repos.CodeHost{
+			ID:          req.CodeHost.ID,
+			Kind:        req.CodeHost.Kind,
+			DisplayName: req.CodeHost.DisplayName,
+			Config:      req.CodeHost.Config,
 		}, httpcli.NewHTTPClientFactory())
 		if err != nil {
 			errch <- err
@@ -356,26 +356,26 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	case err := <-errch:
 		switch {
 		case err == nil:
-			log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)
-			respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
-				ExternalService: req.ExternalService,
+			log15.Info("server.external-service-sync", "synced", req.CodeHost.Kind)
+			respond(w, http.StatusOK, &protocol.CodeHostSyncResult{
+				CodeHost: req.CodeHost,
 			})
 		case err == github.ErrIncompleteResults:
-			log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
-			syncResult := &protocol.ExternalServiceSyncResult{
-				ExternalService: req.ExternalService,
-				Error:           err.Error(),
+			log15.Info("server.external-service-sync", "kind", req.CodeHost.Kind, "error", err)
+			syncResult := &protocol.CodeHostSyncResult{
+				CodeHost: req.CodeHost,
+				Error:    err.Error(),
 			}
 			respond(w, http.StatusOK, syncResult)
 		default:
-			log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+			log15.Error("server.external-service-sync", "kind", req.CodeHost.Kind, "error", err)
 			respond(w, http.StatusInternalServerError, err)
 		}
 
 	case <-time.After(10 * time.Second):
-		respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
-			ExternalService: req.ExternalService,
-			Error:           "warning: took longer than 10s to verify config against code host. Please monitor repo-updater logs.",
+		respond(w, http.StatusOK, &protocol.CodeHostSyncResult{
+			CodeHost: req.CodeHost,
+			Error:    "warning: took longer than 10s to verify config against code host. Please monitor repo-updater logs.",
 		})
 
 	case <-ctx.Done():
@@ -506,9 +506,9 @@ func (s *Server) handleStatusMessages(w http.ResponseWriter, r *http.Request) {
 			for _, e := range multiErr.Errors {
 				if sourceErr, ok := e.(*repos.SourceError); ok {
 					resp.Messages = append(resp.Messages, protocol.StatusMessage{
-						ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-							Message:           sourceErr.Err.Error(),
-							ExternalServiceId: sourceErr.ExtSvc.ID,
+						CodeHostSyncError: &protocol.CodeHostSyncError{
+							Message:    sourceErr.Err.Error(),
+							CodeHostId: sourceErr.ExtSvc.ID,
 						},
 					})
 				} else {

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -132,7 +132,7 @@ func TestServer_handleRepoLookup(t *testing.T) {
 }
 
 func TestServer_SetRepoEnabled(t *testing.T) {
-	githubService := &repos.ExternalService{
+	githubService := &repos.CodeHost{
 		ID:          1,
 		Kind:        "GITHUB",
 		DisplayName: "github.com - test",
@@ -160,7 +160,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 		},
 	}).With(repos.Opt.RepoSources(githubService.URN()))
 
-	gitlabService := &repos.ExternalService{
+	gitlabService := &repos.CodeHost{
 		ID:          1,
 		Kind:        "GITLAB",
 		DisplayName: "gitlab.com - test",
@@ -190,7 +190,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 		},
 	}).With(repos.Opt.RepoSources(gitlabService.URN()))
 
-	bitbucketServerService := &repos.ExternalService{
+	bitbucketServerService := &repos.CodeHost{
 		ID:          1,
 		Kind:        "BITBUCKETSERVER",
 		DisplayName: "Bitbucket Server - Test",
@@ -224,8 +224,8 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 
 	type testCase struct {
 		name  string
-		svcs  repos.ExternalServices // stored services
-		repos repos.Repos            // stored repos
+		svcs  repos.CodeHosts // stored services
+		repos repos.Repos     // stored repos
 		kind  string
 		res   *protocol.ExcludeRepoResponse
 		err   string
@@ -234,16 +234,16 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 	var testCases []testCase
 
 	for _, k := range []struct {
-		svc  *repos.ExternalService
+		svc  *repos.CodeHost
 		repo *repos.Repo
 	}{
 		{githubService, githubRepo},
 		{bitbucketServerService, bitbucketServerRepo},
 		{gitlabService, gitlabRepo},
 	} {
-		svcs := repos.ExternalServices{
+		svcs := repos.CodeHosts{
 			k.svc,
-			k.svc.With(func(e *repos.ExternalService) {
+			k.svc.With(func(e *repos.CodeHost) {
 				e.ID++
 				e.DisplayName += " - Duplicate"
 			}),
@@ -255,7 +255,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			repos: repos.Repos{k.repo}.With(repos.Opt.RepoSources()),
 			kind:  k.svc.Kind,
 			res: &protocol.ExcludeRepoResponse{
-				ExternalServices: apiExternalServices(svcs.With(func(e *repos.ExternalService) {
+				CodeHosts: apiCodeHosts(svcs.With(func(e *repos.CodeHost) {
 					if err := e.Exclude(k.repo); err != nil {
 						panic(err)
 					}
@@ -271,7 +271,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 
 			store := new(repos.FakeStore)
 			storedSvcs := tc.svcs.Clone()
-			err := store.UpsertExternalServices(ctx, storedSvcs...)
+			err := store.UpsertCodeHosts(ctx, storedSvcs...)
 			if err != nil {
 				t.Fatalf("failed to prepare store: %v", err)
 			}
@@ -309,23 +309,23 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 				t.Errorf("response:\n%s", cmp.Diff(have, want))
 			}
 
-			if res == nil || len(res.ExternalServices) == 0 {
+			if res == nil || len(res.CodeHosts) == 0 {
 				return
 			}
 
-			ids := make([]int64, 0, len(res.ExternalServices))
-			for _, s := range res.ExternalServices {
+			ids := make([]int64, 0, len(res.CodeHosts))
+			for _, s := range res.CodeHosts {
 				ids = append(ids, s.ID)
 			}
 
-			svcs, err := store.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+			svcs, err := store.ListCodeHosts(ctx, repos.StoreListCodeHostsArgs{
 				IDs: ids,
 			})
 			if err != nil {
 				t.Fatalf("failed to read from store: %v", err)
 			}
 
-			have, want := apiExternalServices(svcs...), res.ExternalServices
+			have, want := apiCodeHosts(svcs...), res.CodeHosts
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("stored external services:\n%s", cmp.Diff(have, want))
 			}
@@ -452,8 +452,8 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 	}
 }
 
-func TestServer_RepoExternalServices(t *testing.T) {
-	service1 := &repos.ExternalService{
+func TestServer_RepoCodeHosts(t *testing.T) {
+	service1 := &repos.CodeHost{
 		ID:          1,
 		Kind:        "GITHUB",
 		DisplayName: "github.com - test",
@@ -464,7 +464,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 			"token": "secret"
 		}`),
 	}
-	service2 := &repos.ExternalService{
+	service2 := &repos.CodeHost{
 		ID:          2,
 		Kind:        "GITHUB",
 		DisplayName: "github.com - test2",
@@ -500,13 +500,13 @@ func TestServer_RepoExternalServices(t *testing.T) {
 	// set for test cases.
 	ctx := context.Background()
 	store := new(repos.FakeStore)
-	must(store.UpsertExternalServices(ctx, service1, service2))
+	must(store.UpsertCodeHosts(ctx, service1, service2))
 	must(store.UpsertRepos(ctx, repoNoSources, repoSources))
 
 	testCases := []struct {
 		name   string
 		repoID uint32
-		svcs   []api.ExternalService
+		svcs   []api.CodeHost
 		err    string
 	}{{
 		name:   "repo no sources",
@@ -516,7 +516,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 	}, {
 		name:   "repo sources",
 		repoID: repoSources.ID,
-		svcs:   apiExternalServices(service1, service2),
+		svcs:   apiCodeHosts(service1, service2),
 		err:    "<nil>",
 	}, {
 		name:   "repo not in store",
@@ -532,7 +532,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := cli.RepoExternalServices(ctx, tc.repoID)
+			res, err := cli.RepoCodeHosts(ctx, tc.repoID)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have err: %q, want: %q", have, want)
 			}
@@ -545,7 +545,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 }
 
 func TestServer_StatusMessages(t *testing.T) {
-	githubService := &repos.ExternalService{
+	githubService := &repos.CodeHost{
 		ID:          1,
 		Kind:        "GITHUB",
 		DisplayName: "github.com - test",
@@ -640,9 +640,9 @@ func TestServer_StatusMessages(t *testing.T) {
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{
 					{
-						ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-							Message:           "github is down",
-							ExternalServiceId: githubService.ID,
+						CodeHostSyncError: &protocol.CodeHostSyncError{
+							Message:    "github is down",
+							CodeHostId: githubService.ID,
 						},
 					},
 				},
@@ -675,7 +675,7 @@ func TestServer_StatusMessages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = store.UpsertExternalServices(ctx, githubService)
+			err = store.UpsertCodeHosts(ctx, githubService)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -720,14 +720,14 @@ func TestServer_StatusMessages(t *testing.T) {
 	}
 }
 
-func apiExternalServices(es ...*repos.ExternalService) []api.ExternalService {
+func apiCodeHosts(es ...*repos.CodeHost) []api.CodeHost {
 	if len(es) == 0 {
 		return nil
 	}
 
-	svcs := make([]api.ExternalService, 0, len(es))
+	svcs := make([]api.CodeHost, 0, len(es))
 	for _, e := range es {
-		svc := api.ExternalService{
+		svc := api.CodeHost{
 			ID:          e.ID,
 			Kind:        e.Kind,
 			DisplayName: e.DisplayName,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -80,8 +80,8 @@ func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 			m.Done,
 			m.ListRepos,
 			m.UpsertRepos,
-			m.ListExternalServices,
-			m.UpsertExternalServices,
+			m.ListCodeHosts,
+			m.UpsertCodeHosts,
 			m.ListAllRepoNames,
 		} {
 			om.MustRegister(prometheus.DefaultRegisterer)
@@ -125,7 +125,7 @@ func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 	if envvar.SourcegraphDotComMode() {
 		server.SourcegraphDotComMode = true
 
-		es, err := store.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+		es, err := store.ListCodeHosts(ctx, repos.StoreListCodeHostsArgs{
 			Kinds: []string{"GITHUB", "GITLAB"},
 		})
 

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -25,7 +25,7 @@ import (
 )
 
 func initAuthz() {
-	db.ExternalServices = edb.NewExternalServicesStore()
+	db.CodeHosts = edb.NewCodeHostsStore()
 
 	// Warn about usage of auth providers that are not enabled by the license.
 	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
@@ -41,7 +41,7 @@ func initAuthz() {
 		var authzTypes []string
 		ctx := context.Background()
 
-		githubs, err := db.ExternalServices.ListGitHubConnections(ctx)
+		githubs, err := db.CodeHosts.ListGitHubConnections(ctx)
 		if err != nil {
 			return []*graphqlbackend.Alert{{
 				TypeValue:    graphqlbackend.AlertTypeError,
@@ -55,7 +55,7 @@ func initAuthz() {
 			}
 		}
 
-		gitlabs, err := db.ExternalServices.ListGitLabConnections(ctx)
+		gitlabs, err := db.CodeHosts.ListGitLabConnections(ctx)
 		if err != nil {
 			return []*graphqlbackend.Alert{{
 				TypeValue:    graphqlbackend.AlertTypeError,
@@ -130,7 +130,7 @@ func initAuthz() {
 	}
 }
 
-type ExternalServicesStore interface {
+type CodeHostsStore interface {
 	ListGitLabConnections(context.Context) ([]*schema.GitLabConnection, error)
 	ListGitHubConnections(context.Context) ([]*schema.GitHubConnection, error)
 	ListBitbucketServerConnections(context.Context) ([]*schema.BitbucketServerConnection, error)
@@ -143,7 +143,7 @@ type ExternalServicesStore interface {
 func authzProvidersFromConfig(
 	ctx context.Context,
 	cfg *conf.Unified,
-	s ExternalServicesStore,
+	s CodeHostsStore,
 	db *sql.DB, // Needed by Bitbucket Server authz provider
 ) (
 	allowAccessByDefault bool,
@@ -206,9 +206,9 @@ func init() {
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conf.Unified) (problems conf.Problems) {
 		_, _, seriousProblems, warnings :=
-			authzProvidersFromConfig(context.Background(), &cfg, db.ExternalServices, dbconn.Global)
-		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
-		problems = append(problems, conf.NewExternalServiceProblems(warnings...)...)
+			authzProvidersFromConfig(context.Background(), &cfg, db.CodeHosts, dbconn.Global)
+		problems = append(problems, conf.NewCodeHostProblems(seriousProblems...)...)
+		problems = append(problems, conf.NewCodeHostProblems(warnings...)...)
 		return problems
 	})
 }

--- a/enterprise/cmd/frontend/db/external_services.go
+++ b/enterprise/cmd/frontend/db/external_services.go
@@ -8,10 +8,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// NewExternalServicesStore returns an OSS db.ExternalServicesStore set with
+// NewCodeHostsStore returns an OSS db.CodeHostsStore set with
 // enterprise validators.
-func NewExternalServicesStore() *db.ExternalServicesStore {
-	return &db.ExternalServicesStore{
+func NewCodeHostsStore() *db.CodeHostsStore {
+	return &db.CodeHostsStore{
 		GitHubValidators: []func(*schema.GitHubConnection) error{
 			github.ValidateAuthz,
 		},

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -14,7 +14,7 @@ import (
 
 // This test lives in cmd/enterprise because it tests a proprietary
 // super-set of the validation performed by the OSS version.
-func TestExternalServices_ValidateConfig(t *testing.T) {
+func TestCodeHosts_ValidateConfig(t *testing.T) {
 	// Assertion helpers
 	equals := func(want ...string) func(testing.TB, []string) {
 		sort.Strings(want)
@@ -1235,7 +1235,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				tc.ps = conf.Get().AuthProviders
 			}
 
-			s := NewExternalServicesStore()
+			s := NewCodeHostsStore()
 			err := s.ValidateConfig(tc.kind, tc.config, tc.ps)
 			switch e := err.(type) {
 			case nil:

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -47,7 +47,7 @@ func main() {
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _ :=
-				authzProvidersFromConfig(ctx, conf.Get(), db.ExternalServices, dbconn.Global)
+				authzProvidersFromConfig(ctx, conf.Get(), db.CodeHosts, dbconn.Global)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/internal/a8n/resolvers/changesets.go
+++ b/enterprise/internal/a8n/resolvers/changesets.go
@@ -181,7 +181,7 @@ func (r *changesetResolver) ExternalURL() (*externallink.Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return externallink.NewResolver(url, r.Changeset.ExternalServiceType), nil
+	return externallink.NewResolver(url, r.Changeset.CodeHostType), nil
 }
 
 func (r *changesetResolver) ReviewState(ctx context.Context) (a8n.ChangesetReviewState, error) {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -400,7 +400,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	}
 
 	for _, c := range cs {
-		c.ExternalServiceType = repoSet[uint32(c.RepoID)].ExternalRepo.ServiceType
+		c.CodeHostType = repoSet[uint32(c.RepoID)].ExternalRepo.ServiceType
 	}
 
 	err = tx.CreateChangesets(ctx, cs...)

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -263,7 +263,7 @@ func TestCampaigns(t *testing.T) {
 	}
 
 	store := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
-	githubExtSvc := &repos.ExternalService{
+	githubExtSvc := &repos.CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "GitHub",
 		Config: marshalJSON(t, &schema.GitHubConnection{
@@ -280,7 +280,7 @@ func TestCampaigns(t *testing.T) {
 		bbsURL = "https://bitbucket.sgdev.org"
 	}
 
-	bbsExtSvc := &repos.ExternalService{
+	bbsExtSvc := &repos.CodeHost{
 		Kind:        "BITBUCKETSERVER",
 		DisplayName: "Bitbucket Server",
 		Config: marshalJSON(t, &schema.BitbucketServerConnection{
@@ -290,7 +290,7 @@ func TestCampaigns(t *testing.T) {
 		}),
 	}
 
-	err = store.UpsertExternalServices(ctx, githubExtSvc, bbsExtSvc)
+	err = store.UpsertCodeHosts(ctx, githubExtSvc, bbsExtSvc)
 	if err != nil {
 		t.Fatal(t)
 	}
@@ -730,7 +730,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 	}
 
 	repoStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
-	githubExtSvc := &repos.ExternalService{
+	githubExtSvc := &repos.CodeHost{
 		Kind:        "GITHUB",
 		DisplayName: "GitHub",
 		Config: marshalJSON(t, &schema.GitHubConnection{
@@ -740,7 +740,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 		}),
 	}
 
-	err = repoStore.UpsertExternalServices(ctx, githubExtSvc)
+	err = repoStore.UpsertCodeHosts(ctx, githubExtSvc)
 	if err != nil {
 		t.Fatal(t)
 	}
@@ -776,16 +776,16 @@ func TestChangesetCountsOverTime(t *testing.T) {
 
 	changesets := []*a8n.Changeset{
 		{
-			RepoID:              int32(githubRepo.ID),
-			ExternalID:          "5834",
-			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			CampaignIDs:         []int64{campaign.ID},
+			RepoID:       int32(githubRepo.ID),
+			ExternalID:   "5834",
+			CodeHostType: githubRepo.ExternalRepo.ServiceType,
+			CampaignIDs:  []int64{campaign.ID},
 		},
 		{
-			RepoID:              int32(githubRepo.ID),
-			ExternalID:          "5849",
-			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			CampaignIDs:         []int64{campaign.ID},
+			RepoID:       int32(githubRepo.ID),
+			ExternalID:   "5849",
+			CodeHostType: githubRepo.ExternalRepo.ServiceType,
+			CampaignIDs:  []int64{campaign.ID},
 		},
 	}
 

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -297,11 +297,11 @@ func (s *Service) runChangesetJob(
 		return err
 	}
 
-	var externalService *repos.ExternalService
+	var codeHost *repos.CodeHost
 	{
-		args := repos.StoreListExternalServicesArgs{IDs: repo.ExternalServiceIDs()}
+		args := repos.StoreListCodeHostsArgs{IDs: repo.CodeHostIDs()}
 
-		es, err := reposStore.ListExternalServices(ctx, args)
+		es, err := reposStore.ListCodeHosts(ctx, args)
 		if err != nil {
 			return err
 		}
@@ -315,24 +315,24 @@ func (s *Service) runChangesetJob(
 			switch cfg := cfg.(type) {
 			case *schema.GitHubConnection:
 				if cfg.Token != "" {
-					externalService = e
+					codeHost = e
 				}
 			case *schema.BitbucketServerConnection:
 				if cfg.Token != "" {
-					externalService = e
+					codeHost = e
 				}
 			}
-			if externalService != nil {
+			if codeHost != nil {
 				break
 			}
 		}
 	}
 
-	if externalService == nil {
+	if codeHost == nil {
 		return errors.Errorf("no external services found for repo %q", repo.Name)
 	}
 
-	src, err := repos.NewSource(externalService, s.cf)
+	src, err := repos.NewSource(codeHost, s.cf)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -302,13 +302,13 @@ func testStore(db *sql.DB) func(*testing.T) {
 			t.Run("Create", func(t *testing.T) {
 				for i := 0; i < cap(changesets); i++ {
 					th := &a8n.Changeset{
-						RepoID:              42,
-						CreatedAt:           now,
-						UpdatedAt:           now,
-						Metadata:            githubPR,
-						CampaignIDs:         []int64{int64(i) + 1},
-						ExternalID:          fmt.Sprintf("foobar-%d", i),
-						ExternalServiceType: "github",
+						RepoID:       42,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+						Metadata:     githubPR,
+						CampaignIDs:  []int64{int64(i) + 1},
+						ExternalID:   fmt.Sprintf("foobar-%d", i),
+						CodeHostType: "github",
 					}
 
 					changesets = append(changesets, th)
@@ -347,9 +347,9 @@ func testStore(db *sql.DB) func(*testing.T) {
 				for i, c := range changesets {
 					// Set only the fields on which we have a unique constraint
 					clones[i] = &a8n.Changeset{
-						RepoID:              c.RepoID,
-						ExternalID:          c.ExternalID,
-						ExternalServiceType: c.ExternalServiceType,
+						RepoID:       c.RepoID,
+						ExternalID:   c.ExternalID,
+						CodeHostType: c.CodeHostType,
 					}
 				}
 
@@ -516,8 +516,8 @@ func testStore(db *sql.DB) func(*testing.T) {
 				t.Run("ByExternalID", func(t *testing.T) {
 					want := changesets[0]
 					opts := GetChangesetOpts{
-						ExternalID:          want.ExternalID,
-						ExternalServiceType: want.ExternalServiceType,
+						ExternalID:   want.ExternalID,
+						CodeHostType: want.CodeHostType,
 					}
 
 					have, err := s.GetChangeset(ctx, opts)
@@ -549,7 +549,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 				now = now.Add(time.Second)
 				for _, c := range changesets {
 					c.Metadata = &bitbucketserver.PullRequest{ID: 1234}
-					c.ExternalServiceType = bitbucketserver.ServiceType
+					c.CodeHostType = bitbucketserver.ServiceType
 
 					if c.RepoID != 0 {
 						c.RepoID++

--- a/enterprise/internal/a8n/syncer.go
+++ b/enterprise/internal/a8n/syncer.go
@@ -118,14 +118,14 @@ func (s *ChangesetSyncer) GroupChangesetsBySource(ctx context.Context, cs ...*a8
 		}
 	}
 
-	es, err := s.ReposStore.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{RepoIDs: repoIDs})
+	es, err := s.ReposStore.ListCodeHosts(ctx, repos.StoreListCodeHostsArgs{RepoIDs: repoIDs})
 	if err != nil {
 		return nil, err
 	}
 
 	byRepo := make(map[uint32]int64, len(rs))
 	for _, r := range rs {
-		eids := r.ExternalServiceIDs()
+		eids := r.CodeHostIDs()
 		for _, id := range eids {
 			if _, ok := byRepo[r.ID]; !ok {
 				byRepo[r.ID] = id

--- a/enterprise/internal/a8n/webhooks.go
+++ b/enterprise/internal/a8n/webhooks.go
@@ -46,8 +46,8 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *GitHubWebhook) parseEvent(r *http.Request) (interface{}, *httpError) {
-	args := repos.StoreListExternalServicesArgs{Kinds: []string{"GITHUB"}}
-	es, err := h.Repos.ListExternalServices(r.Context(), args)
+	args := repos.StoreListCodeHostsArgs{Kinds: []string{"GITHUB"}}
+	es, err := h.Repos.ListCodeHosts(r.Context(), args)
 	if err != nil {
 		return nil, &httpError{http.StatusInternalServerError, err}
 	}
@@ -146,8 +146,8 @@ func (h *GitHubWebhook) upsertChangesetEvent(
 	defer tx.Done(&err)
 
 	cs, err := tx.GetChangeset(ctx, GetChangesetOpts{
-		ExternalID:          strconv.FormatInt(pr, 10),
-		ExternalServiceType: github.ServiceType,
+		ExternalID:   strconv.FormatInt(pr, 10),
+		CodeHostType: github.ServiceType,
 	})
 	if err != nil {
 		if err == ErrNoResults {

--- a/enterprise/internal/a8n/webhooks_test.go
+++ b/enterprise/internal/a8n/webhooks_test.go
@@ -57,7 +57,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 
 		secret := "secret"
 		repoStore := repos.NewDBStore(db, sql.TxOptions{})
-		githubExtSvc := &repos.ExternalService{
+		githubExtSvc := &repos.CodeHost{
 			Kind:        "GITHUB",
 			DisplayName: "GitHub",
 			Config: marshalJSON(t, &schema.GitHubConnection{
@@ -68,7 +68,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 			}),
 		}
 
-		err = repoStore.UpsertExternalServices(ctx, githubExtSvc)
+		err = repoStore.UpsertCodeHosts(ctx, githubExtSvc)
 		if err != nil {
 			t.Fatal(t)
 		}
@@ -104,10 +104,10 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 
 		changesets := []*a8n.Changeset{
 			{
-				RepoID:              int32(githubRepo.ID),
-				ExternalID:          "16",
-				ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-				CampaignIDs:         []int64{campaign.ID},
+				RepoID:       int32(githubRepo.ID),
+				ExternalID:   "16",
+				CodeHostType: githubRepo.ExternalRepo.ServiceType,
+				CampaignIDs:  []int64{campaign.ID},
 			},
 		}
 

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -10,11 +10,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
 
-// SupportedExternalServices are the external service types currently supported
+// SupportedCodeHosts are the external service types currently supported
 // by Automation features. Repos that are associated with external services
 // whose type is not in this list will simply be filtered out from the search
 // results.
-var SupportedExternalServices = map[string]struct{}{
+var SupportedCodeHosts = map[string]struct{}{
 	github.ServiceType:          {},
 	bitbucketserver.ServiceType: {},
 }
@@ -22,7 +22,7 @@ var SupportedExternalServices = map[string]struct{}{
 // IsRepoSupported returns whether the given ExternalRepoSpec is supported by
 // Automation features, based on the external service type.
 func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
-	_, ok := SupportedExternalServices[spec.ServiceType]
+	_, ok := SupportedCodeHosts[spec.ServiceType]
 	return ok
 }
 
@@ -217,14 +217,14 @@ func (c *ChangesetJob) SuccessfullyCompleted() bool {
 // A Changeset is a changeset on a code host belonging to a Repository and many
 // Campaigns.
 type Changeset struct {
-	ID                  int64
-	RepoID              int32
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-	Metadata            interface{}
-	CampaignIDs         []int64
-	ExternalID          string
-	ExternalServiceType string
+	ID           int64
+	RepoID       int32
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Metadata     interface{}
+	CampaignIDs  []int64
+	ExternalID   string
+	CodeHostType string
 }
 
 // Clone returns a clone of a Changeset.

--- a/internal/a8n/types_test.go
+++ b/internal/a8n/types_test.go
@@ -32,13 +32,13 @@ func TestChangesetMetadata(t *testing.T) {
 	}
 
 	changeset := &Changeset{
-		RepoID:              42,
-		CreatedAt:           now,
-		UpdatedAt:           now,
-		Metadata:            githubPR,
-		CampaignIDs:         []int64{},
-		ExternalID:          "12345",
-		ExternalServiceType: "github",
+		RepoID:       42,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Metadata:     githubPR,
+		CampaignIDs:  []int64{},
+		ExternalID:   "12345",
+		CodeHostType: "github",
 	}
 
 	title, err := changeset.Title()

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -129,8 +129,8 @@ type Settings struct {
 	CreatedAt    time.Time       // the date when this settings value was created
 }
 
-// ExternalService represents an complete external service record.
-type ExternalService struct {
+// CodeHost represents an complete external service record.
+type CodeHost struct {
 	ID          int64
 	Kind        string
 	DisplayName string

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -46,11 +46,11 @@ type PhabricatorRepoCreateRequest struct {
 	URL      string `json:"url"`
 }
 
-type ExternalServiceConfigsRequest struct {
+type CodeHostConfigsRequest struct {
 	Kind string `json:"kind"`
 }
 
-type ExternalServicesListRequest struct {
+type CodeHostsListRequest struct {
 	// NOTE(tsenart): We must keep this field in addition to the
 	// Kinds field until after we roll-out this change, for backwards compatibility.
 	Kind  string   `json:"kind"`

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -299,22 +299,22 @@ func (c *internalClient) PhabricatorRepoCreate(ctx context.Context, repo RepoNam
 	}, nil)
 }
 
-var MockExternalServiceConfigs func(kind string, result interface{}) error
+var MockCodeHostConfigs func(kind string, result interface{}) error
 
-// ExternalServiceConfigs fetches external service configs of a single kind into the result parameter,
+// CodeHostConfigs fetches external service configs of a single kind into the result parameter,
 // which should be a slice of the expected config type.
-func (c *internalClient) ExternalServiceConfigs(ctx context.Context, kind string, result interface{}) error {
-	if MockExternalServiceConfigs != nil {
-		return MockExternalServiceConfigs(kind, result)
+func (c *internalClient) CodeHostConfigs(ctx context.Context, kind string, result interface{}) error {
+	if MockCodeHostConfigs != nil {
+		return MockCodeHostConfigs(kind, result)
 	}
-	return c.postInternal(ctx, "external-services/configs", ExternalServiceConfigsRequest{
+	return c.postInternal(ctx, "external-services/configs", CodeHostConfigsRequest{
 		Kind: kind,
 	}, &result)
 }
 
-// ExternalServicesList returns all external services of the given kind.
-func (c *internalClient) ExternalServicesList(ctx context.Context, opts ExternalServicesListRequest) ([]*ExternalService, error) {
-	var extsvcs []*ExternalService
+// CodeHostsList returns all external services of the given kind.
+func (c *internalClient) CodeHostsList(ctx context.Context, opts CodeHostsListRequest) ([]*CodeHost, error) {
+	var extsvcs []*CodeHost
 	return extsvcs, c.postInternal(ctx, "external-services/list", &opts, &extsvcs)
 }
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -38,7 +38,7 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 
 func AWSCodeCommitConfigs(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
 	var config []*schema.AWSCodeCommitConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "AWSCODECOMMIT", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "AWSCODECOMMIT", &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -46,7 +46,7 @@ func AWSCodeCommitConfigs(ctx context.Context) ([]*schema.AWSCodeCommitConnectio
 
 func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
 	var config []*schema.BitbucketServerConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "BITBUCKETSERVER", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "BITBUCKETSERVER", &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -54,7 +54,7 @@ func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConne
 
 func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
 	var config []*schema.GitHubConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITHUB", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "GITHUB", &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -62,7 +62,7 @@ func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
 
 func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
 	var config []*schema.GitLabConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITLAB", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "GITLAB", &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -70,7 +70,7 @@ func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
 
 func GitoliteConfigs(ctx context.Context) ([]*schema.GitoliteConnection, error) {
 	var config []*schema.GitoliteConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITOLITE", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "GITOLITE", &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -78,7 +78,7 @@ func GitoliteConfigs(ctx context.Context) ([]*schema.GitoliteConnection, error) 
 
 func PhabricatorConfigs(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
 	var config []*schema.PhabricatorConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "PHABRICATOR", &config); err != nil {
+	if err := api.InternalClient.CodeHostConfigs(ctx, "PHABRICATOR", &config); err != nil {
 		return nil, err
 	}
 	return config, nil

--- a/internal/conf/reposource/other.go
+++ b/internal/conf/reposource/other.go
@@ -19,7 +19,7 @@ func (e urlMismatchErr) Error() string {
 }
 
 type Other struct {
-	*schema.OtherExternalServiceConnection
+	*schema.OtherCodeHostConnection
 }
 
 var _ RepoSource = Other{}

--- a/internal/conf/reposource/other_test.go
+++ b/internal/conf/reposource/other_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestOtherCloneURLToRepoName(t *testing.T) {
 	tests := []struct {
-		conn schema.OtherExternalServiceConnection
+		conn schema.OtherCodeHostConnection
 		urls []urlToRepoNameErr
 	}{
 		{
-			conn: schema.OtherExternalServiceConnection{
+			conn: schema.OtherCodeHostConnection{
 				Url:                   "https://github.com",
 				RepositoryPathPattern: "{base}/{repo}",
 				Repos:                 []string{"gorilla/mux"},
@@ -25,7 +25,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			},
 		},
 		{
-			conn: schema.OtherExternalServiceConnection{
+			conn: schema.OtherCodeHostConnection{
 				Url:                   "https://github.com/?access_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				RepositoryPathPattern: "{base}/{repo}",
 				Repos:                 []string{"gorilla/mux"},
@@ -36,7 +36,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			},
 		},
 		{
-			conn: schema.OtherExternalServiceConnection{
+			conn: schema.OtherCodeHostConnection{
 				Url:                   "ssh://thaddeus@gerrit.com:12345",
 				RepositoryPathPattern: "{base}/{repo}",
 				Repos:                 []string{"repos/repo1"},
@@ -44,7 +44,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			urls: []urlToRepoNameErr{{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "gerrit.com-12345/repos/repo1", nil}},
 		},
 		{
-			conn: schema.OtherExternalServiceConnection{
+			conn: schema.OtherCodeHostConnection{
 				Url:                   "ssh://thaddeus@gerrit.com:12345",
 				RepositoryPathPattern: "prettyhost/{repo}",
 				Repos:                 []string{"repos/repo1"},
@@ -52,7 +52,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			urls: []urlToRepoNameErr{{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "prettyhost/repos/repo1", nil}},
 		},
 		{
-			conn: schema.OtherExternalServiceConnection{
+			conn: schema.OtherCodeHostConnection{
 				Url:                   "ssh://thaddeus@gerrit.com:12345/repos",
 				RepositoryPathPattern: "{repo}",
 				Repos:                 []string{"repo1"},

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -50,9 +50,9 @@ var ignoreLegacyKubernetesFields = map[string]struct{}{
 type problemKind string
 
 const (
-	problemCritical        problemKind = "CriticalConfig"
-	problemSite            problemKind = "SiteConfig"
-	problemExternalService problemKind = "ExternalService"
+	problemCritical problemKind = "CriticalConfig"
+	problemSite     problemKind = "SiteConfig"
+	problemCodeHost problemKind = "CodeHost"
 )
 
 // Problem contains kind and description of a specific configuration problem.
@@ -69,10 +69,10 @@ func NewSiteProblem(msg string) *Problem {
 	}
 }
 
-// NewExternalServiceProblem creates a new external service config problem with given message.
-func NewExternalServiceProblem(msg string) *Problem {
+// NewCodeHostProblem creates a new external service config problem with given message.
+func NewCodeHostProblem(msg string) *Problem {
 	return &Problem{
-		kind:        problemExternalService,
+		kind:        problemCodeHost,
 		description: msg,
 	}
 }
@@ -87,9 +87,9 @@ func (p Problem) IsSite() bool {
 	return p.kind == problemSite
 }
 
-// IsExternalService returns true if the problem is about external service config.
-func (p Problem) IsExternalService() bool {
-	return p.kind == problemExternalService
+// IsCodeHost returns true if the problem is about external service config.
+func (p Problem) IsCodeHost() bool {
+	return p.kind == problemCodeHost
 }
 
 func (p Problem) String() string {
@@ -116,9 +116,9 @@ func NewSiteProblems(messages ...string) Problems {
 	return newProblems(problemSite, messages...)
 }
 
-// NewExternalServiceProblems converts a list of messages into external service config problems.
-func NewExternalServiceProblems(messages ...string) Problems {
-	return newProblems(problemExternalService, messages...)
+// NewCodeHostProblems converts a list of messages into external service config problems.
+func NewCodeHostProblems(messages ...string) Problems {
+	return newProblems(problemCodeHost, messages...)
 }
 
 // Messages returns the list of problems in strings.
@@ -154,10 +154,10 @@ func (ps Problems) Site() (problems Problems) {
 	return problems
 }
 
-// ExternalService returns all external service config problems in the list.
-func (ps Problems) ExternalService() (problems Problems) {
+// CodeHost returns all external service config problems in the list.
+func (ps Problems) CodeHost() (problems Problems) {
 	for i := range ps {
-		if ps[i].IsExternalService() {
+		if ps[i].IsCodeHost() {
 			problems = append(problems, ps[i])
 		}
 	}

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -80,20 +80,20 @@ func TestProblems(t *testing.T) {
 		"siteProblem2",
 		"siteProblem3",
 	)
-	externalServiceProblems := NewExternalServiceProblems(
-		"externalServiceProblem1",
-		"externalServiceProblem2",
-		"externalServiceProblem3",
+	codeHostProblems := NewCodeHostProblems(
+		"codeHostProblem1",
+		"codeHostProblem2",
+		"codeHostProblem3",
 	)
 
 	var problems Problems
 	problems = append(problems, siteProblems...)
-	problems = append(problems, externalServiceProblems...)
+	problems = append(problems, codeHostProblems...)
 
 	{
 		messages := make([]string, 0, len(problems))
 		messages = append(messages, siteProblems.Messages()...)
-		messages = append(messages, externalServiceProblems.Messages()...)
+		messages = append(messages, codeHostProblems.Messages()...)
 
 		want := strings.Join(messages, "\n")
 		got := strings.Join(problems.Messages(), "\n")
@@ -111,8 +111,8 @@ func TestProblems(t *testing.T) {
 	}
 
 	{
-		want := strings.Join(externalServiceProblems.Messages(), "\n")
-		got := strings.Join(problems.ExternalService().Messages(), "\n")
+		want := strings.Join(codeHostProblems.Messages(), "\n")
+		got := strings.Join(problems.CodeHost().Messages(), "\n")
 		if want != got {
 			t.Errorf("got %q, want %q", got, want)
 		}

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -177,9 +177,9 @@ func (c *Client) EnqueueRepoUpdate(ctx context.Context, repo gitserver.Repo) (*p
 	return &res, nil
 }
 
-// SyncExternalService requests the given external service to be synced.
-func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
-	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}
+// SyncCodeHost requests the given external service to be synced.
+func (c *Client) SyncCodeHost(ctx context.Context, svc api.CodeHost) (*protocol.CodeHostSyncResult, error) {
+	req := &protocol.CodeHostSyncRequest{CodeHost: svc}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {
 		return nil, err
@@ -191,14 +191,14 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
 
-	var result protocol.ExternalServiceSyncResult
+	var result protocol.CodeHostSyncResult
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		// TODO(tsenart): Use response type for unmarshalling errors too.
 		// This needs to be done after rolling out the response type in prod.
 		return nil, errors.New(string(bs))
 	} else if len(bs) == 0 {
 		// TODO(keegancsmith): Remove once repo-updater update is rolled out.
-		result.ExternalService = svc
+		result.CodeHost = svc
 		return &result, nil
 	} else if err = json.Unmarshal(bs, &result); err != nil {
 		return nil, err
@@ -210,10 +210,10 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 	return &result, nil
 }
 
-// RepoExternalServices requests the external services associated with a
+// RepoCodeHosts requests the external services associated with a
 // repository with the given id.
-func (c *Client) RepoExternalServices(ctx context.Context, id uint32) ([]api.ExternalService, error) {
-	req := protocol.RepoExternalServicesRequest{ID: id}
+func (c *Client) RepoCodeHosts(ctx context.Context, id uint32) ([]api.CodeHost, error) {
+	req := protocol.RepoCodeHostsRequest{ID: id}
 	resp, err := c.httpPost(ctx, "repo-external-services", &req)
 	if err != nil {
 		return nil, err
@@ -225,14 +225,14 @@ func (c *Client) RepoExternalServices(ctx context.Context, id uint32) ([]api.Ext
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
 
-	var res protocol.RepoExternalServicesResponse
+	var res protocol.RepoCodeHostsResponse
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return nil, errors.New(string(bs))
 	} else if err = json.Unmarshal(bs, &res); err != nil {
 		return nil, err
 	}
 
-	return res.ExternalServices, nil
+	return res.CodeHosts, nil
 }
 
 // ExcludeRepo adds the repository with the given id to all of the

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -34,17 +34,17 @@ type RepoQueueState struct {
 	Updating bool
 }
 
-// RepoExternalServicesRequest is a request for the external services
+// RepoCodeHostsRequest is a request for the external services
 // associated with a repository.
-type RepoExternalServicesRequest struct {
+type RepoCodeHostsRequest struct {
 	// ID of the repository being queried.
 	ID uint32
 }
 
-// RepoExternalServicesResponse is returned in response to an
-// RepoExternalServicesRequest.
-type RepoExternalServicesResponse struct {
-	ExternalServices []api.ExternalService
+// RepoCodeHostsResponse is returned in response to an
+// RepoCodeHostsRequest.
+type RepoCodeHostsResponse struct {
+	CodeHosts []api.CodeHost
 }
 
 // ExcludeRepoRequest is a request to exclude a single repo from
@@ -56,7 +56,7 @@ type ExcludeRepoRequest struct {
 
 // ExcludeRepoResponse is returned in response to an ExcludeRepoRequest.
 type ExcludeRepoResponse struct {
-	ExternalServices []api.ExternalService
+	CodeHosts []api.CodeHost
 }
 
 // RepoLookupArgs is a request for information about a repository on repoupdater.
@@ -159,28 +159,28 @@ type RepoUpdateResponse struct {
 	URL string `json:"url"`
 }
 
-// ExternalServiceSyncRequest is a request to sync a specific external service eagerly.
+// CodeHostSyncRequest is a request to sync a specific external service eagerly.
 //
 // The FrontendAPI is one of the issuers of this request. It does so when creating or
 // updating an external service so that admins don't have to wait until the next sync
 // run to see their repos being synced.
-type ExternalServiceSyncRequest struct {
-	ExternalService api.ExternalService
+type CodeHostSyncRequest struct {
+	CodeHost api.CodeHost
 }
 
-// ExternalServiceSyncResult is a result type of an external service's sync request.
-type ExternalServiceSyncResult struct {
-	ExternalService api.ExternalService
-	Error           string
+// CodeHostSyncResult is a result type of an external service's sync request.
+type CodeHostSyncResult struct {
+	CodeHost api.CodeHost
+	Error    string
 }
 
 type CloningProgress struct {
 	Message string
 }
 
-type ExternalServiceSyncError struct {
-	Message           string
-	ExternalServiceId int64
+type CodeHostSyncError struct {
+	Message    string
+	CodeHostId int64
 }
 
 type SyncError struct {
@@ -188,9 +188,9 @@ type SyncError struct {
 }
 
 type StatusMessage struct {
-	Cloning                  *CloningProgress          `json:"cloning"`
-	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
-	SyncError                *SyncError                `json:"sync_error"`
+	Cloning           *CloningProgress   `json:"cloning"`
+	CodeHostSyncError *CodeHostSyncError `json:"external_service_sync_error"`
+	SyncError         *SyncError         `json:"sync_error"`
 }
 
 type StatusMessagesResponse struct {

--- a/schema/gen.go
+++ b/schema/gen.go
@@ -13,7 +13,7 @@ package schema
 //go:generate env GO111MODULE=on go run stringdata.go -i github.schema.json -name GitHubSchemaJSON -pkg schema -o github_stringdata.go
 //go:generate env GO111MODULE=on go run stringdata.go -i gitlab.schema.json -name GitLabSchemaJSON -pkg schema -o gitlab_stringdata.go
 //go:generate env GO111MODULE=on go run stringdata.go -i gitolite.schema.json -name GitoliteSchemaJSON -pkg schema -o gitolite_stringdata.go
-//go:generate env GO111MODULE=on go run stringdata.go -i other_external_service.schema.json -name OtherExternalServiceSchemaJSON -pkg schema -o other_external_service_stringdata.go
+//go:generate env GO111MODULE=on go run stringdata.go -i other_external_service.schema.json -name OtherCodeHostSchemaJSON -pkg schema -o other_external_service_stringdata.go
 //go:generate env GO111MODULE=on go run stringdata.go -i phabricator.schema.json -name PhabricatorSchemaJSON -pkg schema -o phabricator_stringdata.go
 //go:generate env GO111MODULE=on go run stringdata.go -i campaign-types/comby.schema.json -name CombyCampaignTypeSchemaJSON -pkg schema -o campaign-types/comby_stringdata.go
 //go:generate env GO111MODULE=on go run stringdata.go -i campaign-types/credentials.schema.json -name CredentialsCampaignTypeSchemaJSON -pkg schema -o campaign-types/credentials_stringdata.go

--- a/schema/other_external_service_stringdata.go
+++ b/schema/other_external_service_stringdata.go
@@ -2,11 +2,11 @@
 
 package schema
 
-// OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
-const OtherExternalServiceSchemaJSON = `{
+// OtherCodeHostSchemaJSON is the content of the file "other_external_service.schema.json".
+const OtherCodeHostSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "other_external_service.schema.json#",
-  "title": "OtherExternalServiceConnection",
+  "title": "OtherCodeHostConnection",
   "description": "Configuration for a Connection to Git repositories for which an external service integration isn't yet available.",
   "allowComments": true,
   "type": "object",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -635,8 +635,8 @@ type OpenIDConnectAuthProvider struct {
 	Type               string `json:"type"`
 }
 
-// OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
-type OtherExternalServiceConnection struct {
+// OtherCodeHostConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
+type OtherCodeHostConnection struct {
 	Repos []string `json:"repos"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable "{base}" is replaced with the Git clone base URL host and path, and "{repo}" is replaced with the repository path taken from the `repos` field.
 	//


### PR DESCRIPTION
Ran

```shell
ruplacer --go -t go 'ExternalService' 'CodeHost'
ruplacer --go -t go 'externalService' 'codeHost'
git status --porcelain | cut -f 3 -d ' ' | xargs goimports -w
```