### PR TITLE
search: use regex expressions in Zoekt for structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -141,67 +141,64 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 		{
 			Name:     "Just a hole",
 			Pattern:  ":[1]",
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `TRUE`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"()(?-s:.)*?()")`,
 		},
 		{
 			Name:     "Adjacent holes",
 			Pattern:  ":[1]:[2]:[3]",
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `TRUE`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"()(?-s:.)*?()(?-s:.)*?()(?-s:.)*?()")`,
 		},
 		{
 			Name:     "Substring between holes",
 			Pattern:  ":[1] substring :[2]",
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `(and case_content_substr:" substring ")`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"()(?-s:.)*?([\\t-\\n\\f-\\r ]+substring[\\t-\\n\\f-\\r ]+)(?-s:.)*?()")`,
 		},
 		{
 			Name:     "Substring before and after different hole kinds",
 			Pattern:  "prefix :[[1]] :[2.] suffix",
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `(and case_content_substr:"prefix " case_content_substr:" " case_content_substr:" suffix")`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"(prefix[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+suffix)")`,
 		},
 		{
 			Name:     "Substrings covering all hole kinds.",
 			Pattern:  `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `(and case_content_substr:"1. " case_content_substr:" 2. " case_content_substr:" 3. " case_content_substr:" 4. " case_content_substr:" 5. " case_content_substr:" 6. " case_content_substr:" done.")`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"(1\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+2\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+3\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+4\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+5\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+6\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+done\\.)")`,
 		},
 		{
-			Name: "Substrings across multiple lines.",
-			Pattern: `:[1] spans
-multiple
-lines
- :[2]`,
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `(and case_content_substr:" spans\nmultiple\nlines\n ")`,
+			Name:     "Substrings across multiple lines.",
+			Pattern:  ``,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"()")`,
 		},
 		{
 			Name:     "Allow alphanumeric identifiers in holes",
 			Pattern:  "sub :[alphanum_ident_123] string",
-			Function: StructuralPatToConjunctedLiteralsQuery,
-			Want:     `(and case_content_substr:"sub " case_content_substr:" string")`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(and case_regex:"(sub[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+string)")`,
 		},
 
 		{
 			Name:     "Whitespace separated holes",
 			Pattern:  ":[1] :[2]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(?:)" case_regex:"[\\t-\\n\\f-\\r ]+" case_regex:"(?:)")`,
+			Want:     `(and case_regex:"()(?-s:.)*?([\\t-\\n\\f-\\r ]+)(?-s:.)*?()")`,
 		},
 		{
 			Name:     "Expect newline separated pattern",
 			Pattern:  "ParseInt(:[stuff], :[x]) if err ",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_content_substr:"ParseInt(" case_regex:",[\\t-\\n\\f-\\r ]+" case_regex:"\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+")`,
