### PR TITLE
db: remove deprecated Repos.Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The deprecated GraphQL mutation `setAllRepositoriesEnabled` has been removed. [#7478](https://github.com/sourcegraph/sourcegraph/pull/7478)
+- The deprecated GraphQL mutation `deleteRepository` has been removed. [#7483](https://github.com/sourcegraph/sourcegraph/pull/7483)
 
 ## 3.11.0
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -604,17 +604,6 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 	return nil, nil, nil, nil, nil
 }
 
-// Delete deletes the repository row from the repo table.
-func (s *repos) Delete(ctx context.Context, repo api.RepoID) error {
-	if Mocks.Repos.Delete != nil {
-		return Mocks.Repos.Delete(ctx, repo)
-	}
-
-	q := sqlf.Sprintf("DELETE FROM repo WHERE id=%d", repo)
-	_, err := dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	return err
-}
-
 const upsertSQL = `
 WITH upsert AS (
   UPDATE repo

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
@@ -57,6 +59,14 @@ func mustCreate(ctx context.Context, t *testing.T, repos ...*types.Repo) []*type
 		createdRepos = append(createdRepos, repo)
 	}
 	return createdRepos
+}
+
+// Delete the repository row from the repo table. It exists for testing
+// purposes only. Repository mutations are managed by repo-updater.
+func (s *repos) Delete(ctx context.Context, repo api.RepoID) error {
+	q := sqlf.Sprintf("DELETE FROM repo WHERE id=%d", repo)
+	_, err := dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	return err
 }
 
 /*

--- a/cmd/frontend/db/repos_mock.go
+++ b/cmd/frontend/db/repos_mock.go
@@ -13,7 +13,6 @@ type MockRepos struct {
 	Get       func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
 	GetByName func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
 	List      func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	Delete    func(ctx context.Context, repo api.RepoID) error
 	Count     func(ctx context.Context, opt ReposListOptions) (int, error)
 	Upsert    func(api.InsertRepoOp) error
 }

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -76,33 +76,6 @@ func TestParseIncludePattern(t *testing.T) {
 	}
 }
 
-func TestRepos_Delete(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	dbtesting.SetupGlobalTestDB(t)
-	ctx := context.Background()
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
-
-	if err := Repos.Upsert(ctx, api.InsertRepoOp{Name: "myrepo", Description: "", Fork: false, Enabled: true}); err != nil {
-		t.Fatal(err)
-	}
-
-	rp, err := Repos.GetByName(ctx, "myrepo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := Repos.Delete(ctx, rp.ID); err != nil {
-		t.Fatal(err)
-	}
-
-	rp2, err := Repos.Get(ctx, rp.ID)
-	if !errcode.IsNotFound(err) {
-		t.Errorf("expected repo not found, but got error %q with repo %v", err, rp2)
-	}
-}
-
 func TestRepos_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -304,25 +304,6 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 	return &EmptyResponse{}, nil
 }
 
-func (r *schemaResolver) DeleteRepository(ctx context.Context, args *struct {
-	Repository graphql.ID
-}) (*EmptyResponse, error) {
-	// 🚨 SECURITY: Only site admins can delete repositories, because it's a site-wide
-	// and semi-destructive action.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
-	}
-
-	id, err := UnmarshalRepositoryID(args.Repository)
-	if err != nil {
-		return nil, err
-	}
-	if err := db.Repos.Delete(ctx, id); err != nil {
-		return nil, err
-	}
-	return &EmptyResponse{}, nil
-}
-
 func repoNamesToStrings(repoNames []api.RepoName) []string {
 	strings := make([]string, len(repoNames))
 	for i, repoName := range repoNames {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -164,19 +164,6 @@ type Mutation {
     #
     # Only site admins may perform this mutation.
     updateAllMirrorRepositories: EmptyResponse! @deprecated(reason: "syncer ensures all repositories are up to date.")
-    # DEPRECATED: All repositories are accessible or deleted. To prevent a
-    # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration. It will be deleted. This mutation will be removed in 3.6.
-    #
-    # Deletes a repository and all data associated with it, irreversibly.
-    #
-    # If the repository was added because it was present in the site configuration (directly,
-    # or because it originated from a configured code host), then it will be re-added during
-    # the next sync. If you intend to make the repository inaccessible to users and not searchable,
-    # use setRepositoryEnabled to disable the repository instead of deleteRepository.
-    #
-    # Only site admins may perform this mutation.
-    deleteRepository(repository: ID!): EmptyResponse @deprecated(reason: "update external service exclude setting.")
     # Creates a new user account.
     #
     # Only site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -166,19 +166,6 @@ type Mutation {
     #
     # Only site admins may perform this mutation.
     updateAllMirrorRepositories: EmptyResponse! @deprecated(reason: "syncer ensures all repositories are up to date.")
-    # DEPRECATED: All repositories are accessible or deleted. To prevent a
-    # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration. It will be deleted. This mutation will be removed in 3.6.
-    #
-    # Deletes a repository and all data associated with it, irreversibly.
-    #
-    # If the repository was added because it was present in the site configuration (directly,
-    # or because it originated from a configured code host), then it will be re-added during
-    # the next sync. If you intend to make the repository inaccessible to users and not searchable,
-    # use setRepositoryEnabled to disable the repository instead of deleteRepository.
-    #
-    # Only site admins may perform this mutation.
-    deleteRepository(repository: ID!): EmptyResponse @deprecated(reason: "update external service exclude setting.")
     # Creates a new user account.
     #
     # Only site admins may perform this mutation.


### PR DESCRIPTION
Repositories are managed by repo-updater. To quote the documentation of the
graphql mutation:

> DEPRECATED: All repositories are accessible or deleted. To prevent a
> repository from being accessed on Sourcegraph add it to the external
> service exclude configuration. It will be deleted. This mutation will be removed in 3.6.
> 
> Deletes a repository and all data associated with it, irreversibly.
> 
> If the repository was added because it was present in the site configuration (directly,
> or because it originated from a configured code host), then it will be re-added during
> the next sync. If you intend to make the repository inaccessible to users and not searchable,
> use setRepositoryEnabled to disable the repository instead of deleteRepository.