### PR TITLE
go.mod: update gosaml2 dep to include SAML metadata endpoint fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 replace (
 	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20191204145050-b470e5f5cf39
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
-	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab
+	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -779,8 +779,8 @@ github.com/sourcegraph/gonduit v0.4.0 h1:0BTiXaxNto/Jm0uvd/LdnZZr6JOkZz+VqPulU+Y
 github.com/sourcegraph/gonduit v0.4.0/go.mod h1:NEbCUR5u7J+UF4B5ohjOH36WMnEQ3YNS9n32MZqfOZc=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d h1:FxF0pen6r1WOqbm4kVDR3JV078HfPz65inWcMh1aVQI=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d/go.mod h1:8HCyYaC38XwX0AOu0+fuY02Y5Z7CkITW0oVJavbna4Q=
-github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab h1:tXj2rcIvqVGM6SOt6DkGVxcjVE8c03hEethti8D77O8=
-github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab/go.mod h1:ZqB/uu1WtCDmlwK8c+TO8+QSfDkJsWx9LYjQBgGxxtk=
+github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17 h1:9kV7BLsB6gGUXFr7GqNb6VKlUz1WQvh8kkMb1uKEk9Y=
+github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17/go.mod h1:ZqB/uu1WtCDmlwK8c+TO8+QSfDkJsWx9LYjQBgGxxtk=
 github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb h1:bbs7cDhEjewPB6aicTDJ15tseQAsl8bSGDVsnIuG0c0=
 github.com/sourcegraph/gosyntect v0.0.0-20191003053245-e91d603ba4eb/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
 github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c h1:MXlcJZ1VL5nNGkCj6ZTT71P4pImPkeG2lvzcJYzGvU4=


### PR DESCRIPTION
Relevant upstream diff: https://github.com/sourcegraph/gosaml2/commit/5cfddeb48b17ee77306e3833a49abd886c82adf9

This fixes a panic where the `/.auth/saml/metadata` HTTP endpoint would panic and return an error if no SAML encryption key pair was configured (encryption is optional). This broke our Microsoft ADFS SAML instructions.