### PR TITLE
fix: determine authRequired by reading window.context.sourcegraphDotComMode

### DIFF
--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -57,18 +57,16 @@ export function refreshAuthenticatedUser(): Observable<never> {
     )
 }
 
-const initialSiteConfigAuthPublic = window.context ? window.context.site['auth.public'] : false // default to false in tests
-
 /**
  * Whether auth is required to perform any action.
  *
- * If an HTTP request might be triggered by an unauthenticated user on a server with auth.public ==
- * false, the caller must first check authRequired. If authRequired is true, then the component must
+ * If an HTTP request might be triggered by an unauthenticated user on a server that is not Sourcegraph.com
+ * the caller must first check authRequired. If authRequired is true, then the component must
  * not initiate the HTTP request. This prevents the browser's devtools console from showing HTTP 401
  * errors, which mislead the user into thinking there is a problem (and make debugging any actual
  * issue much harder).
  */
-export const authRequired = authenticatedUser.pipe(map(user => user === null && !initialSiteConfigAuthPublic))
+export const authRequired = authenticatedUser.pipe(map(user => user === null && !window.context?.sourcegraphDotComMode))
 
 // Populate authenticatedUser.
 if (window.context && window.context.isAuthenticatedUser) {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -123,14 +123,13 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
         }
 
         const logo = <img className="global-navbar__logo" src={logoSrc} />
-        const logoLink =
-            !this.state.authRequired ? (
-                <Link to="/search" className={logoLinkClassName}>
-                    {logo}
-                </Link>
-            ) : (
-                <div className={logoLinkClassName}>{logo}</div>
-            )
+        const logoLink = !this.state.authRequired ? (
+            <Link to="/search" className={logoLinkClassName}>
+                {logo}
+            </Link>
+        ) : (
+            <div className={logoLinkClassName}>{logo}</div>
+        )
 
         return (
             <div className={`global-navbar ${this.props.lowProfile ? '' : 'global-navbar--bg border-bottom'} py-1`}>

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -124,7 +124,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
 
         const logo = <img className="global-navbar__logo" src={logoSrc} />
         const logoLink =
-            this.props.isSourcegraphDotCom || !this.state.authRequired ? (
+            !this.state.authRequired ? (
                 <Link to="/search" className={logoLinkClassName}>
                     {logo}
                 </Link>
@@ -164,7 +164,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                         ) : (
                             <>
                                 {logoLink}
-                                {(this.props.isSourcegraphDotCom || !this.state.authRequired) && (
+                                {!this.state.authRequired && (
                                     <div className="global-navbar__search-box-container d-none d-sm-flex flex-row">
                                         {this.props.splitSearchModes && (
                                             <SearchModeToggle


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/7369. 

TODO after merge: remove `auth.public: true` from sourcegraph.com site config.