### PR TITLE
ci: wait for e2e tests to pass when pushing to release branches

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -188,7 +188,7 @@ func wait(pipeline *bk.Pipeline) {
 
 func triggerE2E(c Config) func(*bk.Pipeline) {
 	// hardFail if we publish docker images
-	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",


### PR DESCRIPTION
This PR fixes the docker image publishing step on release branches.

Previously, our asynchronous e2e test logic only waited for the e2e tests to pass when a particular commit was pushed with a tag (e.x. `"v3.11.0"`), but not when you pushed to the release branch itself (e.x. `"3.11"`). This would cause the docker image publishing step to fail since it would try to push an image that hadn't finished being built yet (this is done in the e2e tests). 

This PR fixes this by telings our CI pipleline to wait for the e2e tests in both scenarios. 