### PR TITLE
Add MonacoQueryInput: search field with syntax highlighting, hovers, diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Experimental: the search query input now provides syntax highlighting, hover tooltips, and diagnostics on filters in search queries. Requires the global settings value `{ "experimentalFeatures": { "smartSearchField": true } }`.
+
 ### Changed
 
 ### Fixed

--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,6 +1,7 @@
 {
   // This is set from an environment variable
   "experimentalFeatures": {
-    "splitSearchModes": true
+    "splitSearchModes": true,
+    "smartSearchField": true
   }
 }

--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,7 +1,6 @@
 {
   // This is set from an environment variable
   "experimentalFeatures": {
-    "splitSearchModes": true,
-    "smartSearchField": true
+    "splitSearchModes": true
   }
 }

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -29,7 +29,7 @@ const config = {
     // monaco-editor uses the "module" field in package.json, which isn't supported by Jest
     // https://github.com/facebook/jest/issues/2702
     // https://github.com/Microsoft/monaco-editor/issues/996
-    '^monaco-editor': '<rootDir>/../node_modules/monaco-editor/esm/vs/editor/editor.main.js'
+    '^monaco-editor': '<rootDir>/../node_modules/monaco-editor/esm/vs/editor/editor.main.js',
   },
 
   // By default, don't clutter `yarn test --watch` output with the full coverage table. To see it, use the

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -20,10 +20,17 @@ const config = {
   // https://github.com/facebook/create-react-app/issues/5241#issuecomment-426269242 for more information on why
   // this is necessary.
   transformIgnorePatterns: [
-    '/node_modules/(?!abortable-rx|@sourcegraph/react-loading-spinner|@sourcegraph/codeintellify|@sourcegraph/comlink)',
+    '/node_modules/(?!abortable-rx|@sourcegraph/react-loading-spinner|@sourcegraph/codeintellify|@sourcegraph/comlink|monaco-editor)',
   ],
 
-  moduleNameMapper: { '\\.s?css$': 'identity-obj-proxy', '^worker-loader': 'identity-obj-proxy' },
+  moduleNameMapper: {
+    '\\.s?css$': 'identity-obj-proxy',
+    '^worker-loader': 'identity-obj-proxy',
+    // monaco-editor uses the "module" field in package.json, which isn't supported by Jest
+    // https://github.com/facebook/jest/issues/2702
+    // https://github.com/Microsoft/monaco-editor/issues/996
+    '^monaco-editor': '<rootDir>/../node_modules/monaco-editor/esm/vs/editor/editor.main.js'
+  },
 
   // By default, don't clutter `yarn test --watch` output with the full coverage table. To see it, use the
   // `--coverageReporters text` jest option.

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/reactstrap": "8.2.0",
     "@types/recharts": "1.8.4",
+    "@types/resize-observer-browser": "^0.1.3",
     "@types/sanitize-html": "1.18.3",
     "@types/semver": "6.2.0",
     "@types/shelljs": "0.8.6",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -820,6 +820,8 @@ type SettingsExperimentalFeatures struct {
 	SearchStats *bool `json:"searchStats,omitempty"`
 	// ShowBadgeAttachments description: Enables the UI indicators for code intelligence precision.
 	ShowBadgeAttachments *bool `json:"showBadgeAttachments,omitempty"`
+	// SmartSearchField description: Enables displaying a search field that provides syntax highlighting, hover tooltips and diagnostics for search queries.
+	SmartSearchField *bool `json:"smartSearchField,omitempty"`
 	// SplitSearchModes description: Enables toggling between the current omni search mode, and experimental interactive search mode.
 	SplitSearchModes *bool `json:"splitSearchModes,omitempty"`
 }

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -29,6 +29,12 @@
           "type": "boolean",
           "default": true,
           "!go": { "pointer": true }
+        },
+        "smartSearchField": {
+          "description": "Enables displaying a search field that provides syntax highlighting, hover tooltips and diagnostics for search queries.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -34,6 +34,12 @@ const SettingsSchemaJSON = `{
           "type": "boolean",
           "default": true,
           "!go": { "pointer": true }
+        },
+        "smartSearchField": {
+          "description": "Enables displaying a search field that provides syntax highlighting, hover tooltips and diagnostics for search queries.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/shared/dev/jest-environment.js
+++ b/shared/dev/jest-environment.js
@@ -30,6 +30,10 @@ class JSDOMEnvironment {
       ...config.testEnvironmentOptions,
     })
     const global = (this.global = this.dom.window.document.defaultView)
+    // jsdom doesn't support document.queryCommandSupported(), needed for monaco-editor.
+    // https://github.com/testing-library/react-testing-library/issues/546
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    this.dom.window.document.queryCommandSupported = () => false
     if (!global) {
       throw new Error('JSDOM did not return a Window object')
     }

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -31,7 +31,7 @@ import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevContainerRoute } from './repo/RepoRevContainer'
 import { LayoutRouteProps } from './routes'
-import { parseSearchURLQuery, PatternTypeProps, InteractiveSearchProps, CaseSensitivityProps } from './search'
+import { parseSearchURLQuery, PatternTypeProps, InteractiveSearchProps, CaseSensitivityProps, SmartSearchFieldProps } from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { EventLogger, EventLoggerProps } from './tracking/eventLogger'
@@ -61,7 +61,8 @@ export interface LayoutProps
         ActivationProps,
         PatternTypeProps,
         CaseSensitivityProps,
-        InteractiveSearchProps {
+        InteractiveSearchProps,
+        SmartSearchFieldProps {
     exploreSections: readonly ExploreSectionDescriptor[]
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
     extensionAreaHeaderNavItems: readonly ExtensionAreaHeaderNavItem[]

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -31,7 +31,13 @@ import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevContainerRoute } from './repo/RepoRevContainer'
 import { LayoutRouteProps } from './routes'
-import { parseSearchURLQuery, PatternTypeProps, InteractiveSearchProps, CaseSensitivityProps, SmartSearchFieldProps } from './search'
+import {
+    parseSearchURLQuery,
+    PatternTypeProps,
+    InteractiveSearchProps,
+    CaseSensitivityProps,
+    SmartSearchFieldProps,
+} from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { EventLogger, EventLoggerProps } from './tracking/eventLogger'

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -131,6 +131,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      * Whether to display the option to toggle between interactive and omni search modes.
      */
     splitSearchModes: boolean
+
+    /**
+     * Whether to display the MonacoQueryInput search field.
+     */
+    smartSearchField: boolean
 }
 
 const LIGHT_THEME_LOCAL_STORAGE_KEY = 'light-theme'
@@ -195,6 +200,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             filtersInQuery: {},
             splitSearchModes: false,
             interactiveSearchMode: currentSearchMode ? currentSearchMode === 'interactive' : false,
+            smartSearchField: false,
         }
     }
 
@@ -256,12 +262,10 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
 
         this.subscriptions.add(
             from(this.platformContext.settings).subscribe(settingsCascade => {
-                const splitSearchModes =
-                    settingsCascade.final &&
-                    !isErrorLike(settingsCascade.final) &&
-                    settingsCascade.final.experimentalFeatures?.splitSearchModes
-
-                this.setState({ splitSearchModes })
+                if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
+                    const { splitSearchModes, smartSearchField } = settingsCascade.final.experimentalFeatures || {}
+                    this.setState({ splitSearchModes, smartSearchField })
+                }
             })
         )
 
@@ -374,6 +378,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     onFiltersInQueryChange={this.onFiltersInQueryChange}
                                     setPatternType={this.setPatternType}
                                     setCaseSensitivity={this.setCaseSensitivity}
+                                    smartSearchField={this.state.smartSearchField}
                                 />
                             )}
                         />

--- a/web/src/components/MonacoEditor.tsx
+++ b/web/src/components/MonacoEditor.tsx
@@ -23,9 +23,17 @@ interface Props {
     /** Called when the editor has mounted. */
     editorWillMount: (editor: typeof monaco) => void
 
+    /** Called when a standalone code editor has been created with the given props */
+    onEditorCreated?: (editor: monaco.editor.IStandaloneCodeEditor) => void
+
     /** Options for the editor. */
     options: monaco.editor.IEditorOptions
+
+    /** An optional className to add to the editor. */
     className?: string
+
+    /** Whether to add a border to the Monaco editor. Default: true. */
+    border?: boolean
 }
 
 interface State {}
@@ -37,14 +45,17 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         if (!e) {
             return
         }
-
         this.props.editorWillMount(monaco)
-        this.editor = monaco.editor.create(e, {
+        const editor = monaco.editor.create(e, {
             value: this.props.value,
             language: this.props.language,
             theme: this.props.theme,
             ...this.props.options,
         })
+        if (this.props.onEditorCreated) {
+            this.props.onEditorCreated(editor)
+        }
+        this.editor = editor
     }
 
     public componentDidUpdate(prevProps: Props): void {
@@ -71,7 +82,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                 style={{ height: `${this.props.height}px`, position: 'relative' }}
                 ref={this.setRef}
                 id={this.props.id}
-                className={classNames(this.props.className, 'border')}
+                className={classNames(this.props.className, this.props.border !== false && 'border')}
             />
         )
     }

--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -34,6 +34,7 @@ const PROPS: GlobalNavbar['props'] = {
     interactiveSearchMode: false,
     toggleSearchMode: () => undefined,
     onFiltersInQueryChange: () => undefined,
+    smartSearchField: false,
 }
 
 describe('GlobalNavbar', () => {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -7,7 +7,13 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { authRequired } from '../auth'
-import { parseSearchURLQuery, PatternTypeProps, InteractiveSearchProps, CaseSensitivityProps } from '../search'
+import {
+    parseSearchURLQuery,
+    PatternTypeProps,
+    InteractiveSearchProps,
+    CaseSensitivityProps,
+    SmartSearchFieldProps,
+} from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { EventLoggerProps } from '../tracking/eventLogger'
 import { showDotComMarketing } from '../util/features'
@@ -32,7 +38,8 @@ interface Props
         ActivationProps,
         PatternTypeProps,
         CaseSensitivityProps,
-        InteractiveSearchProps {
+        InteractiveSearchProps,
+        SmartSearchFieldProps {
     history: H.History
     location: H.Location<{ query: string }>
     authenticatedUser: GQL.IUser | null
@@ -180,6 +187,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                                             {...this.props}
                                             navbarSearchState={this.props.navbarSearchQueryState}
                                             onChange={this.props.onNavbarQueryChange}
+                                            smartSearchField={this.props.smartSearchField}
                                         />
                                     </div>
                                 )}

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -121,3 +121,7 @@ export interface InteractiveSearchProps {
     interactiveSearchMode: boolean
     toggleSearchMode: (event: React.MouseEvent<HTMLAnchorElement>) => void
 }
+
+export interface SmartSearchFieldProps {
+    smartSearchField: boolean
+}

--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -1,0 +1,19 @@
+import React, { Suspense } from 'react'
+import { MonacoQueryInputProps } from './MonacoQueryInput'
+import { lazyComponent } from '../../util/lazyComponent'
+
+const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'MonacoQueryInput')
+
+const ReadonlyQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({ queryState }) =>
+    <div className="query-input2">
+        <input type="text" readOnly={true} className="form-control query-input2__input e2e-query-input" value={queryState.query}/>
+    </div>
+
+/**
+ * A lazily-loaded {@link MonacoQueryInput}, displaying a read-only query field as a fallback during loading.
+ */
+export const LazyMonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = props => (
+    <Suspense fallback={<ReadonlyQueryInput {...props}/>}>
+        <MonacoQueryInput {...props}></MonacoQueryInput>
+    </Suspense>
+)

--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -4,16 +4,22 @@ import { lazyComponent } from '../../util/lazyComponent'
 
 const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'MonacoQueryInput')
 
