### PR TITLE
a8n: Ensure that same diff produces same commit SHA

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -327,7 +327,7 @@ func (s *Service) RunChangesetJob(
 			Message:     c.Name,
 			AuthorName:  "Sourcegraph Bot",
 			AuthorEmail: "automation@sourcegraph.com",
-			Date:        job.StartedAt,
+			Date:        job.CreatedAt,
 		},
 		// We use unified diffs, not git diffs, which means they're missing the
 		// `a/` and `/b` filename prefixes. `-p0` tells `git apply` to not


### PR DESCRIPTION
Since `StartedAt` gets reset whenever we retry the creation of a
Campaign (or when we update a Campaign later) we produce different
commit SHAs anytime this runs, since one of the "ingredients" changed.

And since #7512 ensures that we can run now push new commits to the same
ref, we want to avoid producing and pushing new commits with the same
diff to the codehost.