### PR TITLE
refactor: remove redundant function definition

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -83,13 +83,7 @@ func (r *commitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
-
 func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
-	if mockSearchCommitDiffsInRepo != nil {
-		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info)
-	}
-
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:    repoRevs,
 		PatternInfo: info,
@@ -97,13 +91,7 @@ func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRev
 	})
 }
 
-var mockSearchCommitLogInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
-
 func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
-	if mockSearchCommitLogInRepo != nil {
-		return mockSearchCommitLogInRepo(ctx, repoRevs, info)
-	}
-
 	var terms []string
 	if info.Pattern != "" {
 		terms = append(terms, info.Pattern)

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -90,17 +90,11 @@ func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRev
 		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info, query)
 	}
 
-	textSearchOptions := git.TextSearchOptions{
-		Pattern:         info.Pattern,
-		IsRegExp:        info.IsRegExp,
-		IsCaseSensitive: info.IsCaseSensitive,
-	}
 	return searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:          repoRevs,
-		PatternInfo:       info,
-		Query:             query,
-		Diff:              true,
-		TextSearchOptions: textSearchOptions,
+		RepoRevs:    repoRevs,
+		PatternInfo: info,
+		Query:       query,
+		Diff:        true,
 	})
 }
 
@@ -120,7 +114,6 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 		PatternInfo:        info,
 		Query:              query,
 		Diff:               false,
-		TextSearchOptions:  git.TextSearchOptions{},
 		ExtraMessageValues: terms,
 	})
 }
@@ -237,10 +230,15 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 		return nil, false, false, err
 	}
 
+	textSearchOptions := git.TextSearchOptions{
+		Pattern:         op.PatternInfo.Pattern,
+		IsRegExp:        op.PatternInfo.IsRegExp,
+		IsCaseSensitive: op.PatternInfo.IsCaseSensitive,
+	}
 	diffParameters := search.DiffParameters{
 		Repo: op.RepoRevs.GitserverRepo(),
 		Options: git.RawLogDiffSearchOptions{
-			Query: op.TextSearchOptions,
+			Query: textSearchOptions,
 			Paths: git.PathOptions{
 				IncludePatterns: op.PatternInfo.IncludePatterns,
 				ExcludePattern:  op.PatternInfo.ExcludePattern,

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -83,26 +83,25 @@ func (r *commitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
+var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
 
-func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	if mockSearchCommitDiffsInRepo != nil {
-		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info, query)
+		return mockSearchCommitDiffsInRepo(ctx, repoRevs, info)
 	}
 
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:    repoRevs,
 		PatternInfo: info,
-		Query:       query,
 		Diff:        true,
 	})
 }
 
-var mockSearchCommitLogInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
+var mockSearchCommitLogInRepo func(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
 
-func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	if mockSearchCommitLogInRepo != nil {
-		return mockSearchCommitLogInRepo(ctx, repoRevs, info, query)
+		return mockSearchCommitLogInRepo(ctx, repoRevs, info)
 	}
 
 	var terms []string
@@ -112,7 +111,6 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 	return searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:           repoRevs,
 		PatternInfo:        info,
-		Query:              query,
 		Diff:               false,
 		ExtraMessageValues: terms,
 	})
@@ -465,7 +463,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.
@@ -530,7 +528,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -83,14 +83,6 @@ func (r *commitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-func searchCommitDiffsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
-	return searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:    repoRevs,
-		PatternInfo: info,
-		Diff:        true,
-	})
-}
-
 func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	var terms []string
 	if info.Pattern != "" {
@@ -451,7 +443,12 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitDiffsInRepo(ctx, repoRev, args.PatternInfo)
+			commitParams := search.CommitParameters{
+				RepoRevs:    repoRev,
+				PatternInfo: args.PatternInfo,
+				Diff:        true,
+			}
+			results, repoLimitHit, repoTimedOut, searchErr := searchCommitsInRepo(ctx, commitParams)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -57,11 +57,10 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:          repoRevs,
-		PatternInfo:       &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
-		Query:             query,
-		Diff:              true,
-		TextSearchOptions: git.TextSearchOptions{Pattern: "p"},
+		RepoRevs:    repoRevs,
+		PatternInfo: &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
+		Query:       query,
+		Diff:        true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1149,7 +1149,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 				args := search.TextParametersForCommitParameters{
 					PatternInfo: patternInfo,
 					Repos:       args.Repos,
-					Query:       args.Query,
 				}
 				diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
@@ -1189,7 +1188,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 				args := search.TextParametersForCommitParameters{
 					PatternInfo: patternInfo,
 					Repos:       args.Repos,
-					Query:       args.Query,
 				}
 				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args)
 				// Timeouts are reported through searchResultsCommon so don't report an error for them

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -97,7 +97,6 @@ type TextParameters struct {
 type TextParametersForCommitParameters struct {
 	PatternInfo *CommitPatternInfo
 	Repos       []*RepositoryRevisions
-	Query       *query.Query
 }
 
 // TextPatternInfo is the struct used by vscode pass on search queries. Keep it in

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -23,7 +23,6 @@ type CommitParameters struct {
 	PatternInfo        *CommitPatternInfo
 	Query              *query.Query
 	Diff               bool
-	TextSearchOptions  git.TextSearchOptions
 	ExtraMessageValues []string
 }
 


### PR DESCRIPTION
Stacked on #7608 

The `searchCommitDiffsInRepo` is just a passhthrough function now, get rid of ittt.