### PR TITLE
Browser extension: remove "cookies" permissions.

### DIFF
--- a/browser/src/extension/manifest.spec.json
+++ b/browser/src/extension/manifest.spec.json
@@ -53,7 +53,6 @@
       }
     ],
     "permissions": [
-      "cookies",
       "storage",
       "activeTab",
       "contextMenus",
@@ -73,13 +72,6 @@
         "js": ["js/inject.bundle.js"]
       }
     ],
-    "permissions": [
-      "cookies",
-      "activeTab",
-      "storage",
-      "contextMenus",
-      "https://github.com/*",
-      "https://sourcegraph.com/*"
-    ]
+    "permissions": ["activeTab", "storage", "contextMenus", "https://github.com/*", "https://sourcegraph.com/*"]
   }
 }


### PR DESCRIPTION
Rel. https://sourcegraph.slack.com/archives/CMT39K56Z/p1578154067022400

All other permissions in the manifest are needed:
- `storage` to use sync and managed storage
- `activeTab` and `contextMenus` through the [`webext-domain-permission-toggle`](https://github.com/fregante/webext-domain-permission-toggle#manifestjson) dependency, and our own feature to allow the user to request permissions for the active tab from the extension's popover.

The `cookies` API, meanwhile, is [not used in our codebase](https://sourcegraph.com/search?q=r:%5Egithub.com/sourcegraph/sourcegraph%24+f:%5Ebrowser/.*%5C.tsx%3F+cookies&patternType=literal) (it's only declared in the vendored `webextension-polyfill` types).
