### PR TITLE
a8n: Add ability to update Campaign's CampaignPlan in UpdateCampaign

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -34,6 +34,7 @@ type UpdateCampaignArgs struct {
 		ID          graphql.ID
 		Name        *string
 		Description *string
+		Plan        *graphql.ID
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -497,6 +497,13 @@ input UpdateCampaignInput {
 
     # The updated description of the campaign as Markdown (if non-null).
     description: String
+
+    # An optional reference to a completed CampaignPlan that was previewed
+    # before updating the Campaign.
+    # If set, the Campaign's changesets will be updated to the Changesets of the given CampaignPlan.
+    # The changesetCreationStatus will be updated accordingly while possibly
+    # new ExternalChangesets are created/updated/closed on the codehosts.
+    plan: ID
 }
 
 # A preview of changes that will be applied by a campaign.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -504,6 +504,13 @@ input UpdateCampaignInput {
 
     # The updated description of the campaign as Markdown (if non-null).
     description: String
+
+    # An optional reference to a completed CampaignPlan that was previewed
+    # before updating the Campaign.
+    # If set, the Campaign's changesets will be updated to the Changesets of the given CampaignPlan.
+    # The changesetCreationStatus will be updated accordingly while possibly
+    # new ExternalChangesets are created/updated/closed on the codehosts.
+    plan: ID
 }
 
 # A preview of changes that will be applied by a campaign.

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -152,30 +151,8 @@ func TestBitbucketCloudSource_MakeRepo(t *testing.T) {
 			for _, r := range repos {
 				got = append(got, s.makeRepo(r))
 			}
-			actual, err := json.MarshalIndent(got, "", "  ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			golden := filepath.Join("testdata", "bitbucketcloud-repos-"+name+".golden")
-			if update(name) {
-				err := ioutil.WriteFile(golden, actual, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			expect, err := ioutil.ReadFile(golden)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(actual, expect) {
-				d, err := testutil.Diff(string(actual), string(expect))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Error(d)
-			}
+			path := filepath.Join("testdata", "bitbucketcloud-repos-"+name+".golden")
+			testutil.AssertGolden(t, path, update(name), got)
 		})
 	}
 }
@@ -253,30 +230,9 @@ func TestBitbucketCloudSource_Exclude(t *testing.T) {
 					got.Include = append(got.Include, r.FullName)
 				}
 			}
-			actual, err := json.MarshalIndent(got, "", "  ")
-			if err != nil {
-				t.Fatal(err)
-			}
 
-			golden := filepath.Join("testdata", "bitbucketcloud-repos-exclude-"+name+".golden")
-			if update(name) {
-				err := ioutil.WriteFile(golden, actual, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			expect, err := ioutil.ReadFile(golden)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(actual, expect) {
-				d, err := testutil.Diff(string(actual), string(expect))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Error(d)
-			}
+			path := filepath.Join("testdata", "bitbucketcloud-repos-exclude-"+name+".golden")
+			testutil.AssertGolden(t, path, update(name), got)
 		})
 	}
 }

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -282,28 +282,7 @@ func TestBitbucketServerSource_LoadChangesets(t *testing.T) {
 				meta = append(meta, cs.Changeset.Metadata.(*bitbucketserver.PullRequest))
 			}
 
-			data, err := json.MarshalIndent(meta, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), meta)
 		})
 	}
 }
@@ -413,28 +392,7 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 			}
 
 			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
-			data, err := json.MarshalIndent(pr, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }
@@ -503,28 +461,7 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 			}
 
 			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
-			data, err := json.MarshalIndent(pr, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -66,30 +64,9 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 			for _, r := range repos {
 				got = append(got, s.makeRepo(r, false))
 			}
-			actual, err := json.MarshalIndent(got, "", "  ")
-			if err != nil {
-				t.Fatal(err)
-			}
 
-			golden := filepath.Join("testdata", "bitbucketserver-repos-"+name+".golden")
-			if update(name) {
-				err := ioutil.WriteFile(golden, actual, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			expect, err := ioutil.ReadFile(golden)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(actual, expect) {
-				d, err := testutil.Diff(string(actual), string(expect))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Error(d)
-			}
+			path := filepath.Join("testdata", "bitbucketserver-repos-"+name+".golden")
+			testutil.AssertGolden(t, path, update(name), got)
 		})
 	}
 }
@@ -172,30 +149,9 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 					got.Include = append(got.Include, name)
 				}
 			}
-			actual, err := json.MarshalIndent(got, "", "  ")
-			if err != nil {
-				t.Fatal(err)
-			}
 
-			golden := filepath.Join("testdata", "bitbucketserver-repos-exclude-"+name+".golden")
-			if update(name) {
-				err := ioutil.WriteFile(golden, actual, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			expect, err := ioutil.ReadFile(golden)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(actual, expect) {
-				d, err := testutil.Diff(string(actual), string(expect))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Error(d)
-			}
+			path := filepath.Join("testdata", "bitbucketserver-repos-exclude-"+name+".golden")
+			testutil.AssertGolden(t, path, update(name), got)
 		})
 	}
 }

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -324,9 +324,10 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name string
-		cs   *Changeset
-		err  string
+		name   string
+		cs     *Changeset
+		err    string
+		exists bool
 	}{
 		{
 			name: "abbreviated refs",
@@ -362,7 +363,8 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 			},
 			// CreateChangeset is idempotent so if the PR already exists
 			// it is not an error
-			err: "",
+			err:    "",
+			exists: true,
 		},
 	}
 
@@ -397,13 +399,17 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 
 			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
 
-			err = bbsSrc.CreateChangeset(ctx, tc.cs)
+			err, exists := bbsSrc.CreateChangeset(ctx, tc.cs)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}
 
 			if err != nil {
 				return
+			}
+
+			if have, want := exists, tc.exists; have != want {
+				t.Errorf("exists:\nhave: %t\nwant: %t", have, want)
 			}
 
 			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -2,9 +2,7 @@ package repos
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -14,12 +12,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -125,28 +123,8 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 			if !ok {
 				t.Fatal("Metadata does not contain PR")
 			}
-			data, err := json.MarshalIndent(pr, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
 
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }
@@ -213,28 +191,7 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 			}
 
 			pr := tc.cs.Changeset.Metadata.(*github.PullRequest)
-			data, err := json.MarshalIndent(pr, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }
@@ -304,28 +261,7 @@ func TestGithubSource_UpdateChangeset(t *testing.T) {
 			}
 
 			pr := tc.cs.Changeset.Metadata.(*github.PullRequest)
-			data, err := json.MarshalIndent(pr, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }
@@ -403,28 +339,7 @@ func TestGithubSource_LoadChangesets(t *testing.T) {
 				meta = append(meta, cs.Changeset.Metadata.(*github.PullRequest))
 			}
 
-			data, err := json.MarshalIndent(meta, " ", " ")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			path := "testdata/golden/" + tc.name
-			if update(tc.name) {
-				if err = ioutil.WriteFile(path, data, 0640); err != nil {
-					t.Fatalf("failed to update golden file %q: %s", path, err)
-				}
-			}
-
-			golden, err := ioutil.ReadFile(path)
-			if err != nil {
-				t.Fatalf("failed to read golden file %q: %s", path, err)
-			}
-
-			if have, want := string(data), string(golden); have != want {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(have, want, false)
-				t.Error(dmp.DiffPrettyText(diffs))
-			}
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), meta)
 		})
 	}
 }

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -239,6 +239,97 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 	}
 }
 
+func TestGithubSource_UpdateChangeset(t *testing.T) {
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs: &Changeset{
+				Title:   "This is a new title",
+				Body:    "This is a new body",
+				BaseRef: "refs/heads/master",
+				Changeset: &a8n.Changeset{
+					Metadata: &github.PullRequest{
+						ID: "MDExOlB1bGxSZXF1ZXN0MzYwNTI5NzI0",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "GithubSource_UpdateChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+
+		t.Run(tc.name, func(t *testing.T) {
+			// The GithubSource uses the github.Client under the hood, which
+			// uses rcache, a caching layer that uses Redis.
+			// We need to clear the cache before we run the tests
+			rcache.SetupForTest(t)
+
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &ExternalService{
+				Kind: "GITHUB",
+				Config: marshalJSON(t, &schema.GitHubConnection{
+					Url:   "https://github.com",
+					Token: os.Getenv("GITHUB_TOKEN"),
+				}),
+			}
+
+			githubSrc, err := NewGithubSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			err = githubSrc.UpdateChangeset(ctx, tc.cs)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*github.PullRequest)
+			data, err := json.MarshalIndent(pr, " ", " ")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			path := "testdata/golden/" + tc.name
+			if update(tc.name) {
+				if err = ioutil.WriteFile(path, data, 0640); err != nil {
+					t.Fatalf("failed to update golden file %q: %s", path, err)
+				}
+			}
+
+			golden, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read golden file %q: %s", path, err)
+			}
+
+			if have, want := string(data), string(golden); have != want {
+				dmp := diffmatchpatch.New()
+				diffs := dmp.DiffMain(have, want, false)
+				t.Error(dmp.DiffPrettyText(diffs))
+			}
+		})
+	}
+}
+
 func TestGithubSource_LoadChangesets(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -42,9 +42,10 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name string
-		cs   *Changeset
-		err  string
+		name   string
+		cs     *Changeset
+		err    string
+		exists bool
 	}{
 		{
 			name: "success",
@@ -68,7 +69,8 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 				Changeset: &a8n.Changeset{},
 			},
 			// If PR already exists we'll just return it, no error
-			err: "",
+			err:    "",
+			exists: true,
 		},
 	}
 
