### PR TITLE
refactor: disjoint parameter types for commits vs text search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -500,10 +500,10 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParameters) 
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-var mockSearchCommitLogInRepos func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitLogInRepos func(args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitLogInRepos != nil {
 		return mockSearchCommitLogInRepos(args)
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1159,6 +1159,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
+				args := search.TextParametersForCommitParameters{
+					PatternInfo: args.PatternInfo,
+					Repos:       args.Repos,
+					Query:       args.Query,
+				}
 				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,11 +1,11 @@
 package search
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -32,7 +32,39 @@ type DiffParameters struct {
 	Options git.RawLogDiffSearchOptions
 }
 
-type SymbolsParameters protocol.SearchArgs
+type SymbolsParameters struct {
+	// Repo is the name of the repository to search in.
+	Repo api.RepoName `json:"repo"`
+
+	// CommitID is the commit to search in.
+	CommitID api.CommitID `json:"commitID"`
+
+	// Query is the search query.
+	Query string
+
+	// IsRegExp if true will treat the Pattern as a regular expression.
+	IsRegExp bool
+
+	// IsCaseSensitive if false will ignore the case of query and file pattern
+	// when finding matches.
+	IsCaseSensitive bool
+
+	// IncludePatterns is a list of regexes that symbol's file paths
+	// need to match to get included in the result
+	//
+	// The patterns are ANDed together; a file's path must match all patterns
+	// for it to be kept. That is also why it is a list (unlike the singular
+	// ExcludePattern); it is not possible in general to construct a single
+	// glob or Go regexp that represents multiple such patterns ANDed together.
+	IncludePatterns []string
+
+	// ExcludePattern is an optional regex that symbol's file paths
+	// need to match to get included in the result
+	ExcludePattern string
+
+	// First indicates that only the first n symbols should be returned.
+	First int
+}
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -58,3 +58,13 @@ type TextParameters struct {
 	Zoekt        *searchbackend.Zoekt
 	SearcherURLs *endpoint.Map
 }
+
+// TextParametersForCommitParameters is an intermediate type based on
+// TextParameters that encodes parameters exclusively for a commit search. The
+// commit search internals converts this type to CommitParameters. The
+// commitParameter type definitions will be merged in future.
+type TextParametersForCommitParameters struct {
+	PatternInfo *PatternInfo
+	Repos       []*RepositoryRevisions
+	Query       *query.Query
+}


### PR DESCRIPTION
Stacked on #7492.

The `TextParameters` data type currently bundles a lot of state for _all_ kinds of search (text, commit, diff) etc. The `search_results.go` logic cases out on the kind of search, passing all of this state down, which is then converted later into the other types like `CommitParameters`, `DiffParameters`, etc. that I've pulled out prior. 

The intent with this PR, and other follow ups, is to disentangle the state that is currently encoded in `TextParameters` (it is basically a dumping ground currently). To disentangle this safely, I am introducing _temporary_ intermediate data types that exclude the struct members that are being threaded along and not needed. This PR introduces a temporary type that converts `TextParameters` -> `TextParametersForCommitParameters`. The verbose naming can change later. This type excludes the `Zoekt` and `SearcherURLs`, and other things that are simply not used for commit search. 

It is simply too error prone to try and rewrite the logic without introducing intermediate types. These types help prop up temporary barriers for bundling irrelevant state, and once the intermediate types are in place, it's easier to create disjoint types that are further bundled inside these.

What I _really_ want to do is fix up `PatternInfo` for `textsearch` by creating disjoint types, but this isn't possible without separating its uses from commit search that is currently entangled in other places.

 To understand the problem down the line, consider that, e.g., `CommitParameters` currently stores both `PatternInfo.Pattern` and `git.TextSearchOptions.Pattern` (these members are either the same, and if they are not, it could lead to some broken invariants). We are also threading `Query` along everywhere which is sloppy (cf. comment note in `TextParameters`).  Further, the `IsCaseSensitive` member is accessible in three ways inside `search.CommitParameters`: through `TextSearchOptions`, `Query`, and `PatternInfo.Info`, which is just, yeah... it's impossible to know which one is used (or should be used) without looking at the code. But the real issue is that underneath the hood, the `PatternInfo` type contains a lot of information that is (a) irrelevant to other kinds of searchers and (b) should itself be separated because it is also a 'dumping ground' for text search logic. This PR is just prep work for that end goal.