### PR TITLE
a8n: Allow empty rewriteTemplates in Comby campaigns

### DIFF
--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -36,6 +36,16 @@ func TestNewCampaignType_ArgsValidation(t *testing.T) {
 			},
 		},
 		{
+			name:         "valid comby with empty rewriteTemplate",
+			campaignType: "comby",
+			args:         `{"scopeQuery":"repo:github","matchTemplate":"foobar","rewriteTemplate":""}`,
+			wantArgs: combyArgs{
+				ScopeQuery:      "repo:github",
+				MatchTemplate:   "foobar",
+				RewriteTemplate: "",
+			},
+		},
+		{
 			name:         "invalid comby",
 			campaignType: "comby",
 			args:         `{"scopeQuery":""}`,

--- a/schema/campaign-types/comby.schema.json
+++ b/schema/campaign-types/comby.schema.json
@@ -16,7 +16,6 @@
     },
     "rewriteTemplate": {
       "type": "string",
-      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     }
   },

--- a/schema/campaign-types/comby_stringdata.go
+++ b/schema/campaign-types/comby_stringdata.go
@@ -21,7 +21,6 @@ const CombyCampaignTypeSchemaJSON = `{
     },
     "rewriteTemplate": {
       "type": "string",
-      "minLength": 1,
       "description": "See https://comby.dev/#match-syntax for syntax"
     }
   },

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
@@ -140,7 +140,6 @@ exports[`CampaignPlanSpecificationFields non-manual type editable 1`] = `
             },
             "rewriteTemplate": Object {
               "description": "See https://comby.dev/#match-syntax for syntax",
-              "minLength": 1,
               "type": "string",
             },
             "scopeQuery": Object {
@@ -210,7 +209,6 @@ exports[`CampaignPlanSpecificationFields non-manual type read-only 1`] = `
             },
             "rewriteTemplate": Object {
               "description": "See https://comby.dev/#match-syntax for syntax",
-              "minLength": 1,
               "type": "string",
             },
             "scopeQuery": Object {


### PR DESCRIPTION
This fixes #7063 by allowing the rewriteTemplate in a Comby campaign to
be a blank string.

Screenshot:

<img width="1161" alt="Screen Shot 2020-01-07 at 11 11 06" src="https://user-images.githubusercontent.com/1185253/71887785-139d5480-313f-11ea-9be4-4a0920d1d9f3.png">
