### PR TITLE
Improve dotcom subscriptions page. 

### DIFF
--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -135,6 +135,7 @@ type ProductSubscriptionArgs struct {
 type ProductSubscriptionsArgs struct {
 	graphqlutil.ConnectionArgs
 	Account *graphql.ID
+	Query   *string
 }
 
 // ProductSubscriptionConnection is the interface for the GraphQL type

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4367,6 +4367,8 @@ type DotcomQuery {
         #
         # Only Sourcegraph.com site admins may perform this query with account == null.
         account: ID
+        # Returns product subscriptions from users with usernames or email addresses that match the query.
+        query: String
     ): ProductSubscriptionConnection!
     # The invoice that would be generated for a new or updated subscription. This is used to show
     # users a preview of the credits, debits, and other billing information before creating or

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4374,6 +4374,8 @@ type DotcomQuery {
         #
         # Only Sourcegraph.com site admins may perform this query with account == null.
         account: ID
+        # Returns product subscriptions from users with usernames or email addresses that match the query.
+        query: String
     ): ProductSubscriptionConnection!
     # The invoice that would be generated for a new or updated subscription. This is used to show
     # users a preview of the credits, debits, and other billing information before creating or

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -84,10 +84,10 @@ type dbSubscriptionsListOptions struct {
 func (o dbSubscriptionsListOptions) sqlConditions() []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if o.UserID != 0 {
-		conds = append(conds, sqlf.Sprintf("user_id=%d", o.UserID))
+		conds = append(conds, sqlf.Sprintf("product_subscriptions.user_id=%d", o.UserID))
 	}
 	if !o.IncludeArchived {
-		conds = append(conds, sqlf.Sprintf("archived_at IS NULL"))
+		conds = append(conds, sqlf.Sprintf("product_subscriptions.archived_at IS NULL"))
 	}
 	if o.Query != "" {
 		conds = append(conds, sqlf.Sprintf("(users.username LIKE %s) OR (primary_emails.primary_email LIKE %s)", "%"+o.Query+"%", "%"+o.Query+"%"))

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -22,6 +22,13 @@ type dbSubscription struct {
 	ArchivedAt            *time.Time
 }
 
+var emailQueries = sqlf.Sprintf(`all_primary_emails AS (
+	SELECT user_id, FIRST_VALUE(email) over (PARTITION BY user_id ORDER BY created_at ASC) AS primary_email
+	FROM user_emails
+	WHERE verified_at IS NOT NULL),
+primary_emails AS (
+	SELECT user_id, primary_email FROM all_primary_emails GROUP BY 1, 2)`)
+
 // errSubscriptionNotFound occurs when a database operation expects a specific Sourcegraph
 // license to exist but it does not exist.
 var errSubscriptionNotFound = errors.New("product subscription not found")
@@ -56,7 +63,7 @@ func (s dbSubscriptions) GetByID(ctx context.Context, id string) (*dbSubscriptio
 	if mocks.subscriptions.GetByID != nil {
 		return mocks.subscriptions.GetByID(id)
 	}
-	results, err := s.list(ctx, []*sqlf.Query{sqlf.Sprintf("id=%s", id)}, nil)
+	results, err := s.list(ctx, []*sqlf.Query{sqlf.Sprintf("product_subscriptions.id=%s", id)}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +76,7 @@ func (s dbSubscriptions) GetByID(ctx context.Context, id string) (*dbSubscriptio
 // dbSubscriptionsListOptions contains options for listing product subscriptions.
 type dbSubscriptionsListOptions struct {
 	UserID          int32 // only list product subscriptions for this user
+	Query           string
 	IncludeArchived bool
 	*db.LimitOffset
 }
@@ -81,6 +89,9 @@ func (o dbSubscriptionsListOptions) sqlConditions() []*sqlf.Query {
 	if !o.IncludeArchived {
 		conds = append(conds, sqlf.Sprintf("archived_at IS NULL"))
 	}
+	if o.Query != "" {
+		conds = append(conds, sqlf.Sprintf("(users.username LIKE %s) OR (primary_emails.primary_email LIKE %s)", "%"+o.Query+"%", "%"+o.Query+"%"))
+	}
 	return conds
 }
 
@@ -91,10 +102,15 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 
 func (dbSubscriptions) list(ctx context.Context, conds []*sqlf.Query, limitOffset *db.LimitOffset) ([]*dbSubscription, error) {
 	q := sqlf.Sprintf(`
-SELECT id, user_id, billing_subscription_id, created_at, archived_at FROM product_subscriptions
+WITH %s
+SELECT product_subscriptions.id, product_subscriptions.user_id, billing_subscription_id, product_subscriptions.created_at, product_subscriptions.archived_at
+FROM product_subscriptions
+LEFT OUTER JOIN users ON product_subscriptions.user_id = users.id
+LEFT OUTER JOIN primary_emails ON users.id = primary_emails.user_id
 WHERE (%s)
 ORDER BY archived_at DESC NULLS FIRST, created_at DESC
 %s`,
+		emailQueries,
 		sqlf.Join(conds, ") AND ("),
 		limitOffset.SQL(),
 	)
@@ -118,7 +134,13 @@ ORDER BY archived_at DESC NULLS FIRST, created_at DESC
 
 // Count counts all product subscriptions that satisfy the options (ignoring limit and offset).
 func (dbSubscriptions) Count(ctx context.Context, opt dbSubscriptionsListOptions) (int, error) {
-	q := sqlf.Sprintf("SELECT COUNT(*) FROM product_subscriptions WHERE (%s)", sqlf.Join(opt.sqlConditions(), ") AND ("))
+	q := sqlf.Sprintf(`
+WITH %s
+SELECT COUNT(*)
+FROM product_subscriptions
+LEFT OUTER JOIN users ON product_subscriptions.user_id = users.id
+LEFT OUTER JOIN primary_emails ON users.id = primary_emails.user_id
+WHERE (%s)`, emailQueries, sqlf.Join(opt.sqlConditions(), ") AND ("))
 	var count int
 	if err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
 		return 0, err

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -464,7 +464,7 @@ func (ProductSubscriptionLicensingResolver) ProductSubscriptions(ctx context.Con
 
 	if args.Query != nil {
 		// 🚨 SECURITY: Only site admins may query or view license for all users, or for any other user.
-		// Note this check is currently repetative with the check above. However, it is duplicated here to
+		// Note this check is currently repetitive with the check above. However, it is duplicated here to
 		// ensure it remains in effect if the code path above chagnes.
 		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -461,6 +461,17 @@ func (ProductSubscriptionLicensingResolver) ProductSubscriptions(ctx context.Con
 	if accountUser != nil {
 		opt.UserID = accountUser.DatabaseID()
 	}
+
+	if args.Query != nil {
+		// 🚨 SECURITY: Only site admins may query or view license for all users, or for any other user.
+		// Note this check is currently repetative with the check above. However, it is duplicated here to
+		// ensure it remains in effect if the code path above chagnes.
+		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+			return nil, err
+		}
+		opt.Query = *args.Query
+	}
+
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &productSubscriptionConnection{opt: opt}, nil
 }

--- a/web/src/enterprise/productSubscription/ProductLicenseTags.tsx
+++ b/web/src/enterprise/productSubscription/ProductLicenseTags.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const ProductLicenseTags: React.FunctionComponent<{
+    tags: string[]
+}> = ({ tags }) => (
+    <>
+        {tags.map(tag => (
+            <div className="mr-1 badge badge-secondary" key={tag}>
+                {tag}
+            </div>
+        ))}
+    </>
+)

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -7,6 +7,7 @@ import { Timestamp } from '../../../../components/time/Timestamp'
 import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 import { ProductLicenseValidity } from '../../../dotcom/productSubscriptions/ProductLicenseValidity'
 import { ProductLicenseInfoDescription } from '../../../productSubscription/ProductLicenseInfoDescription'
+import { ProductLicenseTags } from '../../../productSubscription/ProductLicenseTags'
 
 export const siteAdminProductLicenseFragment = gql`
     fragment ProductLicenseFields on ProductLicense {
@@ -89,12 +90,7 @@ export class SiteAdminProductLicenseNode extends React.PureComponent<SiteAdminPr
                 </div>
                 {this.props.node.info && this.props.node.info.tags.length > 0 && (
                     <div>
-                        Tags:{' '}
-                        {this.props.node.info.tags.map(tag => (
-                            <div className="mr-1 badge badge-secondary" key={tag}>
-                                {tag}
-                            </div>
-                        ))}
+                        Tags: <ProductLicenseTags tags={this.props.node.info.tags} />
                     </div>
                 )}
                 <CopyableText text={this.props.node.licenseKey} className="mt-2 d-block" />

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
@@ -2,8 +2,10 @@ import * as React from 'react'
 import { LinkOrSpan } from '../../../../../../shared/src/components/LinkOrSpan'
 import { gql } from '../../../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../../../shared/src/graphql/schema'
+import { Timestamp } from '../../../../components/time/Timestamp'
 import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 import { ProductSubscriptionLabel } from '../../../dotcom/productSubscriptions/ProductSubscriptionLabel'
+import { ProductLicenseTags } from '../../../productSubscription/ProductLicenseTags'
 
 export const siteAdminProductSubscriptionFragment = gql`
     fragment ProductSubscriptionFields on ProductSubscription {
@@ -13,6 +15,10 @@ export const siteAdminProductSubscriptionFragment = gql`
             id
             username
             displayName
+            emails {
+                email
+                isPrimary
+            }
         }
         invoiceItem {
             plan {
@@ -42,8 +48,10 @@ export const SiteAdminProductSubscriptionNodeHeader: React.FunctionComponent<{ n
     <thead>
         <tr>
             <th>ID</th>
-            <th>Plan</th>
             <th>Customer</th>
+            <th>Plan</th>
+            <th>Expiration</th>
+            <th>Tags</th>
         </tr>
     </thead>
 )
@@ -65,11 +73,37 @@ export class SiteAdminProductSubscriptionNode extends React.PureComponent<SiteAd
                         {this.props.node.name}
                     </LinkOrSpan>
                 </td>
+                <td className="w-100">
+                    <AccountName account={this.props.node.account} />
+                    {this.props.node.account && (
+                        <div>
+                            <small>
+                                {this.props.node.account.emails
+                                    .filter(email => email.isPrimary)
+                                    .map(({ email }) => email)
+                                    .join(', ')}
+                            </small>
+                        </div>
+                    )}
+                </td>
                 <td className="text-nowrap">
                     <ProductSubscriptionLabel productSubscription={this.props.node} className="mr-3" />
                 </td>
+                <td className="text-nowrap">
+                    {this.props.node.activeLicense && this.props.node.activeLicense.info ? (
+                        <Timestamp date={this.props.node.activeLicense.info.expiresAt} />
+                    ) : (
+                        <span className="text-muted font-italic">None</span>
+                    )}
+                </td>
                 <td className="w-100">
-                    <AccountName account={this.props.node.account} />
+                    {this.props.node.activeLicense &&
+                    this.props.node.activeLicense.info &&
+                    this.props.node.activeLicense.info.tags.length > 0 ? (
+                        <ProductLicenseTags tags={this.props.node.activeLicense.info.tags} />
+                    ) : (
+                        <span className="text-muted font-italic">None</span>
+                    )}
                 </td>
             </tr>
         )

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
@@ -90,7 +90,7 @@ export class SiteAdminProductSubscriptionNode extends React.PureComponent<SiteAd
                     <ProductSubscriptionLabel productSubscription={this.props.node} className="mr-3" />
                 </td>
                 <td className="text-nowrap">
-                    {this.props.node.activeLicense && this.props.node.activeLicense.info ? (
+                    {this.props.node.activeLicense?.info ? (
                         <Timestamp date={this.props.node.activeLicense.info.expiresAt} />
                     ) : (
                         <span className="text-muted font-italic">None</span>

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -4,9 +4,8 @@ import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { gql } from '../../../../../../shared/src/graphql/graphql'
+import { dataOrThrowErrors, gql } from '../../../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../../../shared/src/graphql/schema'
-import { createAggregateError } from '../../../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../../../backend/graphql'
 import { FilteredConnection } from '../../../../components/FilteredConnection'
 import { PageTitle } from '../../../../components/PageTitle'
@@ -65,7 +64,6 @@ export class SiteAdminProductSubscriptionsPage extends React.Component<Props> {
                     headComponent={SiteAdminProductSubscriptionNodeHeader}
                     nodeComponent={SiteAdminProductSubscriptionNode}
                     nodeComponentProps={nodeProps}
-                    hideSearch={true}
                     updates={this.updates}
                     history={this.props.history}
                     location={this.props.location}
@@ -74,12 +72,15 @@ export class SiteAdminProductSubscriptionsPage extends React.Component<Props> {
         )
     }
 
-    private queryProductSubscriptions = (args: { first?: number }): Observable<GQL.IProductSubscriptionConnection> =>
+    private queryProductSubscriptions = (args: {
+        first?: number
+        query?: string
+    }): Observable<GQL.IProductSubscriptionConnection> =>
         queryGraphQL(
             gql`
-                query ProductSubscriptions($first: Int, $account: ID) {
+                query ProductSubscriptions($first: Int, $account: ID, $query: String) {
                     dotcom {
-                        productSubscriptions(first: $first, account: $account) {
+                        productSubscriptions(first: $first, account: $account, query: $query) {
                             nodes {
                                 ...ProductSubscriptionFields
                             }
@@ -94,14 +95,11 @@ export class SiteAdminProductSubscriptionsPage extends React.Component<Props> {
             `,
             {
                 first: args.first,
+                query: args.query,
             } as GQL.IProductSubscriptionsOnDotcomQueryArguments
         ).pipe(
-            map(({ data, errors }) => {
-                if (!data || !data.dotcom || !data.dotcom.productSubscriptions || (errors && errors.length > 0)) {
-                    throw createAggregateError(errors)
-                }
-                return data.dotcom.productSubscriptions
-            })
+            map(dataOrThrowErrors),
+            map(data => data.dotcom.productSubscriptions)
         )
 
     private onDidUpdateProductSubscription = (): void => this.updates.next()


### PR DESCRIPTION
Add searching capability, and add primary email, license expiration date, and license tags to display.


This change only affects Sourcegraph.com (for subscription and license management)


Adds more context to the subscriptions page, and adds search:

![image](https://user-images.githubusercontent.com/5589410/71301590-c0ad5a00-2355-11ea-85f3-90915ca7b778.png)


Versus the previous version:

![image](https://user-images.githubusercontent.com/5589410/71301576-8479f980-2355-11ea-8a03-90ebc3c33d82.png)
