### PR TITLE
support searching multiple revs per repo (`repo:r@branch1:branch2`) in text search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Add button to download file in code view. [#5478](https://github.com/sourcegraph/sourcegraph/issues/5478)
 - The new `allowOrgs` site config setting in GitHub `auth.providers` enables admins to restrict GitHub logins to members of specific GitHub organizations. [#4195](https://github.com/sourcegraph/sourcegraph/issues/4195)
 - Skip LFS content when cloning git repositories. [#7322](https://github.com/sourcegraph/sourcegraph/issues/7322)
+- Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2815,6 +2815,9 @@ type FileMatch {
     file: GitBlob!
     # The repository containing the file match.
     repository: Repository!
+    # The revspec of the revision that contains this match. If no revspec was given (such as when no
+    # repository filter or revspec is specified in the search query), it is null.
+    revSpec: GitRevSpec
     # The resource.
     resource: String! @deprecated(reason: "use the file field instead")
     # The symbols found in this file that match the query.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2822,6 +2822,9 @@ type FileMatch {
     file: GitBlob!
     # The repository containing the file match.
     repository: Repository!
+    # The revspec of the revision that contains this match. If no revspec was given (such as when no
+    # repository filter or revspec is specified in the search query), it is null.
+    revSpec: GitRevSpec
     # The resource.
     resource: String! @deprecated(reason: "use the file field instead")
     # The symbols found in this file that match the query.

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -99,6 +100,15 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 
 func (fm *FileMatchResolver) Repository() *RepositoryResolver {
 	return &RepositoryResolver{repo: fm.Repo}
+}
+
+func (fm *FileMatchResolver) RevSpec() *gitRevSpec {
+	if fm.InputRev == nil || *fm.InputRev == "" {
+		return nil // default branch
+	}
+	return &gitRevSpec{
+		expr: &gitRevSpecExpr{expr: *fm.InputRev, repo: fm.Repository()},
+	}
 }
 
 func (fm *FileMatchResolver) Resource() string {
@@ -591,70 +601,79 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			textSearchLimiter.SetLimit(len(eps) * 32)
 		}
 
-		for _, repoRev := range searcherRepos {
-			if len(repoRev.Revs) == 0 {
+	outer:
+		for _, repoAllRevs := range searcherRepos {
+			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
-			if len(repoRev.Revs) >= 2 {
+			if len(repoAllRevs.Revs) >= 2 && !conf.SearchMultipleRevisionsPerRepository() {
 				return errMultipleRevsNotSupported
 			}
 
-			// Only reason acquire can fail is if ctx is cancelled. So we can stop
-			// looping through searcherRepos.
-			limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)
-			if acquireErr != nil {
-				break
-			}
+			for _, rev := range repoAllRevs.Revs {
+				if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
+					return errors.New("searching multiple revisions in a repository using a glob (such as *refs/heads) is not supported; you must list all revspecs with colon separators (such as master:mybranch)")
+				}
 
-			args := *args
-			if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
-				// Modify the search query to only run for the filtered files
-				if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
-					patternCopy := *args.PatternInfo
-					args.PatternInfo = &patternCopy
-					includePatternsCopy := []string{}
-					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
+				// Only reason acquire can fail is if ctx is cancelled. So we can stop
+				// looping through searcherRepos.
+				limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)
+				if acquireErr != nil {
+					break outer
 				}
-			}
 
-			wg.Add(1)
-			go func(ctx context.Context, done context.CancelFunc, repoRev *search.RepositoryRevisions) {
-				defer wg.Done()
-				defer done()
+				// Make a new repoRev for just the operation of searching this revspec.
+				repoRev := &search.RepositoryRevisions{Repo: repoAllRevs.Repo, Revs: []search.RevisionSpecifier{rev}}
 
-				rev := repoRev.RevSpecs()[0] // TODO(sqs): search multiple revs
-				matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), rev, args.PatternInfo, fetchTimeout)
-				if err != nil {
-					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
-					log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
-				}
-				mu.Lock()
-				defer mu.Unlock()
-				if ctx.Err() == nil {
-					common.searched = append(common.searched, repoRev.Repo)
-				}
-				if repoLimitHit {
-					// We did not return all results in this repository.
-					common.partial[repoRev.Repo.Name] = struct{}{}
-				}
-				// non-diff search reports timeout through err, so pass false for timedOut
-				if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, err); fatalErr != nil {
-					if ctx.Err() == context.Canceled {
-						// Our request has been canceled (either because another one of searcherRepos
-						// had a fatal error, or otherwise), so we can just ignore these results. We
-						// handle this here, not in handleRepoSearchResult, because different callers of
-						// handleRepoSearchResult (for different result types) currently all need to
-						// handle cancellations differently.
-						return
-					}
-					if searchErr == nil {
-						searchErr = errors.Wrapf(err, "failed to search %s", repoRev.String())
-						tr.LazyPrintf("cancel due to error: %v", searchErr)
-						cancel()
+				args := *args
+				if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
+					// Modify the search query to only run for the filtered files
+					if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
+						patternCopy := *args.PatternInfo
+						args.PatternInfo = &patternCopy
+						includePatternsCopy := []string{}
+						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 					}
 				}
-				addMatches(matches)
-			}(limitCtx, limitDone, repoRev) // ends the Go routine for a call to searcher for a repo
+
+				wg.Add(1)
+				go func(ctx context.Context, done context.CancelFunc) {
+					defer wg.Done()
+					defer done()
+
+					matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], args.PatternInfo, fetchTimeout)
+					if err != nil {
+						tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
+						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
+					}
+					mu.Lock()
+					defer mu.Unlock()
+					if ctx.Err() == nil {
+						common.searched = append(common.searched, repoRev.Repo)
+					}
+					if repoLimitHit {
+						// We did not return all results in this repository.
+						common.partial[repoRev.Repo.Name] = struct{}{}
+					}
+					// non-diff search reports timeout through err, so pass false for timedOut
+					if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, err); fatalErr != nil {
+						if ctx.Err() == context.Canceled {
+							// Our request has been canceled (either because another one of searcherRepos
+							// had a fatal error, or otherwise), so we can just ignore these results. We
+							// handle this here, not in handleRepoSearchResult, because different callers of
+							// handleRepoSearchResult (for different result types) currently all need to
+							// handle cancellations differently.
+							return
+						}
+						if searchErr == nil {
+							searchErr = errors.Wrapf(err, "failed to search %s", repoRev.String())
+							tr.LazyPrintf("cancel due to error: %v", searchErr)
+							cancel()
+						}
+					}
+					addMatches(matches)
+				}(limitCtx, limitDone) // ends the Go routine for a call to searcher for a repo
+			} // ends the for loop iterating over repo's revs
 		} // ends the for loop iterating over repos
 		return nil
 	} // ends callSearcherOverRepos

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -585,6 +585,13 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-count)
 
 	for _, rev := range revs {
+		if len(rev.RevSpecs()) >= 2 {
+			// Zoekt only indexes 1 rev per repository, so it will not have the full results for the
+			// query on repositories for which multiple revs are searched.
+			unindexed = append(unindexed, rev)
+			continue
+		}
+
 		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
 		if !ok || (filter != nil && !filter(repo)) {
 			unindexed = append(unindexed, rev)

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -282,6 +282,11 @@ func StructuralSearchEnabled() bool {
 	return val == "enabled"
 }
 
+func SearchMultipleRevisionsPerRepository() bool {
+	x := ExperimentalFeatures()
+	return x.SearchMultipleRevisionsPerRepository != nil && *x.SearchMultipleRevisionsPerRepository
+}
+
 func ExperimentalFeatures() schema.ExperimentalFeatures {
 	val := Get().ExperimentalFeatures
 	if val == nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -338,6 +338,8 @@ type ExperimentalFeatures struct {
 	Discussions string `json:"discussions,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// SearchMultipleRevisionsPerRepository description: Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).
+	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// SplitSearchModes description: Enables toggling between the current omni search mode, and experimental interactive search mode.
 	SplitSearchModes string `json:"splitSearchModes,omitempty"`
 	// StructuralSearch description: Enables structural search.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -84,6 +84,12 @@
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "searchMultipleRevisionsPerRepository": {
+          "description": "Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -89,6 +89,12 @@ const SiteSchemaJSON = `{
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "searchMultipleRevisionsPerRepository": {
+          "description": "Enables searching multiple revisions of the same repository (using ` + "`" + `repo:myrepo@branch1:branch2` + "`" + `).",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental",

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -11,7 +11,7 @@ import { Props as ResultContainerProps, ResultContainer } from './ResultContaine
 
 const SUBSET_COUNT_KEY = 'fileMatchSubsetCount'
 
-export type IFileMatch = Partial<Pick<GQL.IFileMatch, 'symbols' | 'limitHit'>> & {
+export type IFileMatch = Partial<Pick<GQL.IFileMatch, 'revSpec' | 'symbols' | 'limitHit'>> & {
     file: Pick<GQL.IFile, 'path' | 'url'> & { commit: Pick<GQL.IGitCommit, 'oid'> }
     repository: Pick<GQL.IRepository, 'name' | 'url'>
     lineMatches: ILineMatch[]
@@ -91,13 +91,24 @@ export class FileMatch extends React.PureComponent<Props> {
             line: m.lineNumber,
         }))
 
+        const { repoAtRevURL, revDisplayName } =
+            result.revSpec?.__typename === 'GitRevSpecExpr' && result.revSpec.object?.commit
+                ? { repoAtRevURL: result.revSpec.object?.commit?.url, revDisplayName: result.revSpec.expr }
+                : result.revSpec?.__typename === 'GitRef'
+                ? { repoAtRevURL: result.revSpec.url, revDisplayName: result.revSpec.displayName }
+                : { repoAtRevURL: result.repository.url, revDisplayName: '' }
+
         const title = (
             <RepoFileLink
                 repoName={result.repository.name}
-                repoURL={result.repository.url}
+                repoURL={repoAtRevURL}
                 filePath={result.file.path}
                 fileURL={result.file.url}
-                repoDisplayName={this.props.repoDisplayName}
+                repoDisplayName={
+                    this.props.repoDisplayName
+                        ? `${this.props.repoDisplayName}${revDisplayName ? `@${revDisplayName}` : ''}`
+                        : undefined
+                }
             />
         )
 

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -94,6 +94,23 @@ export function search(
                                             name
                                             url
                                         }
+                                        revSpec {
+                                            __typename
+                                            ... on GitRef {
+                                                displayName
+                                                url
+                                            }
+                                            ... on GitRevSpecExpr {
+                                                expr
+                                                object { commit { url } }
+                                            }
+                                            ... on GitObject {
+                                                abbreviatedOID
+                                                commit {
+                                                    url
+                                                }
+                                            }
+                                        }
                                         limitHit
                                         symbols {
                                             name


### PR DESCRIPTION
Adds support for searching multiple revisions in the same repository for text search (currently it is only supported for commit/diff search). This is useful in some cases, such as when there are multiple active long-running development branches (and you want to find results on any branch).

When multiple revspecs are given for a repository, the Zoekt index is bypassed completely. There is a slight optimization potential to use the index for the default branch if it is one of the revspecs listed, but for simplicity that optimization is not implemented here. We will evaluate usage patterns with customers manually to see if it is worthwhile.

This is behind the site config feature flag `experimentalFeatures.searchMultipleRevisionsPerRepository` (default off).

This only supports searching explicitly listed revspecs in the query; it does not yet support the `repo:r@*refs/heads:^refs/heads/foo` syntax that diff/commit search support). When that glob syntax is supported (and this feature is evaluated thoroughly for perf impact and use case value), the feature flag will be removed.

The changelog is updated, but docs aren't (because this is still an experimental feature and is not worth adding confusion to the search query syntax page for yet).

- Requested by prospective customer https://app.hubspot.com/contacts/2762526/company/2428850551