### PR TITLE
a8n: Return an error in CreateCampaign if it would create 0 changesets

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -174,6 +174,10 @@ func (s *Service) CreateCampaign(ctx context.Context, c *a8n.Campaign, draft boo
 	return s.createChangesetJobsWithStore(ctx, tx, c)
 }
 
+// ErrNoCampaignJobs is returned by CreateCampaign if a CampaignPlanID was
+// specified but the CampaignPlan does not have any (finished) CampaignJobs.
+var ErrNoCampaignJobs = errors.New("cannot create a Campaign without any changesets")
+
 func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store, c *a8n.Campaign) error {
 	jobs, _, err := store.ListCampaignJobs(ctx, ListCampaignJobsOpts{
 		CampaignPlanID:            c.CampaignPlanID,
@@ -184,6 +188,10 @@ func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store
 	})
 	if err != nil {
 		return err
+	}
+
+	if len(jobs) == 0 {
+		return ErrNoCampaignJobs
 	}
 
 	for _, job := range jobs {

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -125,6 +125,15 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		campaign := testCampaign(u.ID, plan.ID)
+		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+
+		// Without CampaignJobs it should fail
+		err = svc.CreateCampaign(ctx, campaign, false)
+		if err != ErrNoCampaignJobs {
+			t.Fatal("CreateCampaign did not produce expected error")
+		}
+
 		campaignJobs := make([]*a8n.CampaignJob, 0, len(rs))
 		for _, repo := range rs {
 			campaignJob := testCampaignJob(plan.ID, repo.ID, now)
@@ -135,9 +144,7 @@ func TestService(t *testing.T) {
 			campaignJobs = append(campaignJobs, campaignJob)
 		}
 
-		campaign := testCampaign(u.ID, plan.ID)
-
-		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+		// With CampaignJobs it should succeed
 		err = svc.CreateCampaign(ctx, campaign, false)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This is something I discussed with @eseliger: we don't want to create a Campaign if the specified CampaignPlan didn't yield any diffs. It doesn't make a whole lot of sense to have this (non-manual) Campaign without changesets in the first place and introducing this invariant also makes it easier for us to reason about the code.
