### PR TITLE
web: Use passed in href instead of global

### DIFF
--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -64,10 +64,10 @@ function formatLineOrPositionOrRange(lpr: LineOrPositionOrRange): string {
  * @param href The URL whose revision should be replaced.
  */
 export function replaceRevisionInURL(href: string, newRev: string): string {
-    const parsed = parseBrowserRepoURL(window.location.href)
+    const parsed = parseBrowserRepoURL(href)
     const repoRev = `/${encodeRepoRev(parsed.repoName, parsed.rev)}`
 
-    const u = new URL(window.location.href)
+    const u = new URL(href)
     u.pathname = `/${encodeRepoRev(parsed.repoName, newRev)}${u.pathname.slice(repoRev.length)}`
     return `${u.pathname}${u.search}${u.hash}`
 }


### PR DESCRIPTION
Noticed this while reading some code, we are using the global href instead of
the href passed into the function.
