### PR TITLE
RFC 40: Grant permissions on user creation and email verification

### DIFF
--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -40,3 +40,11 @@ func (p Perms) String() string {
 		return "none"
 	}
 }
+
+// PermType is the object type of the user permissions.
+type PermType string
+
+// The list of available user permission types.
+const (
+	PermRepos PermType = "repos"
+)

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -11,11 +11,11 @@ import (
 // site configuration.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the supplied email is verified.
 type GrantPendingPermissionsArgs struct {
-	UserID   int32
-	Username string
-	Email    string
-	Perm     authz.Perms
-	Type     authz.PermType
+	UserID   int32          // The user ID that will be used to bind pending permissions.
+	Username string         // The username that will be used as bind ID.
+	Email    string         // The email address that will be used as bind ID.
+	Perm     authz.Perms    // The permission level to be granted.
+	Type     authz.PermType // The type of permissions to be granted.
 }
 
 // An AuthzStore stores methods for user permissions, they will be no-op in OSS version.

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+)
+
+type GrantPendingPermissionsArgs struct {
+	UserID int32
+	BindID string
+	Perm   authz.Perms
+	Type   authz.PermType
+}
+
+// An AuthzStore stores methods for user permissions, they will be set to non-nil in enterprise version.
+type AuthzStore interface {
+	GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error
+}
+
+// authzStore is a no-op placeholder for the OSS version.
+type authzStore struct{}
+
+func (*authzStore) GrantPendingPermissions(_ context.Context, _ *GrantPendingPermissionsArgs) error {
+	return nil
+}

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -13,7 +13,7 @@ type GrantPendingPermissionsArgs struct {
 	Type   authz.PermType
 }
 
-// An AuthzStore stores methods for user permissions, they will be set to non-nil in enterprise version.
+// An AuthzStore stores methods for user permissions, they will be no-op in OSS version.
 type AuthzStore interface {
 	GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error
 }

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 )
 
