### PR TITLE
db: remove Repos.UpdateRepositoryMetadata

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -636,11 +636,6 @@ func (s *repos) UpdateLanguage(ctx context.Context, repo api.RepoID, language st
 	return err
 }
 
-func (s *repos) UpdateRepositoryMetadata(ctx context.Context, name api.RepoName, description string, fork bool, archived bool) error {
-	_, err := dbconn.Global.ExecContext(ctx, "UPDATE repo SET description=$1, fork=$2, archived=$3 WHERE name=$4 	AND (description <> $1 OR fork <> $2 OR archived <> $3)", description, fork, archived, name)
-	return err
-}
-
 const upsertSQL = `
 WITH upsert AS (
   UPDATE repo

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -102,7 +102,6 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 	m.Get(apirouter.ExternalServicesList).Handler(trace.TraceRoute(handler(serveExternalServicesList)))
 	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.TraceRoute(handler(servePhabricatorRepoCreate)))
 	m.Get(apirouter.ReposCreateIfNotExists).Handler(trace.TraceRoute(handler(serveReposCreateIfNotExists)))
-	m.Get(apirouter.ReposUpdateMetadata).Handler(trace.TraceRoute(handler(serveReposUpdateMetadata)))
 	reposList := &reposListServer{
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		Repos:                 backend.Repos,

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -65,18 +65,6 @@ func serveReposCreateIfNotExists(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func serveReposUpdateMetadata(w http.ResponseWriter, r *http.Request) error {
-	var repo api.ReposUpdateMetadataRequest
-	err := json.NewDecoder(r.Body).Decode(&repo)
-	if err != nil {
-		return err
-	}
-	if err := db.Repos.UpdateRepositoryMetadata(r.Context(), repo.RepoName, repo.Description, repo.Fork, repo.Archived); err != nil {
-		return errors.Wrap(err, "Repos.UpdateRepositoryMetadata failed")
-	}
-	return nil
-}
-
 func servePhabricatorRepoCreate(w http.ResponseWriter, r *http.Request) error {
 	var repo api.PhabricatorRepoCreateRequest
 	err := json.NewDecoder(r.Body).Decode(&repo)

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -42,7 +42,6 @@ const (
 	ReposList              = "internal.repos.list"
 	ReposIndex             = "internal.repos.index"
 	ReposListEnabled       = "internal.repos.list-enabled"
-	ReposUpdateMetadata    = "internal.repos.update-metadata"
 	Configuration          = "internal.configuration"
 	SearchConfiguration    = "internal.search-configuration"
 	ExternalServiceConfigs = "internal.external-services.configs"
@@ -108,7 +107,6 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/repos/list").Methods("POST").Name(ReposList)
 	base.Path("/repos/index").Methods("POST").Name(ReposIndex)
 	base.Path("/repos/list-enabled").Methods("POST").Name(ReposListEnabled)
-	base.Path("/repos/update-metadata").Methods("POST").Name(ReposUpdateMetadata)
 	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)
 	base.Path("/configuration").Methods("POST").Name(Configuration)
 	base.Path("/search/configuration").Methods("GET").Name(SearchConfiguration)

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -33,13 +33,6 @@ type RepoCreateOrUpdateRequest struct {
 	Archived bool `json:"archived"`
 }
 
-type ReposUpdateMetadataRequest struct {
-	RepoName    `json:"repo"`
-	Description string `json:"description"`
-	Fork        bool   `json:"fork"`
-	Archived    bool   `json:"Archived"`
-}
-
 type PhabricatorRepoCreateRequest struct {
 	RepoName `json:"repo"`
 	Callsign string `json:"callsign"`

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -273,15 +273,6 @@ func (c *internalClient) Configuration(ctx context.Context) (conftypes.RawUnifie
 	return cfg, err
 }
 
-func (c *internalClient) ReposUpdateMetadata(ctx context.Context, repo RepoName, description string, fork bool, archived bool) error {
-	return c.postInternal(ctx, "repos/update-metadata", ReposUpdateMetadataRequest{
-		RepoName:    repo,
-		Description: description,
-		Fork:        fork,
-		Archived:    archived,
-	}, nil)
-}
-
 func (c *internalClient) ReposGetByName(ctx context.Context, repoName RepoName) (*Repo, error) {
 	var repo Repo
 	err := c.postInternal(ctx, "repos/"+string(repoName), nil, &repo)


### PR DESCRIPTION
This function is unused since we switched to repo-updater managing all
repository metadata. This commit also removes the unused internal API endpoint
for it.