### PR TITLE
structural search: hardcode threshold to 100 for matching files per repo

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -613,12 +613,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 					patternCopy := *args.PatternInfo
 					args.PatternInfo = &patternCopy
 					includePatternsCopy := []string{}
-					threshold := 100 // if there are more matching files than this threshold, only search up to this many
+					threshold := 200 // if there are more matching files than this threshold, only search up to this many
 					if len(v) > threshold {
-						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v[:threshold]...)
-					} else {
-						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
+						v = v[:threshold]
 					}
+					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
 				}
 			}
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -613,7 +613,12 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 					patternCopy := *args.PatternInfo
 					args.PatternInfo = &patternCopy
 					includePatternsCopy := []string{}
-					args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
+					threshold := 100 // if there are more matching files than this threshold, only search up to this many
+					if len(v) > threshold {
+						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v[:threshold]...)
+					} else {
+						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
+					}
 				}
 			}
 


### PR DESCRIPTION
Structural search gets a list of files to search based on matching files from Zoekt. Given a large enough repo and a common pattern, this can be up to 10K file paths, and will result in:

<img width="1277" alt="Screen Shot 2020-01-04 at 12 33 51 AM" src="https://user-images.githubusercontent.com/888624/72037840-a54eb400-325c-11ea-8572-a22a9d5386a0.png">

Realistically, based on some playing around, this filtered file set _usually_ doesn't exceed 100, and when it does, that should be something that specifying 'count' should/could override. This because filtered files in some sense 'guarantees' a match (and therefore results), so there isn't a good reason to accept a huge file list by default--we should shortcircuit and return results quicker. I'm hardcoding a thumbsuck limit of 100 filtered files to pass onto structural search for now, and will build in overrides when `count` is specified if/as needed in a later PR.