### PR TITLE
a8n: Expose ExternalID on ExternalChangesets

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -251,6 +251,7 @@ type ExternalChangesetsConnectionResolver interface {
 
 type ExternalChangesetResolver interface {
 	ID() graphql.ID
+	ExternalID() string
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
 	Title() (string, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -714,6 +714,10 @@ type ExternalChangeset implements Node {
     # The unique ID for the changeset.
     id: ID!
 
+    # The external ID that uniquely identifies this ExternalChangeset on the
+    # codehost. For example, on GitHub this is the PR number.
+    externalID: String!
+
     # The repository changed by this changeset.
     repository: Repository!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -721,6 +721,10 @@ type ExternalChangeset implements Node {
     # The unique ID for the changeset.
     id: ID!
 
+    # The external ID that uniquely identifies this ExternalChangeset on the
+    # codehost. For example, on GitHub this is the PR number.
+    externalID: String!
+
     # The repository changed by this changeset.
     repository: Repository!
 

--- a/enterprise/internal/a8n/resolvers/changesets.go
+++ b/enterprise/internal/a8n/resolvers/changesets.go
@@ -140,6 +140,10 @@ func (r *changesetResolver) ID() graphql.ID {
 	return marshalChangesetID(r.Changeset.ID)
 }
 
+func (r *changesetResolver) ExternalID() string {
+	return r.Changeset.ExternalID
+}
+
 func (r *changesetResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
 	return r.computeRepo(ctx)
 }


### PR DESCRIPTION
This fixes #7094 by exposing the `ExternalID` of `ExternalChangesets` in the
GraphQL API.