### PR TITLE
graphqlbackend: add mutation for repository permissions

### DIFF
--- a/cmd/frontend/db/user_emails_mock.go
+++ b/cmd/frontend/db/user_emails_mock.go
@@ -1,9 +1,12 @@
 package db
 
-import "context"
+import (
+	"context"
+)
 
 type MockUserEmails struct {
-	GetPrimaryEmail func(ctx context.Context, id int32) (email string, verified bool, err error)
-	Get             func(userID int32, email string) (emailCanonicalCase string, verified bool, err error)
-	ListByUser      func(id int32) ([]*UserEmail, error)
+	GetPrimaryEmail   func(ctx context.Context, id int32) (email string, verified bool, err error)
+	Get               func(userID int32, email string) (emailCanonicalCase string, verified bool, err error)
+	GetVerifiedEmails func(ctx context.Context, emails ...string) ([]*UserEmail, error)
+	ListByUser        func(id int32) ([]*UserEmail, error)
 }

--- a/cmd/frontend/db/user_emails_test.go
+++ b/cmd/frontend/db/user_emails_test.go
@@ -286,3 +286,42 @@ func isUserEmailVerified(ctx context.Context, userID int32, email string) (bool,
 func strptr(s string) *string {
 	return &s
 }
+
+func TestUserEmails_GetVerifiedEmails(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	newUsers := []NewUser{
+		{
+			Email:           "alice@example.com",
+			Username:        "alice",
+			EmailIsVerified: true,
+		},
+		{
+			Email:                 "bob@example.com",
+			Username:              "bob",
+			EmailVerificationCode: "c",
+		},
+	}
+
+	for _, newUser := range newUsers {
+		_, err := Users.Create(ctx, newUser)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	emails, err := UserEmails.GetVerifiedEmails(ctx, "alice@example.com", "bob@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(emails) != 1 {
+		t.Fatalf("got %d emails, but want 1", len(emails))
+	}
+	if emails[0].Email != "alice@example.com" {
+		t.Errorf("got %s, but want %q", emails[0].Email, "alice@example.com")
+	}
+}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -557,6 +557,25 @@ func (u *users) GetByUsername(ctx context.Context, username string) (*types.User
 	return u.getOneBySQL(ctx, "WHERE username=$1 AND deleted_at IS NULL LIMIT 1", username)
 }
 
+// GetByUsernames returns a list of users by given usernames. The number of results list could be less
+// than the candidate list due to no user is associated with some usernames.
+func (u *users) GetByUsernames(ctx context.Context, usernames ...string) ([]*types.User, error) {
+	if Mocks.Users.GetByUsernames != nil {
+		return Mocks.Users.GetByUsernames(ctx, usernames...)
+	}
+
+	if len(usernames) == 0 {
+		return []*types.User{}, nil
+	}
+
+	items := make([]*sqlf.Query, len(usernames))
+	for i := range usernames {
+		items[i] = sqlf.Sprintf("%s", usernames[i])
+	}
+	q := sqlf.Sprintf("WHERE username IN (%s) AND deleted_at IS NULL ORDER BY id ASC", sqlf.Join(items, ","))
+	return u.getBySQL(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+}
+
 var ErrNoCurrentUser = errors.New("no current user")
 
 func (u *users) GetByCurrentAuthUser(ctx context.Context) (*types.User, error) {

--- a/cmd/frontend/db/users_mock.go
+++ b/cmd/frontend/db/users_mock.go
@@ -13,6 +13,7 @@ type MockUsers struct {
 	SetIsSiteAdmin       func(id int32, isSiteAdmin bool) error
 	GetByID              func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername        func(ctx context.Context, username string) (*types.User, error)
+	GetByUsernames       func(ctx context.Context, usernames ...string) ([]*types.User, error)
 	GetByCurrentAuthUser func(ctx context.Context) (*types.User, error)
 	GetByVerifiedEmail   func(ctx context.Context, email string) (*types.User, error)
 	Count                func(ctx context.Context, opt *UsersListOptions) (int, error)

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -392,6 +392,47 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 	}
 }
 
+func TestUsers_GetByUsernames(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	newUsers := []NewUser{
+		{
+			Email:           "alice@example.com",
+			Username:        "alice",
+			EmailIsVerified: true,
+		},
+		{
+			Email:           "bob@example.com",
+			Username:        "bob",
+			EmailIsVerified: true,
+		},
+	}
+
+	for _, newUser := range newUsers {
+		_, err := Users.Create(ctx, newUser)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	users, err := Users.GetByUsernames(ctx, "alice", "bob", "cindy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("got %d users, but want 2", len(users))
+	}
+	for i := range users {
+		if users[i].Username != newUsers[i].Username {
+			t.Errorf("got %s, but want %s", users[i].Username, newUsers[i].Username)
+		}
+	}
+}
+
 func TestUsers_Delete(t *testing.T) {
 	for name, hard := range map[string]bool{"": false, "_Hard": true} {
 		t.Run("TestUsers_Delete"+name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -1,0 +1,30 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
+)
+
+// NewAuthzResolver will be set by enterprise
+var NewAuthzResolver func() AuthzResolver
+
+type AuthzResolver interface {
+	SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error)
+}
+
+type RepoPermsArgs struct {
+	Repository graphql.ID
+	BindIDs    []string
+	Perm       string
+}
+
+var authzInEnterprise = errors.New("authorization mutations and queries are only available in enterprise")
+
+func (*schemaResolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error) {
+	if EnterpriseResolvers.authzResolver == nil {
+		return nil, authzInEnterprise
+	}
+	return EnterpriseResolvers.authzResolver.SetRepositoryPermissionsForUsers(ctx, args)
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -85,9 +85,10 @@ func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldNa
 	}
 }
 
-func NewSchema(a8n A8NResolver, codeIntel CodeIntelResolver) (*graphql.Schema, error) {
+func NewSchema(a8n A8NResolver, codeIntel CodeIntelResolver, authz AuthzResolver) (*graphql.Schema, error) {
 	EnterpriseResolvers.a8nResolver = a8n
 	EnterpriseResolvers.codeIntelResolver = codeIntel
+	EnterpriseResolvers.authzResolver = authz
 
 	return graphql.ParseSchema(
 		Schema,
@@ -241,6 +242,7 @@ type schemaResolver struct{}
 var EnterpriseResolvers = struct {
 	a8nResolver       A8NResolver
 	codeIntelResolver CodeIntelResolver
+	authzResolver     AuthzResolver
 }{}
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -420,6 +420,16 @@ type Mutation {
     # CHANGELOG during this time.
     # Deletes an LSIF upload.
     deleteLSIFUpload(id: ID!): EmptyResponse
+
+    # Set permissions of a repository with a full set of users by their usernames or emails.
+    setRepositoryPermissionsForUsers(
+        # The repository that the mutation is applied to.
+        repository: ID!
+        # A list of usernames or email addresses according to site configuration.
+        bindIDs: [String!]!
+        # The level of repository permission.
+        perm: RepositoryPermission = READ
+    ): EmptyResponse!
 }
 
 # The specification of what changesets Sourcegraph will open when the campaign is created.
@@ -4622,4 +4632,9 @@ union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 # JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
 # Date#toISOString.
 scalar DateTime
+
+# Different repository permission levels.
+enum RepositoryPermission {
+    READ
+}
 `

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -427,6 +427,16 @@ type Mutation {
     # CHANGELOG during this time.
     # Deletes an LSIF upload.
     deleteLSIFUpload(id: ID!): EmptyResponse
+
+    # Set permissions of a repository with a full set of users by their usernames or emails.
+    setRepositoryPermissionsForUsers(
+        # The repository that the mutation is applied to.
+        repository: ID!
+        # A list of usernames or email addresses according to site configuration.
+        bindIDs: [String!]!
+        # The level of repository permission.
+        perm: RepositoryPermission = READ
+    ): EmptyResponse!
 }
 
 # The specification of what changesets Sourcegraph will open when the campaign is created.
@@ -4629,3 +4639,8 @@ union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 # JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
 # Date#toISOString.
 scalar DateTime
+
+# Different repository permission levels.
+enum RepositoryPermission {
+    READ
+}

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -10,7 +10,7 @@ import (
 func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
 	t.Helper()
 
-	schema, err := NewSchema(nil, nil)
+	schema, err := NewSchema(nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -184,7 +184,13 @@ func Main(githubWebhook http.Handler) error {
 		codeIntelResolver = graphqlbackend.NewCodeIntelResolver()
 	}
 
-	schema, err := graphqlbackend.NewSchema(a8nResolver, codeIntelResolver)
+	// graphqlbackend.AuthzResolver is set by enterprise frontend
+	var authzResolver graphqlbackend.AuthzResolver
+	if graphqlbackend.NewAuthzResolver != nil {
+		authzResolver = graphqlbackend.NewAuthzResolver()
+	}
+
+	schema, err := graphqlbackend.NewSchema(a8nResolver, codeIntelResolver, authzResolver)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -1,0 +1,109 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+)
+
+type Resolver struct{}
+
+var _ graphqlbackend.AuthzResolver = &Resolver{}
+
+func NewResolver() graphqlbackend.AuthzResolver {
+	return &Resolver{}
+}
+
+func (*Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *graphqlbackend.RepoPermsArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site admins can mutate repository permissions.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	cfg := conf.Get().SiteConfiguration
+	if cfg.PermissionsUserMapping == nil || !cfg.PermissionsUserMapping.Enabled {
+		return nil, errors.New("permissions user mapping is not enabled")
+	}
+
+	repoID, err := graphqlbackend.UnmarshalRepositoryID(args.Repository)
+	if err != nil {
+		return nil, err
+	}
+	// Make sure the repo ID is valid.
+	if _, err = db.Repos.Get(ctx, repoID); err != nil {
+		return nil, err
+	}
+
+	// Filter out bind IDs that only contains whitespaces.
+	bindIDs := args.BindIDs[:0]
+	for i := range args.BindIDs {
+		args.BindIDs[i] = strings.TrimSpace(args.BindIDs[i])
+		if len(args.BindIDs[i]) == 0 {
+			continue
+		}
+		bindIDs = append(bindIDs, args.BindIDs[i])
+	}
+
+	bindIDSet := make(map[string]struct{})
+	for i := range bindIDs {
+		bindIDSet[bindIDs[i]] = struct{}{}
+	}
+
+	p := &iauthz.RepoPermissions{
+		RepoID:   int32(repoID),
+		Perm:     authz.Read, // Note: We currently only support read for repository permissions.
+		UserIDs:  roaring.NewBitmap(),
+		Provider: iauthz.ProviderSourcegraph,
+	}
+	switch cfg.PermissionsUserMapping.BindID {
+	case "email":
+		emails, err := db.UserEmails.GetVerifiedEmails(ctx, bindIDs...)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range emails {
+			p.UserIDs.Add(uint32(emails[i].UserID))
+			delete(bindIDSet, emails[i].Email)
+		}
+
+	case "username":
+		users, err := db.Users.GetByUsernames(ctx, bindIDs...)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range users {
+			p.UserIDs.Add(uint32(users[i].ID))
+			delete(bindIDSet, users[i].Username)
+		}
+
+	default:
+		return nil, fmt.Errorf("unrecognized user mapping bind ID type %q", cfg.PermissionsUserMapping.BindID)
+	}
+
+	pendingBindIDs := make([]string, 0, len(bindIDSet))
+	for id := range bindIDSet {
+		pendingBindIDs = append(pendingBindIDs, id)
+	}
+
+	s := iauthz.NewStore(dbconn.Global, time.Now)
+	if err = s.SetRepoPermissions(ctx, p); err != nil {
+		return nil, err
+	} else if err = s.SetRepoPendingPermissions(ctx, pendingBindIDs, p); err != nil {
+		return nil, err
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
+}

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
+	authzResolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz/resolvers"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
@@ -110,6 +111,7 @@ func initLicensing() {
 func initResolvers() {
 	graphqlbackend.NewA8NResolver = a8nResolvers.NewResolver
 	graphqlbackend.NewCodeIntelResolver = codeIntelResolvers.NewResolver
+	graphqlbackend.NewAuthzResolver = authzResolvers.NewResolver
 }
 
 func initLSIFEndpoints() {

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -67,7 +67,7 @@ func TestCampaigns(t *testing.T) {
 		httpFactory: cf,
 	}
 
-	s, err := graphqlbackend.NewSchema(sr, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1031,7 +1031,7 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 		store := ee.NewStoreWithClock(dbconn.Global, clock)
 
 		sr := &Resolver{store: store}
-		s, err := graphqlbackend.NewSchema(sr, nil)
+		s, err := graphqlbackend.NewSchema(sr, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1222,7 +1222,7 @@ func TestCampaignPlanResolver(t *testing.T) {
 	}
 
 	sr := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(sr, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Part of #7298, added GQL mutation `setRepositoryPermissionsForUsers`, which sets repository permissions in our PostgreSQL database.

Manually tested with some unit tests, regression tests will be added as the last PR of #7298.

It's safe to merge this PR (after review) alone because the site configuration option is not documented anywhere outside the source code.

Side notes: according to RFC 40, we should also have `add*` and `remove*` mutations, I tried but found it not worth the time effort implementing at this point (we also only have "set" semantic in the "authz/store" layer). Will implement in followup PRs if prospective customer explicitly asks for them.
