### PR TITLE
simplify SearchScopes component

### DIFF
--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -1,6 +1,6 @@
 @import '../../nav/GlobalNavbar';
 @import '../QuickLinks';
-@import './SearchFilterChips';
+@import './SearchScopes';
 @import './QueryInput';
 @import './QueryBuilder';
 @import './QueryBuilderInputRow';

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -17,7 +17,7 @@ import { QuickLinks } from '../QuickLinks'
 import { QueryBuilder } from './QueryBuilder'
 import { QueryInput } from './QueryInput'
 import { SearchButton } from './SearchButton'
-import { ISearchScope, SearchScopes } from './SearchScopes'
+import { SearchScopes } from './SearchScopes'
 import { InteractiveModeInput } from './interactive/InteractiveModeInput'
 import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcuts'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
@@ -87,7 +87,10 @@ export class SearchPage extends React.Component<Props, State> {
                 logoUrl = branding.dark.logo
             }
         }
-        const hasScopes = this.getScopes().length > 0
+        const hasScopes =
+            isSettingsValid<Settings>(this.props.settingsCascade) &&
+            Array.isArray(this.props.settingsCascade.final['search.scopes']) &&
+            this.props.settingsCascade.final['search.scopes'].length > 0
         const quickLinks = this.getQuickLinks()
         return (
             <div className="search-page">
@@ -128,12 +131,10 @@ export class SearchPage extends React.Component<Props, State> {
                                         <>
                                             <div className="search-page__input-sub-container">
                                                 <SearchScopes
-                                                    location={this.props.location}
                                                     history={this.props.history}
                                                     query={this.state.userQueryState.query}
                                                     authenticatedUser={this.props.authenticatedUser}
                                                     settingsCascade={this.props.settingsCascade}
-                                                    isSourcegraphDotCom={this.props.isSourcegraphDotCom}
                                                     patternType={this.props.patternType}
                                                 />
                                             </div>
@@ -160,12 +161,10 @@ export class SearchPage extends React.Component<Props, State> {
                                             />
                                             <div className="search-page__input-sub-container">
                                                 <SearchScopes
-                                                    location={this.props.location}
                                                     history={this.props.history}
                                                     query={this.state.userQueryState.query}
                                                     authenticatedUser={this.props.authenticatedUser}
                                                     settingsCascade={this.props.settingsCascade}
-                                                    isSourcegraphDotCom={this.props.isSourcegraphDotCom}
                                                     patternType={this.props.patternType}
                                                 />
                                             </div>
@@ -205,14 +204,6 @@ export class SearchPage extends React.Component<Props, State> {
             return `${limitString(this.state.userQueryState.query, 25, true)}`
         }
         return undefined
-    }
-
-    private getScopes(): ISearchScope[] {
-        return (
-            (isSettingsValid<Settings>(this.props.settingsCascade) &&
-                this.props.settingsCascade.final['search.scopes']) ||
-            []
-        )
     }
 
     private getQuickLinks(): QuickLink[] {

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -17,7 +17,7 @@ import { QuickLinks } from '../QuickLinks'
 import { QueryBuilder } from './QueryBuilder'
 import { QueryInput } from './QueryInput'
 import { SearchButton } from './SearchButton'
-import { ISearchScope, SearchFilterChips } from './SearchFilterChips'
+import { ISearchScope, SearchScopes } from './SearchScopes'
 import { InteractiveModeInput } from './interactive/InteractiveModeInput'
 import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcuts'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
@@ -127,7 +127,7 @@ export class SearchPage extends React.Component<Props, State> {
                                     {hasScopes ? (
                                         <>
                                             <div className="search-page__input-sub-container">
-                                                <SearchFilterChips
+                                                <SearchScopes
                                                     location={this.props.location}
                                                     history={this.props.history}
                                                     query={this.state.userQueryState.query}
@@ -159,7 +159,7 @@ export class SearchPage extends React.Component<Props, State> {
                                                 className="search-page__input-sub-container"
                                             />
                                             <div className="search-page__input-sub-container">
-                                                <SearchFilterChips
+                                                <SearchScopes
                                                     location={this.props.location}
                                                     history={this.props.history}
                                                     query={this.state.userQueryState.query}

--- a/web/src/search/input/SearchScopes.scss
+++ b/web/src/search/input/SearchScopes.scss
@@ -1,6 +1,6 @@
 @import '../FilterChip';
 
-.search-filter-chips {
+.search-scopes {
     &__edit {
         display: inline-block;
         vertical-align: middle;

--- a/web/src/search/input/SearchScopes.test.tsx
+++ b/web/src/search/input/SearchScopes.test.tsx
@@ -1,0 +1,40 @@
+import { createMemoryHistory } from 'history'
+import renderer from 'react-test-renderer'
+import React from 'react'
+import { MemoryRouter } from 'react-router'
+import { SearchScopes } from './SearchScopes'
+import * as GQL from '../../../../shared/src/graphql/schema'
+import { Settings } from '../../schema/settings.schema'
+
+const BASE_PROPS = {
+    authenticatedUser: {},
+    history: createMemoryHistory(),
+    query: 'abc',
+    patternType: GQL.SearchPatternType.literal,
+}
+
+describe('SearchScopes', () => {
+    test('empty', () =>
+        expect(
+            renderer
+                .create(
+                    <MemoryRouter>
+                        <SearchScopes {...BASE_PROPS} settingsCascade={{ final: {}, subjects: [] }} />
+                    </MemoryRouter>
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+
+    test('with scopes', () => {
+        const settings: Settings = { 'search.scopes': [{ name: 'n', value: 'v', description: 'd', id: 'i' }] }
+        expect(
+            renderer
+                .create(
+                    <MemoryRouter>
+                        <SearchScopes {...BASE_PROPS} settingsCascade={{ final: settings, subjects: [] }} />
+                    </MemoryRouter>
+                )
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/search/input/SearchScopes.tsx
+++ b/web/src/search/input/SearchScopes.tsx
@@ -33,7 +33,7 @@ export interface ISearchScope {
     value: string
 }
 
-export class SearchFilterChips extends React.PureComponent<Props> {
+export class SearchScopes extends React.PureComponent<Props> {
     private componentUpdates = new Subject<Props>()
     private subscriptions = new Subscription()
 
@@ -58,7 +58,7 @@ export class SearchFilterChips extends React.PureComponent<Props> {
         const scopes = this.getScopes()
 
         return (
-            <div className="search-filter-chips">
+            <div className="search-scopes">
                 {/* Filtering out empty strings because old configurations have "All repositories" with empty value, which is useless with new chips design. */}
                 {scopes
                     .filter(scope => scope.value !== '')
@@ -72,15 +72,15 @@ export class SearchFilterChips extends React.PureComponent<Props> {
                         />
                     ))}
                 {this.props.authenticatedUser && (
-                    <div className="search-filter-chips__edit">
+                    <div className="search-scopes__edit">
                         <NavLink
-                            className="search-filter-chips__add-edit"
+                            className="search-scopes__add-edit"
                             to="/settings"
                             data-tooltip={scopes.length > 0 ? 'Edit search scopes' : undefined}
                         >
-                            <small className="search-filter-chips__center">
+                            <small className="search-scopes__center">
                                 {scopes.length === 0 ? (
-                                    <span className="search-filter-chips__add-scopes">
+                                    <span className="search-scopes__add-scopes">
                                         Add search scopes for quick filtering
                                     </span>
                                 ) : (

--- a/web/src/search/input/SearchScopes.tsx
+++ b/web/src/search/input/SearchScopes.tsx
@@ -1,26 +1,17 @@
-import * as H from 'history'
-import { escapeRegExp } from 'lodash'
-import * as path from 'path'
-import * as React from 'react'
-import { matchPath } from 'react-router'
+import H from 'history'
+import React, { useCallback } from 'react'
 import { NavLink } from 'react-router-dom'
-import { Subject, Subscription } from 'rxjs'
-import { distinctUntilChanged } from 'rxjs/operators'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
-import { Tooltip } from '../../components/tooltip/Tooltip'
-import { routes } from '../../routes'
 import { Settings } from '../../schema/settings.schema'
 import { eventLogger } from '../../tracking/eventLogger'
 import { FilterChip } from '../FilterChip'
-import { submitSearch, toggleSearchFilter, toggleSearchFilterAndReplaceSampleRepogroup } from '../helpers'
+import { submitSearch, toggleSearchFilter } from '../helpers'
 import { PatternTypeProps } from '..'
 
-interface Props extends SettingsCascadeProps, Omit<PatternTypeProps, 'setPatternType'> {
-    location: H.Location
+interface Props extends SettingsCascadeProps, Pick<PatternTypeProps, 'patternType'> {
     history: H.History
-    authenticatedUser: GQL.IUser | null
-    isSourcegraphDotCom: boolean
+    authenticatedUser: Pick<GQL.IUser, never> | null
 
     /**
      * The current query.
@@ -28,150 +19,59 @@ interface Props extends SettingsCascadeProps, Omit<PatternTypeProps, 'setPattern
     query: string
 }
 
-export interface ISearchScope {
-    name?: string
-    value: string
-}
+/**
+ * A list of search scopes from the settings, shown as filter chips.
+ */
+export const SearchScopes: React.FunctionComponent<Props> = ({
+    settingsCascade,
+    query,
+    authenticatedUser,
+    history,
+    patternType,
+}) => {
+    const scopes = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final['search.scopes']) || []
 
-export class SearchScopes extends React.PureComponent<Props> {
-    private componentUpdates = new Subject<Props>()
-    private subscriptions = new Subscription()
-
-    public componentDidMount(): void {
-        // Update tooltip text immediately after clicking.
-        this.subscriptions.add(
-            this.componentUpdates
-                .pipe(distinctUntilChanged((a, b) => a.query === b.query))
-                .subscribe(() => Tooltip.forceUpdate())
-        )
-    }
-
-    public componentDidUpdate(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): JSX.Element | null {
-        const scopes = this.getScopes()
-
-        return (
-            <div className="search-scopes">
-                {/* Filtering out empty strings because old configurations have "All repositories" with empty value, which is useless with new chips design. */}
-                {scopes
-                    .filter(scope => scope.value !== '')
-                    .map((scope, i) => (
-                        <FilterChip
-                            query={this.props.query}
-                            onFilterChosen={this.onSearchScopeClicked}
-                            key={i}
-                            value={scope.value}
-                            name={scope.name}
-                        />
-                    ))}
-                {this.props.authenticatedUser && (
-                    <div className="search-scopes__edit">
-                        <NavLink
-                            className="search-scopes__add-edit"
-                            to="/settings"
-                            data-tooltip={scopes.length > 0 ? 'Edit search scopes' : undefined}
-                        >
-                            <small className="search-scopes__center">
-                                {scopes.length === 0 ? (
-                                    <span className="search-scopes__add-scopes">
-                                        Add search scopes for quick filtering
-                                    </span>
-                                ) : (
-                                    'Edit'
-                                )}
-                            </small>
-                        </NavLink>
-                    </div>
-                )}
-            </div>
-        )
-    }
-
-    private getScopes(): ISearchScope[] {
-        const allScopes: ISearchScope[] =
-            (isSettingsValid<Settings>(this.props.settingsCascade) &&
-                this.props.settingsCascade.final['search.scopes']) ||
-            []
-        allScopes.push(...this.getScopesForCurrentRoute())
-        return allScopes
-    }
-
-    /**
-     * Returns contextual scopes for the current route (such as "This Repository" and
-     * "This Directory").
-     */
-    private getScopesForCurrentRoute(): ISearchScope[] {
-        const scopes: ISearchScope[] = []
-
-        // This is basically a programmatical <Switch> with <Route>s
-        // see https://reacttraining.com/react-router/web/api/matchPath
-        // and https://reacttraining.com/react-router/web/example/sidebar
-        for (const route of routes) {
-            const match = matchPath<{ repoRev?: string; filePath?: string }>(this.props.location.pathname, {
-                path: route.path,
-                exact: route.exact,
+    const onSearchScopeClicked = useCallback(
+        (value: string): void => {
+            eventLogger.log('SearchScopeClicked', {
+                search_filter: {
+                    value,
+                },
             })
-            if (match) {
-                switch (match.path) {
-                    case '/:repoRev+': {
-                        // Repo page
-                        const [repoName] = match.params.repoRev!.split('@')
-                        scopes.push(scopeForRepo(repoName))
-                        break
-                    }
-                    case '/:repoRev+/-/tree/:filePath+':
-                    case '/:repoRev+/-/blob/:filePath+': {
-                        // Blob/tree page
-                        const isTree = match.path === '/:repoRev+/-/tree/:filePath+'
 
-                        const [repoName] = match.params.repoRev!.split('@')
+            const newQuery = toggleSearchFilter(query, value)
 
-                        scopes.push({
-                            value: `repo:^${escapeRegExp(repoName)}$`,
-                        })
+            submitSearch(history, newQuery, 'filter', patternType)
+        },
+        [history, patternType, query]
+    )
 
-                        if (match.params.filePath) {
-                            const dirname = isTree ? match.params.filePath : path.dirname(match.params.filePath)
-                            if (dirname !== '.') {
-                                scopes.push({
-                                    value: `repo:^${escapeRegExp(repoName)}$ file:^${escapeRegExp(dirname)}/`,
-                                })
-                            }
-                        }
-                        break
-                    }
-                }
-                break
-            }
-        }
-
-        return scopes
-    }
-
-    private onSearchScopeClicked = (value: string): void => {
-        eventLogger.log('SearchScopeClicked', {
-            search_filter: {
-                value,
-            },
-        })
-
-        const newQuery = this.props.isSourcegraphDotCom
-            ? toggleSearchFilterAndReplaceSampleRepogroup(this.props.query, value)
-            : toggleSearchFilter(this.props.query, value)
-
-        submitSearch(this.props.history, newQuery, 'filter', this.props.patternType)
-    }
-}
-
-function scopeForRepo(repoName: string): ISearchScope {
-    return {
-        value: `repo:^${escapeRegExp(repoName)}$`,
-    }
+    return (
+        <div className="search-scopes">
+            {scopes
+                .filter(scope => scope.value !== '') // clicking on empty scope would not trigger search
+                .map((scope, i) => (
+                    <FilterChip
+                        query={query}
+                        onFilterChosen={onSearchScopeClicked}
+                        key={i}
+                        value={scope.value}
+                        name={scope.name}
+                    />
+                ))}
+            {authenticatedUser && (
+                <div className="search-scopes__edit">
+                    <NavLink className="search-scopes__add-edit" to="/settings">
+                        <small className="search-scopes__center">
+                            {scopes.length === 0 ? (
+                                <span className="search-scopes__add-scopes">Add search scopes for quick filtering</span>
+                            ) : (
+                                'Edit'
+                            )}
+                        </small>
+                    </NavLink>
+                </div>
+            )}
+        </div>
+    )
 }

--- a/web/src/search/input/__snapshots__/SearchScopes.test.tsx.snap
+++ b/web/src/search/input/__snapshots__/SearchScopes.test.tsx.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchScopes empty 1`] = `
+<div
+  className="search-scopes"
+>
+  <div
+    className="search-scopes__edit"
+  >
+    <a
+      aria-current={null}
+      className="search-scopes__add-edit"
+      href="/settings"
+      onClick={[Function]}
+    >
+      <small
+        className="search-scopes__center"
+      >
+        <span
+          className="search-scopes__add-scopes"
+        >
+          Add search scopes for quick filtering
+        </span>
+      </small>
+    </a>
+  </div>
+</div>
+`;
+
+exports[`SearchScopes with scopes 1`] = `
+<div
+  className="search-scopes"
+>
+  <button
+    className="btn btn-sm text-nowrap filter-chip "
+    data-testid="filter-chip"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    title="v"
+    type="button"
+    value="v"
+  >
+    <div>
+      n
+    </div>
+  </button>
+  <div
+    className="search-scopes__edit"
+  >
+    <a
+      aria-current={null}
+      className="search-scopes__add-edit"
+      href="/settings"
+      onClick={[Function]}
+    >
+      <small
+        className="search-scopes__center"
+      >
+        Edit
+      </small>
+    </a>
+  </div>
+</div>
+`;

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -16,14 +16,7 @@ import { PageTitle } from '../../components/PageTitle'
 import { Settings } from '../../schema/settings.schema'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { EventLogger } from '../../tracking/eventLogger'
-import {
-    isSearchResults,
-    submitSearch,
-    toggleSearchFilter,
-    toggleSearchFilterAndReplaceSampleRepogroup,
-    getSearchTypeFromQuery,
-    QueryState,
-} from '../helpers'
+import { isSearchResults, submitSearch, toggleSearchFilter, getSearchTypeFromQuery, QueryState } from '../helpers'
 import { queryTelemetryData } from '../queryTelemetry'
 import { SearchResultsFilterBars, SearchScopeWithOptionalName } from './SearchResultsFilterBars'
 import { SearchResultsList } from './SearchResultsList'
@@ -334,9 +327,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
             search_filter: { value },
         })
 
-        const newQuery = this.props.isSourcegraphDotCom
-            ? toggleSearchFilterAndReplaceSampleRepogroup(this.props.navbarSearchQueryState.query, value)
-            : toggleSearchFilter(this.props.navbarSearchQueryState.query, value)
+        const newQuery = toggleSearchFilter(this.props.navbarSearchQueryState.query, value)
 
         submitSearch(this.props.history, newQuery, 'filter', this.props.patternType)
     }


### PR DESCRIPTION
- Rename Search{FilterChips => Scopes}. This is a better name for the component because it is only concerned with showing search scopes, not all kinds of search filter chips. (Search scopes are one kind of filter that are defined in settings. There are other kinds of filters, such as dynamic filters, that are not called "scopes".)
- Convert to functional component (from class component)
- Remove unneeded ISearchScope interface
- Remove handling of repogroup:sample that is not needed anymore
- Add React component snapshot test
- Remove unused contextual scopes (these were never actually triggered because this component is only shown on the homepage, not on any repository or tree pages)