### PR TITLE
enterprise/a8n: Add global locking around RunChangesetJob

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
@@ -198,7 +198,7 @@ var lockNamespace = int32(fnv1.HashString32("perms"))
 func lockQuery(p *authz.UserPermissions) *sqlf.Query {
 	// Postgres advisory lock ids are a global namespace within one database.
 	// It's very unlikely that another part of our application uses a lock
-	// namespace identicaly to this one. It's equally unlikely that there are
+	// namespace identically to this one. It's equally unlikely that there are
 	// lock id conflicts for different permissions, but if it'd happen, no safety
 	// guarantees would be violated, since those two different users would simply
 	// have to wait on the other's update to finish, using stale permissions until

--- a/enterprise/internal/a8n/integration_test.go
+++ b/enterprise/internal/a8n/integration_test.go
@@ -20,5 +20,8 @@ func TestIntegration(t *testing.T) {
 	defer cleanup()
 
 	t.Run("Store", testStore(db))
+	// This needs to be in its own test because testStore above wraps everything in a transaction
+	// which means we are always able to acquire a lock
+	t.Run("StoreLocking", testStoreLocking(db))
 	t.Run("GitHubWebhook", testGitHubWebhook(db))
 }

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -133,7 +133,7 @@ func lockQuery(key string) *sqlf.Query {
 }
 
 const lockQueryFmtStr = `
--- source: enterprise/internal/a8n/store/store.go:store.lock
+-- source: enterprise/internal/a8n/store/store.go:TryAcquireAdvisoryLock
 SELECT pg_try_advisory_xact_lock(%s, %s)
 `
 

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"github.com/segmentio/fasthash/fnv1"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -80,6 +81,61 @@ func (s *Store) Done(errs ...*error) {
 		_ = tx.Commit()
 	}
 }
+
+var NoTransactionError = errors.New("Not in a transaction")
+
+var lockNamespace = int32(fnv1.HashString32("a8n"))
+
+// TryAcquireAdvisoryLock will attempt to acquire an advisory lock using key
+// and is non blocking. If a lock is acquired, "true, nil" will be returned.
+// It must be called from within a transaction or "false, NoTransactionErr" is returned
+func (s *Store) TryAcquireAdvisoryLock(ctx context.Context, key string) (bool, error) {
+	_, ok := s.db.(dbutil.Tx)
+	if !ok {
+		return false, NoTransactionError
+	}
+	q := lockQuery(key)
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return false, err
+	}
+
+	if !rows.Next() {
+		return false, rows.Err()
+	}
+
+	locked := false
+	if err = rows.Scan(&locked); err != nil {
+		return false, err
+	}
+
+	if err = rows.Close(); err != nil {
+		return false, err
+	}
+
+	return locked, nil
+}
+
+func lockQuery(key string) *sqlf.Query {
+	// Postgres advisory lock ids are a global namespace within one database.
+	// It's very unlikely that another part of our application uses a lock
+	// namespace identically to this one. It's equally unlikely that there are
+	// lock id conflicts for different permissions, but if it'd happen, no safety
+	// guarantees would be violated, since those two different users would simply
+	// have to wait on the other's update to finish, using stale permissions until
+	// it would.
+	lockID := int32(fnv1.HashString32(key))
+	return sqlf.Sprintf(
+		lockQueryFmtStr,
+		lockNamespace,
+		lockID,
+	)
+}
+
+const lockQueryFmtStr = `
+-- source: enterprise/internal/a8n/store/store.go:store.lock
+SELECT pg_try_advisory_xact_lock(%s, %s)
+`
 
 // DB returns the underlying dbutil.DB that this Store was
 // instantiated with.

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -88,7 +88,7 @@ var lockNamespace = int32(fnv1.HashString32("a8n"))
 
 // TryAcquireAdvisoryLock will attempt to acquire an advisory lock using key
 // and is non blocking. If a lock is acquired, "true, nil" will be returned.
-// It must be called from within a transaction or "false, NoTransactionErr" is returned
+// It must be called from within a transaction or "false, NoTransactionError" is returned
 func (s *Store) TryAcquireAdvisoryLock(ctx context.Context, key string) (bool, error) {
 	_, ok := s.db.(dbutil.Tx)
 	if !ok {

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -2223,3 +2223,55 @@ func testStore(db *sql.DB) func(*testing.T) {
 		})
 	}
 }
+
+func testStoreLocking(db *sql.DB) func(*testing.T) {
+	return func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		s := NewStoreWithClock(db, func() time.Time {
+			return now.UTC().Truncate(time.Microsecond)
+		})
+
+		testKey := "test-acquire"
+		s1, err := s.Transact(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s1.Done(nil)
+
+		s2, err := s.Transact(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s2.Done(nil)
+
+		// Get lock
+		ok, err := s1.TryAcquireAdvisoryLock(context.Background(), testKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("Could not acquire lock")
+		}
+
+		// Try and get acquired lock
+		ok, err = s2.TryAcquireAdvisoryLock(context.Background(), testKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Fatal("Should not have acquired lock")
+		}
+
+		// Release lock
+		s1.Done(nil)
+
+		// Try and get released lock
+		ok, err = s2.TryAcquireAdvisoryLock(context.Background(), testKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("Could not acquire lock")
+		}
+	}
+}


### PR DESCRIPTION
Advisory locks in PostgreSQL are used to ensure that only one concurrent
instance of RunChangesetJob can run at a time.

This removes the possibility of making concurrent requests to GitHub.

Fixes: https://github.com/sourcegraph/sourcegraph/issues/7309

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
