### PR TITLE
use eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ libsqlite3-pcre.so
 docker-images/prometheus/config/prometheus_targets.yml
 
 comment.txt
+
+.eslintcache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,6 +55,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
   },
+  "eslint.options": { "cache": true },
   "eslint.workingDirectories": [
     {
       "directory": "dev/release",

--- a/browser/package.json
+++ b/browser/package.json
@@ -15,7 +15,7 @@
     "release:npm": "TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" ts-node ./scripts/publish-npm.ts",
     "lint": "yarn run tslint && yarn run eslint && yarn run stylelint",
     "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json './**/*.ts?(x)'",
-    "eslint": "eslint '**/*.[jt]s?(x)'",
+    "eslint": "eslint --cache '**/*.[jt]s?(x)'",
     "stylelint": "stylelint 'src/**/*.scss'",
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
     "test": "jest --testPathIgnorePatterns e2e",

--- a/lsif/package.json
+++ b/lsif/package.json
@@ -77,7 +77,7 @@
     "build": "tsc -b .",
     "test": "jest",
     "tslint": "../node_modules/.bin/tslint -p tsconfig.json",
-    "eslint": "../node_modules/.bin/eslint 'src/**/*.ts?(x)'",
+    "eslint": "../node_modules/.bin/eslint --cache 'src/**/*.ts?(x)'",
     "run:server": "tsc-watch --onSuccess \"node -r source-map-support/register out/server/server.js\" --noClear",
     "run:worker": "tsc-watch --onSuccess \"node -r source-map-support/register out/worker/worker.js\" --noClear"
   }

--- a/shared/package.json
+++ b/shared/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "tslint": "tslint -t stylish -c ../tslint.config.js -p tsconfig.json",
-    "eslint": "eslint '**/*.[jt]s?(x)'",
+    "eslint": "eslint --cache '**/*.[jt]s?(x)'",
     "stylelint": "stylelint 'src/**/*.scss'",
     "test": "jest",
     "graphql": "gulp graphQLTypes",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "webpack": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" gulp webpack",
     "lint": "yarn run tslint && gulp unusedExports && yarn run stylelint",
     "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json -e 'src/schema/**' 'src/**/*.ts?(x)' 'types/**/*.ts?(x)' './*.ts?(x)'",
-    "eslint": "eslint 'src/**/*.ts?(x)'",
+    "eslint": "eslint --cache 'src/**/*.ts?(x)'",
     "stylelint": "stylelint 'src/**/*.scss'",
     "bundlesize": "cross-env GITHUB_TOKEN= bundlesize",
     "browserslist": "browserslist"


### PR DESCRIPTION
This makes `yarn run eslint` tasks much faster, especially for `web`.