### PR TITLE
LSIF: Update type of upload identifier

### DIFF
--- a/enterprise/internal/codeintel/lsifserver/client/query.go
+++ b/enterprise/internal/codeintel/lsifserver/client/query.go
@@ -45,7 +45,7 @@ func (c *Client) Upload(ctx context.Context, args *struct {
 	Blocking *bool
 	MaxWait  *int32
 	Body     io.ReadCloser
-}) (string, bool, error) {
+}) (int64, bool, error) {
 	query := queryValues{}
 	query.Set("repository", args.RepoName)
 	query.Set("commit", string(args.Commit))
@@ -61,12 +61,12 @@ func (c *Client) Upload(ctx context.Context, args *struct {
 	}
 
 	payload := struct {
-		ID string `json:"id"`
+		ID int64 `json:"id"`
 	}{}
 
 	meta, err := c.do(ctx, req, &payload)
 	if err != nil {
-		return "", false, err
+		return 0, false, err
 	}
 
 	return payload.ID, meta.statusCode == http.StatusAccepted, nil

--- a/enterprise/internal/codeintel/lsifserver/client/upload.go
+++ b/enterprise/internal/codeintel/lsifserver/client/upload.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/lsif"
@@ -51,10 +50,10 @@ func (c *Client) GetUploads(ctx context.Context, args *struct {
 }
 
 func (c *Client) GetUpload(ctx context.Context, args *struct {
-	UploadID string
+	UploadID int64
 }) (*lsif.LSIFUpload, error) {
 	req := &lsifRequest{
-		path: fmt.Sprintf("/uploads/%s", url.PathEscape(args.UploadID)),
+		path: fmt.Sprintf("/uploads/%d", args.UploadID),
 	}
 
 	payload := &lsif.LSIFUpload{}
@@ -63,10 +62,10 @@ func (c *Client) GetUpload(ctx context.Context, args *struct {
 }
 
 func (c *Client) DeleteUpload(ctx context.Context, args *struct {
-	UploadID string
+	UploadID int64
 }) error {
 	req := &lsifRequest{
-		path:   fmt.Sprintf("/uploads/%s", url.PathEscape(args.UploadID)),
+		path:   fmt.Sprintf("/uploads/%d", args.UploadID),
 		method: "DELETE",
 	}
 

--- a/enterprise/internal/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/internal/codeintel/lsifserver/proxy/upload.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -36,7 +37,7 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 			return
 		}
 
-		jobID, queued, err := client.DefaultClient.Upload(ctx, &struct {
+		uploadID, queued, err := client.DefaultClient.Upload(ctx, &struct {
 			RepoName string
 			Commit   graphqlbackend.GitObjectID
 			Root     string
@@ -55,7 +56,8 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 			return
 		}
 
-		payload, err := json.Marshal(map[string]int64{"id": jobID})
+		// Return id as a string to maintain backwards compatibility with src-cli
+		payload, err := json.Marshal(map[string]string{"id": strconv.FormatInt(uploadID, 10)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/enterprise/internal/codeintel/lsifserver/proxy/upload.go
+++ b/enterprise/internal/codeintel/lsifserver/proxy/upload.go
@@ -55,7 +55,7 @@ func uploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *htt
 			return
 		}
 
-		payload, err := json.Marshal(map[string]string{"id": jobID})
+		payload, err := json.Marshal(map[string]int64{"id": jobID})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -110,7 +110,7 @@ func (r *Resolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (graphqlba
 	}
 
 	lsifUpload, err := client.DefaultClient.GetUpload(ctx, &struct {
-		UploadID string
+		UploadID int64
 	}{
 		UploadID: uploadID,
 	})
@@ -133,7 +133,7 @@ func (r *Resolver) DeleteLSIFUpload(ctx context.Context, id graphql.ID) (*graphq
 	}
 
 	err = client.DefaultClient.DeleteUpload(ctx, &struct {
-		UploadID string
+		UploadID int64
 	}{
 		UploadID: uploadID,
 	})

--- a/enterprise/internal/codeintel/resolvers/upload.go
+++ b/enterprise/internal/codeintel/resolvers/upload.go
@@ -177,11 +177,11 @@ func (r *lsifUploadStatsResolver) ErroredCount() int32    { return r.stats.Error
 func (r *lsifUploadStatsResolver) CompletedCount() int32  { return r.stats.CompletedCount }
 func (r *lsifUploadStatsResolver) QueuedCount() int32     { return r.stats.QueuedCount }
 
-func marshalLSIFUploadGQLID(lsifUploadID string) graphql.ID {
+func marshalLSIFUploadGQLID(lsifUploadID int64) graphql.ID {
 	return relay.MarshalID("LSIFUpload", lsifUploadID)
 }
 
-func unmarshalLSIFUploadGQLID(id graphql.ID) (lsifUploadID string, err error) {
+func unmarshalLSIFUploadGQLID(id graphql.ID) (lsifUploadID int64, err error) {
 	err = relay.UnmarshalSpec(id, &lsifUploadID)
 	return
 }

--- a/enterprise/internal/codeintel/resolvers/upload.go
+++ b/enterprise/internal/codeintel/resolvers/upload.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"encoding/base64"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -182,6 +183,19 @@ func marshalLSIFUploadGQLID(lsifUploadID int64) graphql.ID {
 }
 
 func unmarshalLSIFUploadGQLID(id graphql.ID) (lsifUploadID int64, err error) {
+	// First, try to unmarshal the ID as a string and then convert it to an
+	// integer. This is here to maintain backwards compatibility with the
+	// src-cli lsif upload command, which constructs its own relay identifier
+	// from a the string payload returned by the upload proxy.
+
+	var lsifUploadIDString string
+	err = relay.UnmarshalSpec(id, &lsifUploadIDString)
+	if err == nil {
+		lsifUploadID, err = strconv.ParseInt(lsifUploadIDString, 10, 64)
+		return
+	}
+
+	// If it wasn't unmarshal-able as a string, it's a new-style int identifier
 	err = relay.UnmarshalSpec(id, &lsifUploadID)
 	return
 }

--- a/internal/lsif/types.go
+++ b/internal/lsif/types.go
@@ -31,7 +31,7 @@ type LSIFUploadStats struct {
 }
 
 type LSIFUpload struct {
-	ID                string     `json:"id"`
+	ID                int64      `json:"id"`
 	Repository        string     `json:"repository"`
 	Commit            string     `json:"commit"`
 	Root              string     `json:"root"`

--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -837,7 +837,7 @@ components:
       description: A payload indicating the enqueued upload.
       properties:
         id:
-          type: string
+          type: number
           description: The upload identifier.
       required:
         - id
@@ -884,7 +884,7 @@ components:
       description: An LSIF upload.
       properties:
         id:
-          type: string
+          type: number
           description: A unique identifier.
         repository:
           type: string


### PR DESCRIPTION
Typeorm incorrectly (at least unintuitively) returned bigint columns as strings rather than numbers in lsif-server. This corrects that issue I had skipped over in the past within the resolvers.