### PR TITLE
Fix initial rendering of ActionsNavItems

### DIFF
--- a/shared/src/actions/ActionsNavItems.test.tsx
+++ b/shared/src/actions/ActionsNavItems.test.tsx
@@ -1,0 +1,56 @@
+import * as H from 'history'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
+import { ActionsNavItems } from './ActionsNavItems'
+import { ContributableMenu } from '../api/protocol'
+import { of } from 'rxjs'
+import { Services } from '../api/client/services'
+
+jest.mock('mdi-react/OpenInNewIcon', () => 'OpenInNewIcon')
+
+describe('ActionItem', () => {
+    const MOCK_EXTENSIONS_CONTROLLER = { executeCommand: () => Promise.resolve(undefined) }
+    const NOOP_PLATFORM_CONTEXT = { forceUpdateTooltip: () => undefined }
+    const location = H.createLocation(
+        'https://github.com/sourcegraph/sourcegraph/pull/5287/files#diff-eb9883bb910397a210512a13fd7384ac'
+    )
+
+    test('Renders contributed action items', () => {
+        const component = renderer.create(
+            <ActionsNavItems
+                menu={ContributableMenu.EditorTitle}
+                location={location}
+                extensionsController={{
+                    ...MOCK_EXTENSIONS_CONTROLLER,
+                    services: {
+                        contribution: {
+                            getContributions: () =>
+                                of({
+                                    actions: [
+                                        {
+                                            id: 'a',
+                                            actionItem: {
+                                                label: 'Action A',
+                                                description: 'This is Action A',
+                                            },
+                                        },
+                                    ],
+                                    menus: {
+                                        'editor/title': [
+                                            {
+                                                action: 'a',
+                                            },
+                                        ],
+                                    },
+                                }),
+                        },
+                    } as Services,
+                }}
+                platformContext={NOOP_PLATFORM_CONTEXT}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+            />
+        )
+        expect(component.toJSON()).toMatchSnapshot()
+    })
+})

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -67,6 +67,7 @@ export class ActionsNavItems extends React.PureComponent<ActionsNavItemsProps, A
                 .subscribe(contributions => this.setState({ contributions }))
         )
         this.scopeChanges.next(this.props.scope)
+        this.extraContextChanges.next(this.props.extraContext)
     }
 
     public componentDidUpdate(prevProps: ActionsProps): void {

--- a/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionItem Renders contributed action items 1`] = `
+Array [
+  " ",
+  <li>
+    <span
+      className="action-item  action-item--variant-action-item"
+      data-tooltip="This is Action A"
+    >
+      Action A
+    </span>
+  </li>,
+]
+`;


### PR DESCRIPTION
Rel https://sourcegraph.slack.com/archives/CMT39K56Z/p1578371825036600

Initial rendering of `<ActionsNavItems/>` was broken in https://github.com/sourcegraph/sourcegraph/pull/5287/files#diff-eb9883bb910397a210512a13fd7384ac.

This fixes it, and adds a snapshot test that would've caught the issue.

