### PR TITLE
web: faster SearchResultsList test

### DIFF
--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -223,7 +223,7 @@ describe('SearchResultsList', () => {
         const showMore = sinon.spy()
         const props = {
             ...defaultProps,
-            resultsOrError: mockResults({ resultCount: 31, limitHit: true }),
+            resultsOrError: mockResults({ resultCount: 2, limitHit: true }),
             onShowMoreResultsClick: showMore,
         }
         const { container, rerender } = render(
@@ -246,7 +246,7 @@ describe('SearchResultsList', () => {
             <BrowserRouter>
                 <SearchResultsList
                     {...defaultProps}
-                    resultsOrError={mockResults({ resultCount: 1001, limitHit: false })}
+                    resultsOrError={mockResults({ resultCount: 4, limitHit: false })}
                 />
             </BrowserRouter>
         )


### PR DESCRIPTION
Previously this test took ~33s to run. Now it takes ~3s (which is about as good as it'll get because it uses the DOM). The reason it took so long was that the `resultCount` values were needlessly high, and the algorithm appears to be superlinear. The component itself does not appear to have the same performance problem; it only occurs using the test mocks (eg MockVisibilitySensor), probably because after-scroll callbacks are debounced in the browser automatically.