### PR TITLE
remove obsolete TODO

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -171,11 +171,6 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             // Force a hard reload so that we delegate to the HTTP handler for /help, which handles
             // redirecting /help to https://docs.sourcegraph.com. That logic is not duplicated in
             // the web app because that would add complexity with no user benefit.
-            //
-            // TODO(sqs): This currently has a bug in dev mode where you can't go back to the app
-            // after following the redirect. This will be fixed when we run docsite on
-            // http://localhost:5080 in Procfile because then the redirect will be cross-domain and
-            // won't reuse the same history stack.
             window.location.reload()
             return null
         },


### PR DESCRIPTION
We now run docsite as a separate program in local dev mode in goreman, so this TODO is obsolete.