### PR TITLE
bitbucketserver: Update default testing URL to be consistent

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -28,7 +28,7 @@ var update = flag.Bool("update", false, "update testdata")
 func TestProvider_Validate(t *testing.T) {
 	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
 	if instanceURL == "" {
-		instanceURL = "http://127.0.0.1:7990"
+		instanceURL = "https://bitbucket.sgdev.org"
 	}
 
 	for _, tc := range []struct {

--- a/internal/extsvc/bitbucketserver/testing.go
+++ b/internal/extsvc/bitbucketserver/testing.go
@@ -32,7 +32,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 
 	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
 	if instanceURL == "" {
-		instanceURL = "http://127.0.0.1:7990"
+		instanceURL = "https://bitbucket.sgdev.org"
 	}
 
 	u, err := url.Parse(instanceURL)


### PR DESCRIPTION
We want to consistently use https://bitbucket.sgdev.org. We missed one place
in the changeover, leading to tests failing if you don't have
BITBUCKET_SERVER_URL set.