@@ -106,13 +108,17 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			err = githubSrc.CreateChangeset(ctx, tc.cs)
+			err, exists := githubSrc.CreateChangeset(ctx, tc.cs)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}
 
 			if err != nil {
 				return
+			}
+
+			if have, want := exists, tc.exists; have != want {
+				t.Errorf("exists:\nhave: %t\nwant: %t", have, want)
 			}
 
 			pr, ok := tc.cs.Changeset.Metadata.(*github.PullRequest)

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -94,12 +94,18 @@ type ChangesetSource interface {
 	// the returned slice.
 	LoadChangesets(context.Context, ...*Changeset) error
 	// CreateChangeset will create the Changeset on the source. If it already
-	// exists, *Changeset will be populated.
-	CreateChangeset(context.Context, *Changeset) error
+	// exists, *Changeset will be populated and the second return value will be
+	// true.
+	CreateChangeset(context.Context, *Changeset) (error, bool)
 	// CloseChangeset will close the Changeset on the source, where "close"
 	// means the appropriate final state on the codehost (e.g. "declined" on
 	// Bitbucket Server).
 	CloseChangeset(context.Context, *Changeset) error
+}
+
+// A UpdateChangesetSource can update Changesets.
+type UpdateChangesetSource interface {
+	UpdateChangeset(context.Context, *Changeset) error
 }
 
 // ChangesetsNotFoundError is returned by LoadChangesets if any of the passed

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-all.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-all.golden
@@ -1,8 +1,8 @@
 {
   "Include": null,
   "Exclude": [
-    "sg/go-langserver",
-    "sg/python-langserver",
-    "sg/python-langserver-fork"
+   "sg/go-langserver",
+   "sg/python-langserver",
+   "sg/python-langserver-fork"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-name.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-name.golden
@@ -1,9 +1,9 @@
 {
   "Include": [
-    "sg/python-langserver",
-    "sg/python-langserver-fork"
+   "sg/python-langserver",
+   "sg/python-langserver-fork"
   ],
   "Exclude": [
-    "sg/go-langserver"
+   "sg/go-langserver"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-none.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-none.golden
@@ -1,8 +1,8 @@
 {
   "Include": [
-    "sg/go-langserver",
-    "sg/python-langserver",
-    "sg/python-langserver-fork"
+   "sg/go-langserver",
+   "sg/python-langserver",
+   "sg/python-langserver-fork"
   ],
   "Exclude": null
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-pattern.golden
@@ -1,9 +1,9 @@
 {
   "Include": [
-    "sg/go-langserver",
-    "sg/python-langserver"
+   "sg/go-langserver",
+   "sg/python-langserver"
   ],
   "Exclude": [
-    "sg/python-langserver-fork"
+   "sg/python-langserver-fork"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-uuid.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-exclude-uuid.golden
@@ -1,9 +1,9 @@
 {
   "Include": [
-    "sg/go-langserver",
-    "sg/python-langserver-fork"
+   "sg/go-langserver",
+   "sg/python-langserver-fork"
   ],
   "Exclude": [
-    "sg/python-langserver"
+   "sg/python-langserver"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-path-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-path-pattern.golden
@@ -1,164 +1,164 @@
 [
   {
-    "ID": 0,
-    "Name": "bb/sg/go-langserver",
-    "URI": "bitbucket.org/sg/go-langserver",
-    "Description": "Go Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "go-langserver",
-      "name": "go-langserver",
-      "full_name": "sg/go-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "scm": "git",
-      "description": "Go Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/go-langserver"
-        }
-      }
+   "ID": 0,
+   "Name": "bb/sg/go-langserver",
+   "URI": "bitbucket.org/sg/go-langserver",
+   "Description": "Go Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/sg/python-langserver",
-    "URI": "bitbucket.org/sg/python-langserver",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "name": "python-langserver",
-      "full_name": "sg/python-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver"
-        }
-      }
-    }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/sg/python-langserver-fork",
-    "URI": "bitbucket.org/sg/python-langserver-fork",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "name": "python-langserver-fork",
-      "full_name": "sg/python-langserver-fork",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": {
-        "slug": "",
-        "name": "python-langserver",
-        "full_name": "sg/python-langserver",
-        "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-        "scm": "",
-        "description": "",
-        "parent": null,
-        "is_private": false,
-        "links": {
-          "clone": null,
-          "html": {
-            "href": "https://bitbucket.org/sg/python-langserver"
-          }
-        }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "name": "go-langserver",
+    "full_name": "sg/go-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "scm": "git",
+    "description": "Go Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/go-langserver.git",
+       "name": "ssh"
       },
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver-fork.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver-fork"
-        }
+      {
+       "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
+       "name": "https"
       }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/go-langserver"
+     }
     }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/sg/python-langserver",
+   "URI": "bitbucket.org/sg/python-langserver",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "name": "python-langserver",
+    "full_name": "sg/python-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver"
+     }
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/sg/python-langserver-fork",
+   "URI": "bitbucket.org/sg/python-langserver-fork",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "name": "python-langserver-fork",
+    "full_name": "sg/python-langserver-fork",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": {
+     "slug": "",
+     "name": "python-langserver",
+     "full_name": "sg/python-langserver",
+     "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+     "scm": "",
+     "description": "",
+     "parent": null,
+     "is_private": false,
+     "links": {
+      "clone": null,
+      "html": {
+       "href": "https://bitbucket.org/sg/python-langserver"
+      }
+     }
+    },
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver-fork.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver-fork"
+     }
+    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-simple.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-simple.golden
@@ -1,164 +1,164 @@
 [
   {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/go-langserver",
-    "URI": "bitbucket.org/sg/go-langserver",
-    "Description": "Go Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "go-langserver",
-      "name": "go-langserver",
-      "full_name": "sg/go-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "scm": "git",
-      "description": "Go Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/go-langserver"
-        }
-      }
+   "ID": 0,
+   "Name": "bitbucket.org/sg/go-langserver",
+   "URI": "bitbucket.org/sg/go-langserver",
+   "Description": "Go Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/python-langserver",
-    "URI": "bitbucket.org/sg/python-langserver",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "name": "python-langserver",
-      "full_name": "sg/python-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver"
-        }
-      }
-    }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/python-langserver-fork",
-    "URI": "bitbucket.org/sg/python-langserver-fork",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "name": "python-langserver-fork",
-      "full_name": "sg/python-langserver-fork",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": {
-        "slug": "",
-        "name": "python-langserver",
-        "full_name": "sg/python-langserver",
-        "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-        "scm": "",
-        "description": "",
-        "parent": null,
-        "is_private": false,
-        "links": {
-          "clone": null,
-          "html": {
-            "href": "https://bitbucket.org/sg/python-langserver"
-          }
-        }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "name": "go-langserver",
+    "full_name": "sg/go-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "scm": "git",
+    "description": "Go Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/go-langserver.git",
+       "name": "ssh"
       },
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver-fork.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver-fork"
-        }
+      {
+       "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
+       "name": "https"
       }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/go-langserver"
+     }
     }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.org/sg/python-langserver",
