### PR TITLE
dev: fix run-server-image script

### DIFF
--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -30,7 +30,7 @@ echo "starting server..."
 docker run "$@" \
  --publish 7080:7080 \
  --rm \
- -e SRC_LOG_LEVEL=dbug \
+ -e SRC_LOG_LEVEL=debug \
  -e DEBUG=t \
  --volume $DATA/config:/etc/sourcegraph \
  --volume $DATA/data:/var/opt/sourcegraph \


### PR DESCRIPTION
> 17:20:05 postgres_exporter | postgres_exporter: error: not a valid logrus Level: "dbug", try --help

when I run `IMAGE=sourcegraph/server:3.11.0-rc.2 ./dev/run-server-image.sh`

I changed it to `debug` and it works. Don't know if this is the right move. No recent change to this line so I don't know why this didn't fail before.