### PR TITLE
search: support case field in repository search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Skip LFS content when cloning git repositories. [#7322](https://github.com/sourcegraph/sourcegraph/issues/7322)
 - An experimental site setting `experimentalFeatures/tls.external` which allows you to configure SSL/TLS settings for Sourcegraph contacting your code hosts. Currently just supports turning off TLS/SSL verification. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
 - Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. To search all branches, use `repo:myrepo@*refs/heads/`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
+- Support case field in repository search. [#7671](https://github.com/sourcegraph/sourcegraph/issues/7671)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -35,6 +35,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		query.FieldTimeout:     {},
 		query.FieldFork:        {},
 		query.FieldArchived:    {},
+		query.FieldCase:        {},
 		query.FieldRepoHasFile: {},
 	}
 	// Don't return repo results if the search contains fields that aren't on the whitelist.
@@ -45,7 +46,12 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		}
 	}
 
-	pattern, err := regexp.Compile(args.PatternInfo.Pattern)
+	patternRe := args.PatternInfo.Pattern
+	if !args.Query.IsCaseSensitive() {
+		patternRe = "(?i)" + patternRe
+	}
+
+	pattern, err := regexp.Compile(patternRe)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Previously it wasn't part of the repository search field whitelist, so we
would return no repository results. This commit adds it to the search, and
additionally uses it to influence if case sensitivity should be used.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7671