### PR TITLE
search: use reposet to reduce work in indexed repohasfile filtering

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -785,7 +785,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 				PathPatternsAreRegExps:       true,
 			}
 
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, searcher, *repoSet)
+			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, searcher, repoSet)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -669,8 +669,11 @@ func (repoPaths repoURLsFakeSearcher) Search(ctx context.Context, q zoektquery.Q
 				}
 				return &zoektquery.Const{Value: false}
 
+			case *zoektquery.And:
+				return q
+
 			default:
-				errS = "unexpected query atom"
+				errS = "unexpected query atom: " + q.String()
 				return q
 			}
 		})

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -261,14 +261,15 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 	return matches, limitHit, reposLimitHit, nil
 }
 
-// Returns a new repoSet which accounts for the `repohasfile` and `-repohasfile` flags that may have been passed in the query.
+// createNewRepoSetWithRepoHasFileInputs mutates repoSet such that it accounts
+// for the `repohasfile` and `-repohasfile` flags that may have been passed in
+// the query. As a convenience it returns the mutated RepoSet.
 func createNewRepoSetWithRepoHasFileInputs(ctx context.Context, query *search.PatternInfo, searcher zoekt.Searcher, repoSet *zoektquery.RepoSet) (*zoektquery.RepoSet, error) {
 	// Shortcut if we have no repos to search
 	if len(repoSet.Set) == 0 {
 		return repoSet, nil
 	}
 
-	newRepoSet := repoSet.Set
 	flagIsInQuery := len(query.FilePatternsReposMustInclude) > 0
 	negatedFlagIsInQuery := len(query.FilePatternsReposMustExclude) > 0
 
@@ -286,37 +287,26 @@ func createNewRepoSetWithRepoHasFileInputs(ctx context.Context, query *search.Pa
 	newSearchOpts.SetDefaults()
 
 	if flagIsInQuery {
-		// Set newRepoSet to an empty map if the `repohasflag` exists.
-		newRepoSet = make(map[string]bool)
+		for _, q := range filesToIncludeQueries {
+			// Shortcut if we have no repos to search
+			if len(repoSet.Set) == 0 {
+				return repoSet, nil
+			}
 
-		for i, q := range filesToIncludeQueries {
 			// Execute a new Zoekt search for each file passed in to a `repohasfile` flag.
 			includeResp, err := searcher.Search(ctx, zoektquery.NewAnd(repoSet, q), &newSearchOpts)
 			if err != nil {
 				return nil, errors.Wrapf(err, "searching for %v", q.String())
 			}
 
+			newRepoSet := make(map[string]bool, len(includeResp.RepoURLs))
 			for repoURL := range includeResp.RepoURLs {
-				if i == 0 {
-					// For the results from the first file query, add each repo that is in the result set to newRepoSet.
-					//
-					// Only add repoURLs that exist in the original repoSet, since
-					// repoSet is already filtered down to repositories that adhere to
-					// fit the `repo` filters in the query.
-					if repoSet.Set[repoURL] {
-						newRepoSet[repoURL] = true
-					}
-				} else {
-					// Then, for all following file queries, if there are repositories already existing in newRepoSet that do not appear in
-					// the result set for the current file query, remove them so that we only include repos that have at least
-					// one match for each `repohasfile` value in newRepoSet.
-					for existing := range newRepoSet {
-						if _, ok := includeResp.RepoURLs[existing]; !ok {
-							delete(newRepoSet, existing)
-						}
-					}
-				}
+				newRepoSet[repoURL] = true
 			}
+
+			// We want repoSet = repoSet intersect newRepoSet. but newRepoSet
+			// is a subset, so we can just set repoSet = newRepoSet.
+			repoSet.Set = newRepoSet
 		}
 	}
 
@@ -328,25 +318,25 @@ func createNewRepoSetWithRepoHasFileInputs(ctx context.Context, query *search.Pa
 
 	if negatedFlagIsInQuery {
 		for _, q := range filesToExcludeQueries {
-			// Can't make an empty set smaller
-			if len(newRepoSet) == 0 {
-				break
+			// Shortcut if we have no repos to search
+			if len(repoSet.Set) == 0 {
+				return repoSet, nil
 			}
 
-			excludeResp, err := searcher.Search(ctx, zoektquery.NewAnd(&zoektquery.RepoSet{Set: newRepoSet}, q), &newSearchOpts)
+			excludeResp, err := searcher.Search(ctx, zoektquery.NewAnd(repoSet, q), &newSearchOpts)
 			if err != nil {
 				return nil, err
 			}
 			for repoURL := range excludeResp.RepoURLs {
 				// For each repo that had a result in the exclude set, if it exists in the repoSet, set the value to false so we don't search over it.
-				if newRepoSet[repoURL] {
-					delete(newRepoSet, repoURL)
+				if repoSet.Set[repoURL] {
+					delete(repoSet.Set, repoURL)
 				}
 			}
 		}
 	}
 
-	return &zoektquery.RepoSet{Set: newRepoSet}, nil
+	return repoSet, nil
 }
 
 func noOpAnyChar(re *syntax.Regexp) {


### PR DESCRIPTION
Currently we search all indexed repositories on zoekt when filtering with
repohasfile. However, we can reduce that work and only search within the
current reposet.

On large instances this should increase performance whenever we are dealing
with a subset of all repos. This is quite common if a user does not have
permission to access all repositories. Additionally when a query contains a
repo filter or multiple repohasfile filters this will reduce the work done.

Part of https://github.com/sourcegraph/sourcegraph/issues/7380