### PR TITLE
Fix: make patternType detection in queries case insensitive

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -164,7 +164,7 @@ func detectSearchType(version string, patternType *string, input string) (Search
 	// The patterntype field is Singular, but not enforced since we do not
 	// properly parse the input. The regex extraction, takes the left-most
 	// "patterntype:value" match.
-	var patternTypeRegex = lazyregexp.New(`patterntype:([a-zA-Z"']+)`)
+	var patternTypeRegex = lazyregexp.New(`(?i)patterntype:([a-zA-Z"']+)`)
 	patternFromField := patternTypeRegex.FindStringSubmatch(input)
 	if len(patternFromField) > 1 {
 		extracted := patternFromField[1]

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -327,6 +327,7 @@ func Test_detectSearchType(t *testing.T) {
 		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, SearchTypeRegex},
 		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, SearchTypeRegex},
 		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", SearchTypeLiteral},
+		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", SearchTypeLiteral},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
The `patternType` filter should be case insensitive, but `detectSearchType` only matches it in lowercase .
