### PR TITLE
Add back the quick-configure actions that used to exist for critical site config

### DIFF
--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -6,7 +6,7 @@ Select your SAML identity provider for setup instructions:
 - [Azure Active Directory (Azure AD)](azure_ad.md)
 - [Microsoft Active Directory Federation Services (ADFS)](microsoft_adfs.md)
 - [Auth0](generic.md)
-- [OneLogin](generic.md)
+- [OneLogin](one_login.md)
 - [Ping Identity](generic.md)
 - [Salesforce Identity](generic.md)
 - [Other](generic.md)

--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -23,17 +23,17 @@
 1. In Sourcegraph [site config](../../config/site_config.md), ensure `externalURL` is set the same Sourcegraph URL you used in the previous section (i.e., what you replaced `https://sourcegraph.example.com` with). Be mindful to use the exact same scheme (`http` or `https`), and there should be no trailing slash.
 1. Add an item to `auth.providers` with `type` "saml" and `identityProviderMetadataURL` set to the URL you copied from the "Identity Provider metadata" link in the previous section. Here is an example of what your site configuration should look like:
 
-   ```json
+```json
+{
+ // ...
+ "externalURL": "https://sourcegraph.example.com",
+ "auth.providers": [
    {
-    // ...
-    "externalURL": "https://sourcegraph.example.com",
-    "auth.providers": [
-      {
-        "type": "saml",
-        "identityProviderMetadataURL": "https://okta.example.com/app/8VglnckX0yyhdkp0bk00/sso/saml/metadata"
-      }
-    ]
+     "type": "saml",
+     "identityProviderMetadataURL": "https://okta.example.com/app/8VglnckX0yyhdkp0bk00/sso/saml/metadata"
    }
-   ```
+ ]
+}
+```
 
 Confirm there are no error messages in the `sourcegraph/server` Docker container logs (or the `sourcegraph-frontend` pod logs, if Sourcegraph is deployed to a Kubernetes cluster). The most likely error message indicating a problem is `Error prefetching SAML service provider metadata`. See [SAML troubleshooting](../saml.md#saml-troubleshooting) for more tips.

--- a/doc/admin/auth/saml/one_login.md
+++ b/doc/admin/auth/saml/one_login.md
@@ -8,7 +8,7 @@
 1. Under the "Configuration" tab, set the following properties (replacing `https://sourcegraph.example.com` with your Sourcegraph URL):
    * `Audience`:  https://sourcegraph.example.com/.auth/saml/metadata
    * `Recipient`: https://sourcegraph.example.com/.auth/saml/acs
-   * `ACS (Consumer) URL Validator`: https://sourcegraph\\.example\\.com\\/\\.auth\\/saml\\/acs<br>
+   * `ACS (Consumer) URL Validator`: https:<span>//</span>sourcegraph\\.example\\.com\\/\\.auth\\/saml\\/acs<br>
      (This is regular expression that matches the URL `https://sourcegraph.example.com/.auth/saml/acs`)
    * `ACS (Consumer) URL`: https://sourcegraph.example.com/.auth/saml/acs
 1. Under the "Parameters" tab, ensure the following parameters exist:<br>

--- a/doc/admin/auth/saml/one_login.md
+++ b/doc/admin/auth/saml/one_login.md
@@ -1,0 +1,45 @@
+# Configuring SAML with One Login
+
+## 1. Create a SAML app in OneLogin
+
+1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your company's OneLogin
+   ID).
+1. Select "SAML Test Connector (SP)" and click "Save".
+1. Under the "Configuration" tab, set the following properties (replacing `https://sourcegraph.example.com` with your Sourcegraph URL):
+   * `Audience`:  https://sourcegraph.example.com/.auth/saml/metadata
+   * `Recipient`: https://sourcegraph.example.com/.auth/saml/acs
+   * `ACS (Consumer) URL Validator`: https://sourcegraph\\.example\\.com\\/\\.auth\\/saml\\/acs<br>
+     (This is regular expression that matches the URL `https://sourcegraph.example.com/.auth/saml/acs`)
+   * `ACS (Consumer) URL`: https://sourcegraph.example.com/.auth/saml/acs
+1. Under the "Parameters" tab, ensure the following parameters exist:<br>
+   * Email (NameID): Email
+   * DisplayName:    First Name         Include in SAML Assertion: ✓
+   * login:          AD user name       Include in SAML Assertion: ✓
+1. Save the app in OneLogin.
+1. Find the Issuer URL in the OneLogin app configuration page, under the "SSO" tab, under "Issuer
+   URL". It should look something like `https://mycompany.onelogin.com/saml/metadata/123456` or
+   `https://app.onelogin.com/saml/metadata/123456`. Record this for the next section.
+
+## 2. Add the SAMl auth provider to Sourcegraph site config
+
+1. In Sourcegraph [site config](../../config/site_config.md), ensure `externalURL` is set the same Sourcegraph URL you used in the previous section (i.e., what you replaced `https://sourcegraph.example.com` with). Be mindful to use the exact same scheme (`http` or `https`), and there should be no trailing slash.
+1. Add an item to `auth.providers` with `type` "saml" and `identityProviderMetadataURL` set to the
+   Issuer URL recorded from the previous section. Here is an example:
+
+```json
+{
+ // ...
+ "externalURL": "https://sourcegraph.example.com",
+ "auth.providers": [
+   {
+     "type": "saml",
+     "identityProviderMetadataURL": "<issuer URL>"
+   }
+ ]
+}
+```
+
+Confirm there are no error messages in the `sourcegraph/server` Docker container logs (or the
+`sourcegraph-frontend` pod logs, if Sourcegraph is deployed to a Kubernetes cluster). The most
+likely error message indicating a problem is `Error prefetching SAML service provider metadata`. See
+[SAML troubleshooting](../saml.md#saml-troubleshooting) for more tips.

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -62,21 +62,23 @@ const quickConfigureActions: {
         id: 'addGitLabAuth',
         label: 'Add GitLab sign-in',
         run: config => {
-            const edits = [editWithComments(
-                config,
-                ['auth.providers', -1],
-                {
-                    COMMENT: true,
-                    type: 'gitlab',
-                    displayName: 'GitLab',
-                    url: '<GitLab URL>',
-                    clientID: '<client ID>',
-                    clientSecret: '<client secret>',
-                },
-                {
-                    COMMENT: '// See https://docs.sourcegraph.com/admin/auth#gitlab for instructions'
-                }
-            )]
+            const edits = [
+                editWithComments(
+                    config,
+                    ['auth.providers', -1],
+                    {
+                        COMMENT: true,
+                        type: 'gitlab',
+                        displayName: 'GitLab',
+                        url: '<GitLab URL>',
+                        clientID: '<client ID>',
+                        clientSecret: '<client secret>',
+                    },
+                    {
+                        COMMENT: '// See https://docs.sourcegraph.com/admin/auth#gitlab for instructions',
+                    }
+                ),
+            ]
             return { edits, selectText: '<GitLab URL>' }
         },
     },
@@ -84,20 +86,22 @@ const quickConfigureActions: {
         id: 'addGitHubAuth',
         label: 'Add GitHub sign-in',
         run: config => {
-            const edits = [editWithComments(
-                config,
-                ['auth.providers', -1],
-                {
-                    COMMENT: true,
-                    type: 'github',
-                    displayName: 'GitHub',
-                    url: 'https://github.com/',
-                    allowSignup: true,
-                    clientID: '<client ID>',
-                    clientSecret: '<client secret>',
-                },
-                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#github for instructions'}
-            )]
+            const edits = [
+                editWithComments(
+                    config,
+                    ['auth.providers', -1],
+                    {
+                        COMMENT: true,
+                        type: 'github',
+                        displayName: 'GitHub',
+                        url: 'https://github.com/',
+                        allowSignup: true,
+                        clientID: '<client ID>',
+                        clientSecret: '<client secret>',
+                    },
+                    { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#github for instructions' }
+                ),
+            ]
             return { edits, selectText: '<client ID>' }
         },
     },
@@ -105,21 +109,23 @@ const quickConfigureActions: {
         id: 'useOneLoginSAML',
         label: 'Add OneLogin SAML',
         run: config => {
-            const edits = [editWithComments(
-                config,
-                ['auth.providers', -1],
-                {
-                    COMMENT: true,
+            const edits = [
+                editWithComments(
+                    config,
+                    ['auth.providers', -1],
+                    {
+                        COMMENT: true,
 
-                    type: 'saml',
-                    displayName: 'OneLogin',
-                    identityProviderMetadataURL: '<identity provider metadata URL>',
-                },
-                {
-                    COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/one_login for instructions'
-                },
-            )]
-            return { edits, selectText: '<identity provider metadata URL>'}
+                        type: 'saml',
+                        displayName: 'OneLogin',
+                        identityProviderMetadataURL: '<identity provider metadata URL>',
+                    },
+                    {
+                        COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/one_login for instructions',
+                    }
+                ),
+            ]
+            return { edits, selectText: '<identity provider metadata URL>' }
         },
     },
     {
@@ -132,9 +138,11 @@ const quickConfigureActions: {
                 displayName: 'Okta',
                 identityProviderMetadataURL: '<identity provider metadata URL>',
             }
-            const edits = [editWithComments(config, ['auth.providers', -1], value, {
-                COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/okta for instructions'
-            })]
+            const edits = [
+                editWithComments(config, ['auth.providers', -1], value, {
+                    COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/okta for instructions',
+                }),
+            ]
             return { edits, selectText: '<identity provider metadata URL>' }
         },
     },
@@ -142,17 +150,19 @@ const quickConfigureActions: {
         id: 'useSAML',
         label: 'Add other SAML',
         run: config => {
-            const edits = [editWithComments(
-                config,
-                ['auth.providers', -1],
-                {
-                    COMMENT: true,
-                    type: 'saml',
-                    displayName: 'SAML',
-                    identityProviderMetadataURL: '<SAML IdP metadata URL>',
-                },
-                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml for instructions'},
-            )]
+            const edits = [
+                editWithComments(
+                    config,
+                    ['auth.providers', -1],
+                    {
+                        COMMENT: true,
+                        type: 'saml',
+                        displayName: 'SAML',
+                        identityProviderMetadataURL: '<SAML IdP metadata URL>',
+                    },
+                    { COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml for instructions' }
+                ),
+            ]
             return { edits, selectText: '<SAML IdP metadata URL>' }
         },
     },
@@ -160,19 +170,21 @@ const quickConfigureActions: {
         id: 'useOIDC',
         label: 'Add OpenID Connect',
         run: config => {
-            const edits = [editWithComments(
-                config,
-                ['auth.providers', -1],
-                {
-                    COMMENT: true,
-                    type: 'openidconnect',
-                    displayName: 'OpenID Connect',
-                    issuer: '<identity provider URL>',
-                    clientID: '<client ID>',
-                    clientSecret: '<client secret>',
-                },
-                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#openid-connect for instructions'}
-            )]
+            const edits = [
+                editWithComments(
+                    config,
+                    ['auth.providers', -1],
+                    {
+                        COMMENT: true,
+                        type: 'openidconnect',
+                        displayName: 'OpenID Connect',
+                        issuer: '<identity provider URL>',
+                        clientID: '<client ID>',
+                        clientSecret: '<client secret>',
+                    },
+                    { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#openid-connect for instructions' }
+                ),
+            ]
             return { edits, selectText: '<identity provider URL>' }
         },
     },

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -21,22 +21,6 @@ const defaultFormattingOptions: jsonc.FormattingOptions = {
     tabSize: 2,
 }
 
-function getExternalURLPlaceholders(config: string): { externalURL: string; externalURLRegexp: string } {
-    let externalURL
-    let externalURLRegexp
-    try {
-        externalURL = jsonc.parse(config).externalURL
-        externalURLRegexp = externalURL.replace(/\//g, '\\/')
-    } catch {
-        /* not necessarily an error, config might be empty */
-    }
-    if (!externalURL) {
-        externalURL = '<externalURL>'
-        externalURLRegexp = '<externalURL regex>'
-    }
-    return { externalURL, externalURLRegexp }
-}
-
 function editWithComments(
     config: string,
     path: jsonc.JSONPath,
@@ -78,18 +62,21 @@ const quickConfigureActions: {
         id: 'addGitLabAuth',
         label: 'Add GitLab sign-in',
         run: config => {
-            const edits = setProperty(
+            const edits = [editWithComments(
                 config,
                 ['auth.providers', -1],
                 {
+                    COMMENT: true,
                     type: 'gitlab',
                     displayName: 'GitLab',
                     url: '<GitLab URL>',
                     clientID: '<client ID>',
                     clientSecret: '<client secret>',
                 },
-                defaultFormattingOptions
-            )
+                {
+                    COMMENT: '// See https://docs.sourcegraph.com/admin/auth#gitlab for instructions'
+                }
+            )]
             return { edits, selectText: '<GitLab URL>' }
         },
     },
@@ -97,10 +84,11 @@ const quickConfigureActions: {
         id: 'addGitHubAuth',
         label: 'Add GitHub sign-in',
         run: config => {
-            const edits = setProperty(
+            const edits = [editWithComments(
                 config,
                 ['auth.providers', -1],
                 {
+                    COMMENT: true,
                     type: 'github',
                     displayName: 'GitHub',
                     url: 'https://github.com/',
@@ -108,8 +96,8 @@ const quickConfigureActions: {
                     clientID: '<client ID>',
                     clientSecret: '<client secret>',
                 },
-                defaultFormattingOptions
-            )
+                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#github for instructions'}
+            )]
             return { edits, selectText: '<client ID>' }
         },
     },
@@ -117,108 +105,54 @@ const quickConfigureActions: {
         id: 'useOneLoginSAML',
         label: 'Add OneLogin SAML',
         run: config => {
-            const { externalURL, externalURLRegexp } = getExternalURLPlaceholders(config)
-            const value = {
-                type: 'saml',
-                displayName: 'OneLogin',
-                COMMENT_1: true,
-                COMMENT_2: true,
-                identityProviderMetadataURL: '<identity provider metadata URL>',
-            }
-            const comments = {
-                COMMENT_1: `
-      // OneLogin SAML instructions
-      // ==========================
-      //
-      // Before proceeding, ensure you've set externalURL to the appropriate value.
-      // (The instructions below use the current value of externalURL.)
-      //
-      // Create a SAML app in OneLogin:
-      // 1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your
-      //    company's OneLogin ID).
-      // 2. Select "SAML Test Connector (SP)" and click "Save".
-      // 3. Under the "Configuration" tab, set the following properties:
-      //    Audience:  ${externalURL}/.auth/saml/metadata
-      //    Recipient: ${externalURL}/.auth/saml/acs
-      //    ACS (Consumer) URL Validator: ${externalURLRegexp}\\/\\.auth\\/saml\\/acs
-      //    ACS (Consumer) URL: ${externalURL}/.auth/saml/acs
-      // 4. Under the "Parameters" tab, ensure the following parameters exist:
-      //    Email (NameID): Email
-      //    DisplayName:    First Name         Include in SAML Assertion: ✓
-      //    login:          AD user name       Include in SAML Assertion: ✓
-      // 5. Save the app in OneLogin and fill in the fields below:`,
-                COMMENT_2: `
-      // This URL describes OneLogin to Sourcegraph. Find it in the OneLogin app config GUI
-      // under the "SSO" tab, under "Issuer URL".
-      // It should look something like "https://mycompany.onelogin.com/saml/metadata/123456"
-      // or "https://app.onelogin.com/saml/metadata/123456".`,
-            }
-            const edits = [editWithComments(config, ['auth.providers', -1], value, comments)]
-            return { edits, selectText: 'OneLogin SAML instructions' }
+            const edits = [editWithComments(
+                config,
+                ['auth.providers', -1],
+                {
+                    COMMENT: true,
+
+                    type: 'saml',
+                    displayName: 'OneLogin',
+                    identityProviderMetadataURL: '<identity provider metadata URL>',
+                },
+                {
+                    COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/one_login for instructions'
+                },
+            )]
+            return { edits, selectText: '<identity provider metadata URL>'}
         },
     },
     {
         id: 'useOktaSAML',
         label: 'Add Okta SAML',
         run: config => {
-            const { externalURL } = getExternalURLPlaceholders(config)
             const value = {
+                COMMENT: true,
                 type: 'saml',
                 displayName: 'Okta',
-                COMMENT_1: true,
-                COMMENT_2: true,
                 identityProviderMetadataURL: '<identity provider metadata URL>',
             }
-            const comments = {
-                COMMENT_1: `
-      // Okta SAML instructions
-      // ======================
-      //
-      // Before proceeding, ensure you've set externalURL to the appropriate value.
-      // (The instructions below use the current value of externalURL.)
-      //
-      // Create a SAML app in Okta:
-      // 1. Go to the Okta admin "Add Application" page, classic UI (looks like
-      //    https://my-org.okta.com/admin/apps/add-app or https://dev-12345.oktapreview.com/admin/apps/add-app).
-      // 2. Click "Create New App", select "SAML 2.0", and "Create".
-      // 3. Give the app the name "Sourcegraph", click "Next".
-      // 4. Set the following SAML settings:
-      //    Single Sign On URL: ${externalURL}/.auth/saml/acs
-      //      Use this for Recipient URL and Destination URL: ✓
-      //    Audience URI (SP Entity ID) / Audience Restriction: ${externalURL}/.auth/saml/metadata
-      //    Attribute statements:
-      //      Email: user.email
-      //      Login: user.login
-      //      DisplayName: \${user.firstName} \${user.lastName}
-      //    Click "Next".
-      // 5. Select "I'm an Okta customer adding an internal app" and click "Finish".
-      // 6. Go to the "Assignments" tab, click the "Assign" dropdown > "Assign to Groups"
-      //    > Everyone ("Assign" button).
-      // 7. Fill in the fields below:`,
-                COMMENT_2: `
-      // This URL describes Okta to Sourcegraph. Go to the "Sign On" tab and copy
-      // the hyperlink "Identity Provider metadata is available if this application
-      // supports dynamic configuration." The value looks like
-      // "https://my-org.okta.com/app/abcdefghijk012345678/sso/saml/metadata" or "https://dev-123435.oktapreview.com/app/abcdefghijk012345678/sso/saml/metadata".`,
-            }
-            const edits = [editWithComments(config, ['auth.providers', -1], value, comments)]
-            return { edits, selectText: 'Okta SAML instructions' }
+            const edits = [editWithComments(config, ['auth.providers', -1], value, {
+                COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml/okta for instructions'
+            })]
+            return { edits, selectText: '<identity provider metadata URL>' }
         },
     },
     {
         id: 'useSAML',
         label: 'Add other SAML',
         run: config => {
-            const edits = setProperty(
+            const edits = [editWithComments(
                 config,
                 ['auth.providers', -1],
                 {
+                    COMMENT: true,
                     type: 'saml',
                     displayName: 'SAML',
                     identityProviderMetadataURL: '<SAML IdP metadata URL>',
                 },
-                defaultFormattingOptions
-            )
+                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth/saml for instructions'},
+            )]
             return { edits, selectText: '<SAML IdP metadata URL>' }
         },
     },
@@ -226,18 +160,19 @@ const quickConfigureActions: {
         id: 'useOIDC',
         label: 'Add OpenID Connect',
         run: config => {
-            const edits = setProperty(
+            const edits = [editWithComments(
                 config,
                 ['auth.providers', -1],
                 {
+                    COMMENT: true,
                     type: 'openidconnect',
                     displayName: 'OpenID Connect',
                     issuer: '<identity provider URL>',
                     clientID: '<client ID>',
                     clientSecret: '<client secret>',
                 },
-                defaultFormattingOptions
-            )
+                { COMMENT: '// See https://docs.sourcegraph.com/admin/auth#openid-connect for instructions'}
+            )]
             return { edits, selectText: '<identity provider URL>' }
         },
     },


### PR DESCRIPTION
The critical config editor used to have quick-configure actions to make it easier and more obvious how to set the external URL and add auth providers. This adds those to site config.

![image](https://user-images.githubusercontent.com/1646931/72317280-90ec2c00-364d-11ea-8e27-51b33d1c06aa.png)