+   "URI": "bitbucket.org/sg/python-langserver",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "name": "python-langserver",
+    "full_name": "sg/python-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver"
+     }
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.org/sg/python-langserver-fork",
+   "URI": "bitbucket.org/sg/python-langserver-fork",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "name": "python-langserver-fork",
+    "full_name": "sg/python-langserver-fork",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": {
+     "slug": "",
+     "name": "python-langserver",
+     "full_name": "sg/python-langserver",
+     "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+     "scm": "",
+     "description": "",
+     "parent": null,
+     "is_private": false,
+     "links": {
+      "clone": null,
+      "html": {
+       "href": "https://bitbucket.org/sg/python-langserver"
+      }
+     }
+    },
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver-fork.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver-fork"
+     }
+    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-ssh.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketcloud-repos-ssh.golden
@@ -1,164 +1,164 @@
 [
   {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/go-langserver",
-    "URI": "bitbucket.org/sg/go-langserver",
-    "Description": "Go Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "git@https://bitbucket.org:sg/go-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "go-langserver",
-      "name": "go-langserver",
-      "full_name": "sg/go-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
-      "scm": "git",
-      "description": "Go Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/go-langserver"
-        }
-      }
+   "ID": 0,
+   "Name": "bitbucket.org/sg/go-langserver",
+   "URI": "bitbucket.org/sg/go-langserver",
+   "Description": "Go Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "git@https://bitbucket.org:sg/go-langserver.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/python-langserver",
-    "URI": "bitbucket.org/sg/python-langserver",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "git@https://bitbucket.org:sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "name": "python-langserver",
-      "full_name": "sg/python-langserver",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": null,
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver"
-        }
-      }
-    }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.org/sg/python-langserver-fork",
-    "URI": "bitbucket.org/sg/python-langserver-fork",
-    "Description": "Python Language Server",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "ServiceType": "bitbucketCloud",
-      "ServiceID": "https://bitbucket.org/"
-    },
-    "Sources": {
-      "extsvc:bitbucketcloud:1": {
-        "ID": "extsvc:bitbucketcloud:1",
-        "CloneURL": "git@https://bitbucket.org:sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "name": "python-langserver-fork",
-      "full_name": "sg/python-langserver-fork",
-      "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
-      "scm": "git",
-      "description": "Python Language Server",
-      "parent": {
-        "slug": "",
-        "name": "python-langserver",
-        "full_name": "sg/python-langserver",
-        "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
-        "scm": "",
-        "description": "",
-        "parent": null,
-        "is_private": false,
-        "links": {
-          "clone": null,
-          "html": {
-            "href": "https://bitbucket.org/sg/python-langserver"
-          }
-        }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "name": "go-langserver",
+    "full_name": "sg/go-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}",
+    "scm": "git",
+    "description": "Go Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/go-langserver.git",
+       "name": "ssh"
       },
-      "is_private": true,
-      "links": {
-        "clone": [
-          {
-            "href": "git@bitbucket.org:sg/python-langserver-fork.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
-            "name": "https"
-          }
-        ],
-        "html": {
-          "href": "https://bitbucket.org/sg/python-langserver-fork"
-        }
+      {
+       "href": "https://jchen@bitbucket.org/sg/go-langserver.git",
+       "name": "https"
       }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/go-langserver"
+     }
     }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.org/sg/python-langserver",
+   "URI": "bitbucket.org/sg/python-langserver",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "git@https://bitbucket.org:sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "name": "python-langserver",
+    "full_name": "sg/python-langserver",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": null,
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver"
+     }
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.org/sg/python-langserver-fork",
+   "URI": "bitbucket.org/sg/python-langserver-fork",
+   "Description": "Python Language Server",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "ServiceType": "bitbucketCloud",
+    "ServiceID": "https://bitbucket.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketcloud:1": {
+     "ID": "extsvc:bitbucketcloud:1",
+     "CloneURL": "git@https://bitbucket.org:sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "name": "python-langserver-fork",
+    "full_name": "sg/python-langserver-fork",
+    "uuid": "{fceb73c7-cef6-4abe-956d-e471281126be}",
+    "scm": "git",
+    "description": "Python Language Server",
+    "parent": {
+     "slug": "",
+     "name": "python-langserver",
+     "full_name": "sg/python-langserver",
+     "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+     "scm": "",
+     "description": "",
+     "parent": null,
+     "is_private": false,
+     "links": {
+      "clone": null,
+      "html": {
+       "href": "https://bitbucket.org/sg/python-langserver"
+      }
+     }
+    },
+    "is_private": true,
+    "links": {
+     "clone": [
+      {
+       "href": "git@bitbucket.org:sg/python-langserver-fork.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://jchen@bitbucket.org/sg/python-langserver-fork.git",
+       "name": "https"
+      }
+     ],
+     "html": {
+      "href": "https://bitbucket.org/sg/python-langserver-fork"
+     }
+    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-both.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-both.golden
@@ -1,11 +1,11 @@
 {
   "Include": [
-    "SG/python-langserver"
+   "SG/python-langserver"
   ],
   "Exclude": [
-    "SG/go-langserver",
-    "SG/python-langserver-fork",
-    "~KEEGAN/rgp",
-    "~KEEGAN/rgp-unavailable"
+   "SG/go-langserver",
+   "SG/python-langserver-fork",
+   "~KEEGAN/rgp",
+   "~KEEGAN/rgp-unavailable"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-id.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-id.golden
@@ -1,11 +1,11 @@
 {
   "Include": [
-    "SG/go-langserver",
-    "SG/python-langserver",
-    "SG/python-langserver-fork"
+   "SG/go-langserver",
+   "SG/python-langserver",
+   "SG/python-langserver-fork"
   ],
   "Exclude": [
-    "~KEEGAN/rgp",
-    "~KEEGAN/rgp-unavailable"
+   "~KEEGAN/rgp",
+   "~KEEGAN/rgp-unavailable"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-name.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-name.golden
@@ -1,11 +1,11 @@
 {
   "Include": [
-    "SG/go-langserver",
-    "SG/python-langserver"
+   "SG/go-langserver",
+   "SG/python-langserver"
   ],
   "Exclude": [
-    "SG/python-langserver-fork",
-    "~KEEGAN/rgp",
-    "~KEEGAN/rgp-unavailable"
+   "SG/python-langserver-fork",
+   "~KEEGAN/rgp",
+   "~KEEGAN/rgp-unavailable"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-none.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-none.golden
@@ -1,11 +1,11 @@
 {
   "Include": [
-    "SG/go-langserver",
-    "SG/python-langserver",
-    "SG/python-langserver-fork",
-    "~KEEGAN/rgp"
+   "SG/go-langserver",
+   "SG/python-langserver",
+   "SG/python-langserver-fork",
+   "~KEEGAN/rgp"
   ],
   "Exclude": [
-    "~KEEGAN/rgp-unavailable"
+   "~KEEGAN/rgp-unavailable"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-pattern.golden
@@ -1,11 +1,11 @@
 {
   "Include": [
-    "SG/go-langserver"
+   "SG/go-langserver"
   ],
   "Exclude": [
-    "SG/python-langserver",
-    "SG/python-langserver-fork",
-    "~KEEGAN/rgp",
-    "~KEEGAN/rgp-unavailable"
+   "SG/python-langserver",
+   "SG/python-langserver-fork",
+   "~KEEGAN/rgp",
+   "~KEEGAN/rgp-unavailable"
   ]
-}
+ }

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
@@ -1,373 +1,373 @@
 [
   {
-    "ID": 0,
-    "Name": "bb/SG/go-langserver",
-    "URI": "bitbucket.example.com/SG/go-langserver",
-    "Description": "go-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "1",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   "ID": 0,
+   "Name": "bb/SG/go-langserver",
+   "URI": "bitbucket.example.com/SG/go-langserver",
+   "Description": "go-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "1",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "id": 1,
+    "name": "go-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
+       "name": "http"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/SG/python-langserver",
+   "URI": "bitbucket.example.com/SG/python-langserver",
+   "Description": "python-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "2",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "id": 2,
+    "name": "python-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Metadata": {
-      "slug": "go-langserver",
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/SG/python-langserver-fork",
+   "URI": "bitbucket.example.com/SG/python-langserver-fork",
+   "Description": "python-langserver-fork",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "5",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "id": 5,
+    "name": "python-langserver-fork",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": {
+     "slug": "python-langserver",
+     "id": 2,
+     "name": "python-langserver",
+     "scmId": "git",
+     "state": "AVAILABLE",
+     "statusMessage": "Available",
+     "forkable": true,
+     "origin": null,
+     "project": {
+      "key": "SG",
       "id": 1,
-      "name": "go-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
+      "name": "sgtest",
       "public": false,
+      "type": "NORMAL",
       "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
-          }
-        ]
+       "self": [
+        {
+         "href": "https://bitbucket.example.com/projects/SG"
+        }
+       ]
       }
+     },
+     "public": false,
+     "links": {
+      "clone": [
+       {
+        "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+        "name": "ssh"
+       },
+       {
+        "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+        "name": "http"
+       }
+      ],
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+       }
+      ]
+     }
+    },
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
+      }
+     ]
     }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bb/SG/python-langserver",
-    "URI": "bitbucket.example.com/SG/python-langserver",
-    "Description": "python-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "2",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "id": 2,
-      "name": "python-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bb/~KEEGAN/rgp",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp",
+   "Description": "rgp",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     }
+   },
+   "Metadata": {
+    "slug": "rgp",
+    "id": 4,
+    "name": "rgp",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
+    }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bb/SG/python-langserver-fork",
-    "URI": "bitbucket.example.com/SG/python-langserver-fork",
-    "Description": "python-langserver-fork",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "5",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "id": 5,
-      "name": "python-langserver-fork",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": {
-        "slug": "python-langserver",
-        "id": 2,
-        "name": "python-langserver",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "origin": null,
-        "project": {
-          "key": "SG",
-          "id": 1,
-          "name": "sgtest",
-          "public": false,
-          "type": "NORMAL",
-          "links": {
-            "self": [
-              {
-                "href": "https://bitbucket.example.com/projects/SG"
-              }
-            ]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [
-            {
-              "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-              "name": "ssh"
-            },
-            {
-              "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-              "name": "http"
-            }
-          ],
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-            }
-          ]
-        }
-      },
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bb/~KEEGAN/rgp-unavailable",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
+   "Description": "rgp-unavailable",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/~KEEGAN/rgp",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp",
-    "Description": "rgp",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Metadata": {
+    "slug": "rgp-unavailable",
+    "id": 4,
+    "name": "rgp-unavailable",
+    "scmId": "git",
+    "state": "UNAVAILABLE",
+    "statusMessage": "Unavailable",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp",
-      "id": 4,
-      "name": "rgp",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
       },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/~KEEGAN/rgp-unavailable",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
