### PR TITLE
a8n: Count CampaignJobs as completed even if they didn't produce diff

### DIFF
--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1407,7 +1407,7 @@ SELECT
   (SELECT canceled_at IS NOT NULL FROM campaign_plans WHERE id = %s) AS canceled,
   COUNT(*) AS total,
   COUNT(*) FILTER (WHERE finished_at IS NULL) AS pending,
-  COUNT(*) FILTER (WHERE finished_at IS NOT NULL AND (diff != '' OR error != '')) AS completed,
+  COUNT(*) FILTER (WHERE finished_at IS NOT NULL) AS completed,
   array_agg(error) FILTER (WHERE error != '') AS errors
 FROM campaign_jobs
 WHERE %s

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1449,7 +1449,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					want: &a8n.BackgroundProcessStatus{
 						ProcessState:  a8n.BackgroundProcessStateCompleted,
 						Total:         2,
-						Completed:     1,
+						Completed:     2,
 						Pending:       0,
 						ProcessErrors: nil,
 					},
@@ -1485,7 +1485,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					want: &a8n.BackgroundProcessStatus{
 						ProcessState:  a8n.BackgroundProcessStateProcessing,
 						Total:         6,
-						Completed:     3,
+						Completed:     4,
 						Pending:       2,
 						ProcessErrors: []string{"error1", "error2"},
 					},


### PR DESCRIPTION
This is a fix for the issue discussed in #7064 where a CampaignPlan
launches N CampaignJobs but only X produce a diff or an error. The
result was that the state of the CampaignPlan BackgroundProcessStatus
was `COMPLETED` instead of the desired `ERRORED`.

This change here fixes that behavior by essentially reverting what I
previously introduced in d270de30a173c47ecb3b9bcea3caa16ba3dfb8e1 with
the motivation of keeping the invariant of
`campaignPlan.changesets.totalCount == campaignPlan.status.completed`.

The problem is that we often launch way more CampaignJobs than we
actually produce diffs. These jobs _do_ complete, just without a diff.

As discussed in #7064 we're fine with reporting them as completed.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
