### PR TITLE
support previewing existing campaign plans

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -301,6 +301,8 @@ type CampaignPlanResolver interface {
 	Status(ctx context.Context) (BackgroundProcessStatus, error)
 
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
+
+	PreviewURL() string
 }
 
 type PreviewFileDiff interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -511,6 +511,9 @@ type CampaignPlan implements Node {
 
     # The changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!
+
+    # The URL where the plan can be previewed and a campaign can be created from it.
+    previewURL: String!
 }
 
 # A paginated list of repository diffs committed to git.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -518,6 +518,9 @@ type CampaignPlan implements Node {
 
     # The changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!
+
+    # The URL where the plan can be previewed and a campaign can be created from it.
+    previewURL: String!
 }
 
 # A paginated list of repository diffs committed to git.

--- a/enterprise/internal/a8n/resolvers/campaign_plans.go
+++ b/enterprise/internal/a8n/resolvers/campaign_plans.go
@@ -6,11 +6,13 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -62,6 +64,14 @@ func (r *campaignPlanResolver) Changesets(
 			OnlyWithDiff:   true,
 		},
 	}
+}
+
+func (r *campaignPlanResolver) PreviewURL() string {
+	u := globals.ExternalURL().ResolveReference(&url.URL{Path: "/campaigns/new"})
+	q := url.Values{}
+	q.Set("plan", string(r.ID()))
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 type campaignJobsConnectionResolver struct {

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -955,6 +955,7 @@ type CampaignPlan struct {
 	Changesets   struct {
 		Nodes []ChangesetPlan
 	}
+	PreviewURL string
 }
 
 func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
@@ -1089,6 +1090,7 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
                 }
 			  }
             }
+            previewURL
           }
         }
       }
@@ -1121,6 +1123,10 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 		}
 		if !cmp.Equal(result.Changesets.Nodes, wantChangesets) {
 			t.Error("wrong changesets", cmp.Diff(result.Changesets.Nodes, wantChangesets))
+		}
+
+		if have, want := result.PreviewURL, "http://example.com/campaigns/new?plan=Q2FtcGFpZ25QbGFuOjE%3D"; have != want {
+			t.Fatalf("have PreviewURL %q, want %q", have, want)
 		}
 	})
 }


### PR DESCRIPTION
Adds a new GraphQL API field `CampaignPlan.previewURL` that returns a URL to the CampaignDetails page (`/campaigns/new?plan=...`) that shows the diffs and changesets for an existing campaign plan.

This makes it so that API clients (such as the `src` CLI) can create campaign plans programmatically (eg using `createCampaignPlanFromPatches`) but still allow users to visually preview them before creating the campaign.