### PR TITLE
test: add commit and diff search e2e regression tests

### DIFF
--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -386,6 +386,24 @@ describe('Search regression test suite', () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
         })
+        test('Commit search, nonzero result', async () => {
+            const urlQuery = buildSearchURLQuery(
+                'repo:^github\\.com/facebook/react$ type:commit hello world',
+                GQL.SearchPatternType.regexp
+            )
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
+        })
+        test('Diff search, nonzero result', async () => {
+            const urlQuery = buildSearchURLQuery(
+                'repo:^github\\.com/sgtest/mux$ type:diff main',
+                GQL.SearchPatternType.regexp
+            )
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
+        })
+
+
 
         test(
             'Search timeout',

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -403,8 +403,6 @@ describe('Search regression test suite', () => {
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
         })
 
-
-
         test(
             'Search timeout',
             async () => {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/7634 caused a nil dereference in prod. The function in question was not covered by any tests, and e2e tests were green.

This adds tests that covers the search path for `commit` and `diff` searches.