### PR TITLE
ensure regeneratorRuntime is available in jest tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -38,6 +38,7 @@ const config = {
     path.join(__dirname, 'shared/dev/fetch'),
     path.join(__dirname, 'shared/dev/setLinkComponentForTest.ts'),
   ],
+  setupFilesAfterEnv: [require.resolve('core-js/stable'), require.resolve('regenerator-runtime/runtime')],
 }
 
 module.exports = config


### PR DESCRIPTION
Fixes CI flakiness as seen at https://buildkite.com/sourcegraph/sourcegraph/builds/52561#4c52bf45-b34c-4990-9dda-78a91d6c8722 and many other recent test runs.