### PR TITLE
a8n: Fix generation of diffs for files in subfolders

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -347,10 +347,10 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 	return strings.Join(diffs, "\n"), description.String(), nil
 }
 
-func tmpfileDiff(filename, a, b string) (string, error) {
-	dir, err := ioutil.TempDir("", fmt.Sprintf("diffing-%s", filename))
+func tmpfileDiff(path, a, b string) (string, error) {
+	dir, err := ioutil.TempDir("", fmt.Sprintf("diffing-%s", filepath.Base(path)))
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "creating temp dir failed")
 	}
 	defer os.RemoveAll(dir)
 
@@ -375,8 +375,8 @@ func tmpfileDiff(filename, a, b string) (string, error) {
 	cmd := exec.Command(
 		"diff",
 		"-u",
-		"--label", filename,
-		"--label", filename,
+		"--label", path,
+		"--label", path,
 		fileA,
 		fileB,
 	)


### PR DESCRIPTION
This fixes #7064 by making sure that the `filename` passed into `tmpfileDiff` is actually a filename and not a full path.

<img width="1131" alt="Screen Shot 2019-12-17 at 20 11 27" src="https://user-images.githubusercontent.com/1185253/71026382-6f108f80-2109-11ea-9b38-32826f43f4e5.png">
