### PR TITLE
LSIF: Fallback to original values when project root cannot be resolved

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -45,6 +45,9 @@ type LSIFUploadsQueryArgs struct {
 type LSIFDumpResolver interface {
 	ID() graphql.ID
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
+	InputRepoName() string
+	InputCommit() string
+	InputRoot() string
 	IsLatestForRepo() bool
 	UploadedAt() DateTime
 	ProcessedAt() DateTime
@@ -67,6 +70,9 @@ type LSIFUploadStatsResolver interface {
 type LSIFUploadResolver interface {
 	ID() graphql.ID
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
+	InputRepoName() string
+	InputCommit() string
+	InputRoot() string
 	State() string
 	Failure() LSIFUploadFailureReasonResolver
 	UploadedAt() DateTime

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4044,7 +4044,16 @@ type LSIFDump implements Node {
     id: ID!
 
     # The project for which this dump provides code intelligence.
-    projectRoot: GitTree!
+    projectRoot: GitTree
+
+    # The original repository name supplied at upload time.
+    inputRepoName: String!
+
+    # The original 40-character commit commit supplied at upload time.
+    inputCommit: String!
+
+    # The original root supplied at upload time.
+    inputRoot: String!
 
     # Whether or not this dump provides intelligence for the tip of the default branch. Find reference queries
     # will return symbols from remote repositories only when this property is true. This property is updated
@@ -4127,7 +4136,16 @@ type LSIFUpload implements Node {
     id: ID!
 
     # The project for which this upload provides code intelligence.
-    projectRoot: GitTree!
+    projectRoot: GitTree
+
+    # The original repository name supplied at upload time.
+    inputRepoName: String!
+
+    # The original 40-character commit commit supplied at upload time.
+    inputCommit: String!
+
+    # The original root supplied at upload time.
+    inputRoot: String!
 
     # The upload's current state.
     state: LSIFUploadState!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4051,7 +4051,16 @@ type LSIFDump implements Node {
     id: ID!
 
     # The project for which this dump provides code intelligence.
-    projectRoot: GitTree!
+    projectRoot: GitTree
+
+    # The original repository name supplied at upload time.
+    inputRepoName: String!
+
+    # The original 40-character commit commit supplied at upload time.
+    inputCommit: String!
+
+    # The original root supplied at upload time.
+    inputRoot: String!
 
     # Whether or not this dump provides intelligence for the tip of the default branch. Find reference queries
     # will return symbols from remote repositories only when this property is true. This property is updated
@@ -4134,7 +4143,16 @@ type LSIFUpload implements Node {
     id: ID!
 
     # The project for which this upload provides code intelligence.
-    projectRoot: GitTree!
+    projectRoot: GitTree
+
+    # The original repository name supplied at upload time.
+    inputRepoName: String!
+
+    # The original 40-character commit commit supplied at upload time.
+    inputCommit: String!
+
+    # The original root supplied at upload time.
+    inputRoot: String!
 
     # The upload's current state.
     state: LSIFUploadState!

--- a/enterprise/internal/codeintel/resolvers/dump.go
+++ b/enterprise/internal/codeintel/resolvers/dump.go
@@ -33,7 +33,23 @@ func (r *lsifDumpResolver) ProjectRoot(ctx context.Context) (*graphqlbackend.Git
 		return nil, err
 	}
 
+	if commitResolver == nil {
+		return nil, nil
+	}
+
 	return graphqlbackend.NewGitTreeEntryResolver(commitResolver, graphqlbackend.CreateFileInfo(r.lsifDump.Root, true)), nil
+}
+
+func (r *lsifDumpResolver) InputRepoName() string {
+	return r.lsifDump.Repository
+}
+
+func (r *lsifDumpResolver) InputCommit() string {
+	return r.lsifDump.Commit
+}
+
+func (r *lsifDumpResolver) InputRoot() string {
+	return r.lsifDump.Root
 }
 
 func (r *lsifDumpResolver) IsLatestForRepo() bool {

--- a/enterprise/internal/codeintel/resolvers/upload.go
+++ b/enterprise/internal/codeintel/resolvers/upload.go
@@ -38,7 +38,23 @@ func (r *lsifUploadResolver) ProjectRoot(ctx context.Context) (*graphqlbackend.G
 		return nil, err
 	}
 
+	if commitResolver == nil {
+		return nil, nil
+	}
+
 	return graphqlbackend.NewGitTreeEntryResolver(commitResolver, graphqlbackend.CreateFileInfo(r.lsifUpload.Root, true)), nil
+}
+
+func (r *lsifUploadResolver) InputRepoName() string {
+	return r.lsifUpload.Repository
+}
+
+func (r *lsifUploadResolver) InputCommit() string {
+	return r.lsifUpload.Commit
+}
+
+func (r *lsifUploadResolver) InputRoot() string {
+	return r.lsifUpload.Root
 }
 
 func (r *lsifUploadResolver) State() string {

--- a/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
@@ -15,11 +15,15 @@ const LsifDumpNode: FunctionComponent<{ node: GQL.ILSIFDump }> = ({ node }) => (
     <div className="w-100 list-group-item py-2 lsif-data__main">
         <div className="lsif-data__meta">
             <div className="lsif-data__meta-root">
-                <code>{node.projectRoot.commit.abbreviatedOID}</code>
+                <code>{node.projectRoot?.commit.abbreviatedOID || node.inputCommit.substring(0, 7)}</code>
                 <span className="ml-2">
-                    <Link to={node.projectRoot.url}>
-                        <strong>{node.projectRoot.path || '/'}</strong>
-                    </Link>
+                    {node.projectRoot ? (
+                        <Link to={node.projectRoot.url}>
+                            <strong>{node.projectRoot.path || '/'}</strong>
+                        </Link>
+                    ) : (
+                        node.inputRoot || '/'
+                    )}
                 </span>
             </div>
         </div>
@@ -34,11 +38,15 @@ const LsifUploadNode: FunctionComponent<{ node: GQL.ILSIFUpload }> = ({ node }) 
     <div className="w-100 list-group-item py-2 lsif-data__main">
         <div className="lsif-data__meta">
             <div className="lsif-data__meta-root">
-                <code>{node.projectRoot.commit.abbreviatedOID}</code>
+                <code>{node.projectRoot?.commit.abbreviatedOID || node.inputCommit.substring(0, 7)}</code>
                 <span className="ml-2">
-                    <Link to={node.projectRoot.url}>
-                        <strong>{node.projectRoot.path || '/'}</strong>
-                    </Link>
+                    {node.projectRoot ? (
+                        <Link to={node.projectRoot.url}>
+                            <strong>{node.projectRoot.path || '/'}</strong>
+                        </Link>
+                    ) : (
+                        node.inputRoot || '/'
+                    )}
                 </span>
                 <span className="ml-2">
                     -

--- a/web/src/enterprise/repo/settings/backend.tsx
+++ b/web/src/enterprise/repo/settings/backend.tsx
@@ -30,6 +30,9 @@ export function fetchLsifDumps({
                                     path
                                     url
                                 }
+                                inputRepoName
+                                inputCommit
+                                inputRoot
                                 processedAt
                             }
 
@@ -80,6 +83,9 @@ export function fetchLsifUploads({
                             path
                             url
                         }
+                        inputRepoName
+                        inputCommit
+                        inputRoot
                         state
                         uploadedAt
                         startedAt

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -46,12 +46,12 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
                         <h2 className="mb-0">
                             Upload for{' '}
                             {uploadOrError.projectRoot
-                                ? description(
+                                ? lsifUploadDescription(
                                       uploadOrError.projectRoot.commit.repository.name,
                                       uploadOrError.projectRoot.commit.abbreviatedOID,
                                       uploadOrError.projectRoot.path
                                   )
-                                : description(
+                                : lsifUploadDescription(
                                       uploadOrError.inputRepoName,
                                       uploadOrError.inputCommit.substring(0, 7),
                                       uploadOrError.inputRoot
@@ -160,6 +160,6 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
     )
 }
 
-function description(repoName: string, commit: string, root: string): string {
+export function lsifUploadDescription(repoName: string, commit: string, root: string): string {
     return `${repoName}@${commit}${root === '' ? '' : ` rooted at ${root}`}`
 }

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -44,11 +44,18 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
                 <>
                     <div className="mt-3 mb-1">
                         <h2 className="mb-0">
-                            Upload for {uploadOrError.projectRoot.commit.repository.name}@
-                            {uploadOrError.projectRoot.commit.abbreviatedOID}
-                            {uploadOrError.projectRoot.path === ''
-                                ? ''
-                                : ` rooted at ${uploadOrError.projectRoot.path}`}
+                            Upload for{' '}
+                            {uploadOrError.projectRoot
+                                ? description(
+                                      uploadOrError.projectRoot.commit.repository.name,
+                                      uploadOrError.projectRoot.commit.abbreviatedOID,
+                                      uploadOrError.projectRoot.path
+                                  )
+                                : description(
+                                      uploadOrError.inputRepoName,
+                                      uploadOrError.inputCommit.substring(0, 7),
+                                      uploadOrError.inputRoot
+                                  )}
                         </h2>
                     </div>
 
@@ -76,27 +83,39 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
                             <tr>
                                 <td>Repository</td>
                                 <td>
-                                    <Link to={uploadOrError.projectRoot.commit.repository.url}>
-                                        {uploadOrError.projectRoot.commit.repository.name}
-                                    </Link>
+                                    {uploadOrError.projectRoot ? (
+                                        <Link to={uploadOrError.projectRoot.commit.repository.url}>
+                                            {uploadOrError.projectRoot.commit.repository.name}
+                                        </Link>
+                                    ) : (
+                                        uploadOrError.inputRepoName
+                                    )}
                                 </td>
                             </tr>
 
                             <tr>
                                 <td>Commit</td>
                                 <td>
-                                    <Link to={uploadOrError.projectRoot.commit.url}>
-                                        <code>{uploadOrError.projectRoot.commit.oid}</code>
-                                    </Link>
+                                    {uploadOrError.projectRoot ? (
+                                        <Link to={uploadOrError.projectRoot.commit.url}>
+                                            <code>{uploadOrError.projectRoot.commit.oid}</code>
+                                        </Link>
+                                    ) : (
+                                        uploadOrError.inputCommit
+                                    )}
                                 </td>
                             </tr>
 
                             <tr>
                                 <td>Root</td>
                                 <td>
-                                    <Link to={uploadOrError.projectRoot.url}>
-                                        <strong>{uploadOrError.projectRoot.path || '/'}</strong>
-                                    </Link>
+                                    {uploadOrError.projectRoot ? (
+                                        <Link to={uploadOrError.projectRoot.url}>
+                                            <strong>{uploadOrError.projectRoot.path || '/'}</strong>
+                                        </Link>
+                                    ) : (
+                                        uploadOrError.inputRoot || '/'
+                                    )}
                                 </td>
                             </tr>
 
@@ -139,4 +158,8 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
             )}
         </div>
     )
+}
+
+function description(repoName: string, commit: string, root: string): string {
+    return `${repoName}@${commit}${root === '' ? '' : `rooted at ${root}`}`
 }

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -161,5 +161,5 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
 }
 
 function description(repoName: string, commit: string, root: string): string {
-    return `${repoName}@${commit}${root === '' ? '' : `rooted at ${root}`}`
+    return `${repoName}@${commit}${root === '' ? '' : ` rooted at ${root}`}`
 }

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadsPage.tsx
@@ -17,6 +17,7 @@ import {
     FilteredConnectionFilter,
 } from '../../components/FilteredConnection'
 import { ErrorAlert } from '../../components/alerts'
+import { lsifUploadDescription } from './SiteAdminLsifUploadPage'
 
 interface LsifUploadNodeProps {
     node: GQL.ILSIFUpload
@@ -29,12 +30,16 @@ const LsifUploadNode: FunctionComponent<LsifUploadNodeProps> = ({ node }) => (
                 <div className="lsif-upload__meta-root">
                     <Link to={`/site-admin/lsif-uploads/${node.id}`}>
                         {node.projectRoot
-                            ? description(
+                            ? lsifUploadDescription(
                                   node.projectRoot.commit.repository.name,
                                   node.projectRoot.commit.abbreviatedOID,
                                   node.projectRoot.path
                               )
-                            : description(node.inputRepoName, node.inputCommit.substring(0, 7), node.inputRoot)}
+                            : lsifUploadDescription(
+                                  node.inputRepoName,
+                                  node.inputCommit.substring(0, 7),
+                                  node.inputRoot
+                              )}
                     </Link>
                 </div>
             </div>
@@ -158,8 +163,4 @@ export class SiteAdminLsifUploadsPage extends React.Component<Props, State> {
             ...args,
         })
     }
-}
-
-function description(repoName: string, commit: string, root: string): string {
-    return `${repoName}@${commit}${root === '' ? '' : `rooted at ${root}`}`
 }

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadsPage.tsx
@@ -28,8 +28,13 @@ const LsifUploadNode: FunctionComponent<LsifUploadNodeProps> = ({ node }) => (
             <div className="lsif-upload__meta">
                 <div className="lsif-upload__meta-root">
                     <Link to={`/site-admin/lsif-uploads/${node.id}`}>
-                        {node.projectRoot.commit.repository.name}@<code>{node.projectRoot.commit.abbreviatedOID}</code>
-                        {node.projectRoot.path === '' ? '' : ` rooted at ${node.projectRoot.path}`}
+                        {node.projectRoot
+                            ? description(
+                                  node.projectRoot.commit.repository.name,
+                                  node.projectRoot.commit.abbreviatedOID,
+                                  node.projectRoot.path
+                              )
+                            : description(node.inputRepoName, node.inputCommit.substring(0, 7), node.inputRoot)}
                     </Link>
                 </div>
             </div>
@@ -153,4 +158,8 @@ export class SiteAdminLsifUploadsPage extends React.Component<Props, State> {
             ...args,
         })
     }
+}
+
+function description(repoName: string, commit: string, root: string): string {
+    return `${repoName}@${commit}${root === '' ? '' : `rooted at ${root}`}`
 }

--- a/web/src/enterprise/site-admin/backend.ts
+++ b/web/src/enterprise/site-admin/backend.ts
@@ -54,6 +54,9 @@ export function fetchLsifUploads({
                         failure {
                             summary
                         }
+                        inputRepoName
+                        inputCommit
+                        inputRoot
                         uploadedAt
                         startedAt
                         finishedAt
@@ -98,6 +101,9 @@ export function fetchLsifUpload({ id }: { id: string }): Observable<GQL.ILSIFUpl
                             path
                             url
                         }
+                        inputRepoName
+                        inputCommit
+                        inputRoot
                         state
                         failure {
                             summary


### PR DESCRIPTION
This applies for dumps and uploads. When a commit that has LSIF data gets force-pushed over, it's impossible to resolve the `projectRoot: GitTree!`, which the UI attempts to use in order to show the repo, commit, and path for that dump. This PR attaches that info as a sibling to `projectRoot` so that it's always present, and makes `projectRoot: GitTree` nullable.

This exposes the original repository, commit, and root arguments for uploads and dumps so they can be shown in the UI.

This is currently problematic on dot-com right now, which throws both a GraphQL error (on the code intel repo panel) and a frontend null pointer exception (in site-admin uploads list).