### PR TITLE
search: alert on structural search for unindexed repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 
@@ -912,6 +913,18 @@ func alertOnError(multiErr *multierror.Error) (newMultiErr *multierror.Error, al
 					prometheusType: "structural_search_needs_more_memory",
 					title:          "Structural search needs more memory",
 					description:    "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
+				}
+			} else if strings.Contains(err.Error(), "No indexed repositories for structural search") {
+				var msg string
+				if envvar.SourcegraphDotComMode() {
+					msg = "The good news is you can index any repository you like in a self-install. It takes less than 5 minutes to set up: https://docs.sourcegraph.com/"
+				} else {
+					msg = "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."
+				}
+				alert = &searchAlert{
+					prometheusType: "structural_search_on_zero_indexed_repos",
+					title:          "Unindexed repositories with structural search",
+					description:    fmt.Sprintf("Structural search currently only works on indexed repositories. Some of the repositories to search are not indexed, so we can't return results for them. %s", msg),
 				}
 			} else {
 				newMultiErr = multierror.Append(newMultiErr, err)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -917,7 +917,7 @@ func alertOnError(multiErr *multierror.Error) (newMultiErr *multierror.Error, al
 			} else if strings.Contains(err.Error(), "No indexed repositories for structural search") {
 				var msg string
 				if envvar.SourcegraphDotComMode() {
-					msg = "The good news is you can index any repository you like in a self-install. It takes less than 5 minutes to set up: https://docs.sourcegraph.com/"
+					msg = "The good news is you can index any repository you like in a self-install. It takes less than 5 minutes to set up: https://docs.sourcegraph.com/#quickstart"
 				} else {
 					msg = "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."
 				}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -481,7 +481,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	// if there are no indexed repos and this is a structural search
 	// query, there will be no results. Raise a friendly alert.
 	if len(zoektRepos) == 0 && args.PatternInfo.IsStructuralPat {
-		return nil, nil, fmt.Errorf("No indexed repositories for structural search")
+		return nil, nil, errors.New("no indexed repositories for structural search")
 	}
 
 	common.repos = make([]*types.Repo, len(args.Repos))

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -478,6 +478,12 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		}
 	}
 
+	// if there are no indexed repos and this is a structural search
+	// query, there will be no results. Raise a friendly alert.
+	if len(zoektRepos) == 0 && args.PatternInfo.IsStructuralPat {
+		return nil, nil, fmt.Errorf("No indexed repositories for structural search")
+	}
+
 	common.repos = make([]*types.Repo, len(args.Repos))
 	for i, repo := range args.Repos {
 		common.repos[i] = repo.Repo


### PR DESCRIPTION
Currently structural search will return no results for unindexed repos. This is a silent behavior and can confuse users. This PR raises an alert when unindexed repos are searched. Here's what the current message looks like on sourcegraph.com (casual users who may want to try self-install):

<img width="1434" alt="Screen Shot 2019-12-20 at 3 59 32 PM" src="https://user-images.githubusercontent.com/888624/71298137-d7e34c00-2343-11ea-8f1c-d1b51ae5244b.png">

Here's what it looks like on non-sourcegraph.com (e.g., fo admins or self-installers)

<img width="1440" alt="Screen Shot 2019-12-20 at 3 54 35 PM" src="https://user-images.githubusercontent.com/888624/71298128-cd28b700-2343-11ea-9838-f36b302a336f.png">

Notes:

- I couldn't find a way to selectively create indexed and unindexed repos (to see whether partial results are shown). I only set ` "search.index.enabled": false` in the config to see that the messages are shown. If you have an idea how, please comment.

- The only real mechanism to raise an alert without doing a substantial rewrite is to return an error in `doResults` and then promote it to an alert. I really don't like this but a substantial rewrite will be involved.

- Test pending. Putting this up now so that I can get feedback on the above points, and the message phrasing.