### PR TITLE
Refactor and add some tests for CampaignDetails

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -12,6 +12,8 @@ jest.mock('./form/CampaignPlanSpecificationFields', () => ({
 jest.mock('./form/CampaignNamespaceField', () => ({ CampaignNamespaceField: 'CampaignNamespaceField' }))
 jest.mock('./form/CampaignTitleField', () => ({ CampaignTitleField: 'CampaignTitleField' }))
 jest.mock('./form/CampaignDescriptionField', () => ({ CampaignDescriptionField: 'CampaignDescriptionField' }))
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+jest.mock('./CampaignStatus', () => ({ CampaignStatus: (props: any) => `CampaignStatus(state=${props.status.state})` }))
 
 const history = H.createMemoryHistory()
 
@@ -47,6 +49,13 @@ describe('CampaignDetails', () => {
                     plan: { type: 'comby', arguments: '{}' },
                     changesets: { nodes: [] as GQL.IExternalChangeset[], totalCount: 2 },
                     changesetCountsOverTime: [] as GQL.IChangesetCounts[],
+                    changesetCreationStatus: {
+                        __typename: 'BackgroundProcessStatus',
+                        completedCount: 3,
+                        pendingCount: 3,
+                        errors: ['a'],
+                        state: GQL.BackgroundProcessState.PROCESSING,
+                    },
                     createdAt: '2020-01-01',
                     updatedAt: '2020-01-01',
                 } as GQL.ICampaign)

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { CampaignDetails } from './CampaignDetails'
+import * as H from 'history'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+jest.mock('../../../settings/MonacoSettingsEditor', () => ({ MonacoSettingsEditor: 'MonacoSettingsEditor' }))
+
+describe('CampaignDetails', () => {
+    test('creation form', () => {
+        const history = H.createMemoryHistory()
+        expect(
+            createRenderer().render(
+                <CampaignDetails
+                    campaignID={undefined}
+                    history={history}
+                    location={history.location}
+                    authenticatedUser={{ username: 'alice', avatarURL: null }}
+                    isLightTheme={true}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -6,7 +6,9 @@ import * as H from 'history'
 import { createRenderer } from 'react-test-renderer/shallow'
 import { of } from 'rxjs'
 
-jest.mock('../../../settings/MonacoSettingsEditor', () => ({ MonacoSettingsEditor: 'MonacoSettingsEditor' }))
+jest.mock('./form/CampaignPlanSpecificationFields', () => ({
+    CampaignPlanSpecificationFields: 'CampaignPlanSpecificationFields',
+}))
 jest.mock('./form/CampaignNamespaceField', () => ({ CampaignNamespaceField: 'CampaignNamespaceField' }))
 jest.mock('./form/CampaignTitleField', () => ({ CampaignTitleField: 'CampaignTitleField' }))
 jest.mock('./form/CampaignDescriptionField', () => ({ CampaignDescriptionField: 'CampaignDescriptionField' }))

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -1,13 +1,20 @@
 import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import * as GQL from '../../../../../shared/src/graphql/schema'
 import { CampaignDetails } from './CampaignDetails'
 import * as H from 'history'
 import { createRenderer } from 'react-test-renderer/shallow'
+import { of } from 'rxjs'
 
 jest.mock('../../../settings/MonacoSettingsEditor', () => ({ MonacoSettingsEditor: 'MonacoSettingsEditor' }))
+jest.mock('./form/CampaignNamespaceField', () => ({ CampaignNamespaceField: 'CampaignNamespaceField' }))
+jest.mock('./form/CampaignTitleField', () => ({ CampaignTitleField: 'CampaignTitleField' }))
+jest.mock('./form/CampaignDescriptionField', () => ({ CampaignDescriptionField: 'CampaignDescriptionField' }))
+
+const history = H.createMemoryHistory()
 
 describe('CampaignDetails', () => {
-    test('creation form', () => {
-        const history = H.createMemoryHistory()
+    test('creation form', () =>
         expect(
             createRenderer().render(
                 <CampaignDetails
@@ -18,6 +25,46 @@ describe('CampaignDetails', () => {
                     isLightTheme={true}
                 />
             )
-        ).toMatchSnapshot()
+        ).toMatchSnapshot())
+
+    const EXISTING_CAMPAIGN_DETAILS = (
+        <CampaignDetails
+            campaignID="c"
+            history={history}
+            location={history.location}
+            authenticatedUser={{ username: 'alice', avatarURL: null }}
+            isLightTheme={true}
+            _fetchCampaignById={() =>
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                of({
+                    __typename: 'Campaign',
+                    id: 'c',
+                    description: 'd',
+                    namespace: { namespaceName: 'alice' },
+                    author: { username: 'alice' },
+                    plan: { type: 'comby', arguments: '{}' },
+                    changesets: { nodes: [] as GQL.IExternalChangeset[] },
+                    changesetCountsOverTime: [] as GQL.IChangesetCounts[],
+                    createdAt: '2020-01-01',
+                    updatedAt: '2020-01-01',
+                } as GQL.ICampaign)
+            }
+        />
+    )
+
+    test('viewing existing', () => {
+        const component = renderer.create(EXISTING_CAMPAIGN_DETAILS)
+        act(() => undefined) // eslint-disable-line @typescript-eslint/no-floating-promises
+        expect(component).toMatchSnapshot()
+    })
+
+    test('editing existing', () => {
+        const component = renderer.create(EXISTING_CAMPAIGN_DETAILS)
+        act(() => undefined) // eslint-disable-line @typescript-eslint/no-floating-promises
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        act(() =>
+            component.root.findByProps({ id: 'e2e-campaign-edit' }).props.onClick({ preventDefault: () => undefined })
+        )
+        expect(component).toMatchSnapshot()
     })
 })

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -43,7 +43,7 @@ describe('CampaignDetails', () => {
                     namespace: { namespaceName: 'alice' },
                     author: { username: 'alice' },
                     plan: { type: 'comby', arguments: '{}' },
-                    changesets: { nodes: [] as GQL.IExternalChangeset[] },
+                    changesets: { nodes: [] as GQL.IExternalChangeset[], totalCount: 2 },
                     changesetCountsOverTime: [] as GQL.IChangesetCounts[],
                     createdAt: '2020-01-01',
                     updatedAt: '2020-01-01',

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -125,7 +125,8 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                                 () =>
                                                     !!currentCampaign &&
                                                     !!currentCampaign.changesetCreationStatus &&
-                                                    currentCampaign.changesetCreationStatus.state === 'PROCESSING'
+                                                    currentCampaign.changesetCreationStatus.state ===
+                                                        GQL.BackgroundProcessState.PROCESSING
                                             ),
                                             delay(2000)
                                         )
@@ -202,7 +203,10 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                           timer(0, 2000).pipe(
                                               concatMap(() => fetchCampaignPlanById(previewPlan.id)),
                                               takeWhile(isDefined),
-                                              takeWhile(plan => plan.status.state === 'PROCESSING', true)
+                                              takeWhile(
+                                                  plan => plan.status.state === GQL.BackgroundProcessState.PROCESSING,
+                                                  true
+                                              )
                                           )
                                       )
                                   )
@@ -361,7 +365,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     const previewRefreshNeeded =
         !currentSpec ||
         (campaignPlanArguments && !isEqual(currentSpec, parseJSONC(campaignPlanArguments))) ||
-        (status && status.state !== 'COMPLETED')
+        (status && status.state !== GQL.BackgroundProcessState.COMPLETED)
 
     return (
         <>

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -39,14 +39,13 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { TabsWithLocalStorageViewStatePersistence } from '../../../../../shared/src/components/Tabs'
 import { isDefined } from '../../../../../shared/src/util/types'
 import { FileDiffTab } from './FileDiffTab'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import classNames from 'classnames'
-import WarningIcon from 'mdi-react/WarningIcon'
 import { CampaignNamespaceField } from './form/CampaignNamespaceField'
 import { CampaignTitleField } from './form/CampaignTitleField'
 import { CampaignDescriptionField } from './form/CampaignDescriptionField'
 import { CloseDeleteCampaignPrompt } from './form/CloseDeleteCampaignPrompt'
 import { CampaignPlanSpecificationFields } from './form/CampaignPlanSpecificationFields'
+import { CampaignStatus } from './CampaignStatus'
 
 interface Props extends ThemeProps {
     /**
@@ -324,8 +323,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         }
     }
 
-    const onRetry: React.MouseEventHandler = async event => {
-        event.preventDefault()
+    const onRetry = async (): Promise<void> => {
         try {
             await retryCampaign(campaign!.id)
             campaignUpdates.next()
@@ -557,46 +555,8 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                 )}
             </Form>
 
-            {status && (
-                <>
-                    {status.state === 'PROCESSING' && (
-                        <div className="d-flex mt-3 e2e-preview-loading">
-                            <LoadingSpinner className="icon-inline" />{' '}
-                            <span data-tooltip="Computing changesets">
-                                {status.completedCount} / {status.pendingCount + status.completedCount}
-                            </span>
-                        </div>
-                    )}
-                    {campaign && campaign.__typename === 'Campaign' && campaign.closedAt ? (
-                        <div className="d-flex my-3">
-                            <WarningIcon className="icon-inline text-warning mr-1" /> Campaign is closed
-                        </div>
-                    ) : (
-                        type &&
-                        status.state !== 'PROCESSING' && (
-                            <div className="d-flex my-3">
-                                {status.state === 'COMPLETED' && (
-                                    <CheckCircleIcon className="icon-inline text-success mr-1 e2e-preview-success" />
-                                )}
-                                {status.state === 'ERRORED' && (
-                                    <AlertCircleIcon className="icon-inline text-danger mr-1" />
-                                )}{' '}
-                                {/* Status asserts on campaign being set, this will never be null */}
-                                {campaign!.__typename === 'Campaign' ? 'Creation' : 'Preview'}{' '}
-                                {status.state.toLocaleLowerCase()}
-                            </div>
-                        )
-                    )}
-                    {status.errors.map((error, i) => (
-                        <ErrorAlert error={error} className="mt-3" key={i} />
-                    ))}
-                    {status.state === 'ERRORED' && campaign?.__typename === 'Campaign' && (
-                        <button type="button" className="btn btn-primary mb-2" onClick={onRetry}>
-                            Retry failed jobs
-                        </button>
-                    )}
-                </>
-            )}
+            {/* Status asserts on campaign being set, so `campaign` will never be null. */}
+            {status && <CampaignStatus campaign={campaign!} status={status} onRetry={onRetry} />}
 
             {campaign && campaign.__typename === 'Campaign' && (
                 <>

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -55,10 +55,9 @@ interface Props extends ThemeProps {
      * If not given, will display a creation form.
      */
     campaignID?: GQL.ID
-    authenticatedUser: GQL.IUser
+    authenticatedUser: Pick<GQL.IUser, 'username' | 'avatarURL'>
     history: H.History
     location: H.Location
-    isSourcegraphDotCom: boolean
 }
 
 const jsonSchemaByType: { [K in CampaignType]: any } = {
@@ -93,7 +92,6 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     location,
     authenticatedUser,
     isLightTheme,
-    isSourcegraphDotCom,
 }) => {
     // State for the form in editing mode
     const [name, setName] = useState<string>('')
@@ -554,13 +552,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                 {mode === 'editing' && (
                     <p className="ml-1 mb-0">
                         <small>
-                            <a
-                                rel="noopener noreferrer"
-                                target="_blank"
-                                href={
-                                    (isSourcegraphDotCom ? 'https://docs.sourcegraph.com' : '/help') + '/user/markdown'
-                                }
-                            >
+                            <a rel="noopener noreferrer" target="_blank" href="/help/user/markdown">
                                 Markdown supported
                             </a>
                         </small>
@@ -614,7 +606,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                     height={110}
                                     onChange={onChangeArguments}
                                     readOnly={!!(campaign && campaign.__typename === 'Campaign')}
-                                ></MonacoSettingsEditor>
+                                />
                             </div>
                         )}
                     </div>

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -47,6 +47,7 @@ import classNames from 'classnames'
 import WarningIcon from 'mdi-react/WarningIcon'
 import { CampaignNamespaceField } from './form/CampaignNamespaceField'
 import { CampaignTitleField } from './form/CampaignTitleField'
+import { CampaignDescriptionField } from './form/CampaignDescriptionField'
 
 interface Props extends ThemeProps {
     /**
@@ -536,12 +537,9 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         )}
                     </div>
                     {mode === 'editing' || mode === 'saving' ? (
-                        <textarea
-                            className="form-control"
+                        <CampaignDescriptionField
                             value={description}
-                            onChange={event => setDescription(event.target.value)}
-                            placeholder="Describe the purpose of this campaign, link to relevant internal documentation, etc."
-                            rows={8}
+                            onChange={setDescription}
                             disabled={mode === 'saving'}
                         />
                     ) : (

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -48,6 +48,7 @@ import WarningIcon from 'mdi-react/WarningIcon'
 import { CampaignNamespaceField } from './form/CampaignNamespaceField'
 import { CampaignTitleField } from './form/CampaignTitleField'
 import { CampaignDescriptionField } from './form/CampaignDescriptionField'
+import { CloseDeleteCampaignPrompt } from './form/CloseDeleteCampaignPrompt'
 
 interface Props extends ThemeProps {
     /**
@@ -307,8 +308,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         setAlertError(undefined)
     }
 
-    const onClose: React.MouseEventHandler = async event => {
-        event.preventDefault()
+    const onClose = async (): Promise<void> => {
         if (!confirm('Are you sure you want to close the campaign?')) {
             return
         }
@@ -323,8 +323,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         }
     }
 
-    const onDelete: React.MouseEventHandler = async event => {
-        event.preventDefault()
+    const onDelete = async (): Promise<void> => {
         if (!confirm('Are you sure you want to delete the campaign?')) {
             return
         }
@@ -347,10 +346,6 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         } catch (err) {
             setAlertError(asError(err))
         }
-    }
-
-    const onCloseChangesetsToggle: React.ChangeEventHandler = (event: React.ChangeEvent) => {
-        setCloseChangesets((event.target as HTMLInputElement).checked)
     }
 
     const author = campaign && campaign.__typename === 'Campaign' ? campaign.author : authenticatedUser
@@ -461,64 +456,42 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                                             Close
                                                         </span>
                                                     </summary>
-                                                    <div className="position-absolute campaign-details__details-menu">
-                                                        <div className="card mt-1">
-                                                            <div className="card-body">
-                                                                <p>
-                                                                    Close campaign <b>{campaign.name}</b>?
-                                                                </p>
-                                                                <div className="form-group">
-                                                                    <input
-                                                                        type="checkbox"
-                                                                        checked={closeChangesets}
-                                                                        onChange={onCloseChangesetsToggle}
-                                                                    />{' '}
-                                                                    Close all {campaign.changesets.totalCount}{' '}
-                                                                    changesets on codehosts
-                                                                </div>
-                                                                <button
-                                                                    type="button"
-                                                                    disabled={mode === 'deleting' || mode === 'closing'}
-                                                                    className="btn btn-secondary mr-1"
-                                                                    onClick={onClose}
-                                                                >
-                                                                    Close
-                                                                </button>
-                                                            </div>
-                                                        </div>
-                                                    </div>
+                                                    <CloseDeleteCampaignPrompt
+                                                        message={
+                                                            <p>
+                                                                Close campaign <b>{campaign.name}</b>?
+                                                            </p>
+                                                        }
+                                                        changesetsCount={campaign.changesets.totalCount}
+                                                        closeChangesets={closeChangesets}
+                                                        onCloseChangesetsToggle={setCloseChangesets}
+                                                        buttonText="Close"
+                                                        onButtonClick={onClose}
+                                                        buttonClassName="btn-secondary"
+                                                        buttonDisabled={mode === 'deleting' || mode === 'closing'}
+                                                        className="position-absolute campaign-details__details-menu"
+                                                    />
                                                 </details>
                                             )}
                                             <details className="campaign-details__details">
                                                 <summary>
                                                     <span className="btn btn-danger dropdown-toggle">Delete</span>
                                                 </summary>
-                                                <div className="position-absolute campaign-details__details-menu">
-                                                    <div className="card mt-1">
-                                                        <div className="card-body">
-                                                            <p>
-                                                                Delete campaign <b>{campaign.name}</b>?
-                                                            </p>
-                                                            <div className="form-group">
-                                                                <input
-                                                                    type="checkbox"
-                                                                    checked={closeChangesets}
-                                                                    onChange={onCloseChangesetsToggle}
-                                                                />{' '}
-                                                                Close all {campaign.changesets.totalCount} changesets on
-                                                                codehosts
-                                                            </div>
-                                                            <button
-                                                                type="button"
-                                                                disabled={mode === 'deleting' || mode === 'closing'}
-                                                                className="btn btn-danger mr-1"
-                                                                onClick={onDelete}
-                                                            >
-                                                                Delete
-                                                            </button>
-                                                        </div>
-                                                    </div>
-                                                </div>
+                                                <CloseDeleteCampaignPrompt
+                                                    message={
+                                                        <p>
+                                                            Delete campaign <b>{campaign.name}</b>?
+                                                        </p>
+                                                    }
+                                                    changesetsCount={campaign.changesets.totalCount}
+                                                    closeChangesets={closeChangesets}
+                                                    onCloseChangesetsToggle={setCloseChangesets}
+                                                    buttonText="Delete"
+                                                    onButtonClick={onDelete}
+                                                    buttonClassName="btn-danger"
+                                                    buttonDisabled={mode === 'deleting' || mode === 'closing'}
+                                                    className="position-absolute campaign-details__details-menu"
+                                                />
                                             </details>
                                         </>
                                     )}

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -384,7 +384,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
 
     return (
         <>
-            <PageTitle title={campaign && campaign.__typename === 'Campaign' ? campaign.name : 'New Campaign'} />
+            <PageTitle title={campaign && campaign.__typename === 'Campaign' ? campaign.name : 'New campaign'} />
             <Form onSubmit={onSubmit} onReset={onCancel} className="e2e-campaign-form position-relative">
                 <div className="d-flex mb-2">
                     <h2 className="m-0">

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -46,6 +46,7 @@ import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import classNames from 'classnames'
 import WarningIcon from 'mdi-react/WarningIcon'
 import { CampaignNamespaceField } from './form/CampaignNamespaceField'
+import { CampaignTitleField } from './form/CampaignTitleField'
 
 interface Props extends ThemeProps {
     /**
@@ -413,14 +414,11 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         )}
                         <span className="text-muted d-inline-block mx-2">/</span>
                         {mode === 'editing' || mode === 'saving' ? (
-                            <input
-                                className="form-control w-auto d-inline-block e2e-campaign-title"
+                            <CampaignTitleField
+                                className="w-auto d-inline-block e2e-campaign-title"
                                 value={name}
-                                onChange={event => setName(event.target.value)}
-                                placeholder="Campaign title"
+                                onChange={setName}
                                 disabled={mode === 'saving'}
-                                autoFocus={true}
-                                required={true}
                             />
                         ) : (
                             <span>{campaign && campaign.__typename === 'Campaign' && campaign.name}</span>

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -58,6 +58,9 @@ interface Props extends ThemeProps {
     authenticatedUser: Pick<GQL.IUser, 'username' | 'avatarURL'>
     history: H.History
     location: H.Location
+
+    /** For testing only. */
+    _fetchCampaignById?: typeof fetchCampaignById
 }
 
 const jsonSchemaByType: { [K in CampaignType]: any } = {
@@ -92,6 +95,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     location,
     authenticatedUser,
     isLightTheme,
+    _fetchCampaignById = fetchCampaignById,
 }) => {
     // State for the form in editing mode
     const [name, setName] = useState<string>('')
@@ -122,7 +126,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                     () =>
                         new Observable<GQL.ICampaign | null>(observer => {
                             let currentCampaign: GQL.ICampaign | null
-                            const subscription = fetchCampaignById(campaignID)
+                            const subscription = _fetchCampaignById(campaignID)
                                 .pipe(
                                     tap(campaign => {
                                         currentCampaign = campaign
@@ -155,7 +159,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                 error: triggerError,
             })
         return () => subscription.unsubscribe()
-    }, [campaignID, triggerError, nextChangesetUpdate, campaignUpdates])
+    }, [campaignID, triggerError, nextChangesetUpdate, campaignUpdates, _fetchCampaignById])
 
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArgs) => queryChangesets(campaignID!, args),
@@ -441,6 +445,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                 <>
                                     <button
                                         type="button"
+                                        id="e2e-campaign-edit"
                                         className="btn btn-secondary mr-1"
                                         onClick={onEdit}
                                         disabled={mode === 'deleting' || mode === 'closing'}

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { CampaignStatus } from './CampaignStatus'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+const PROPS = {
+    onRetry: () => undefined,
+}
+
+const CAMPAIGN: Pick<GQL.ICampaign, '__typename' | 'closedAt'> = {
+    __typename: 'Campaign',
+    closedAt: null,
+}
+
+const CAMPAIGN_PLAN: Pick<GQL.ICampaignPlan, '__typename'> = {
+    __typename: 'CampaignPlan',
+}
+
+describe('CampaignStatus', () => {
+    test('closed campaign', () =>
+        expect(
+            createRenderer().render(
+                <CampaignStatus
+                    {...PROPS}
+                    campaign={{ ...CAMPAIGN, closedAt: '2020-01-01' }}
+                    status={{
+                        completedCount: 1,
+                        pendingCount: 0,
+                        errors: [],
+                        state: GQL.BackgroundProcessState.COMPLETED,
+                    }}
+                />
+            )
+        ).toMatchSnapshot())
+
+    test('campaign processing', () =>
+        expect(
+            createRenderer().render(
+                <CampaignStatus
+                    {...PROPS}
+                    campaign={CAMPAIGN}
+                    status={{
+                        completedCount: 3,
+                        pendingCount: 3,
+                        errors: ['a', 'b'],
+                        state: GQL.BackgroundProcessState.PROCESSING,
+                    }}
+                />
+            )
+        ).toMatchSnapshot())
+
+    test('campaign plan processing', () =>
+        expect(
+            createRenderer().render(
+                <CampaignStatus
+                    {...PROPS}
+                    campaign={CAMPAIGN_PLAN}
+                    status={{
+                        completedCount: 3,
+                        pendingCount: 3,
+                        errors: ['a', 'b'],
+                        state: GQL.BackgroundProcessState.PROCESSING,
+                    }}
+                />
+            )
+        ).toMatchSnapshot())
+
+    test('campaign errored', () =>
+        expect(
+            createRenderer().render(
+                <CampaignStatus
+                    {...PROPS}
+                    campaign={CAMPAIGN}
+                    status={{
+                        completedCount: 3,
+                        pendingCount: 0,
+                        errors: ['a', 'b'],
+                        state: GQL.BackgroundProcessState.ERRORED,
+                    }}
+                />
+            )
+        ).toMatchSnapshot())
+})

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import WarningIcon from 'mdi-react/WarningIcon'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import { ErrorAlert } from '../../../components/alerts'
+
+interface Props {
+    campaign: Pick<GQL.ICampaign, '__typename' | 'closedAt'> | Pick<GQL.ICampaignPlan, '__typename'>
+
+    /** The campaign status. */
+    status: Omit<GQL.IBackgroundProcessStatus, '__typename'>
+
+    /** Called when the "Retry failed jobs" button is clicked. */
+    onRetry: () => void
+}
+
+/**
+ * The status of a campaign's jobs, plus its closed state and errors.
+ */
+export const CampaignStatus: React.FunctionComponent<Props> = ({ campaign, status, onRetry }) => (
+    <>
+        {status.state === GQL.BackgroundProcessState.PROCESSING && (
+            <div className="d-flex mt-3 e2e-preview-loading">
+                <LoadingSpinner className="icon-inline" />{' '}
+                <span data-tooltip="Computing changesets">
+                    {status.completedCount} / {status.pendingCount + status.completedCount}
+                </span>
+            </div>
+        )}
+        {campaign.__typename === 'Campaign' && campaign.closedAt ? (
+            <div className="d-flex my-3">
+                <WarningIcon className="icon-inline text-warning mr-1" /> Campaign is closed
+            </div>
+        ) : (
+            status.pendingCount + status.completedCount > 0 &&
+            status.state !== GQL.BackgroundProcessState.PROCESSING && (
+                <div className="d-flex my-3">
+                    {status.state === GQL.BackgroundProcessState.COMPLETED && (
+                        <CheckCircleIcon className="icon-inline text-success mr-1 e2e-preview-success" />
+                    )}
+                    {status.state === GQL.BackgroundProcessState.ERRORED && (
+                        <AlertCircleIcon className="icon-inline text-danger mr-1" />
+                    )}{' '}
+                    {campaign.__typename === 'Campaign' ? 'Creation' : 'Preview'} {status.state.toLocaleLowerCase()}
+                </div>
+            )
+        )}
+        {status.errors.map((error, i) => (
+            // There is no other suitable key, so:
+            // eslint-disable-next-line react/no-array-index-key
+            <ErrorAlert error={error} className="mt-3" key={i} />
+        ))}
+        {status.state === GQL.BackgroundProcessState.ERRORED && campaign?.__typename === 'Campaign' && (
+            <button type="button" className="btn btn-primary mb-2" onClick={onRetry}>
+                Retry failed jobs
+            </button>
+        )}
+    </>
+)

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignDetails creation form 1`] = `
+<React.Fragment>
+  <PageTitle
+    title="New campaign"
+  />
+  <Form
+    className="e2e-campaign-form position-relative"
+    onReset={[Function]}
+    onSubmit={[Function]}
+  >
+    <div
+      className="d-flex mb-2"
+    >
+      <h2
+        className="m-0"
+      >
+        <Memo(ChartHistogramIcon)
+          className="icon-inline mr-2 text-muted"
+        />
+        <span>
+          <AnchorLink
+            to="/campaigns"
+          >
+            Campaigns
+          </AnchorLink>
+        </span>
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <CampaignNamespaceField
+          className="w-auto d-inline-block"
+          id="new-campaign-page__namespace"
+          onChange={[Function]}
+        />
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <CampaignTitleField
+          className="w-auto d-inline-block e2e-campaign-title"
+          disabled={false}
+          onChange={[Function]}
+          value=""
+        />
+      </h2>
+      <span
+        className="flex-grow-1 d-flex justify-content-end align-items-center"
+      />
+    </div>
+    <div
+      className="card"
+    >
+      <div
+        className="card-header"
+      >
+        <strong>
+          <UserAvatar
+            className="icon-inline"
+            user={
+              Object {
+                "avatarURL": null,
+                "username": "alice",
+              }
+            }
+          />
+           
+          alice
+        </strong>
+      </div>
+      <CampaignDescriptionField
+        disabled={false}
+        onChange={[Function]}
+        value=""
+      />
+    </div>
+    <p
+      className="ml-1 mb-0"
+    >
+      <small>
+        <a
+          href="/help/user/markdown"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Markdown supported
+        </a>
+      </small>
+    </p>
+    <div
+      className="container-fluid my-3"
+    >
+      <div
+        className="row campaign-details__property-row"
+      >
+        <h3
+          className="mr-3 mb-0 campaign-details__property-label"
+        >
+          Type
+        </h3>
+        <div
+          className="flex-grow-1 form-group mb-0"
+        >
+          <React.Fragment>
+             
+            <select
+              className="form-control w-auto d-inline-block e2e-campaign-type"
+              onChange={[Function]}
+              placeholder="Select campaign type"
+            >
+              <option
+                value=""
+              >
+                Manual
+              </option>
+              <option
+                value="comby"
+              >
+                Comby search and replace
+              </option>
+              <option
+                value="credentials"
+              >
+                Find leaked credentials
+              </option>
+            </select>
+          </React.Fragment>
+        </div>
+      </div>
+    </div>
+    <React.Fragment>
+      <button
+        className="btn btn-primary"
+        disabled={false}
+        type="submit"
+      >
+        Create
+      </button>
+    </React.Fragment>
+  </Form>
+</React.Fragment>
+`;

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -229,6 +229,7 @@ Array [
       type="comby"
     />
   </form>,
+  "CampaignStatus(state=PROCESSING)",
   <h3>
     Progress
   </h3>,
@@ -500,6 +501,7 @@ Array [
       type="comby"
     />
   </form>,
+  "CampaignStatus(state=PROCESSING)",
   <h3>
     Progress
   </h3>,

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -376,7 +376,9 @@ Array [
            
           <span
             className="badge badge-secondary badge-pill"
-          />
+          >
+            2
+          </span>
         </span>
       </button>
     </div>
@@ -480,11 +482,13 @@ Array [
                   />
                    
                   Close all 
+                  2
                    
-                  changesets on codehosts
+                  changesets
+                   changesets on code hosts
                 </div>
                 <button
-                  className="btn btn-secondary mr-1"
+                  className="btn mr-1 btn-secondary"
                   disabled={false}
                   onClick={[Function]}
                   type="button"
@@ -529,10 +533,13 @@ Array [
                   />
                    
                   Close all 
-                   changesets on codehosts
+                  2
+                   
+                  changesets
+                   changesets on code hosts
                 </div>
                 <button
-                  className="btn btn-danger mr-1"
+                  className="btn mr-1 btn-danger"
                   disabled={false}
                   onClick={[Function]}
                   type="button"
@@ -701,7 +708,9 @@ Array [
            
           <span
             className="badge badge-secondary badge-pill"
-          />
+          >
+            2
+          </span>
         </span>
       </button>
     </div>

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -144,3 +144,570 @@ exports[`CampaignDetails creation form 1`] = `
   </Form>
 </React.Fragment>
 `;
+
+exports[`CampaignDetails editing existing 1`] = `
+Array [
+  <form
+    className="e2e-campaign-form position-relative "
+    onInvalid={[Function]}
+    onReset={[Function]}
+    onSubmit={[Function]}
+  >
+    <div
+      className="d-flex mb-2"
+    >
+      <h2
+        className="m-0"
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 text-success"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M3,3H5V13H9V7H13V11H17V15H21V21H3V3Z"
+          />
+        </svg>
+        <span>
+          <a
+            href="/campaigns"
+          >
+            Campaigns
+          </a>
+        </span>
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <span>
+          alice
+        </span>
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <CampaignTitleField
+          className="w-auto d-inline-block e2e-campaign-title"
+          disabled={false}
+          onChange={[Function]}
+        />
+      </h2>
+      <span
+        className="flex-grow-1 d-flex justify-content-end align-items-center"
+      >
+        <button
+          className="btn btn-primary mr-1"
+          disabled={false}
+          type="submit"
+        >
+          Save
+        </button>
+        <button
+          className="btn btn-secondary"
+          disabled={false}
+          type="reset"
+        >
+          Cancel
+        </button>
+      </span>
+    </div>
+    <div
+      className="card"
+    >
+      <div
+        className="card-header"
+      >
+        <strong>
+           
+          alice
+        </strong>
+         
+        started 
+        <span
+          className="timestamp"
+          data-tooltip="2020-01-01"
+        >
+          in almost 14 years
+        </span>
+      </div>
+      <CampaignDescriptionField
+        disabled={false}
+        onChange={[Function]}
+        value="d"
+      />
+    </div>
+    <p
+      className="ml-1 mb-0"
+    >
+      <small>
+        <a
+          href="/help/user/markdown"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Markdown supported
+        </a>
+      </small>
+    </p>
+    <div
+      className="container-fluid my-3"
+    >
+      <div
+        className="row campaign-details__property-row"
+      >
+        <h3
+          className="mr-3 mb-0 campaign-details__property-label"
+        >
+          Type
+        </h3>
+        <div
+          className="flex-grow-1 form-group mb-0"
+        >
+          <p
+            className="mb-0"
+          >
+            Comby search and replace
+          </p>
+        </div>
+      </div>
+      <div
+        className="row mt-3"
+      >
+        <h3
+          className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
+        >
+          Arguments
+        </h3>
+        <MonacoSettingsEditor
+          className="flex-grow-1 e2e-campaign-arguments"
+          height={110}
+          isLightTheme={true}
+          jsonSchema={
+            Object {
+              "$id": "comby-spec.json#",
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "description": "Schema for comby options",
+              "properties": Object {
+                "matchTemplate": Object {
+                  "description": "See https://comby.dev/#match-syntax for syntax",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "rewriteTemplate": Object {
+                  "description": "See https://comby.dev/#match-syntax for syntax",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "scopeQuery": Object {
+                  "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
+                  "minLength": 1,
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "scopeQuery",
+                "matchTemplate",
+                "rewriteTemplate",
+              ],
+              "type": "object",
+            }
+          }
+          onChange={[Function]}
+          readOnly={true}
+          value="{}"
+        />
+      </div>
+    </div>
+  </form>,
+  <h3>
+    Progress
+  </h3>,
+  <div
+    className="alert alert-info"
+  >
+    Burndown chart will be shown when there is more than 1 day of data.
+  </div>,
+  <div
+    className="tabs mt-3"
+  >
+    <div
+      className="tab-bar "
+    >
+      <button
+        className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--flex-grow tab-bar__tab--active tab-bar__tab--h5like"
+        data-e2e-tab="diff"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="e2e-campaign-diff-tab"
+        >
+          Diff 
+          <span
+            className="text-success"
+          >
+            +
+            0
+          </span>
+           
+          <span
+            className="text-danger"
+          >
+            -
+            0
+          </span>
+        </span>
+      </button>
+      <button
+        className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--flex-grow tab-bar__tab--inactive tab-bar__tab--h5like"
+        data-e2e-tab="changesets"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="e2e-campaign-changesets-tab"
+        >
+          Changesets
+           
+          <span
+            className="badge badge-secondary badge-pill"
+          />
+        </span>
+      </button>
+    </div>
+    <div
+      className="mt-3"
+    />
+  </div>,
+]
+`;
+
+exports[`CampaignDetails viewing existing 1`] = `
+Array [
+  <form
+    className="e2e-campaign-form position-relative "
+    onInvalid={[Function]}
+    onReset={[Function]}
+    onSubmit={[Function]}
+  >
+    <div
+      className="d-flex mb-2"
+    >
+      <h2
+        className="m-0"
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 text-success"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M3,3H5V13H9V7H13V11H17V15H21V21H3V3Z"
+          />
+        </svg>
+        <span>
+          <a
+            href="/campaigns"
+          >
+            Campaigns
+          </a>
+        </span>
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <span>
+          alice
+        </span>
+        <span
+          className="text-muted d-inline-block mx-2"
+        >
+          /
+        </span>
+        <span />
+      </h2>
+      <span
+        className="flex-grow-1 d-flex justify-content-end align-items-center"
+      >
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={false}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <details
+          className="campaign-details__details"
+        >
+          <summary>
+            <span
+              className="btn btn-secondary mr-1 dropdown-toggle"
+            >
+              Close
+            </span>
+          </summary>
+          <div
+            className="position-absolute campaign-details__details-menu"
+          >
+            <div
+              className="card mt-1"
+            >
+              <div
+                className="card-body"
+              >
+                <p>
+                  Close campaign 
+                  <b />
+                  ?
+                </p>
+                <div
+                  className="form-group"
+                >
+                  <input
+                    checked={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                   
+                  Close all 
+                   
+                  changesets on codehosts
+                </div>
+                <button
+                  className="btn btn-secondary mr-1"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        </details>
+        <details
+          className="campaign-details__details"
+        >
+          <summary>
+            <span
+              className="btn btn-danger dropdown-toggle"
+            >
+              Delete
+            </span>
+          </summary>
+          <div
+            className="position-absolute campaign-details__details-menu"
+          >
+            <div
+              className="card mt-1"
+            >
+              <div
+                className="card-body"
+              >
+                <p>
+                  Delete campaign 
+                  <b />
+                  ?
+                </p>
+                <div
+                  className="form-group"
+                >
+                  <input
+                    checked={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                   
+                  Close all 
+                   changesets on codehosts
+                </div>
+                <button
+                  className="btn btn-danger mr-1"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        </details>
+      </span>
+    </div>
+    <div
+      className="card"
+    >
+      <div
+        className="card-header"
+      >
+        <strong>
+           
+          alice
+        </strong>
+         
+        started 
+        <span
+          className="timestamp"
+          data-tooltip="2020-01-01"
+        >
+          in almost 14 years
+        </span>
+      </div>
+      <div
+        className="card-body"
+      >
+        <div
+          className="markdown"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>d</p>
+",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="container-fluid my-3"
+    >
+      <div
+        className="row campaign-details__property-row"
+      >
+        <h3
+          className="mr-3 mb-0 campaign-details__property-label"
+        >
+          Type
+        </h3>
+        <div
+          className="flex-grow-1 form-group mb-0"
+        >
+          <p
+            className="mb-0"
+          >
+            Comby search and replace
+          </p>
+        </div>
+      </div>
+      <div
+        className="row mt-3"
+      >
+        <h3
+          className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
+        >
+          Arguments
+        </h3>
+        <MonacoSettingsEditor
+          className="flex-grow-1 e2e-campaign-arguments"
+          height={110}
+          isLightTheme={true}
+          jsonSchema={
+            Object {
+              "$id": "comby-spec.json#",
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "description": "Schema for comby options",
+              "properties": Object {
+                "matchTemplate": Object {
+                  "description": "See https://comby.dev/#match-syntax for syntax",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "rewriteTemplate": Object {
+                  "description": "See https://comby.dev/#match-syntax for syntax",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "scopeQuery": Object {
+                  "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
+                  "minLength": 1,
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "scopeQuery",
+                "matchTemplate",
+                "rewriteTemplate",
+              ],
+              "type": "object",
+            }
+          }
+          onChange={[Function]}
+          readOnly={true}
+          value="{}"
+        />
+      </div>
+    </div>
+  </form>,
+  <h3>
+    Progress
+  </h3>,
+  <div
+    className="alert alert-info"
+  >
+    Burndown chart will be shown when there is more than 1 day of data.
+  </div>,
+  <div
+    className="tabs mt-3"
+  >
+    <div
+      className="tab-bar "
+    >
+      <button
+        className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--flex-grow tab-bar__tab--active tab-bar__tab--h5like"
+        data-e2e-tab="diff"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="e2e-campaign-diff-tab"
+        >
+          Diff 
+          <span
+            className="text-success"
+          >
+            +
+            0
+          </span>
+           
+          <span
+            className="text-danger"
+          >
+            -
+            0
+          </span>
+        </span>
+      </button>
+      <button
+        className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--flex-grow tab-bar__tab--inactive tab-bar__tab--h5like"
+        data-e2e-tab="changesets"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="e2e-campaign-changesets-tab"
+        >
+          Changesets
+           
+          <span
+            className="badge badge-secondary badge-pill"
+          />
+        </span>
+      </button>
+    </div>
+    <div
+      className="mt-3"
+    />
+  </div>,
+]
+`;

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -91,47 +91,13 @@ exports[`CampaignDetails creation form 1`] = `
         </a>
       </small>
     </p>
-    <div
+    <CampaignPlanSpecificationFields
       className="container-fluid my-3"
-    >
-      <div
-        className="row campaign-details__property-row"
-      >
-        <h3
-          className="mr-3 mb-0 campaign-details__property-label"
-        >
-          Type
-        </h3>
-        <div
-          className="flex-grow-1 form-group mb-0"
-        >
-          <React.Fragment>
-             
-            <select
-              className="form-control w-auto d-inline-block e2e-campaign-type"
-              onChange={[Function]}
-              placeholder="Select campaign type"
-            >
-              <option
-                value=""
-              >
-                Manual
-              </option>
-              <option
-                value="comby"
-              >
-                Comby search and replace
-              </option>
-              <option
-                value="credentials"
-              >
-                Find leaked credentials
-              </option>
-            </select>
-          </React.Fragment>
-        </div>
-      </div>
-    </div>
+      isLightTheme={true}
+      onArgumentsJSONCChange={[Function]}
+      onTypeChange={[Function]}
+      readOnly={false}
+    />
     <React.Fragment>
       <button
         className="btn btn-primary"
@@ -253,76 +219,15 @@ Array [
         </a>
       </small>
     </p>
-    <div
+    <CampaignPlanSpecificationFields
+      argumentsJSONC="{}"
       className="container-fluid my-3"
-    >
-      <div
-        className="row campaign-details__property-row"
-      >
-        <h3
-          className="mr-3 mb-0 campaign-details__property-label"
-        >
-          Type
-        </h3>
-        <div
-          className="flex-grow-1 form-group mb-0"
-        >
-          <p
-            className="mb-0"
-          >
-            Comby search and replace
-          </p>
-        </div>
-      </div>
-      <div
-        className="row mt-3"
-      >
-        <h3
-          className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
-        >
-          Arguments
-        </h3>
-        <MonacoSettingsEditor
-          className="flex-grow-1 e2e-campaign-arguments"
-          height={110}
-          isLightTheme={true}
-          jsonSchema={
-            Object {
-              "$id": "comby-spec.json#",
-              "$schema": "http://json-schema.org/draft-07/schema#",
-              "additionalProperties": false,
-              "description": "Schema for comby options",
-              "properties": Object {
-                "matchTemplate": Object {
-                  "description": "See https://comby.dev/#match-syntax for syntax",
-                  "minLength": 1,
-                  "type": "string",
-                },
-                "rewriteTemplate": Object {
-                  "description": "See https://comby.dev/#match-syntax for syntax",
-                  "minLength": 1,
-                  "type": "string",
-                },
-                "scopeQuery": Object {
-                  "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
-                  "minLength": 1,
-                  "type": "string",
-                },
-              },
-              "required": Array [
-                "scopeQuery",
-                "matchTemplate",
-                "rewriteTemplate",
-              ],
-              "type": "object",
-            }
-          }
-          onChange={[Function]}
-          readOnly={true}
-          value="{}"
-        />
-      </div>
-    </div>
+      isLightTheme={true}
+      onArgumentsJSONCChange={[Function]}
+      onTypeChange={[Function]}
+      readOnly={true}
+      type="comby"
+    />
   </form>,
   <h3>
     Progress
@@ -585,76 +490,15 @@ Array [
         />
       </div>
     </div>
-    <div
+    <CampaignPlanSpecificationFields
+      argumentsJSONC="{}"
       className="container-fluid my-3"
-    >
-      <div
-        className="row campaign-details__property-row"
-      >
-        <h3
-          className="mr-3 mb-0 campaign-details__property-label"
-        >
-          Type
-        </h3>
-        <div
-          className="flex-grow-1 form-group mb-0"
-        >
-          <p
-            className="mb-0"
-          >
-            Comby search and replace
-          </p>
-        </div>
-      </div>
-      <div
-        className="row mt-3"
-      >
-        <h3
-          className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
-        >
-          Arguments
-        </h3>
-        <MonacoSettingsEditor
-          className="flex-grow-1 e2e-campaign-arguments"
-          height={110}
-          isLightTheme={true}
-          jsonSchema={
-            Object {
-              "$id": "comby-spec.json#",
-              "$schema": "http://json-schema.org/draft-07/schema#",
-              "additionalProperties": false,
-              "description": "Schema for comby options",
-              "properties": Object {
-                "matchTemplate": Object {
-                  "description": "See https://comby.dev/#match-syntax for syntax",
-                  "minLength": 1,
-                  "type": "string",
-                },
-                "rewriteTemplate": Object {
-                  "description": "See https://comby.dev/#match-syntax for syntax",
-                  "minLength": 1,
-                  "type": "string",
-                },
-                "scopeQuery": Object {
-                  "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
-                  "minLength": 1,
-                  "type": "string",
-                },
-              },
-              "required": Array [
-                "scopeQuery",
-                "matchTemplate",
-                "rewriteTemplate",
-              ],
-              "type": "object",
-            }
-          }
-          onChange={[Function]}
-          readOnly={true}
-          value="{}"
-        />
-      </div>
-    </div>
+      isLightTheme={true}
+      onArgumentsJSONCChange={[Function]}
+      onTypeChange={[Function]}
+      readOnly={true}
+      type="comby"
+    />
   </form>,
   <h3>
     Progress

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -391,7 +391,7 @@ Array [
                   2
                    
                   changesets
-                   changesets on code hosts
+                   on code hosts
                 </div>
                 <button
                   className="btn mr-1 btn-secondary"
@@ -442,7 +442,7 @@ Array [
                   2
                    
                   changesets
-                   changesets on code hosts
+                   on code hosts
                 </div>
                 <button
                   className="btn mr-1 btn-danger"

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignStatus campaign errored 1`] = `
+<React.Fragment>
+  <div
+    className="d-flex my-3"
+  >
+    <Memo(AlertCircleIcon)
+      className="icon-inline text-danger mr-1"
+    />
+     
+    Creation
+     
+    errored
+  </div>
+  <ErrorAlert
+    className="mt-3"
+    error="a"
+  />
+  <ErrorAlert
+    className="mt-3"
+    error="b"
+  />
+  <button
+    className="btn btn-primary mb-2"
+    onClick={[Function]}
+    type="button"
+  >
+    Retry failed jobs
+  </button>
+</React.Fragment>
+`;
+
+exports[`CampaignStatus campaign plan processing 1`] = `
+<React.Fragment>
+  <div
+    className="d-flex mt-3 e2e-preview-loading"
+  >
+    <LoadingSpinner
+      className="icon-inline"
+    />
+     
+    <span
+      data-tooltip="Computing changesets"
+    >
+      3
+       / 
+      6
+    </span>
+  </div>
+  <ErrorAlert
+    className="mt-3"
+    error="a"
+  />
+  <ErrorAlert
+    className="mt-3"
+    error="b"
+  />
+</React.Fragment>
+`;
+
+exports[`CampaignStatus campaign processing 1`] = `
+<React.Fragment>
+  <div
+    className="d-flex mt-3 e2e-preview-loading"
+  >
+    <LoadingSpinner
+      className="icon-inline"
+    />
+     
+    <span
+      data-tooltip="Computing changesets"
+    >
+      3
+       / 
+      6
+    </span>
+  </div>
+  <ErrorAlert
+    className="mt-3"
+    error="a"
+  />
+  <ErrorAlert
+    className="mt-3"
+    error="b"
+  />
+</React.Fragment>
+`;
+
+exports[`CampaignStatus closed campaign 1`] = `
+<React.Fragment>
+  <div
+    className="d-flex my-3"
+  >
+    <Memo(WarningIcon)
+      className="icon-inline text-warning mr-1"
+    />
+     Campaign is closed
+  </div>
+</React.Fragment>
+`;

--- a/web/src/enterprise/campaigns/detail/form/CampaignDescriptionField.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignDescriptionField.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { CampaignDescriptionField } from './CampaignDescriptionField'
+
+describe('CampaignDescriptionField', () => {
+    test('renders', () =>
+        expect(renderer.create(<CampaignDescriptionField value="a" onChange={() => undefined} />)).toMatchSnapshot())
+})

--- a/web/src/enterprise/campaigns/detail/form/CampaignDescriptionField.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignDescriptionField.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface Props {
+    value: string | undefined
+    onChange: (newValue: string) => void
+
+    className?: string
+    disabled?: boolean
+}
+
+/**
+ * A multi-line text field for a campaign's description.
+ */
+export const CampaignDescriptionField: React.FunctionComponent<Props> = ({
+    value,
+    onChange,
+    className = '',
+    disabled,
+}) => (
+    <textarea
+        className={`form-control ${className}`}
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        placeholder="Describe the purpose of this campaign, link to relevant internal documentation, etc."
+        rows={8}
+        disabled={disabled}
+    />
+)

--- a/web/src/enterprise/campaigns/detail/form/CampaignNamespaceField.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignNamespaceField.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import sinon from 'sinon'
+import * as GQL from '../../../../../../shared/src/graphql/schema'
+import renderer, { act } from 'react-test-renderer'
+import { CampaignNamespaceField } from './CampaignNamespaceField'
+import { NEVER, of } from 'rxjs'
+
+const USER: Pick<GQL.Namespace, '__typename' | 'id' | 'namespaceName' | 'url'> = {
+    __typename: 'User',
+    id: 'u0',
+    namespaceName: 'alice',
+    url: 'https://example.com/u0',
+}
+
+describe('CampaignNamespaceField', () => {
+    test('loading', () =>
+        expect(
+            renderer.create(
+                <CampaignNamespaceField value={undefined} onChange={() => undefined} _queryNamespaces={() => NEVER} />
+            )
+        ).toMatchSnapshot())
+
+    test('has initial value and calls onChange', () => {
+        const onChange = sinon.spy()
+        const component = renderer.create(
+            <CampaignNamespaceField value={undefined} onChange={onChange} _queryNamespaces={() => of([USER])} />
+        )
+        act(() => undefined) // eslint-disable-line @typescript-eslint/no-floating-promises
+        expect(component).toMatchSnapshot()
+
+        expect(onChange.calledOnceWith(USER.id)).toBeTruthy()
+    })
+})

--- a/web/src/enterprise/campaigns/detail/form/CampaignNamespaceField.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignNamespaceField.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react'
+import * as GQL from '../../../../../../shared/src/graphql/schema'
+import { useError } from '../../../../util/useObservable'
+import { queryNamespaces } from '../../../namespaces/backend'
+
+interface Props {
+    value: GQL.Namespace['id'] | undefined
+    onChange: (newValue: GQL.Namespace['id']) => void
+
+    id?: string
+    className?: string
+
+    /** For testing only. */
+    _queryNamespaces?: typeof queryNamespaces
+}
+
+/**
+ * A select field for a campaign's namespace.
+ */
+export const CampaignNamespaceField: React.FunctionComponent<Props> = ({
+    value,
+    onChange,
+    id,
+    className = '',
+    _queryNamespaces = queryNamespaces,
+}) => {
+    const [namespaces, setNamespaces] = useState<Pick<GQL.Namespace, 'id' | 'namespaceName'>[]>()
+
+    // For errors during fetching.
+    const triggerError = useError()
+
+    useEffect(() => {
+        const subscription = _queryNamespaces().subscribe({ next: setNamespaces, error: triggerError })
+        return () => subscription.unsubscribe()
+    }, [_queryNamespaces, triggerError])
+
+    // Set initial namespace (in case use never interacts with the field and onChange is never called).
+    useEffect(() => {
+        if (value === undefined && namespaces !== undefined) {
+            onChange(namespaces?.[0].id)
+        }
+    }, [namespaces, onChange, value])
+
+    return (
+        <select
+            id={id}
+            className={`form-control ${className}`}
+            required={true}
+            value={value || namespaces?.[0].id}
+            onChange={event => onChange(event.target.value)}
+            disabled={namespaces === undefined}
+        >
+            {namespaces ? (
+                namespaces.map(namespace => (
+                    <option value={namespace.id} key={namespace.id}>
+                        {namespace.namespaceName}
+                    </option>
+                ))
+            ) : (
+                <option disabled={true}>Loading...</option>
+            )}
+        </select>
+    )
+}

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { CampaignPlanSpecificationFields } from './CampaignPlanSpecificationFields'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+jest.mock('../../../../settings/MonacoSettingsEditor', () => ({ MonacoSettingsEditor: 'MonacoSettingsEditor' }))
+
+const PROPS = {
+    onTypeChange: () => undefined,
+    argumentsJSONC: undefined,
+    onArgumentsJSONCChange: () => undefined,
+    isLightTheme: true,
+}
+
+describe('CampaignPlanSpecificationFields', () => {
+    describe('manual type', () => {
+        test('editable', () =>
+            expect(
+                createRenderer().render(
+                    <CampaignPlanSpecificationFields {...PROPS} type={undefined} readOnly={false} />
+                )
+            ).toMatchSnapshot())
+
+        test('read-only', () =>
+            expect(
+                createRenderer().render(<CampaignPlanSpecificationFields {...PROPS} type={undefined} readOnly={true} />)
+            ).toMatchSnapshot())
+    })
+
+    describe('non-manual type', () => {
+        test('editable', () =>
+            expect(
+                createRenderer().render(<CampaignPlanSpecificationFields {...PROPS} type="comby" readOnly={false} />)
+            ).toMatchSnapshot())
+
+        test('read-only', () =>
+            expect(
+                createRenderer().render(<CampaignPlanSpecificationFields {...PROPS} type="comby" readOnly={true} />)
+            ).toMatchSnapshot())
+    })
+})

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import combyJsonSchema from '../../../../../../schema/campaign-types/comby.schema.json'
+import credentialsJsonSchema from '../../../../../../schema/campaign-types/credentials.schema.json'
+import { ThemeProps } from '../../../../../../shared/src/theme'
+import { MonacoSettingsEditor } from '../../../../settings/MonacoSettingsEditor'
+import { CampaignType } from '../backend.js'
+
+interface Props extends ThemeProps {
+    /** The campaign plan specification type (e.g., "comby"). */
+    type: CampaignType | undefined
+    onTypeChange: (newType: CampaignType) => void
+
+    /** The campaign plan specification arguments (as JSONC). */
+    argumentsJSONC: string | undefined
+    onArgumentsJSONCChange: (newArguments: string) => void
+
+    readOnly?: boolean
+    className?: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jsonSchemaByType: { [K in CampaignType]: any } = {
+    comby: combyJsonSchema,
+    credentials: credentialsJsonSchema,
+}
+
+const typeLabels: Record<CampaignType | '', string> = {
+    '': 'Manual',
+    comby: 'Comby search and replace',
+    credentials: 'Find leaked credentials',
+}
+
+/**
+ * Fields for selecting the type and arguments for the campaign plan specification.
+ */
+export const CampaignPlanSpecificationFields: React.FunctionComponent<Props> = ({
+    type,
+    onTypeChange,
+    argumentsJSONC,
+    onArgumentsJSONCChange,
+    readOnly,
+    className,
+    isLightTheme,
+}) => (
+    <div className={className}>
+        <div className="row campaign-details__property-row">
+            <h3 className="mr-3 mb-0 campaign-details__property-label">Type</h3>
+            <div className="flex-grow-1 form-group mb-0">
+                {!readOnly ? (
+                    <>
+                        <select
+                            className="form-control w-auto d-inline-block e2e-campaign-type"
+                            placeholder="Select campaign type"
+                            onChange={e => onTypeChange(e.currentTarget.value as CampaignType)}
+                            value={type}
+                        >
+                            {(Object.keys(typeLabels) as CampaignType[]).map(typeName => (
+                                <option value={typeName || ''} key={typeName}>
+                                    {typeLabels[typeName]}
+                                </option>
+                            ))}
+                        </select>
+                        {type === 'comby' && (
+                            <small className="ml-1">
+                                <a rel="noopener noreferrer" target="_blank" href="https://comby.dev/#match-syntax">
+                                    Learn about comby syntax
+                                </a>
+                            </small>
+                        )}
+                    </>
+                ) : (
+                    <p className="mb-0">{typeLabels[type || '']}</p>
+                )}
+            </div>
+        </div>
+        {type && (
+            <div className="row mt-3">
+                <h3 className="mr-3 mb-0 flex-grow-0 campaign-details__property-label">Arguments</h3>
+                <MonacoSettingsEditor
+                    className="flex-grow-1 e2e-campaign-arguments"
+                    isLightTheme={isLightTheme}
+                    value={argumentsJSONC}
+                    jsonSchema={type ? jsonSchemaByType[type] : undefined}
+                    height={110}
+                    onChange={onArgumentsJSONCChange}
+                    readOnly={readOnly}
+                />
+            </div>
+        )}
+    </div>
+)

--- a/web/src/enterprise/campaigns/detail/form/CampaignTitleField.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignTitleField.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { CampaignTitleField } from './CampaignTitleField'
+
+describe('CampaignTitleField', () => {
+    test('renders', () =>
+        expect(renderer.create(<CampaignTitleField value="a" onChange={() => undefined} />)).toMatchSnapshot())
+})

--- a/web/src/enterprise/campaigns/detail/form/CampaignTitleField.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignTitleField.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface Props {
+    value: string | undefined
+    onChange: (newValue: string) => void
+
+    className?: string
+    disabled?: boolean
+}
+
+/**
+ * A text field for a campaign's title.
+ */
+export const CampaignTitleField: React.FunctionComponent<Props> = ({ value, onChange, className = '', disabled }) => (
+    <input
+        className={`form-control ${className}`}
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        placeholder="Campaign title"
+        disabled={disabled}
+        autoFocus={true}
+        required={true}
+    />
+)

--- a/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { CloseDeleteCampaignPrompt } from './CloseDeleteCampaignPrompt'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+describe('CloseDeleteCampaignPrompt', () => {
+    test('renders', () =>
+        expect(
+            createRenderer().render(
+                <CloseDeleteCampaignPrompt
+                    message={<p>message</p>}
+                    changesetsCount={2}
+                    closeChangesets={true}
+                    onCloseChangesetsToggle={() => undefined}
+                    buttonText="Delete"
+                    onButtonClick={() => undefined}
+                    buttonClassName="btn-danger"
+                    buttonDisabled={false}
+                    className="c"
+                />
+            )
+        ).toMatchSnapshot())
+})

--- a/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.tsx
@@ -41,7 +41,7 @@ export const CloseDeleteCampaignPrompt: React.FunctionComponent<Props> = ({
                         checked={closeChangesets}
                         onChange={e => onCloseChangesetsToggle(e.target.checked)}
                     />{' '}
-                    Close all {changesetsCount} {pluralize('changeset', changesetsCount)} changesets on code hosts
+                    Close all {changesetsCount} {pluralize('changeset', changesetsCount)} on code hosts
                 </div>
                 <button
                     type="button"

--- a/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CloseDeleteCampaignPrompt.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { pluralize } from '../../../../../../shared/src/util/strings'
+
+interface Props {
+    message: React.ReactFragment
+
+    changesetsCount: number
+    closeChangesets: boolean
+    onCloseChangesetsToggle: (newValue: boolean) => void
+
+    buttonText: string
+    onButtonClick: () => void
+    buttonClassName?: string
+    buttonDisabled?: boolean
+
+    className?: string
+}
+
+/**
+ * A prompt for closing or deleting a campaign, with an option to also close all associated
+ * changesets.
+ */
+export const CloseDeleteCampaignPrompt: React.FunctionComponent<Props> = ({
+    message,
+    changesetsCount,
+    closeChangesets,
+    onCloseChangesetsToggle,
+    buttonText,
+    onButtonClick,
+    buttonClassName = '',
+    buttonDisabled,
+    className,
+}) => (
+    <div className={className}>
+        <div className="card mt-1">
+            <div className="card-body">
+                {message}
+                <div className="form-group">
+                    <input
+                        type="checkbox"
+                        checked={closeChangesets}
+                        onChange={e => onCloseChangesetsToggle(e.target.checked)}
+                    />{' '}
+                    Close all {changesetsCount} {pluralize('changeset', changesetsCount)} changesets on code hosts
+                </div>
+                <button
+                    type="button"
+                    disabled={buttonDisabled}
+                    className={`btn mr-1 ${buttonClassName}`}
+                    onClick={onButtonClick}
+                >
+                    {buttonText}
+                </button>
+            </div>
+        </div>
+    </div>
+)

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignDescriptionField.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignDescriptionField.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignDescriptionField renders 1`] = `
+<textarea
+  className="form-control "
+  onChange={[Function]}
+  placeholder="Describe the purpose of this campaign, link to relevant internal documentation, etc."
+  rows={8}
+  value="a"
+/>
+`;

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignNamespaceField.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignNamespaceField.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignNamespaceField has initial value and calls onChange 1`] = `
+<select
+  className="form-control "
+  disabled={false}
+  onChange={[Function]}
+  required={true}
+  value="u0"
+>
+  <option
+    value="u0"
+  >
+    alice
+  </option>
+</select>
+`;
+
+exports[`CampaignNamespaceField loading 1`] = `
+<select
+  className="form-control "
+  disabled={true}
+  onChange={[Function]}
+  required={true}
+>
+  <option
+    disabled={true}
+  >
+    Loading...
+  </option>
+</select>
+`;

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
@@ -1,0 +1,235 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignPlanSpecificationFields manual type editable 1`] = `
+<div>
+  <div
+    className="row campaign-details__property-row"
+  >
+    <h3
+      className="mr-3 mb-0 campaign-details__property-label"
+    >
+      Type
+    </h3>
+    <div
+      className="flex-grow-1 form-group mb-0"
+    >
+      <React.Fragment>
+        <select
+          className="form-control w-auto d-inline-block e2e-campaign-type"
+          onChange={[Function]}
+          placeholder="Select campaign type"
+        >
+          <option
+            value=""
+          >
+            Manual
+          </option>
+          <option
+            value="comby"
+          >
+            Comby search and replace
+          </option>
+          <option
+            value="credentials"
+          >
+            Find leaked credentials
+          </option>
+        </select>
+      </React.Fragment>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CampaignPlanSpecificationFields manual type read-only 1`] = `
+<div>
+  <div
+    className="row campaign-details__property-row"
+  >
+    <h3
+      className="mr-3 mb-0 campaign-details__property-label"
+    >
+      Type
+    </h3>
+    <div
+      className="flex-grow-1 form-group mb-0"
+    >
+      <p
+        className="mb-0"
+      >
+        Manual
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CampaignPlanSpecificationFields non-manual type editable 1`] = `
+<div>
+  <div
+    className="row campaign-details__property-row"
+  >
+    <h3
+      className="mr-3 mb-0 campaign-details__property-label"
+    >
+      Type
+    </h3>
+    <div
+      className="flex-grow-1 form-group mb-0"
+    >
+      <React.Fragment>
+        <select
+          className="form-control w-auto d-inline-block e2e-campaign-type"
+          onChange={[Function]}
+          placeholder="Select campaign type"
+          value="comby"
+        >
+          <option
+            value=""
+          >
+            Manual
+          </option>
+          <option
+            value="comby"
+          >
+            Comby search and replace
+          </option>
+          <option
+            value="credentials"
+          >
+            Find leaked credentials
+          </option>
+        </select>
+        <small
+          className="ml-1"
+        >
+          <a
+            href="https://comby.dev/#match-syntax"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn about comby syntax
+          </a>
+        </small>
+      </React.Fragment>
+    </div>
+  </div>
+  <div
+    className="row mt-3"
+  >
+    <h3
+      className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
+    >
+      Arguments
+    </h3>
+    <MonacoSettingsEditor
+      className="flex-grow-1 e2e-campaign-arguments"
+      height={110}
+      isLightTheme={true}
+      jsonSchema={
+        Object {
+          "$id": "comby-spec.json#",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "description": "Schema for comby options",
+          "properties": Object {
+            "matchTemplate": Object {
+              "description": "See https://comby.dev/#match-syntax for syntax",
+              "minLength": 1,
+              "type": "string",
+            },
+            "rewriteTemplate": Object {
+              "description": "See https://comby.dev/#match-syntax for syntax",
+              "minLength": 1,
+              "type": "string",
+            },
+            "scopeQuery": Object {
+              "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
+              "minLength": 1,
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "scopeQuery",
+            "matchTemplate",
+            "rewriteTemplate",
+          ],
+          "type": "object",
+        }
+      }
+      onChange={[Function]}
+      readOnly={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`CampaignPlanSpecificationFields non-manual type read-only 1`] = `
+<div>
+  <div
+    className="row campaign-details__property-row"
+  >
+    <h3
+      className="mr-3 mb-0 campaign-details__property-label"
+    >
+      Type
+    </h3>
+    <div
+      className="flex-grow-1 form-group mb-0"
+    >
+      <p
+        className="mb-0"
+      >
+        Comby search and replace
+      </p>
+    </div>
+  </div>
+  <div
+    className="row mt-3"
+  >
+    <h3
+      className="mr-3 mb-0 flex-grow-0 campaign-details__property-label"
+    >
+      Arguments
+    </h3>
+    <MonacoSettingsEditor
+      className="flex-grow-1 e2e-campaign-arguments"
+      height={110}
+      isLightTheme={true}
+      jsonSchema={
+        Object {
+          "$id": "comby-spec.json#",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "description": "Schema for comby options",
+          "properties": Object {
+            "matchTemplate": Object {
+              "description": "See https://comby.dev/#match-syntax for syntax",
+              "minLength": 1,
+              "type": "string",
+            },
+            "rewriteTemplate": Object {
+              "description": "See https://comby.dev/#match-syntax for syntax",
+              "minLength": 1,
+              "type": "string",
+            },
+            "scopeQuery": Object {
+              "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported.",
+              "minLength": 1,
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "scopeQuery",
+            "matchTemplate",
+            "rewriteTemplate",
+          ],
+          "type": "object",
+        }
+      }
+      onChange={[Function]}
+      readOnly={true}
+    />
+  </div>
+</div>
+`;

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignTitleField.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignTitleField.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CampaignTitleField renders 1`] = `
+<input
+  autoFocus={true}
+  className="form-control "
+  onChange={[Function]}
+  placeholder="Campaign title"
+  required={true}
+  value="a"
+/>
+`;

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CloseDeleteCampaignPrompt.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CloseDeleteCampaignPrompt.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CloseDeleteCampaignPrompt renders 1`] = `
+<div
+  className="c"
+>
+  <div
+    className="card mt-1"
+  >
+    <div
+      className="card-body"
+    >
+      <p>
+        message
+      </p>
+      <div
+        className="form-group"
+      >
+        <input
+          checked={true}
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        Close all 
+        2
+         
+        changesets
+         changesets on code hosts
+      </div>
+      <button
+        className="btn mr-1 btn-danger"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Delete
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CloseDeleteCampaignPrompt.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CloseDeleteCampaignPrompt.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`CloseDeleteCampaignPrompt renders 1`] = `
         2
          
         changesets
-         changesets on code hosts
+         on code hosts
       </div>
       <button
         className="btn mr-1 btn-danger"

--- a/web/src/enterprise/namespaces/backend.ts
+++ b/web/src/enterprise/namespaces/backend.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { Namespace } from '../../../../shared/src/graphql/schema'
 import { map } from 'rxjs/operators'
 
-export const queryNamespaces = (): Observable<Namespace[]> =>
+export const queryNamespaces = (): Observable<Pick<Namespace, '__typename' | 'id' | 'namespaceName' | 'url'>[]> =>
     queryGraphQL(
         gql`
             query ViewerNamespaces {


### PR DESCRIPTION
See commit messages.

There is no behavior change except one thing:

- The campaign job status used to be shown when the campaign type was non-manual. Now it is shown if `pending + completed` jobs is non-zero. I think this is equivalent. Let me know if I am wrong. (This change just lets us avoid passing another prop to the new CampaignStatus component.)