### PR TITLE
search: set zoekt *MaxImportantMatch options for repohasfile search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
 - Show errors on repository settings page when repo-updater is down. [#3593](https://github.com/sourcegraph/sourcegraph/issues/3593)
 - Remove benign warning that verifying config took more than 10s when updating or saving an external service. [#7176](https://github.com/sourcegraph/sourcegraph/issues/7176)
+- `repohasfile` search filter correctly filters over large sets of indexed repositories. [#7380](https://github.com/sourcegraph/sourcegraph/issues/7380)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ All notable changes to Sourcegraph are documented in this file.
 - We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
 - Show errors on repository settings page when repo-updater is down. [#3593](https://github.com/sourcegraph/sourcegraph/issues/3593)
 - Remove benign warning that verifying config took more than 10s when updating or saving an external service. [#7176](https://github.com/sourcegraph/sourcegraph/issues/7176)
-- `repohasfile` search filter correctly filters over large sets of indexed repositories. [#7380](https://github.com/sourcegraph/sourcegraph/issues/7380)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -274,9 +274,11 @@ func createNewRepoSetWithRepoHasFileInputs(ctx context.Context, query *search.Pa
 	}
 
 	newSearchOpts := zoekt.SearchOptions{
-		ShardMaxMatchCount: 1,
-		TotalMaxMatchCount: math.MaxInt32,
-		MaxDocDisplayCount: 0,
+		ShardMaxMatchCount:     1,
+		TotalMaxMatchCount:     math.MaxInt32,
+		ShardMaxImportantMatch: 1,
+		TotalMaxImportantMatch: math.MaxInt32,
+		MaxDocDisplayCount:     0,
 	}
 	newSearchOpts.SetDefaults()
 


### PR DESCRIPTION
Previously we would rely on the defaults for *MaxImportantMatch. Currently this is benign, but could lead to a regression if zoekt starts to respect TotalMaxImportantMatch option.

Part of https://github.com/sourcegraph/sourcegraph/issues/7380