### PR TITLE
bitbucketserver: Documentation for archived label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Experimental feature flag `BitbucketServerFastPerm` can be enabled to speed up fetching ACL data from Bitbucket Server instances. This requires [Bitbucket Server Sourcegraph plugin](https://github.com/sourcegraph/bitbucket-server-plugin) to be installed.
+- Bitbucket Server repositories with the label `archived` can be excluded from search with `archived:no` [syntax](https://docs.sourcegraph.com/user/search/queries). [#5494](https://github.com/sourcegraph/sourcegraph/issues/5494)
 
 ### Changed
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -34,6 +34,10 @@ Bitbucket Server versions older than v5.5 require specifying a less secure usern
 
 Sourcegraph by default clones repositories from your Bitbucket Server via HTTP(S), using the access token or account credentials you provide in the configuration. The [`username`](bitbucket_server.md#configuration) field is always used when cloning, so it is required.
 
+## Repository labels
+
+Sourcegraph will mark repositories as archived if they have the `archived` label on Bitbucket Server. You can exclude these repositories in search with `archived:no` [search syntax](../../user/search/queries.md).
+
 ## Configuration
 
 Bitbucket Server external service connections support the following configuration options, which are specified in the JSON editor in the site admin external services area.


### PR DESCRIPTION
Follow-up of https://github.com/sourcegraph/sourcegraph/pull/7284

Part of https://github.com/sourcegraph/sourcegraph/issues/5494