### PR TITLE
frontend/highlighting: don't repeat token highlighting

### DIFF
--- a/shared/src/util/dom.test.tsx
+++ b/shared/src/util/dom.test.tsx
@@ -45,6 +45,14 @@ describe('util/dom', () => {
             expect(cell.innerHTML).toBe(newCell)
         })
 
+        test('does not repeatedly highlight multiple nodes', () => {
+            dom.highlightNode(cell, 0, 11)
+            dom.highlightNode(cell, 0, 23)
+            const newCell =
+                '<span style="color:#c0c5ce;"><span><span><span class="selection-highlight">	</span></span></span></span><span style="color:#fff3bf;"><span><span><span class="selection-highlight">ServeHTTP</span></span></span></span><span style="color:#c0c5ce;"><span><span><span class="selection-highlight">(</span></span></span></span><span style="color:#c0c5ce;"><span><span><span class="selection-highlight">ResponseWrit</span>er</span></span></span><span style="color:#c0c5ce;"><span>,</span></span><span style="color:#c0c5ce;"><span> </span></span><span style="color:#329af0;"><span>*</span></span><span style="color:#c0c5ce;"><span>Request</span></span><span style="color:#c0c5ce;"><span>)</span></span>'
+            expect(cell.innerHTML).toBe(newCell)
+        })
+
         test('highlights after offset', () => {
             dom.highlightNode(cell, 2, 3)
             const newCell =

--- a/shared/src/util/dom.tsx
+++ b/shared/src/util/dom.tsx
@@ -114,7 +114,12 @@ function highlightNodeHelper(
                     containerNode.appendChild(highlight)
 
                     if (currNode.childNodes.length === 0 || isLastNode) {
-                        currNode.appendChild(containerNode)
+                        if (currNode.classList.contains('selection-highlight')) {
+                            // Nothing to do; it's already highlighted.
+                            currNode.appendChild(child)
+                        } else {
+                            currNode.appendChild(containerNode)
+                        }
                     } else {
                         currNode.insertBefore(containerNode, currNode.childNodes[i] || currNode.firstChild)
                     }


### PR DESCRIPTION
This highlighting bug from #6441 started to bother me more and more and this is a fix. Example:

![Screen Shot 2020-01-15 at 12 49 15 AM](https://user-images.githubusercontent.com/888624/72417978-2dd6c400-3737-11ea-8bbe-310e1b3edaea.png)


I debugged this and found that extra `selection-highlight` nodes are sometimes added. While we check for repeat highlighting in along the [one branch of this code](https://github.com/sourcegraph/sourcegraph/compare/rvt/get-rid-of-a-very-annoying-highlight-bug?expand=1#diff-82cebe1bcac06b581c0d054fe9b6b4d7R84-R86), we don't do it for the other. This adds the check to the other branch.

Testing:

- I added a test and checked that it fails as expected without this change. Without the change, this test will fail, and you'll see nested/repeated `<span class=selection-highlight>` when that shouldn't happen. The cell values are based off of the reported issue in #6441.
- All existing tests pass.

---

Note:

There's probably a way to restructure this code so that we don't do the work of constructing the `highlight` or `containerNode` elements before this check, but since the other branch isn't exactly trying to avoid this either, I making a minimal change to get the desired functionality rather than restructuring this code.

