### PR TITLE
remove remnants of repogroup:sample

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/src-d/enry/v2"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine"
@@ -272,46 +271,7 @@ func resolveRepoGroups(ctx context.Context) (map[string][]*types.Repo, error) {
 		groups[name] = repos
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		sampleRepos, err := getSampleRepos(ctx)
-		if err != nil {
-			return nil, err
-		}
-		groups["sample"] = sampleRepos
-	}
-
 	return groups, nil
-}
-
-var (
-	sampleReposMu sync.Mutex
-	sampleRepos   []*types.Repo
-)
-
-func getSampleRepos(ctx context.Context) ([]*types.Repo, error) {
-	sampleReposMu.Lock()
-	defer sampleReposMu.Unlock()
-	if sampleRepos == nil {
-		sampleRepoPaths := []api.RepoName{
-			"github.com/sourcegraph/jsonrpc2",
-			"github.com/sourcegraph/javascript-typescript-langserver",
-			"github.com/gorilla/mux",
-			"github.com/gorilla/schema",
-			"github.com/golang/lint",
-			"github.com/golang/oauth2",
-			"github.com/pallets/flask",
-		}
-		repos := make([]*types.Repo, len(sampleRepoPaths))
-		for i, path := range sampleRepoPaths {
-			repo, err := backend.Repos.GetByName(ctx, path)
-			if err != nil {
-				return nil, fmt.Errorf("get %q: %s", path, err)
-			}
-			repos[i] = repo
-		}
-		sampleRepos = repos
-	}
-	return sampleRepos, nil
 }
 
 // resolveRepositories calls doResolveRepositories, caching the result for the common

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -175,7 +175,7 @@ func TestSearchSuggestions(t *testing.T) {
 			defer mu.Unlock()
 			calledResolveRepoGroups = true
 			return map[string][]*types.Repo{
-				"sample": {
+				"baz": {
 					&types.Repo{Name: "foo-repo1"},
 					&types.Repo{Name: "repo3"},
 				},
@@ -183,7 +183,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 		defer func() { mockResolveRepoGroups = nil }()
 		for _, v := range searchVersions {
-			testSuggestions(t, "repogroup:sample foo", v, []string{"repo:foo-repo1", "file:dir/foo-repo3-file-name-match", "file:dir/foo-repo1-file-name-match", "file:dir/file-content-match"})
+			testSuggestions(t, "repogroup:baz foo", v, []string{"repo:foo-repo1", "file:dir/foo-repo3-file-name-match", "file:dir/foo-repo1-file-name-match", "file:dir/file-content-match"})
 			if !calledReposListReposInGroup {
 				t.Error("!calledReposListReposInGroup")
 			}

--- a/doc/api/graphql/search.md
+++ b/doc/api/graphql/search.md
@@ -12,7 +12,7 @@ Putting together a comprehensive GraphQL search query can be difficult. For this
 export SRC_ENDPOINT=https://sourcegraph.com
 export SRC_ACCESS_TOKEN=secret
 
-src search -json 'repogroup:sample error'
+src search -json 'repo:pallets/flask error'
 ```
 
 You can then consume the JSON output directly, add `--get-curl` to get a `curl` execution line, and more. See [the `src` CLI tool](https://github.com/sourcegraph/src-cli) for more details.

--- a/doc/user/search/examples.md
+++ b/doc/user/search/examples.md
@@ -7,7 +7,7 @@ Below are examples that search repositories on [Sourcegraph.com](https://sourceg
 - [Recent security-related changes on all branches](https://sourcegraph.com/search?q=type:diff+repo:github%5C.com/kubernetes/kubernetes%24+repo:%40*refs/heads/+after:"5+days+ago"+%5Cb%28auth%5B%5Eo%5D%5B%5Er%5D%7Csecurity%5Cb%7Ccve%7Cpassword%7Csecure%7Cunsafe%7Cperms%7Cpermissions%29)<br/>
 `type:diff repo:@*refs/heads/ after:"5 days ago" \b(auth[^o][^r]|security\b|cve|password|secure|unsafe|perms|permissions)`
 
-- [Admitted hacks and TODOs in app code](https://sourcegraph.com/search?q=repogroup:sample+-file:%5C.%28json%7Cmd%7Ctxt%29%24+hack%7Ctodo%7Ckludge%7Cfixme)<br/>
+- [Admitted hacks and TODOs in app code](https://sourcegraph.com/search?q=-file:%5C.%28json%7Cmd%7Ctxt%29%24+hack%7Ctodo%7Ckludge%7Cfixme)<br/>
 `-file:\.(json|md|txt)$ hack|todo|kludge|fixme`
 
 - [New usages of a function](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+type:diff+after:%221+week+ago%22+%5C.subscribe%5C%28+lang:typescript)<br/>

--- a/shared/src/settings/settings.test.ts
+++ b/shared/src/settings/settings.test.ts
@@ -92,13 +92,11 @@ describe('mergeSettings', () => {
                     b?: { [key: string]: { [key: string]: string }[] }
                 } & Settings
             >([
-                { 'search.scopes': [{ name: 'sample repos', value: 'repogroup:sample' }] },
                 { 'search.scopes': [{ name: 'test repos', value: 'repogroup:test' }] },
                 { 'search.scopes': [{ name: 'sourcegraph repos', value: 'repogroup:sourcegraph' }] },
             ])
         ).toEqual({
             'search.scopes': [
-                { name: 'sample repos', value: 'repogroup:sample' },
                 { name: 'test repos', value: 'repogroup:test' },
                 { name: 'sourcegraph repos', value: 'repogroup:sourcegraph' },
             ],

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -130,30 +130,6 @@ export function toggleSearchType(query: string, searchType: SearchType): string 
 export const isSearchResults = (val: any): val is GQL.ISearchResults =>
     val && typeof val === 'object' && val.__typename === 'SearchResults'
 
-/**
- * Toggles the given search scope by adding it or removing it from the current string, and removes `repogroup:sample`
- * from the query if it exists in the query, and the search scope being added contains a `repogroup:` filter.
- *
- * @param query the current user query
- * @param searchFilter the search scope (sub query) or dynamic filter to toggle (add/remove from the current user query)
- * @returns The new query
- */
-export const toggleSearchFilterAndReplaceSampleRepogroup = (query: string, searchFilter: string): string => {
-    const newQuery = toggleSearchFilter(query, searchFilter)
-    // RegExp to replace `repogroup:sample` without removing leading whitespace.
-    const replaceSampleRepogroupRegexp = /(\b|^)repogroup:sample(\s|$)/
-    // RegExp to match `repogroup:sample` in any part of a query.
-    const matchSampleRepogroupRegexp = /(\s*|^)repogroup:sample(\s*|$)/
-    if (
-        /\brepogroup:/.test(searchFilter) &&
-        matchSampleRepogroupRegexp.test(newQuery) &&
-        !matchSampleRepogroupRegexp.test(searchFilter)
-    ) {
-        return newQuery.replace(replaceSampleRepogroupRegexp, '')
-    }
-    return newQuery
-}
-
 const isValidFilter = (filter: string = ''): filter is FiltersSuggestionTypes =>
     Object.prototype.hasOwnProperty.call(SuggestionTypes, filter) ||
     Object.prototype.hasOwnProperty.call(filterAliases, filter)


### PR DESCRIPTION
Now that Sourcegraph.com indexes ~10k public repositories, we don't need or recommend `repogroup:sample` anymore. This commit removes remnants of it from code and docs to avoid confusion.
    
It is extremely unlikely that any users actually used `repogroup:sample` and are relying on it, so this change is safe to make.