-    "Description": "rgp-unavailable",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp-unavailable",
-      "id": 4,
-      "name": "rgp-unavailable",
-      "scmId": "git",
-      "state": "UNAVAILABLE",
-      "statusMessage": "Unavailable",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
-      }
-    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-simple.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-simple.golden
@@ -1,373 +1,373 @@
 [
   {
-    "ID": 0,
-    "Name": "/SG/go-langserver",
-    "URI": "/SG/go-langserver",
-    "Description": "go-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "1",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+   "ID": 0,
+   "Name": "/SG/go-langserver",
+   "URI": "/SG/go-langserver",
+   "Description": "go-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "1",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "id": 1,
+    "name": "go-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
+       "name": "http"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "/SG/python-langserver",
+   "URI": "/SG/python-langserver",
+   "Description": "python-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "2",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "id": 2,
+    "name": "python-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Metadata": {
-      "slug": "go-langserver",
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "/SG/python-langserver-fork",
+   "URI": "/SG/python-langserver-fork",
+   "Description": "python-langserver-fork",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "5",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "id": 5,
+    "name": "python-langserver-fork",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": {
+     "slug": "python-langserver",
+     "id": 2,
+     "name": "python-langserver",
+     "scmId": "git",
+     "state": "AVAILABLE",
+     "statusMessage": "Available",
+     "forkable": true,
+     "origin": null,
+     "project": {
+      "key": "SG",
       "id": 1,
-      "name": "go-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
+      "name": "sgtest",
       "public": false,
+      "type": "NORMAL",
       "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
-          }
-        ]
+       "self": [
+        {
+         "href": "https://bitbucket.example.com/projects/SG"
+        }
+       ]
       }
+     },
+     "public": false,
+     "links": {
+      "clone": [
+       {
+        "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+        "name": "ssh"
+       },
+       {
+        "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+        "name": "http"
+       }
+      ],
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+       }
+      ]
+     }
+    },
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
+      }
+     ]
     }
+   }
   },
   {
-    "ID": 0,
-    "Name": "/SG/python-langserver",
-    "URI": "/SG/python-langserver",
-    "Description": "python-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "2",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "id": 2,
-      "name": "python-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "/~KEEGAN/rgp",
+   "URI": "/~KEEGAN/rgp",
+   "Description": "rgp",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     }
+   },
+   "Metadata": {
+    "slug": "rgp",
+    "id": 4,
+    "name": "rgp",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
+    }
+   }
   },
   {
-    "ID": 0,
-    "Name": "/SG/python-langserver-fork",
-    "URI": "/SG/python-langserver-fork",
-    "Description": "python-langserver-fork",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "5",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "id": 5,
-      "name": "python-langserver-fork",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": {
-        "slug": "python-langserver",
-        "id": 2,
-        "name": "python-langserver",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "origin": null,
-        "project": {
-          "key": "SG",
-          "id": 1,
-          "name": "sgtest",
-          "public": false,
-          "type": "NORMAL",
-          "links": {
-            "self": [
-              {
-                "href": "https://bitbucket.example.com/projects/SG"
-              }
-            ]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [
-            {
-              "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-              "name": "ssh"
-            },
-            {
-              "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-              "name": "http"
-            }
-          ],
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-            }
-          ]
-        }
-      },
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "/~KEEGAN/rgp-unavailable",
+   "URI": "/~KEEGAN/rgp-unavailable",
+   "Description": "rgp-unavailable",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "/~KEEGAN/rgp",
-    "URI": "/~KEEGAN/rgp",
-    "Description": "rgp",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+   },
+   "Metadata": {
+    "slug": "rgp-unavailable",
+    "id": 4,
+    "name": "rgp-unavailable",
+    "scmId": "git",
+    "state": "UNAVAILABLE",
+    "statusMessage": "Unavailable",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp",
-      "id": 4,
-      "name": "rgp",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
       },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
     }
-  },
-  {
-    "ID": 0,
-    "Name": "/~KEEGAN/rgp-unavailable",
-    "URI": "/~KEEGAN/rgp-unavailable",
-    "Description": "rgp-unavailable",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp-unavailable",
-      "id": 4,
-      "name": "rgp-unavailable",
-      "scmId": "git",
-      "state": "UNAVAILABLE",
-      "statusMessage": "Unavailable",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
-      }
-    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-ssh.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-ssh.golden
@@ -1,373 +1,373 @@
 [
   {
-    "ID": 0,
-    "Name": "bitbucket.example.com/SG/go-langserver",
-    "URI": "bitbucket.example.com/SG/go-langserver",
-    "Description": "go-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "1",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   "ID": 0,
+   "Name": "bitbucket.example.com/SG/go-langserver",
+   "URI": "bitbucket.example.com/SG/go-langserver",
+   "Description": "go-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "1",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "id": 1,
+    "name": "go-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git"
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
+       "name": "http"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.example.com/SG/python-langserver",
+   "URI": "bitbucket.example.com/SG/python-langserver",
+   "Description": "python-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "2",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "id": 2,
+    "name": "python-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Metadata": {
-      "slug": "go-langserver",
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bitbucket.example.com/SG/python-langserver-fork",
+   "URI": "bitbucket.example.com/SG/python-langserver-fork",
+   "Description": "python-langserver-fork",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "5",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "id": 5,
+    "name": "python-langserver-fork",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": {
+     "slug": "python-langserver",
+     "id": 2,
+     "name": "python-langserver",
+     "scmId": "git",
+     "state": "AVAILABLE",
+     "statusMessage": "Available",
+     "forkable": true,
+     "origin": null,
+     "project": {
+      "key": "SG",
       "id": 1,
-      "name": "go-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
+      "name": "sgtest",
       "public": false,
+      "type": "NORMAL",
       "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
-          }
-        ]
+       "self": [
+        {
+         "href": "https://bitbucket.example.com/projects/SG"
+        }
+       ]
       }
+     },
+     "public": false,
+     "links": {
+      "clone": [
+       {
+        "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+        "name": "ssh"
+       },
+       {
+        "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+        "name": "http"
+       }
+      ],
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+       }
+      ]
+     }
+    },
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
+      }
+     ]
     }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bitbucket.example.com/SG/python-langserver",
-    "URI": "bitbucket.example.com/SG/python-langserver",
-    "Description": "python-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "2",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "id": 2,
-      "name": "python-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bitbucket.example.com/~KEEGAN/rgp",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp",
+   "Description": "rgp",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
     }
+   },
+   "Metadata": {
+    "slug": "rgp",
+    "id": 4,
+    "name": "rgp",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
+    }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bitbucket.example.com/SG/python-langserver-fork",
-    "URI": "bitbucket.example.com/SG/python-langserver-fork",
-    "Description": "python-langserver-fork",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "5",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "id": 5,
-      "name": "python-langserver-fork",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": {
-        "slug": "python-langserver",
-        "id": 2,
-        "name": "python-langserver",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "origin": null,
-        "project": {
-          "key": "SG",
-          "id": 1,
-          "name": "sgtest",
-          "public": false,
-          "type": "NORMAL",
-          "links": {
-            "self": [
-              {
-                "href": "https://bitbucket.example.com/projects/SG"
-              }
-            ]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [
-            {
-              "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-              "name": "ssh"
-            },
-            {
-              "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-              "name": "http"
-            }
-          ],
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-            }
-          ]
-        }
-      },
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
+   "Description": "rgp-unavailable",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.example.com/~KEEGAN/rgp",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp",
-    "Description": "rgp",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Metadata": {
+    "slug": "rgp-unavailable",
+    "id": 4,
+    "name": "rgp-unavailable",
+    "scmId": "git",
+    "state": "UNAVAILABLE",
+    "statusMessage": "Unavailable",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp",
-      "id": 4,
-      "name": "rgp",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
       },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
