### PR TITLE
single-server: sourcegraph log level value unknown to postgres exporter

### DIFF
--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -375,3 +375,22 @@ func readStatus(path string) (status, version string, err error) {
 func l(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, "✱ "+format+"\n", args...)
 }
+
+var logLevelConverter = map[string]string{
+	"dbug":  "debug",
+	"info":  "info",
+	"warn":  "warn",
+	"error": "error",
+	"crit":  "fatal",
+}
+
+// convertLogLevel converts a sourcegraph log level (dbug, info, warn, error, crit) into
+// values postgres exporter accepts (debug, info, warn, error, fatal)
+// If value cannot be converted returns "warn" which seems like a good middle-ground.
+func convertLogLevel(level string) string {
+	lvl, ok := logLevelConverter[level]
+	if ok {
+		return lvl
+	}
+	return "warn"
+}

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -127,7 +127,7 @@ func Main() {
 		log.Fatal("Failed to setup nginx:", err)
 	}
 
-	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("postgres", os.Getenv), os.Getenv("SRC_LOG_LEVEL"))
+	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("postgres", os.Getenv), convertLogLevel(os.Getenv("SRC_LOG_LEVEL")))
 
 	procfile := []string{
 		nginx,


### PR DESCRIPTION
log level values are slightly different so directly setting the sourcegraph values won't work for postgres exporter