### PR TITLE
vcs/git: Resolve relative symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)
+- We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
 
 ### Removed
 

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -84,7 +84,9 @@ func Stat(ctx context.Context, repo gitserver.Repo, commit api.CommitID, path st
 		if err != nil {
 			return nil, err
 		}
-		fi2, err := Lstat(ctx, repo, commit, string(b))
+		// Resolve relative links from the directory path is in
+		symlink := filepath.Join(filepath.Dir(path), string(b))
+		fi2, err := Lstat(ctx, repo, commit, symlink)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
A relative symlink needs to be resolved from the directory the symlink is in.
Previously we would not do this, which would lead to a git error message like
"../{rest of symlink path} is outside repository".

This PR also contains some refactorings to the test, which can be reviewed commit by commit.

Fixes https://github.com/sourcegraph/sourcegraph/issues/6034