### PR TITLE
refactor: remove dead reference to Query in commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -83,26 +83,25 @@ func (r *commitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
+var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
 
-func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	if mockSearchCommitDiffsInRepo != nil {
-		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info, query)
+		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info)
 	}
 
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:    repoRevs,
 		PatternInfo: info,
-		Query:       query,
 		Diff:        true,
 	})
 }
 
-var mockSearchCommitLogInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
+var mockSearchCommitLogInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
 
-func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	if mockSearchCommitLogInRepo != nil {
-		return mockSearchCommitLogInRepo(ctx, repoRevs, info, query)
+		return mockSearchCommitLogInRepo(ctx, repoRevs, info)
 	}
 
 	var terms []string
@@ -112,7 +111,6 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:           repoRevs,
 		PatternInfo:        info,
-		Query:              query,
 		Diff:               false,
 		ExtraMessageValues: terms,
 	})
@@ -465,7 +463,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.
@@ -530,7 +528,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1149,7 +1149,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 				args := search.TextParametersForCommitParameters{
 					PatternInfo: patternInfo,
 					Repos:       args.Repos,
-					Query:       args.Query,
 				}
 				diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
@@ -1189,7 +1188,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 				args := search.TextParametersForCommitParameters{
 					PatternInfo: patternInfo,
 					Repos:       args.Repos,
-					Query:       args.Query,
 				}
 				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -97,7 +97,6 @@ type TextParameters struct {
 type TextParametersForCommitParameters struct {
 	PatternInfo *CommitPatternInfo
 	Repos       []*RepositoryRevisions
-	Query       *query.Query
 }
 
 // TextPatternInfo is the struct used by vscode pass on search queries. Keep it in


### PR DESCRIPTION
Stacked on #7605

Um, it turns out `Query` is being passed in here but it's completely dead?


![](https://media2.giphy.com/media/ZPQLVgoXJT7K8/giphy.gif?cid=5a38a5a26eb33f3ddb85bdcd9c97cb12076c4815fedda0c5&rid=giphy.gif)

