### PR TITLE
search: reduce boilerplate for indexed repohasfile tests

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -711,7 +711,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		wantRepoSet []string
 	}{
 		{
-			name:    "returns filtered repoSet when repoHasFileFlag is in query",
+			name:    "one include",
 			include: []string{"1"},
 			searcher: repoURLsFakeSearcher{
 				"github.com/test/1": []string{"1.md"},
@@ -720,7 +720,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 			wantRepoSet: []string{"github.com/test/1"},
 		},
 		{
-			name:    "returns filtered repoSet when multiple repoHasFileFlags are in query",
+			name:    "two include",
 			include: []string{"1", "2"},
 			searcher: repoURLsFakeSearcher{
 				"github.com/test/1": []string{"1.md"},
@@ -730,7 +730,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name:    "returns filtered repoSet when negated repoHasFileFlag is in query",
+			name:    "exclude",
 			exclude: []string{"1"},
 			searcher: repoURLsFakeSearcher{
 				"github.com/test/1": []string{"1.md"},
@@ -739,7 +739,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name:    "returns a new repoSet that includes at most the repos from original repoSet",
+			name:    "subset of reposet",
 			include: []string{"1"},
 			searcher: repoURLsFakeSearcher{
 				"github.com/test/1": []string{"1.md"},

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -700,61 +700,52 @@ func (repoURLsFakeSearcher) Close() {
 
 func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	type args struct {
-		include  []string
-		exclude  []string
-		searcher zoekt.Searcher
-		repoSet  []string
 	}
 
 	tests := []struct {
 		name        string
-		args        args
+		include     []string
+		exclude     []string
+		searcher    zoekt.Searcher
+		repoSet     []string
 		wantRepoSet []string
 	}{
 		{
-			name: "returns filtered repoSet when repoHasFileFlag is in query",
-			args: args{
-				include: []string{"1"},
-				searcher: repoURLsFakeSearcher{
-					"github.com/test/1": []string{"1.md"},
-				},
-				repoSet: []string{"github.com/test/1", "github.com/test/2"},
+			name:    "returns filtered repoSet when repoHasFileFlag is in query",
+			include: []string{"1"},
+			searcher: repoURLsFakeSearcher{
+				"github.com/test/1": []string{"1.md"},
 			},
+			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
 			wantRepoSet: []string{"github.com/test/1"},
 		},
 		{
-			name: "returns filtered repoSet when multiple repoHasFileFlags are in query",
-			args: args{
-				include: []string{"1", "2"},
-				searcher: repoURLsFakeSearcher{
-					"github.com/test/1": []string{"1.md"},
-					"github.com/test/2": []string{"1.md", "2.md"},
-				},
-				repoSet: []string{"github.com/test/1", "github.com/test/2"},
+			name:    "returns filtered repoSet when multiple repoHasFileFlags are in query",
+			include: []string{"1", "2"},
+			searcher: repoURLsFakeSearcher{
+				"github.com/test/1": []string{"1.md"},
+				"github.com/test/2": []string{"1.md", "2.md"},
 			},
+			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name: "returns filtered repoSet when negated repoHasFileFlag is in query",
-			args: args{
-				exclude: []string{"1"},
-				searcher: repoURLsFakeSearcher{
-					"github.com/test/1": []string{"1.md"},
-				},
-				repoSet: []string{"github.com/test/1", "github.com/test/2"},
+			name:    "returns filtered repoSet when negated repoHasFileFlag is in query",
+			exclude: []string{"1"},
+			searcher: repoURLsFakeSearcher{
+				"github.com/test/1": []string{"1.md"},
 			},
+			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name: "returns a new repoSet that includes at most the repos from original repoSet",
-			args: args{
-				include: []string{"1"},
-				searcher: repoURLsFakeSearcher{
-					"github.com/test/1": []string{"1.md"},
-					"github.com/test/2": []string{"1.md"},
-				},
-				repoSet: []string{"github.com/test/1"},
+			name:    "returns a new repoSet that includes at most the repos from original repoSet",
+			include: []string{"1"},
+			searcher: repoURLsFakeSearcher{
+				"github.com/test/1": []string{"1.md"},
+				"github.com/test/2": []string{"1.md"},
 			},
+			repoSet:     []string{"github.com/test/1"},
 			wantRepoSet: []string{"github.com/test/1"},
 		},
 	}
@@ -762,17 +753,17 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repoSet := &zoektquery.RepoSet{Set: map[string]bool{}}
-			for _, r := range tt.args.repoSet {
+			for _, r := range tt.repoSet {
 				repoSet.Set[r] = true
 			}
 
 			info := &search.PatternInfo{
-				FilePatternsReposMustInclude: tt.args.include,
-				FilePatternsReposMustExclude: tt.args.exclude,
+				FilePatternsReposMustInclude: tt.include,
+				FilePatternsReposMustExclude: tt.exclude,
 				PathPatternsAreRegExps:       true,
 			}
 
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, tt.args.searcher, *repoSet)
+			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, tt.searcher, *repoSet)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -700,9 +700,10 @@ func (repoURLsFakeSearcher) Close() {
 
 func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	type args struct {
-		queryPatternInfo *search.PatternInfo
-		searcher         zoekt.Searcher
-		repoSet          []string
+		include  []string
+		exclude  []string
+		searcher zoekt.Searcher
+		repoSet  []string
 	}
 
 	tests := []struct {
@@ -713,7 +714,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		{
 			name: "returns filtered repoSet when repoHasFileFlag is in query",
 			args: args{
-				queryPatternInfo: &search.PatternInfo{FilePatternsReposMustInclude: []string{"1"}, PathPatternsAreRegExps: true},
+				include: []string{"1"},
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 				},
@@ -724,7 +725,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		{
 			name: "returns filtered repoSet when multiple repoHasFileFlags are in query",
 			args: args{
-				queryPatternInfo: &search.PatternInfo{FilePatternsReposMustInclude: []string{"1", "2"}, PathPatternsAreRegExps: true},
+				include: []string{"1", "2"},
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 					"github.com/test/2": []string{"1.md", "2.md"},
@@ -736,7 +737,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		{
 			name: "returns filtered repoSet when negated repoHasFileFlag is in query",
 			args: args{
-				queryPatternInfo: &search.PatternInfo{FilePatternsReposMustExclude: []string{"1"}, PathPatternsAreRegExps: true},
+				exclude: []string{"1"},
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 				},
@@ -747,7 +748,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		{
 			name: "returns a new repoSet that includes at most the repos from original repoSet",
 			args: args{
-				queryPatternInfo: &search.PatternInfo{FilePatternsReposMustInclude: []string{"1"}, PathPatternsAreRegExps: true},
+				include: []string{"1"},
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 					"github.com/test/2": []string{"1.md"},
@@ -765,7 +766,13 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				repoSet.Set[r] = true
 			}
 
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), tt.args.queryPatternInfo, tt.args.searcher, *repoSet)
+			info := &search.PatternInfo{
+				FilePatternsReposMustInclude: tt.args.include,
+				FilePatternsReposMustExclude: tt.args.exclude,
+				PathPatternsAreRegExps:       true,
+			}
+
+			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, tt.args.searcher, *repoSet)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -713,6 +713,17 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 		wantRepoSet []string
 	}{
 		{
+			name:        "all",
+			include:     []string{"md"},
+			repoSet:     allRepos,
+			wantRepoSet: allRepos,
+		},
+		{
+			name:    "none",
+			include: []string{"foo"},
+			repoSet: allRepos,
+		},
+		{
 			name:        "one include",
 			include:     []string{"1"},
 			repoSet:     allRepos,
@@ -725,16 +736,39 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
+			name:        "include exclude",
+			include:     []string{"md"},
+			exclude:     []string{"1"},
+			repoSet:     allRepos,
+			wantRepoSet: []string{"github.com/test/2"},
+		},
+		{
 			name:        "exclude",
 			exclude:     []string{"1"},
 			repoSet:     allRepos,
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
+			name:    "exclude all",
+			exclude: []string{"md"},
+			repoSet: allRepos,
+		},
+		{
+			name:        "exclude none",
+			exclude:     []string{"foo"},
+			repoSet:     allRepos,
+			wantRepoSet: allRepos,
+		},
+		{
 			name:        "subset of reposet",
 			include:     []string{"md"},
 			repoSet:     []string{"github.com/test/1"},
 			wantRepoSet: []string{"github.com/test/1"},
+		},
+		{
+			name:    "exclude subset of reposet",
+			exclude: []string{"1"},
+			repoSet: []string{"github.com/test/1"},
 		},
 	}
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -700,12 +700,9 @@ func (repoURLsFakeSearcher) Close() {
 
 func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	type args struct {
-		ctx                             context.Context
-		queryPatternInfo                *search.PatternInfo
-		searcher                        zoekt.Searcher
-		repoSet                         []string
-		repoHasFileFlagIsInQuery        bool
-		negatedRepoHasFileFlagIsInQuery bool
+		queryPatternInfo *search.PatternInfo
+		searcher         zoekt.Searcher
+		repoSet          []string
 	}
 
 	tests := []struct {
@@ -720,9 +717,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 				},
-				repoSet:                         []string{"github.com/test/1", "github.com/test/2"},
-				repoHasFileFlagIsInQuery:        true,
-				negatedRepoHasFileFlagIsInQuery: false,
+				repoSet: []string{"github.com/test/1", "github.com/test/2"},
 			},
 			wantRepoSet: []string{"github.com/test/1"},
 		},
@@ -734,9 +729,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 					"github.com/test/1": []string{"1.md"},
 					"github.com/test/2": []string{"1.md", "2.md"},
 				},
-				repoSet:                         []string{"github.com/test/1", "github.com/test/2"},
-				repoHasFileFlagIsInQuery:        true,
-				negatedRepoHasFileFlagIsInQuery: false,
+				repoSet: []string{"github.com/test/1", "github.com/test/2"},
 			},
 			wantRepoSet: []string{"github.com/test/2"},
 		},
@@ -747,9 +740,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				searcher: repoURLsFakeSearcher{
 					"github.com/test/1": []string{"1.md"},
 				},
-				repoSet:                         []string{"github.com/test/1", "github.com/test/2"},
-				repoHasFileFlagIsInQuery:        false,
-				negatedRepoHasFileFlagIsInQuery: true,
+				repoSet: []string{"github.com/test/1", "github.com/test/2"},
 			},
 			wantRepoSet: []string{"github.com/test/2"},
 		},
@@ -761,9 +752,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 					"github.com/test/1": []string{"1.md"},
 					"github.com/test/2": []string{"1.md"},
 				},
-				repoSet:                         []string{"github.com/test/1"},
-				repoHasFileFlagIsInQuery:        false,
-				negatedRepoHasFileFlagIsInQuery: true,
+				repoSet: []string{"github.com/test/1"},
 			},
 			wantRepoSet: []string{"github.com/test/1"},
 		},
@@ -776,7 +765,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				repoSet.Set[r] = true
 			}
 
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(tt.args.ctx, tt.args.queryPatternInfo, tt.args.searcher, *repoSet)
+			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), tt.args.queryPatternInfo, tt.args.searcher, *repoSet)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -699,52 +699,40 @@ func (repoURLsFakeSearcher) Close() {
 }
 
 func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
-	type args struct {
+	searcher := repoURLsFakeSearcher{
+		"github.com/test/1": []string{"1.md"},
+		"github.com/test/2": []string{"2.md"},
 	}
+	allRepos := []string{"github.com/test/1", "github.com/test/2"}
 
 	tests := []struct {
 		name        string
 		include     []string
 		exclude     []string
-		searcher    zoekt.Searcher
 		repoSet     []string
 		wantRepoSet []string
 	}{
 		{
-			name:    "one include",
-			include: []string{"1"},
-			searcher: repoURLsFakeSearcher{
-				"github.com/test/1": []string{"1.md"},
-			},
-			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
+			name:        "one include",
+			include:     []string{"1"},
+			repoSet:     allRepos,
 			wantRepoSet: []string{"github.com/test/1"},
 		},
 		{
-			name:    "two include",
-			include: []string{"1", "2"},
-			searcher: repoURLsFakeSearcher{
-				"github.com/test/1": []string{"1.md"},
-				"github.com/test/2": []string{"1.md", "2.md"},
-			},
-			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
+			name:        "two include",
+			include:     []string{"md", "2"},
+			repoSet:     allRepos,
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name:    "exclude",
-			exclude: []string{"1"},
-			searcher: repoURLsFakeSearcher{
-				"github.com/test/1": []string{"1.md"},
-			},
-			repoSet:     []string{"github.com/test/1", "github.com/test/2"},
+			name:        "exclude",
+			exclude:     []string{"1"},
+			repoSet:     allRepos,
 			wantRepoSet: []string{"github.com/test/2"},
 		},
 		{
-			name:    "subset of reposet",
-			include: []string{"1"},
-			searcher: repoURLsFakeSearcher{
-				"github.com/test/1": []string{"1.md"},
-				"github.com/test/2": []string{"1.md"},
-			},
+			name:        "subset of reposet",
+			include:     []string{"md"},
 			repoSet:     []string{"github.com/test/1"},
 			wantRepoSet: []string{"github.com/test/1"},
 		},
@@ -763,7 +751,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				PathPatternsAreRegExps:       true,
 			}
 
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, tt.searcher, *repoSet)
+			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, searcher, *repoSet)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Best reviewed commit by commit.

This PR greatly reduces the boilerplate for the indexed repohasfile tests. This is motivated by finding it hard to understand and extend the current tests. Additionally it will give us the power to reproduce a current issue in the implementation. Most of the commits are pretty straight-forward, but the first is the most interesting. Instead of using hardcoded responses, we create a simple zoekt searcher which can evaluate the queries we expect from repohasfile filtering.

Part of https://github.com/sourcegraph/sourcegraph/issues/7380