### PR TITLE
refactor: pull out search type

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -65,14 +65,6 @@ type SearchImplementer interface {
 	Stats(context.Context) (*searchResultsStats, error)
 }
 
-type SearchType int
-
-const (
-	SearchTypeRegex SearchType = iota
-	SearchTypeLiteral
-	SearchTypeStructural
-)
-
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	tr, _ := trace.New(context.Background(), "graphql.schemaResolver", "Search")
@@ -83,12 +75,12 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 		return &didYouMeanQuotedResolver{query: args.Query, err: err}, nil
 	}
 
-	if searchType == SearchTypeStructural && !conf.StructuralSearchEnabled() {
+	if searchType == search.SearchTypeStructural && !conf.StructuralSearchEnabled() {
 		return nil, errors.New("Structural search is disabled in the site configuration.")
 	}
 
 	var queryString string
-	if searchType == SearchTypeLiteral {
+	if searchType == search.SearchTypeLiteral {
 		queryString = query.ConvertToLiteral(args.Query)
 	} else {
 		queryString = args.Query
@@ -136,25 +128,25 @@ func (r *schemaResolver) Search(args *SearchArgs) (SearchImplementer, error) {
 // patternType parameters passed to the search endpoint (literal search is the
 // default in V2), and the `patternType:` filter in the input query string which
 // overrides the searchType, if present.
-func detectSearchType(version string, patternType *string, input string) (SearchType, error) {
-	var searchType SearchType
+func detectSearchType(version string, patternType *string, input string) (search.SearchType, error) {
+	var searchType search.SearchType
 	if patternType != nil {
 		switch *patternType {
 		case "literal":
-			searchType = SearchTypeLiteral
+			searchType = search.SearchTypeLiteral
 		case "regexp":
-			searchType = SearchTypeRegex
+			searchType = search.SearchTypeRegex
 		case "structural":
-			searchType = SearchTypeStructural
+			searchType = search.SearchTypeStructural
 		default:
 			return -1, fmt.Errorf("unrecognized patternType: %v", patternType)
 		}
 	} else {
 		switch version {
 		case "V1":
-			searchType = SearchTypeRegex
+			searchType = search.SearchTypeRegex
 		case "V2":
-			searchType = SearchTypeLiteral
+			searchType = search.SearchTypeLiteral
 		default:
 			return -1, fmt.Errorf("unrecognized version: %v", version)
 		}
@@ -168,12 +160,12 @@ func detectSearchType(version string, patternType *string, input string) (Search
 	if len(patternFromField) > 1 {
 		extracted := patternFromField[1]
 		if match, _ := regexp.MatchString("regex", extracted); match {
-			searchType = SearchTypeRegex
+			searchType = search.SearchTypeRegex
 		} else if match, _ := regexp.MatchString("literal", extracted); match {
-			searchType = SearchTypeLiteral
+			searchType = search.SearchTypeLiteral
 
 		} else if match, _ := regexp.MatchString("structural", extracted); match {
-			searchType = SearchTypeStructural
+			searchType = search.SearchTypeStructural
 		}
 	}
 
@@ -196,7 +188,7 @@ type searchResolver struct {
 	query         *query.Query          // the parsed search query
 	originalQuery string                // the raw string of the original search query
 	pagination    *searchPaginationInfo // pagination information, or nil if the request is not paginated.
-	patternType   SearchType
+	patternType   search.SearchType
 
 	// Cached resolveRepositories results.
 	reposMu                   sync.Mutex
@@ -749,7 +741,7 @@ func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver,
 		query:         q,
 		originalQuery: plainQuery,
 		pagination:    nil,
-		patternType:   SearchTypeLiteral,
+		patternType:   search.SearchTypeLiteral,
 		zoekt:         search.Indexed(),
 		searcherURLs:  search.SearcherURLs(),
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -21,7 +21,7 @@ type searchAlert struct {
 	prometheusType  string
 	title           string
 	description     string
-	patternType     SearchType
+	patternType     search.SearchType
 	proposedQueries []*searchQueryDescription
 }
 
@@ -41,11 +41,11 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	for _, proposedQuery := range a.proposedQueries {
 		if proposedQuery.description != "Remove quotes" {
 			switch a.patternType {
-			case SearchTypeRegex:
+			case search.SearchTypeRegex:
 				proposedQuery.query = proposedQuery.query + " patternType:regexp"
-			case SearchTypeLiteral:
+			case search.SearchTypeLiteral:
 				proposedQuery.query = proposedQuery.query + " patternType:literal"
-			case SearchTypeStructural:
+			case search.SearchTypeStructural:
 				// Don't append patternType:structural, it is not erased from the query like
 				// patterntype:regexp and patterntype:literal.
 				// TODO(RVT): Making this consistent requires a change on the UI side.

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
@@ -20,7 +21,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: searchAlert{
 				title:       "An alert for regex",
 				description: "An alert for regex",
-				patternType: SearchTypeRegex,
+				patternType: search.SearchTypeRegex,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "Some query description",
@@ -35,7 +36,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: searchAlert{
 				title:       "An alert for structural",
 				description: "An alert for structural",
-				patternType: SearchTypeStructural,
+				patternType: search.SearchTypeStructural,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "Some query description",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -964,7 +964,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	options := &getPatternInfoOptions{}
-	if r.patternType == SearchTypeStructural {
+	if r.patternType == search.SearchTypeStructural {
 		options = &getPatternInfoOptions{performStructuralSearch: true}
 	}
 	p, err := r.getPatternInfo(options)
@@ -1259,7 +1259,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		alert = r.alertForMissingRepoRevs(missingRepoRevs)
 	}
 
-	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == SearchTypeLiteral {
+	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == search.SearchTypeLiteral {
 		alert, err = r.alertForQuotesInQueryInLiteralMode(ctx)
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1060,7 +1060,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 	}
 	resolver := &searchResolver{
 		query:        q,
-		patternType:  SearchTypeStructural,
+		patternType:  search.SearchTypeStructural,
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -314,20 +314,20 @@ func Test_detectSearchType(t *testing.T) {
 		version     string
 		patternType *string
 		input       string
-		want        SearchType
+		want        search.SearchType
 	}{
-		{"V1, no pattern type", "V1", nil, "", SearchTypeRegex},
-		{"V2, no pattern type", "V2", nil, "", SearchTypeLiteral},
-		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", SearchTypeLiteral},
-		{"V1, regexp pattern type", "V1", &typeRegexp, "", SearchTypeRegex},
-		{"V2, regexp pattern type", "V2", &typeRegexp, "", SearchTypeRegex},
-		{"V1, literal pattern type", "V1", &typeLiteral, "", SearchTypeLiteral},
-		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", SearchTypeRegex},
-		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", SearchTypeRegex},
-		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, SearchTypeRegex},
-		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, SearchTypeRegex},
-		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", SearchTypeLiteral},
-		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", SearchTypeLiteral},
+		{"V1, no pattern type", "V1", nil, "", search.SearchTypeRegex},
+		{"V2, no pattern type", "V2", nil, "", search.SearchTypeLiteral},
+		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", search.SearchTypeLiteral},
+		{"V1, regexp pattern type", "V1", &typeRegexp, "", search.SearchTypeRegex},
+		{"V2, regexp pattern type", "V2", &typeRegexp, "", search.SearchTypeRegex},
+		{"V1, literal pattern type", "V1", &typeLiteral, "", search.SearchTypeLiteral},
+		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", search.SearchTypeRegex},
+		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", search.SearchTypeRegex},
+		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, search.SearchTypeRegex},
+		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, search.SearchTypeRegex},
+		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", search.SearchTypeLiteral},
+		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", search.SearchTypeLiteral},
 	}
 
 	for _, test := range testCases {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -9,6 +9,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
+type SearchType int
+
+const (
+	SearchTypeRegex SearchType = iota
+	SearchTypeLiteral
+	SearchTypeStructural
+)
+
 type TypeParameters interface {
 	typeParametersValue()
 }


### PR DESCRIPTION
prep for passing `SearchType` to the scanner to split logic for literal/regex parsing.