+// GrantPendingPermissionsArgs contains required arguments to grant pending permissions for a user.
 type GrantPendingPermissionsArgs struct {
 	UserID int32
 	BindID string

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -7,18 +7,18 @@ import (
 )
 
 // GrantPendingPermissionsArgs contains required arguments to grant pending permissions for a user.
-// Both "Username" and "Email" could be supplied but only one of it will be used according to the
+// Both "Username" and "Email" could be supplied but only one of them will be used according to the
 // site configuration.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the supplied email is verified.
 type GrantPendingPermissionsArgs struct {
 	UserID   int32          // The user ID that will be used to bind pending permissions.
 	Username string         // The username that will be used as bind ID.
-	Email    string         // The email address that will be used as bind ID.
+	Email    string         // The email address that will be used as bind ID. It is the caller's responsibility to ensure the email is verified.
 	Perm     authz.Perms    // The permission level to be granted.
 	Type     authz.PermType // The type of permissions to be granted.
 }
 
-// An AuthzStore stores methods for user permissions, they will be no-op in OSS version.
+// AuthzStore contains methods for assigning user permissions.
 type AuthzStore interface {
 	GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error
 }

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -7,11 +7,15 @@ import (
 )
 
 // GrantPendingPermissionsArgs contains required arguments to grant pending permissions for a user.
+// Both "Username" and "Email" could be supplied but only one of it will be used according to the
+// site configuration.
+// 🚨 SECURITY: It is the caller's responsibility to ensure the supplied email is verified.
 type GrantPendingPermissionsArgs struct {
-	UserID int32
-	BindID string
-	Perm   authz.Perms
-	Type   authz.PermType
+	UserID   int32
+	Username string
+	Email    string
+	Perm     authz.Perms
+	Type     authz.PermType
 }
 
 // An AuthzStore stores methods for user permissions, they will be no-op in OSS version.

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -11,15 +11,22 @@ import (
 // site configuration.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the supplied email is verified.
 type GrantPendingPermissionsArgs struct {
-	UserID   int32          // The user ID that will be used to bind pending permissions.
-	Username string         // The username that will be used as bind ID.
-	Email    string         // The email address that will be used as bind ID. It is the caller's responsibility to ensure the email is verified.
-	Perm     authz.Perms    // The permission level to be granted.
-	Type     authz.PermType // The type of permissions to be granted.
+	// The user ID that will be used to bind pending permissions.
+	UserID int32
+	// The username that will be used as bind ID.
+	Username string
+	// The verified email address that will be used as bind ID.
+	// 🚨 SECURITY: It is the caller's responsibility to ensure the email is verified.
+	VerifiedEmail string
+	// The permission level to be granted.
+	Perm authz.Perms
+	// The type of permissions to be granted.
+	Type authz.PermType
 }
 
 // AuthzStore contains methods for assigning user permissions.
 type AuthzStore interface {
+	// GrantPendingPermissions grants pending permissions for a user, it is a no-op in the OSS version.
 	GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error
 }
 

--- a/cmd/frontend/db/authz_mock.go
+++ b/cmd/frontend/db/authz_mock.go
@@ -1,0 +1,9 @@
+package db
+
+import (
+	"context"
+)
+
+type MockAuthz struct {
+	GrantPendingPermissions func(ctx context.Context, args *GrantPendingPermissionsArgs) error
+}

--- a/cmd/frontend/db/authz_test.go
+++ b/cmd/frontend/db/authz_test.go
@@ -1,0 +1,16 @@
+package db
+
+import "context"
+
+var _ AuthzStore = &mockAuthzStore{}
+
+// mockAuthzStore is a mock struct that implements AuthzStore interface and only calls mock methods
+// when they are not nil.
+type mockAuthzStore struct{}
+
+func (*mockAuthzStore) GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error {
+	if Mocks.Authz.GrantPendingPermissions == nil {
+		return nil
+	}
+	return Mocks.Authz.GrantPendingPermissions(ctx, args)
+}

--- a/cmd/frontend/db/mockstores.go
+++ b/cmd/frontend/db/mockstores.go
@@ -25,4 +25,6 @@ type MockStores struct {
 	OrgInvitations MockOrgInvitations
 
 	ExternalServices MockExternalServices
+
+	Authz MockAuthz
 }

--- a/cmd/frontend/db/stores.go
+++ b/cmd/frontend/db/stores.go
@@ -23,4 +23,6 @@ var (
 	ExternalAccounts = &userExternalAccounts{}
 
 	OrgInvitations = &orgInvitations{}
+
+	Authz AuthzStore = &authzStore{}
 )

--- a/cmd/frontend/db/user_emails.go
+++ b/cmd/frontend/db/user_emails.go
@@ -125,10 +125,10 @@ func (*userEmails) Verify(ctx context.Context, userID int32, email, code string)
 	}
 
 	return true, Authz.GrantPendingPermissions(ctx, &GrantPendingPermissionsArgs{
-		UserID: userID,
-		Email:  email,
-		Perm:   authz.Read,
-		Type:   authz.PermRepos,
+		UserID:        userID,
+		VerifiedEmail: email,
+		Perm:          authz.Read,
+		Type:          authz.PermRepos,
 	})
 }
 

--- a/cmd/frontend/db/user_emails.go
+++ b/cmd/frontend/db/user_emails.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
 )
@@ -125,23 +124,9 @@ func (*userEmails) Verify(ctx context.Context, userID int32, email, code string)
 		return false, err
 	}
 
-	return true, (&userEmails{}).grantPendingPermissions(ctx, userID, email)
-}
-
-// grantPendingPermissions attempts to grant pending permissions by email.
-// 🚨 SECURITY: It is the caller's responsibility to ensure the email is verified.
-func (*userEmails) grantPendingPermissions(ctx context.Context, userID int32, email string) error {
-	cfg := conf.Get().SiteConfiguration
-	if cfg.PermissionsUserMapping == nil || !cfg.PermissionsUserMapping.Enabled {
-		return nil
-	}
-
-	if cfg.PermissionsUserMapping.BindID != "email" {
-		return nil
-	}
-	return Authz.GrantPendingPermissions(ctx, &GrantPendingPermissionsArgs{
+	return true, Authz.GrantPendingPermissions(ctx, &GrantPendingPermissionsArgs{
 		UserID: userID,
-		BindID: email,
+		Email:  email,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,
 	})

--- a/cmd/frontend/db/user_emails.go
+++ b/cmd/frontend/db/user_emails.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
 )
@@ -122,7 +124,27 @@ func (*userEmails) Verify(ctx context.Context, userID int32, email, code string)
 	if _, err := dbconn.Global.ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=now() WHERE user_id=$1 AND email=$2", userID, email); err != nil {
 		return false, err
 	}
-	return true, nil
+
+	return true, (&userEmails{}).grantPendingPermissions(ctx, userID, email)
+}
+
+// grantPendingPermissions attempts to grant pending permissions by email.
+// 🚨 SECURITY: It is the caller's responsibility to ensure the email is verified.
+func (*userEmails) grantPendingPermissions(ctx context.Context, userID int32, email string) error {
+	cfg := conf.Get().SiteConfiguration
+	if cfg.PermissionsUserMapping == nil || !cfg.PermissionsUserMapping.Enabled {
+		return nil
+	}
+
+	if cfg.PermissionsUserMapping.BindID != "email" {
+		return nil
+	}
+	return Authz.GrantPendingPermissions(ctx, &GrantPendingPermissionsArgs{
+		UserID: userID,
+		BindID: email,
+		Perm:   authz.Read,
+		Type:   authz.PermRepos,
+	})
 }
 
 // SetVerified bypasses the normal email verification code process and manually sets the verified

