### PR TITLE
import semver function module to avoid webpack dynamic require warning

### DIFF
--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -2,7 +2,6 @@ import { parseISO } from 'date-fns'
 import differenceInDays from 'date-fns/differenceInDays'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
-import * as semver from 'semver'
 import { Markdown } from '../../../shared/src/components/Markdown'
 import { isSettingsValid, SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
@@ -17,6 +16,13 @@ import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfig
 import { UpdateAvailableAlert } from '../site/UpdateAvailableAlert'
 import { GlobalAlert } from './GlobalAlert'
 import { Notices } from './Notices'
+
+// This module is not in @types/semver yet. We can't use the top-level semver module because it uses
+// dynamic requires, which Webpack complains about.
+//
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import semverParse from 'semver/functions/parse'
 
 interface Props extends SettingsCascadeProps {
     isSiteAdmin: boolean
@@ -116,13 +122,13 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
 }
 
 function isMinorUpdateAvailable(currentVersion: string, updateVersion: string): boolean {
-    const cv = semver.parse(currentVersion, { loose: false })
-    const uv = semver.parse(updateVersion, { loose: false })
+    const cv = semverParse(currentVersion, { loose: false })
+    const uv = semverParse(updateVersion, { loose: false })
     // If either current or update versions aren't semvers (e.g., a user is on a date-based build version, or "dev"),
     // always return true and allow any alerts to be shown. This has the effect of simply deferring to the response
     // from Sourcegraph.com about whether an update alert is needed.
     if (cv === null || uv === null) {
         return true
     }
-    return semver.major(cv) !== semver.major(uv) || semver.minor(cv) !== semver.minor(uv)
+    return cv.major !== uv.major || cv.minor !== uv.minor
 }


### PR DESCRIPTION
The upgraded semver prints a warning:

```
index.js?21b9:135 ../node_modules/semver/index.js 4:51-64
Critical dependency: the request of a dependency is an expression
```

See https://github.com/npm/node-semver/issues/299#issuecomment-566337962 for the explanation for this fix.