### PR TITLE
refactor: make search pattern info naming consistent

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -500,10 +500,10 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParameters) 
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-var mockSearchCommitLogInRepos func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitLogInRepos func(args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitLogInRepos != nil {
 		return mockSearchCommitLogInRepos(args)
 	}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -97,7 +97,7 @@ func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRev
 	}
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:          repoRevs,
-		Info:              info,
+		PatternInfo:       info,
 		Query:             query,
 		Diff:              true,
 		TextSearchOptions: textSearchOptions,
@@ -117,7 +117,7 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 	}
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:           repoRevs,
-		Info:               info,
+		PatternInfo:        info,
 		Query:              query,
 		Diff:               false,
 		TextSearchOptions:  git.TextSearchOptions{},
@@ -126,7 +126,7 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 }
 
 func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
-	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.Info))
+	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.PatternInfo))
 	defer func() {
 		tr.LazyPrintf("%d results, limitHit=%v, timedOut=%v", len(results), limitHit, timedOut)
 		tr.SetError(err)
@@ -134,7 +134,7 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 	}()
 
 	repo := op.RepoRevs.Repo
-	maxResults := int(op.Info.FileMatchLimit)
+	maxResults := int(op.PatternInfo.FileMatchLimit)
 
 	args := []string{
 		"--no-prefix",
@@ -145,7 +145,7 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 			"--unified=0",
 		)
 	}
-	if op.Info.IsRegExp {
+	if op.PatternInfo.IsRegExp {
 		args = append(args, "--extended-regexp")
 	}
 	if !op.Query.IsCaseSensitive() {
@@ -242,10 +242,10 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 		Options: git.RawLogDiffSearchOptions{
 			Query: op.TextSearchOptions,
 			Paths: git.PathOptions{
-				IncludePatterns: op.Info.IncludePatterns,
-				ExcludePattern:  op.Info.ExcludePattern,
-				IsCaseSensitive: op.Info.PathPatternsAreCaseSensitive,
-				IsRegExp:        op.Info.PathPatternsAreRegExps,
+				IncludePatterns: op.PatternInfo.IncludePatterns,
+				ExcludePattern:  op.PatternInfo.ExcludePattern,
+				IsCaseSensitive: op.PatternInfo.PathPatternsAreCaseSensitive,
+				IsRegExp:        op.PatternInfo.PathPatternsAreRegExps,
 			},
 			Diff:              op.Diff,
 			OnlyMatchingHunks: true,

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -58,7 +58,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:          repoRevs,
-		Info:              &search.PatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
+		PatternInfo:       &search.PatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
 		Query:             query,
 		Diff:              true,
 		TextSearchOptions: git.TextSearchOptions{Pattern: "p"},

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1159,6 +1159,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
+				args := search.TextParametersForCommitParameters{
+					PatternInfo: args.PatternInfo,
+					Repos:       args.Repos,
+					Query:       args.Query,
+				}
 				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,11 +1,11 @@
 package search
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -32,7 +32,39 @@ type DiffParameters struct {
 	Options git.RawLogDiffSearchOptions
 }
 
-type SymbolsParameters protocol.SearchArgs
+type SymbolsParameters struct {
+	// Repo is the name of the repository to search in.
+	Repo api.RepoName `json:"repo"`
+
+	// CommitID is the commit to search in.
+	CommitID api.CommitID `json:"commitID"`
+
+	// Query is the search query.
+	Query string
+
+	// IsRegExp if true will treat the Pattern as a regular expression.
+	IsRegExp bool
+
+	// IsCaseSensitive if false will ignore the case of query and file pattern
+	// when finding matches.
+	IsCaseSensitive bool
+
+	// IncludePatterns is a list of regexes that symbol's file paths
+	// need to match to get included in the result
+	//
+	// The patterns are ANDed together; a file's path must match all patterns
+	// for it to be kept. That is also why it is a list (unlike the singular
+	// ExcludePattern); it is not possible in general to construct a single
+	// glob or Go regexp that represents multiple such patterns ANDed together.
+	IncludePatterns []string
+
+	// ExcludePattern is an optional regex that symbol's file paths
+	// need to match to get included in the result
+	ExcludePattern string
+
+	// First indicates that only the first n symbols should be returned.
+	First int
+}
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to
@@ -57,4 +89,14 @@ type TextParameters struct {
 
 	Zoekt        *searchbackend.Zoekt
 	SearcherURLs *endpoint.Map
+}
+
+// TextParametersForCommitParameters is an intermediate type based on
+// TextParameters that encodes parameters exclusively for a commit search. The
+// commit search internals converts this type to CommitParameters. The
+// commitParameter type definitions will be merged in future.
+type TextParametersForCommitParameters struct {
+	PatternInfo *PatternInfo
+	Repos       []*RepositoryRevisions
+	Query       *query.Query
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -20,7 +20,7 @@ func (t TextParameters) typeParametersValue()    {}
 
 type CommitParameters struct {
 	RepoRevs           *RepositoryRevisions
-	Info               *PatternInfo
+	PatternInfo        *PatternInfo
 	Query              *query.Query
 	Diff               bool
 	TextSearchOptions  git.TextSearchOptions


### PR DESCRIPTION
Commit search uses the struct member name `Info` to refer to the `PatternInfo` type, whereas we use `PatternInfo` for text search. 

This change makes the naming consistent (commit search should use `PatternInfo` too). This is important for future steps that split the data type.