-    "Description": "rgp-unavailable",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp-unavailable",
-      "id": 4,
-      "name": "rgp-unavailable",
-      "scmId": "git",
-      "state": "UNAVAILABLE",
-      "statusMessage": "Unavailable",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
-      }
-    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
@@ -1,373 +1,373 @@
 [
   {
-    "ID": 0,
-    "Name": "bb/SG/go-langserver",
-    "URI": "bitbucket.example.com/SG/go-langserver",
-    "Description": "go-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "1",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   "ID": 0,
+   "Name": "bb/SG/go-langserver",
+   "URI": "bitbucket.example.com/SG/go-langserver",
+   "Description": "go-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "1",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "go-langserver",
+    "id": 1,
+    "name": "go-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
+       "name": "http"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/SG/python-langserver",
+   "URI": "bitbucket.example.com/SG/python-langserver",
+   "Description": "python-langserver",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "2",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver",
+    "id": 2,
+    "name": "python-langserver",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
     },
-    "Metadata": {
-      "slug": "go-langserver",
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "bb/SG/python-langserver-fork",
+   "URI": "bitbucket.example.com/SG/python-langserver-fork",
+   "Description": "python-langserver-fork",
+   "Language": "",
+   "Fork": true,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "5",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+    }
+   },
+   "Metadata": {
+    "slug": "python-langserver-fork",
+    "id": 5,
+    "name": "python-langserver-fork",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": {
+     "slug": "python-langserver",
+     "id": 2,
+     "name": "python-langserver",
+     "scmId": "git",
+     "state": "AVAILABLE",
+     "statusMessage": "Available",
+     "forkable": true,
+     "origin": null,
+     "project": {
+      "key": "SG",
       "id": 1,
-      "name": "go-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
+      "name": "sgtest",
       "public": false,
+      "type": "NORMAL",
       "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse"
-          }
-        ]
+       "self": [
+        {
+         "href": "https://bitbucket.example.com/projects/SG"
+        }
+       ]
       }
+     },
+     "public": false,
+     "links": {
+      "clone": [
+       {
+        "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
+        "name": "ssh"
+       },
+       {
+        "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
+        "name": "http"
+       }
+      ],
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
+       }
+      ]
+     }
+    },
+    "project": {
+     "key": "SG",
+     "id": 1,
+     "name": "sgtest",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/projects/SG"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
+      }
+     ]
     }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bb/SG/python-langserver",
-    "URI": "bitbucket.example.com/SG/python-langserver",
-    "Description": "python-langserver",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "2",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver",
-      "id": 2,
-      "name": "python-langserver",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-            "name": "ssh"
-          },
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-            "name": "http"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bb/~KEEGAN/rgp",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp",
+   "Description": "rgp",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     }
+   },
+   "Metadata": {
+    "slug": "rgp",
+    "id": 4,
+    "name": "rgp",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
+      },
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
+    }
+   }
   },
   {
-    "ID": 0,
-    "Name": "bb/SG/python-langserver-fork",
-    "URI": "bitbucket.example.com/SG/python-langserver-fork",
-    "Description": "python-langserver-fork",
-    "Language": "",
-    "Fork": true,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "5",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
-      }
-    },
-    "Metadata": {
-      "slug": "python-langserver-fork",
-      "id": 5,
-      "name": "python-langserver-fork",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": {
-        "slug": "python-langserver",
-        "id": 2,
-        "name": "python-langserver",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "origin": null,
-        "project": {
-          "key": "SG",
-          "id": 1,
-          "name": "sgtest",
-          "public": false,
-          "type": "NORMAL",
-          "links": {
-            "self": [
-              {
-                "href": "https://bitbucket.example.com/projects/SG"
-              }
-            ]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [
-            {
-              "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git",
-              "name": "ssh"
-            },
-            {
-              "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git",
-              "name": "http"
-            }
-          ],
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse"
-            }
-          ]
-        }
-      },
-      "project": {
-        "key": "SG",
-        "id": 1,
-        "name": "sgtest",
-        "public": false,
-        "type": "NORMAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/projects/SG"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse"
-          }
-        ]
-      }
+   "ID": 0,
+   "Name": "bb/~KEEGAN/rgp-unavailable",
+   "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
+   "Description": "rgp-unavailable",
+   "Language": "",
+   "Fork": false,
+   "Enabled": true,
+   "Archived": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "4",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://foo:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/~KEEGAN/rgp",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp",
-    "Description": "rgp",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
+   },
+   "Metadata": {
+    "slug": "rgp-unavailable",
+    "id": 4,
+    "name": "rgp-unavailable",
+    "scmId": "git",
+    "state": "UNAVAILABLE",
+    "statusMessage": "Unavailable",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "~KEEGAN",
+     "id": 2,
+     "name": "Keegan",
+     "public": false,
+     "type": "PERSONAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.example.com/users/keegan"
+       }
+      ]
+     }
     },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp",
-      "id": 4,
-      "name": "rgp",
-      "scmId": "git",
-      "state": "AVAILABLE",
-      "statusMessage": "Available",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
+       "name": "http"
       },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
+      {
+       "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+       "name": "ssh"
       }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+      }
+     ]
     }
-  },
-  {
-    "ID": 0,
-    "Name": "bb/~KEEGAN/rgp-unavailable",
-    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
-    "Description": "rgp-unavailable",
-    "Language": "",
-    "Fork": false,
-    "Enabled": true,
-    "Archived": false,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "UpdatedAt": "0001-01-01T00:00:00Z",
-    "DeletedAt": "0001-01-01T00:00:00Z",
-    "ExternalRepo": {
-      "ID": "4",
-      "ServiceType": "bitbucketServer",
-      "ServiceID": "https://bitbucket.example.com/"
-    },
-    "Sources": {
-      "extsvc:bitbucketserver:1": {
-        "ID": "extsvc:bitbucketserver:1",
-        "CloneURL": "https://foo:secret@bitbucket.example.com/scm/~keegan/rgp.git"
-      }
-    },
-    "Metadata": {
-      "slug": "rgp-unavailable",
-      "id": 4,
-      "name": "rgp-unavailable",
-      "scmId": "git",
-      "state": "UNAVAILABLE",
-      "statusMessage": "Unavailable",
-      "forkable": true,
-      "origin": null,
-      "project": {
-        "key": "~KEEGAN",
-        "id": 2,
-        "name": "Keegan",
-        "public": false,
-        "type": "PERSONAL",
-        "links": {
-          "self": [
-            {
-              "href": "https://bitbucket.example.com/users/keegan"
-            }
-          ]
-        }
-      },
-      "public": false,
-      "links": {
-        "clone": [
-          {
-            "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
-            "name": "http"
-          },
-          {
-            "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
-            "name": "ssh"
-          }
-        ],
-        "self": [
-          {
-            "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
-          }
-        ]
-      }
-    }
+   }
   }
-]
+ ]

--- a/cmd/repo-updater/repos/testdata/golden/GithubSource_UpdateChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/GithubSource_UpdateChangeset_success
@@ -1,0 +1,54 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0MzYwNTI5NzI0",
+  "Title": "This is a new title",
+  "Body": "This is a new body",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/91",
+  "HeadRefOid": "2ee6f96506c75f1851a6d6be8f4b11e6bd3fd6a1",
+  "BaseRefOid": "97f8a75319760990c187710c50a957358f663366",
+  "HeadRefName": "sourcegraph/campaign-1578499147",
+  "BaseRefName": "master",
+  "Number": 91,
+  "Author": {
+   "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "TimelineItems": [
+   {
+    "Type": "RenamedTitleEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "PreviousTitle": "boring title",
+     "CurrentTitle": "AMAZING NAME!",
+     "CreatedAt": "2020-01-08T16:00:35Z"
+    }
+   },
+   {
+    "Type": "RenamedTitleEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "PreviousTitle": "AMAZING NAME!",
+     "CurrentTitle": "This is a new title",
+     "CreatedAt": "2020-01-08T16:24:43Z"
+    }
+   }
+  ],
+  "CreatedAt": "2020-01-08T15:59:11Z",
+  "UpdatedAt": "2020-01-08T16:24:44Z"
+ }

