### PR TITLE
Add TS_NODE_COMPILER_OPTIONS in release-ff script

### DIFF
--- a/browser/scripts/release-ff.sh
+++ b/browser/scripts/release-ff.sh
@@ -17,6 +17,8 @@ for filename in $(ls build/web-ext); do
     gsutil -m acl set -R -a public-read gs://sourcegraph-for-firefox/latest.xpi
 done
 
+export TS_NODE_COMPILER_OPTIONS="{\"module\":\"commonjs\"}"
+
 gsutil ls gs://sourcegraph-for-firefox | xargs yarn ts-node scripts/build-updates-manifest.ts
 gsutil cp src/extension/updates.manifest.json gs://sourcegraph-for-firefox/updates.json
 gsutil -m acl set -R -a public-read gs://sourcegraph-for-firefox/updates.json


### PR DESCRIPTION
Fixes https://buildkite.com/sourcegraph/sourcegraph/builds/52879#d530aa8c-003f-4b5f-b6d6-9687a0e0f261

```
(node:29928) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
/buildkite/builds/buildkite-agent-5cd6968c7c-kgtkz-1/sourcegraph/sourcegraph/browser/scripts/build-updates-manifest.ts:2
import * as fs from 'fs';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```