### PR TITLE
graphqlbackend: Quieten test output unless verbose

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"flag"
+	"io/ioutil"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -69,6 +71,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {
 		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))
+		log.SetOutput(ioutil.Discard)
 	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Currently we log all the graphql requests in tests since they do not have the
graphql name set. It is useful to test this code path, so instead of setting
the name I decided to log to /dev/null if verbose is not set.
