### PR TITLE
Change signature of CreateChangeset to return err last

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -334,7 +334,7 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 
 			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
 
-			err, exists := bbsSrc.CreateChangeset(ctx, tc.cs)
+			exists, err := bbsSrc.CreateChangeset(ctx, tc.cs)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -148,8 +148,10 @@ func (s GithubSource) ExternalServices() ExternalServices {
 	return ExternalServices{s.svc}
 }
 
+var _ ChangesetSource = GithubSource{}
+
 // CreateChangeset creates the given *Changeset in the code host.
-func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (error, bool) {
+func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error) {
 	var exists bool
 	repo := c.Repo.Metadata.(*github.Repository)
 
@@ -163,15 +165,15 @@ func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (error,
 
 	if err != nil {
 		if err != github.ErrPullRequestAlreadyExists {
-			return err, exists
+			return exists, err
 		}
 		owner, name, err := github.SplitRepositoryNameWithOwner(repo.NameWithOwner)
 		if err != nil {
-			return errors.Wrap(err, "getting repo owner and name"), exists
+			return exists, errors.Wrap(err, "getting repo owner and name")
 		}
 		pr, err = s.client.GetOpenPullRequestByRefs(ctx, owner, name, c.BaseRef, c.HeadRef)
 		if err != nil {
-			return errors.Wrap(err, "fetching existing PR"), exists
+			return exists, errors.Wrap(err, "fetching existing PR")
 		}
 		exists = true
 	}
@@ -180,7 +182,7 @@ func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (error,
 	c.Changeset.ExternalID = strconv.FormatInt(pr.Number, 10)
 	c.Changeset.ExternalServiceType = github.ServiceType
 
-	return nil, exists
+	return exists, nil
 }
 
 // CloseChangeset closes the given *Changeset on the code host and updates the

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -106,7 +106,7 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			err, exists := githubSrc.CreateChangeset(ctx, tc.cs)
+			exists, err := githubSrc.CreateChangeset(ctx, tc.cs)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -94,9 +94,9 @@ type ChangesetSource interface {
 	// the returned slice.
 	LoadChangesets(context.Context, ...*Changeset) error
 	// CreateChangeset will create the Changeset on the source. If it already
-	// exists, *Changeset will be populated and the second return value will be
+	// exists, *Changeset will be populated and the return value will be
 	// true.
-	CreateChangeset(context.Context, *Changeset) (error, bool)
+	CreateChangeset(context.Context, *Changeset) (bool, error)
 	// CloseChangeset will close the Changeset on the source, where "close"
 	// means the appropriate final state on the codehost (e.g. "declined" on
 	// Bitbucket Server).

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -420,7 +420,7 @@ func (s *Service) RunChangesetJob(
 	// TODO: If we're updating the changeset, there's a race condition here.
 	// It's possible that `CreateChangeset` doesn't return the newest head ref
 	// commit yet, because the API of the codehost doesn't return it yet.
-	err, exists := ccs.CreateChangeset(ctx, &cs)
+	exists, err := ccs.CreateChangeset(ctx, &cs)
 	if err != nil {
 		return errors.Wrap(err, "creating changeset")
 	}


### PR DESCRIPTION
This is a follow-up to #7328 and changes the signature of the
`CreateChangeset` method according to @tsenart's suggestions.

I'm going to leave the `CreateChangeset` method as it is right now,
instead of turning it into an `UpsertChangeset` method, since we don't
have BitbucketServer support yet and I'm not sure the interface would be
better.