### PR TITLE
LSIF: Do not return an LSIF resolver when the dump does not exist.

### DIFF
--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -211,6 +211,10 @@ func (r *Resolver) LSIF(ctx context.Context, args *graphqlbackend.LSIFQueryArgs)
 		return nil, err
 	}
 
+	if dump == nil {
+		return nil, nil
+	}
+
 	return &lsifQueryResolver{
 		repoName: args.RepoName,
 		commit:   args.Commit,


### PR DESCRIPTION
The exists endpoint returns a null dump when one is not suitable for use. Not checking this condition causes resolvers to deference the nil dump value.