### PR TITLE
auth: Limit password length to 256 characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The "Files" tab in the search results page has been renamed to "Filenames" for clarity.
 - The search query builder now lives on its own page at `/search/query-builder`. The home search page has a link to it.
+- User passwords when using builtin auth are limited to 256 characters. Existing passwords longer than 256 characters will continue to work.
 
 ### Fixed
 

--- a/cmd/frontend/db/users_builtin_auth.go
+++ b/cmd/frontend/db/users_builtin_auth.go
@@ -103,6 +103,10 @@ func (u *users) UpdatePassword(ctx context.Context, id int32, oldPassword, newPa
 		return errors.New("wrong old password")
 	}
 
+	if err := checkPasswordLength(newPassword); err != nil {
+		return err
+	}
+
 	passwd, err := hashPassword(newPassword)
 	if err != nil {
 		return err

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,6 +86,22 @@ func TestUsers_ValidUsernames(t *testing.T) {
 				t.Errorf("%q: got valid %v, want %v", test.name, valid, test.wantValid)
 			}
 		})
+	}
+}
+
+func TestUsers_LimitPasswordLength(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	longPassword := strings.Repeat("x", maxPasswordRunes+1)
+	expectedErr := "Passwords may not be more than 256 characters."
+
+	_, err := Users.Create(ctx, NewUser{Username: "test", Password: longPassword})
+	if pm := errcode.PresentationMessage(err); pm != expectedErr {
+		t.Fatalf("expected error %q; got %q", expectedErr, pm)
 	}
 }
 


### PR DESCRIPTION
This safety limit is to protect us from a DDOS attack caused by hashing very large passwords on Sourcegraph.com.

Fixes https://github.com/sourcegraph/security-issues/issues/52

Screenshots:

<img width="421" alt="Screen Shot 2020-01-07 at 9 35 44 AM" src="https://user-images.githubusercontent.com/754768/71915751-43ddf680-3131-11ea-88d9-be58b7356b73.png">

<img width="609" alt="Screen Shot 2020-01-07 at 9 38 34 AM" src="https://user-images.githubusercontent.com/754768/71915862-7f78c080-3131-11ea-9c3b-13475b786866.png">

