### PR TITLE
a8n: accept incoming BBS plugin webhook payloads

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -111,6 +111,10 @@ func AllowAnonymousRequest(req *http.Request) bool {
 		return true
 	}
 
+	if strings.HasPrefix(req.URL.Path, "/.api/bitbucket-server-webhooks") {
+		return true
+	}
+
 	apiRouteName := matchedRouteName(req, router.Router())
 	if apiRouteName == router.UI {
 		// Test against UI router. (Some of its handlers inject private data into the title or meta tags.)

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -28,14 +28,14 @@ import (
 
 // newExternalHTTPHandler creates and returns the HTTP handler that serves the app and API pages to
 // external clients.
-func newExternalHTTPHandler(schema *graphql.Schema, githubWebhook http.Handler, lsifServerProxy *httpapi.LSIFServerProxy) (http.Handler, error) {
+func newExternalHTTPHandler(schema *graphql.Schema, githubWebhook, bitbucketServerWebhook http.Handler, lsifServerProxy *httpapi.LSIFServerProxy) (http.Handler, error) {
 	// Each auth middleware determines on a per-request basis whether it should be enabled (if not, it
 	// immediately delegates the request to the next middleware in the chain).
 	authMiddlewares := auth.AuthMiddleware()
 
 	// HTTP API handler.
 	r := router.New(mux.NewRouter().PathPrefix("/.api/").Subrouter())
-	apiHandler := internalhttpapi.NewHandler(r, schema, githubWebhook, lsifServerProxy)
+	apiHandler := internalhttpapi.NewHandler(r, schema, githubWebhook, bitbucketServerWebhook, lsifServerProxy)
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication (except those with the
 	// X-Requested-With header). Doing so would open it up to CSRF attacks.

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -80,7 +80,7 @@ func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
 }
 
 // Main is the main entrypoint for the frontend server program.
-func Main(githubWebhook http.Handler) error {
+func Main(githubWebhook, bitbucketServerWebhook http.Handler) error {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
@@ -205,7 +205,7 @@ func Main(githubWebhook http.Handler) error {
 	}
 
 	// Create the external HTTP handler.
-	externalHandler, err := newExternalHTTPHandler(schema, githubWebhook, lsifServerProxy)
+	externalHandler, err := newExternalHTTPHandler(schema, githubWebhook, bitbucketServerWebhook, lsifServerProxy)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -12,6 +12,6 @@ func init() {
 }
 
 func newTest() *httptestutil.Client {
-	mux := NewHandler(router.New(mux.NewRouter()), nil, nil, nil)
+	mux := NewHandler(router.New(mux.NewRouter()), nil, nil, nil, nil)
 	return httptestutil.NewTest(mux)
 }

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -30,7 +30,7 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook http.Handler, lsifServerProxy *httpapi.LSIFServerProxy) http.Handler {
+func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, bitbucketServerWebhook http.Handler, lsifServerProxy *httpapi.LSIFServerProxy) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}
@@ -50,6 +50,10 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook http.Handle
 
 	if githubWebhook != nil {
 		m.Get(apirouter.GitHubWebhooks).Handler(trace.TraceRoute(githubWebhook))
+	}
+
+	if bitbucketServerWebhook != nil {
+		m.Get(apirouter.BitbucketServerWebhooks).Handler(trace.TraceRoute(bitbucketServerWebhook))
 	}
 
 	if envvar.SourcegraphDotComMode() {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -20,7 +20,8 @@ const (
 	RepoRefresh = "repo.refresh"
 	Telemetry   = "telemetry"
 
-	GitHubWebhooks = "github.webhooks"
+	GitHubWebhooks          = "github.webhooks"
+	BitbucketServerWebhooks = "bitbucketServer.webhooks"
 
 	SavedQueriesListAll    = "internal.saved-queries.list-all"
 	SavedQueriesGetInfo    = "internal.saved-queries.get-info"
@@ -62,6 +63,7 @@ func New(base *mux.Router) *mux.Router {
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 	base.Path("/github-webhooks").Methods("POST").Name(GitHubWebhooks)
+	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	base.Path("/lsif/{rest:.*}").Methods("GET", "POST").Name(LSIF)
 	base.Path("/src-cli/version").Methods("GET").Name(SrcCliVersion)

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -9,5 +9,5 @@ import (
 // function for details.
 
 func main() {
-	shared.Main(nil)
+	shared.Main(nil, nil)
 }

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -17,9 +17,9 @@ import (
 // It is exposed as function in a package so that it can be called by other
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
-func Main(githubWebhook http.Handler) {
+func Main(githubWebhook, bitbucketServerWebhook http.Handler) {
 	env.Lock()
-	err := cli.Main(githubWebhook)
+	err := cli.Main(githubWebhook, bitbucketServerWebhook)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "fatal:", err)
 		os.Exit(1)

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -66,17 +66,15 @@ func main() {
 	}
 
 	a8nStore := a8n.NewStoreWithClock(dbconn.Global, clock)
+	repositories := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 
-	githubWebhook := &a8n.GitHubWebhook{
-		Store: a8nStore,
-		Repos: repos.NewDBStore(dbconn.Global, sql.TxOptions{}),
-		Now:   clock,
-	}
+	githubWebhook := a8n.NewGitHubWebhook(a8nStore, repositories, clock)
+	bitbucketServerWebhook := a8n.NewBitbucketServerWebhook(a8nStore, repositories, clock)
 
 	go a8n.RunCampaignJobs(ctx, a8nStore, clock, 5*time.Second)
 	go a8n.RunChangesetJobs(ctx, a8nStore, clock, gitserver.DefaultClient, 5*time.Second)
 
-	shared.Main(githubWebhook)
+	shared.Main(githubWebhook, bitbucketServerWebhook)
 }
 
 func initLicensing() {

--- a/enterprise/internal/a8n/webhooks.go
+++ b/enterprise/internal/a8n/webhooks.go
@@ -12,7 +12,6 @@ import (
 	gh "github.com/google/go-github/v28/github"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
-	// "github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -71,6 +70,11 @@ func (h Webhook) upsertChangesetEvent(
 	}
 
 	if existing != nil {
+		// Upsert is used to create or update the record in the database,
+		// but we're actually "patching" the record with specific merge semantics
+		// encoded in Update. This is because some webhooks payloads don't contain
+		// all the information that we can get from the API, so we only update the
+		// bits that we know are more up to date and leave the others as they were.
 		existing.Update(event)
 		event = existing
 	}

--- a/enterprise/internal/a8n/webhooks_test.go
+++ b/enterprise/internal/a8n/webhooks_test.go
@@ -133,8 +133,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 		}
 
 		fs := loadFixtures(t)
-		hook := &GitHubWebhook{Store: store, Repos: repoStore, Now: clock}
-
+		hook := NewGitHubWebhook(store, repoStore, clock)
 		issueComment := github.IssueComment{
 			DatabaseID: 540540777,
 			Author: github.Actor{

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -59,6 +59,17 @@
       "pattern": "^-----BEGIN CERTIFICATE-----\n",
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
+    "webhooks": {
+      "description": "Configuration for Bitbucket Server Sourcegraph plugin webhooks",
+      "type": "object",
+      "properties": {
+        "secret": {
+          "description": "Secret for authenticating incoming webhook paylods",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server repository.\n\n - \"{host}\" is replaced with the Bitbucket Server URL's host (such as bitbucket.example.com)\n - \"{projectKey}\" is replaced with the Bitbucket repository's parent project key (such as \"PRJ\")\n - \"{repositorySlug}\" is replaced with the Bitbucket repository's slug key (such as \"my-repo\").\n\nFor example, if your Bitbucket Server is https://bitbucket.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{projectKey}/{repositorySlug}\" would mean that a Bitbucket Server repository at https://bitbucket.example.com/projects/PRJ/repos/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.example.com/PRJ/my-repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
       "type": "string",

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -64,6 +64,17 @@ const BitbucketServerSchemaJSON = `{
       "pattern": "^-----BEGIN CERTIFICATE-----\n",
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
+    "webhooks": {
+      "description": "Configuration for Bitbucket Server Sourcegraph plugin webhooks",
+      "type": "object",
+      "properties": {
+        "secret": {
+          "description": "Secret for authenticating incoming webhook paylods",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server repository.\n\n - \"{host}\" is replaced with the Bitbucket Server URL's host (such as bitbucket.example.com)\n - \"{projectKey}\" is replaced with the Bitbucket repository's parent project key (such as \"PRJ\")\n - \"{repositorySlug}\" is replaced with the Bitbucket repository's slug key (such as \"my-repo\").\n\nFor example, if your Bitbucket Server is https://bitbucket.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{projectKey}/{repositorySlug}\" would mean that a Bitbucket Server repository at https://bitbucket.example.com/projects/PRJ/repos/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.example.com/PRJ/my-repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
       "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -205,6 +205,8 @@ type BitbucketServerConnection struct {
 	Url string `json:"url"`
 	// Username description: The username to use when authenticating to the Bitbucket Server instance. Also set the corresponding "token" or "password" field.
 	Username string `json:"username"`
+	// Webhooks description: Configuration for Bitbucket Server Sourcegraph plugin webhooks
+	Webhooks *Webhooks `json:"webhooks,omitempty"`
 }
 
 // BitbucketServerIdentityProvider description: The source of identity to use when computing permissions. This defines how to compute the Bitbucket Server identity to use for a given Sourcegraph user. When 'username' is used, Sourcegraph assumes usernames are identical in Sourcegraph and Bitbucket Server accounts and `auth.enableUsernameChanges` must be set to false for security reasons.
@@ -942,4 +944,10 @@ type TlsExternal struct {
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`
+}
+
+// Webhooks description: Configuration for Bitbucket Server Sourcegraph plugin webhooks
+type Webhooks struct {
+	// Secret description: Secret for authenticating incoming webhook paylods
+	Secret string `json:"secret,omitempty"`
 }


### PR DESCRIPTION
This PR is a preliminary piece of #6726. It registers a HTTP handler to accept incoming BBS plugin webhook payload requests and verify their HMAC signature.

This is a very rough PR. There is a bunch of duplicate code that can be modularized/abstractified. Down the line, more code hosts will be added. I'm not sure how the webhooks interfaces differ between future code hosts at the moment, so the code design isn't decided on yet. This will go through some refactoring/cleaning.