### PR TITLE
e2e: add kludge to see if this fixes flakes

### DIFF
--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -207,6 +207,11 @@ export function getConfig<T extends keyof Config>(...required: T[]): Pick<Config
         if (envValue) {
             config[fieldName] = field.parser ? field.parser(envValue) : envValue
         }
+
+        // @TODO: @ggilmore remove kludge experiment once we figure out what's going on
+        if (fieldName === 'sourcegraphBaseUrl') {
+            config[fieldName] = 'http://localhost:7080'
+        }
     }
 
     // Check required fields for type safety


### PR DESCRIPTION
We've been experiencing constant flakiness from our e2e tests for the past few days. 

In https://github.com/sourcegraph/sourcegraph/issues/7212#issuecomment-566101552, @lguychard noticed some oddities with the base sourcegraph URL changing in the middle of the test suite. This PR adds a kludge to see if hard coding the sourcegraph URL to always be `http://localhost:7080` (no matter what the `BASE_SOURCEGRAPH_URL` env var is set to) fixes the flakiness. 

Note that if this actually fixes the flakes, then there might be a real race condition in Sourcegraph itself and **merging this PR only hides the underlying problem**.