### PR TITLE
fix: always show searchbar in global navbar on sourcegraph.com

### DIFF
--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -123,12 +123,13 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
         }
 
         const logo = <img className="global-navbar__logo" src={logoSrc} />
-        const logoLink = this.state.authRequired ? (
-            <div className={logoLinkClassName}>{logo}</div>
-        ) : (
+        const logoLink = (this.props.isSourcegraphDotCom || !this.state.authRequired) ? (
             <Link to="/search" className={logoLinkClassName}>
                 {logo}
             </Link>
+        ) : (
+            <div className={logoLinkClassName}>{logo}</div>
+
         )
 
         return (
@@ -163,7 +164,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                         ) : (
                             <>
                                 {logoLink}
-                                {!this.state.authRequired && (
+                                {(this.props.isSourcegraphDotCom || !this.state.authRequired) && (
                                     <div className="global-navbar__search-box-container d-none d-sm-flex flex-row">
                                         {this.props.splitSearchModes && (
                                             <SearchModeToggle

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -123,14 +123,14 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
         }
 
         const logo = <img className="global-navbar__logo" src={logoSrc} />
-        const logoLink = (this.props.isSourcegraphDotCom || !this.state.authRequired) ? (
-            <Link to="/search" className={logoLinkClassName}>
-                {logo}
-            </Link>
-        ) : (
-            <div className={logoLinkClassName}>{logo}</div>
-
-        )
+        const logoLink =
+            this.props.isSourcegraphDotCom || !this.state.authRequired ? (
+                <Link to="/search" className={logoLinkClassName}>
+                    {logo}
+                </Link>
+            ) : (
+                <div className={logoLinkClassName}>{logo}</div>
+            )
 
         return (
             <div className={`global-navbar ${this.props.lowProfile ? '' : 'global-navbar--bg border-bottom'} py-1`}>


### PR DESCRIPTION
Fixes a bug where the search bar doesn't appear on sourcegraph.com for logged out users. 

@eseliger and I tried to find the last "good" commit so we could bisect and find the root cause, but it appeared to be a bug as far back as 3.8. This should at least fix the immediate problem.

Context: https://sourcegraph.slack.com/archives/CMT39K56Z/p1576889557007700

