### PR TITLE
use "API console" as page title for API console

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -212,7 +212,7 @@ func initRouter() {
 	router.Get(routeSiteAdmin).Handler(handler(serveBrandedPageString("Admin")))
 	router.Get(uirouter.RoutePasswordReset).Handler(handler(serveBrandedPageString("Reset password")))
 	router.Get(routeDiscussions).Handler(handler(serveBrandedPageString("Discussions")))
-	router.Get(routeAPIConsole).Handler(handler(serveBrandedPageString("API explorer")))
+	router.Get(routeAPIConsole).Handler(handler(serveBrandedPageString("API console")))
 	router.Get(routeRepoSettings).Handler(handler(serveBrandedPageString("Repository settings")))
 	router.Get(routeRepoCommit).Handler(handler(serveBrandedPageString("Commit")))
 	router.Get(routeRepoBranches).Handler(handler(serveBrandedPageString("Branches")))

--- a/web/src/api/APIConsole.tsx
+++ b/web/src/api/APIConsole.tsx
@@ -8,6 +8,7 @@ import { catchError, debounceTime } from 'rxjs/operators'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { eventLogger } from '../tracking/eventLogger'
 import { ErrorAlert } from '../components/alerts'
+import { PageTitle } from '../components/PageTitle'
 
 const defaultQuery = `# Type queries here, with completion, validation, and hovers.
 #
@@ -121,6 +122,7 @@ export class APIConsole extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         return (
             <div className="api-console">
+                <PageTitle title="API console" />
                 {this.state.graphiqlOrError === undefined ? (
                     <span className="api-console__loader">
                         <LoadingSpinner className="icon-inline" /> Loading…


### PR DESCRIPTION
Previously it was "API explorer" if loaded directly and no title (just "Sourcegraph") if navigated to from another page.

This does not merit a changelog entry.