### PR TITLE
enterprise/a8n: Allow individually publishing changeset jobs

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -146,6 +146,7 @@ Foreign-key constraints:
  updated_at      | timestamp with time zone | not null default now()
  started_at      | timestamp with time zone | 
  finished_at     | timestamp with time zone | 
+ published_at    | timestamp with time zone | 
 Indexes:
     "changeset_jobs_pkey" PRIMARY KEY, btree (id)
     "changeset_jobs_unique" UNIQUE CONSTRAINT, btree (campaign_id, campaign_job_id)

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -280,6 +280,7 @@ type ChangesetPlanResolver interface {
 	BaseRepository(ctx context.Context) (*RepositoryResolver, error)
 	Diff() ChangesetPlanResolver
 	FileDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (PreviewFileDiffConnection, error)
+	PublicationEnqueued(ctx context.Context) (bool, error)
 }
 
 type ChangesetEventsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -234,7 +234,7 @@ type CampaignResolver interface {
 	Plan(ctx context.Context) (CampaignPlanResolver, error)
 	Status(context.Context) (BackgroundProcessStatus, error)
 	ClosedAt() *DateTime
-	PublishedAt() *DateTime
+	PublishedAt(ctx context.Context) (*DateTime, error)
 	ChangesetPlans(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -697,6 +697,16 @@ type ChangesetPlan {
 
     # The diff of the changeset.
     diff: PreviewRepositoryComparison!
+
+    # Whether the ChangesetPlan is enqueued for publication. Default is false.
+    # It will be true when:
+    # - a Campaign has been created with the CampaignPlan to which this
+    # ChangesetPlan belongs
+    # - when a Campaign with the CampaignPlan has been published after being in
+    # draft mode
+    # - when the ChangesetPlan has been individually published through the
+    # publishChangeset mutation
+    publicationEnqueued: Boolean!
 }
 
 # A changeset in a code host (e.g. a PR on Github)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -704,6 +704,16 @@ type ChangesetPlan {
 
     # The diff of the changeset.
     diff: PreviewRepositoryComparison!
+
+    # Whether the ChangesetPlan is enqueued for publication. Default is false.
+    # It will be true when:
+    # - a Campaign has been created with the CampaignPlan to which this
+    # ChangesetPlan belongs
+    # - when a Campaign with the CampaignPlan has been published after being in
+    # draft mode
+    # - when the ChangesetPlan has been individually published through the
+    # publishChangeset mutation
+    publicationEnqueued: Boolean!
 }
 
 # A changeset in a code host (e.g. a PR on Github)

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -124,11 +124,18 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.Campaign.ClosedAt}
 }
 
-func (r *campaignResolver) PublishedAt() *graphqlbackend.DateTime {
-	if r.Campaign.PublishedAt.IsZero() {
-		return nil
+func (r *campaignResolver) PublishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+	if !r.Campaign.PublishedAt.IsZero() {
+		return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}, nil
 	}
-	return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}
+	publishedAt, err := r.store.GetLatestChangesetPublishedAt(ctx, r.Campaign.ID)
+	if err != nil {
+		return nil, err
+	}
+	if publishedAt.IsZero() {
+		return nil, nil
+	}
+	return &graphqlbackend.DateTime{Time: publishedAt}, nil
 }
 
 func (r *campaignResolver) Changesets(ctx context.Context, args struct {

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -128,7 +128,7 @@ func (r *campaignResolver) PublishedAt(ctx context.Context) (*graphqlbackend.Dat
 	if !r.Campaign.PublishedAt.IsZero() {
 		return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}, nil
 	}
-	publishedAt, err := r.store.GetLatestChangesetPublishedAt(ctx, r.Campaign.ID)
+	publishedAt, err := r.store.GetLatestChangesetJobPublishedAt(ctx, r.Campaign.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -680,7 +680,7 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 	}
 
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
-	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID, true)
+	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -93,7 +93,7 @@ func (r *Resolver) ChangesetPlanByID(ctx context.Context, id graphql.ID) (graphq
 		return nil, err
 	}
 
-	return &campaignJobResolver{job: job}, nil
+	return &campaignJobResolver{store: r.store, job: job}, nil
 }
 
 func (r *Resolver) CampaignPlanByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignPlanResolver, error) {

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -680,7 +680,7 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 	}
 
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
-	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
+	err = svc.PublishChangesetJobForCampaignJob(ctx, campaignJobID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -680,7 +680,7 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 	}
 
 	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
