### PR TITLE
document need for LSIF action github_token parameter

### DIFF
--- a/doc/user/code_intelligence/lsif_on_github.md
+++ b/doc/user/code_intelligence/lsif_on_github.md
@@ -30,6 +30,9 @@ jobs:
           verbose: "true"
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
 ```
 
 Once that workflow is committed to your repository, you will start to see LSIF workflows in the Actions tab of your repository (e.g. https://github.com/sourcegraph/sourcegraph/actions).


### PR DESCRIPTION
#7114 removed this necessary part from the documentation. Without this, all users will get the following error in their GitHub action run for LSIF:

```
error: you must provide -github-token=TOKEN, where TOKEN is a GitHub personal access token with 'repo' or 'public_repo' scope
```