### PR TITLE
enterprise/a8n: Don't replace NPM environment variables

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -268,7 +268,7 @@ type credentialsArgs struct {
 
 var npmTokenRegexp = regexp.MustCompile(`((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
 var npmTokenRegexpMultiline = regexp.MustCompile(`(?m)((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
-var npmEnvironmentVariable = regexp.MustCompile(`\${.+}$`)
+var npmEnvironmentVariableRegexp = regexp.MustCompile(`\${.+}$`)
 
 type credentials struct {
 	args credentialsArgs
@@ -323,7 +323,7 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 		submatches := npmTokenRegexpMultiline.FindAllStringSubmatch(content, -1)
 		for _, match := range submatches {
 			token := match[len(match)-1]
-			if npmEnvironmentVariable.MatchString(token) {
+			if npmEnvironmentVariableRegexp.MatchString(token) {
 				continue
 			}
 			tokens = append(tokens, token)
@@ -336,7 +336,7 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 			}
 			left := old[:idx+1]
 			right := old[idx+1:]
-			if npmEnvironmentVariable.MatchString(right) {
+			if npmEnvironmentVariableRegexp.MatchString(right) {
 				return old
 			}
 			return left + c.args.Matchers[0].ReplaceWith

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -268,6 +268,7 @@ type credentialsArgs struct {
 
 var npmTokenRegexp = regexp.MustCompile(`((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
 var npmTokenRegexpMultiline = regexp.MustCompile(`(?m)((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
+var npmEnvironmentVariable = regexp.MustCompile(`\${(.+)}$`)
 
 type credentials struct {
 	args credentialsArgs
@@ -305,7 +306,6 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 
 	diffs := []string{}
 	tokens := []string{}
-
 	for _, res := range resultsResolver.Results() {
 		fm, ok := res.ToFileMatch()
 		if !ok {
@@ -318,13 +318,29 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 			return "", "", err
 		}
 
+		// If the token is in the form ${ABC} we should not replace it as this is valid and indicates
+		// a value that should be read from the environment
 		submatches := npmTokenRegexpMultiline.FindAllStringSubmatch(content, -1)
 		for _, match := range submatches {
-			tokens = append(tokens, match[len(match)-1])
+			token := match[len(match)-1]
+			if npmEnvironmentVariable.MatchString(token) {
+				continue
+			}
+			tokens = append(tokens, token)
 		}
-
-		replacement := fmt.Sprintf("${1}%s", c.args.Matchers[0].ReplaceWith)
-		newContent := npmTokenRegexpMultiline.ReplaceAllString(content, replacement)
+		newContent := npmTokenRegexpMultiline.ReplaceAllStringFunc(content, func(old string) string {
+			// Don't replace right hand side if it is an environment variable
+			idx := strings.Index(old, "=")
+			if idx == -1 {
+				return old
+			}
+			left := old[:idx+1]
+			right := old[idx+1:]
+			if npmEnvironmentVariable.MatchString(right) {
+				return old
+			}
+			return left + c.args.Matchers[0].ReplaceWith
+		})
 
 		diff, err := tmpfileDiff(path, content, newContent)
 		if err != nil {

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -268,7 +268,7 @@ type credentialsArgs struct {
 
 var npmTokenRegexp = regexp.MustCompile(`((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
 var npmTokenRegexpMultiline = regexp.MustCompile(`(?m)((?:^|:)_(?:auth|authToken|password)\s*=\s*)(.+)$`)
-var npmEnvironmentVariable = regexp.MustCompile(`\${(.+)}$`)
+var npmEnvironmentVariable = regexp.MustCompile(`\${.+}$`)
 
 type credentials struct {
 	args credentialsArgs

--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -330,12 +330,11 @@ func (c *credentials) generateDiff(ctx context.Context, repo api.RepoName, commi
 		}
 		newContent := npmTokenRegexpMultiline.ReplaceAllStringFunc(content, func(old string) string {
 			// Don't replace right hand side if it is an environment variable
-			idx := strings.Index(old, "=")
-			if idx == -1 {
+			submatches := npmTokenRegexp.FindAllStringSubmatch(old, -1)
+			if len(submatches) != 1 && len(submatches[0]) != 3 {
 				return old
 			}
-			left := old[:idx+1]
-			right := old[idx+1:]
+			left, right := submatches[0][1], submatches[0][2]
 			if npmEnvironmentVariableRegexp.MatchString(right) {
 				return old
 			}

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -298,16 +298,15 @@ _authToken=YET_ANOTHER_TOKEN_LEAKED
 --- .npmrc
 +++ .npmrc
 @@ -1,4 +1,4 @@
--//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+ //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 -//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
 -:_authToken=ANOTHER_TOKEN
 -_authToken=YET_ANOTHER_TOKEN_LEAKED
-+//registry.npmjs.org/:_authToken=
 +//npm.fontawesome.com/:_authToken=
 +:_authToken=
 +_authToken=
 `,
-			wantDescription: "Tokens found:\n\n- [ ] `${NPM_TOKEN}`\n- [ ] `12345678-2323-1111-1111-12345670B312`\n- [ ] `ANOTHER_TOKEN`\n- [ ] `YET_ANOTHER_TOKEN_LEAKED`\n",
+			wantDescription: "Tokens found:\n\n- [ ] `12345678-2323-1111-1111-12345670B312`\n- [ ] `ANOTHER_TOKEN`\n- [ ] `YET_ANOTHER_TOKEN_LEAKED`\n",
 		},
 		{
 			name: "single NPM token and replaceWith",


### PR DESCRIPTION
It is valid for a .npmrc file to contain a line like:
:_authToken=${ABC}

In this case ${ABC} will be replaced with the environment variable ABC

We should therefore not remove these occurrences

Fixes: https://github.com/sourcegraph/sourcegraph/pull/7392


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
