### PR TITLE
web: Handle missing partial graphql response when repo-updater is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)
 - We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
+- Show errors on repository settings page when repo-updater is down. [#3593](https://github.com/sourcegraph/sourcegraph/issues/3593)
 
 ### Removed
 

--- a/web/src/repo/settings/backend.tsx
+++ b/web/src/repo/settings/backend.tsx
@@ -46,7 +46,7 @@ export function fetchRepository(name: string): Observable<GQL.IRepository> {
         { name }
     ).pipe(
         map(({ data, errors }) => {
-            if (!data || !data.repository) {
+            if (!data || !data.repository || !data.repository.externalServices) {
                 throw createAggregateError(errors)
             }
             return data.repository


### PR DESCRIPTION
Previously we would fail later in our app with "Cannot read property nodes of
null". This check now passes on the actual error.

Test Plan: Killed repo-updater and observing an error about failing to contact
repo-updater on the settings page.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3593