-const ReadonlyQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({ queryState }) =>
+const ReadonlyQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({ queryState }) => (
     <div className="query-input2">
-        <input type="text" readOnly={true} className="form-control query-input2__input e2e-query-input" value={queryState.query}/>
+        <input
+            type="text"
+            readOnly={true}
+            className="form-control query-input2__input e2e-query-input"
+            value={queryState.query}
+        />
     </div>
+)
 
 /**
  * A lazily-loaded {@link MonacoQueryInput}, displaying a read-only query field as a fallback during loading.
  */
 export const LazyMonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = props => (
-    <Suspense fallback={<ReadonlyQueryInput {...props}/>}>
+    <Suspense fallback={<ReadonlyQueryInput {...props} />}>
         <MonacoQueryInput {...props}></MonacoQueryInput>
     </Suspense>
 )

--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -1,0 +1,30 @@
+.monaco-query-input-container {
+    position: relative;
+    border: 1px solid $input-border-color;
+    box-sizing: border-box;
+    &:focus-within {
+        border: 1px solid $input-focus-border-color;
+        box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
+    }
+    .monaco-editor {
+        .decorationsOverviewRuler {
+            display: none;
+        }
+        .view-overlays {
+            .current-line {
+                border: none;
+            }
+        }
+        .view-lines {
+            border: none;
+        }
+        .monaco-editor-background {
+            width: 100% !important;
+        }
+        .monaco-editor-hover-content {
+            .status-bar {
+                display: none;
+            }
+        }
+    }
+}

--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -6,6 +6,13 @@
         border: 1px solid $input-focus-border-color;
         box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
     }
