### PR TITLE
comby: kill child processes on context timeout

### DIFF
--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -133,7 +133,10 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 	select {
 	case <-ctx.Done():
 		log15.Error("comby context deadline reached")
-		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err != nil {
+			return errors.Wrap(err, "error killing comby command")
+		}
 	case err := <-errorC:
 		if err != nil {
 			return errors.Wrap(err, "failed to wait for executing comby command")

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -106,7 +106,7 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 	log15.Info("running comby", "args", args.String())
 
 	cmd := exec.Command(combyPath, rawArgs...)
-	// ensure forked child processes are killed
+	// Ensure forked child processes are killed
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout, err := cmd.StdoutPipe()
@@ -127,8 +127,7 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 
 	errorC := make(chan error, 1)
 	go func() {
-		err := waitForCompletion(cmd, stdout, stderr, w)
-		errorC <- err
+		errorC <- waitForCompletion(cmd, stdout, stderr, w)
 	}()
 
 	select {

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -139,7 +139,12 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 		}
 	case err := <-errorC:
 		if err != nil {
-			return errors.Wrap(err, "failed to wait for executing comby command")
+			err = errors.Wrap(err, "failed to wait for executing comby command")
+			errKill := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			if errKill != nil {
+				return errors.Wrap(errKill, "error killing comby command")
+			}
+			return err
 		}
 	}
 


### PR DESCRIPTION
This is a cleaner follow up to #7177. See #7177 for details, but in summary:

> CommandContext is used to kill comby when it takes too long, but only kills the parent comby process, and all child processes are oprhaned.

> Setting `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}` and then killing the PID is the right thing to do to kill child processes. But doing so doesn't work with `CommandContext`. 

The solution takes care of manually removing child processes when `ctx.Done` is reached: 

- start the command (blocking, so that PID exists when we `select` on completion or context deadline as per https://github.com/sourcegraph/sourcegraph/pull/7177/files#r357532408)
- wait for the command (nonblocking, in separate goroutine). This function is extracted as per https://github.com/sourcegraph/sourcegraph/pull/7177/files#r357532693
- select on `ctx.Done` or wait completion (blocking), and send sigkill to get rid of child processes

---

Tested manually, since it's hard to check that child processes are properly receiving `sigkill`. I used this script that reports child proc status in a tight loop:

```
#!/bin/bash

while [ : ]; do
    ps -aef | grep comby
    sleep .1
done
```

and then ran a search command 

```
repo:^github\.com/sourcegraph/sourcegraph$  "func Test" count:10000 lang:go timeout:500ms
```

multiple times. Before this PR, the orphaned child procs are (briefly) visible, and with the change, they are not.