--- a/cmd/repo-updater/repos/testdata/sources/GithubSource_UpdateChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GithubSource_UpdateChangeset_success.yaml
@@ -1,0 +1,84 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor { avatarUrl, login, url }\nfragment
+      commit on Commit {\n\toid, message, messageHeadline, committedDate, pushedDate,
+      url\n\tcommitter {\n\tavatarUrl, email, name\n\tuser { ...actor }\n\t}\n}\nfragment
+      review on PullRequestReview {\n\tdatabaseId\n\tauthor { ...actor }\n\tauthorAssociation\n\tbody\n\tstate\n\turl\n\tcreatedAt\n\tupdatedAt\n\tcommit
+      { ...commit }\n\tincludesCreatedEdit\n}\nfragment pr on PullRequest {\n\tid,
+      title, body, state, url, number, createdAt, updatedAt\n\theadRefOid, baseRefOid,
+      headRefName, baseRefName\n\tauthor { ...actor }\n\tparticipants(first: 100)
+      { nodes { ...actor } }\n\ttimelineItems(\n\tfirst: 250\n\titemTypes: [\n\t\tASSIGNED_EVENT\n\t\tCLOSED_EVENT\n\t\tISSUE_COMMENT\n\t\tRENAMED_TITLE_EVENT\n\t\tMERGED_EVENT\n\t\tPULL_REQUEST_REVIEW\n\t\tPULL_REQUEST_REVIEW_THREAD\n\t\tREOPENED_EVENT\n\t\tREVIEW_DISMISSED_EVENT\n\t\tREVIEW_REQUEST_REMOVED_EVENT\n\t\tREVIEW_REQUESTED_EVENT\n\t\tUNASSIGNED_EVENT\n\t]\n\t)
+      {\n\tnodes {\n\t\t__typename\n\t\t... on AssignedEvent {\n\t\tactor { ...actor
+      }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ClosedEvent {\n\t\tactor
+      { ...actor }\n\t\tcreatedAt\n\t\turl\n\t\t}\n\t\t... on IssueComment {\n\t\tdatabaseId\n\t\tauthor
+      { ...actor }\n\t\tauthorAssociation\n\t\tbody\n\t\tcreatedAt\n\t\teditor { ...actor
+      }\n\t\turl\n\t\tupdatedAt\n\t\tincludesCreatedEdit\n\t\tpublishedAt\n\t\t}\n\t\t...
+      on RenamedTitleEvent {\n\t\tactor { ...actor }\n\t\tpreviousTitle\n\t\tcurrentTitle\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on MergedEvent {\n\t\tactor { ...actor }\n\t\tmergeRefName\n\t\turl\n\t\tcommit
+      { ...commit }\n\t\tcreatedAt\n\t\t}\n\t\t... on PullRequestReview {\n\t\t...review\n\t\t}\n\t\t...
+      on PullRequestReviewThread {\n\t\tcomments(last: 100) {\n\t\t\tnodes {\n\t\t\tdatabaseId\n\t\t\tauthor
+      { ...actor }\n\t\t\tauthorAssociation\n\t\t\teditor { ...actor }\n\t\t\tcommit
+      { ...commit }\n\t\t\tbody\n\t\t\tstate\n\t\t\turl\n\t\t\tcreatedAt\n\t\t\tupdatedAt\n\t\t\tincludesCreatedEdit\n\t\t\t}\n\t\t}\n\t\t}\n\t\t...
+      on ReopenedEvent {\n\t\tactor { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on
+      ReviewDismissedEvent {\n\t\tactor { ...actor }\n\t\treview { ...review }\n\t\tdismissalMessage\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on ReviewRequestRemovedEvent {\n\t\tactor { ...actor }\n\t\trequestedReviewer
+      { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t... on ReviewRequestedEvent {\n\t\tactor
+      { ...actor }\n\t\trequestedReviewer { ...actor }\n\t\tcreatedAt\n\t\t}\n\t\t...
+      on UnassignedEvent {\n\t\tactor { ...actor }\n\t\tassignee { ...actor }\n\t\tcreatedAt\n\t\t}\n\t}\n\t}\n}\nmutation\tUpdatePullRequest($input:UpdatePullRequestInput!)
+      {\n  updatePullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0MzYwNTI5NzI0","baseRefName":"master","title":"This
+      is a new title","body":"This is a new body"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0MzYwNTI5NzI0","title":"This
+      is a new title","body":"This is a new body","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/91","number":91,"createdAt":"2020-01-08T15:59:11Z","updatedAt":"2020-01-08T16:24:44Z","headRefOid":"2ee6f96506c75f1851a6d6be8f4b11e6bd3fd6a1","baseRefOid":"97f8a75319760990c187710c50a957358f663366","headRefName":"sourcegraph/campaign-1578499147","baseRefName":"master","author":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"timelineItems":{"nodes":[{"__typename":"RenamedTitleEvent","actor":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"previousTitle":"boring
+      title","currentTitle":"AMAZING NAME!","createdAt":"2020-01-08T16:00:35Z"},{"__typename":"RenamedTitleEvent","actor":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"previousTitle":"AMAZING
+      NAME!","currentTitle":"This is a new title","createdAt":"2020-01-08T16:24:43Z"}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 08 Jan 2020 16:24:44 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - C9C2:22974:136A27C:178E699:5E16024B
+      X-Oauth-Scopes:
+      - public_repo
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -261,27 +261,19 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 		return nil, err
 	}
 
-	tx, err := r.store.Transact(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	defer tx.Done(&err)
-
-	campaign, err := tx.GetCampaign(ctx, ee.GetCampaignOpts{ID: campaignID})
-	if err != nil {
-		return nil, err
-	}
+	updateArgs := ee.UpdateCampaignArgs{Campaign: campaignID}
 
 	if args.Input.Name != nil {
-		campaign.Name = *args.Input.Name
+		updateArgs.Name = args.Input.Name
 	}
 
 	if args.Input.Description != nil {
-		campaign.Description = *args.Input.Description
+		updateArgs.Description = args.Input.Description
 	}
 
-	if err := tx.UpdateCampaign(ctx, campaign); err != nil {
+	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	campaign, err := svc.UpdateCampaign(ctx, updateArgs)
+	if err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -291,17 +291,13 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 		return nil, err
 	}
 
-	// TODO(a8n): Even though RunChangesetJobs is idempotent, we should
-	// probably only run this when the CampaignPlanID actually changed.
-	if args.Input.Plan != nil {
-		go func() {
-			ctx := trace.ContextWithTrace(context.Background(), tr)
-			err := svc.RunChangesetJobs(ctx, campaign)
-			if err != nil {
-				log15.Error("RunChangesetJobs", "err", err)
-			}
-		}()
-	}
+	go func() {
+		ctx := trace.ContextWithTrace(context.Background(), tr)
+		err := svc.RunChangesetJobs(ctx, campaign)
+		if err != nil {
+			log15.Error("RunChangesetJobs", "err", err)
+		}
+	}()
 
 	return &campaignResolver{store: r.store, Campaign: campaign}, nil
 }

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -271,6 +271,14 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 		updateArgs.Description = args.Input.Description
 	}
 
+	if args.Input.Plan != nil {
+		campaignPlanID, err := unmarshalCampaignPlanID(*args.Input.Plan)
+		if err != nil {
+			return nil, err
+		}
+		updateArgs.Plan = &campaignPlanID
+	}
+
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
 	campaign, err := svc.UpdateCampaign(ctx, updateArgs)
 	if err != nil {

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -712,6 +712,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 
 	// TODO: If the name and description change, we also need to update the
 	// changesets on the codehost
+	//
 
 	// If the campaign.PlanID is different to the previous one, we need to
 	// do the full update. Otherwise, we're done.
@@ -824,6 +825,13 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 			currentChangesetJob.FinishedAt = time.Time{}
 		}
 		toKeep = append(toKeep, currentChangesetJob)
+
+		// TODO: We also need to check whether the Rev/BaseRef changed
+		// Along with Campaign.{Name,Description} we can probably do that in
+		// `RunChangesetJob`:
+		// if the Changeset on the codehost already exist, we check whether its
+		// Title/Description/BaseRef differ from what we have and if so, we
+		// update it
 	}
 
 	// And if we have CampaignJobs that don't have an existing ChangesetJob

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -174,9 +174,10 @@ func (s *Service) CreateCampaign(ctx context.Context, c *a8n.Campaign, draft boo
 	return s.createChangesetJobsWithStore(ctx, tx, c)
 }
 
-// ErrNoCampaignJobs is returned by CreateCampaign if a CampaignPlanID was
-// specified but the CampaignPlan does not have any (finished) CampaignJobs.
-var ErrNoCampaignJobs = errors.New("cannot create a Campaign without any changesets")
+// ErrNoCampaignJobs is returned by CreateCampaign or UpdateCampaign if a
+// CampaignPlanID was specified but the CampaignPlan does not have any
+// (finished) CampaignJobs.
+var ErrNoCampaignJobs = errors.New("cannot create or update a Campaign without any changesets")
 
 func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store, c *a8n.Campaign) error {
 	jobs, _, err := store.ListCampaignJobs(ctx, ListCampaignJobsOpts{
@@ -806,6 +807,10 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	if err != nil {
 		return nil, errors.Wrap(err, "listing new campaign jobs")
 	}
+	if len(newCampaignJobs) == 0 {
+		return nil, ErrNoCampaignJobs
+	}
+
 	newCampaignJobsByRepoID := make(map[int32]*a8n.CampaignJob, len(newCampaignJobs))
 	for _, j := range newCampaignJobs {
 		newCampaignJobsByRepoID[j.RepoID] = j

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -825,12 +825,12 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		}
 		toKeep = append(toKeep, currentChangesetJob)
 
-		// TODO: We also need to check whether the Rev/BaseRef changed
-		// Along with Campaign.{Name,Description} we can probably do that in
-		// `RunChangesetJob`:
-		// if the Changeset on the codehost already exist, we check whether its
-		// Title/Description/BaseRef differ from what we have and if so, we
-		// update it
+		// TODO: We also need to check whether the
+		// CampaignJob.{Rev,BaseRef,Description} changed.
+		// Along with Campaign.{Name,Description} we can probably do
+		// that in `RunChangesetJob`: if the Changeset on the codehost already
+		// exist, we check whether its Title/Description/BaseRef differ from
+		// what we have and if so, we update it
 	}
 
 	// And if we have CampaignJobs that don't have an existing ChangesetJob

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -714,6 +714,9 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		return campaign, err
 	}
 
+	// TODO: If the name and description change, we also need to update the
+	// changesets on the codehost
+
 	// TODO: Update the campaign.PlanID if it's set in args.Plan
 	//
 	// if the campaign.PlanID is different to the previous one, we need to

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -791,8 +791,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	)
 
 	for repoID, currentChangesetJob := range currentChangesetJobsByRepoID {
-		currentCampaignJob, _ := currentCampaignJobsByID[currentChangesetJob.CampaignJobID]
-
+		currentCampaignJob := currentCampaignJobsByID[currentChangesetJob.CampaignJobID]
 		newCampaignJob, ok := newCampaignJobsByRepoID[repoID]
 		// Case (a): we _don't_ have a matching _new_ CampaignJob.
 		// We delete the ChangesetJob and Changeset.

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -328,6 +328,22 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 			},
 		},
 		{
+			name: "1 modified rev",
+			oldCampaignJobs: func(plan int64) []*a8n.CampaignJob {
+				return []*a8n.CampaignJob{testCampaignJob(plan, rs[0].ID, now)}
+			},
+			newCampaignJobs: func(plan int64, oldCampaignJobs []*a8n.CampaignJob) []*a8n.CampaignJob {
+				job := oldCampaignJobs[0].Clone()
+				job.CampaignPlanID = plan
+				job.Rev = "deadbeef23"
+				return []*a8n.CampaignJob{job}
+			},
+			wantModifiedChangesetJobs: func(changesetJobs []*a8n.ChangesetJob, newCampaignJobs []*a8n.CampaignJob) (jobs []*a8n.ChangesetJob) {
+				// We only have 1 ChangesetJob and that should be modified
+				return changesetJobs
+			},
+		},
+		{
 			name: "1 unmodified, 1 modified, 1 new changeset",
 			oldCampaignJobs: func(plan int64) (jobs []*a8n.CampaignJob) {
 				for _, repo := range rs[:3] {

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -469,6 +469,26 @@ func TestService(t *testing.T) {
 			t.Fatalf("ChangesetJob.ChangesetID is not 0")
 		}
 
+		// Check that Changesets attached to unmodified and updated
+		// ChangesetJob are still attached to Campaign
+		changesets, _, err := store.ListChangesets(ctx, ListChangesetsOpts{
+			IDs: []int64{
+				unmodified.ChangesetID,
+				modified.ChangesetID,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(changesets) != 2 {
+			t.Fatalf("wrong number of changesets. want=%d, have=%d", 2, len(changesets))
+		}
+		for _, c := range changesets {
+			if len(c.CampaignIDs) != 1 || c.CampaignIDs[0] != campaign.ID {
+				t.Fatalf("changeset has wrong CampaignIDs. want=[%d], have=%v", campaign.ID, c.CampaignIDs)
+			}
+		}
+
 		// Check Changeset with RepoID == CampaignJobToBeDeleted.RepoID is
 		// detached from campaign
 		var oldChangesetToBeDetached *a8n.Changeset

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -444,10 +444,34 @@ func TestService(t *testing.T) {
 			t.Fatalf("ChangesetJob FinishedAt not reset. have=%v", modified.FinishedAt)
 		}
 
-		// TODO: check that Changeset with RepoID ==
-		// oldCampaignJobToBeDeleted.RepoID is detached from campaign and
-		// closed on Codehost (which we can't here without mocking a lot of
-		// things, so we might need to do that somewhere else)
+		// Check Changeset with RepoID == CampaignJobToBeDeleted.RepoID is
+		// detached from campaign
+		var oldChangesetToBeDetached *a8n.Changeset
+		for _, c := range oldChangesets {
+			if c.RepoID == oldCampaignJobToBeDeleted.RepoID {
+				oldChangesetToBeDetached = c
+				break
+			}
+		}
+		if oldChangesetToBeDetached == nil {
+			t.Fatalf("could not find old changeset to be detached")
+		}
+		changeset, err := store.GetChangeset(ctx, GetChangesetOpts{ID: oldChangesetToBeDetached.ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(changeset.CampaignIDs) != 0 {
+			t.Fatalf("old changeset still attached to campaign")
+		}
+		for _, changesetID := range campaign.ChangesetIDs {
+			if changesetID == changeset.ID {
+				t.Fatalf("old changeset still attached to campaign")
+			}
+		}
+
+		// TODO: Check that it's closed on Codehost (which we can't here
+		// without mocking a lot of things, so we might need to do that
+		// somewhere else)
 	})
 }
 

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -415,7 +415,7 @@ func TestService(t *testing.T) {
 
 		newChangesetJobsByCampaignJobID := make(map[int64]*a8n.ChangesetJob)
 		for _, j := range newChangesetJobs {
-			if j.ID == oldCampaignJobToBeDeleted.ID {
+			if j.CampaignJobID == oldCampaignJobToBeDeleted.ID {
 				t.Errorf("ChangesetJob should have been deleted")
 			}
 			newChangesetJobsByCampaignJobID[j.CampaignJobID] = j
@@ -429,7 +429,6 @@ func TestService(t *testing.T) {
 		if unmodified.StartedAt != oldTime {
 			t.Fatalf("ChangesetJob StartedAt changed. want=%v, have=%v", oldTime, unmodified.StartedAt)
 		}
-
 		if unmodified.FinishedAt != oldTime {
 			t.Fatalf("ChangesetJob FinishedAt changed. want=%v, have=%v", oldTime, unmodified.FinishedAt)
 		}
@@ -445,7 +444,6 @@ func TestService(t *testing.T) {
 		if !modified.StartedAt.IsZero() {
 			t.Fatalf("ChangesetJob StartedAt not reset. have=%v", modified.StartedAt)
 		}
-
 		if !modified.FinishedAt.IsZero() {
 			t.Fatalf("ChangesetJob FinishedAt not reset. have=%v", modified.FinishedAt)
 		}
@@ -501,6 +499,7 @@ func TestService(t *testing.T) {
 		if oldChangesetToBeDetached == nil {
 			t.Fatalf("could not find old changeset to be detached")
 		}
+
 		changeset, err := store.GetChangeset(ctx, GetChangesetOpts{ID: oldChangesetToBeDetached.ID})
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -307,13 +307,24 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 				return []*a8n.CampaignJob{job}
 			},
 			wantUnmodifiedChangesetJobs: func(changesetJobs []*a8n.ChangesetJob, newCampaignJobs []*a8n.CampaignJob) (jobs []*a8n.ChangesetJob) {
-				for _, j := range changesetJobs {
-					// CampaignJob has same diff, so ChangesetJob should not be reset
-					if j.CampaignJobID == newCampaignJobs[0].ID {
-						jobs = append(jobs, j)
-					}
-				}
-				return jobs
+				// We only have 1 ChangesetJob and that should be unmodified
+				return changesetJobs
+			},
+		},
+		{
+			name: "1 modified diff",
+			oldCampaignJobs: func(plan int64) []*a8n.CampaignJob {
+				return []*a8n.CampaignJob{testCampaignJob(plan, rs[0].ID, now)}
+			},
+			newCampaignJobs: func(plan int64, oldCampaignJobs []*a8n.CampaignJob) []*a8n.CampaignJob {
+				job := oldCampaignJobs[0].Clone()
+				job.CampaignPlanID = plan
+				job.Diff = "different diff"
+				return []*a8n.CampaignJob{job}
+			},
+			wantModifiedChangesetJobs: func(changesetJobs []*a8n.ChangesetJob, newCampaignJobs []*a8n.CampaignJob) (jobs []*a8n.ChangesetJob) {
+				// We only have 1 ChangesetJob and that should be modified
+				return changesetJobs
 			},
 		},
 		{

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -106,6 +106,16 @@ func (c *Campaign) Clone() *Campaign {
 	return &cc
 }
 
+// RemoveChangesetID removes the given id from the Campaigns ChangesetIDs slice.
+// If the id is not in ChangesetIDs calling this method doesn't have an effect.
+func (c *Campaign) RemoveChangesetID(id int64) {
+	for i := len(c.ChangesetIDs) - 1; i >= 0; i-- {
+		if c.ChangesetIDs[i] == id {
+			c.ChangesetIDs = append(c.ChangesetIDs[:i], c.ChangesetIDs[i+1:]...)
+		}
+	}
+}
+
 // ChangesetState defines the possible states of a Changeset.
 type ChangesetState string
 

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -106,6 +106,9 @@ func (c *Campaign) Clone() *Campaign {
 	return &cc
 }
 
+// Published returns whether the PublishedAt timestamp is non-zero.
+func (c *Campaign) Published() bool { return !c.PublishedAt.IsZero() }
+
 // RemoveChangesetID removes the given id from the Campaigns ChangesetIDs slice.
 // If the id is not in ChangesetIDs calling this method doesn't have an effect.
 func (c *Campaign) RemoveChangesetID(id int64) {

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,10 +19,10 @@ import (
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/pkg/errors"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -160,7 +159,7 @@ func TestClient_LoadPullRequests(t *testing.T) {
 				return
 			}
 
-			assertGolden(t,
+			testutil.AssertGolden(t,
 				"testdata/golden/LoadPullRequests-"+strconv.Itoa(i),
 				update("LoadPullRequests"),
 				tc.prs,
@@ -235,7 +234,7 @@ func TestClient_CreatePullRequest(t *testing.T) {
 				return
 			}
 
-			assertGolden(t,
+			testutil.AssertGolden(t,
 				"testdata/golden/CreatePullRequest-"+strconv.Itoa(i),
 				update("CreatePullRequest"),
 				pr,
@@ -290,7 +289,7 @@ func TestClient_ClosePullRequest(t *testing.T) {
 				return
 			}
 
-			assertGolden(t,
+			testutil.AssertGolden(t,
 				"testdata/golden/ClosePullRequest-"+strconv.Itoa(i),
 				update("ClosePullRequest"),
 				tc.pr,
@@ -309,36 +308,11 @@ func TestClient_GetAuthenticatedUserOrgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertGolden(t,
+	testutil.AssertGolden(t,
 		"testdata/golden/GetAuthenticatedUserOrgs",
 		update("GetAuthenticatedUserOrgs"),
 		orgs,
 	)
-}
-func assertGolden(t testing.TB, path string, update bool, want interface{}) {
-	t.Helper()
-
-	data, err := json.MarshalIndent(want, " ", " ")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if update {
-		if err = ioutil.WriteFile(path, data, 0640); err != nil {
-			t.Fatalf("failed to update golden file %q: %s", path, err)
-		}
-	}
-
-	golden, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read golden file %q: %s", path, err)
-	}
-
-	if have, want := string(data), string(golden); have != want {
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(have, want, false)
-		t.Error(dmp.DiffPrettyText(diffs))
-	}
 }
 
 func newClient(t testing.TB, name string) (*Client, func()) {

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -395,6 +395,58 @@ func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInp
 	return pr, nil
 }
 
+type UpdatePullRequestInput struct {
+	// The Node ID of the pull request.
+	PullRequestID string `json:"pullRequestID"`
+	// The name of the branch you want your changes pulled into. This should be
+	// an existing branch on the current repository.
+	BaseRefName string `json:"baseRefName"`
+	// The title of the pull request.
+	Title string `json:"title"`
+	// The body of the pull request (optional).
+	Body string `json:"body"`
+}
+
+// UpdatePullRequest creates a PullRequest on Github.
+func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {
+	var q strings.Builder
+	q.WriteString(pullRequestFragments)
+	q.WriteString(`mutation	UpdatePullRequest($input:UpdatePullRequestInput!) {
+  updatePullRequest(input:$input) {
+    pullRequest {
+      ... pr
+    }
+  }
+}`)
+
+	var result struct {
+		UpdatePullRequest struct {
+			PullRequest struct {
+				PullRequest
+				Participants  struct{ Nodes []Actor }
+				TimelineItems struct{ Nodes []TimelineItem }
+			} `json:"pullRequest"`
+		} `json:"createPullRequest"`
+	}
+
+	input := map[string]interface{}{"input": in}
+	err := c.requestGraphQL(ctx, "", q.String(), input, &result)
+	if err != nil {
+		if gqlErrs, ok := err.(graphqlErrors); ok && len(gqlErrs) == 1 {
+			e := gqlErrs[0]
+			if strings.Contains(e.Message, "A pull request already exists for") {
+				return nil, ErrPullRequestAlreadyExists
+			}
+		}
+		return nil, err
+	}
+
+	pr := &result.UpdatePullRequest.PullRequest.PullRequest
+	pr.TimelineItems = result.UpdatePullRequest.PullRequest.TimelineItems.Nodes
+	pr.Participants = result.UpdatePullRequest.PullRequest.Participants.Nodes
+	return pr, nil
+}
+
 // ClosePullRequest closes the PullRequest on Github.
 func (c *Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
 	var q strings.Builder

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -397,7 +397,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInp
 
 type UpdatePullRequestInput struct {
 	// The Node ID of the pull request.
-	PullRequestID string `json:"pullRequestID"`
+	PullRequestID string `json:"pullRequestId"`
 	// The name of the branch you want your changes pulled into. This should be
 	// an existing branch on the current repository.
 	BaseRefName string `json:"baseRefName"`
@@ -426,7 +426,7 @@ func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInp
 				Participants  struct{ Nodes []Actor }
 				TimelineItems struct{ Nodes []TimelineItem }
 			} `json:"pullRequest"`
-		} `json:"createPullRequest"`
+		} `json:"updatePullRequest"`
 	}
 
 	input := map[string]interface{}{"input": in}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(want, " ", " ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if update {
+		if err = ioutil.WriteFile(path, data, 0640); err != nil {
+			t.Fatalf("failed to update golden file %q: %s", path, err)
+		}
+	}
+
+	golden, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read golden file %q: %s", path, err)
+	}
+
+	if have, want := string(data), string(golden); have != want {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(have, want, false)
+		t.Error(dmp.DiffPrettyText(diffs))
+	}
+}


### PR DESCRIPTION
This PR implements the majority of the implementation proposed in [RFC 95](https://docs.google.com/document/d/1_0fOwbmIov3utmpFa2cs_3qSM3HGO3mNLTUVB8sZxIg/edit#heading=h.umigb8il1vw3) (see rest of ticket for what's missing). It started out as a proof of concept but as I realized that updating a campaign might not be that complicated if we say that updating a Campaign means changing its CampaignPlanID I implemented it "properly" (there's still bits missing, like Bitbucket Server support, see bottom of this description).

That being said: this idea behind updating a Campaign (and the API) still needs to be validated by @eseliger and @felixfbecker. That's what I expect as their review here.

What I want from @tsenart @ryanslade is a "standard" technical review with feedback on APIs and implementation, so I can work on the PR and possibly shift its direction/implementation while @eseliger and @felixfbecker think about the frontend side of this implementation.

#### What's in here?

It extends the GraphQL API to accept an optional `plan: ID` in `UpdateCampaignArgs`. If the ID points to a finished `CampaignPlan`, the `Campaign` will be updated to the new `CampaignPlan`.

Every `CampaignJob` (`changeset` in GraphQL) belonging to the new `CampaignPlan` will then be compared with the existing `ChangesetJobs/Changesets` pairs (`ExternalChangeset` in GraphQL) to decide whether to

1. detach `ExternalChangeset` from `Campaign` and close it on codehost
2. update title/body/diff of `ExternalChangeset` on codehost
3. keep `ExternalChangeset` as it is
4. create new `ExternalChangeset` on the codehost

The decision what to do with which changeset happens _synchronously_ in the `updateCampaign` mutation.

Then, _asynchronously_, the changesets are updated/created/closed on the codehost.

#### What's missing?

The update process as described above is implemented in this PR, except:

- [ ] Close detached changesets on the codehosts
- [ ] Updating changesets on BitbucketServer. That only works for GitHub now.

But I don't think these need to necessarily be in this PR and can be addressed in follow-ups.

