### PR TITLE
search: support searching text in multiple refs specified by glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Add button to download file in code view. [#5478](https://github.com/sourcegraph/sourcegraph/issues/5478)
 - The new `allowOrgs` site config setting in GitHub `auth.providers` enables admins to restrict GitHub logins to members of specific GitHub organizations. [#4195](https://github.com/sourcegraph/sourcegraph/issues/4195)
 - Skip LFS content when cloning git repositories. [#7322](https://github.com/sourcegraph/sourcegraph/issues/7322)
-- Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
+- Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. To search all branches, use `repo:myrepo@*refs/heads/`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -585,7 +585,7 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-count)
 
 	for _, rev := range revs {
-		if len(rev.RevSpecs()) >= 2 {
+		if len(rev.RevSpecs()) >= 2 || len(rev.RevSpecs()) != len(rev.Revs) {
 			// Zoekt only indexes 1 rev per repository, so it will not have the full results for the
 			// query on repositories for which multiple revs are searched.
 			unindexed = append(unindexed, rev)

--- a/internal/vcs/git/ref_globs.go
+++ b/internal/vcs/git/ref_globs.go
@@ -1,0 +1,98 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// RefGlob describes a glob pattern that either includes or excludes refs. Exactly 1 of the fields
+// must be set.
+type RefGlob struct {
+	// Include is a glob pattern for including refs interpreted as in `git log --glob`. See the
+	// git-log(1) manual page for details.
+	Include string
+
+	// Exclude is a glob pattern for excluding refs interpreted as in `git log --exclude`. See the
+	// git-log(1) manual page for details.
+	Exclude string
+}
+
+// RefGlobs is a compiled matcher based on RefGlob patterns. Use CompileRefGlobs to create it.
+type RefGlobs []compiledRefGlobPattern
+
+type compiledRefGlobPattern struct {
+	pattern glob.Glob
+	include bool // true for include, false for exclude
+}
+
+// CompileRefGlobs compiles the ordered ref glob patterns (interpreted as in `git log --glob
+// ... --exclude ...`; see the git-log(1) manual page) into a matcher. If the input patterns are
+// invalid, an error is returned.
+func CompileRefGlobs(globs []RefGlob) (RefGlobs, error) {
+	c := make(RefGlobs, len(globs))
+	for i, g := range globs {
+		// Validate exclude globs according to `git log --exclude`'s specs: "The patterns
+		// given...must begin with refs/... If a trailing /* is intended, it must be given
+		// explicitly."
+		if g.Exclude != "" {
+			if !strings.HasPrefix(g.Exclude, "refs/") {
+				return nil, fmt.Errorf(`git ref exclude glob must begin with "refs/" (got %q)`, g.Exclude)
+			}
+		}
+
+		// Add implicits (according to `git log --glob`'s specs).
+		if g.Include != "" {
+			// `git log --glob`: "Leading refs/ is automatically prepended if missing.".
+			if !strings.HasPrefix(g.Include, "refs/") {
+				g.Include = "refs/" + g.Include
+			}
+
+			// `git log --glob`: "If pattern lacks ?, *, or [, /* at the end is implied." Also
+			// support an important undocumented case: support exact matches. For example, the
+			// pattern refs/heads/a should match the ref refs/heads/a (i.e., just appending /* to
+			// the pattern would yield refs/heads/a/*, which would *not* match refs/heads/a, so we
+			// need to make the /* optional).
+			if !strings.ContainsAny(g.Include, "?*[") {
+				var suffix string
+				if strings.HasSuffix(g.Include, "/") {
+					suffix = "*"
+				} else {
+					suffix = "/*"
+				}
+				g.Include += "{," + suffix + "}"
+			}
+		}
+
+		var pattern string
+		if g.Include != "" {
+			pattern = g.Include
+			c[i].include = true
+		} else {
+			pattern = g.Exclude
+		}
+		var err error
+		c[i].pattern, err = glob.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+// Match reports whether the named ref matches the ref globs.
+func (gs RefGlobs) Match(ref string) bool {
+	match := false
+	for _, g := range gs {
+		if g.include == match {
+			// If the glob does not change the outcome, skip it. (For example, if the ref is already
+			// matched, and the next glob is another include glob.)
+			continue
+		}
+		if g.pattern.Match(ref) {
+			match = g.include
+		}
+	}
+	return match
+}

--- a/internal/vcs/git/ref_globs_test.go
+++ b/internal/vcs/git/ref_globs_test.go
@@ -1,0 +1,58 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestRefGlobs(t *testing.T) {
+	tests := map[string]struct {
+		globs   []RefGlob
+		match   []string
+		noMatch []string
+		want    []string
+	}{
+		"empty": {
+			globs:   nil,
+			noMatch: []string{"a"},
+		},
+		"globs": {
+			globs:   []RefGlob{{Include: "refs/heads/"}},
+			match:   []string{"refs/heads/a", "refs/heads/b/c"},
+			noMatch: []string{"refs/tags/t"},
+		},
+		"excludes": {
+			globs: []RefGlob{
+				{Include: "refs/heads/"}, {Exclude: "refs/heads/x"},
+			},
+			match:   []string{"refs/heads/a", "refs/heads/b", "refs/heads/x/c"},
+			noMatch: []string{"refs/tags/t", "refs/heads/x"},
+		},
+		"implicit leading refs/": {
+			globs: []RefGlob{{Include: "heads/"}},
+			match: []string{"refs/heads/a"},
+		},
+		"implicit trailing /*": {
+			globs:   []RefGlob{{Include: "refs/heads/a"}},
+			match:   []string{"refs/heads/a", "refs/heads/a/b"},
+			noMatch: []string{"refs/heads/b"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m, err := CompileRefGlobs(test.globs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, ref := range test.match {
+				if !m.Match(ref) {
+					t.Errorf("want match %q", ref)
+				}
+			}
+			for _, ref := range test.noMatch {
+				if m.Match(ref) {
+					t.Errorf("want no match %q", ref)
+				}
+			}
+		})
+	}
+}

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1181,7 +1181,7 @@ describe('e2e test suite', () => {
             test('searches', async () => {
                 await driver.page.goto(
                     sourcegraphBaseUrl +
-                        '/search?q=repo:sourcegraph/go-diff%24%40master:print-options+func+NewHunksReader&patternType=regexp'
+                        '/search?q=repo:sourcegraph/go-diff%24%40master:print-options:*refs/heads/+func+NewHunksReader&patternType=regexp'
                 )
                 await driver.page.waitForSelector('.e2e-search-results-stats', { visible: true })
                 await retry(async () => {
@@ -1196,10 +1196,22 @@ describe('e2e test suite', () => {
                         as.map(a => (a as HTMLAnchorElement).pathname)
                     )
                 ).sort()
-                expect(fileMatchHrefs).toEqual([
-                    '/github.com/sourcegraph/go-diff@master/-/blob/diff/parse.go',
-                    '/github.com/sourcegraph/go-diff@print-options/-/blob/diff/parse.go',
-                ])
+
+                // Only check for specific branches, so that the test doesn't break when new
+                // branches are added (it's an active repository).
+                const checkBranches = [
+                    'master',
+                    'print-options',
+
+                    // These next 2 branches are included because of the *refs/heads/ in the query.
+                    // If they are ever deleted from the actual live repository, replace them with
+                    // any other branches that still exist.
+                    'test-already-exist-pr',
+                    'bug-fix-wip',
+                ].sort()
+                expect(
+                    fileMatchHrefs.filter(href => checkBranches.some(branch => href.includes(`@${branch}/`)))
+                ).toEqual(checkBranches.map(branch => `/github.com/sourcegraph/go-diff@${branch}/-/blob/diff/parse.go`))
             })
         })
 


### PR DESCRIPTION
Adds support for searching for text in multiple refs per repository where the refs are matched by glob. Previously you needed to explicitly list each revspec you wanted to search.

To use this, give a query of the form `repo:myrepo@*refs/heads/:^refs/heads/myexclude`. That will search all branches except for the `myexclude` branch. The glob syntax is the same as used for diff search (which, in turn, is the same as used by `git log --glob ... --exclude ...`).

This is all behind the searchMultipleRevisionsPerRepository site config feature flag (disabled by default).

- For https://app.hubspot.com/contacts/2762526/company/2428850551 https://app.hubspot.com/contacts/2762526/company/407948923
- Closes #4948