### PR TITLE
docs/automation: tighter campaign walkthrough

### DIFF
--- a/doc/user/automation.md
+++ b/doc/user/automation.md
@@ -52,9 +52,9 @@ We are actively working on campaign support for regex search and replace. Let us
 1. Click `Create new campaign`.
 1. Enter the title and an optional description for your campaign.
 1. Select the type of campaign to run. For example, enter patterns to match and replace code for `Comby` using the JSON editor.
-1. To generate a preview campaign, click `Preview changes` and wait for all repositories to be processed. When the preview completes, you'll see a set of diffs and the changesets that will go into a Pull Request.
+1. To generate a preview campaign, click `Preview changes` and wait for all repositories to be processed. When the preview is ready, you'll see a list of diffs.
 1. Feel free to change the search and replace patterns to create a new preview.
-1. Once the preview looks good, click `create`. **This will create pull requests on your code host**. Once created, changeset progress (e.g., `open`, `merged`) can be tracked in the campaign view.
+1. Once the preview looks good, click `create`. **This will create a pull request of the changset on your codehost**. Once created, changeset progress (e.g., `open`, `merged`) can be tracked in the campaign view.
 
 ---
 

--- a/doc/user/automation.md
+++ b/doc/user/automation.md
@@ -49,13 +49,12 @@ We are actively working on campaign support for regex search and replace. Let us
 ## Creating a new campaign
 
 1. Navigate to `sourcegraph.example.com/campaigns` or simply click the "Campaigns" entry in the top navbar. (It will only appear when correctly configured).
-1. Click "Create new campaign".
+1. Click `Create new campaign`.
 1. Enter the title and an optional description for your campaign.
-1. Select the type of campaign you wish to run.
-   1. Comby search and replace requires additional parameters, enter them into the json editor.
-1. For automatically generated campaigns, preview the changes by selecting the 'preview' button and wait for all repositories to be processed. After the preview has finished loading, you can preview the complete set of diffs that were generated, as well as the changesets that will be opened as a result.
-1. Adjust parameters as needed.
-1. Select 'create'. If the campaign runs automatic changes, they will be applied asynchronously and you can track the progress on that page. Once fully created, the whole list of changesets will be available and you can track the progress of your newly created campaign.
+1. Select the type of campaign to run. For example, enter patterns to match and replace code for `Comby` using the JSON editor.
+1. To generate a preview campaign, click `Preview changes` and wait for all repositories to be processed. When the preview completes, you'll see a set of diffs and the changesets that will go into a Pull Request.
+1. Feel free to change the search and replace patterns to create a new preview.
+1. Once the preview looks good, click `create`. **This will create pull requests on your code host**. Once created, changeset progress (e.g., `open`, `merged`) can be tracked in the campaign view.
 
 ---
 


### PR DESCRIPTION
Cleans up and tightens the campaign walkthrough description.

- remove dangling `i.` bullet
- replace quotes with ticks (the quotes render weird)
- clarify create campaign section (e.g., what does 'progress' mean?, do user's care about whether this is done 'async'?, etc)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
