### PR TITLE
gitserver: Allow overriding commit name and email

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -123,13 +123,25 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	if message == "" {
 		message = "<Sourcegraph> Creating commit from patch"
 	}
+	const (
+		defaultName  = "Sourcegraph"
+		defaultEmail = "support@sourcegraph.com"
+	)
 	authorName := req.CommitInfo.AuthorName
 	if authorName == "" {
-		authorName = "Sourcegraph"
+		authorName = defaultName
 	}
 	authorEmail := req.CommitInfo.AuthorEmail
 	if authorEmail == "" {
-		authorEmail = "support@sourcegraph.com"
+		authorEmail = defaultEmail
+	}
+	committerName := req.CommitInfo.CommitterName
+	if committerName == "" {
+		committerName = defaultName
+	}
+	committerEmail := req.CommitInfo.CommitterEmail
+	if committerEmail == "" {
+		committerEmail = defaultEmail
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "commit", "-m", message)
@@ -137,8 +149,8 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Env = append(cmd.Env, []string{
 		tmpGitPathEnv,
 		altObjectsEnv,
-		"GIT_COMMITTER_NAME=sourcegraph-committer",
-		"GIT_COMMITTER_EMAIL=support@sourcegraph.com",
+		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committerName),
+		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committerEmail),
 		fmt.Sprintf("GIT_AUTHOR_NAME=%s", authorName),
 		fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", authorEmail),
 		fmt.Sprintf("GIT_COMMITTER_DATE=%v", req.CommitInfo.Date),

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -123,25 +123,21 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	if message == "" {
 		message = "<Sourcegraph> Creating commit from patch"
 	}
-	const (
-		defaultName  = "Sourcegraph"
-		defaultEmail = "support@sourcegraph.com"
-	)
 	authorName := req.CommitInfo.AuthorName
 	if authorName == "" {
-		authorName = defaultName
+		authorName = "Sourcegraph"
 	}
 	authorEmail := req.CommitInfo.AuthorEmail
 	if authorEmail == "" {
-		authorEmail = defaultEmail
+		authorEmail = "support@sourcegraph.com"
 	}
 	committerName := req.CommitInfo.CommitterName
 	if committerName == "" {
-		committerName = defaultName
+		committerName = authorName
 	}
 	committerEmail := req.CommitInfo.CommitterEmail
 	if committerEmail == "" {
-		committerEmail = defaultEmail
+		committerEmail = authorEmail
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "commit", "-m", message)

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -149,10 +149,12 @@ type CreateCommitFromPatchRequest struct {
 
 // PatchCommitInfo will be used for commit information when creating a commit from a patch
 type PatchCommitInfo struct {
-	Message     string
-	AuthorName  string
-	AuthorEmail string
-	Date        time.Time
+	Message        string
+	AuthorName     string
+	AuthorEmail    string
+	CommitterName  string
+	CommitterEmail string
+	Date           time.Time
 }
 
 // CreateCommitFromPatchResponse is the response type returned after creating


### PR DESCRIPTION
If left blank, it'll fall back to the author values

Fixes https://github.com/sourcegraph/sourcegraph/issues/7546

