### PR TITLE
more closely dogfood our recommended LSIF action

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -14,7 +14,6 @@ jobs:
           verbose: "true"
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
-        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file: cmd/dump.lsif


### PR DESCRIPTION
Do not continue on error. If an error occurs, we want to see it because it means our users likely are seeing it, too. Note that we can still merge because LSIF is not a required PR check (so this change will not prevent us from fixing our site if it's down and the only way to fix it is by merging a new commit).

@chrismwendt Why was continue-on-error set?