### PR TITLE
enterprise/a8n: Fix panic in store

### DIFF
--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -394,7 +394,7 @@ func (s *Store) ListChangesets(ctx context.Context, opts ListChangesetsOpts) (cs
 		return int64(c.ID), 1, err
 	})
 
-	if len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.Limit {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}
@@ -1127,7 +1127,7 @@ func (s *Store) ListCampaigns(ctx context.Context, opts ListCampaignsOpts) (cs [
 		return int64(c.ID), 1, err
 	})
 
-	if len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.Limit {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}
@@ -1496,7 +1496,7 @@ func (s *Store) ListCampaignPlans(ctx context.Context, opts ListCampaignPlansOpt
 		return int64(c.ID), 1, err
 	})
 
-	if len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.Limit {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -417,7 +417,6 @@ SELECT
 FROM changesets
 WHERE %s
 ORDER BY id ASC
-LIMIT %s
 `
 
 const defaultListLimit = 50
@@ -427,6 +426,11 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 		opts.Limit = defaultListLimit
 	}
 	opts.Limit++
+
+	var limitClause string
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+	}
 
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
@@ -451,9 +455,8 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetsQueryFmtstr,
+		listChangesetsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
-		opts.Limit,
 	)
 }
 

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -524,6 +524,18 @@ func testStore(db *sql.DB) func(*testing.T) {
 						t.Fatalf("have %d changesets. want 0", len(have))
 					}
 				}
+
+				// Limit of -1 should return all ChangeSets
+				{
+					have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{Limit: -1})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if len(have) != 3 {
+						t.Fatalf("have %d changesets. want 3", len(have))
+					}
+				}
 			})
 
 			t.Run("Get", func(t *testing.T) {


### PR DESCRIPTION
Many of our List functions could panic if opts.Limit was set to 0 and
zero results were returned.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7345



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
