### PR TITLE
auth: GitHub authentication fixes

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config.go
@@ -21,7 +21,7 @@ func init() {
 			} else {
 				newProvidersList := make([]providers.Provider, 0, len(newProviders))
 				for _, p := range newProviders {
-					newProvidersList = append(newProvidersList, p)
+					newProvidersList = append(newProvidersList, p.Provider)
 				}
 				providers.Update(pkgName, newProvidersList)
 			}

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -746,7 +746,7 @@
         },
         "allowOrgs": {
           "description": "Restricts new logins to members of these GitHub organizations. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.",
-          "default": false,
+          "default": [],
           "type": "array",
           "items": {
             "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -751,7 +751,7 @@ const SiteSchemaJSON = `{
         },
         "allowOrgs": {
           "description": "Restricts new logins to members of these GitHub organizations. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.",
-          "default": false,
+          "default": [],
           "type": "array",
           "items": {
             "type": "string",


### PR DESCRIPTION
This PR fixes a regression introduced in #7331 and reported in #7518 as
well setting a well-typed default for the new `allowOrgs` setting.

The issue was that [`oauth.getProvider`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a2d6dc4feb68693d93444e5e16abba7befa4d9df/-/blob/enterprise/cmd/frontend/auth/oauth/provider.go#L30) does a concrete type assertion
and in the previous PR we changed what was stored in as the interface
implementation to a wrapper type.

Fixes #7518
