### PR TITLE
repo-updater: Return a friendlier error when org not found

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -370,7 +370,8 @@ func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *gi
 			// Catch 404 to handle
 			if page == 1 {
 				if apiErr, ok := err.(*github.APIError); ok && apiErr.Code == 404 {
-					oerr, err = err, nil
+					oerr = fmt.Errorf("organisation %q not found", org)
+					err = nil
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/3983

After digging through a lot of code I decided to make the smallest change I could. We're no worse off as the original error was just a string anyway but now at least the wording can be presented to the user.

I did this instead of propagating the status code up the chain as this would require changes to all code host sources and would also need us to differentiate between orgs or repos not being found.