### PR TITLE
Fix incorrect license expiration warning

### DIFF
--- a/web/src/site/LicenseExpirationAlert.test.tsx
+++ b/web/src/site/LicenseExpirationAlert.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { subMonths, addDays } from 'date-fns'
+import renderer from 'react-test-renderer'
+import { LicenseExpirationAlert } from './LicenseExpirationAlert'
+
+describe('LicenseExpirationAlert.test.tsx', () => {
+    test('expiring soon', () => {
+        expect(
+            renderer.create(
+                <LicenseExpirationAlert expiresAt={addDays(new Date(), 3)} daysLeft={3}></LicenseExpirationAlert>
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('expired', () => {
+        expect(
+            renderer.create(
+                <LicenseExpirationAlert expiresAt={subMonths(new Date(), 3)} daysLeft={0}></LicenseExpirationAlert>
+            )
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/site/LicenseExpirationAlert.tsx
+++ b/web/src/site/LicenseExpirationAlert.tsx
@@ -3,6 +3,7 @@ import WarningIcon from 'mdi-react/WarningIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { DismissibleAlert } from '../components/DismissibleAlert'
+import { isProductLicenseExpired, formatRelativeExpirationDate } from '../enterprise/productSubscription/helpers'
 
 /**
  * A global alert that appears telling the site admin that their license key is about to expire. Even after being dismissed,
@@ -18,7 +19,12 @@ export const LicenseExpirationAlert: React.FunctionComponent<{
         className={`alert alert-warning align-items-center ${className}`}
     >
         <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
-        Your Sourcegraph license will expire in {formatDistanceStrict(expiresAt, Date.now())}.&nbsp;
+        Your Sourcegraph license{' '}
+        {isProductLicenseExpired(expiresAt)
+            ? 'expired ' + formatRelativeExpirationDate(expiresAt) // 'Expired two months ago'
+            : 'will expire in ' + formatDistanceStrict(expiresAt, Date.now()) // 'Will expire in two months'
+        }
+        .&nbsp;
         <Link className="site-alert__link" to="/site-admin/license">
             <span className="underline">Renew now</span>
         </Link>

--- a/web/src/site/LicenseExpirationAlert.tsx
+++ b/web/src/site/LicenseExpirationAlert.tsx
@@ -1,9 +1,9 @@
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import WarningIcon from 'mdi-react/WarningIcon'
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { DismissibleAlert } from '../components/DismissibleAlert'
 import { isProductLicenseExpired, formatRelativeExpirationDate } from '../enterprise/productSubscription/helpers'
+import { Link } from '../../../shared/src/components/Link'
 
 /**
  * A global alert that appears telling the site admin that their license key is about to expire. Even after being dismissed,

--- a/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
+++ b/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LicenseExpirationAlert.test.tsx expired 1`] = `
+<div
+  className="alert dismissible-alert alert alert-warning align-items-center "
+>
+  <div
+    className="dismissible-alert__content"
+  >
+    <svg
+      className="mdi-icon icon-inline mr-2 flex-shrink-0"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z"
+      />
+    </svg>
+    Your Sourcegraph license
+     
+    expired 3 months ago
+    . 
+    <a
+      className="site-alert__link"
+      href="/site-admin/license"
+    >
+      <span
+        className="underline"
+      >
+        Renew now
+      </span>
+    </a>
+     or 
+    <a
+      className="site-alert__link"
+      href="https://about.sourcegraph.com/contact"
+    >
+      <span
+        className="underline"
+      >
+        contact Sourcegraph
+      </span>
+    </a>
+  </div>
+  <button
+    className="btn btn-icon"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="mdi-icon icon-inline"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`LicenseExpirationAlert.test.tsx expiring soon 1`] = `
+<div
+  className="alert dismissible-alert alert alert-warning align-items-center "
+>
+  <div
+    className="dismissible-alert__content"
+  >
+    <svg
+      className="mdi-icon icon-inline mr-2 flex-shrink-0"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z"
+      />
+    </svg>
+    Your Sourcegraph license
+     
+    will expire in 3 days
+    . 
+    <a
+      className="site-alert__link"
+      href="/site-admin/license"
+    >
+      <span
+        className="underline"
+      >
+        Renew now
+      </span>
+    </a>
+     or 
+    <a
+      className="site-alert__link"
+      href="https://about.sourcegraph.com/contact"
+    >
+      <span
+        className="underline"
+      >
+        contact Sourcegraph
+      </span>
+    </a>
+  </div>
+  <button
+    className="btn btn-icon"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="mdi-icon icon-inline"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+      />
+    </svg>
+  </button>
+</div>
+`;


### PR DESCRIPTION
Fixes #7350

Now displays a different wording depending on whether the license will expire soon, or is already expired:

![image](https://user-images.githubusercontent.com/1741180/71670897-70fc6480-2d3f-11ea-81eb-cadeedf0cacf.png)
![image](https://user-images.githubusercontent.com/1741180/71670910-79ed3600-2d3f-11ea-80c8-b3c1804d8098.png)