--- a/cmd/frontend/db/user_emails_test.go
+++ b/cmd/frontend/db/user_emails_test.go
@@ -325,3 +325,67 @@ func TestUserEmails_GetVerifiedEmails(t *testing.T) {
 		t.Errorf("got %s, but want %q", emails[0].Email, "alice@example.com")
 	}
 }
+
+func TestUserEmails_VerifyAndGrantPendingPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	opts := NewUser{
+		Email:                 "foo@bar.com",
+		Username:              "foo",
+		DisplayName:           "foo",
+		Password:              "right-password",
+		EmailVerificationCode: "email-code",
+	}
+	user, err := Users.Create(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Must mock after call of Users.Create because that method has a call to the Authz.GrantPendingPermissions as well.
+	Authz = &mockAuthzStore{}
+	defer func() {
+		Authz = &authzStore{}
+	}()
+
+	tests := []struct {
+		name         string
+		code         string
+		isValid      bool
+		expectCalled bool
+	}{
+		{
+			name:         "not called when fail to verify the email",
+			code:         "wrong_email-code",
+			isValid:      false,
+			expectCalled: false,
+		},
+		{
+			name:         "called when successfully verified the email",
+			code:         "email-code",
+			isValid:      true,
+			expectCalled: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calledGrantPendingPermissions := false
+			Mocks.Authz.GrantPendingPermissions = func(_ context.Context, _ *GrantPendingPermissionsArgs) error {
+				calledGrantPendingPermissions = true
+				return nil
+			}
+
+			isValid, err := UserEmails.Verify(ctx, user.ID, opts.Email, test.code)
+			if err != nil {
+				t.Fatal(err)
+			} else if test.isValid != isValid {
+				t.Fatalf("isValid: want %v but got %v", test.isValid, isValid)
+			} else if test.expectCalled != calledGrantPendingPermissions {
+				t.Fatalf("calledGrantPendingPermissions: want %v but got %v", test.expectCalled, calledGrantPendingPermissions)
+			}
+		})
+	}
+}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -11,6 +11,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -270,6 +271,11 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		}
 	}
 
+	// If permissions user mapping is enabled, grant pending permissions for the user.
+	if err = u.grantPendingPermissions(ctx, id, info); err != nil {
+		return nil, err
+	}
+
 	return &types.User{
 		ID:          id,
 		Username:    info.Username,
@@ -279,6 +285,36 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		UpdatedAt:   updatedAt,
 		SiteAdmin:   siteAdmin,
 	}, nil
+}
+
+// grantPendingPermissions attempts to grant pending permissions by either username or email according
+// to the site configuration.
+func (*users) grantPendingPermissions(ctx context.Context, userID int32, info NewUser) error {
+	cfg := conf.Get().SiteConfiguration
+	if cfg.PermissionsUserMapping == nil || !cfg.PermissionsUserMapping.Enabled {
+		return nil
+	}
+
+	args := &GrantPendingPermissionsArgs{
+		UserID: userID,
+		Perm:   authz.Read,
+		Type:   authz.PermRepos,
+	}
+	switch cfg.PermissionsUserMapping.BindID {
+	case "email":
+		if info.Email == "" || !info.EmailIsVerified {
+			return nil
+		}
+		args.BindID = info.Email
+
+	case "username":
+		args.BindID = info.Username
+
+	default:
+		return fmt.Errorf("unrecognized user mapping bind ID type %q", cfg.PermissionsUserMapping.BindID)
+	}
+
+	return Authz.GrantPendingPermissions(ctx, args)
 }
 
 // orgsForAllUsersToJoin returns the list of org names that all users should be joined to. The second return value

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -271,16 +271,16 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		}
 	}
 
