### PR TITLE
graphqlbackend: add query `authorizedUserRepositories`

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -98,6 +98,27 @@ func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.R
 	return repos[0], nil
 }
 
+// GetByIDs returns a list of repositories by given IDs. The number of results list could be less
+// than the candidate list due to no repository is associated with some IDs.
+// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
+// is the site admin because this method returns dall available ata from the database.
+func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
+	if Mocks.Repos.GetByIDs != nil {
+		return Mocks.Repos.GetByIDs(ctx, ids...)
+	}
+
+	if len(ids) == 0 {
+		return []*types.Repo{}, nil
+	}
+
+	items := make([]*sqlf.Query, len(ids))
+	for i := range ids {
+		items[i] = sqlf.Sprintf("%d", ids[i])
+	}
+	q := sqlf.Sprintf("id IN (%s)", sqlf.Join(items, ","))
+	return s.getReposBySQL(ctx, false, true, q)
+}
+
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)
@@ -136,10 +157,12 @@ var getBySQLColumns = []string{
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
-	return s.getReposBySQL(ctx, false, querySuffix)
+	return s.getReposBySQL(ctx, true, false, querySuffix)
 }
 
-func (s *repos) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
+// is the site admin who could see all the repositories when enforcePermission=false.
+func (s *repos) getReposBySQL(ctx context.Context, enforcePermission, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {
 		columns = columns[:5]
@@ -173,6 +196,9 @@ func (s *repos) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sq
 		return nil, err
 	}
 
+	if !enforcePermission {
+		return repos, nil
+	}
 	// 🚨 SECURITY: This enforces repository permissions
 	return authzFilter(ctx, repos, authz.Read)
 }
@@ -312,7 +338,7 @@ func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*type
 	// fetch matching repos
 	fetchSQL := sqlf.Sprintf("%s %s %s", sqlf.Join(conds, "AND"), opt.OrderBy.SQL(), opt.LimitOffset.SQL())
 	tr.LazyPrintf("SQL query: %s, SQL args: %v", fetchSQL.Query(sqlf.PostgresBindVar), fetchSQL.Args())
-	return s.getReposBySQL(ctx, opt.OnlyRepoIDs, fetchSQL)
+	return s.getReposBySQL(ctx, true, opt.OnlyRepoIDs, fetchSQL)
 }
 
 // ListEnabledNames returns a list of all enabled repo names. This is commonly

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -101,7 +101,7 @@ func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.R
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin because this method returns dall available ata from the database.
+// is the site admin because this method returns all available data from the database.
 func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
 	if Mocks.Repos.GetByIDs != nil {
 		return Mocks.Repos.GetByIDs(ctx, ids...)
@@ -161,7 +161,7 @@ func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types
 }
 
 // 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin who could see all the repositories when enforcePermission=false.
+// is the site admin who is authorized to see the repositories returned even when enforcePermission=false.
 func (s *repos) getReposBySQL(ctx context.Context, enforcePermission, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -161,8 +161,8 @@ func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types
 }
 
 // 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin who is authorized to see the repositories returned even when enforcePermission=false.
-func (s *repos) getReposBySQL(ctx context.Context, enforcePermission, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+// is the site admin who is authorized to see the repositories returned even when authorize=false.
+func (s *repos) getReposBySQL(ctx context.Context, authorize, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {
 		columns = columns[:5]
@@ -196,7 +196,7 @@ func (s *repos) getReposBySQL(ctx context.Context, enforcePermission, minimal bo
 		return nil, err
 	}
 
-	if !enforcePermission {
+	if !authorize {
 		return repos, nil
 	}
 	// 🚨 SECURITY: This enforces repository permissions

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -203,6 +203,38 @@ func TestRepos_Get(t *testing.T) {
 	}
 }
 
+func TestRepos_GetByIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	want := mustCreate(ctx, t, &types.Repo{
+		Name: "r",
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "a",
+			ServiceType: "b",
+			ServiceID:   "c",
+		},
+	})
+
+	repos, err := Repos.GetByIDs(ctx, want[0].ID, 404)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("got %d repos, but want 1", len(repos))
+	}
+
+	// We don't need the RepoFields to indentify a repository.
+	want[0].RepoFields = nil
+	if !jsonEqual(t, repos[0], want[0]) {
+		t.Errorf("got %v, want %v", repos[0], want[0])
+	}
+}
+
 func TestRepos_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/cmd/frontend/db/repos_mock.go
