### PR TITLE
repo-updater: remove duplicate func scheduler.Set

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -253,19 +253,6 @@ func (s *updateScheduler) Update(rs ...*Repo) {
 	schedKnownRepos.Set(float64(known))
 }
 
-// Set updates the schedule with the given repos. However, rs is assumed to be
-// the known universe of repositories, rather than a subset.
-func (s *updateScheduler) Set(rs ...*Repo) {
-	s.Update(rs...)
-	known := 0
-	for _, r := range rs {
-		if !r.IsDeleted() {
-			known++
-		}
-	}
-	schedKnownRepos.Set(float64(known))
-}
-
 func (s *updateScheduler) upsert(r *Repo) {
 	repo := configuredRepo2FromRepo(r)
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -227,7 +227,6 @@ func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 }
 
 type scheduler interface {
-	Set(...*repos.Repo)
 	Update(...*repos.Repo)
 }
 
@@ -238,7 +237,7 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 		select {
 		case rs := <-syncer.Synced:
 			if !conf.Get().DisableAutoGitUpdates {
-				sched.Set(rs...)
+				sched.Update(rs...)
 			}
 
 			go func() {


### PR DESCRIPTION
For a while this function has just used Update directly, then set the same
metric that Update does. Remove it and update the only call site.