### PR TITLE
a8n: GraphQL API for draft campaigns

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -87,6 +87,7 @@ Referenced by:
  changeset_ids     | jsonb                    | not null default '{}'::jsonb
  campaign_plan_id  | integer                  | 
  closed_at         | timestamp with time zone | 
+ published_at      | timestamp with time zone | 
 Indexes:
     "campaigns_pkey" PRIMARY KEY, btree (id)
     "campaigns_changeset_ids_gin_idx" gin (changeset_ids)

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -84,7 +84,7 @@ type PublishCampaignArgs struct {
 	Campaign graphql.ID
 }
 
-type PublishChangesetPlanArgs struct {
+type PublishChangesetArgs struct {
 	ChangesetPlan graphql.ID
 }
 
@@ -97,7 +97,7 @@ type A8NResolver interface {
 	RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (CampaignResolver, error)
 	PublishCampaign(ctx context.Context, args *PublishCampaignArgs) (CampaignResolver, error)
-	PublishChangesetPlan(ctx context.Context, args *PublishChangesetPlanArgs) (*EmptyResponse, error)
+	PublishChangeset(ctx context.Context, args *PublishChangesetArgs) (*EmptyResponse, error)
 
 	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error)
@@ -185,11 +185,11 @@ func (r *schemaResolver) PublishCampaign(ctx context.Context, args *PublishCampa
 	return EnterpriseResolvers.a8nResolver.PublishCampaign(ctx, args)
 }
 
-func (r *schemaResolver) PublishChangesetPlan(ctx context.Context, args *PublishChangesetPlanArgs) (*EmptyResponse, error) {
+func (r *schemaResolver) PublishChangeset(ctx context.Context, args *PublishChangesetArgs) (*EmptyResponse, error) {
 	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return EnterpriseResolvers.a8nResolver.PublishChangesetPlan(ctx, args)
+	return EnterpriseResolvers.a8nResolver.PublishChangeset(ctx, args)
 }
 
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -25,6 +25,7 @@ type CreateCampaignArgs struct {
 		Name        string
 		Description string
 		Plan        *graphql.ID
+		Draft       *bool
 	}
 }
 
@@ -79,6 +80,14 @@ type CreateChangesetsArgs struct {
 	}
 }
 
+type PublishCampaignArgs struct {
+	Campaign graphql.ID
+}
+
+type PublishChangesetPlanArgs struct {
+	ChangesetPlan graphql.ID
+}
+
 type A8NResolver interface {
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
 	UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error)
@@ -87,6 +96,8 @@ type A8NResolver interface {
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 	RetryCampaign(ctx context.Context, args *RetryCampaignArgs) (CampaignResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (CampaignResolver, error)
+	PublishCampaign(ctx context.Context, args *PublishCampaignArgs) (CampaignResolver, error)
+	PublishChangesetPlan(ctx context.Context, args *PublishChangesetPlanArgs) (*EmptyResponse, error)
 
 	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error)
@@ -98,6 +109,8 @@ type A8NResolver interface {
 	CreateCampaignPlanFromPatches(ctx context.Context, args CreateCampaignPlanFromPatchesArgs) (CampaignPlanResolver, error)
 	CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error)
 	CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error)
+
+	ChangesetPlanByID(ctx context.Context, id graphql.ID) (ChangesetPlanResolver, error)
 }
 
 var a8nOnlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
@@ -165,6 +178,20 @@ func (r *schemaResolver) CloseCampaign(ctx context.Context, args *CloseCampaignA
 	return EnterpriseResolvers.a8nResolver.CloseCampaign(ctx, args)
 }
 
