### PR TITLE
clearer search result tab names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- The "Files" tab in the search results page has been renamed to "Filenames" for clarity.
+
 ### Fixed
 
 - The experimental search pagination API no longer times out when large repositories are encountered. [#6384](https://github.com/sourcegraph/sourcegraph/issues/6384)

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1243,7 +1243,7 @@ describe('e2e test suite', () => {
             )
 
             expect(tabs.length).toEqual(6)
-            expect(tabs).toStrictEqual(['Code', 'Diffs', 'Commits', 'Symbols', 'Repos', 'Files'])
+            expect(tabs).toStrictEqual(['Code', 'Diffs', 'Commits', 'Symbols', 'Repositories', 'Filenames'])
 
             const activeTab = await driver.page.evaluate(
                 () => document.querySelectorAll('.e2e-search-result-tab--active').length

--- a/web/src/search/results/SearchResultTab.tsx
+++ b/web/src/search/results/SearchResultTab.tsx
@@ -19,8 +19,8 @@ const typeToProse: Record<Exclude<SearchType, null>, string> = {
     diff: 'Diffs',
     commit: 'Commits',
     symbol: 'Symbols',
-    repo: 'Repos',
-    path: 'Files',
+    repo: 'Repositories',
+    path: 'Filenames',
 }
 
 export const SearchResultTabHeader: React.FunctionComponent<Props> = ({


### PR DESCRIPTION
- "Files" -> "Filenames" (to address the confusion of thinking this meant searching in files, eg at https://sourcegraph.slack.com/archives/CQ9383QF9/p1577143893093400?thread_ts=1577129858.092000&cid=CQ9383QF9 from https://app.hubspot.com/contacts/2762526/company/974120254)
- "Repos" -> "Repositories" per our style guide

![image](https://user-images.githubusercontent.com/1976/71423789-863b0a00-2640-11ea-8a8b-94727e78f71b.png)
