### PR TITLE
search: aggregate RepoURLs from zoekt replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - We resolve relative symbolic links from the directory of the symlink, rather than the root of the repository. [#6034](https://github.com/sourcegraph/sourcegraph/issues/6034)
 - Show errors on repository settings page when repo-updater is down. [#3593](https://github.com/sourcegraph/sourcegraph/issues/3593)
 - Remove benign warning that verifying config took more than 10s when updating or saving an external service. [#7176](https://github.com/sourcegraph/sourcegraph/issues/7176)
+- repohasfile search filter works again (regressed in 3.10). [#7380](https://github.com/sourcegraph/sourcegraph/issues/7380)
 
 ### Removed
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -28,6 +28,7 @@ func TestHorizontalSearcher(t *testing.T) {
 					Files: []zoekt.FileMatch{{
 						Repository: endpoint,
 					}},
+					RepoURLs: map[string]string{endpoint: endpoint},
 				},
 				listResult: &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{&rle}},
 			}
@@ -79,6 +80,16 @@ func TestHorizontalSearcher(t *testing.T) {
 		}
 		sort.Strings(got)
 		want := []string(m)
+		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
+			t.Errorf("search mismatch (-want +got):\n%s", cmp.Diff(want, got))
+		}
+
+		// repohasfile depends on RepoURLs aggregating
+		got = got[:0]
+		for repo := range sr.RepoURLs {
+			got = append(got, repo)
+		}
+		sort.Strings(got)
 		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
 			t.Errorf("search mismatch (-want +got):\n%s", cmp.Diff(want, got))
 		}


### PR DESCRIPTION
When horizontal search was released this was assumed to be an unused
field. However, the repohasfile filter uses it. Not aggregating leads to
repohasfile filtering to always getting an empty set. So when using
repohasfilter you would never get any repos. When using -repohasfilter you
would get all repos. This is a regression since 3.10.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7380