### PR TITLE
symbols: use zoekt for symbol sidebar

### DIFF
--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -51,6 +51,9 @@ func limitOrDefault(first *int32) int {
 	return int(*first)
 }
 
+// indexedSymbols checks to see if Zoekt has indexed
+// symbols information for a repository at a specific
+// commit.
 func indexedSymbols(commit *GitCommitResolver) bool {
 	z := search.Indexed()
 	if !z.Enabled() {

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -54,7 +54,7 @@ func limitOrDefault(first *int32) int {
 // indexedSymbols checks to see if Zoekt has indexed
 // symbols information for a repository at a specific
 // commit.
-func indexedSymbols(commit *GitCommitResolver) bool {
+func indexedSymbols(repository, commit string) bool {
 	z := search.Indexed()
 	if !z.Enabled() {
 		return false
@@ -67,13 +67,13 @@ func indexedSymbols(commit *GitCommitResolver) bool {
 		return false
 	}
 
-	repo, ok := set[strings.ToLower(string(commit.repo.repo.Name))]
+	repo, ok := set[strings.ToLower(repository)]
 	if !ok || !repo.HasSymbols {
 		return false
 	}
 
 	for _, branch := range repo.Branches {
-		if branch.Version == string(commit.oid) {
+		if branch.Version == commit {
 			return true
 		}
 	}
@@ -164,7 +164,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, queryStr
 }
 
 func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
-	if indexedSymbols(commit) {
+	if indexedSymbols(string(commit.repo.repo.Name), string(commit.oid)) {
 		return searchZoektSymbols(ctx, commit, query, first, includePatterns)
 	}
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -135,24 +135,28 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, queryStr
 	baseURI, err := gituri.Parse("git://" + string(commit.repo.repo.Name) + "?" + string(commit.oid))
 	for _, file := range resp.Files {
 		for _, l := range file.LineMatches {
-			if !l.FileName {
-				for _, m := range l.LineFragments {
-					if m.SymbolInfo != nil {
-						res = append(res, toSymbolResolver(
-							protocol.Symbol{
-								Name:       m.SymbolInfo.Sym,
-								Kind:       m.SymbolInfo.Kind,
-								Parent:     m.SymbolInfo.Parent,
-								ParentKind: m.SymbolInfo.ParentKind,
-								Path:       file.FileName,
-								Line:       l.LineNumber,
-							},
-							baseURI,
-							strings.ToLower(file.Language),
-							commit,
-						))
-					}
+			if l.FileName {
+				continue
+			}
+
+			for _, m := range l.LineFragments {
+				if m.SymbolInfo == nil {
+					continue
 				}
+
+				res = append(res, toSymbolResolver(
+					protocol.Symbol{
+						Name:       m.SymbolInfo.Sym,
+						Kind:       m.SymbolInfo.Kind,
+						Parent:     m.SymbolInfo.Parent,
+						ParentKind: m.SymbolInfo.ParentKind,
+						Path:       file.FileName,
+						Line:       l.LineNumber,
+					},
+					baseURI,
+					strings.ToLower(file.Language),
+					commit,
+				))
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -33,7 +33,6 @@ func (r *GitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (
 
 func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
 	symbols, err := computeSymbols(ctx, r, args.Query, args.First, args.IncludePatterns)
-	//symbols, err := searchZoektSymbols(ctx, r, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -67,7 +67,7 @@ func indexedSymbols(commit *GitCommitResolver) bool {
 		return false
 	}
 
-	repo, ok := set[string(commit.repo.repo.Name)]
+	repo, ok := set[strings.ToLower(string(commit.repo.repo.Name))]
 	if !ok || !repo.HasSymbols {
 		return false
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -128,6 +128,9 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, queryStr
 		TotalMaxImportantMatch: match * 25,
 		MaxDocDisplayCount:     match,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	baseURI, err := gituri.Parse("git://" + string(commit.repo.repo.Name) + "?" + string(commit.oid))
 	for _, file := range resp.Files {


### PR DESCRIPTION
This PR aims to improve the responsiveness of the symbol sidebar by taking advantage of the already indexed symbols data within Zoekt. This is only applicable to the HEAD branch. If there isn't an available index, it will fallback to the on demand ctags generation service.

Testing: I believe the e2e tests cover this, but I'll double check.
https://github.com/sourcegraph/sourcegraph/blob/master/web/src/e2e/e2e.test.ts#L594

<img width="300" alt="Screen Shot 2019-12-19 at 3 57 47 AM" src="https://user-images.githubusercontent.com/3507526/71171916-c438c800-2213-11ea-88b2-d5b8c4c2e607.png">

This closes #6078.