### PR TITLE
dev: do not specify separate critical config file, only site config

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# set to true if unset so set -u won't break us
-: ${SOURCEGRAPH_COMBINE_CONFIG:=false}
-
 set -euf -o pipefail
 
 unset CDPATH
@@ -73,7 +70,6 @@ export GRAFANA_SERVER_URL=http://localhost:3370
 export SRC_HTTP_ADDR=":3082"
 export WEBPACK_DEV_SERVER=1
 
-export CRITICAL_CONFIG_FILE=${CRITICAL_CONFIG_FILE:-./dev/critical-config.json}
 export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-./dev/site-config.json}
 export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-./dev/global-settings.json}
 export SITE_CONFIG_ALLOW_EDITS=true

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -10,15 +10,22 @@ if [ ! -d "$DEV_PRIVATE_PATH" ]; then
     exit 1
 fi
 
+# Warn if dev-private needs to be updated.
+if [ -f "$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json" ]; then
+    echo "Error: You need to update dev-private to a commit that incorporates https://github.com/sourcegraph/dev-private/pull/10."
+    echo
+    echo "Try running:"
+    echo
+    echo "    cd $DEV_PRIVATE_PATH && git pull"
+    echo
+    exit 1
+fi
+
 echo "Installing enterprise web dependencies..."
 [ -n "${OFFLINE-}" ] || yarn --check-files
 
 source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 
-# set to true if unset so set -u won't break us
-: ${SOURCEGRAPH_COMBINE_CONFIG:=false}
-
-export CRITICAL_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json
 export SITE_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json
 export EXTSVC_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json
 export GLOBAL_SETTINGS_FILE=$PWD/../dev/global-settings.json


### PR DESCRIPTION
Now that https://github.com/sourcegraph/sourcegraph/pull/7197 was merged (removing the management console and merging site config and critical config), it is not necessary to have separate files for site config and critical config.

After this PR is merged, anyone running `enterprise/dev/start.sh` will be notified to update dev-private to a commit that incorporates https://github.com/sourcegraph/dev-private/pull/10 (which removes the dev-private critical-config.json file).