### PR TITLE
server: remove redundant parallel command from pre-build

### DIFF
--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -3,19 +3,5 @@
 cd $(dirname "${BASH_SOURCE[0]}")/../../..
 set -euxo pipefail
 
-parallel_run() {
-    log_file=$(mktemp)
-    trap "rm -rf $log_file" EXIT
-
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
-    cat $log_file
-}
-
-build_frontend_enterprise() {
-    echo "--- (enterprise) pre-build frontend"
-   ./enterprise/cmd/frontend/pre-build.sh
-}
-export -f build_frontend_enterprise
-
-echo "--- (enterprise) pre-build frontend in parallel"
-parallel_run {} ::: build_frontend_enterprise
+echo "--- (enterprise) pre-build frontend"
+./enterprise/cmd/frontend/pre-build.sh


### PR DESCRIPTION
There is no need to use `parallel` in this script if only one job is submitted to it. 