-	var bindEmail string
+	var verifiedEmail string
 	if info.Email != "" && info.EmailIsVerified {
-		bindEmail = info.Email
+		verifiedEmail = info.Email
 	}
 	if err = Authz.GrantPendingPermissions(ctx, &GrantPendingPermissionsArgs{
-		UserID:   id,
-		Username: info.Username,
-		Email:    bindEmail,
-		Perm:     authz.Read,
-		Type:     authz.PermRepos,
+		UserID:        id,
+		Username:      info.Username,
+		VerifiedEmail: verifiedEmail,
+		Perm:          authz.Read,
+		Type:          authz.PermRepos,
 	}); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -636,8 +636,8 @@ func TestUsers_CreateAndGrantPendingPermissions(t *testing.T) {
 				calledGrantPendingPermissions = true
 				if test.expectUsername != args.Username {
 					return fmt.Errorf("args.Username: want %q but got %q", test.expectUsername, args.Username)
-				} else if test.expectEmail != args.Email {
-					return fmt.Errorf("args.Email: want %q but got %q", test.expectEmail, args.Email)
+				} else if test.expectEmail != args.VerifiedEmail {
+					return fmt.Errorf("args.Email: want %q but got %q", test.expectEmail, args.VerifiedEmail)
 				}
 				return nil
 			}

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -580,4 +581,72 @@ func normalizeUsers(users []*types.User) []*types.User {
 		u.UpdatedAt = u.UpdatedAt.Local().Round(time.Second)
 	}
 	return users
