### PR TITLE
dev: enable splitSearchModes by default

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,3 +1,6 @@
 {
   // This is set from an environment variable
+  "experimentalFeatures": {
+    "splitSearchModes": true
+  }
 }


### PR DESCRIPTION
Enable experimental `splitSearchModes` feature by default on dev instances.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
