### PR TITLE
LSIF: Re-enable dump cleanup

### DIFF
--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -65,7 +65,7 @@ async function main(logger: Logger): Promise<void> {
     await ensureFilenamesAreIDs(connection) // TODO - remove after 3.10
 
     // Start background tasks
-    startTasks(connection, uploadManager, logger)
+    startTasks(connection, dumpManager, uploadManager, logger)
 
     const app = express()
 

--- a/lsif/src/server/settings.ts
+++ b/lsif/src/server/settings.ts
@@ -18,12 +18,12 @@ export const CLEAN_OLD_UPLOADS_INTERVAL = readEnvInt('CLEAN_OLD_UPLOADS_INTERVAL
 /**
  * The interval (in seconds) to clean the dbs directory.
  */
-export const PURGE_OLD_DUMPS_INTERVAL = readEnvInt('PURGE_OLD_DUMPS_INTERVAL', 60 * 60 * 8)
+export const PURGE_OLD_DUMPS_INTERVAL = readEnvInt('PURGE_OLD_DUMPS_INTERVAL', 60 * 30)
 
 /**
  * How many uploads to query at once when determining if a db file is unreferenced.
  */
-export const DEAD_DUMP_CHUNK_SIZE = readEnvInt('DEAD_DUMP_CHUNK_SIZE', 60 * 60 * 8)
+export const DEAD_DUMP_CHUNK_SIZE = readEnvInt('DEAD_DUMP_CHUNK_SIZE', 100)
 
 /**
  * The default number of remote dumps to open when performing a global find-reference operation.

--- a/lsif/src/server/settings.ts
+++ b/lsif/src/server/settings.ts
@@ -16,6 +16,16 @@ export const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
 export const CLEAN_OLD_UPLOADS_INTERVAL = readEnvInt('CLEAN_OLD_UPLOADS_INTERVAL', 60 * 60 * 8)
 
 /**
+ * The interval (in seconds) to clean the dbs directory.
+ */
+export const PURGE_OLD_DUMPS_INTERVAL = readEnvInt('PURGE_OLD_DUMPS_INTERVAL', 60 * 60 * 8)
+
+/**
+ * How many uploads to query at once when determining if a db file is unreferenced.
+ */
+export const DEAD_DUMP_CHUNK_SIZE = readEnvInt('DEAD_DUMP_CHUNK_SIZE', 60 * 60 * 8)
+
+/**
  * The default number of remote dumps to open when performing a global find-reference operation.
  */
 export const DEFAULT_REFERENCES_NUM_REMOTE_DUMPS = readEnvInt('DEFAULT_REFERENCES_NUM_REMOTE_DUMPS', 10)
@@ -76,3 +86,8 @@ export const FAILED_UPLOAD_MAX_AGE = readEnvInt('FAILED_UPLOAD_MAX_AGE', 24 * 60
  * The maximum age (in seconds) that the an upload can be unlocked and in the `processing` state.
  */
 export const STALLED_UPLOAD_MAX_AGE = readEnvInt('STALLED_UPLOAD_MAX_AGE', 5)
+
+/**
+ * The maximum space (in bytes) that the dbs directory can use.
+ */
+export const DBS_DIR_MAXIMUM_SIZE_BYTES = readEnvInt('DBS_DIR_MAXIMUM_SIZE_BYTES', 1024 * 1024 * 1024 * 10)

--- a/lsif/src/server/tasks/uploads.ts
+++ b/lsif/src/server/tasks/uploads.ts
@@ -3,9 +3,14 @@ import * as fs from 'mz/fs'
 import * as metrics from '../metrics'
 import * as path from 'path'
 import * as settings from '../settings'
+import { chunk } from 'lodash'
 import { createSilentLogger } from '../../shared/logging'
 import { TracingContext } from '../../shared/tracing'
 import { UploadManager } from '../../shared/store/uploads'
+import { withLock } from '../../shared/store/locks'
+import { DumpManager } from '../../shared/store/dumps'
+import { dbFilename } from '../../shared/paths'
+import { Connection } from 'typeorm'
 
 /**
  * Update the value of the unconverted uploads gauge.
@@ -44,6 +49,110 @@ export const cleanOldUploads = async (
     const count = await uploadManager.clean(settings.UPLOAD_MAX_AGE)
     if (count > 0) {
         logger.debug('Cleaned old uploads', { count })
+    }
+}
+
+/**
+ * Remove dumps until the space occupied by the dbs directory is below
+ * the given limit.
+ *
+ * @param connection The Postgres connection.
+ * @param dumpManager The dumps manager instance.
+ * @param storageRoot The path where SQLite databases are stored.
+ * @param maximumSizeBytes The maximum number of bytes.
+ * @param ctx The tracing context.
+ */
+export function purgeOldDumps(
+    connection: Connection,
+    dumpManager: DumpManager,
+    storageRoot: string,
+    maximumSizeBytes: number,
+    { logger = createSilentLogger() }: TracingContext = {}
+): Promise<void> {
+    const purge = async (): Promise<void> => {
+        // First, remove all the files in the DB dir that don't have a corresponding
+        // lsif_upload record in the database. This will happen in the cases where an
+        // upload overlaps existing uploads which are deleted in batch from the db,
+        // but not from disk. This can also happen if the db file is written during
+        // processing but fails later while updating commits for that repo.
+        await removeDeadDumps(dumpManager, storageRoot, { logger })
+
+        if (maximumSizeBytes < 0) {
+            return Promise.resolve()
+        }
+
+        let currentSizeBytes = await dirsize(path.join(storageRoot, constants.DBS_DIR))
+
+        while (currentSizeBytes > maximumSizeBytes) {
+            // While our current data usage is too big, find candidate dumps to delete
+            const dump = await dumpManager.getOldestPrunableDump()
+            if (!dump) {
+                logger.warn(
+                    'Unable to reduce disk usage of the DB directory because deleting any single dump would drop in-use code intel for a repository.',
+                    { currentSizeBytes, softMaximumSizeBytes: maximumSizeBytes }
+                )
+
+                break
+            }
+
+            logger.info('Pruning dump', {
+                repository: dump.repository,
+                commit: dump.commit,
+                root: dump.root,
+            })
+
+            // Delete this dump and subtract its size from the current dir size
+            const filename = dbFilename(storageRoot, dump.id, dump.repository, dump.commit)
+            currentSizeBytes -= await filesize(filename)
+
+            // This delete cascades to the packages and references tables as well
+            await dumpManager.deleteDump(dump)
+        }
+    }
+
+    // Ensure only one worker is doing this at the same time so that we don't
+    // choose more dumps than necessary to purge. This can happen if the directory
+    // size check and the selection of a purgeable dump are interleaved between
+    // multiple workers.
+    return withLock(connection, 'retention', purge)
+}
+
+/**
+ * Remove db files that are not reachable from a pending or completed upload record.
+ *
+ * @param dumpManager The dumps manager instance.
+ * @param storageRoot The path where SQLite databases are stored.
+ * @param ctx The tracing context.
+ */
+async function removeDeadDumps(
+    dumpManager: DumpManager,
+    storageRoot: string,
+    { logger = createSilentLogger() }: TracingContext = {}
+): Promise<void> {
+    let count = 0
+    for (const basenames of chunk(
+        await fs.readdir(path.join(storageRoot, constants.DBS_DIR)),
+        settings.DEAD_DUMP_CHUNK_SIZE
+    )) {
+        const pathsById = new Map<number, string>()
+        for (const basename of basenames) {
+            const id = parseInt(basename.split('-')[0], 10)
+            if (!isNaN(id)) {
+                pathsById.set(id, path.join(storageRoot, constants.DBS_DIR, basename))
+            }
+        }
+
+        const states = await dumpManager.getUploadStates(Array.from(pathsById.keys()))
+        for (const [id, dbPath] of pathsById.entries()) {
+            if (!states.has(id) || states.get(id) === 'errored') {
+                count++
+                await fs.unlink(dbPath)
+            }
+        }
+    }
+
+    if (count > 0) {
+        logger.debug('Removed dead dumps', { count })
     }
 }
 
@@ -91,4 +200,32 @@ async function purgeFile(filename: string): Promise<boolean> {
 
     await fs.unlink(filename)
     return true
+}
+
+/**
+ * Calculate the size of a directory.
+ *
+ * @param directory The directory path.
+ */
+async function dirsize(directory: string): Promise<number> {
+    return (
+        await Promise.all((await fs.readdir(directory)).map(filename => filesize(path.join(directory, filename))))
+    ).reduce((a, b) => a + b, 0)
+}
+
+/**
+ * Get the file size or zero if it doesn't exist.
+ *
+ * @param filename The filename.
+ */
+async function filesize(filename: string): Promise<number> {
+    try {
+        return (await fs.stat(filename)).size
+    } catch (error) {
+        if (!(error && error.code === 'ENOENT')) {
+            throw error
+        }
+
+        return 0
+    }
 }

--- a/lsif/src/shared/store/dumps.ts
+++ b/lsif/src/shared/store/dumps.ts
@@ -107,13 +107,17 @@ export class DumpManager {
      * @param ids The upload ids to fetch.
      */
     public async getUploadStates(ids: pgModels.DumpId[]): Promise<Map<pgModels.DumpId, pgModels.LsifUploadState>> {
-        const result = await instrumentQuery(() =>
+        if (ids.length === 0) {
+            return new Map()
+        }
+
+        const result: { id: pgModels.DumpId; state: pgModels.LsifUploadState }[] = await instrumentQuery(() =>
             this.connection
                 .getRepository(pgModels.LsifUpload)
                 .createQueryBuilder()
                 .select(['id', 'state'])
                 .where('id IN (:...ids)', { ids })
-                .getMany()
+                .getRawMany()
         )
 
         return new Map<pgModels.DumpId, pgModels.LsifUploadState>(result.map(u => [u.id, u.state]))

--- a/lsif/src/shared/store/dumps.ts
+++ b/lsif/src/shared/store/dumps.ts
@@ -102,6 +102,24 @@ export class DumpManager {
     }
 
     /**
+     * Return a map from upload ids to their state.
+     *
+     * @param ids The upload ids to fetch.
+     */
+    public async getUploadStates(ids: pgModels.DumpId[]): Promise<Map<pgModels.DumpId, pgModels.LsifUploadState>> {
+        const result = await instrumentQuery(() =>
+            this.connection
+                .getRepository(pgModels.LsifUpload)
+                .createQueryBuilder()
+                .select(['id', 'state'])
+                .where('id IN (:...ids)', { ids })
+                .getMany()
+        )
+
+        return new Map<pgModels.DumpId, pgModels.LsifUploadState>(result.map(u => [u.id, u.state]))
+    }
+
+    /**
      * Find the visible dumps. This method is used for testing.
      *
      * @param repository The repository.

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -209,7 +209,7 @@ export async function convertTestData(
 /**
  * A wrapper around tests for the Backend class. This abstracts a lot
  * of the common setup and teardown around creating a temporary Postgres
- * database, a storage root, a dump manager, a dependency manager, and a
+ * database, a storage root, a dumps manager, a dependency manager, and a
  * backend instance.
  */
 export class BackendTestContext {
@@ -244,7 +244,7 @@ export class BackendTestContext {
     public dependencyManager?: DependencyManager
 
     /**
-     * Create a backend, a dump manager, and a dependency manager instance.
+     * Create a backend, a dumps manager, and a dependency manager instance.
      * This will create temporary resources (database and temporary directory)
      * that should be cleaned up via the `teardown` method.
      *

--- a/lsif/src/worker/settings.ts
+++ b/lsif/src/worker/settings.ts
@@ -14,8 +14,3 @@ export const WORKER_POLLING_INTERVAL = readEnvInt('WORKER_POLLING_INTERVAL', 1)
  * Where on the file system to store LSIF files.
  */
 export const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'
-
-/**
- * The maximum space (in bytes) that the dbs directory can use.
- */
-export const DBS_DIR_MAXIMUM_SIZE_BYTES = readEnvInt('DBS_DIR_MAXIMUM_SIZE_BYTES', 1024 * 1024 * 1024 * 10)


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/7486 removed the call to `purgeOldDumps`, which makes the cleanup code dead in the eyes of the worker.

This moves the cleanup of dead and outdated dumps to the server, where it is instead run on a schedule. This tasks removes the oldest uploads when the disk is above a configured threshold, and also removes databases that are no longer referenced inside of the postgres db.