### PR TITLE
vscode settings: fix eslint.validate deprecation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,18 +40,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.packageManager": "yarn",
   "eslint.lintTask.enable": false,
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    {
-      "language": "typescript",
-      "autoFix": true,
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true,
-    },
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
   },


### PR DESCRIPTION
The autoFix attribute defaults to true, so we can just use the string element form.