### PR TITLE
Fix GitLab file actions spacing issue

### DIFF
--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -49,6 +49,10 @@ export function createFileActionsToolbarMount(codeView: HTMLElement): HTMLElemen
         throw new Error('Could not find GitHub file actions with selector .file-actions')
     }
 
+    // Add a class to the .file-actions element, so that we can reliably match it in
+    // stylesheets without bleeding CSS to other code hosts (GitLab also uses .file-actions elements).
+    fileActions.classList.add('sg-github-file-actions')
+
     // Old GitHub Enterprise PR views have a "☑ show comments" text that we want to insert *after*
     const showCommentsElement = codeView.querySelector('.show-file-notes')
     if (showCommentsElement) {

--- a/browser/src/libs/github/style.scss
+++ b/browser/src/libs/github/style.scss
@@ -20,7 +20,7 @@
 
 // This naturally only has one element but we add the toolbar mount
 // so we need to make sure they don't stack
-.file-actions {
+.sg-github-file-actions {
     display: flex;
 }
 


### PR DESCRIPTION
GitLab reported that the Sourcegraph native integration messes up the spacing in their .file-actions toolbar: https://gitlab.com/gitlab-org/gitlab/issues/118445#note_260782106

This is due to a CSS rule in the _GitHub_ styles packaged in the browser extension / native integration, applying `display: flex` to `.file-actions` elements, which unfortunately also matches elements on GitLab.

Since I did not find a reasonable way to unambigually match `.file-actions` on GitHub only, I resorted to adding a class to it so that we can match it in our GitHub stylesheets without bleeding CSS to GitLab.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
