### PR TITLE
a8n: Make fast path in UpdateCampaign faster by only talking to database

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -783,6 +783,12 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		return nil, ErrUpdateProcessingCampaign
 	}
 
+	// Fast path: if we don't update the CampaignPlan, we don't need to rewire
+	// ChangesetJobs, but only update name/description if they changed.
+	if !updatePlanID && updateAttributes {
+		return campaign, tx.ResetChangesetJobs(ctx, campaign.ID)
+	}
+
 	diff, err := computeCampaignUpdateDiff(ctx, tx, campaign, oldPlanID, updateAttributes)
 	if err != nil {
 		return nil, err
@@ -862,18 +868,6 @@ func computeCampaignUpdateDiff(
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "listing changesets jobs")
-	}
-
-	// Fast path: if we don't update the CampaignPlan, we don't need to rewire
-	// ChangesetJobs, but only update name/description if they changed.
-	if campaign.CampaignPlanID == oldPlanID && updateAttributes {
-		for _, job := range changesetJobs {
-			job.Error = ""
-			job.StartedAt = time.Time{}
-			job.FinishedAt = time.Time{}
-			diff.Update = append(diff.Update, job)
-		}
-		return diff, nil
 	}
 
 	// We need OnlyFinished and OnlyWithDiff because we don't create


### PR DESCRIPTION
This is a little refactoring follow-up to #7328 and changes the `UpdateCampaign` code to be a bit more efficient.

If we only need to update the title/description of the existing changesets, we can simply reset the ChangesetJobs in the DB with a single query instead of first loading them into memory and them updating them individually.