### PR TITLE
Eslint autosave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,4 +75,7 @@
       "changeProcessCWD": true,
     },
   ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,5 +77,4 @@
       "changeProcessCWD": true,
     },
   ],
-  "go.inferGopath": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,7 +40,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.packageManager": "yarn",
   "eslint.lintTask.enable": false,
-  "eslint.autoFixOnSave": true,
   "eslint.validate": [
     "javascript",
     "javascriptreact",
@@ -53,6 +52,9 @@
       "autoFix": true,
     },
   ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+  },
   "eslint.workingDirectories": [
     {
       "directory": "dev/release",
@@ -75,7 +77,5 @@
       "changeProcessCWD": true,
     },
   ],
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
+  "go.inferGopath": false,
 }


### PR DESCRIPTION
The `eslint.autoFixOnSave` setting is now deprecated and replaced with a new setting: `"editor.codeActionsOnSave": {
    "source.fixAll.eslint": true,
  }`