### PR TITLE
repo-updater: Specify what want and got is in test diffs

### DIFF
--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -827,15 +827,6 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		})
 	}
 
-	{
-		stored := repositories.With(repos.Opt.RepoDeletedAt(now))
-		testCases = append(testCases, testCase{
-			name:   "excludes deleted repos",
-			stored: stored,
-			repos:  repos.Assert.ReposEqual(),
-		})
-	}
-
 	testCases = append(testCases, testCase{
 		name:   "returns repos in ascending order by id",
 		stored: mkRepos(7, repositories...),

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -394,7 +394,7 @@ var Assert = struct {
 			// Exclude auto-generated IDs from equality tests
 			have = append(Repos{}, have...).With(Opt.RepoID(0))
 			if !reflect.DeepEqual(have, want) {
-				t.Errorf("repos: %s", cmp.Diff(have, want))
+				t.Errorf("repos (-want +got): %s", cmp.Diff(want, have))
 			}
 		}
 	},
@@ -406,7 +406,7 @@ var Assert = struct {
 				return ord(want[i], want[j])
 			})
 			if !reflect.DeepEqual(have, want) {
-				t.Errorf("repos: %s", cmp.Diff(have, want))
+				t.Errorf("repos (-want +got): %s", cmp.Diff(want, have))
 			}
 		}
 	},
@@ -417,7 +417,7 @@ var Assert = struct {
 			// Exclude auto-generated IDs from equality tests
 			have = append(ExternalServices{}, have...).With(Opt.ExternalServiceID(0))
 			if !reflect.DeepEqual(have, want) {
-				t.Errorf("external services: %s", cmp.Diff(have, want))
+				t.Errorf("external services (-want +got): %s", cmp.Diff(want, have))
 			}
 		}
 	},
@@ -429,7 +429,7 @@ var Assert = struct {
 				return ord(want[i], want[j])
 			})
 			if !reflect.DeepEqual(have, want) {
-				t.Errorf("external services: %s", cmp.Diff(have, want))
+				t.Errorf("external services (-want +got): %s", cmp.Diff(want, have))
 			}
 		}
 	},


### PR DESCRIPTION
Minor change to improve readability when tests fail. Put order so that it is consistent with the rest of the codebase.

Also removed a test case that @unknwon noticed was a duplicate.