### PR TITLE
all: introduce tls.external site setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Add button to download file in code view. [#5478](https://github.com/sourcegraph/sourcegraph/issues/5478)
 - The new `allowOrgs` site config setting in GitHub `auth.providers` enables admins to restrict GitHub logins to members of specific GitHub organizations. [#4195](https://github.com/sourcegraph/sourcegraph/issues/4195)
 - Skip LFS content when cloning git repositories. [#7322](https://github.com/sourcegraph/sourcegraph/issues/7322)
+- A new site setting `tls.external` which allows you to configure SSL/TLS settings for Sourcegraph contacting your code hosts. Currently just supports turning off TLS/SSL verification. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
 - Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. To search all branches, use `repo:myrepo@*refs/heads/`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
 
 ### Changed

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -18,7 +18,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -63,7 +65,7 @@ func checkSpecArgSafety(spec string) error {
 // runWithRemoteOpts runs the command after applying the remote options.
 // If progress is not nil, all output is written to it in a separate goroutine.
 func runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) ([]byte, error) {
-	configureGitCommand(cmd)
+	configureRemoteGitCommand(cmd, conf.Get().TlsExternal)
 
 	var b interface {
 		Bytes() []byte
@@ -93,7 +95,7 @@ func runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) (
 	return b.Bytes(), err
 }
 
-func configureGitCommand(cmd *exec.Cmd) {
+func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *schema.TlsExternal) {
 	if cmd.Args[0] != "git" {
 		panic("Only git commands are supported")
 	}
@@ -105,6 +107,12 @@ func configureGitCommand(cmd *exec.Cmd) {
 	//
 	// And set a timeout to avoid indefinite hangs if the server is unreachable.
 	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
+
+	if tlsConf != nil {
+		if tlsConf.InsecureSkipVerify {
+			cmd.Env = append(cmd.Env, "GIT_SSL_NO_VERIFY=true")
+		}
+	}
 
 	extraArgs := []string{
 		// Unset credential helper because the command is non-interactive.

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -54,7 +54,7 @@ func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnect
 	}
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer(func(c *http.Client) error {

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -40,7 +40,7 @@ func NewBitbucketCloudSource(svc *ExternalService, cf *httpcli.Factory) (*Bitbuc
 
 func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer()

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -47,7 +47,7 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 	baseURL = NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	var opts []httpcli.Opt

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -61,7 +61,7 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 	apiURL, githubDotCom := github.APIRoot(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	opts := []httpcli.Opt{

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -46,7 +46,7 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 	baseURL = NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	var opts []httpcli.Opt

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -32,7 +32,7 @@ func NewOtherSource(svc *ExternalService, cf *httpcli.Factory) (*OtherSource, er
 	}
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer()

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -181,7 +181,7 @@ func (s *PhabricatorSource) client(ctx context.Context) (*phabricator.Client, er
 
 // RunPhabricatorRepositorySyncWorker runs the worker that syncs repositories from Phabricator to Sourcegraph
 func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 
 	for {
 		phabs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -342,7 +342,7 @@ func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceS
 		Kind:        req.ExternalService.Kind,
 		DisplayName: req.ExternalService.DisplayName,
 		Config:      req.ExternalService.Config,
-	}, httpcli.NewHTTPClientFactory())
+	}, httpcli.NewExternalHTTPClientFactory())
 	if err != nil {
 		return err
 	}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -95,7 +95,7 @@ func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 		)
 	}
 
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 	var src repos.Sourcer
 	{
 		m := repos.NewSourceMetrics()

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -37,7 +37,7 @@ func TestService(t *testing.T) {
 	}
 
 	gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 
 	u, err := db.Users.Create(ctx, db.NewUser{
 		Email:                 "thorsten@sourcegraph.com",

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -57,14 +57,18 @@ type Factory struct {
 	common []Opt
 }
 
-// NewHTTPClientFactory returns an httpcli.Factory with common
-// options and middleware pre-set.
-func NewHTTPClientFactory() *Factory {
+// NewExternalHTTPClientFactory returns an httpcli.Factory with common options
+// and middleware pre-set for communicating to external services.
+func NewExternalHTTPClientFactory() *Factory {
 	return NewFactory(
 		// TODO(tsenart): Use middle for Prometheus instrumentation later.
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
+		// ExternalTransportOpt needs to be before TracedTransportOpt and
+		// NewCachedTransportOpt since it wants to extract a http.Transport,
+		// not a generic http.RoundTripper.
+		ExternalTransportOpt,
 		TracedTransportOpt,
 		NewCachedTransportOpt(httputil.Cache, true),
 	)

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -155,6 +155,19 @@ func ContextErrorMiddleware(cli Doer) Doer {
 // Common Opts
 //
 
+// ExternalTransportOpt returns an Opt that ensures the http.Client.Transport
+// can contact non-Sourcegraph services. For example Admins can configure
+// TLS/SSL settings.
+func ExternalTransportOpt(cli *http.Client) error {
+	tr, err := getTransportForMutation(cli)
+	if err != nil {
+		return errors.Wrap(err, "httpcli.ExternalTransportOpt")
+	}
+
+	cli.Transport = &externalTransport{base: tr}
+	return nil
+}
+
 // NewCertPoolOpt returns a Opt that sets the RootCAs pool of an http.Client's
 // transport.
 func NewCertPoolOpt(pool *x509.CertPool) Opt {

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -1,0 +1,52 @@
+package httpcli
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type externalTransport struct {
+	base *http.Transport
+
+	mu        sync.RWMutex
+	config    *schema.TlsExternal
+	effective *http.Transport
+}
+
+func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.RLock()
+	config, effective := t.config, t.effective
+	t.mu.RUnlock()
+
+	if current := conf.Get().TlsExternal; current == nil {
+		return t.base.RoundTrip(r)
+	} else if reflect.DeepEqual(config, current) {
+		return effective.RoundTrip(r)
+	}
+
+	effective = t.update()
+	return effective.RoundTrip(r)
+}
+
+func (t *externalTransport) update() *http.Transport {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	config := conf.Get().TlsExternal
+	effective := t.base.Clone()
+
+	if effective.TLSClientConfig == nil {
+		effective.TLSClientConfig = new(tls.Config)
+	}
+
+	effective.TLSClientConfig.InsecureSkipVerify = config.InsecureSkipVerify
+
+	t.config = config
+	t.effective = effective
+	return effective
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -914,6 +914,8 @@ type SiteConfiguration struct {
 	SearchIndexSymbolsEnabled *bool `json:"search.index.symbols.enabled,omitempty"`
 	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.
 	SearchLargeFiles []string `json:"search.largeFiles,omitempty"`
+	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
+	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
 	// UpdateChannel description: The channel on which to automatically check for Sourcegraph updates.
 	UpdateChannel string `json:"update.channel,omitempty"`
 	// UseJaeger description: Use local Jaeger instance for tracing. Kubernetes cluster deployments only.
@@ -930,6 +932,13 @@ type SiteConfiguration struct {
 	// 1. `kubectl port-forward $(kubectl get pods | grep jaeger-query | awk '{ print $1 }') 16686`
 	// 1. Go to http://localhost:16686 to view the Jaeger dashboard.
 	UseJaeger bool `json:"useJaeger,omitempty"`
+}
+
+// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
+type TlsExternal struct {
+	// InsecureSkipVerify description: insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -427,6 +427,18 @@
       "examples": [{ "*": ["myorg1"] }],
       "hide": true
     },
+    "tls.external": {
+      "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "insecureSkipVerify": {
+          "description": "insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.\nIf InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
     "log": {
       "description": "Configuration for logging and alerting, including to external services.",
       "type": "object",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -432,6 +432,18 @@ const SiteSchemaJSON = `{
       "examples": [{ "*": ["myorg1"] }],
       "hide": true
     },
+    "tls.external": {
+      "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "insecureSkipVerify": {
+          "description": "insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.\nIf InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
     "log": {
       "description": "Configuration for logging and alerting, including to external services.",
       "type": "object",


### PR DESCRIPTION
We introduce the site setting `tls.external` which administrators can configure for all external communication. This setting is taken into account by all external service communication as well as remote git commands. Initially we just target `InsecureSkipVerify`, but a follow up PR will implement RootCAs.

Best reviewed commit by commit.

Meta: This approach could be extended for supporting http proxies. Should we rename the site setting to `https.external` maybe?

Follow-up PRs:
- Support TLS certifications
- Updating documentation