+
+    &__regexp-toggle {
+        position: absolute;
+        right: 0.25rem;
+        top: 0.25rem;
+    }
+
     .monaco-editor {
         // stylelint-disable-next-line selector-class-pattern
         .decorationsOverviewRuler {

--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -7,6 +7,7 @@
         box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
     }
     .monaco-editor {
+        // stylelint-disable-next-line selector-class-pattern
         .decorationsOverviewRuler {
             display: none;
         }

--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -7,10 +7,11 @@
         box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
     }
 
-    &__regexp-toggle {
+    &__toggles {
         position: absolute;
         right: 0.25rem;
         top: 0.25rem;
+        display: flex;
     }
 
     .monaco-editor {

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -1,0 +1,249 @@
+import React from 'react'
+import * as Monaco from 'monaco-editor'
+import { MonacoEditor } from '../../components/MonacoEditor'
+import { QueryState } from '../helpers'
+import { getProviders } from '../parser/providers'
+import { Subscription, Observable, Subject, Unsubscribable } from 'rxjs'
+import { fetchSuggestions } from '../backend'
+import { toArray, map, distinctUntilChanged, publishReplay, refCount } from 'rxjs/operators'
+import { RegexpToggle, RegexpToggleProps } from './RegexpToggle'
+import { Omit } from 'utility-types'
+import { ThemeProps } from '../../../../shared/src/theme'
+
+export interface MonacoQueryInputProps extends Omit<RegexpToggleProps, 'navbarSearchQuery'>, ThemeProps {
+    queryState: QueryState
+    onChange: (newState: QueryState) => void
+    onSubmit: () => void
+    autoFocus?: boolean
+}
+
+const SOURCEGRAPH_SEARCH: 'sourcegraphSearch' = 'sourcegraphSearch'
+
+type Theme = 'sourcegraph-dark' | 'sourcegraph-light'
+
+/**
+ * Maps a Monaco IDisposable to an rxjs Unsubscribable.
+ */
+const toUnsubscribable = (disposable: Monaco.IDisposable): Unsubscribable => ({
+    unsubscribe: () => disposable.dispose(),
+})
+
+/**
+ * Adds code intelligence for the Sourcegraph search syntax to Monaco.
+ *
+ * @returns Subscription
+ */
+function addSouregraphSearchCodeIntelligence(
+    monaco: typeof Monaco,
+    searchQueries: Observable<string>,
+    themeChanges: Observable<Theme>
+): Subscription {
+    const subscriptions = new Subscription()
+
+    // Register language ID
+    monaco.languages.register({ id: SOURCEGRAPH_SEARCH })
+
+    // Register themes and handle theme change
+    monaco.editor.defineTheme('sourcegraph-dark', {
+        base: 'vs-dark',
+        inherit: true,
+        colors: {
+            'editor.background': '#0E121B',
+            'editor.foreground': '#ffffff',
+            'editorCursor.foreground': '#ffffff',
+            'editor.selectionBackground': '#1C7CD650',
+            'editor.selectionHighlightBackground': '#1C7CD625',
+            'editor.inactiveSelectionBackground': '#1C7CD625',
+            'editorSuggestWidget.background': '#1c2736',
+            'editorSuggestWidget.foreground': '#F2F4F8',
+            'editorSuggestWidget.border': '#2b3750',
+            'editorHoverWidget.background': '#1c2736',
+            'editorHoverWidget.foreground': '#F2F4F8',
+            'editorHoverWidget.border': '#2b3750',
+        },
+        rules: [],
+    })
+    monaco.editor.defineTheme('sourcegraph-light', {
+        base: 'vs',
+        inherit: true,
+        colors: {
+            'editor.background': '#ffffff',
+            'editor.foreground': '#2b3750',
+            'editorCursor.foreground': '#2b3750',
+            'editor.selectionBackground': '#1C7CD650',
+            'editor.selectionHighlightBackground': '#1C7CD625',
+            'editor.inactiveSelectionBackground': '#1C7CD625',
+            'editorSuggestWidget.background': '#ffffff',
+            'editorSuggestWidget.foreground': '#2b3750',
+            'editorSuggestWidget.border': '#cad2e2',
+            'editorHoverWidget.background': '#ffffff',
+            'editorHoverWidget.foreground': '#2b3750',
+            'editorHoverWidget.border': '#cad2e2',
+        },
+        rules: [],
+    })
+    subscriptions.add(
+        themeChanges.subscribe(theme => {
+            monaco.editor.setTheme(theme)
+        })
+    )
+
+    // Register providers
+    const providers = getProviders(searchQueries, (query: string) => fetchSuggestions(query).pipe(toArray()))
+    subscriptions.add(toUnsubscribable(monaco.languages.setTokensProvider(SOURCEGRAPH_SEARCH, providers.tokens)))
+    subscriptions.add(toUnsubscribable(monaco.languages.registerHoverProvider(SOURCEGRAPH_SEARCH, providers.hover)))
+    subscriptions.add(
+        toUnsubscribable(monaco.languages.registerCompletionItemProvider(SOURCEGRAPH_SEARCH, providers.completion))
+    )
+    subscriptions.add(
+        providers.diagnostics.subscribe(markers => {
+            monaco.editor.setModelMarkers(monaco.editor.getModels()[0], 'diagnostics', markers)
+        })
+    )
+
+    return subscriptions
+}
+
+/**
+ * A search query input backed by the Monaco editor, allowing it to provide
+ * syntax highlighting, hovers, completions and diagnostics for search queries.
+ */
+export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps> {
+    private componentUpdates = new Subject<MonacoQueryInputProps>()
+    private searchQueries = this.componentUpdates.pipe(
+        map(({ queryState }) => queryState.query),
+        distinctUntilChanged(),
+        publishReplay(1),
+        refCount()
+    )
+    private themeChanges = this.componentUpdates.pipe(
+        map(({ isLightTheme }): Theme => (isLightTheme ? 'sourcegraph-light' : 'sourcegraph-dark')),
+        distinctUntilChanged(),
+        publishReplay(1),
+        refCount()
+    )
+    private containerRef: HTMLElement | null = null
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        this.componentUpdates.next(this.props)
+    }
+
+    public componentDidUpdate(): void {
+        this.componentUpdates.next(this.props)
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element {
+        const options: Monaco.editor.IEditorOptions = {
+            readOnly: false,
+            lineNumbers: 'off',
+            lineHeight: 32,
+            minimap: {
+                enabled: false,
+            },
+            scrollbar: {
+                vertical: 'hidden',
+                horizontal: 'hidden',
+            },
+            glyphMargin: false,
+            lineDecorationsWidth: 0,
+            lineNumbersMinChars: 0,
+            overviewRulerBorder: false,
+            folding: false,
+            rulers: [],
+            overviewRulerLanes: 0,
+            wordBasedSuggestions: false,
+            quickSuggestions: false,
+            fixedOverflowWidgets: true,
+            contextmenu: false,
+        }
+        return (
+            <div ref={this.setContainerRef} className="monaco-query-input-container flex-1">
+                <MonacoEditor
+                    id="monaco-query-input"
+                    language={SOURCEGRAPH_SEARCH}
+                    value={this.props.queryState.query}
+                    height={34}
+                    theme="sourcegraph-dark"
+                    editorWillMount={this.editorWillMount}
+                    onEditorCreated={this.onEditorCreated}
+                    options={options}
+                    border={false}
+                ></MonacoEditor>
+                <RegexpToggle {...this.props} navbarSearchQuery={this.props.queryState.query}></RegexpToggle>
+            </div>
+        )
+    }
+
+    private setContainerRef = (ref: HTMLElement | null): void => {
+        this.containerRef = ref
+    }
+
+    private onChange = (query: string): void => {
+        // Cursor position is irrelevant for the Monaco query input.
+        this.props.onChange({ query, cursorPosition: 0 })
+    }
+
+    private onSubmit = (): void => {
+        this.props.onSubmit()
+    }
+
+    private editorWillMount = (monaco: typeof Monaco): void => {
+        // Register themes and code intelligence providers.
+        this.subscriptions.add(addSouregraphSearchCodeIntelligence(monaco, this.searchQueries, this.themeChanges))
+    }
+
+    private onEditorCreated = (editor: Monaco.editor.IStandaloneCodeEditor): void => {
+        // Focus the editor by default, with cursor at end.
+        editor.focus()
+        editor.setPosition({
+            column: editor.getValue().length + 2,
+            lineNumber: 1,
+        })
+        // Prevent newline insertion in model, and surface query changes with stripped newlines.
+        this.subscriptions.add(
+            toUnsubscribable(
+                editor.onDidChangeModelContent(() => {
+                    this.onChange(editor.getValue().replace(/[\n\r↵]/g, ''))
+                })
+            )
+        )
+
+        // Submit on enter when not showing suggestions.
+        this.subscriptions.add(
+            toUnsubscribable(
+                editor.addAction({
+                    id: 'submitOnEnter',
+                    label: 'submitOnEnter',
+                    keybindings: [Monaco.KeyCode.Enter],
+                    precondition: '!suggestWidgetVisible',
+                    run: () => {
+                        this.onSubmit()
+                    },
+                })
+            )
+        )
+        // Prevent inserting newlines.
+        this.subscriptions.add(
+            toUnsubscribable(
+                editor.onKeyDown(e => {
+                    if (e.keyCode === Monaco.KeyCode.Enter) {
+                        e.preventDefault()
+                    }
+                })
+            )
+        )
+        // Trigger a layout of the Monaco editor when its container gets resized.
+        if (this.containerRef) {
+            const resizeObserver = new ResizeObserver(() => {
+                editor.layout()
+            })
+            resizeObserver.observe(this.containerRef)
+            this.subscriptions.add(() => resizeObserver.disconnect())
+        }
+    }
+}

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -107,6 +107,9 @@ function addSouregraphSearchCodeIntelligence(
 /**
  * A search query input backed by the Monaco editor, allowing it to provide
  * syntax highlighting, hovers, completions and diagnostics for search queries.
+ * 
+ * This component should not be imported directly: use {@link LazyMonacoQueryInput} instead
+ * to avoid bundling the Monaco editor on every page.
  */
 export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps> {
     private componentUpdates = new Subject<MonacoQueryInputProps>()

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -245,6 +245,8 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
             )
         )
         // Trigger a layout of the Monaco editor when its container gets resized.
+        // The Monaco editor doesn't auto-resize with its container:
+        // https://github.com/microsoft/monaco-editor/issues/28
         if (this.containerRef) {
             const resizeObserver = new ResizeObserver(() => {
                 editor.layout()

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -107,7 +107,7 @@ function addSouregraphSearchCodeIntelligence(
 /**
  * A search query input backed by the Monaco editor, allowing it to provide
  * syntax highlighting, hovers, completions and diagnostics for search queries.
- * 
+ *
  * This component should not be imported directly: use {@link LazyMonacoQueryInput} instead
  * to avoid bundling the Monaco editor on every page.
  */

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -177,7 +177,11 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
                     options={options}
                     border={false}
                 ></MonacoEditor>
-                <RegexpToggle {...this.props} navbarSearchQuery={this.props.queryState.query}></RegexpToggle>
+                <RegexpToggle
+                    {...this.props}
+                    navbarSearchQuery={this.props.queryState.query}
+                    className="monaco-query-input-container__regexp-toggle"
+                ></RegexpToggle>
             </div>
         )
     }

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -208,6 +208,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
         // Focus the editor by default, with cursor at end.
         editor.focus()
         editor.setPosition({
+            // +2 as Monaco is 1-indexed, and the cursor should be placed after the query.
             column: editor.getValue().length + 2,
             lineNumber: 1,
         })

--- a/web/src/search/input/RegexpToggle.tsx
+++ b/web/src/search/input/RegexpToggle.tsx
@@ -8,7 +8,7 @@ import { filter } from 'rxjs/operators'
 import { PatternTypeProps, CaseSensitivityProps } from '..'
 import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
 
-interface RegexpToggleProps extends PatternTypeProps, CaseSensitivityProps {
+export interface RegexpToggleProps extends PatternTypeProps, CaseSensitivityProps {
     navbarSearchQuery: string
     history: H.History
     filtersInQuery?: FiltersToTypeAndValue

--- a/web/src/search/input/RegexpToggle.tsx
+++ b/web/src/search/input/RegexpToggle.tsx
@@ -48,7 +48,10 @@ export class RegexpToggle extends React.Component<RegexpToggleProps> {
             <div
                 ref={this.toggleCheckbox}
                 onClick={this.toggle}
-                className={classNames('btn btn-icon icon-inline query-input2__toggle e2e-regexp-toggle', this.props.className)}
+                className={classNames(
+                    'btn btn-icon icon-inline query-input2__toggle e2e-regexp-toggle',
+                    this.props.className
+                )}
                 role="checkbox"
                 aria-checked={isRegexp}
                 aria-label="Regular expression toggle"

--- a/web/src/search/input/RegexpToggle.tsx
+++ b/web/src/search/input/RegexpToggle.tsx
@@ -7,12 +7,14 @@ import { Subscription, fromEvent } from 'rxjs'
 import { filter } from 'rxjs/operators'
 import { PatternTypeProps, CaseSensitivityProps } from '..'
 import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
+import classNames from 'classnames'
 
 export interface RegexpToggleProps extends PatternTypeProps, CaseSensitivityProps {
     navbarSearchQuery: string
     history: H.History
     filtersInQuery?: FiltersToTypeAndValue
     hasGlobalQueryBehavior?: boolean
+    className?: string
 }
 
 export class RegexpToggle extends React.Component<RegexpToggleProps> {
@@ -46,7 +48,7 @@ export class RegexpToggle extends React.Component<RegexpToggleProps> {
             <div
                 ref={this.toggleCheckbox}
                 onClick={this.toggle}
-                className="btn btn-icon icon-inline query-input2__toggle e2e-regexp-toggle"
+                className={classNames('btn btn-icon icon-inline query-input2__toggle e2e-regexp-toggle', this.props.className)}
                 role="checkbox"
                 aria-checked={isRegexp}
                 aria-label="Regular expression toggle"

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -5,7 +5,7 @@ import { Form } from '../../components/Form'
 import { submitSearch, QueryState } from '../helpers'
 import { SearchButton } from './SearchButton'
 import { PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '..'
-import { MonacoQueryInput } from './MonacoQueryInput'
+import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { QueryInput } from './QueryInput'
 import { ThemeProps } from '../../../../shared/src/theme'
 
@@ -37,12 +37,12 @@ export class SearchNavbarItem extends React.PureComponent<Props> {
                 onSubmit={this.onFormSubmit}
             >
                 {this.props.smartSearchField ? (
-                    <MonacoQueryInput
+                    <LazyMonacoQueryInput
                         {...this.props}
                         hasGlobalQueryBehavior={true}
                         queryState={this.props.navbarSearchState}
                         onSubmit={this.onSubmit}
-                    ></MonacoQueryInput>
+                    ></LazyMonacoQueryInput>
                 ) : (
                     <QueryInput
                         {...this.props}

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -42,6 +42,7 @@ export class SearchNavbarItem extends React.PureComponent<Props> {
                         hasGlobalQueryBehavior={true}
                         queryState={this.props.navbarSearchState}
                         onSubmit={this.onSubmit}
+                        autoFocus={true}
                     ></LazyMonacoQueryInput>
                 ) : (
                     <QueryInput

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -1,13 +1,15 @@
 import * as H from 'history'
-import React, { useCallback } from 'react'
+import React from 'react'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import { Form } from '../../components/Form'
 import { submitSearch, QueryState } from '../helpers'
-import { QueryInput } from './QueryInput'
 import { SearchButton } from './SearchButton'
-import { PatternTypeProps, CaseSensitivityProps } from '..'
+import { PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '..'
+import { MonacoQueryInput } from './MonacoQueryInput'
+import { QueryInput } from './QueryInput'
+import { ThemeProps } from '../../../../shared/src/theme'
 
-interface Props extends ActivationProps, PatternTypeProps, CaseSensitivityProps {
+interface Props extends ActivationProps, PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps, ThemeProps {
     location: H.Location
     history: H.History
     navbarSearchState: QueryState
@@ -17,45 +19,40 @@ interface Props extends ActivationProps, PatternTypeProps, CaseSensitivityProps 
 /**
  * The search item in the navbar
  */
-export const SearchNavbarItem: React.FunctionComponent<Props> = ({
-    navbarSearchState,
-    onChange,
-    activation,
-    location,
-    history,
-    patternType,
-    caseSensitive,
-    setCaseSensitivity,
-    setPatternType,
-}) => {
-    // Only autofocus the query input on search result pages (otherwise we
-    // capture down-arrow keypresses that the user probably intends to scroll down
-    // in the page).
-    const autoFocus = location.pathname === '/search'
+export class SearchNavbarItem extends React.PureComponent<Props> {
+    private onSubmit = (): void => {
+        const { history, navbarSearchState, patternType, activation, caseSensitive } = this.props
+        submitSearch(history, navbarSearchState.query, 'nav', patternType, caseSensitive, activation)
+    }
 
-    const onSubmit = useCallback(
-        (e: React.FormEvent<HTMLFormElement>): void => {
-            e.preventDefault()
-            submitSearch(history, navbarSearchState.query, 'nav', patternType, caseSensitive, activation)
-        },
-        [history, navbarSearchState.query, patternType, caseSensitive, activation]
-    )
+    private onFormSubmit = (e: React.FormEvent): void => {
+        e.preventDefault()
+        this.onSubmit()
+    }
 
-    return (
-        <Form className="search search--navbar-item d-flex align-items-start flex-grow-1" onSubmit={onSubmit}>
-            <QueryInput
-                value={navbarSearchState}
-                onChange={onChange}
-                autoFocus={autoFocus ? 'cursor-at-end' : undefined}
-                hasGlobalQueryBehavior={true}
-                location={location}
-                history={history}
-                patternType={patternType}
-                setPatternType={setPatternType}
-                caseSensitive={caseSensitive}
-                setCaseSensitivity={setCaseSensitivity}
-            />
-            <SearchButton />
-        </Form>
-    )
+    public render(): React.ReactNode {
+        return (
+            <Form
+                className="search search--navbar-item d-flex align-items-start flex-grow-1"
+                onSubmit={this.onFormSubmit}
+            >
+                {this.props.smartSearchField ? (
+                    <MonacoQueryInput
+                        {...this.props}
+                        hasGlobalQueryBehavior={true}
+                        queryState={this.props.navbarSearchState}
+                        onSubmit={this.onSubmit}
+                    ></MonacoQueryInput>
+                ) : (
+                    <QueryInput
+                        {...this.props}
+                        value={this.props.navbarSearchState}
+                        autoFocus={this.props.location.pathname === '/search' ? 'cursor-at-end' : undefined}
+                        hasGlobalQueryBehavior={true}
+                    ></QueryInput>
+                )}
+                <SearchButton />
+            </Form>
+        )
+    }
 }

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -2,6 +2,7 @@
 @import '../QuickLinks';
 @import './SearchScopes';
 @import './QueryInput';
+@import './MonacoQueryInput';
 @import './InfoDropdown';
 @import './interactive/InteractiveModeInput';
 

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -21,7 +21,7 @@ import { limitString } from '../../util'
 import { submitSearch, QueryState } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 import { QueryInput } from './QueryInput'
-import { MonacoQueryInput } from './MonacoQueryInput'
+import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { SearchButton } from './SearchButton'
 import { SearchScopes } from './SearchScopes'
 import { InteractiveModeInput } from './interactive/InteractiveModeInput'
@@ -122,7 +122,7 @@ export class SearchPage extends React.Component<Props, State> {
                                         )}
 
                                         {this.props.smartSearchField ? (
-                                            <MonacoQueryInput
+                                            <LazyMonacoQueryInput
                                                 {...this.props}
                                                 hasGlobalQueryBehavior={true}
                                                 queryState={this.state.userQueryState}

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -1,6 +1,12 @@
 import * as H from 'history'
 import * as React from 'react'
-import { parseSearchURLQuery, PatternTypeProps, InteractiveSearchProps, CaseSensitivityProps } from '..'
+import {
+    parseSearchURLQuery,
+    PatternTypeProps,
+    InteractiveSearchProps,
+    CaseSensitivityProps,
+    SmartSearchFieldProps,
+} from '..'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
@@ -15,6 +21,7 @@ import { limitString } from '../../util'
 import { submitSearch, QueryState } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 import { QueryInput } from './QueryInput'
+import { MonacoQueryInput } from './MonacoQueryInput'
 import { SearchButton } from './SearchButton'
 import { SearchScopes } from './SearchScopes'
 import { InteractiveModeInput } from './interactive/InteractiveModeInput'
@@ -35,7 +42,8 @@ interface Props
         EventLoggerProps,
         ExtensionsControllerProps<'executeCommand' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
-        InteractiveSearchProps {
+        InteractiveSearchProps,
+        SmartSearchFieldProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History
@@ -104,7 +112,7 @@ export class SearchPage extends React.Component<Props, State> {
                             />
                         ) : (
                             <>
-                                <Form className="search flex-grow-1" onSubmit={this.onSubmit}>
+                                <Form className="search flex-grow-1" onSubmit={this.onFormSubmit}>
                                     <div className="search-page__input-container">
                                         {this.props.splitSearchModes && (
                                             <SearchModeToggle
@@ -112,16 +120,28 @@ export class SearchPage extends React.Component<Props, State> {
                                                 interactiveSearchMode={this.props.interactiveSearchMode}
                                             />
                                         )}
-                                        <QueryInput
-                                            {...this.props}
-                                            value={this.state.userQueryState}
-                                            onChange={this.onUserQueryChange}
-                                            autoFocus="cursor-at-end"
-                                            hasGlobalQueryBehavior={true}
-                                            patternType={this.props.patternType}
-                                            setPatternType={this.props.setPatternType}
-                                            withSearchModeToggle={this.props.splitSearchModes}
-                                        />
+
+                                        {this.props.smartSearchField ? (
+                                            <MonacoQueryInput
+                                                {...this.props}
+                                                hasGlobalQueryBehavior={true}
+                                                queryState={this.state.userQueryState}
+                                                onChange={this.onUserQueryChange}
+                                                onSubmit={this.onSubmit}
+                                                autoFocus={true}
+                                            />
+                                        ) : (
+                                            <QueryInput
+                                                {...this.props}
+                                                value={this.state.userQueryState}
+                                                onChange={this.onUserQueryChange}
+                                                autoFocus="cursor-at-end"
+                                                hasGlobalQueryBehavior={true}
+                                                patternType={this.props.patternType}
+                                                setPatternType={this.props.setPatternType}
+                                                withSearchModeToggle={this.props.splitSearchModes}
+                                            ></QueryInput>
+                                        )}
                                         <SearchButton />
                                     </div>
                                     <div className="search-page__input-sub-container">
@@ -157,8 +177,7 @@ export class SearchPage extends React.Component<Props, State> {
         this.setState({ userQueryState })
     }
 
-    private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
-        event.preventDefault()
+    private onSubmit = (): void => {
         const query = [this.state.builderQuery, this.state.userQueryState.query].filter(s => !!s).join(' ')
         submitSearch(
             this.props.history,
@@ -168,6 +187,11 @@ export class SearchPage extends React.Component<Props, State> {
             this.props.caseSensitive,
             this.props.activation
         )
+    }
+
+    private onFormSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+        event.preventDefault()
+        this.onSubmit()
     }
 
     private getPageTitle(): string | undefined {

--- a/web/src/search/parser/completion.test.ts
+++ b/web/src/search/parser/completion.test.ts
@@ -1,0 +1,154 @@
+import { getCompletionItems } from './completion'
+import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { NEVER, of } from 'rxjs'
+import { IFile } from '../../../../shared/src/graphql/schema'
+
+describe('getCompletionItems()', () => {
+    test('returns static filter type completions', async () => {
+        expect(
+            await getCompletionItems(
+                'a',
+                (parseSearchQuery('re') as ParseSuccess<Sequence>).token,
+                { column: 3 },
+                {} as any,
+                () => NEVER
+            )
+        ).toStrictEqual(
+            {
+                suggestions: [
+                    {
+                        detail: 'Include only results from repositories matching the given regex pattern.',
+                        filterText: 'repo',
+                        insertText: 'repo:',
+                        kind: 17,
+                        label: 'repo',
+                        range: {
+                            endColumn: 3,
+                            endLineNumber: 1,
+                            startColumn: 1,
+                            startLineNumber: 1,
+                        },
+                    },
+                    {
+                        detail: 'group-name (include results from the named group)',
+                        filterText: 'repogroup',
+                        insertText: 'repogroup:',
+                        kind: 17,
+                        label: 'repogroup',
+                        range: {
+                            endColumn: 3,
+                            endLineNumber: 1,
+                            startColumn: 1,
+                            startLineNumber: 1,
+                        },
+                    },
+                    {
+                        detail: 'regex-pattern (include results from repos that contain a matching file)',
+                        filterText: 'repohasfile',
+                        insertText: 'repohasfile:',
+                        kind: 17,
+                        label: 'repohasfile',
+                        range: {
+                            endColumn: 3,
+                            endLineNumber: 1,
+                            startColumn: 1,
+                            startLineNumber: 1,
+                        },
+                    },
+                    {
+                        detail: '"string specifying time frame" (filter out stale repositories without recent commits)',
+                        filterText: 'repohascommitafter',
+                        insertText: 'repohascommitafter:',
+                        kind: 17,
+                        label: 'repohascommitafter',
+                        range: {
+                            endColumn: 3,
+                            endLineNumber: 1,
+                            startColumn: 1,
+                            startLineNumber: 1,
+                        },
+                    },
+                ],
+            })
+    })
+
+    test('returns completions for filters with discrete values', async () => {
+        expect(
+            await getCompletionItems(
+                'a',
+                (parseSearchQuery('case:y') as ParseSuccess<Sequence>).token,
+                { column: 7 },
+                {} as any,
+                () => NEVER
+            )
+        ).toStrictEqual(
+            {
+                suggestions: [
+                    {
+                        filterText: 'yes',
+                        insertText: 'yes ',
+                        kind: 18,
+                        label: 'yes',
+                        range: {
+                            endColumn: 7,
+                            endLineNumber: 1,
+                            startColumn: 6,
+                            startLineNumber: 1,
+                        },
+                    },
+                    {
+                        filterText: 'no',
+                        insertText: 'no ',
+                        kind: 18,
+                        label: 'no',
+                        range: {
+                            endColumn: 7,
+                            endLineNumber: 1,
+                            startColumn: 6,
+                            startLineNumber: 1,
+                        },
+                    },
+                ],
+            })
+    })
+
+    test('returns dynamically fetched completions', async () => {
+        expect(
+            await getCompletionItems(
+                'a',
+                (parseSearchQuery('file:c') as ParseSuccess<Sequence>).token,
+                { column: 7 },
+                {} as any,
+                () =>
+                    of([
+                        {
+                            __typename: 'File',
+                            path: 'connect.go',
+                            name: 'connect.go',
+                            isDirectory: false,
+                            url: 'b',
+                            repository: {
+                                name: 'r',
+                            },
+                        } as IFile,
+                    ])
+            )
+        ).toStrictEqual({
+            suggestions: [
+                {
+                    detail: 'connect.go - r',
+                    filterText: 'file:connect.go',
+                    insertText: '^connect\\.go$ ',
+                    kind: 18,
+                    label: 'connect.go',
+                    range: {
+                        endColumn: 7,
+                        endLineNumber: 1,
+                        startColumn: 6,
+                        startLineNumber: 1,
+                    },
+                },
+            ],
+        })
+    })
+})

--- a/web/src/search/parser/completion.test.ts
+++ b/web/src/search/parser/completion.test.ts
@@ -13,63 +13,62 @@ describe('getCompletionItems()', () => {
                 {} as any,
                 () => NEVER
             )
-        ).toStrictEqual(
-            {
-                suggestions: [
-                    {
-                        detail: 'Include only results from repositories matching the given regex pattern.',
-                        filterText: 'repo',
-                        insertText: 'repo:',
-                        kind: 17,
-                        label: 'repo',
-                        range: {
-                            endColumn: 3,
-                            endLineNumber: 1,
-                            startColumn: 1,
-                            startLineNumber: 1,
-                        },
+        ).toStrictEqual({
+            suggestions: [
+                {
+                    detail: 'Include only results from repositories matching the given regex pattern.',
+                    filterText: 'repo',
+                    insertText: 'repo:',
+                    kind: 17,
+                    label: 'repo',
+                    range: {
+                        endColumn: 3,
+                        endLineNumber: 1,
+                        startColumn: 1,
+                        startLineNumber: 1,
                     },
-                    {
-                        detail: 'group-name (include results from the named group)',
-                        filterText: 'repogroup',
-                        insertText: 'repogroup:',
-                        kind: 17,
-                        label: 'repogroup',
-                        range: {
-                            endColumn: 3,
-                            endLineNumber: 1,
-                            startColumn: 1,
-                            startLineNumber: 1,
-                        },
+                },
+                {
+                    detail: 'group-name (include results from the named group)',
+                    filterText: 'repogroup',
+                    insertText: 'repogroup:',
+                    kind: 17,
+                    label: 'repogroup',
+                    range: {
+                        endColumn: 3,
+                        endLineNumber: 1,
+                        startColumn: 1,
+                        startLineNumber: 1,
                     },
-                    {
-                        detail: 'regex-pattern (include results from repos that contain a matching file)',
-                        filterText: 'repohasfile',
-                        insertText: 'repohasfile:',
-                        kind: 17,
-                        label: 'repohasfile',
-                        range: {
-                            endColumn: 3,
-                            endLineNumber: 1,
-                            startColumn: 1,
-                            startLineNumber: 1,
-                        },
+                },
+                {
+                    detail: 'regex-pattern (include results from repos that contain a matching file)',
+                    filterText: 'repohasfile',
+                    insertText: 'repohasfile:',
+                    kind: 17,
+                    label: 'repohasfile',
+                    range: {
+                        endColumn: 3,
+                        endLineNumber: 1,
+                        startColumn: 1,
+                        startLineNumber: 1,
                     },
-                    {
-                        detail: '"string specifying time frame" (filter out stale repositories without recent commits)',
-                        filterText: 'repohascommitafter',
-                        insertText: 'repohascommitafter:',
-                        kind: 17,
-                        label: 'repohascommitafter',
-                        range: {
-                            endColumn: 3,
-                            endLineNumber: 1,
-                            startColumn: 1,
-                            startLineNumber: 1,
-                        },
+                },
+                {
+                    detail: '"string specifying time frame" (filter out stale repositories without recent commits)',
+                    filterText: 'repohascommitafter',
+                    insertText: 'repohascommitafter:',
+                    kind: 17,
+                    label: 'repohascommitafter',
+                    range: {
+                        endColumn: 3,
+                        endLineNumber: 1,
+                        startColumn: 1,
+                        startLineNumber: 1,
                     },
-                ],
-            })
+                },
+            ],
+        })
     })
 
     test('returns completions for filters with discrete values', async () => {
@@ -81,35 +80,34 @@ describe('getCompletionItems()', () => {
                 {} as any,
                 () => NEVER
             )
-        ).toStrictEqual(
-            {
-                suggestions: [
-                    {
-                        filterText: 'yes',
-                        insertText: 'yes ',
-                        kind: 18,
-                        label: 'yes',
-                        range: {
-                            endColumn: 7,
-                            endLineNumber: 1,
-                            startColumn: 6,
-                            startLineNumber: 1,
-                        },
+        ).toStrictEqual({
+            suggestions: [
+                {
+                    filterText: 'yes',
+                    insertText: 'yes ',
+                    kind: 18,
+                    label: 'yes',
+                    range: {
+                        endColumn: 7,
+                        endLineNumber: 1,
+                        startColumn: 6,
+                        startLineNumber: 1,
                     },
-                    {
-                        filterText: 'no',
-                        insertText: 'no ',
-                        kind: 18,
-                        label: 'no',
-                        range: {
-                            endColumn: 7,
-                            endLineNumber: 1,
-                            startColumn: 6,
-                            startLineNumber: 1,
-                        },
+                },
+                {
+                    filterText: 'no',
+                    insertText: 'no ',
+                    kind: 18,
+                    label: 'no',
+                    range: {
+                        endColumn: 7,
+                        endLineNumber: 1,
+                        startColumn: 6,
+                        startLineNumber: 1,
                     },
-                ],
-            })
+                },
+            ],
+        })
     })
 
     test('returns dynamically fetched completions', async () => {

--- a/web/src/search/parser/completion.test.ts
+++ b/web/src/search/parser/completion.test.ts
@@ -10,7 +10,6 @@ describe('getCompletionItems()', () => {
                 'a',
                 (parseSearchQuery('re') as ParseSuccess<Sequence>).token,
                 { column: 3 },
-                {} as any,
                 () => NEVER
             )
         ).toStrictEqual({
@@ -77,7 +76,6 @@ describe('getCompletionItems()', () => {
                 'a',
                 (parseSearchQuery('case:y') as ParseSuccess<Sequence>).token,
                 { column: 7 },
-                {} as any,
                 () => NEVER
             )
         ).toStrictEqual({
@@ -116,7 +114,6 @@ describe('getCompletionItems()', () => {
                 'a',
                 (parseSearchQuery('file:c') as ParseSuccess<Sequence>).token,
                 { column: 7 },
-                {} as any,
                 () =>
                     of([
                         {

--- a/web/src/search/parser/completion.ts
+++ b/web/src/search/parser/completion.ts
@@ -1,0 +1,119 @@
+import * as Monaco from 'monaco-editor'
+import { escapeRegExp } from 'lodash'
+import { FILTERS, getFilterDefinition } from './filters'
+import { Sequence } from './parser'
+import { Omit } from 'utility-types'
+import { SearchSuggestion } from '../../../../shared/src/graphql/schema'
+import { Observable } from 'rxjs'
+import { isDefined } from '../../../../shared/src/util/types'
+
+const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] = FILTERS.flatMap(
+    ({ aliases, description }) =>
+        aliases.map(
+            (label: string): Omit<Monaco.languages.CompletionItem, 'range'> => ({
+                label,
+                kind: Monaco.languages.CompletionItemKind.Keyword,
+                detail: description,
+                insertText: `${label}:`,
+                filterText: label,
+            })
+        )
+)
+
+/**
+ * Returns the completion items for a search query being typed in the Monaco query input,
+ * including both static and dynamically fetched suggestions.
+ */
+export async function getCompletionItems(
+    rawQuery: string,
+    { members }: Pick<Sequence, 'members'>,
+    { column }: Pick<Monaco.Position, 'column'>,
+    context: Monaco.languages.CompletionContext,
+    fetchSuggestions: (query: string) => Observable<SearchSuggestion[]>
+): Promise<Monaco.languages.CompletionList | null> {
+    const tokenAtColumn = members.find(({ range }) => range.start + 2 <= column && range.end + 2 >= column)
+    if (!tokenAtColumn || tokenAtColumn.token.type === 'whitespace') {
+        return null
+    }
+    const { token, range } = tokenAtColumn
+    if (token.type === 'literal') {
+        // Offer autocompletion of filter values
+        return {
+            suggestions: FILTER_TYPE_COMPLETIONS.filter(({ label }) => label.startsWith(token.value)).map(
+                (suggestion): Monaco.languages.CompletionItem => ({
+                    ...suggestion,
+                    range: {
+                        startLineNumber: 1,
+                        endLineNumber: 1,
+                        startColumn: range.start + 1,
+                        endColumn: range.end + 2,
+                    },
+                })
+            ),
+        }
+    }
+    if (token.type === 'filter') {
+        const { filterValue } = token
+        if (!filterValue) {
+            return null
+        }
+        const completingValue = filterValue.range.start + 2 <= column
+        if (!completingValue) {
+            return null
+        }
+        const filterDefinition = getFilterDefinition(token.filterType.token.value)
+        if (!filterDefinition) {
+            return null
+        }
+        if (filterDefinition.suggestions) {
+            const suggestions = await fetchSuggestions(rawQuery).toPromise()
+            return {
+                suggestions: suggestions
+                    .filter(({ __typename }) => __typename === filterDefinition.suggestions)
+                    .map((suggestion): Monaco.languages.CompletionItem | null => {
+                        if (suggestion.__typename === 'Repository' || suggestion.__typename === 'File') {
+                            return {
+                                label: suggestion.name,
+                                kind: Monaco.languages.CompletionItemKind.Text,
+                                insertText: `^${escapeRegExp(
+                                    suggestion.__typename === 'File' ? suggestion.path : suggestion.name
+                                )}$ `,
+                                filterText: `${token.filterType.token.value}:${suggestion.name}`,
+                                detail:
+                                    suggestion.__typename === 'File'
+                                        ? `${suggestion.path} - ${suggestion.repository.name}`
+                                        : '',
+                                range: {
+                                    startLineNumber: 1,
+                                    endLineNumber: 1,
+                                    startColumn: filterValue.range.start + 1,
+                                    endColumn: filterValue.range.end + 2,
+                                },
+                            }
+                        }
+                        return null
+                    })
+                    .filter(isDefined),
+            }
+        }
+        if (filterDefinition.discreteValues) {
+            return {
+                suggestions: filterDefinition.discreteValues.map(
+                    (label): Monaco.languages.CompletionItem => ({
+                        label,
+                        kind: Monaco.languages.CompletionItemKind.Text,
+                        insertText: `${label} `,
+                        filterText: label,
+                        range: {
+                            startLineNumber: 1,
+                            endLineNumber: 1,
+                            startColumn: filterValue.range.start + 1,
+                            endColumn: filterValue.range.end + 2,
+                        },
+                    })
+                ),
+            }
+        }
+    }
+    return null
+}

--- a/web/src/search/parser/completion.ts
+++ b/web/src/search/parser/completion.ts
@@ -28,7 +28,6 @@ export async function getCompletionItems(
     rawQuery: string,
     { members }: Pick<Sequence, 'members'>,
     { column }: Pick<Monaco.Position, 'column'>,
-    context: Monaco.languages.CompletionContext,
     fetchSuggestions: (query: string) => Observable<SearchSuggestion[]>
 ): Promise<Monaco.languages.CompletionList | null> {
     const tokenAtColumn = members.find(({ range }) => range.start + 2 <= column && range.end + 2 >= column)

--- a/web/src/search/parser/completion.ts
+++ b/web/src/search/parser/completion.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { escapeRegExp } from 'lodash'
 import { FILTERS, getFilterDefinition } from './filters'
-import { Sequence } from './parser'
+import { Sequence, toMonacoRange } from './parser'
 import { Omit } from 'utility-types'
 import { SearchSuggestion } from '../../../../shared/src/graphql/schema'
 import { Observable } from 'rxjs'
@@ -41,12 +41,7 @@ export async function getCompletionItems(
             suggestions: FILTER_TYPE_COMPLETIONS.filter(({ label }) => label.startsWith(token.value)).map(
                 (suggestion): Monaco.languages.CompletionItem => ({
                     ...suggestion,
-                    range: {
-                        startLineNumber: 1,
-                        endLineNumber: 1,
-                        startColumn: range.start + 1,
-                        endColumn: range.end + 2,
-                    },
+                    range: toMonacoRange(range),
                 })
             ),
         }
@@ -82,12 +77,7 @@ export async function getCompletionItems(
                                     suggestion.__typename === 'File'
                                         ? `${suggestion.path} - ${suggestion.repository.name}`
                                         : '',
-                                range: {
-                                    startLineNumber: 1,
-                                    endLineNumber: 1,
-                                    startColumn: filterValue.range.start + 1,
-                                    endColumn: filterValue.range.end + 2,
-                                },
+                                range: toMonacoRange(filterValue.range),
                             }
                         }
                         return null
@@ -103,12 +93,7 @@ export async function getCompletionItems(
                         kind: Monaco.languages.CompletionItemKind.Text,
                         insertText: `${label} `,
                         filterText: label,
-                        range: {
-                            startLineNumber: 1,
-                            endLineNumber: 1,
-                            startColumn: filterValue.range.start + 1,
-                            endColumn: filterValue.range.end + 2,
-                        },
+                        range: toMonacoRange(filterValue.range),
                     })
                 ),
             }

--- a/web/src/search/parser/diagnostics.test.ts
+++ b/web/src/search/parser/diagnostics.test.ts
@@ -1,0 +1,47 @@
+import { getDiagnostics } from './diagnostics'
+import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+
+describe('getDiagnostics()', () => {
+    test('invalid filter type', () => {
+        expect(
+            getDiagnostics((parseSearchQuery('repos:^github.com/sourcegraph') as ParseSuccess<Sequence>).token)
+        ).toStrictEqual([
+            {
+                endColumn: 6,
+                endLineNumber: 1,
+                message: 'Invalid filter type.',
+                severity: 8,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        ])
+    })
+
+    test('invalid filter value', () => {
+        expect(getDiagnostics((parseSearchQuery('case:maybe') as ParseSuccess<Sequence>).token)).toStrictEqual([
+            {
+                endColumn: 5,
+                endLineNumber: 1,
+                message: 'Invalid filter value, expected one of: yes, no.',
+                severity: 8,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        ])
+    })
+
+    test('search query containing colon', () => {
+        expect(
+            getDiagnostics((parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token)
+        ).toStrictEqual([
+            {
+                endColumn: 28,
+                endLineNumber: 1,
+                message: 'Quoting the query may help if you want a literal match.',
+                severity: 4,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        ])
+    })
+})

--- a/web/src/search/parser/diagnostics.ts
+++ b/web/src/search/parser/diagnostics.ts
@@ -1,0 +1,39 @@
+import * as Monaco from 'monaco-editor'
+import { Sequence } from './parser'
+import { validateFilter } from './filters'
+
+/**
+ * Returns the diagnostics for a parsed search query to be displayed in the Monaco query input.
+ */
+export function getDiagnostics({ members }: Pick<Sequence, 'members'>): Monaco.editor.IMarkerData[] {
+    const diagnostics: Monaco.editor.IMarkerData[] = []
+    for (const { token, range } of members) {
+        if (token.type === 'filter') {
+            const { filterType, filterValue } = token
+            const validationResult = validateFilter(filterType.token.value, filterValue)
+            if (validationResult.valid) {
+                continue
+            }
+            diagnostics.push({
+                severity: Monaco.MarkerSeverity.Error,
+                message: validationResult.reason,
+                startLineNumber: 1,
+                endLineNumber: 1,
+                startColumn: filterType.range.start + 1,
+                endColumn: filterType.range.end + 2,
+            })
+        } else if (token.type === 'literal') {
+            if (token.value.includes(':')) {
+                diagnostics.push({
+                    severity: Monaco.MarkerSeverity.Warning,
+                    message: 'Quoting the query may help if you want a literal match.',
+                    startLineNumber: 1,
+                    endLineNumber: 1,
+                    startColumn: range.start + 1,
+                    endColumn: range.end + 2,
+                })
+            }
+        }
+    }
+    return diagnostics
+}

--- a/web/src/search/parser/diagnostics.ts
+++ b/web/src/search/parser/diagnostics.ts
@@ -1,5 +1,5 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence } from './parser'
+import { Sequence, toMonacoRange } from './parser'
 import { validateFilter } from './filters'
 
 /**
@@ -17,20 +17,14 @@ export function getDiagnostics({ members }: Pick<Sequence, 'members'>): Monaco.e
             diagnostics.push({
                 severity: Monaco.MarkerSeverity.Error,
                 message: validationResult.reason,
-                startLineNumber: 1,
-                endLineNumber: 1,
-                startColumn: filterType.range.start + 1,
-                endColumn: filterType.range.end + 2,
+                ...toMonacoRange(filterType.range),
             })
         } else if (token.type === 'literal') {
             if (token.value.includes(':')) {
                 diagnostics.push({
                     severity: Monaco.MarkerSeverity.Warning,
                     message: 'Quoting the query may help if you want a literal match.',
-                    startLineNumber: 1,
-                    endLineNumber: 1,
-                    startColumn: range.start + 1,
-                    endColumn: range.end + 2,
+                    ...toMonacoRange(range),
                 })
             }
         }

--- a/web/src/search/parser/filters.test.ts
+++ b/web/src/search/parser/filters.test.ts
@@ -1,0 +1,61 @@
+import { validateFilter } from './filters'
+import { Literal, Quoted } from './parser'
+
+describe('validateFilter()', () => {
+    interface TestCase {
+        description: string
+        filterType: string
+        expected: ReturnType<typeof validateFilter>
+        token: Literal | Quoted
+    }
+    const TESTCASES: TestCase[] = [
+        {
+            description: 'Valid repo filter',
+            filterType: 'repo',
+            expected: { valid: true },
+            token: { type: 'literal', value: 'a' },
+        },
+        {
+            description: 'Valid repo filter - quoted value',
+            filterType: 'repo',
+            expected: { valid: true },
+            token: { type: 'quoted', quotedValue: 'a' },
+        },
+        {
+            description: 'Valid repo filter - alias',
+            filterType: 'repo',
+            expected: { valid: true },
+            token: { type: 'quoted', quotedValue: 'a' },
+        },
+        {
+            description: 'Invalid filter type',
+            filterType: 'repoo',
+            expected: { valid: false, reason: 'Invalid filter type' },
+            token: { type: 'literal', value: 'a' },
+        },
+        {
+            description: 'Valid case filter',
+            filterType: 'case',
+            expected: { valid: true },
+            token: { type: 'literal', value: 'yes' },
+        },
+        {
+            description: 'Invalid quoted value for case filter',
+            filterType: 'case',
+            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no' },
+            token: { type: 'quoted', quotedValue: 'yes' },
+        },
+        {
+            description: 'Invalid literal value for case filter',
+            filterType: 'case',
+            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no' },
+            token: { type: 'literal', value: 'yess' },
+        },
+    ]
+
+    for (const { description, filterType, expected, token } of TESTCASES) {
+        test(description, () => {
+            expect(validateFilter(filterType, { token, range: { start: 0, end: 1 } })).toStrictEqual(expected)
+        })
+    }
+})

--- a/web/src/search/parser/filters.test.ts
+++ b/web/src/search/parser/filters.test.ts
@@ -30,7 +30,7 @@ describe('validateFilter()', () => {
         {
             description: 'Invalid filter type',
             filterType: 'repoo',
-            expected: { valid: false, reason: 'Invalid filter type' },
+            expected: { valid: false, reason: 'Invalid filter type.' },
             token: { type: 'literal', value: 'a' },
         },
         {
@@ -42,13 +42,13 @@ describe('validateFilter()', () => {
         {
             description: 'Invalid quoted value for case filter',
             filterType: 'case',
-            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no' },
+            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no.' },
             token: { type: 'quoted', quotedValue: 'yes' },
         },
         {
             description: 'Invalid literal value for case filter',
             filterType: 'case',
-            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no' },
+            expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no.' },
             token: { type: 'literal', value: 'yess' },
         },
     ]

--- a/web/src/search/parser/filters.ts
+++ b/web/src/search/parser/filters.ts
@@ -1,0 +1,120 @@
+import { SearchSuggestion } from '../../../../shared/src/graphql/schema'
+import { Filter } from './parser'
+
+export interface FilterDefinition {
+    aliases: string[]
+    description: string
+    discreteValues?: string[]
+    suggestions?: SearchSuggestion['__typename'] | string[]
+    default?: string
+}
+
+export const FILTERS: readonly FilterDefinition[] = [
+    {
+        aliases: ['r', 'repo'],
+        description: 'Include only results from repositories matching the given regex pattern.',
+        suggestions: 'Repository',
+    },
+    {
+        aliases: ['-r', '-repo'],
+        description: 'Exclude results from repositories matching the given regex pattern.',
+        suggestions: 'Repository',
+    },
+    {
+        aliases: ['f', 'file'],
+        description: 'Include only results from files matching the given regex pattern.',
+        suggestions: 'File',
+    },
+    {
+        aliases: ['-f', '-file'],
+        description: 'Exclude results from files matching the given regex pattern.',
+        suggestions: 'File',
+    },
+    {
+        aliases: ['repogroup'],
+        description: 'group-name (include results from the named group)',
+    },
+    {
+        aliases: ['repohasfile'],
+        description: 'regex-pattern (include results from repos that contain a matching file)',
+        suggestions: 'File',
+    },
+    {
+        aliases: ['-repohasfile'],
+        description: 'regex-pattern (exclude results from repositories that contain a matching file)',
+        suggestions: 'File',
+    },
+    {
+        aliases: ['repohascommitafter'],
+        description: '"string specifying time frame" (filter out stale repositories without recent commits)',
+    },
+    {
+        aliases: ['type'],
+        description: 'Limit results to the specified type.',
+        discreteValues: ['code', 'diff', 'commit', 'symbol'],
+    },
+    {
+        aliases: ['case'],
+        description: 'Treat the search pattern as case-sensitive.',
+        discreteValues: ['yes', 'no'],
+        default: 'no',
+    },
+    {
+        aliases: ['lang'],
+        description: 'Include only results from the given language',
+        discreteValues: ['ts', 'go', 'js', 'cpp'],
+    },
+    {
+        aliases: ['-lang'],
+        description: 'Exclude results from the given language',
+        discreteValues: ['ts', 'go', 'js', 'cpp'],
+    },
+    {
+        aliases: ['fork'],
+        discreteValues: ['yes', 'no', 'only'],
+        description: 'Fork',
+    },
+    {
+        aliases: ['archived'],
+        description: 'Archived',
+    },
+    {
+        aliases: ['count'],
+        description: 'Number of results to fetch (integer)',
+    },
+    {
+        aliases: ['timeout'],
+        description: 'Duration before timeout',
+    },
+]
+
+/**
+ * Returns the {@link FilterDefinition} for the given filterType if it exists, or `undefined` otherwise.
+ */
+export const getFilterDefinition = (filterType: string): FilterDefinition | undefined =>
+    FILTERS.find(({ aliases }) => aliases.some(a => a === filterType))
+
+/**
+ * Validates a filter given its type and value.
+ */
+export const validateFilter = (
+    filterType: string,
+    filterValue: Filter['filterValue']
+): { valid: true } | { valid: false; reason: string } => {
+    const definition = getFilterDefinition(filterType)
+    if (!definition) {
+        return { valid: false, reason: 'Invalid filter type.' }
+    }
+    if (
+        definition.discreteValues &&
+        (!filterValue ||
+            filterValue.token.type !== 'literal' ||
+            !definition.discreteValues.includes(filterValue.token.value))
+    ) {
+        return {
+            valid: false,
+            reason: `Invalid filter value, expected one of: ${definition.discreteValues.join(', ')}.`,
+        }
+    }
+    return { valid: true }
+}

--- a/web/src/search/parser/filters.ts
+++ b/web/src/search/parser/filters.ts
@@ -9,6 +9,30 @@ export interface FilterDefinition {
     default?: string
 }
 
+const LANGUAGES: string[] = [
+    'c',
+    'cpp',
+    'csharp',
+    'css',
+    'go',
+    'graphql',
+    'haskell',
+    'html',
+    'java',
+    'javascript',
+    'json',
+    'lua',
+    'markdown',
+    'php',
+    'powershell',
+    'python',
+    'r',
+    'ruby',
+    'sass',
+    'swift',
+    'typescript',
+]
+
 export const FILTERS: readonly FilterDefinition[] = [
     {
         aliases: ['r', 'repo'],
@@ -62,12 +86,12 @@ export const FILTERS: readonly FilterDefinition[] = [
     {
         aliases: ['lang'],
         description: 'Include only results from the given language',
-        discreteValues: ['ts', 'go', 'js', 'cpp'],
+        discreteValues: LANGUAGES,
     },
     {
         aliases: ['-lang'],
         description: 'Exclude results from the given language',
-        discreteValues: ['ts', 'go', 'js', 'cpp'],
+        discreteValues: LANGUAGES,
     },
     {
         aliases: ['fork'],

--- a/web/src/search/parser/hover.test.ts
+++ b/web/src/search/parser/hover.test.ts
@@ -1,0 +1,35 @@
+import { getHoverResult } from './hover'
+import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+
+describe('getHoverResult()', () => {
+    test('returns hover contents for filters', () => {
+        const parsedQuery = (parseSearchQuery('repo:sourcegraph file:code_intelligence') as ParseSuccess<Sequence>)
+            .token
+        expect(getHoverResult(parsedQuery, { column: 4 })).toStrictEqual({
+            contents: [
+                {
+                    value: 'Include only results from repositories matching the given regex pattern.',
+                },
+            ],
+            range: {
+                endColumn: 17,
+                endLineNumber: 1,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        })
+        expect(getHoverResult(parsedQuery, { column: 30 })).toStrictEqual({
+            contents: [
+                {
+                    value: 'Include only results from files matching the given regex pattern.',
+                },
+            ],
+            range: {
+                endColumn: 40,
+                endLineNumber: 1,
+                startColumn: 18,
+                startLineNumber: 1,
+            },
+        })
+    })
+})

--- a/web/src/search/parser/hover.ts
+++ b/web/src/search/parser/hover.ts
@@ -1,0 +1,30 @@
+import * as Monaco from 'monaco-editor'
+import { Sequence } from './parser'
+import { FILTERS } from './filters'
+
+/**
+ * Returns the hover result for a hovered search token in the Monaco query input.
+ */
+export const getHoverResult = (
+    { members }: Pick<Sequence, 'members'>,
+    { column }: Pick<Monaco.Position, 'column'>
+): Monaco.languages.Hover | null => {
+    const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
+    if (!tokenAtColumn || tokenAtColumn.token.type !== 'filter') {
+        return null
+    }
+    const { filterType } = tokenAtColumn.token
+    const matchedFilterDefinition = FILTERS.find(({ aliases }) => aliases.includes(filterType.token.value))
+    if (!matchedFilterDefinition) {
+        return null
+    }
+    return {
+        contents: [{ value: matchedFilterDefinition.description }],
+        range: {
+            startLineNumber: 1,
+            endLineNumber: 1,
+            startColumn: tokenAtColumn.range.start + 1,
+            endColumn: tokenAtColumn.range.end + 2,
+        },
+    }
+}

--- a/web/src/search/parser/hover.ts
+++ b/web/src/search/parser/hover.ts
@@ -1,5 +1,5 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence } from './parser'
+import { Sequence, toMonacoRange } from './parser'
 import { FILTERS } from './filters'
 
 /**
@@ -20,11 +20,6 @@ export const getHoverResult = (
     }
     return {
         contents: [{ value: matchedFilterDefinition.description }],
-        range: {
-            startLineNumber: 1,
-            endLineNumber: 1,
-            startColumn: tokenAtColumn.range.start + 1,
-            endColumn: tokenAtColumn.range.end + 2,
-        },
+        range: toMonacoRange(tokenAtColumn.range),
     }
 }

--- a/web/src/search/parser/parser.test.ts
+++ b/web/src/search/parser/parser.test.ts
@@ -1,0 +1,391 @@
+import { parseSearchQuery } from './parser'
+
+describe('parseSearchQuery()', () => {
+    test('empty', () =>
+        expect(parseSearchQuery('')).toMatchObject({
+            range: {
+                end: 0,
+                start: 0,
+            },
+            token: {
+                members: [],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('whitespace', () =>
+        expect(parseSearchQuery('  ')).toMatchObject({
+            range: {
+                end: 1,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 1,
+                            start: 0,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('literal', () =>
+        expect(parseSearchQuery('a')).toMatchObject({
+            range: {
+                end: 0,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 0,
+                            start: 0,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'a',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('filter', () =>
+        expect(parseSearchQuery('a:b')).toMatchObject({
+            range: {
+                end: 2,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 2,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 0,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'a',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 2,
+                                    start: 2,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'b',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('negated filter', () =>
+        expect(parseSearchQuery('-a:b')).toMatchObject({
+            range: {
+                end: 3,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 3,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 1,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: '-a',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 3,
+                                    start: 3,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'b',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('filter with quoted value', () => {
+        expect(parseSearchQuery('a:"b"')).toMatchObject({
+            range: {
+                end: 4,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 4,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 0,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'a',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 4,
+                                    start: 2,
+                                },
+                                token: {
+                                    quotedValue: 'b',
+                                    type: 'quoted',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
+    test('quoted', () =>
+        expect(parseSearchQuery('"a:b"')).toMatchObject({
+            range: {
+                end: 4,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 4,
+                            start: 0,
+                        },
+                        token: {
+                            quotedValue: 'a:b',
+                            type: 'quoted',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('quoted (escaped quotes)', () =>
+        expect(parseSearchQuery('"-\\"a\\":b"')).toMatchObject({
+            range: {
+                end: 9,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 9,
+                            start: 0,
+                        },
+                        token: {
+                            quotedValue: '-\\"a\\":b',
+                            type: 'quoted',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('complex query', () =>
+        expect(parseSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchObject({
+            range: {
+                end: 57,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 29,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 3,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'repo',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 29,
+                                    start: 5,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: '^github\\.com/gorilla/mux$',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 30,
+                            start: 30,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 37,
+                            start: 31,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 34,
+                                    start: 31,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'lang',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 37,
+                                    start: 36,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'go',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 38,
+                            start: 38,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 50,
+                            start: 39,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 43,
+                                    start: 39,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: '-file',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 50,
+                                    start: 45,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'mux.go',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 51,
+                            start: 51,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 57,
+                            start: 52,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'Router',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+})

--- a/web/src/search/parser/parser.test.ts
+++ b/web/src/search/parser/parser.test.ts
@@ -4,8 +4,8 @@ describe('parseSearchQuery()', () => {
     test('empty', () =>
         expect(parseSearchQuery('')).toMatchObject({
             range: {
-                end: 0,
                 start: 0,
+                end: 1,
             },
             token: {
                 members: [],
@@ -17,14 +17,14 @@ describe('parseSearchQuery()', () => {
     test('whitespace', () =>
         expect(parseSearchQuery('  ')).toMatchObject({
             range: {
-                end: 1,
                 start: 0,
+                end: 2,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 1,
+                            end: 2,
                             start: 0,
                         },
                         token: {
@@ -40,15 +40,15 @@ describe('parseSearchQuery()', () => {
     test('literal', () =>
         expect(parseSearchQuery('a')).toMatchObject({
             range: {
-                end: 0,
                 start: 0,
+                end: 1,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 0,
                             start: 0,
+                            end: 1,
                         },
                         token: {
                             type: 'literal',
@@ -64,20 +64,20 @@ describe('parseSearchQuery()', () => {
     test('filter', () =>
         expect(parseSearchQuery('a:b')).toMatchObject({
             range: {
-                end: 2,
+                end: 3,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 2,
+                            end: 3,
                             start: 0,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 0,
+                                    end: 1,
                                     start: 0,
                                 },
                                 token: {
@@ -88,7 +88,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 2,
+                                    end: 3,
                                     start: 2,
                                 },
                                 token: {
@@ -109,20 +109,20 @@ describe('parseSearchQuery()', () => {
     test('negated filter', () =>
         expect(parseSearchQuery('-a:b')).toMatchObject({
             range: {
-                end: 3,
+                end: 4,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 3,
+                            end: 4,
                             start: 0,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 1,
+                                    end: 2,
                                     start: 0,
                                 },
                                 token: {
@@ -133,7 +133,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 3,
+                                    end: 4,
                                     start: 3,
                                 },
                                 token: {
@@ -154,20 +154,20 @@ describe('parseSearchQuery()', () => {
     test('filter with quoted value', () => {
         expect(parseSearchQuery('a:"b"')).toMatchObject({
             range: {
-                end: 4,
+                end: 5,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 4,
+                            end: 5,
                             start: 0,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 0,
+                                    end: 1,
                                     start: 0,
                                 },
                                 token: {
@@ -178,7 +178,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 4,
+                                    end: 5,
                                     start: 2,
                                 },
                                 token: {
@@ -200,14 +200,14 @@ describe('parseSearchQuery()', () => {
     test('quoted', () =>
         expect(parseSearchQuery('"a:b"')).toMatchObject({
             range: {
-                end: 4,
+                end: 5,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 4,
+                            end: 5,
                             start: 0,
                         },
                         token: {
@@ -224,14 +224,14 @@ describe('parseSearchQuery()', () => {
     test('quoted (escaped quotes)', () =>
         expect(parseSearchQuery('"-\\"a\\":b"')).toMatchObject({
             range: {
-                end: 9,
+                end: 10,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 9,
+                            end: 10,
                             start: 0,
                         },
                         token: {
@@ -248,20 +248,20 @@ describe('parseSearchQuery()', () => {
     test('complex query', () =>
         expect(parseSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchObject({
             range: {
-                end: 57,
+                end: 58,
                 start: 0,
             },
             token: {
                 members: [
                     {
                         range: {
-                            end: 29,
+                            end: 30,
                             start: 0,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 3,
+                                    end: 4,
                                     start: 0,
                                 },
                                 token: {
@@ -272,7 +272,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 29,
+                                    end: 30,
                                     start: 5,
                                 },
                                 token: {
@@ -286,7 +286,7 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 30,
+                            end: 31,
                             start: 30,
                         },
                         token: {
@@ -295,13 +295,13 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 37,
+                            end: 38,
                             start: 31,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 34,
+                                    end: 35,
                                     start: 31,
                                 },
                                 token: {
@@ -312,7 +312,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 37,
+                                    end: 38,
                                     start: 36,
                                 },
                                 token: {
@@ -326,7 +326,7 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 38,
+                            end: 39,
                             start: 38,
                         },
                         token: {
@@ -335,13 +335,13 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 50,
+                            end: 51,
                             start: 39,
                         },
                         token: {
                             filterType: {
                                 range: {
-                                    end: 43,
+                                    end: 44,
                                     start: 39,
                                 },
                                 token: {
@@ -352,7 +352,7 @@ describe('parseSearchQuery()', () => {
                             },
                             filterValue: {
                                 range: {
-                                    end: 50,
+                                    end: 51,
                                     start: 45,
                                 },
                                 token: {
@@ -366,7 +366,7 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 51,
+                            end: 52,
                             start: 51,
                         },
                         token: {
@@ -375,7 +375,7 @@ describe('parseSearchQuery()', () => {
                     },
                     {
                         range: {
-                            end: 57,
+                            end: 58,
                             start: 52,
                         },
                         token: {

--- a/web/src/search/parser/parser.ts
+++ b/web/src/search/parser/parser.ts
@@ -1,0 +1,197 @@
+interface CharacterRange {
+    start: number
+    end: number
+}
+
+export interface Literal {
+    type: 'literal'
+    value: string
+}
+
+export interface Filter {
+    type: 'filter'
+    filterType: Pick<ParseSuccess<Literal>, 'range' | 'token'>
+    filterValue: Pick<ParseSuccess<Literal | Quoted>, 'range' | 'token'> | undefined
+}
+
+export interface Sequence {
+    type: 'sequence'
+    members: Pick<ParseSuccess<Exclude<Token, Sequence>>, 'range' | 'token'>[]
+}
+
+export interface Quoted {
+    type: 'quoted'
+    quotedValue: string
+}
+
+export type Token = { type: 'whitespace' } | Literal | Filter | Sequence | Quoted
+
+interface ParseError {
+    type: 'error'
+    expected: string
+    at: number
+}
+
+export interface ParseSuccess<T = Token> {
+    type: 'success'
+    token: T
+    range: CharacterRange
+}
+
+type ParserResult<T = Token> = ParseError | ParseSuccess<T>
+
+type Parser<T = Token> = (input: string, start: number) => ParserResult<T>
+
+const flatten = (members: Pick<ParseSuccess, 'range' | 'token'>[]): Sequence['members'] =>
+    members.reduce(
+        (merged: Sequence['members'], { range, token }) =>
+            token.type === 'sequence' ? [...merged, ...flatten(token.members)] : [...merged, { token, range }],
+        []
+    )
+
+const zeroOrMore = (parse: Parser, parseSeparator: Parser): Parser<Sequence> => (input, start) => {
+    const members: Pick<ParseSuccess, 'range' | 'token'>[] = []
+    let adjustedStart = start
+    let end = start
+    // try to start with separator
+    const separatorResult = parseSeparator(input, start)
+    if (separatorResult.type === 'success') {
+        end = separatorResult.range.end
+        adjustedStart = separatorResult.range.end + 1
+        const { token, range } = separatorResult
+        members.push({ token, range })
+    }
+    let result = parse(input, adjustedStart)
+    while (result.type !== 'error') {
+        const { token, range } = result
+        members.push({ token, range })
+        end = result.range.end
+        adjustedStart = end + 1
+        if (input[adjustedStart] === undefined) {
+            // EOF
+            break
+        }
+        // Parse separator
+        const separatorResult = parseSeparator(input, adjustedStart)
+        if (separatorResult.type === 'error') {
+            return separatorResult
+        }
+        // Try to parse another token.
+        end = separatorResult.range.end
+        adjustedStart = end + 1
+        members.push({ token: separatorResult.token, range: separatorResult.range })
+        result = parse(input, adjustedStart)
+    }
+    return {
+        type: 'success',
+        range: { start, end },
+        token: { type: 'sequence', members: flatten(members) },
+    }
+}
+
+const oneOf = <T = Token>(...parsers: Parser<T>[]): Parser<T> => (input, start) => {
+    const expected: string[] = []
+    for (const parser of parsers) {
+        const result = parser(input, start)
+        if (result.type === 'success') {
+            return result
+        }
+        expected.push(result.expected)
+    }
+    return {
+        type: 'error',
+        expected: `One of: ${expected.join(', ')}`,
+        at: start,
+    }
+}
+
+const quoted: Parser<Quoted> = (input, start) => {
+    if (input[start] !== '"') {
+        return { type: 'error', expected: '"', at: start }
+    }
+    let end = start + 1
+    while (input[end] && (input[end] !== '"' || input[end - 1] === '\\')) {
+        end = end + 1
+    }
+    if (!input[end]) {
+        return { type: 'error', expected: '"', at: end }
+    }
+    return {
+        type: 'success',
+        range: { start, end },
+        token: { type: 'quoted', quotedValue: input.substring(start + 1, end) },
+    }
+}
+
+const character = (c: string): Parser<Literal> => (input, start) => {
+    if (input[start] !== c) {
+        return { type: 'error', expected: c, at: start }
+    }
+    return {
+        type: 'success',
+        range: { start, end: start },
+        token: { type: 'literal', value: c },
+    }
+}
+
+const pattern = <T = Literal>(p: RegExp, output?: T, expected?: string): Parser<T> => {
+    if (!p.source.startsWith('^')) {
+        p = new RegExp(`^${p.source}`)
+    }
+    return (input, start) => {
+        const matchTarget = input.substring(start)
+        if (!matchTarget) {
+            return { type: 'error', expected: expected || `/${p.source}/`, at: start }
+        }
+        const match = input.substring(start).match(p)
+        if (!match) {
+            return { type: 'error', expected: expected || `/${p.source}/`, at: start }
+        }
+        return {
+            type: 'success',
+            range: { start, end: start + match[0].length - 1 },
+            token: (output || { type: 'literal', value: match[0] }) as T,
+        }
+    }
+}
+
+const whitespace = pattern(/\s+/, { type: 'whitespace' as const }, 'whitespace')
+
+const literal = pattern(/[^\s]+/)
+
+const filterKeyword = pattern(/-?[a-z]+(?=:)/)
+
+const filterDelimiter = character(':')
+
+const filterValue = oneOf<Quoted | Literal>(quoted, pattern(/[^:\s'"]+/))
+
+const filter: Parser<Filter> = (input, start) => {
+    const parsedKeyword = filterKeyword(input, start)
+    if (parsedKeyword.type === 'error') {
+        return parsedKeyword
+    }
+    const parsedDelimiter = filterDelimiter(input, parsedKeyword.range.end + 1)
+    if (parsedDelimiter.type === 'error') {
+        return parsedDelimiter
+    }
+    const parsedValue =
+        input[parsedDelimiter.range.end + 1] === undefined
+            ? undefined
+            : filterValue(input, parsedDelimiter.range.end + 1)
+    if (parsedValue && parsedValue.type === 'error') {
+        return parsedValue
+    }
+    return {
+        type: 'success',
+        range: { start, end: parsedValue ? parsedValue.range.end : parsedDelimiter.range.end },
+        token: {
+            type: 'filter',
+            filterType: parsedKeyword,
+            filterValue: parsedValue,
+        },
+    }
+}
+
+const searchQuery = zeroOrMore(oneOf<Filter | Quoted | Literal>(filter, quoted, literal), whitespace)
+
+export const parseSearchQuery = (query: string): ParserResult<Sequence> => searchQuery(query, 0)

--- a/web/src/search/parser/parser.ts
+++ b/web/src/search/parser/parser.ts
@@ -17,7 +17,7 @@ export const toMonacoRange = ({ start, end }: CharacterRange): IRange => ({
     startLineNumber: 1,
     endLineNumber: 1,
     startColumn: start + 1,
-    endColumn: end + 1
+    endColumn: end + 1,
 })
 
 /**

--- a/web/src/search/parser/providers.ts
+++ b/web/src/search/parser/providers.ts
@@ -1,0 +1,115 @@
+import * as Monaco from 'monaco-editor'
+import { Observable, fromEventPattern, of } from 'rxjs'
+import { parseSearchQuery } from './parser'
+import { map, first, takeUntil, publishReplay, refCount, switchMap } from 'rxjs/operators'
+import { getMonacoTokens } from './tokens'
+import { getDiagnostics } from './diagnostics'
+import { getCompletionItems } from './completion'
+import { SearchSuggestion } from '../../../../shared/src/graphql/schema'
+import { getHoverResult } from './hover'
+
+interface SearchFieldProviders {
+    tokens: Monaco.languages.TokensProvider
+    hover: Monaco.languages.HoverProvider
+    completion: Monaco.languages.CompletionItemProvider
+    diagnostics: Observable<Monaco.editor.IMarkerData[]>
+}
+
+/**
+ * A dummy parsing state, required for the token provider.
+ */
+const PARSER_STATE: Monaco.languages.IState = {
+    clone: () => ({ ...PARSER_STATE }),
+    equals: () => false,
+}
+
+/**
+ * Returns the providers used by the Monaco query input to provide syntax highlighting,
+ * hovers, completions and diagnostics for the Sourcegraph search syntax.
+ */
+export function getProviders(
+    searchQueries: Observable<string>,
+    fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>
+): SearchFieldProviders {
+    const parsedQueries = searchQueries.pipe(
+        map(rawQuery => {
+            const parsed = parseSearchQuery(rawQuery)
+            return { rawQuery, parsed }
+        }),
+        publishReplay(1),
+        refCount()
+    )
+    return {
+        tokens: {
+            getInitialState: () => PARSER_STATE,
+            tokenize: line => {
+                const result = parseSearchQuery(line)
+                if (result.type === 'success') {
+                    return {
+                        tokens: getMonacoTokens(result.token),
+                        endState: PARSER_STATE,
+                    }
+                }
+                return { endState: PARSER_STATE, tokens: [] }
+            },
+        },
+        hover: {
+            provideHover: (_, position, token) =>
+                parsedQueries
+                    .pipe(
+                        first(),
+                        map(({ parsed }) => (parsed.type === 'error' ? null : getHoverResult(parsed.token, position))),
+                        takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
+                    )
+                    .toPromise(),
+        },
+        completion: {
+            // An explicit list of trigger characters is needed for the Monaco editor to show completions.
+            triggerCharacters: [
+                ':',
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+                'j',
+                'k',
+                'l',
+                'm',
+                'n',
+                'o',
+                'p',
+                'q',
+                'r',
+                's',
+                't',
+                'u',
+                'v',
+                'w',
+                'x',
+                'y',
+                'z',
+                '-',
+            ],
+            provideCompletionItems: (_, position, context, token) =>
+                parsedQueries
+                    .pipe(
+                        first(),
+                        switchMap(({ rawQuery, parsed }) =>
+                            parsed.type === 'error'
+                                ? of(null)
+                                : getCompletionItems(rawQuery, parsed.token, position, context, fetchSuggestions)
+                        ),
+                        takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
+                    )
+                    .toPromise(),
+        },
+        diagnostics: parsedQueries.pipe(
+            map(({ parsed }) => (parsed.type === 'success' ? getDiagnostics(parsed.token) : []))
+        ),
+    }
+}

--- a/web/src/search/parser/providers.ts
+++ b/web/src/search/parser/providers.ts
@@ -102,7 +102,7 @@ export function getProviders(
                         switchMap(({ rawQuery, parsed }) =>
                             parsed.type === 'error'
                                 ? of(null)
-                                : getCompletionItems(rawQuery, parsed.token, position, context, fetchSuggestions)
+                                : getCompletionItems(rawQuery, parsed.token, position, fetchSuggestions)
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )

--- a/web/src/search/parser/tokens.test.ts
+++ b/web/src/search/parser/tokens.test.ts
@@ -1,0 +1,42 @@
+import { getMonacoTokens } from './tokens'
+import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+
+describe('getMonacoTokens()', () => {
+    test('returns the tokens for a parsed search query', () => {
+        expect(
+            getMonacoTokens(
+                (parseSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews') as ParseSuccess<Sequence>)
+                    .token
+            )
+        ).toStrictEqual([
+            {
+                scopes: 'keyword',
+                startIndex: 0,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 2,
+            },
+            {
+                scopes: 'whitespace',
+                startIndex: 25,
+            },
+            {
+                scopes: 'keyword',
+                startIndex: 26,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 28,
+            },
+            {
+                scopes: 'whitespace',
+                startIndex: 45,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 46,
+            },
+        ])
+    })
+})

--- a/web/src/search/parser/tokens.ts
+++ b/web/src/search/parser/tokens.ts
@@ -1,0 +1,34 @@
+import * as Monaco from 'monaco-editor'
+import { Sequence } from './parser'
+
+/**
+ * Returns the tokens in a parsed search query displayed in the Monaco query input.
+ */
+export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
+    const tokens: Monaco.languages.IToken[] = []
+    for (const { token, range } of parsedQuery.members) {
+        if (token.type === 'whitespace') {
+            tokens.push({
+                startIndex: range.start,
+                scopes: 'whitespace',
+            })
+        } else if (token.type === 'quoted' || token.type === 'literal') {
+            tokens.push({
+                startIndex: range.start,
+                scopes: 'identifier',
+            })
+        } else if (token.type === 'filter') {
+            tokens.push({
+                startIndex: token.filterType.range.start,
+                scopes: 'keyword',
+            })
+            if (token.filterValue) {
+                tokens.push({
+                    startIndex: token.filterValue.range.start,
+                    scopes: 'identifier',
+                })
+            }
+        }
+    }
+    return tokens
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,8 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.0.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.1":
   version "3.0.1"
@@ -2952,6 +2953,11 @@
     "@types/d3-shape" "*"
     "@types/react" "*"
     "@types/recharts-scale" "*"
+
+"@types/resize-observer-browser@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.3.tgz#5cca2445e6fc34a380760bd6ef8c492863469c47"
+  integrity sha512-3tGjLIDH8L57fWOfC7NVn/BbGQD7pXwbkk2+8Z4hK/S7kOIv1MUN4nkKjfx0qg4ctkukjzp3Bgr/Z+Hq5ZQZTQ==
 
 "@types/retry@^0.12.0":
   version "0.12.0"
@@ -17687,7 +17693,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "23.0.1"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
This PR adds a new component, `MonacoQueryInput`, to the Sourcegraph web app. It provides:
- Basic syntax highlighting of search queries
- Autocompletion of filter types.
- Autocompletion of filter values (both static and dynamically fetched)
- Hover tooltips on filters
- Diagnostics for invalid filter types, invalid filter values, improper use of colons in queries

![smarterSearchField_1](https://user-images.githubusercontent.com/1741180/72238170-03f09680-35ab-11ea-9e8c-ad298b1a32e8.gif)
![smarterSearchField_2](https://user-images.githubusercontent.com/1741180/72238178-05ba5a00-35ab-11ea-97b5-579c9c2958e4.gif)

In order to do so, it is backed by a small search query parser, implemented in `web/src/search/query/parser.ts`.

This new query input is currently **feature-flagged**, off by default (on in dev environments), behind `experimentalFeatures.smartSearchField` in global settings. Very little pre-existing code has been changed. The intention is to refine this after merging, and to test it extensively internally before enabling it by default for all users. For instance (and I will file known issues):
- The completions dropdown still looks very Monaco-y
- Some dynamically fetched suggestions are not shown (eg. symbols)
- Resize is still buggy

This PR is split in two commits:
- The first commit contains the implementation of `MonacoQueryInput`.
- The second commit integrates `MonacoQueryInput` in the webapp, behind a feature flag.

Known issues:
- https://github.com/sourcegraph/sourcegraph/issues/7692
- https://github.com/sourcegraph/sourcegraph/issues/7693
- https://github.com/sourcegraph/sourcegraph/issues/7694
- https://github.com/sourcegraph/sourcegraph/issues/7695
- https://github.com/sourcegraph/sourcegraph/issues/7696
- https://github.com/sourcegraph/sourcegraph/issues/7697
- https://github.com/sourcegraph/sourcegraph/issues/7698
