### PR TITLE
conf: extract lazily computed and cached configuration

### DIFF
--- a/internal/conf/reposource/custom_test.go
+++ b/internal/conf/reposource/custom_test.go
@@ -45,9 +45,8 @@ func Test_customCloneURLToRepoName(t *testing.T) {
 		},
 	}}
 
-	cloneURLResolversOnce.Do(func() {}) // Prevent conf watching
 	for i, test := range tests {
-		cloneURLResolvers.Store(test.cloneURLResolvers)
+		cloneURLResolvers = func() interface{} { return test.cloneURLResolvers }
 		for cloneURL, expName := range test.cloneURLToRepoName {
 			if name := CustomCloneURLToRepoName(cloneURL); name != api.RepoName(expName) {
 				t.Errorf("In test case %d, expected %s -> %s, but got %s", i+1, cloneURL, expName, name)


### PR DESCRIPTION
In a few places we want to compute a value from the config. We don't need to
do it on start, but only when it is first used. So we can use a mix of
sync.Once to kick off conf.Watch + some synchronization like a Mutex or atomic
Value. This commit introduces a helper to simplify this pattern.

This pattern I wanted to use in some new code I was writing. I realised we
used it in some other places so I am putting the pattern in the conf
package. One benefit is the sites that use this pattern are now much clearer.

This commit only updates one of the call sites which use this pattern.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
