### PR TITLE
Add semi-opaque background to badge attachments.

### DIFF
--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -3,12 +3,11 @@
         width: 1.75rem;
         height: 1.75rem;
         padding: 0.25rem;
-        border-radius: 0;
         background: transparent;
         z-index: 1;
         border: none;
-        background-color: rgba(0, 0, 0, 0.8);
-        border-radius: 1em;
+        border-radius: 1rem;
+        background-color: rgba(255, 255, 255, 0.8);
     }
 
     width: 100%;

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -7,8 +7,18 @@
         background: transparent;
         z-index: 1;
         border: none;
+        background-color: rgba(0, 0, 0, 0.8);
+        border-radius: 1em;
     }
 
     width: 100%;
     text-align: right;
+}
+
+.theme-light {
+    .badge-decoration-attachment {
+        img {
+            background-color: rgba(255, 255, 255, 0.8);
+        }
+    }
 }


### PR DESCRIPTION
This prevents badge attachments from overlapping the hover text in a very hard to read way.