+			Want:     `(and case_regex:"(ParseInt\\()(?-s:.)*?(,[\\t-\\n\\f-\\r ]+)(?-s:.)*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
 		},
 		{
 			Name: "Contiguous whitespace is replaced by regex",
 			Pattern: `ParseInt(:[stuff],    :[x])
              if err `,
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_content_substr:"ParseInt(" case_regex:",[\\t-\\n\\f-\\r ]+" case_regex:"\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+")`,
+			Want:     `(and case_regex:"(ParseInt\\()(?-s:.)*?(,[\\t-\\n\\f-\\r ]+)(?-s:.)*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
 		},
 	}
 	for _, tt := range cases {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -398,87 +398,42 @@ func splitOnHolesPattern() string {
 
 var matchHoleRegexp = lazyregexp.New(splitOnHolesPattern())
 
-// Parses comby a structural syntax by stripping holes and returns a Zoekt
-// query. The Zoekt query is (only) a a conjunction of constant substrings.
-// Examples:
-//
-// "foo(:[args])"          -> "foo(" AND ")"
-// ":[fn](:[[1]], :[[2]])" -> "(" AND ", " AND ")"
-// ":[1\n] :[ whitespace]" -> " "
-func StructuralPatToConjunctedLiteralsQuery(pattern string) (zoektquery.Q, error) {
-	var children []zoektquery.Q
-	substrings := matchHoleRegexp.Split(pattern, -1)
-	for _, s := range substrings {
-		if s != "" {
-			children = append(children, &zoektquery.Substring{
-				Pattern:       s,
-				CaseSensitive: true,
-				Content:       true,
-			})
-		}
-	}
-	if len(children) == 0 {
-		return &zoektquery.Const{Value: true}, nil
-	}
-	return &zoektquery.And{Children: children}, nil
-}
-
-// Converts comby a structural pattern to a Zoekt regular expression query. This
-// conversion conceptually performs the same conversion as
-// StructuralPatToConjunctedLiteralsQuery, except that whitespace in the pattern
-// is converted so that content across newlines can be matched in the index. The
-// function produces a conjunction of regular expressions where whitespace is
-// converted to \s+, rather than a conjunction of literal strings.
+// Converts comby a structural pattern to a Zoekt regular expression query. It
+// converts whitespace in the pattern so that content across newlines can be
+// matched in the index. As an incomplete approximation, we use the regex
+// pattern .*? to scan ahead.
 // Example:
-// "ParseInt(:[args]) if err != nil" -> "ParseInt(" AND ")\s+if\s+err!=\s+nil"
+// "ParseInt(:[args]) if err != nil" -> "ParseInt(.*)\s+if\s+err!=\s+nil"
 func StructuralPatToRegexpQuery(pattern string) (zoektquery.Q, error) {
 	substrings := matchHoleRegexp.Split(pattern, -1)
 	var children []zoektquery.Q
+	var pieces []string
 	for _, s := range substrings {
-		rs := regexp.QuoteMeta(s)
+		piece := regexp.QuoteMeta(s)
 		onMatchWhitespace := lazyregexp.New(`[\s]+`)
-		rs = onMatchWhitespace.ReplaceAllLiteralString(rs, `[\s]+`)
-		re, err := syntax.Parse(rs, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
-		if err != nil {
-			return nil, err
-		}
-		// zoekt decides to use its literal optimization at the query parser
-		// level, so we check if our regex can just be a literal.
-		if re.Op == syntax.OpLiteral {
-			children = append(children, &zoektquery.Substring{
-				Pattern:       s,
-				CaseSensitive: true,
-				Content:       true,
-			})
-		} else {
-			children = append(children, &zoektquery.Regexp{
-				Regexp:        re,
-				CaseSensitive: true,
-				Content:       true,
-			})
-		}
+		piece = onMatchWhitespace.ReplaceAllLiteralString(piece, `[\s]+`)
+		pieces = append(pieces, piece)
 	}
-	if len(children) == 0 {
+
+	if len(pieces) == 0 {
 		return &zoektquery.Const{Value: true}, nil
 	}
+	rs := "(" + strings.Join(pieces, ").*?(") + ")"
+	re, _ := syntax.Parse(rs, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
+	children = append(children, &zoektquery.Regexp{
+		Regexp:        re,
+		CaseSensitive: true,
+		Content:       true,
+	})
 	return &zoektquery.And{Children: children}, nil
 }
 
 func StructuralPatToQuery(pattern string) (zoektquery.Q, error) {
-	// ToConjunctedLiteralsQuery cannot return an error. @rvantonder added
-	// an error type so that the function signatures below are equal,
-	// resulting in cleaner test code.
-	conjunctedLiteralsQuery, _ := StructuralPatToConjunctedLiteralsQuery(pattern)
 	regexpQuery, err := StructuralPatToRegexpQuery(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return &zoektquery.Or{
-		Children: []zoektquery.Q{
-			conjunctedLiteralsQuery,
-			regexpQuery,
-		},
-	}, nil
+	return &zoektquery.Or{Children: []zoektquery.Q{regexpQuery}}, nil
 }
 
 func queryToZoektQuery(query *search.TextPatternInfo, isSymbol bool) (zoektquery.Q, error) {


### PR DESCRIPTION
This PR is also for discussion, I'd appreciate some insights @keegancsmith.

The problem: For structural search I just want Zoekt to tell me which files contain some content. Currently I use a Zoekt query that returns file matches, and then I extract thee file paths. A [comment here](https://github.com/sourcegraph/sourcegraph/pull/6309#issuecomment-548691096) mentions that 

```
Our zoekt fork contains two extensions that may interest you:
- type:file will only return path file matches. IE type:file foo returns all files which has foo in contents.
...
```

But, (a) `type:file` doesn't seem to do anything in search (it does not give a list of files, just the matches as usual? [example query](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+type:file+main&patternType=literal)) and the code [just calls `searcherFilesInRepos`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6dec34af821c1269d6e107beabac10ca6243c267/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1104) so it doesn't look like anything special is happening here. (b) I cannot find any indication in `zoekt.go` that we can specify an option that only returns file matches where the file contains some contents--it always seems to retrieve [the matched contents and put them in `[]FileMatchResolver`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6dec34af821c1269d6e107beabac10ca6243c267/-/blob/cmd/frontend/graphqlbackend/zoekt.go#L261).

Now, the problem is that I care about only retrieving a list of files containing a matched string, _but zoekt will always return the number of matches in these files too_ as far as I can tell from above. This behavior affects _how many file matches zoekt will return_, because it will return the number of matching files based on how many matches it finds _in_ that file (something that I don't care about), leading to the following problematic behavior for structural search:

- Specifying a pattern like `foo(:[args])` will convert to a zoekt query that says "find me all files that contain matches of string `foo(` and `)`". 
- Zoekt finds a file `bar.c` and sees it contains both `foo(` and `)`, so it satisfies the query. Then it does a bunch of work and _counts and returns_ how many matches there are of the strings `foo(` and `)` in this file. It will find hundreds to thousands of matches of the dangling `)`.
- Zoekt does this for a few more files then says "dang, that's a lot of matches, let's stop returning files that satisfy this query". Upstream, in `zoekt.go`, we look at this information and also say "dang, that's a lot of matches, let's set `limitHit` to true".
- Meanwhile, I don't care how many matches there are in the file, I just want file paths irrespective of number of containing matches. 
- So, Zoekt only returns information about, say, 5 or 7 files that satisfy the original query, whereas I'd be happy to get 30 to 100.
- All this messes with whether `limitHit` gets set or not inside zoekt, and I'll need to do extra accounting so that limitHit is accurate for structural search.

Ways to fix this? 

- Tell Zoekt to give me file matches and stop looking at match counts. I couldn't find a way to have Zoekt ignore the number of matches and just give me the files irrespective of match count. Setting the match count in [`searchOptions`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6dec34af821c1269d6e107beabac10ca6243c267/-/blob/cmd/frontend/graphqlbackend/zoekt.go#L50) to some very high number is not a solution here, because that might force it to do _a lot_ of work for cases it doesn't need to. In general it's just not the right approach to fiddle with match counts (if that's the only control we have) to get Zoekt to return matching files. The ideal behavior would be if zoekt shortcircuited on a matching file and just return that.
- This PR: Change the conversion of `foo(:[args])` to regex `foo\(.*\)` so that Zoekt doesn't tell me about all the thousands of matches it might find for some patterns, and only finds a handful satisfying `foo\(.*\)`. This solution is unsatisfying because it's regex now, but it _does_ play much better with the number of matching files and `limitHit`logic. 

It's possible I'm completely missing something. However, I spent 1d+ just figuring out why this behavior is what it is, so putting this up to see if I can get a quicker path to a solution.