### PR TITLE
e2e: sort symbols list to avoid flakiness

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -8,7 +8,7 @@ import { retry } from '../../../shared/src/e2e/e2e-test-utils'
 import { createDriverForTest, Driver, percySnapshot } from '../../../shared/src/e2e/driver'
 import got from 'got'
 import { gql } from '../../../shared/src/graphql/graphql'
-import { random } from 'lodash'
+import { random, sortBy } from 'lodash'
 import MockDate from 'mockdate'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { getConfig } from '../../../shared/src/e2e/config'
@@ -721,8 +721,8 @@ describe('e2e test suite', () => {
                         )
                     )
 
-                    expect(symbolNames).toEqual(symbolTest.symbolNames)
-                    expect(symbolTypes).toEqual(symbolTest.symbolTypes)
+                    expect(sortBy(symbolNames)).toEqual(sortBy(symbolTest.symbolNames))
+                    expect(sortBy(symbolTypes)).toEqual(sortBy(symbolTest.symbolTypes))
                 })
             }
 


### PR DESCRIPTION
The symbols e2e test had flakiness at https://buildkite.com/sourcegraph/sourcegraph-e2e/builds/1755#86f72961-3331-4c82-834b-6ced0cbe290d/154-681. This sorts the list to avoid the flakiness. Because the symbols order is not strictly defined anyway, sorting does not make the test any less effective.

![image](https://user-images.githubusercontent.com/1976/71339324-001ba800-2508-11ea-99c5-ceb5a0a81373.png)