### PR TITLE
search: add a prometheus metric for structural search queries

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -158,7 +158,7 @@ func lookupMatcher(language string) string {
 	case "xml":
 		return ".xml"
 	}
-	return ".generic"
+	return ""
 }
 
 func structuralSearch(ctx context.Context, zipPath, pattern, rule string, languages, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -158,7 +158,7 @@ func lookupMatcher(language string) string {
 	case "xml":
 		return ".xml"
 	}
-	return ""
+	return ".generic"
 }
 
 func structuralSearch(ctx context.Context, zipPath, pattern, rule string, languages, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {
@@ -174,6 +174,8 @@ func structuralSearch(ctx context.Context, zipPath, pattern, rule string, langua
 		matcher = lookupMatcher(languages[0])
 		log15.Debug("structural search", "language", languages[0], "matcher", matcher)
 	}
+
+	requestTotalStructuralSearch.WithLabelValues(matcher).Inc()
 
 	args := comby.Args{
 		Input:         comby.ZipPath(zipPath),
@@ -202,7 +204,7 @@ var requestTotalStructuralSearch = prometheus.NewCounterVec(prometheus.CounterOp
 	Subsystem: "service",
 	Name:      "request_total_structural_search",
 	Help:      "Number of returned structural search requests.",
-}, []string{"code"})
+}, []string{"language"})
 
 func init() {
 	prometheus.MustRegister(requestTotalStructuralSearch)

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -175,7 +175,11 @@ func structuralSearch(ctx context.Context, zipPath, pattern, rule string, langua
 		log15.Debug("structural search", "language", languages[0], "matcher", matcher)
 	}
 
-	requestTotalStructuralSearch.WithLabelValues(matcher).Inc()
+	if matcher == "" {
+		requestTotalStructuralSearch.WithLabelValues("inferred").Inc()
+	} else {
+		requestTotalStructuralSearch.WithLabelValues(matcher).Inc()
+	}
 
 	args := comby.Args{
 		Input:         comby.ZipPath(zipPath),

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
@@ -194,4 +195,15 @@ func structuralSearch(ctx context.Context, zipPath, pattern, rule string, langua
 		return nil, false, err
 	}
 	return matches, false, err
+}
+
+var requestTotalStructuralSearch = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "searcher",
+	Subsystem: "service",
+	Name:      "request_total_structural_search",
+	Help:      "Number of returned structural search requests.",
+}, []string{"code"})
+
+func init() {
+	prometheus.MustRegister(requestTotalStructuralSearch)
 }


### PR DESCRIPTION
I want to know how many of the search queries bound for searcher are asking for structural search. This PR adds a counter that labels by language. It is not all languages ever, just the extensions supported in this function: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/searcher/search/search_structural.go#L85

Very low-res example:

<img width="1125" alt="Screen Shot 2020-01-09 at 5 02 30 PM" src="https://user-images.githubusercontent.com/888624/72114974-8dca0680-3302-11ea-8afd-8791a5d435d1.png">
