### PR TITLE
a8n: When retrying Campaign creation only retry failed jobs

### DIFF
--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -2288,7 +2288,10 @@ SET
   error = '',
   started_at = NULL,
   finished_at = NULL
-WHERE campaign_id = %s
+WHERE
+  campaign_id = %s
+AND
+  error != '';
 `
 
 func (s *Store) exec(ctx context.Context, q *sqlf.Query, sc scanFunc) error {


### PR DESCRIPTION
This was an oversight on my part. I didn't check the opposite case in
the test.

The bug manifested itself in that we retried every job when retrying
Campaign creation, even the ones that successfully created a changeset
on a codehost. That wasn't a huge problem since that function is
idempotent, but it's still needless work and the behavior of the method
doesn't match its name.