### PR TITLE
cmd/frontend: Stop relying on FileInfo.Size()

### DIFF
--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -163,8 +163,8 @@ func TestReposGetInventory(t *testing.T) {
 			useEnhancedLanguageDetection: false,
 			want: &inventory.Inventory{
 				Languages: []inventory.Lang{
-					{Name: "Go", TotalBytes: 12, TotalLines: 0},
-					{Name: "Limbo", TotalBytes: 24, TotalLines: 0}, // obviously incorrect, but this is how the pre-enhanced lang detection worked
+					{Name: "Go", TotalBytes: 0, TotalLines: 0},
+					{Name: "Limbo", TotalBytes: 0, TotalLines: 0}, // obviously incorrect, but this is how the pre-enhanced lang detection worked
 				},
 			},
 		},

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -92,7 +92,6 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{
 					path:  fileMatch.JPath,
 					isDir: fileMatch.File().IsDirectory(),
-					size:  1, // fake size 1 to force reading of contents (if size == 0, no read occurs)
 				})
 			}
 		} else if repo, ok := res.ToRepository(); ok && !hasNonRepoMatches {
@@ -160,8 +159,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 			// by the number of matched lines in the file.
 			for partialFile, lines := range work.partialFiles {
 				inv, err := invCtx.Entries(ctx,
-					// Fake size 1 to force reading of contents (if size == 0, no read occurs).
-					fileInfo{path: partialFile, isDir: false, size: 1},
+					fileInfo{path: partialFile, isDir: false},
 				)
 				if err != nil {
 					run.Error(err)

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -71,7 +71,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 					CommitID: wantCommitID,
 				},
 			},
-			want: []inventory.Lang{{Name: "Go", TotalBytes: 1, TotalLines: 3}},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 3}},
 		},
 		"line matches in 1 file": {
 			results: []SearchResultResolver{
@@ -82,7 +82,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 					JLineMatches: []*lineMatch{{JLineNumber: 1}},
 				},
 			},
-			want: []inventory.Lang{{Name: "Go", TotalBytes: 1, TotalLines: 1}},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 1}},
 		},
 		"line matches in 2 files": {
 			results: []SearchResultResolver{
@@ -99,7 +99,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 					JLineMatches: []*lineMatch{{JLineNumber: 1}},
 				},
 			},
-			want: []inventory.Lang{{Name: "Go", TotalBytes: 2, TotalLines: 3}},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 3}},
 		},
 		"1 entire repo": {
 			results: []SearchResultResolver{
@@ -108,10 +108,10 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 				},
 			},
 			getFiles: []os.FileInfo{
-				fileInfo{path: "two.go", size: 1},
-				fileInfo{path: "three.go", size: 1},
+				fileInfo{path: "two.go"},
+				fileInfo{path: "three.go"},
 			},
-			want: []inventory.Lang{{Name: "Go", TotalBytes: 2, TotalLines: 5}},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 5}},
 		},
 	}
 	for name, test := range tests {

--- a/cmd/frontend/internal/inventory/entries.go
+++ b/cmd/frontend/internal/inventory/entries.go
@@ -14,11 +14,6 @@ const fileReadBufferSize = 16 * 1024
 // Entries computes the inventory of languages for the given entries. It traverses trees recursively
 // and caches results for each subtree. Results for listed files are cached.
 //
-// Known issue: If a listed entry's (os.FileInfo).Size() == 0, it is treated as empty. Callers must
-// ensure that either the size is known. If the size is not known and the caller only cares about
-// line counts, the caller must ensure that a nonzero size is reported and must ignore all
-// TotalBytes counts.
-//
 // If a file is referenced more than once (e.g., because it is a descendent of a subtree and it is
 // passed directly), it will be double-counted in the result.
 func (c *Context) Entries(ctx context.Context, entries ...os.FileInfo) (inv Inventory, err error) {

--- a/cmd/frontend/internal/inventory/entries_test.go
+++ b/cmd/frontend/internal/inventory/entries_test.go
@@ -70,11 +70,11 @@ func TestContext_Entries(t *testing.T) {
 	}
 	if want := (Inventory{
 		Languages: []Lang{
-			{Name: "Go", TotalBytes: 13, TotalLines: 2},
+			{Name: "Go", TotalBytes: 21, TotalLines: 2},
 			{Name: "Objective-C", TotalBytes: 24, TotalLines: 1},
 		},
 	}); !reflect.DeepEqual(inv, want) {
-		t.Errorf("got  %#v\nwant %#v", inv, want)
+		t.Fatalf("got  %#v\nwant %#v", inv, want)
 	}
 
 	// Check that our mocks were called as expected.
@@ -106,7 +106,7 @@ func TestContext_Entries(t *testing.T) {
 		},
 		"f.go": {
 			Languages: []Lang{
-				{Name: "Go", TotalBytes: 1, TotalLines: 1},
+				{Name: "Go", TotalBytes: 9, TotalLines: 1},
 			},
 		},
 	}; !reflect.DeepEqual(cacheSetCalls, want) {

--- a/cmd/frontend/internal/inventory/inventory_test.go
+++ b/cmd/frontend/internal/inventory/inventory_test.go
@@ -42,7 +42,6 @@ func TestGetLang_language(t *testing.T) {
 			TotalBytes: 2,
 			TotalLines: 1,
 		}},
-
 		// Ensure that .tsx and .jsx are considered as valid extensions for TypeScript and JavaScript,
 		// respectively.
 		"override tsx": {file: fi{"a.tsx", "xx"}, want: Lang{


### PR DESCRIPTION
Instead, count the number of bytes and lines at the same time.

fix https://github.com/sourcegraph/sourcegraph/issues/7270