### PR TITLE
frontend: Do not warn if sync took longer than 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)
 - We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
 - Show errors on repository settings page when repo-updater is down. [#3593](https://github.com/sourcegraph/sourcegraph/issues/3593)
+- Remove benign warning that verifying config took more than 10s when updating or saving an external service. [#7176](https://github.com/sourcegraph/sourcegraph/issues/7176)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
@@ -103,6 +104,11 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
 
 // Eagerly trigger a repo-updater sync.
 func syncExternalService(ctx context.Context, svc *types.ExternalService) error {
+	// Only give 5s to validate external service sync. Usually if there is a
+	// problem it fails sooner.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	_, err := repoupdater.DefaultClient.SyncExternalService(ctx, api.ExternalService{
 		ID:          svc.ID,
 		Kind:        svc.Kind,
@@ -112,7 +118,7 @@ func syncExternalService(ctx context.Context, svc *types.ExternalService) error 
 		UpdatedAt:   svc.UpdatedAt,
 		DeletedAt:   svc.DeletedAt,
 	})
-	if err != nil {
+	if err != nil && ctx.Err() == nil {
 		return err
 	}
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -304,78 +304,69 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 
 	s.Syncer.TriggerSync()
 
-	errch := make(chan error, 1)
-	go func() {
-		if req.ExternalService.DeletedAt != nil {
-			// We don't need to check deleted services.
-			errch <- nil
-			return
+	err := externalServiceValidate(ctx, &req)
+	if err == github.ErrIncompleteResults {
+		log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		syncResult := &protocol.ExternalServiceSyncResult{
+			ExternalService: req.ExternalService,
+			Error:           err.Error(),
 		}
-
-		src, err := repos.NewSource(&repos.ExternalService{
-			ID:          req.ExternalService.ID,
-			Kind:        req.ExternalService.Kind,
-			DisplayName: req.ExternalService.DisplayName,
-			Config:      req.ExternalService.Config,
-		}, httpcli.NewHTTPClientFactory())
-		if err != nil {
-			errch <- err
-			return
-		}
-
-		results := make(chan repos.SourceResult)
-
-		go func() {
-			src.ListRepos(ctx, results)
-			close(results)
-		}()
-
-		err = nil
-		for res := range results {
-			if res.Err != nil {
-				err = res.Err
-				// Send error to user before waiting for all results, but drain
-				// the rest of the results to not leak a blocked goroutine
-				go func() {
-					for res = range results {
-					}
-				}()
-				break
-			}
-		}
-
-		if err != nil && ctx.Err() != nil {
-			// ignore if we took too long
-			err = nil
-		}
-
-		errch <- err
-	}()
-
-	select {
-	case err := <-errch:
-		switch {
-		case err == nil:
-			log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)
-			respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
-				ExternalService: req.ExternalService,
-			})
-		case err == github.ErrIncompleteResults:
-			log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
-			syncResult := &protocol.ExternalServiceSyncResult{
-				ExternalService: req.ExternalService,
-				Error:           err.Error(),
-			}
-			respond(w, http.StatusOK, syncResult)
-		default:
-			log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
-			respond(w, http.StatusInternalServerError, err)
-		}
-
-	case <-ctx.Done():
+		respond(w, http.StatusOK, syncResult)
+		return
+	} else if ctx.Err() != nil {
 		// client is gone
 		return
+	} else if err != nil {
+		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		respond(w, http.StatusInternalServerError, err)
+		return
 	}
+
+	log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)
+	respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
+		ExternalService: req.ExternalService,
+	})
+}
+
+func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceSyncRequest) error {
+	if req.ExternalService.DeletedAt != nil {
+		// We don't need to check deleted services.
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	src, err := repos.NewSource(&repos.ExternalService{
+		ID:          req.ExternalService.ID,
+		Kind:        req.ExternalService.Kind,
+		DisplayName: req.ExternalService.DisplayName,
+		Config:      req.ExternalService.Config,
+	}, httpcli.NewHTTPClientFactory())
+	if err != nil {
+		return err
+	}
+
+	results := make(chan repos.SourceResult)
+
+	go func() {
+		src.ListRepos(ctx, results)
+		close(results)
+	}()
+
+	for res := range results {
+		if res.Err != nil {
+			// Send error to user before waiting for all results, but drain
+			// the rest of the results to not leak a blocked goroutine
+			go func() {
+				for range results {
+				}
+			}()
+			return res.Err
+		}
+	}
+
+	return nil
 }
 
 var mockRepoLookup func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -372,12 +372,6 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 			respond(w, http.StatusInternalServerError, err)
 		}
 
-	case <-time.After(10 * time.Second):
-		respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
-			ExternalService: req.ExternalService,
-			Error:           "warning: took longer than 10s to verify config against code host. Please monitor repo-updater logs.",
-		})
-
 	case <-ctx.Done():
 		// client is gone
 		return


### PR DESCRIPTION
This warning just causes confusion. If a sync fails, it will usually
fail quickly (eg bad token). So additionally we lower the timeout to 5s, and
don't warn if we go over 5s.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7176