### PR TITLE
refactor: copy search symbols to search types

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,11 +1,11 @@
 package search
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -32,7 +32,39 @@ type DiffParameters struct {
 	Options git.RawLogDiffSearchOptions
 }
 
-type SymbolsParameters protocol.SearchArgs
+type SymbolsParameters struct {
+	// Repo is the name of the repository to search in.
+	Repo api.RepoName `json:"repo"`
+
+	// CommitID is the commit to search in.
+	CommitID api.CommitID `json:"commitID"`
+
+	// Query is the search query.
+	Query string
+
+	// IsRegExp if true will treat the Pattern as a regular expression.
+	IsRegExp bool
+
+	// IsCaseSensitive if false will ignore the case of query and file pattern
+	// when finding matches.
+	IsCaseSensitive bool
+
+	// IncludePatterns is a list of regexes that symbol's file paths
+	// need to match to get included in the result
+	//
+	// The patterns are ANDed together; a file's path must match all patterns
+	// for it to be kept. That is also why it is a list (unlike the singular
+	// ExcludePattern); it is not possible in general to construct a single
+	// glob or Go regexp that represents multiple such patterns ANDed together.
+	IncludePatterns []string
+
+	// ExcludePattern is an optional regex that symbol's file paths
+	// need to match to get included in the result
+	ExcludePattern string
+
+	// First indicates that only the first n symbols should be returned.
+	First int
+}
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to


### PR DESCRIPTION
Stacked on #7495.

This just expands the `protocol.SearchArgs` type to its full struct definition (it is copied directly from `SearchArgs` in `symbols/protocol/symbols.go`. From here we can see what state is being duplicated or otherwise exclusive to symbols search in `types.go`.

This is needed for follow up diffs that will separate logic for indexed search and `PatternInfo` state.