+func (r *schemaResolver) PublishCampaign(ctx context.Context, args *PublishCampaignArgs) (CampaignResolver, error) {
+	if EnterpriseResolvers.a8nResolver == nil {
+		return nil, a8nOnlyInEnterprise
+	}
+	return EnterpriseResolvers.a8nResolver.PublishCampaign(ctx, args)
+}
+
+func (r *schemaResolver) PublishChangesetPlan(ctx context.Context, args *PublishChangesetPlanArgs) (*EmptyResponse, error) {
+	if EnterpriseResolvers.a8nResolver == nil {
+		return nil, a8nOnlyInEnterprise
+	}
+	return EnterpriseResolvers.a8nResolver.PublishChangesetPlan(ctx, args)
+}
+
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {
 	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
@@ -206,6 +233,8 @@ type CampaignResolver interface {
 	Plan(ctx context.Context) (CampaignPlanResolver, error)
 	ChangesetCreationStatus(context.Context) (BackgroundProcessStatus, error)
 	ClosedAt() *DateTime
+	PublishedAt() *DateTime
+	ChangesetPlans(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
 }
 
 type CampaignsConnectionResolver interface {
@@ -244,6 +273,7 @@ type ChangesetPlansConnectionResolver interface {
 }
 
 type ChangesetPlanResolver interface {
+	ID() graphql.ID
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 	BaseRepository(ctx context.Context) (*RepositoryResolver, error)
 	Diff() ChangesetPlanResolver

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -275,6 +275,11 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 			return nil, a8nOnlyInEnterprise
 		}
 		return EnterpriseResolvers.a8nResolver.ChangesetByID(ctx, id)
+	case "ChangesetPlan":
+		if EnterpriseResolvers.a8nResolver == nil {
+			return nil, a8nOnlyInEnterprise
+		}
+		return EnterpriseResolvers.a8nResolver.ChangesetPlanByID(ctx, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -629,6 +629,8 @@ type Campaign implements Node {
 
     # The changesets that will be created on the code host when publishing the
     # Campaign.
+    # If the Campaign is a "manual" campaign and doesn't have a CampaignPlan
+    # attached, there won't be any nodes returned by this connection
     # When publishing a Campaign, the number of nodes in changesets will
     # increase with each decrease in changesetPlans. The Completed count in the
     # Campaign.status increments with every ChangesetPlan turned into an

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -99,8 +99,12 @@ type Mutation {
     # update according to the progress of turning the changesetPlans into
     # changesets.
     publishCampaign(campaign: ID!): Campaign!
-    # Creates a Changeset on the codehost.
-    publishChangesetPlan(changeset: ID!): Changeset!
+    # Creates an ExternalChangeset on the codehost asynchronously.
+    # The ChangesetPlan has to belong to a CampaignPlan that has been attached
+    # to a Campaign. Otherwise an error is returned.
+    # Since this is an asynchronous operation, the Campaign.status field can be
+    # used to keep track of progress.
+    publishChangesetPlan(changesetPlan: ID!): EmptyResponse!
 
     # Updates the user profile information for the user with the given ID.
     #

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -93,6 +93,14 @@ type Mutation {
         # on the codehost (e.g. "declined" on Bitbucket Server).
         closeChangesets: Boolean = false
     ): Campaign!
+    # Publishes the Campaign by turning its changesetPlans into changesets on
+    # the codehosts.
+    # The Campaign.draft field will be set to false and Campaign.status will
+    # update according to the progress of turning the changesetPlans into
+    # changesets.
+    publishCampaign(campaign: ID!): Campaign!
+    # Creates a Changeset on the codehost.
+    publishChangesetPlan(changeset: ID!): Changeset!
 
     # Updates the user profile information for the user with the given ID.
     #
@@ -480,6 +488,11 @@ input CreateCampaignInput {
     # Will error if the plan is not completed yet.
     # Using a campaign plan for a campaign will retain it for the lifetime of the campaign and prevents it from being purged.
     plan: ID
+
+    # Whether or not to create the Campaign in draft mode. Default is false.
+    # When a Campaign is created in draft mode, its changesetPlans are not
+    # created on the codehost, but only when publishing the Campaign.
+    draft: Boolean
 }
 
 # Input arguments for updating a campaign.
@@ -603,6 +616,20 @@ type Campaign implements Node {
 
     # The date and time when the campaign was closed.
     closedAt: DateTime
+
+    # Whether the Campaign is in draft mode or not. Default is false.
+    draft: Boolean!
+
+    # The date and time when the Campaign changed from draft mode to published.
+    # Default value is the same as createdAt in case the Campaign was never in
+    # draft mode
+    publishedAt: DateTime
+
+    # The changesets that will be created on the code host when marking the
+    # Campaign as ready.
+    # When publishing a Campaign, the number of nodes in changesets will
+    # increase with each increment of Completed in the Campaign.status.
+    changesetPlans(first: Int): ChangesetPlanConnection!
 }
 
 # The counts of changesets in certain states at a specific point in time.
@@ -663,6 +690,9 @@ input CreateChangesetInput {
 
 # Preview of a changeset planned to be created.
 type ChangesetPlan {
+    # The id of the changeset plan.
+    id: ID!
+
     # The repository changed by the changeset.
     repository: Repository!
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -104,7 +104,7 @@ type Mutation {
     # to a Campaign. Otherwise an error is returned.
     # Since this is an asynchronous operation, the Campaign.status field can be
     # used to keep track of progress.
-    publishChangesetPlan(changesetPlan: ID!): EmptyResponse!
+    publishChangeset(changesetPlan: ID!): EmptyResponse!
 
     # Updates the user profile information for the user with the given ID.
     #

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -617,18 +617,18 @@ type Campaign implements Node {
     # The date and time when the campaign was closed.
     closedAt: DateTime
 
-    # Whether the Campaign is in draft mode or not. Default is false.
-    draft: Boolean!
-
     # The date and time when the Campaign changed from draft mode to published.
-    # Default value is the same as createdAt in case the Campaign was never in
-    # draft mode
+    # If the Campaign has not been published yet (is still in draft mode) this
+    # is null.
+    # If the Campaign was never in draft mode the value is the same as createdAt.
     publishedAt: DateTime
 
-    # The changesets that will be created on the code host when marking the
-    # Campaign as ready.
+    # The changesets that will be created on the code host when publishing the
+    # Campaign.
     # When publishing a Campaign, the number of nodes in changesets will
-    # increase with each increment of Completed in the Campaign.status.
+    # increase with each decrease in changesetPlans. The Completed count in the
+    # Campaign.status increments with every ChangesetPlan turned into an
+    # ExternalChangeset.
     changesetPlans(first: Int): ChangesetPlanConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -636,6 +636,8 @@ type Campaign implements Node {
 
     # The changesets that will be created on the code host when publishing the
     # Campaign.
+    # If the Campaign is a "manual" campaign and doesn't have a CampaignPlan
+    # attached, there won't be any nodes returned by this connection
     # When publishing a Campaign, the number of nodes in changesets will
     # increase with each decrease in changesetPlans. The Completed count in the
     # Campaign.status increments with every ChangesetPlan turned into an

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -624,18 +624,18 @@ type Campaign implements Node {
     # The date and time when the campaign was closed.
     closedAt: DateTime
 
-    # Whether the Campaign is in draft mode or not. Default is false.
-    draft: Boolean!
-
     # The date and time when the Campaign changed from draft mode to published.
-    # Default value is the same as createdAt in case the Campaign was never in
-    # draft mode
+    # If the Campaign has not been published yet (is still in draft mode) this
+    # is null.
+    # If the Campaign was never in draft mode the value is the same as createdAt.
     publishedAt: DateTime
 
-    # The changesets that will be created on the code host when marking the
-    # Campaign as ready.
+    # The changesets that will be created on the code host when publishing the
+    # Campaign.
     # When publishing a Campaign, the number of nodes in changesets will
-    # increase with each increment of Completed in the Campaign.status.
+    # increase with each decrease in changesetPlans. The Completed count in the
+    # Campaign.status increments with every ChangesetPlan turned into an
+    # ExternalChangeset.
     changesetPlans(first: Int): ChangesetPlanConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -106,7 +106,7 @@ type Mutation {
     # to a Campaign. Otherwise an error is returned.
     # Since this is an asynchronous operation, the Campaign.status field can be
     # used to keep track of progress.
-    publishChangesetPlan(changesetPlan: ID!): EmptyResponse!
+    publishChangeset(changesetPlan: ID!): EmptyResponse!
 
     # Updates the user profile information for the user with the given ID.
     #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -101,8 +101,12 @@ type Mutation {
     # update according to the progress of turning the changesetPlans into
     # changesets.
     publishCampaign(campaign: ID!): Campaign!
-    # Creates a Changeset on the codehost.
-    publishChangesetPlan(changeset: ID!): Changeset!
+    # Creates an ExternalChangeset on the codehost asynchronously.
+    # The ChangesetPlan has to belong to a CampaignPlan that has been attached
+    # to a Campaign. Otherwise an error is returned.
+    # Since this is an asynchronous operation, the Campaign.status field can be
+    # used to keep track of progress.
+    publishChangesetPlan(changesetPlan: ID!): EmptyResponse!
 
     # Updates the user profile information for the user with the given ID.
     #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -95,6 +95,14 @@ type Mutation {
         # on the codehost (e.g. "declined" on Bitbucket Server).
         closeChangesets: Boolean = false
     ): Campaign!
+    # Publishes the Campaign by turning its changesetPlans into changesets on
+    # the codehosts.
+    # The Campaign.draft field will be set to false and Campaign.status will
+    # update according to the progress of turning the changesetPlans into
+    # changesets.
+    publishCampaign(campaign: ID!): Campaign!
+    # Creates a Changeset on the codehost.
+    publishChangesetPlan(changeset: ID!): Changeset!
 
     # Updates the user profile information for the user with the given ID.
     #
@@ -487,6 +495,11 @@ input CreateCampaignInput {
     # Will error if the plan is not completed yet.
     # Using a campaign plan for a campaign will retain it for the lifetime of the campaign and prevents it from being purged.
     plan: ID
+
+    # Whether or not to create the Campaign in draft mode. Default is false.
+    # When a Campaign is created in draft mode, its changesetPlans are not
+    # created on the codehost, but only when publishing the Campaign.
+    draft: Boolean
 }
 
 # Input arguments for updating a campaign.
@@ -610,6 +623,20 @@ type Campaign implements Node {
 
     # The date and time when the campaign was closed.
     closedAt: DateTime
+
+    # Whether the Campaign is in draft mode or not. Default is false.
+    draft: Boolean!
+
+    # The date and time when the Campaign changed from draft mode to published.
+    # Default value is the same as createdAt in case the Campaign was never in
+    # draft mode
+    publishedAt: DateTime
+
+    # The changesets that will be created on the code host when marking the
+    # Campaign as ready.
+    # When publishing a Campaign, the number of nodes in changesets will
+    # increase with each increment of Completed in the Campaign.status.
+    changesetPlans(first: Int): ChangesetPlanConnection!
 }
 
 # The counts of changesets in certain states at a specific point in time.
@@ -670,6 +697,9 @@ input CreateChangesetInput {
 
 # Preview of a changeset planned to be created.
 type ChangesetPlan {
+    # The id of the changeset plan.
+    id: ID!
+
     # The repository changed by the changeset.
     repository: Repository!
 

--- a/enterprise/internal/a8n/resolvers/campaign_plans.go
+++ b/enterprise/internal/a8n/resolvers/campaign_plans.go
@@ -30,6 +30,17 @@ func unmarshalCampaignPlanID(id graphql.ID) (campaignPlanID int64, err error) {
 	return
 }
 
+const campaignJobIDKind = "ChangesetPlan"
+
+func marshalCampaignJobID(id int64) graphql.ID {
+	return relay.MarshalID(campaignJobIDKind, id)
+}
+
+func unmarshalCampaignJobID(id graphql.ID) (cid int64, err error) {
+	err = relay.UnmarshalSpec(id, &cid)
+	return
+}
+
 type campaignPlanResolver struct {
 	store        *ee.Store
 	campaignPlan *a8n.CampaignPlan
@@ -163,6 +174,10 @@ func (r *campaignJobResolver) computeRepoCommit(ctx context.Context) (*graphqlba
 		r.commit, r.err = r.repo.Commit(ctx, args)
 	})
 	return r.repo, r.commit, r.err
+}
+
+func (r *campaignJobResolver) ID() graphql.ID {
+	return marshalCampaignJobID(r.job.ID)
 }
 
 func (r *campaignJobResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {

--- a/enterprise/internal/a8n/resolvers/campaign_plans.go
+++ b/enterprise/internal/a8n/resolvers/campaign_plans.go
@@ -78,10 +78,6 @@ type campaignJobsConnectionResolver struct {
 	store *ee.Store
 	opts  ee.ListCampaignJobsOpts
 
-	// when a campaign doesn't have a CampaignPlan we set this so we don't
-	// query the database for non-existent CampaignJobs
-	empty bool
-
 	// cache results because they are used by multiple fields
 	once      sync.Once
 	jobs      []*a8n.CampaignJob
@@ -91,10 +87,6 @@ type campaignJobsConnectionResolver struct {
 }
 
 func (r *campaignJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetPlanResolver, error) {
-	if r.empty {
-		return []graphqlbackend.ChangesetPlanResolver{}, nil
-	}
-
 	jobs, reposByID, _, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
@@ -140,10 +132,6 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 }
 
 func (r *campaignJobsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	if r.empty {
-		return 0, nil
-	}
-
 	opts := ee.CountCampaignJobsOpts{
 		CampaignPlanID: r.opts.CampaignPlanID,
 		OnlyFinished:   r.opts.OnlyFinished,
@@ -154,10 +142,6 @@ func (r *campaignJobsConnectionResolver) TotalCount(ctx context.Context) (int32,
 }
 
 func (r *campaignJobsConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if r.empty {
-		return graphqlutil.HasNextPage(false), nil
-	}
-
 	_, _, next, err := r.compute(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/a8n/resolvers/campaign_plans.go
+++ b/enterprise/internal/a8n/resolvers/campaign_plans.go
@@ -133,9 +133,10 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 
 func (r *campaignJobsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	opts := ee.CountCampaignJobsOpts{
-		CampaignPlanID: r.opts.CampaignPlanID,
-		OnlyFinished:   r.opts.OnlyFinished,
-		OnlyWithDiff:   r.opts.OnlyWithDiff,
+		CampaignPlanID:            r.opts.CampaignPlanID,
+		OnlyFinished:              r.opts.OnlyFinished,
+		OnlyWithDiff:              r.opts.OnlyWithDiff,
+		OnlyUnpublishedInCampaign: r.opts.OnlyUnpublishedInCampaign,
 	}
 	count, err := r.store.CountCampaignJobs(ctx, opts)
 	return int32(count), err

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -143,6 +143,10 @@ func (r *campaignResolver) ChangesetPlans(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,
 ) graphqlbackend.ChangesetPlansConnectionResolver {
+	if r.Campaign.CampaignPlanID == 0 {
+		return &emptyChangesetPlansConnectionsResolver{}
+	}
+
 	resolver := &campaignJobsConnectionResolver{
 		store: r.store,
 		opts: ee.ListCampaignJobsOpts{
@@ -152,10 +156,6 @@ func (r *campaignResolver) ChangesetPlans(
 			OnlyWithDiff:   true,
 			// TODO: Only without ChangesetJob and Changeset
 		},
-	}
-
-	if r.Campaign.CampaignPlanID == 0 {
-		resolver.empty = true
 	}
 
 	return resolver
@@ -270,4 +270,18 @@ func (r *changesetDiffsConnectionResolver) Nodes(ctx context.Context) ([]*graphq
 		}
 	}
 	return resolvers, nil
+}
+
+type emptyChangesetPlansConnectionsResolver struct{}
+
+func (r *emptyChangesetPlansConnectionsResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetPlanResolver, error) {
+	return []graphqlbackend.ChangesetPlanResolver{}, nil
+}
+
+func (r *emptyChangesetPlansConnectionsResolver) TotalCount(ctx context.Context) (int32, error) {
+	return 0, nil
+}
+
+func (r *emptyChangesetPlansConnectionsResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
 }

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -143,21 +143,21 @@ func (r *campaignResolver) ChangesetPlans(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,
 ) graphqlbackend.ChangesetPlansConnectionResolver {
-	if r.Campaign.CampaignPlanID == 0 {
-		return nil
-	}
-
 	resolver := &campaignJobsConnectionResolver{
 		store: r.store,
-		// TODO(a8n): Does campaignJobsConnectionResolver need the campaignPlan?
-		campaignPlan: nil,
 		opts: ee.ListCampaignJobsOpts{
 			CampaignPlanID: r.Campaign.CampaignPlanID,
 			Limit:          int(args.GetFirst()),
 			OnlyFinished:   true,
 			OnlyWithDiff:   true,
+			// TODO: Only without ChangesetJob and Changeset
 		},
 	}
+
+	if r.Campaign.CampaignPlanID == 0 {
+		resolver.empty = true
+	}
+
 	return resolver
 }
 

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -120,6 +120,15 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.Campaign.ClosedAt}
 }
 
+func (r *campaignResolver) PublishedAt() *graphqlbackend.DateTime {
+	return nil
+	// TODO(a8n): Implement this
+	// if r.Campaign.PublishedAt.IsZero() {
+	// 	return nil
+	// }
+	// return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}
+}
+
 func (r *campaignResolver) Changesets(ctx context.Context, args struct {
 	graphqlutil.ConnectionArgs
 }) graphqlbackend.ExternalChangesetsConnectionResolver {
@@ -130,6 +139,28 @@ func (r *campaignResolver) Changesets(ctx context.Context, args struct {
 			Limit:      int(args.ConnectionArgs.GetFirst()),
 		},
 	}
+}
+
+func (r *campaignResolver) ChangesetPlans(
+	ctx context.Context,
+	args *graphqlutil.ConnectionArgs,
+) graphqlbackend.ChangesetPlansConnectionResolver {
+	if r.Campaign.CampaignPlanID == 0 {
+		return nil
+	}
+
+	resolver := &campaignJobsConnectionResolver{
+		store: r.store,
+		// TODO(a8n): Does campaignJobsConnectionResolver need the campaignPlan?
+		campaignPlan: nil,
+		opts: ee.ListCampaignJobsOpts{
+			CampaignPlanID: r.Campaign.CampaignPlanID,
+			Limit:          int(args.GetFirst()),
+			OnlyFinished:   true,
+			OnlyWithDiff:   true,
+		},
+	}
+	return resolver
 }
 
 func (r *campaignResolver) ChangesetCountsOverTime(

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -121,12 +121,10 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 }
 
 func (r *campaignResolver) PublishedAt() *graphqlbackend.DateTime {
-	return nil
-	// TODO(a8n): Implement this
-	// if r.Campaign.PublishedAt.IsZero() {
-	// 	return nil
-	// }
-	// return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}
+	if r.Campaign.PublishedAt.IsZero() {
+		return nil
+	}
+	return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}
 }
 
 func (r *campaignResolver) Changesets(ctx context.Context, args struct {

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -147,18 +147,16 @@ func (r *campaignResolver) ChangesetPlans(
 		return &emptyChangesetPlansConnectionsResolver{}
 	}
 
-	resolver := &campaignJobsConnectionResolver{
+	return &campaignJobsConnectionResolver{
 		store: r.store,
 		opts: ee.ListCampaignJobsOpts{
-			CampaignPlanID: r.Campaign.CampaignPlanID,
-			Limit:          int(args.GetFirst()),
-			OnlyFinished:   true,
-			OnlyWithDiff:   true,
-			// TODO: Only without ChangesetJob and Changeset
+			CampaignPlanID:            r.Campaign.CampaignPlanID,
+			Limit:                     int(args.GetFirst()),
+			OnlyFinished:              true,
+			OnlyWithDiff:              true,
+			OnlyUnpublishedInCampaign: r.Campaign.ID,
 		},
 	}
-
-	return resolver
 }
 
 func (r *campaignResolver) ChangesetCountsOverTime(

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -691,10 +691,13 @@ func (r *Resolver) PublishChangesetPlan(ctx context.Context, args *graphqlbacken
 	}
 
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
-	// TODO(a8n): What if a ChangesetJob already exists? Return error?
 	changesetJob, campaign, err := svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
 	if err != nil {
 		return nil, err
+	}
+
+	if changesetJob.SuccessfullyCompleted() {
+		return &graphqlbackend.EmptyResponse{}, nil
 	}
 
 	go func() {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -670,7 +670,7 @@ func (r *Resolver) PublishCampaign(ctx context.Context, args *graphqlbackend.Pub
 		}
 	}()
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, errors.New("TODO: not implemented yet")
+	return &campaignResolver{store: r.store, Campaign: campaign}, nil
 }
 
 func (r *Resolver) PublishChangesetPlan(ctx context.Context, args *graphqlbackend.PublishChangesetPlanArgs) (_ *graphqlbackend.EmptyResponse, err error) {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -77,6 +77,25 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 	return &campaignResolver{store: r.store, Campaign: campaign}, nil
 }
 
+func (r *Resolver) ChangesetPlanByID(ctx context.Context, id graphql.ID) (graphqlbackend.ChangesetPlanResolver, error) {
+	// 🚨 SECURITY: Only site admins may access changesets for now.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	campaignJobID, err := unmarshalCampaignJobID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := r.store.GetCampaignJob(ctx, ee.GetCampaignJobOpts{ID: campaignJobID})
+	if err != nil {
+		return nil, err
+	}
+
+	return &campaignJobResolver{job: job}, nil
+}
+
 func (r *Resolver) CampaignPlanByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignPlanResolver, error) {
 	// 🚨 SECURITY: Only site admins may access campaign plans for now.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
@@ -611,4 +630,46 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 	}
 
 	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+}
+
+func (r *Resolver) PublishCampaign(ctx context.Context, args *graphqlbackend.PublishCampaignArgs) (_ graphqlbackend.CampaignResolver, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.PublishCampaign", fmt.Sprintf("Campaign: %q", args.Campaign))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	// 🚨 SECURITY: Only site admins may update campaigns for now
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, errors.Wrap(err, "checking if user is admin")
+	}
+
+	campaignID, err := unmarshalCampaignID(args.Campaign)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling campaign id")
+	}
+
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+
+	campaign, err := svc.PublishCampaign(ctx, campaignID)
+	if err != nil {
+		return nil, errors.Wrap(err, "closing campaign")
+	}
+
+	return &campaignResolver{store: r.store, Campaign: campaign}, errors.New("TODO: not implemented yet")
+}
+
+func (r *Resolver) PublishChangesetPlan(ctx context.Context, args *graphqlbackend.PublishChangesetPlanArgs) (_ *graphqlbackend.EmptyResponse, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.PublishChangesetPlan", fmt.Sprintf("ChangesetPlan: %q", args.ChangesetPlan))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	// 🚨 SECURITY: Only site admins may update campaigns for now
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, errors.Wrap(err, "checking if user is admin")
+	}
+
+	return nil, errors.New("TODO: not implemented yet")
 }

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -673,8 +673,8 @@ func (r *Resolver) PublishCampaign(ctx context.Context, args *graphqlbackend.Pub
 	return &campaignResolver{store: r.store, Campaign: campaign}, nil
 }
 
-func (r *Resolver) PublishChangesetPlan(ctx context.Context, args *graphqlbackend.PublishChangesetPlanArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.PublishChangesetPlan", fmt.Sprintf("ChangesetPlan: %q", args.ChangesetPlan))
+func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.PublishChangesetArgs) (_ *graphqlbackend.EmptyResponse, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.PublishChangeset", fmt.Sprintf("ChangesetPlan: %q", args.ChangesetPlan))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -690,26 +690,13 @@ func (r *Resolver) PublishChangesetPlan(ctx context.Context, args *graphqlbacken
 		return nil, err
 	}
 
-	job, err := r.store.GetCampaignJob(ctx, ee.GetCampaignJobOpts{ID: campaignJobID})
-	if err != nil {
-		return nil, err
-	}
-
-	campaign, err := r.store.GetCampaign(ctx, ee.GetCampaignOpts{CampaignPlanID: job.CampaignPlanID})
-	if err != nil {
-		return nil, err
-	}
-
-	changesetJob := &a8n.ChangesetJob{
-		CampaignID:    campaign.ID,
-		CampaignJobID: job.ID,
-	}
-	err = r.store.CreateChangesetJob(ctx, changesetJob)
-	if err != nil {
-		return nil, err
-	}
-
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	// TODO(a8n): What if a ChangesetJob already exists? Return error?
+	changesetJob, campaign, err := svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
+	if err != nil {
+		return nil, err
+	}
+
 	go func() {
 		ctx := trace.ContextWithTrace(context.Background(), tr)
 		err := svc.RunChangesetJob(ctx, campaign, changesetJob)

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -131,6 +131,7 @@ func TestCampaigns(t *testing.T) {
 		Author      User
 		CreatedAt   string
 		UpdatedAt   string
+		PublishedAt string
 		Namespace   UserOrg
 	}
 
@@ -153,7 +154,7 @@ func TestCampaigns(t *testing.T) {
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
 		fragment c on Campaign {
-			id, name, description, createdAt, updatedAt
+			id, name, description, createdAt, updatedAt, publishedAt
 			author    { ...u }
 			namespace {
 				... on User { ...u }
@@ -190,7 +191,7 @@ func TestCampaigns(t *testing.T) {
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
 		fragment c on Campaign {
-			id, name, description, createdAt, updatedAt
+			id, name, description, createdAt, updatedAt, publishedAt
 			author    { ...u }
 			namespace {
 				... on User { ...u }
@@ -245,7 +246,7 @@ func TestCampaigns(t *testing.T) {
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
 		fragment c on Campaign {
-			id, name, description, createdAt, updatedAt
+			id, name, description, createdAt, updatedAt, publishedAt
 			author    { ...u }
 			namespace {
 				... on User { ...u }

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -469,13 +469,13 @@ func (s *Service) PublishCampaign(ctx context.Context, id int64) (campaign *a8n.
 		return nil, errors.Wrap(err, "getting campaign")
 	}
 
-	// TODO(a8n): Implement this
+	if !campaign.PublishedAt.IsZero() {
+		return campaign, nil
+	}
 
-	// if !campaign.PublishedAt.IsZero() {
-	// 	return campaign, nil
-	// }
-	//
-	// campaign.PublishedAt = time.Now().UTC()
+	campaign.PublishedAt = time.Now().UTC()
+
+	// TODO(a8n): Implement creation of ChangesetJobs and running them
 
 	return campaign, nil
 }

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -446,6 +446,40 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 	return campaign, nil
 }
 
+// PublishCampaign publishes the Campaign with the given ID if it has not been
+// published yet by turning the CampaignJobs attached to the CampaignPlan of
+// the Campaign into ChangesetJobs and running them.
+func (s *Service) PublishCampaign(ctx context.Context, id int64) (campaign *a8n.Campaign, err error) {
+	traceTitle := fmt.Sprintf("campaign: %d", id)
+	tr, ctx := trace.New(ctx, "service.PublishCampaign", traceTitle)
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	tx, err := s.store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer tx.Done(&err)
+
+	campaign, err = tx.GetCampaign(ctx, GetCampaignOpts{ID: id})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting campaign")
+	}
+
+	// TODO(a8n): Implement this
+
+	// if !campaign.PublishedAt.IsZero() {
+	// 	return campaign, nil
+	// }
+	//
+	// campaign.PublishedAt = time.Now().UTC()
+
+	return campaign, nil
+}
+
 // DeleteCampaign deletes the Campaign with the given ID if it hasn't been
 // deleted yet. If closeChangesets is true, the changesets associated with the
 // Campaign will be closed on the codehosts.

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -24,9 +24,7 @@ import (
 
 // NewService returns a Service.
 func NewService(store *Store, git GitserverClient, repoResolveRevision repoResolveRevision, cf *httpcli.Factory) *Service {
-	return NewServiceWithClock(store, git, repoResolveRevision, cf, func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	})
+	return NewServiceWithClock(store, git, repoResolveRevision, cf, store.Clock())
 }
 
 // NewServiceWithClock returns a Service the given clock used

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -220,7 +220,7 @@ func (s *Service) RunChangesetJobs(ctx context.Context, c *a8n.Campaign) error {
 
 	errs := &multierror.Error{}
 	for _, job := range jobs {
-		err := s.runChangesetJob(ctx, c, job)
+		err := s.RunChangesetJob(ctx, c, job)
 		if err != nil {
 			err = errors.Wrapf(err, "ChangesetJob %d", job.ID)
 			errs = multierror.Append(errs, err)
@@ -230,12 +230,12 @@ func (s *Service) RunChangesetJobs(ctx context.Context, c *a8n.Campaign) error {
 	return errs.ErrorOrNil()
 }
 
-func (s *Service) runChangesetJob(
+func (s *Service) RunChangesetJob(
 	ctx context.Context,
 	c *a8n.Campaign,
 	job *a8n.ChangesetJob,
 ) (err error) {
-	tr, ctx := trace.New(ctx, "service.runChangeSetJob", fmt.Sprintf("job_id: %d", job.ID))
+	tr, ctx := trace.New(ctx, "service.RunChangeSetJob", fmt.Sprintf("job_id: %d", job.ID))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -176,10 +176,11 @@ func (s *Service) CreateCampaign(ctx context.Context, c *a8n.Campaign, draft boo
 
 func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store, c *a8n.Campaign) error {
 	jobs, _, err := store.ListCampaignJobs(ctx, ListCampaignJobsOpts{
-		CampaignPlanID: c.CampaignPlanID,
-		Limit:          -1,
-		OnlyFinished:   true,
-		OnlyWithDiff:   true,
+		CampaignPlanID:            c.CampaignPlanID,
+		Limit:                     -1,
+		OnlyFinished:              true,
+		OnlyWithDiff:              true,
+		OnlyUnpublishedInCampaign: c.ID,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -184,7 +184,6 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		campaignJobs := make([]*a8n.CampaignJob, 0, len(rs))
 		for _, repo := range rs {
 			campaignJob := &a8n.CampaignJob{
 				CampaignPlanID: testPlan.ID,
@@ -199,7 +198,6 @@ func TestService(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			campaignJobs = append(campaignJobs, campaignJob)
 		}
 
 		campaign := &a8n.Campaign{

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1891,7 +1891,7 @@ func listCampaignJobsQuery(opts *ListCampaignJobsOpts) *sqlf.Query {
 
 var onlyUnpublishedInCampaignQueryFmtstr = `
 NOT EXISTS (
-  SELECT *
+  SELECT 1
   FROM changeset_jobs
   WHERE
     campaign_job_id = campaign_jobs.id

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -844,9 +844,10 @@ INSERT INTO campaigns (
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
+  closed_at,
+  published_at
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   name,
@@ -858,7 +859,8 @@ RETURNING
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
+  closed_at,
+  published_at
 `
 
 func (s *Store) createCampaignQuery(c *a8n.Campaign) (*sqlf.Query, error) {
@@ -887,6 +889,7 @@ func (s *Store) createCampaignQuery(c *a8n.Campaign) (*sqlf.Query, error) {
 		changesetIDs,
 		nullInt64Column(c.CampaignPlanID),
 		nullTimeColumn(c.ClosedAt),
+		nullTimeColumn(c.PublishedAt),
 	), nil
 }
 
@@ -943,8 +946,9 @@ SET (
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
-) = (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+  closed_at,
+  published_at
+) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -957,7 +961,8 @@ RETURNING
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
+  closed_at,
+  published_at
 `
 
 func (s *Store) updateCampaignQuery(c *a8n.Campaign) (*sqlf.Query, error) {
@@ -979,6 +984,7 @@ func (s *Store) updateCampaignQuery(c *a8n.Campaign) (*sqlf.Query, error) {
 		changesetIDs,
 		nullInt64Column(c.CampaignPlanID),
 		nullTimeColumn(c.ClosedAt),
+		nullTimeColumn(c.PublishedAt),
 		c.ID,
 	), nil
 }
@@ -1071,7 +1077,8 @@ SELECT
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
+  closed_at,
+  published_at
 FROM campaigns
 WHERE %s
 LIMIT 1
@@ -1133,7 +1140,8 @@ SELECT
   updated_at,
   changeset_ids,
   campaign_plan_id,
-  closed_at
+  closed_at,
+  published_at
 FROM campaigns
 WHERE %s
 ORDER BY id ASC
@@ -2294,6 +2302,7 @@ func scanCampaign(c *a8n.Campaign, s scanner) error {
 		&dbutil.JSONInt64Set{Set: &c.ChangesetIDs},
 		&dbutil.NullInt64{N: &c.CampaignPlanID},
 		&dbutil.NullTime{Time: &c.ClosedAt},
+		&dbutil.NullTime{Time: &c.PublishedAt},
 	)
 }
 

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -2075,6 +2075,7 @@ func countChangesetJobsQuery(opts *CountChangesetJobsOpts) *sqlf.Query {
 type GetChangesetJobOpts struct {
 	ID            int64
 	CampaignJobID int64
+	CampaignID    int64
 	ChangesetID   int64
 }
 
@@ -2118,6 +2119,10 @@ func getChangesetJobQuery(opts *GetChangesetJobOpts) *sqlf.Query {
 	var preds []*sqlf.Query
 	if opts.ID != 0 {
 		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+
+	if opts.CampaignID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaign_id = %s", opts.CampaignID))
 	}
 
 	if opts.CampaignJobID != 0 {

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1042,7 +1042,8 @@ func countCampaignsQuery(opts *CountCampaignsOpts) *sqlf.Query {
 
 // GetCampaignOpts captures the query options needed for getting a Campaign
 type GetCampaignOpts struct {
-	ID int64
+	ID             int64
+	CampaignPlanID int64
 }
 
 // GetCampaign gets a campaign matching the given options.
@@ -1088,6 +1089,10 @@ func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
 	var preds []*sqlf.Query
 	if opts.ID != 0 {
 		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+
+	if opts.CampaignPlanID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaign_plan_id = %s", opts.CampaignPlanID))
 	}
 
 	if len(preds) == 0 {

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -1691,7 +1691,9 @@ type CountCampaignJobsOpts struct {
 	OnlyFinished   bool
 	OnlyWithDiff   bool
 
-	// See the explanation for this parameter in ListCampaignJobsOpts
+	// If this is set to a Campaign ID only the CampaignJobs are returned that
+	// are _not_ associated with a successfully completed ChangesetJob (meaning
+	// that a Changeset on the codehost was created) for the given Campaign.
 	OnlyUnpublishedInCampaign int64
 }
 

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -37,6 +37,9 @@ func NewStoreWithClock(db dbutil.DB, clock func() time.Time) *Store {
 	return &Store{db: db, now: clock}
 }
 
+// Clock returns the clock used by the Store.
+func (s *Store) Clock() func() time.Time { return s.now }
+
 // Transact returns a Store whose methods operate within the context of a transaction.
 // This method will return an error if the underlying DB cannot be interface upgraded
 // to a TxBeginner.

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -2013,6 +2013,25 @@ func testStore(db *sql.DB) func(*testing.T) {
 					}
 				})
 
+				t.Run("ByCampaignID", func(t *testing.T) {
+					if len(changesetJobs) == 0 {
+						t.Fatal("changesetJobs is empty")
+					}
+					// Use the last changesetJob, which we don't get by
+					// accident when selecting all with LIMIT 1
+					want := changesetJobs[2]
+					opts := GetChangesetJobOpts{CampaignID: want.CampaignID}
+
+					have, err := s.GetChangesetJob(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
 				t.Run("NoResults", func(t *testing.T) {
 					opts := GetChangesetJobOpts{ID: 0xdeadbeef}
 

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -41,6 +41,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 						ChangesetIDs:   []int64{int64(i) + 1},
 						CampaignPlanID: 42,
 						ClosedAt:       now,
+						PublishedAt:    now,
 					}
 
 					if i%2 == 0 {
@@ -170,6 +171,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					c.Description += "-updated"
 					c.AuthorID++
 					c.ClosedAt = c.ClosedAt.Add(5 * time.Second)
+					c.PublishedAt = c.PublishedAt.Add(5 * time.Second)
 
 					if c.NamespaceUserID != 0 {
 						c.NamespaceUserID++

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1404,7 +1404,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 					t.Fatal(err)
 				}
 
-				have, want = have, campaignJobs // All CampaignJobs
+				want = campaignJobs // All CampaignJobs
 				if len(have) != len(want) {
 					t.Fatalf("listed %d campaignJobs, want: %d", len(have), len(want))
 				}

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -39,7 +39,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 						Description:    "All the Javascripts are belong to us",
 						AuthorID:       23,
 						ChangesetIDs:   []int64{int64(i) + 1},
-						CampaignPlanID: 42,
+						CampaignPlanID: 42 + int64(i),
 						ClosedAt:       now,
 						PublishedAt:    now,
 					}
@@ -238,6 +238,20 @@ func testStore(db *sql.DB) func(*testing.T) {
 				t.Run("ByID", func(t *testing.T) {
 					want := campaigns[0]
 					opts := GetCampaignOpts{ID: want.ID}
+
+					have, err := s.GetCampaign(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
+				t.Run("ByCampaignPlanID", func(t *testing.T) {
+					want := campaigns[0]
+					opts := GetCampaignOpts{CampaignPlanID: want.CampaignPlanID}
 
 					have, err := s.GetCampaign(ctx, opts)
 					if err != nil {

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -96,6 +96,7 @@ type Campaign struct {
 	ChangesetIDs    []int64
 	CampaignPlanID  int64
 	ClosedAt        time.Time
+	PublishedAt     time.Time
 }
 
 // Clone returns a clone of a Campaign.

--- a/migrations/1528395628_add_published_at_to_campaigns.down.sql
+++ b/migrations/1528395628_add_published_at_to_campaigns.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaigns DROP COLUMN IF EXISTS published_at;
+
+COMMIT;

--- a/migrations/1528395628_add_published_at_to_campaigns.up.sql
+++ b/migrations/1528395628_add_published_at_to_campaigns.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE campaigns ADD COLUMN published_at timestamptz;
+
+UPDATE campaigns SET published_at = created_at;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -92,6 +92,8 @@
 // 1528395626_create_explicit_repo_permissions_tables.up.sql (2.612kB)
 // 1528395627_add_external_deleted_at_to_changesets.down.sql (83B)
 // 1528395627_add_external_deleted_at_to_changesets.up.sql (84B)
+// 1528395628_add_published_at_to_campaigns.down.sql (75B)
+// 1528395628_add_published_at_to_campaigns.up.sql (125B)
 
 package migrations
 
@@ -2000,6 +2002,46 @@ func _1528395627_add_external_deleted_at_to_changesetsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395628_add_published_at_to_campaignsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xbf\xd5\xbb\x2b\x4b\x00\x00\x00")
+
+func _1528395628_add_published_at_to_campaignsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395628_add_published_at_to_campaignsDownSql,
+		"1528395628_add_published_at_to_campaigns.down.sql",
+	)
+}
+
+func _1528395628_add_published_at_to_campaignsDownSql() (*asset, error) {
+	bytes, err := _1528395628_add_published_at_to_campaignsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395628_add_published_at_to_campaigns.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x24, 0x43, 0x87, 0x58, 0x4b, 0x3f, 0xba, 0x8e, 0x52, 0xb6, 0xfd, 0xb8, 0x3a, 0xc6, 0x26, 0xcb, 0x8b, 0x4f, 0xcb, 0x57, 0x36, 0x77, 0xff, 0xc0, 0x85, 0x45, 0x3b, 0xe8, 0x6c, 0x58, 0xb9, 0xdf}}
+	return a, nil
+}
+
+var __1528395628_add_published_at_to_campaignsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\x51\x28\xc9\xcc\x4d\x2d\x2e\x49\xcc\x2d\x28\xa9\xb2\xe6\xe2\x0a\x0d\x70\x71\x0c\x41\xd6\x16\xec\x1a\x82\xaa\xde\x56\x21\xb9\x28\x35\xb1\x04\xcc\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x9d\xbd\x05\xcd\x7d\x00\x00\x00")
+
+func _1528395628_add_published_at_to_campaignsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395628_add_published_at_to_campaignsUpSql,
+		"1528395628_add_published_at_to_campaigns.up.sql",
+	)
+}
+
+func _1528395628_add_published_at_to_campaignsUpSql() (*asset, error) {
+	bytes, err := _1528395628_add_published_at_to_campaignsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395628_add_published_at_to_campaigns.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0xf7, 0x62, 0xc4, 0xbb, 0xd3, 0x29, 0x6e, 0x4f, 0xb7, 0x34, 0x81, 0x32, 0x5b, 0x5d, 0xc6, 0x97, 0x64, 0x11, 0x31, 0x3e, 0xc9, 0xa9, 0xb6, 0x73, 0x95, 0xc7, 0x2e, 0xc3, 0xc5, 0x1f, 0x36}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2183,6 +2225,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395626_create_explicit_repo_permissions_tables.up.sql":                _1528395626_create_explicit_repo_permissions_tablesUpSql,
 	"1528395627_add_external_deleted_at_to_changesets.down.sql":                _1528395627_add_external_deleted_at_to_changesetsDownSql,
 	"1528395627_add_external_deleted_at_to_changesets.up.sql":                  _1528395627_add_external_deleted_at_to_changesetsUpSql,
+	"1528395628_add_published_at_to_campaigns.down.sql":                        _1528395628_add_published_at_to_campaignsDownSql,
+	"1528395628_add_published_at_to_campaigns.up.sql":                          _1528395628_add_published_at_to_campaignsUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -2318,6 +2362,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395626_create_explicit_repo_permissions_tables.up.sql":                {_1528395626_create_explicit_repo_permissions_tablesUpSql, map[string]*bintree{}},
 	"1528395627_add_external_deleted_at_to_changesets.down.sql":                {_1528395627_add_external_deleted_at_to_changesetsDownSql, map[string]*bintree{}},
 	"1528395627_add_external_deleted_at_to_changesets.up.sql":                  {_1528395627_add_external_deleted_at_to_changesetsUpSql, map[string]*bintree{}},
+	"1528395628_add_published_at_to_campaigns.down.sql":                        {_1528395628_add_published_at_to_campaignsDownSql, map[string]*bintree{}},
+	"1528395628_add_published_at_to_campaigns.up.sql":                          {_1528395628_add_published_at_to_campaignsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This adds the GraphQL API necessary for #7217. It implements the API as proposed in [this comment](https://github.com/sourcegraph/sourcegraph/issues/7217#issuecomment-566587683) with a few minor changes that I discussed with @eseliger, in order to make the client implementation easier.

The API flow for creating a `Campaign` in draft mode (that is: without creating pull requests on the code host) is this:

1. Create a `Campaign` as a draft: `createCampaign` with `draft = true`:

```graphql
mutation CreateDraftCampaignWithPlan($input: CreateCampaignInput!) {
  createCampaign(input: $input) {
    id
    name
    description
    publishedAt
    
    changesetCreationStatus {
      state
      completedCount
      pendingCount
      errors
    }
    changesets {
      totalCount
    }
    
    changesetPlans {
      totalCount
      nodes {
        id
      }
    }
  }
}
```
Variables:
```json
{
  "input":{
    "namespace":"VXNlcjox",
    "name":"This is a draft campaign",
    "description":"This is another cool campaign before release",
    "plan": "Q2FtcGFpZ25QbGFuOjUy",
    "draft": true
  }
}
```
Response:
```json
{
  "data": {
    "createCampaign": {
      "id": "Q2FtcGFpZ246OQ==",
      "name": "This is a draft campaign",
      "description": "This is another cool campaign before release",
      "publishedAt": null,
      "changesetCreationStatus": {
        "state": "COMPLETED",
        "completedCount": 0,
        "pendingCount": 0,
        "errors": []
      },
      "changesets": {
        "totalCount": 0
      },
      "changesetPlans": {
        "totalCount": 2,
        "nodes": [
          {
            "id": "Q2hhbmdlc2V0UGxhbjoyNjU3"
          },
          {
            "id": "Q2hhbmdlc2V0UGxhbjoyNjU4"
          }
        ]
      }
    }
  }
}
```
**Note**: We have `2` `changesetPlans` and `publishedAt` is `null`.

2. Publish 1/2 of the `changesetPlans`:

```graphql
mutation PublishChangesetPlan($id: ID!) {
  publishChangesetPlan(changesetPlan: $id) {
    alwaysNil
  }
}
```
Variables:
```json
{
  "id":"Q2hhbmdlc2V0UGxhbjoyNjU3"
}
```
Response:
```json
{
  "data": {
    "publishChangesetPlan": {
      "alwaysNil": null
    }
  }
}
```

3. Query the Campaign to see that one `changesetPlan` has been turned into a `changeset`:

```graphql
query CampaignStatus($id: ID!) {
  node(id: $id) {
    ... on Campaign {
      id
      name
      description
      publishedAt
      changesetCreationStatus {
        state
        completedCount
        pendingCount
        errors
      }
      changesets {
        totalCount
      }
      changesetPlans {
        totalCount
        nodes {
          id
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "node": {
      "id": "Q2FtcGFpZ246OQ==",
      "name": "This is a draft campaign",
      "description": "This is another cool campaign before release",
      "publishedAt": null,
      "changesetCreationStatus": {
        "state": "COMPLETED",
        "completedCount": 1,
        "pendingCount": 0,
        "errors": []
      },
      "changesets": {
        "totalCount": 1
      },
      "changesetPlans": {
        "totalCount": 1,
        "nodes": [
          {
            "id": "Q2hhbmdlc2V0UGxhbjoyNjU3"
          }
        ]
      }
    }
  }
}
```

3. Publish the complete campaign:

```graphql
mutation PublishCampaign($id: ID!) {
  publishCampaign(campaign: $id) {
    id
  }
}
```
Response:
```json
{
  "data": {
    "node": {
      "id": "Q2FtcGFpZ246OQ=="
    }
  }
}
```

4. Query the CampaignStatus:

Response:

```json
{
  "data": {
    "node": {
      "id": "Q2FtcGFpZ246OQ==",
      "name": "This is a draft campaign",
      "description": "This is another cool campaign before release",
      "publishedAt": "2019-12-19T08:45:14Z",
      "changesetCreationStatus": {
        "state": "COMPLETED",
        "completedCount": 2,
        "pendingCount": 0,
        "errors": []
      },
      "changesets": {
        "totalCount": 2
      },
      "changesetPlans": {
        "totalCount": 0,
        "nodes": []
      }
    }
  }
}
```

**Note** we now have `2` `changesets` and `0` `changesetPlans`.