### PR TITLE
refactor: remove unused state from commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -90,17 +90,11 @@ func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRev
 		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info, query)
 	}
 
-	textSearchOptions := git.TextSearchOptions{
-		Pattern:         info.Pattern,
-		IsRegExp:        info.IsRegExp,
-		IsCaseSensitive: info.IsCaseSensitive,
-	}
 	return searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:          repoRevs,
-		PatternInfo:       info,
-		Query:             query,
-		Diff:              true,
-		TextSearchOptions: textSearchOptions,
+		RepoRevs:    repoRevs,
+		PatternInfo: info,
+		Query:       query,
+		Diff:        true,
 	})
 }
 
@@ -120,7 +114,6 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 		PatternInfo:        info,
 		Query:              query,
 		Diff:               false,
-		TextSearchOptions:  git.TextSearchOptions{},
 		ExtraMessageValues: terms,
 	})
 }
@@ -237,10 +230,15 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 		return nil, false, false, err
 	}
 
+	textSearchOptions := git.TextSearchOptions{
+		Pattern:         op.PatternInfo.Pattern,
+		IsRegExp:        op.PatternInfo.IsRegExp,
+		IsCaseSensitive: op.PatternInfo.IsCaseSensitive,
+	}
 	diffParameters := search.DiffParameters{
 		Repo: op.RepoRevs.GitserverRepo(),
 		Options: git.RawLogDiffSearchOptions{
-			Query: op.TextSearchOptions,
+			Query: textSearchOptions,
 			Paths: git.PathOptions{
 				IncludePatterns: op.PatternInfo.IncludePatterns,
 				ExcludePattern:  op.PatternInfo.ExcludePattern,

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -57,11 +57,10 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:          repoRevs,
-		PatternInfo:       &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
-		Query:             query,
-		Diff:              true,
-		TextSearchOptions: git.TextSearchOptions{Pattern: "p"},
+		RepoRevs:    repoRevs,
+		PatternInfo: &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
+		Query:       query,
+		Diff:        true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -23,7 +23,6 @@ type CommitParameters struct {
 	PatternInfo        *CommitPatternInfo
 	Query              *query.Query
 	Diff               bool
-	TextSearchOptions  git.TextSearchOptions
 	ExtraMessageValues []string
 }
 


### PR DESCRIPTION
Removes the `git.TextSearchOptions{},` from `CommitParameters`, which turns out is only duplicated because it is passed in `DiffParameters`.