### PR TITLE
use same timezone for all jest tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -39,6 +39,7 @@ const config = {
     path.join(__dirname, 'shared/dev/setLinkComponentForTest.ts'),
   ],
   setupFilesAfterEnv: [require.resolve('core-js/stable'), require.resolve('regenerator-runtime/runtime')],
+  globalSetup: path.join(__dirname, 'shared/dev/jestGlobalSetup.js'),
 }
 
 module.exports = config

--- a/shared/dev/jestGlobalSetup.js
+++ b/shared/dev/jestGlobalSetup.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+// Use same timezone for all test runs. This affects Intl.DateTimeFormat in node.
+module.exports = () => {
+  process.env.TZ = 'UTC'
+}


### PR DESCRIPTION
Fixes nondeterminism (seen in, eg, CampaignBurndownChart when the timezone is not UTC).