+++ b/cmd/frontend/db/repos_mock.go
@@ -12,6 +12,7 @@ import (
 type MockRepos struct {
 	Get       func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
 	GetByName func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
+	GetByIDs  func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List      func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	Count     func(ctx context.Context, opt ReposListOptions) (int, error)
 }

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -12,6 +12,7 @@ var NewAuthzResolver func() AuthzResolver
 
 type AuthzResolver interface {
 	SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error)
+	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
 }
 
 type RepoPermsArgs struct {
@@ -27,4 +28,19 @@ func (*schemaResolver) SetRepositoryPermissionsForUsers(ctx context.Context, arg
 		return nil, authzInEnterprise
 	}
 	return EnterpriseResolvers.authzResolver.SetRepositoryPermissionsForUsers(ctx, args)
+}
+
+type AuthorizedRepoArgs struct {
+	Username *string
+	Email    *string
+	Perm     string
+	First    int32
+	After    *string
+}
+
+func (*schemaResolver) AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error) {
+	if EnterpriseResolvers.authzResolver == nil {
+		return nil, authzInEnterprise
+	}
+	return EnterpriseResolvers.authzResolver.AuthorizedUserRepositories(ctx, args)
 }

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -76,7 +76,7 @@ type TotalCountArgs struct {
 
 type RepositoryConnectionResolver interface {
 	Nodes(ctx context.Context) ([]*RepositoryResolver, error)
-	TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error)
+	TotalCount(ctx context.Context, args *TotalCountArgs) (*int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -70,6 +70,18 @@ func (r *schemaResolver) Repositories(args *struct {
 	}, nil
 }
 
+type TotalCountArgs struct {
+	Precise bool
+}
+
+type RepositoryConnectionResolver interface {
+	Nodes(ctx context.Context) ([]*RepositoryResolver, error)
+	TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+var _ RepositoryConnectionResolver = &repositoryConnectionResolver{}
+
 type repositoryConnectionResolver struct {
 	opt             db.ReposListOptions
 	cloned          bool
@@ -215,9 +227,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 	return resolvers, nil
 }
 
-func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *struct {
-	Precise bool
-}) (countptr *int32, err error) {
+func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error) {
 	if isAdminErr := backend.CheckCurrentUserIsSiteAdmin(ctx); isAdminErr != nil {
 		if args.Precise {
 			// Only site admins can perform precise counts, because it is a slow operation.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1354,8 +1354,8 @@ type Query {
 
     # The repositories a user is authorized to access with the given permission.
     # This isn’t defined in the User type because we store permissions for users
-    # that don’t yet exist (i.e. late binding). Only "username" or "email" is
-    # required to identify a user according to site configuration "permissions.userMapping".
+    # that don’t yet exist (i.e. late binding). Only one of "username" or "email"
+    # is required to identify a user.
     authorizedUserRepositories(
         # The username.
         username: String

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1352,14 +1352,16 @@ type Query {
         after: String
     ): LSIFUploadConnection!
 
-    # A user’s repository permissions. This isn’t defined in the User type
-    # because we store permissions for users that don’t yet exist (i.e. late binding).
+    # The repositories a user is authorized to access with the given permission.
+    # This isn’t defined in the User type because we store permissions for users
+    # that don’t yet exist (i.e. late binding). Only `username` or `email` is
+    # required to identify a user according to site configuration `permissions.userMapping`.
     authorizedUserRepositories(
         # The username.
         username: String
         # One of the email addresses.
         email: String
-        # Permission that the user has on this repository.
+        # Permission that the user has on the repositories.
         perm: RepositoryPermission = READ
         # Number of repositories to return after the given cursor.
         first: Int!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1354,8 +1354,8 @@ type Query {
 
     # The repositories a user is authorized to access with the given permission.
     # This isn’t defined in the User type because we store permissions for users
-    # that don’t yet exist (i.e. late binding). Only `username` or `email` is
-    # required to identify a user according to site configuration `permissions.userMapping`.
+    # that don’t yet exist (i.e. late binding). Only "username" or "email" is
+    # required to identify a user according to site configuration "permissions.userMapping".
     authorizedUserRepositories(
         # The username.
         username: String

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1351,6 +1351,21 @@ type Query {
         # 'LSIFUploadConnection.pageInfo.endCursor' that is returned.
         after: String
     ): LSIFUploadConnection!
+
+    # A user’s repository permissions. This isn’t defined in the User type
+    # because we store permissions for users that don’t yet exist (i.e. late binding).
+    authorizedUserRepositories(
+        # The username.
+        username: String
+        # One of the email addresses.
+        email: String
+        # Permission that the user has on this repository.
+        perm: RepositoryPermission = READ
+        # Number of repositories to return after the given cursor.
+        first: Int!
+        # Opaque pagination cursor.
+        after: String
+    ): RepositoryConnection!
 }
 
 # The version of the search syntax.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1361,8 +1361,8 @@ type Query {
 
     # The repositories a user is authorized to access with the given permission.
     # This isn’t defined in the User type because we store permissions for users
-    # that don’t yet exist (i.e. late binding). Only `username` or `email` is
-    # required to identify a user according to site configuration `permissions.userMapping`.
+    # that don’t yet exist (i.e. late binding). Only "username" or "email" is
+    # required to identify a user according to site configuration "permissions.userMapping".
     authorizedUserRepositories(
         # The username.
         username: String

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1361,8 +1361,8 @@ type Query {
 
     # The repositories a user is authorized to access with the given permission.
     # This isn’t defined in the User type because we store permissions for users
-    # that don’t yet exist (i.e. late binding). Only "username" or "email" is
-    # required to identify a user according to site configuration "permissions.userMapping".
+    # that don’t yet exist (i.e. late binding). Only one of "username" or "email"
+    # is required to identify a user.
     authorizedUserRepositories(
         # The username.
         username: String

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1358,6 +1358,21 @@ type Query {
         # 'LSIFUploadConnection.pageInfo.endCursor' that is returned.
         after: String
     ): LSIFUploadConnection!
+
+    # A user’s repository permissions. This isn’t defined in the User type
+    # because we store permissions for users that don’t yet exist (i.e. late binding).
+    authorizedUserRepositories(
+        # The username.
+        username: String
+        # One of the email addresses.
+        email: String
+        # Permission that the user has on this repository.
+        perm: RepositoryPermission = READ
+        # Number of repositories to return after the given cursor.
+        first: Int!
+        # Opaque pagination cursor.
+        after: String
+    ): RepositoryConnection!
 }
 
 # The version of the search syntax.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1359,14 +1359,14 @@ type Query {
         after: String
     ): LSIFUploadConnection!
 
-    # A user’s repository permissions. This isn’t defined in the User type
+    # The repositories a user is authorized to access with the given permission. This isn’t defined in the User type
     # because we store permissions for users that don’t yet exist (i.e. late binding).
     authorizedUserRepositories(
         # The username.
         username: String
         # One of the email addresses.
         email: String
-        # Permission that the user has on this repository.
+        # Permission that the user has on the repositories.
         perm: RepositoryPermission = READ
         # Number of repositories to return after the given cursor.
         first: Int!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1359,8 +1359,10 @@ type Query {
         after: String
     ): LSIFUploadConnection!
 
-    # The repositories a user is authorized to access with the given permission. This isn’t defined in the User type
-    # because we store permissions for users that don’t yet exist (i.e. late binding).
+    # The repositories a user is authorized to access with the given permission.
+    # This isn’t defined in the User type because we store permissions for users
+    # that don’t yet exist (i.e. late binding). Only `username` or `email` is
+    # required to identify a user according to site configuration `permissions.userMapping`.
     authorizedUserRepositories(
         # The username.
         username: String

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -65,6 +66,11 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 }
 
 func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.RepositoryResolver, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	repos, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
@@ -77,11 +83,21 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 }
 
 func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *graphqlbackend.TotalCountArgs) (*int32, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	count := int32(r.ids.GetCardinality())
 	return &count, nil
 }
 
 func (r *repositoryConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	_, err := r.compute(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -1,0 +1,94 @@
+package resolvers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+var _ graphqlbackend.RepositoryConnectionResolver = &repositoryConnectionResolver{}
+
+type repositoryConnectionResolver struct {
+	ids *roaring.Bitmap
+
+	first int32
+	after *string
+
+	// cache results because they are used by multiple fields
+	once        sync.Once
+	repos       []*types.Repo
+	endCursor   string
+	hasNextPage bool
+	err         error
+}
+
+// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
+// is the site admin because this method computes data from all available information in
+// the database.
+func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Repo, error) {
+	r.once.Do(func() {
+		// Create the bitmap iterator and advance to the next value of r.after.
+		var afterID api.RepoID
+		if r.after != nil {
+			afterID, r.err = graphqlbackend.UnmarshalRepositoryID(graphql.ID(*r.after))
+			if r.err != nil {
+				return
+			}
+		}
+		iter := r.ids.Iterator()
+		iter.AdvanceIfNeeded(uint32(afterID) + 1) // Plus 1 since r.after should be excluded.
+
+		repoIDs := make([]api.RepoID, 0, r.first)
+		for iter.HasNext() {
+			repoIDs = append(repoIDs, api.RepoID(iter.Next()))
+			if len(repoIDs) >= int(r.first) {
+				break
+			}
+		}
+
+		r.repos, r.err = db.Repos.GetByIDs(ctx, repoIDs...)
+		if r.err != nil {
+			return
+		}
+
+		r.endCursor = string(graphqlbackend.MarshalRepositoryID(repoIDs[len(repoIDs)-1]))
+		r.hasNextPage = iter.HasNext()
+	})
+	return r.repos, r.err
+}
+
+func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.RepositoryResolver, error) {
+	repos, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvers := make([]*graphqlbackend.RepositoryResolver, len(repos))
+	for i := range repos {
+		resolvers[i] = graphqlbackend.NewRepositoryResolver(repos[i])
+	}
+	return resolvers, nil
+}
+
+func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *graphqlbackend.TotalCountArgs) (countptr *int32, err error) {
+	count := int32(r.ids.GetCardinality())
+	return &count, nil
+}
+
+func (r *repositoryConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.hasNextPage {
+		return graphqlutil.NextPageCursor(r.endCursor), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -76,7 +76,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 	return resolvers, nil
 }
 
-func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *graphqlbackend.TotalCountArgs) (countptr *int32, err error) {
+func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *graphqlbackend.TotalCountArgs) (*int32, error) {
 	count := int32(r.ids.GetCardinality())
 	return &count, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -12,9 +12,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
 type Resolver struct{}
@@ -98,6 +100,11 @@ func (*Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *gra
 		pendingBindIDs = append(pendingBindIDs, id)
 	}
 
+	// Note: We're not warpping these two operations in a transaction because PostgreSQL 9.6 (the minimal version
+	// we support) does not support nested transactions. Besides, these two operations will acquire row-level locks
+	// over 4 tables, which could greatly increase chances of causing deadlocks with other methods. Practically,
+	// the result of SetRepoPermissions is much more important because it takes effect immediately. If the call of
+	// the SetRepoPendingPermissions method failed, a retry from client won't hurt.
 	s := iauthz.NewStore(dbconn.Global, time.Now)
 	if err = s.SetRepoPermissions(ctx, p); err != nil {
 		return nil, err
@@ -106,4 +113,70 @@ func (*Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *gra
 	}
 
 	return &graphqlbackend.EmptyResponse{}, nil
+}
+
+func (*Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphqlbackend.AuthorizedRepoArgs) (graphqlbackend.RepositoryConnectionResolver, error) {
+	// 🚨 SECURITY: Only site admins can query repository permissions.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	cfg := conf.Get().SiteConfiguration
+	if cfg.PermissionsUserMapping == nil || !cfg.PermissionsUserMapping.Enabled {
+		return nil, errors.New("permissions user mapping is not enabled")
+	}
+
+	var err error
+	var bindID string
+	var user *types.User
+	if args.Email != nil {
+		bindID = *args.Email
+		user, err = db.Users.GetByVerifiedEmail(ctx, *args.Email)
+	} else if args.Username != nil {
+		bindID = *args.Username
+		user, err = db.Users.GetByUsername(ctx, *args.Username)
+	} else {
+		return nil, errors.New("neither email nor username is given to identify a user")
+	}
+	if err != nil && !errcode.IsNotFound(err) {
+		return nil, err
+	}
+
+	var ids *roaring.Bitmap
+	s := iauthz.NewStore(dbconn.Global, time.Now)
+	if user != nil {
+		p := &iauthz.UserPermissions{
+			UserID:   user.ID,
+			Perm:     authz.Read, // Note: We currently only support read for repository permissions.
+			Type:     iauthz.PermRepos,
+			Provider: iauthz.ProviderSourcegraph,
+		}
+		err = s.LoadUserPermissions(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+
+		ids = p.IDs
+	} else {
+		p := &iauthz.UserPendingPermissions{
+			BindID: bindID,
+			Perm:   authz.Read, // Note: We currently only support read for repository permissions.
+			Type:   iauthz.PermRepos,
+		}
+		err = s.LoadUserPendingPermissions(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+
+		ids = p.IDs
+	}
+	if ids.GetCardinality() == 0 {
+		return nil, iauthz.ErrNotFound
+	}
+
+	return &repositoryConnectionResolver{
+		ids:   ids,
+		first: args.First,
+		after: args.After,
+	}, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -100,7 +100,7 @@ func (*Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *gra
 		pendingBindIDs = append(pendingBindIDs, id)
 	}
 
-	// Note: We're not warpping these two operations in a transaction because PostgreSQL 9.6 (the minimal version
+	// Note: We're not wrapping these two operations in a transaction because PostgreSQL 9.6 (the minimal version
 	// we support) does not support nested transactions. Besides, these two operations will acquire row-level locks
 	// over 4 tables, which could greatly increase chances of causing deadlocks with other methods. Practically,
 	// the result of SetRepoPermissions is much more important because it takes effect immediately. If the call of


### PR DESCRIPTION
Part of #7298, added GQL query `authorizedUserRepositories`, which returns paginated list of repositories a user has access to.

Manually tested with some unit tests, regression tests will be added as the last PR of #7298.

It's safe to merge this PR (after review) alone because the site configuration option is not documented anywhere outside the source code.