+}
+
+func TestUsers_CreateAndGrantPendingPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	Authz = &mockAuthzStore{}
+	defer func() {
+		Authz = &authzStore{}
+	}()
+
+	tests := []struct {
+		name           string
+		opts           NewUser
+		expectCalled   bool
+		expectUsername string
+		expectEmail    string
+	}{
+		{
+			name: "create with an unverified email",
+			opts: NewUser{
+				Email:                 "alice@example.com",
+				Username:              "alice",
+				DisplayName:           "alice",
+				Password:              "right-password",
+				EmailVerificationCode: "email-code",
+			},
+			expectCalled:   true,
+			expectUsername: "alice",
+			expectEmail:    "",
+		},
+		{
+			name: "create with a verified email",
+			opts: NewUser{
+				Email:           "bob@example.com",
+				Username:        "bob",
+				DisplayName:     "bob",
+				Password:        "right-password",
+				EmailIsVerified: true,
+			},
+			expectCalled:   true,
+			expectUsername: "bob",
+			expectEmail:    "bob@example.com",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calledGrantPendingPermissions := false
+			Mocks.Authz.GrantPendingPermissions = func(_ context.Context, args *GrantPendingPermissionsArgs) error {
+				calledGrantPendingPermissions = true
+				if test.expectUsername != args.Username {
+					return fmt.Errorf("args.Username: want %q but got %q", test.expectUsername, args.Username)
+				} else if test.expectEmail != args.Email {
+					return fmt.Errorf("args.Email: want %q but got %q", test.expectEmail, args.Email)
+				}
+				return nil
+			}
+			_, err := Users.Create(ctx, test.opts)
+			if err != nil {
+				t.Fatal(err)
+			} else if test.expectCalled != calledGrantPendingPermissions {
+				t.Fatalf("calledGrantPendingPermissions: want %v but got %v", test.expectCalled, calledGrantPendingPermissions)
+			}
+		})
+	}
 }

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -26,6 +26,7 @@ import (
 
 func initAuthz() {
 	db.ExternalServices = edb.NewExternalServicesStore()
+	db.Authz = edb.NewAuthzStore()
 
 	// Warn about usage of auth providers that are not enabled by the license.
 	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {

--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+)
+
+// NewAuthzStore returns an OSS db.AuthzStore set with enterprise implementation.
+func NewAuthzStore() db.AuthzStore {
+	return &authzStore{}
+}
+
+type authzStore struct {
+	once  sync.Once
+	store *iauthz.Store
+}
+
+// The global DB is not initialized when NewAuthzStore is called, so we need to create the store at runtime.
+func (s *authzStore) init() {
+	s.once.Do(func() {
+		s.store = iauthz.NewStore(dbconn.Global, time.Now)
+	})
+}
+
+func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.GrantPendingPermissionsArgs) error {
+	s.init()
+	return s.store.GrantPendingPermissions(ctx, args.UserID, &iauthz.UserPendingPermissions{
+		BindID: args.BindID,
+		Perm:   args.Perm,
+		Type:   args.Type,
+	})
+}

--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -43,7 +43,7 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.Grant
 	var bindID string
 	switch cfg.PermissionsUserMapping.BindID {
 	case "email":
-		bindID = args.Email
+		bindID = args.VerifiedEmail
 	case "username":
 		bindID = args.Username
 	default:

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -107,7 +107,7 @@ func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, 
 	ps := &iauthz.UserPermissions{
 		UserID:   userID,
 		Perm:     authz.Read,
-		Type:     iauthz.PermRepos,
+		Type:     authz.PermRepos,
 		Provider: iauthz.ProviderBitbucketServer,
 	}
 
@@ -125,7 +125,7 @@ func (p *Provider) UpdatePermissions(ctx context.Context, u *types.User) error {
 	ps := &iauthz.UserPermissions{
 		UserID:   u.ID,
 		Perm:     authz.Read,
-		Type:     iauthz.PermRepos,
+		Type:     authz.PermRepos,
 		Provider: iauthz.ProviderBitbucketServer,
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/permissions.go
+++ b/enterprise/cmd/frontend/internal/authz/permissions.go
@@ -11,14 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 )
 
-// PermType is the object type of the user permissions.
-type PermType string
-
-// The list of available user permission types.
-const (
-	PermRepos PermType = "repos"
-)
-
 // ProviderType is the type of provider implementation for the permissions.
 type ProviderType string
 
@@ -34,7 +26,7 @@ const (
 type UserPermissions struct {
 	UserID    int32
 	Perm      authz.Perms
-	Type      PermType
+	Type      authz.PermType
 	IDs       *roaring.Bitmap
 	Provider  ProviderType
 	UpdatedAt time.Time
@@ -48,7 +40,7 @@ func (p *UserPermissions) Expired(ttl time.Duration, now time.Time) bool {
 // AuthorizedRepos returns the intersection of the given repository IDs with
 // the authorized IDs.
 func (p *UserPermissions) AuthorizedRepos(repos []*types.Repo) []authz.RepoPerms {
-	if p.Type != PermRepos {
+	if p.Type != authz.PermRepos {
 		return nil
 	}
 
@@ -139,7 +131,7 @@ type UserPendingPermissions struct {
 	ID        int32
 	BindID    string
 	Perm      authz.Perms
-	Type      PermType
+	Type      authz.PermType
 	IDs       *roaring.Bitmap
 	UpdatedAt time.Time
 }
@@ -152,7 +144,7 @@ func (p *UserPendingPermissions) Expired(ttl time.Duration, now time.Time) bool 
 // AuthorizedRepos returns the intersection of the given repository IDs with
 // the authorized IDs.
 func (p *UserPendingPermissions) AuthorizedRepos(repos []*types.Repo) []authz.RepoPerms {
-	if p.Type != PermRepos {
+	if p.Type != authz.PermRepos {
 		return nil
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -152,7 +152,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 		p := &iauthz.UserPermissions{
 			UserID:   user.ID,
 			Perm:     authz.Read, // Note: We currently only support read for repository permissions.
-			Type:     iauthz.PermRepos,
+			Type:     authz.PermRepos,
 			Provider: iauthz.ProviderSourcegraph,
 		}
 		err = r.store.LoadUserPermissions(ctx, p)
@@ -161,7 +161,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 		p := &iauthz.UserPendingPermissions{
 			BindID: bindID,
 			Perm:   authz.Read, // Note: We currently only support read for repository permissions.
-			Type:   iauthz.PermRepos,
+			Type:   authz.PermRepos,
 		}
 		err = r.store.LoadUserPendingPermissions(ctx, p)
 		ids = p.IDs

--- a/enterprise/cmd/frontend/internal/authz/store.go
+++ b/enterprise/cmd/frontend/internal/authz/store.go
@@ -171,7 +171,7 @@ func (s *Store) SetRepoPermissions(ctx context.Context, p *RepoPermissions) (err
 		return nil
 	}
 
-	q := loadUserPermissionsBatchQuery(changedIDs, p.Perm, PermRepos, p.Provider, "FOR UPDATE")
+	q := loadUserPermissionsBatchQuery(changedIDs, p.Perm, authz.PermRepos, p.Provider, "FOR UPDATE")
 	loadedIDs, err := txs.batchLoadIDs(ctx, q)
 	if err != nil {
 		return errors.Wrap(err, "batch load user permissions")
@@ -197,7 +197,7 @@ func (s *Store) SetRepoPermissions(ctx context.Context, p *RepoPermissions) (err
 		updatedPerms = append(updatedPerms, &UserPermissions{
 			UserID:    userID,
 			Perm:      p.Perm,
-			Type:      PermRepos,
+			Type:      authz.PermRepos,
 			IDs:       repoIDs,
 			Provider:  p.Provider,
 			UpdatedAt: updatedAt,
@@ -223,7 +223,7 @@ func (s *Store) SetRepoPermissions(ctx context.Context, p *RepoPermissions) (err
 func loadUserPermissionsBatchQuery(
 	userIDs []uint32,
 	perm authz.Perms,
-	typ PermType,
+	typ authz.PermType,
 	provider ProviderType,
 	lock string,
 ) *sqlf.Query {
@@ -408,7 +408,7 @@ func (s *Store) SetRepoPendingPermissions(ctx context.Context, bindIDs []string,
 		return nil
 	}
 
-	q = loadUserPendingPermissionsByIDBatchQuery(changedIDs, p.Perm, PermRepos, "FOR UPDATE")
+	q = loadUserPendingPermissionsByIDBatchQuery(changedIDs, p.Perm, authz.PermRepos, "FOR UPDATE")
 	bindIDSet, loadedIDs, err := txs.batchLoadUserPendingPermissions(ctx, q)
 	if err != nil {
 		return errors.Wrap(err, "batch load user pending permissions")
@@ -432,7 +432,7 @@ func (s *Store) SetRepoPendingPermissions(ctx context.Context, bindIDs []string,
 		updatedPerms = append(updatedPerms, &UserPendingPermissions{
 			BindID:    bindIDSet[userID],
 			Perm:      p.Perm,
-			Type:      PermRepos,
+			Type:      authz.PermRepos,
 			IDs:       repoIDs,
 			UpdatedAt: updatedAt,
 		})
@@ -557,7 +557,7 @@ RETURNING id
 		items[i] = sqlf.Sprintf("(%s, %s, %s, %s, %s)",
 			bindIDs[i],
 			p.Perm.String(),
-			PermRepos,
+			authz.PermRepos,
 			[]byte{},
 			p.UpdatedAt.UTC(),
 		)
@@ -584,7 +584,7 @@ AND permission = %s
 	)
 }
 
-func loadUserPendingPermissionsByIDBatchQuery(ids []uint32, perm authz.Perms, typ PermType, lock string) *sqlf.Query {
+func loadUserPendingPermissionsByIDBatchQuery(ids []uint32, perm authz.Perms, typ authz.PermType, lock string) *sqlf.Query {
 	const format = `
 -- source: enterprise/cmd/frontend/internal/authz/store.go:loadUserPendingPermissionsByIDBatchQuery
 SELECT id, bind_id, object_ids

--- a/enterprise/cmd/frontend/internal/authz/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/store_test.go
@@ -78,7 +78,7 @@ func testStoreLoadUserPermissions(db *sql.DB) func(*testing.T) {
 			up := &UserPermissions{
 				UserID:   1,
 				Perm:     authz.Read,
-				Type:     PermRepos,
+				Type:     authz.PermRepos,
 				Provider: ProviderSourcegraph,
 			}
 			err := s.LoadUserPermissions(context.Background(), up)
@@ -103,7 +103,7 @@ func testStoreLoadUserPermissions(db *sql.DB) func(*testing.T) {
 			up := &UserPermissions{
 				UserID:   2,
 				Perm:     authz.Read,
-				Type:     PermRepos,
+				Type:     authz.PermRepos,
 				Provider: ProviderSourcegraph,
 			}
 			if err := s.LoadUserPermissions(context.Background(), up); err != nil {
@@ -140,7 +140,7 @@ func testStoreLoadUserPermissions(db *sql.DB) func(*testing.T) {
 			up1 := &UserPermissions{
 				UserID:   1,
 				Perm:     authz.Read,
-				Type:     PermRepos,
+				Type:     authz.PermRepos,
 				Provider: ProviderSourcegraph,
 			}
 			if err := s.LoadUserPermissions(context.Background(), up1); err != nil {
@@ -151,7 +151,7 @@ func testStoreLoadUserPermissions(db *sql.DB) func(*testing.T) {
 			up2 := &UserPermissions{
 				UserID:   2,
 				Perm:     authz.Read,
-				Type:     PermRepos,
+				Type:     authz.PermRepos,
 				Provider: ProviderSourcegraph,
 			}
 			if err := s.LoadUserPermissions(context.Background(), up2); err != nil {
@@ -163,7 +163,7 @@ func testStoreLoadUserPermissions(db *sql.DB) func(*testing.T) {
 			up3 := &UserPermissions{
 				UserID:   3,
 				Perm:     authz.Read,
-				Type:     PermRepos,
+				Type:     authz.PermRepos,
 				Provider: ProviderSourcegraph,
 			}
 			if err := s.LoadUserPermissions(context.Background(), up3); err != nil {
@@ -450,7 +450,7 @@ func testStoreLoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			up := &UserPendingPermissions{
 				BindID: "alice",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}
 			err := s.LoadUserPendingPermissions(context.Background(), up)
 			equal(t, "err", err, ErrNotFound)
@@ -473,7 +473,7 @@ func testStoreLoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			up := &UserPendingPermissions{
 				BindID: "alice",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}
 			if err := s.LoadUserPendingPermissions(context.Background(), up); err != nil {
 				t.Fatal(err)
@@ -507,7 +507,7 @@ func testStoreLoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			up1 := &UserPendingPermissions{
 				BindID: "alice",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}
 			if err := s.LoadUserPendingPermissions(context.Background(), up1); err != nil {
 				t.Fatal(err)
@@ -517,7 +517,7 @@ func testStoreLoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			up2 := &UserPendingPermissions{
 				BindID: "bob",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}
 			if err := s.LoadUserPendingPermissions(context.Background(), up2); err != nil {
 				t.Fatal(err)
@@ -528,7 +528,7 @@ func testStoreLoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			up3 := &UserPendingPermissions{
 				BindID: "cindy",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}
 			if err := s.LoadUserPendingPermissions(context.Background(), up3); err != nil {
 				t.Fatal(err)
@@ -931,7 +931,7 @@ func testStoreGrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 				perm: &UserPendingPermissions{
 					BindID: "alice",
 					Perm:   authz.Read,
-					Type:   PermRepos,
+					Type:   authz.PermRepos,
 				},
 			},
 		},
@@ -976,7 +976,7 @@ func testStoreGrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 				perm: &UserPendingPermissions{
 					BindID: "cindy",
 					Perm:   authz.Read,
-					Type:   PermRepos,
+					Type:   authz.PermRepos,
 				},
 			},
 			expectUserPerms: map[int32][]uint32{
@@ -1037,7 +1037,7 @@ func testStoreGrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 				perm: &UserPendingPermissions{
 					BindID: "alice",
 					Perm:   authz.Read,
-					Type:   PermRepos,
+					Type:   authz.PermRepos,
 				},
 			},
 			expectUserPerms: map[int32][]uint32{
@@ -1140,7 +1140,7 @@ func testStoreDatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 			if err := s.GrantPendingPermissions(ctx, 1, &UserPendingPermissions{
 				BindID: "alice",
 				Perm:   authz.Read,
-				Type:   PermRepos,
+				Type:   authz.PermRepos,
 			}); err != nil &&
 				!strings.Contains(err.Error(), `pq: duplicate key value violates unique constraint "user_permissions_perm_object_provider_unique"`) {
 				t.Fatal(err)


### PR DESCRIPTION
This PR implements #7679, which basically attempts to grant pending permissions when:
1. A user is created
2. A email address is verified

~~Uint tests will be added once people agree that code logics are added in the reasonable places.~~