### PR TITLE
refactor: remove unused state for commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1135,9 +1135,19 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			wg.Add(1)
 			goroutine.Go(func() {
 				defer wg.Done()
-				patternInfo := search.CommitPatternInfo(*args.PatternInfo)
+				old := args.PatternInfo
+				patternInfo := &search.CommitPatternInfo{
+					Pattern:                      old.Pattern,
+					IsRegExp:                     old.IsRegExp,
+					IsCaseSensitive:              old.IsCaseSensitive,
+					FileMatchLimit:               old.FileMatchLimit,
+					IncludePatterns:              old.IncludePatterns,
+					ExcludePattern:               old.ExcludePattern,
+					PathPatternsAreRegExps:       old.PathPatternsAreRegExps,
+					PathPatternsAreCaseSensitive: p.PathPatternsAreCaseSensitive,
+				}
 				args := search.TextParametersForCommitParameters{
-					PatternInfo: &patternInfo,
+					PatternInfo: patternInfo,
 					Repos:       args.Repos,
 					Query:       args.Query,
 				}
@@ -1165,9 +1175,19 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
-				patternInfo := search.CommitPatternInfo(*args.PatternInfo)
+				old := args.PatternInfo
+				patternInfo := &search.CommitPatternInfo{
+					Pattern:                      old.Pattern,
+					IsRegExp:                     old.IsRegExp,
+					IsCaseSensitive:              old.IsCaseSensitive,
+					FileMatchLimit:               old.FileMatchLimit,
+					IncludePatterns:              old.IncludePatterns,
+					ExcludePattern:               old.ExcludePattern,
+					PathPatternsAreRegExps:       old.PathPatternsAreRegExps,
+					PathPatternsAreCaseSensitive: old.PathPatternsAreCaseSensitive,
+				}
 				args := search.TextParametersForCommitParameters{
-					PatternInfo: &patternInfo,
+					PatternInfo: patternInfo,
 					Repos:       args.Repos,
 					Query:       args.Query,
 				}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -134,25 +134,12 @@ type TextPatternInfo struct {
 type CommitPatternInfo struct {
 	Pattern         string
 	IsRegExp        bool
-	IsStructuralPat bool
-	CombyRule       string
-	IsWordMatch     bool
 	IsCaseSensitive bool
 	FileMatchLimit  int32
 
-	// We do not support IsMultiline
-	// IsMultiline     bool
 	IncludePatterns []string
 	ExcludePattern  string
 
-	FilePatternsReposMustInclude []string
-	FilePatternsReposMustExclude []string
-
 	PathPatternsAreRegExps       bool
 	PathPatternsAreCaseSensitive bool
-
-	PatternMatchesContent bool
-	PatternMatchesPath    bool
-
-	Languages []string
 }


### PR DESCRIPTION
Stacked on #7540.

Removes the unused state in `CommitPatternInfo`. Note that the way I set this up, the compiler will complain if I removed anything that is used, so this is quite safe.