### PR TITLE
Do not return 401 Unauthorized on /sign-in?returnTo=

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -253,15 +253,6 @@ func serveSignIn(w http.ResponseWriter, r *http.Request) error {
 	}
 	common.Title = brandNameSubtitle("Sign in")
 
-	// If we are being redirected to another page after sign in, it means the
-	// user attempted to access something without authorization. Reflect this
-	// in the status code. This is useful when users curl / code which
-	// interacts with the Sourcegraph endpoints. Specifically this is a common
-	// issue facing extension developers interacting with the raw API.
-	if r.URL.Query().Get("returnTo") != "" {
-		w.WriteHeader(http.StatusUnauthorized)
-	}
-
 	return renderTemplate(w, "app.html", common)
 }
 


### PR DESCRIPTION
This has been verified to fix https://github.com/sourcegraph/sourcegraph/issues/7338 for the customer.

The code that returned the 401 was added in https://github.com/sourcegraph/sourcegraph/pull/2002 after discussion in https://github.com/sourcegraph/sourcegraph/issues/1248.

Merging this will re-introduce the original issue, which was that the raw API redirects to the sign-in page when the user is not authenticated and a 200 status is returned (even though a 401 is more appropriate for machine consumers of the raw API).

A proper follow-up fix to the original issue would be: update the raw API to return 401, instead of redirecting to sign-in.

I am going to merge this preemptively, because the customer is already running a patched version and the original issue appears to only affect Sourcegraph devs, not end-users.

Note: the test shows failure, but that's just because I pushed the revision to a `docker-image-patch-notest/` branch, which broke. It really succeeded: https://buildkite.com/sourcegraph/sourcegraph/builds/51895