### PR TITLE
blob: Add button to download file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Experimental feature flag `BitbucketServerFastPerm` can be enabled to speed up fetching ACL data from Bitbucket Server instances. This requires [Bitbucket Server Sourcegraph plugin](https://github.com/sourcegraph/bitbucket-server-plugin) to be installed.
 - Bitbucket Server repositories with the label `archived` can be excluded from search with `archived:no` [syntax](https://docs.sourcegraph.com/user/search/queries). [#5494](https://github.com/sourcegraph/sourcegraph/issues/5494)
+- Add button to download file in code view. [#5478](https://github.com/sourcegraph/sourcegraph/issues/5478)
 
 ### Changed
 

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -32,6 +32,7 @@ import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { Blob } from './Blob'
 import { BlobPanel } from './panel/BlobPanel'
+import { GoToRawAction } from './GoToRawAction'
 import { RenderedFile } from './RenderedFile'
 import { ThemeProps } from '../../../../shared/src/theme'
 
@@ -247,6 +248,19 @@ export class BlobPage extends React.PureComponent<Props, State> {
                         repoHeaderContributionsLifecycleProps={this.props.repoHeaderContributionsLifecycleProps}
                     />
                 )}
+                <RepoHeaderContributionPortal
+                    position="right"
+                    priority={30}
+                    element={
+                        <GoToRawAction
+                            key="raw-action"
+                            repoName={this.props.repoName}
+                            rev={this.props.rev}
+                            filePath={this.props.filePath}
+                        />
+                    }
+                    repoHeaderContributionsLifecycleProps={this.props.repoHeaderContributionsLifecycleProps}
+                />
             </>
         )
 

--- a/web/src/repo/blob/GoToRawAction.tsx
+++ b/web/src/repo/blob/GoToRawAction.tsx
@@ -1,6 +1,5 @@
 import FileDownloadIcon from 'mdi-react/FileDownloadIcon'
 import * as React from 'react'
-import { LinkOrButton } from '../../../../shared/src/components/LinkOrButton'
 import { encodeRepoRev } from '../../../../shared/src/util/url'
 
 interface Props {
@@ -16,9 +15,9 @@ export class GoToRawAction extends React.PureComponent<Props> {
     public render(): JSX.Element {
         const to = `/${encodeRepoRev(this.props.repoName, this.props.rev)}/-/raw/${this.props.filePath}`
         return (
-            <LinkOrButton to={to} data-tooltip="Raw (download file)">
+            <a href={to} className="nav-link" data-tooltip="Raw (download file)" download={true}>
                 <FileDownloadIcon className="icon-inline" />
-            </LinkOrButton>
+            </a>
         )
     }
 }

--- a/web/src/repo/blob/GoToRawAction.tsx
+++ b/web/src/repo/blob/GoToRawAction.tsx
@@ -1,0 +1,24 @@
+import FileDownloadIcon from 'mdi-react/FileDownloadIcon'
+import * as React from 'react'
+import { LinkOrButton } from '../../../../shared/src/components/LinkOrButton'
+import { encodeRepoRev } from '../../../../shared/src/util/url'
+
+interface Props {
+    repoName: string
+    rev?: string
+    filePath: string
+}
+
+/**
+ * A repository header action that replaces the blob in the URL with the raw URL.
+ */
+export class GoToRawAction extends React.PureComponent<Props> {
+    public render(): JSX.Element {
+        const to = `/${encodeRepoRev(this.props.repoName, this.props.rev)}/-/raw/${this.props.filePath}`
+        return (
+            <LinkOrButton to={to} data-tooltip="Raw (download file)">
+                <FileDownloadIcon className="icon-inline" />
+            </LinkOrButton>
+        )
+    }
+}


### PR DESCRIPTION
This uses our existing "raw" endpoint to download a file. It is displayed as
part of the BlobPage.

<img width="285" alt="image" src="https://user-images.githubusercontent.com/187831/71212126-5f37ad80-22b9-11ea-81b5-c5b3a3e089f9.png">

Fixes https://github.com/sourcegraph/sourcegraph/issues/5478