-	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
+	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID, true)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -635,12 +635,13 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs []*a8n.Changeset) 
 	return syncer.SyncChangesetsWithSources(ctx, bySource)
 }
 
-// CreateChangesetJob creates a ChangesetJob for the CampaignJob with the given
-// ID. The CampaignJob has to belong to a CampaignPlan that was attached to a
-// Campaign. It will ensure that the ChangesetJob is published, even if it already exists.
-func (s *Service) CreateChangesetJobForCampaignJob(ctx context.Context, campaignJobID int64) (err error) {
+// PublishChangesetJobForCampaignJob creates or updates a ChangesetJob for the
+// CampaignJob with the given ID. The CampaignJob has to belong to a
+// CampaignPlan that was attached to a Campaign. It will ensure that the
+// ChangesetJob is published, even if it already exists.
+func (s *Service) PublishChangesetJobForCampaignJob(ctx context.Context, campaignJobID int64) (err error) {
 	traceTitle := fmt.Sprintf("campaignJob: %d", campaignJobID)
-	tr, ctx := trace.New(ctx, "service.CreateChangesetJobForCampaignJob", traceTitle)
+	tr, ctx := trace.New(ctx, "service.PublishChangesetJobForCampaignJob", traceTitle)
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -673,7 +674,9 @@ func (s *Service) CreateChangesetJobForCampaignJob(ctx context.Context, campaign
 		// No need to update
 		return nil
 	}
+
 	if existing != nil {
+		existing.PublishedAt = s.clock()
 		err = tx.UpdateChangesetJob(ctx, existing)
 		if err != nil {
 			return err

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -231,7 +231,7 @@ func TestService(t *testing.T) {
 		}
 
 		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
-		err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJob.ID)
+		err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJob.ID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,7 +245,7 @@ func TestService(t *testing.T) {
 		}
 
 		// Try to create again, check that it's the same one
-		err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJob.ID)
+		err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJob.ID, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -2245,11 +2245,11 @@ func countChangesetJobsQuery(opts *CountChangesetJobsOpts) *sqlf.Query {
 	return sqlf.Sprintf(countChangesetJobsQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
-func (s *Store) GetLatestChangesetPublishedAt(ctx context.Context, campaignID int64) (time.Time, error) {
-	q := sqlf.Sprintf(getLatestChangesetPublishedAtFmtstr, campaignID, campaignID)
+func (s *Store) GetLatestChangesetJobPublishedAt(ctx context.Context, campaignID int64) (time.Time, error) {
+	q := sqlf.Sprintf(getLatestChangesetJobPublishedAtFmtstr, campaignID, campaignID)
 	var publishedAt time.Time
 	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
-		err = sc.Scan(&publishedAt)
+		err = sc.Scan(&dbutil.NullTime{Time: &publishedAt})
 		if err != nil {
 			return 0, 0, err
 		}
@@ -2261,12 +2261,12 @@ func (s *Store) GetLatestChangesetPublishedAt(ctx context.Context, campaignID in
 	return publishedAt, nil
 }
 
-var getLatestChangesetPublishedAtFmtstr = `
+var getLatestChangesetJobPublishedAtFmtstr = `
 SELECT max(published_at)
 FROM changeset_jobs
 WHERE campaign_id = %d
 AND NOT EXISTS
-  (SELECT id FROM changeset_jobs WHERE id = %d AND published_at IS NULL)
+  (SELECT id FROM changeset_jobs WHERE campaign_id = %d AND published_at IS NULL)
 `
 
 // GetChangesetJobOpts captures the query options needed for getting a ChangesetJob

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -2339,85 +2339,13 @@ func getChangesetJobQuery(opts *GetChangesetJobOpts) *sqlf.Query {
 	return sqlf.Sprintf(getChangesetJobsQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
-// ListChangesetJobsByCampaignPlanOpts captures the query options needed
-// for fetching changeset jobs for a campaign plan
-type ListChangesetJobsByCampaignPlanOpts struct {
-	CampaignPlanID int64
-	Cursor         int64
-	Limit          int
-}
-
-func (s *Store) ListChangesetJobsByCampaignPlan(ctx context.Context, opts ListChangesetJobsByCampaignPlanOpts) (cs []*a8n.ChangesetJob, next int64, err error) {
-	if opts.CampaignPlanID == 0 {
-		return nil, 0, fmt.Errorf("CampaignPlanID must be supplied")
-	}
-	q := listChangesetJobsByCampaignPlanQuery(&opts)
-
-	cs = make([]*a8n.ChangesetJob, 0, opts.Limit)
-	_, _, err = s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
-		var c a8n.ChangesetJob
-		if err = scanChangesetJob(&c, sc); err != nil {
-			return 0, 0, err
-		}
-		cs = append(cs, &c)
-		return c.ID, 1, err
-	})
-
-	if opts.Limit != 0 && len(cs) == opts.Limit {
-		next = cs[len(cs)-1].ID
-		cs = cs[:len(cs)-1]
-	}
-
-	return cs, next, err
-}
-
-var listChangesetJobsByCampaignPlanQueryFmtstr = `
--- source: internal/a8n/store.go:ListChangesetJobsByCampaignPlan
-SELECT
-  j.id,
-  j.campaign_id,
-  j.campaign_job_id,
-  j.changeset_id,
-  j.error,
-  j.started_at,
-  j.finished_at,
-  j.created_at,
-  j.updated_at,
-  j.published_at
-FROM changeset_jobs j
-JOIN campaigns c ON j.campaign_id = c.id
-WHERE %s
-ORDER BY id ASC
-`
-
-func listChangesetJobsByCampaignPlanQuery(opts *ListChangesetJobsByCampaignPlanOpts) *sqlf.Query {
-	if opts.Limit == 0 {
-		opts.Limit = defaultListLimit
-	}
-	opts.Limit++
-
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
-	}
-
-	preds := []*sqlf.Query{
-		sqlf.Sprintf("id >= %s", opts.Cursor),
-	}
-	preds = append(preds, sqlf.Sprintf("c.campaign_plan_id = %s", opts.CampaignPlanID))
-
-	return sqlf.Sprintf(
-		listChangesetJobsByCampaignPlanQueryFmtstr+limitClause,
-		sqlf.Join(preds, "\n AND "),
-	)
-}
-
 // ListChangesetJobsOpts captures the query options needed for
 // listing changeset jobs.
 type ListChangesetJobsOpts struct {
-	CampaignID int64
-	Cursor     int64
-	Limit      int
+	CampaignID     int64
+	CampaignPlanID int64
+	Cursor         int64
+	Limit          int
 }
 
 // ListChangesetJobs lists ChangesetJobs with the given filters.
@@ -2442,22 +2370,25 @@ func (s *Store) ListChangesetJobs(ctx context.Context, opts ListChangesetJobsOpt
 	return cs, next, err
 }
 
-var listChangesetJobsQueryFmtstr = `
+var listChangesetJobsQueryFmtstrSelect = `
 -- source: internal/a8n/store.go:ListChangesetJobs
 SELECT
-  id,
-  campaign_id,
-  campaign_job_id,
-  changeset_id,
-  error,
-  started_at,
-  finished_at,
-  created_at,
-  updated_at,
-  published_at
+  changeset_jobs.id,
+  changeset_jobs.campaign_id,
+  changeset_jobs.campaign_job_id,
+  changeset_jobs.changeset_id,
+  changeset_jobs.error,
+  changeset_jobs.started_at,
+  changeset_jobs.finished_at,
+  changeset_jobs.created_at,
+  changeset_jobs.updated_at,
+  changeset_jobs.published_at
 FROM changeset_jobs
+`
+
+var listChangesetJobsQueryFmtstrConditions = `
 WHERE %s
-ORDER BY id ASC
+ORDER BY changeset_jobs.id ASC
 `
 
 func listChangesetJobsQuery(opts *ListChangesetJobsOpts) *sqlf.Query {
@@ -2472,17 +2403,24 @@ func listChangesetJobsQuery(opts *ListChangesetJobsOpts) *sqlf.Query {
 	}
 
 	preds := []*sqlf.Query{
-		sqlf.Sprintf("id >= %s", opts.Cursor),
+		sqlf.Sprintf("changeset_jobs.id >= %s", opts.Cursor),
 	}
 
 	if opts.CampaignID != 0 {
-		preds = append(preds, sqlf.Sprintf("campaign_id = %s", opts.CampaignID))
+		preds = append(preds, sqlf.Sprintf("changeset_jobs.campaign_id = %s", opts.CampaignID))
 	}
 
-	return sqlf.Sprintf(
-		listChangesetJobsQueryFmtstr+limitClause,
-		sqlf.Join(preds, "\n AND "),
-	)
+	var joinClause string
+	if opts.CampaignPlanID != 0 {
+		joinClause = "JOIN campaigns ON changeset_jobs.campaign_id = campaigns.id"
+
+		preds = append(preds, sqlf.Sprintf("campaigns.campaign_plan_id = %s", opts.CampaignPlanID))
+	}
+
+	queryTemplate := listChangesetJobsQueryFmtstrSelect + joinClause +
+		listChangesetJobsQueryFmtstrConditions + limitClause
+
+	return sqlf.Sprintf(queryTemplate, sqlf.Join(preds, "\n AND "))
 }
 
 // ResetFailedChangesetJobs resets the Error, StartedAt and FinishedAt fields

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -100,7 +100,7 @@ UPDATE changeset_jobs j SET started_at = now() WHERE id = (
 	JOIN campaign_plans p ON p.id = c.campaign_plan_id
 	WHERE j.started_at IS NULL
 	AND p.canceled_at IS NULL
-	AND c.published_at IS NOT NULL
+	AND (c.published_at IS NOT NULL OR j.published_at IS NOT NULL)
 	ORDER BY j.id ASC
 	FOR UPDATE SKIP LOCKED LIMIT 1
 )
@@ -112,7 +112,8 @@ RETURNING j.id,
   j.started_at,
   j.finished_at,
   j.created_at,
-  j.updated_at
+  j.updated_at,
+  j.published_at
 `
 
 // ProcessPendingCampaignJob attempts to fetch one pending campaign job. If found, 'process'
@@ -633,7 +634,7 @@ func (s *Store) UpdateChangesets(ctx context.Context, cs ...*a8n.Changeset) erro
 	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
 		i++
 		err = scanChangeset(cs[i], sc)
-		return int64(cs[i].ID), 1, err
+		return cs[i].ID, 1, err
 	})
 }
 
@@ -1852,7 +1853,7 @@ DELETE FROM campaign_jobs WHERE id = %s
 `
 
 // CountCampaignJobsOpts captures the query options needed for
-// counting code mods.
+// counting campaign jobs
 type CountCampaignJobsOpts struct {
 	CampaignPlanID int64
 	OnlyFinished   bool
@@ -2082,7 +2083,7 @@ func (s *Store) CreateChangesetJob(ctx context.Context, c *a8n.ChangesetJob) err
 
 	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
 		err = scanChangesetJob(c, sc)
-		return int64(c.ID), 1, err
+		return c.ID, 1, err
 	})
 }
 
@@ -2096,9 +2097,10 @@ INSERT INTO changeset_jobs (
   started_at,
   finished_at,
   created_at,
-  updated_at
+  updated_at,
+  published_at
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   campaign_id,
@@ -2108,7 +2110,8 @@ RETURNING
   started_at,
   finished_at,
   created_at,
-  updated_at
+  updated_at,
+  published_at
 `
 
 func (s *Store) createChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error) {
@@ -2130,6 +2133,7 @@ func (s *Store) createChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error
 		nullTimeColumn(c.FinishedAt),
 		c.CreatedAt,
 		c.UpdatedAt,
+		nullTimeColumn(c.PublishedAt),
 	), nil
 }
 
@@ -2142,7 +2146,7 @@ func (s *Store) UpdateChangesetJob(ctx context.Context, c *a8n.ChangesetJob) err
 
 	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
 		err = scanChangesetJob(c, sc)
-		return int64(c.ID), 1, err
+		return c.ID, 1, err
 	})
 }
 
@@ -2156,8 +2160,9 @@ SET (
   error,
   started_at,
   finished_at,
-  updated_at
-) = (%s, %s, %s, %s, %s, %s, %s)
+  updated_at,
+  published_at
+) = (%s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -2168,7 +2173,8 @@ RETURNING
   started_at,
   finished_at,
   created_at,
-  updated_at
+  updated_at,
+  published_at
 `
 
 func (s *Store) updateChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error) {
@@ -2183,6 +2189,7 @@ func (s *Store) updateChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error
 		nullTimeColumn(c.StartedAt),
 		nullTimeColumn(c.FinishedAt),
 		c.UpdatedAt,
+		nullTimeColumn(c.PublishedAt),
 		c.ID,
 	), nil
 }
@@ -2246,7 +2253,7 @@ type GetChangesetJobOpts struct {
 	ChangesetID   int64
 }
 
-// GetChangesetJob gets a code mod matching the given options.
+// GetChangesetJob gets a ChangesetJob matching the given options.
 func (s *Store) GetChangesetJob(ctx context.Context, opts GetChangesetJobOpts) (*a8n.ChangesetJob, error) {
 	q := getChangesetJobQuery(&opts)
 
@@ -2276,7 +2283,8 @@ SELECT
   started_at,
   finished_at,
   created_at,
-  updated_at
+  updated_at,
+  published_at
 FROM changeset_jobs
 WHERE %s
 LIMIT 1
@@ -2348,7 +2356,8 @@ SELECT
   started_at,
   finished_at,
   created_at,
-  updated_at
+  updated_at,
+  published_at
 FROM changeset_jobs
 WHERE %s
 ORDER BY id ASC
@@ -2586,6 +2595,7 @@ func scanChangesetJob(c *a8n.ChangesetJob, s scanner) error {
 		&dbutil.NullTime{Time: &c.FinishedAt},
 		&c.CreatedAt,
 		&c.UpdatedAt,
+		&dbutil.NullTime{Time: &c.PublishedAt},
 	)
 }
 

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1973,6 +1973,50 @@ func testStore(db *sql.DB) func(*testing.T) {
 						cursor = next
 					}
 				})
+
+				t.Run("WithCampaignPlanID", func(t *testing.T) {
+					for i := 1; i <= len(changesetJobs); i++ {
+						c := &a8n.Campaign{
+							Name:            fmt.Sprintf("Upgrade ES-Lint %d", i),
+							Description:     "All the Javascripts are belong to us",
+							AuthorID:        4567,
+							NamespaceUserID: 4567,
+							CampaignPlanID:  1234 + int64(i),
+							PublishedAt:     now,
+						}
+
+						err := s.CreateCampaign(ctx, c)
+						if err != nil {
+							t.Fatal(err)
+						}
+						job := changesetJobs[i-1]
+
+						job.CampaignID = c.ID
+						err = s.UpdateChangesetJob(ctx, job)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						opts := ListChangesetJobsOpts{CampaignPlanID: c.CampaignPlanID}
+						ts, next, err := s.ListChangesetJobs(ctx, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						if have, want := next, int64(0); have != want {
+							t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+						}
+
+						have, want := ts, changesetJobs[i-1:i]
+						if len(have) != len(want) {
+							t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
+						}
+
+						if diff := cmp.Diff(have, want); diff != "" {
+							t.Fatalf("opts: %+v, diff: %s", opts, diff)
+						}
+					}
+				})
 			})
 
 			t.Run("Update", func(t *testing.T) {

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -215,6 +215,8 @@ type ChangesetJob struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+
+	PublishedAt time.Time
 }
 
 // Clone returns a clone of a ChangesetJob.

--- a/migrations/1528395636_add_published_at_to_changeset_jobs.down.sql
+++ b/migrations/1528395636_add_published_at_to_changeset_jobs.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs DROP COLUMN IF EXISTS published_at;
+
+COMMIT;

--- a/migrations/1528395636_add_published_at_to_changeset_jobs.up.sql
+++ b/migrations/1528395636_add_published_at_to_changeset_jobs.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs ADD COLUMN published_at timestamptz;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -64,6 +64,8 @@
 // 1528395634_lsif_unify_dumps_and_uploads.up.sql (2.607kB)
 // 1528395635_check_campaign_name_not_blank.down.sql (81B)
 // 1528395635_check_campaign_name_not_blank.up.sql (189B)
+// 1528395636_add_published_at_to_changeset_jobs.down.sql (80B)
+// 1528395636_add_published_at_to_changeset_jobs.up.sql (81B)
 
 package migrations
 
@@ -1412,6 +1414,46 @@ func _1528395635_check_campaign_name_not_blankUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395636_add_published_at_to_changeset_jobsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x89\xcf\xca\x4f\x2a\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xcb\x01\x9f\x51\x50\x00\x00\x00")
+
+func _1528395636_add_published_at_to_changeset_jobsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395636_add_published_at_to_changeset_jobsDownSql,
+		"1528395636_add_published_at_to_changeset_jobs.down.sql",
+	)
+}
+
+func _1528395636_add_published_at_to_changeset_jobsDownSql() (*asset, error) {
+	bytes, err := _1528395636_add_published_at_to_changeset_jobsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395636_add_published_at_to_changeset_jobs.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x69, 0x4e, 0x1, 0x24, 0xcf, 0x1a, 0x32, 0x3f, 0x2e, 0xb5, 0x62, 0x47, 0x70, 0xc5, 0x97, 0x23, 0x9c, 0x7, 0xd1, 0xa5, 0xad, 0x8e, 0xef, 0xd9, 0x54, 0x32, 0x36, 0xbf, 0xbe, 0xfd, 0x1f, 0x1d}}
+	return a, nil
+}
+
+var __1528395636_add_published_at_to_changeset_jobsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x89\xcf\xca\x4f\x2a\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\x51\x28\xc9\xcc\x4d\x2d\x2e\x49\xcc\x2d\x28\xa9\xb2\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x86\xae\x59\x0b\x51\x00\x00\x00")
+
+func _1528395636_add_published_at_to_changeset_jobsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395636_add_published_at_to_changeset_jobsUpSql,
+		"1528395636_add_published_at_to_changeset_jobs.up.sql",
+	)
+}
+
+func _1528395636_add_published_at_to_changeset_jobsUpSql() (*asset, error) {
+	bytes, err := _1528395636_add_published_at_to_changeset_jobsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395636_add_published_at_to_changeset_jobs.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x78, 0xd5, 0xc6, 0x78, 0x4f, 0x88, 0xb3, 0x8a, 0x2c, 0xe1, 0xc0, 0x53, 0x17, 0xa3, 0xc3, 0xc4, 0x7b, 0xc0, 0x66, 0xf4, 0x86, 0x40, 0xf6, 0xa7, 0x21, 0xdf, 0xa, 0xb2, 0xb4, 0xb3, 0xb2, 0x67}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1567,6 +1609,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395634_lsif_unify_dumps_and_uploads.up.sql":                     _1528395634_lsif_unify_dumps_and_uploadsUpSql,
 	"1528395635_check_campaign_name_not_blank.down.sql":                  _1528395635_check_campaign_name_not_blankDownSql,
 	"1528395635_check_campaign_name_not_blank.up.sql":                    _1528395635_check_campaign_name_not_blankUpSql,
+	"1528395636_add_published_at_to_changeset_jobs.down.sql":             _1528395636_add_published_at_to_changeset_jobsDownSql,
+	"1528395636_add_published_at_to_changeset_jobs.up.sql":               _1528395636_add_published_at_to_changeset_jobsUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1674,6 +1718,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395634_lsif_unify_dumps_and_uploads.up.sql":                     {_1528395634_lsif_unify_dumps_and_uploadsUpSql, map[string]*bintree{}},
 	"1528395635_check_campaign_name_not_blank.down.sql":                  {_1528395635_check_campaign_name_not_blankDownSql, map[string]*bintree{}},
 	"1528395635_check_campaign_name_not_blank.up.sql":                    {_1528395635_check_campaign_name_not_blankUpSql, map[string]*bintree{}},
+	"1528395636_add_published_at_to_changeset_jobs.down.sql":             {_1528395636_add_published_at_to_changeset_jobsDownSql, map[string]*bintree{}},
+	"1528395636_add_published_at_to_changeset_jobs.up.sql":               {_1528395636_add_published_at_to_changeset_jobsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
published_at was added to a changeset job. Jobs will now be run if
either their campaign has been published or they are explicitly
published.




