### PR TITLE
SAML: accept ADFS standard claims

### DIFF
--- a/doc/admin/auth/saml/microsoft_adfs.md
+++ b/doc/admin/auth/saml/microsoft_adfs.md
@@ -60,7 +60,8 @@ Click **Add Rule...** and proceed through the "Add Transform Claim Rule Wizard" 
   - Attribute store: `Active Directory`
   - Mapping of LDAP attributes to outgoing claim types:<br>
     `E-Mail-Addresses` -> `E-Mail Address`<br>
-    `Display-Name` -> `Name`<br>
+    `Display-Name` -> `Common Name`<br>
+    `SAM-Account-Name` -> `Name` (optional, username will be derived from email if omitted)<br>
   - Click **Finish**.
 
 #### Claim Rule 2: Email to NameID

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -50,7 +50,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 		return ""
 	}
 	attr := samlAssertionValues(assertions.Values)
-	email := firstNonempty(attr.Get("email"), attr.Get("emailaddress"))
+	email := firstNonempty(attr.Get("email"), attr.Get("emailaddress"), attr.Get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"), attr.Get("http://schemas.xmlsoap.org/claims/EmailAddress"))
 	if email == "" && mightBeEmail(assertions.NameID) {
 		email = assertions.NameID
 	}
@@ -65,8 +65,8 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 			AccountID:   assertions.NameID,
 		},
 		email:                email,
-		unnormalizedUsername: firstNonempty(attr.Get("login"), attr.Get("uid"), email),
-		displayName:          firstNonempty(attr.Get("displayName"), attr.Get("givenName")+" "+attr.Get("surname")),
+		unnormalizedUsername: firstNonempty(attr.Get("login"), attr.Get("uid"), attr.Get("username"), attr.Get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"), email),
+		displayName:          firstNonempty(attr.Get("displayName"), attr.Get("givenName")+" "+attr.Get("surname"), attr.Get("http://schemas.xmlsoap.org/claims/CommonName"), attr.Get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname")),
 		accountData:          assertions,
 	}
 	if assertions.NameID == "" {


### PR DESCRIPTION
Update SAML handler to handle ADFS standard claims for email address, username, and display name. Update docs to set the right claims names.