### PR TITLE
repo-updater: fool-proof listing of IDs of inserted repos

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -500,7 +500,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 		{"delete", deleteReposQuery, deletes},
 		{"update", updateReposQuery, updates},
 		{"insert", insertReposQuery, inserts},
-		{"list", listRepoIDsQuery, inserts},
+		{"list", listRepoIDsQuery, inserts}, // list must run last to pick up inserted IDs
 	} {
 		if len(op.repos) == 0 {
 			continue
@@ -545,7 +545,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 
 	// Assert we have set ID for all repos.
 	for _, r := range repos {
-		if r.ID <= 0 && !r.IsDeleted() {
+		if r.ID == 0 && !r.IsDeleted() {
 			return errors.Errorf("DBStore.UpsertRepos did not set ID for %v", r)
 		}
 	}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -531,6 +531,13 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 		}
 	}
 
+	// Assert we have set ID for all repos.
+	for _, r := range repos {
+		if r.ID <= 0 {
+			return errors.Errorf("DBStore.UpsertRepos did not set ID for %v", r)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -500,7 +500,12 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 		{"delete", deleteReposQuery, deletes},
 		{"update", updateReposQuery, updates},
 		{"insert", insertReposQuery, inserts},
+		{"list", listRepoIDsQuery, inserts},
 	} {
+		if len(op.repos) == 0 {
+			continue
+		}
+
 		q, err := batchReposQuery(op.query, op.repos)
 		if err != nil {
 			return errors.Wrap(err, op.name)
@@ -511,7 +516,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 			return errors.Wrap(err, op.name)
 		}
 
-		if op.name != "insert" {
+		if op.name != "list" {
 			if err = rows.Close(); err != nil {
 				return errors.Wrap(err, op.name)
 			}
@@ -519,11 +524,18 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 			continue
 		}
 
-		i := -1
 		_, _, err = scanAll(rows, func(sc scanner) (last, count int64, err error) {
-			i++
-			err = sc.Scan(&(op.repos[i].ID))
-			return int64(op.repos[i].ID), 1, err
+			var (
+				i  int
+				id uint32
+			)
+
+			err = sc.Scan(&i, &id)
+			if err != nil {
+				return 0, 0, err
+			}
+			op.repos[i-1].ID = id
+			return int64(id), 1, nil
 		})
 
 		if err != nil {
@@ -533,7 +545,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 
 	// Assert we have set ID for all repos.
 	for _, r := range repos {
-		if r.ID <= 0 {
+		if r.ID <= 0 && !r.IsDeleted() {
 			return errors.Errorf("DBStore.UpsertRepos did not set ID for %v", r)
 		}
 	}
@@ -677,49 +689,48 @@ WHERE batch.deleted_at IS NOT NULL
 AND repo.id = batch.id
 `
 
-var insertReposQuery = batchReposQueryFmtstr + `,
-inserted AS (
-  INSERT INTO repo (
-    name,
-    uri,
-    description,
-    language,
-    created_at,
-    updated_at,
-    deleted_at,
-    external_service_type,
-    external_service_id,
-    external_id,
-    enabled,
-    archived,
-    fork,
-    sources,
-    metadata
-  )
-  SELECT
-    name,
-    NULLIF(BTRIM(uri), ''),
-    description,
-    language,
-    created_at,
-    updated_at,
-    deleted_at,
-    external_service_type,
-    external_service_id,
-    external_id,
-    enabled,
-    archived,
-    fork,
-    sources,
-    metadata
-  FROM batch
-  ON CONFLICT (external_service_type, external_service_id, external_id) DO NOTHING
-  RETURNING repo.*
+var insertReposQuery = batchReposQueryFmtstr + `
+INSERT INTO repo (
+  name,
+  uri,
+  description,
+  language,
+  created_at,
+  updated_at,
+  deleted_at,
+  external_service_type,
+  external_service_id,
+  external_id,
+  enabled,
+  archived,
+  fork,
+  sources,
+  metadata
 )
-SELECT inserted.id
-FROM inserted
-LEFT JOIN batch USING (external_service_type, external_service_id, external_id)
-ORDER BY batch.ordinality
+SELECT
+  name,
+  NULLIF(BTRIM(uri), ''),
+  description,
+  language,
+  created_at,
+  updated_at,
+  deleted_at,
+  external_service_type,
+  external_service_id,
+  external_id,
+  enabled,
+  archived,
+  fork,
+  sources,
+  metadata
+FROM batch
+ON CONFLICT (external_service_type, external_service_id, external_id) DO NOTHING
+`
+
+var listRepoIDsQuery = batchReposQueryFmtstr + `
+SELECT batch.ordinality, repo.id
+FROM batch
+JOIN repo USING (external_service_type, external_service_id, external_id)
 `
 
 func nullTimeColumn(t time.Time) *time.Time {

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -736,7 +736,7 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 }
 
 func hasNoID(r *repos.Repo) bool {
-	return r.ID <= 0
+	return r.ID == 0
 }
 
 func hasID(ids ...uint32) func(r *repos.Repo) bool {

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -679,6 +679,59 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 				t.Errorf("ListRepos returned IDs of soft deleted repos: %v", sameIDs.Names())
 			}
 		}))
+
+		t.Run("many repos soft-deleted and single repo reinserted", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+			all := mkRepos(7, repositories...)
+
+			if err := tx.UpsertRepos(ctx, all...); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			sort.Sort(all)
+
+			if noID := all.Filter(hasNoID); len(noID) > 0 {
+				t.Fatalf("UpsertRepos didn't assign an ID to all repos: %v", noID.Names())
+			}
+
+			have, err := tx.ListRepos(ctx, repos.StoreListReposArgs{
+				Kinds: kinds,
+			})
+			if err != nil {
+				t.Fatalf("ListRepos error: %s", err)
+			}
+
+			if diff := pretty.Compare(have, all); diff != "" {
+				t.Fatalf("ListRepos:\n%s", diff)
+			}
+
+			allDeleted := all.Clone().With(repos.Opt.RepoDeletedAt(now))
+			args := repos.StoreListReposArgs{}
+
+			if err = tx.UpsertRepos(ctx, allDeleted...); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			} else if have, err = tx.ListRepos(ctx, args); err != nil {
+				t.Errorf("ListRepos error: %s", err)
+			} else if diff := pretty.Compare(have, repos.Repos{}); diff != "" {
+				t.Errorf("ListRepos:\n%s", diff)
+			}
+
+			// Insert one of the previously soft-deleted repos. Ensure ID on upserted repo is set and we get back the same ID.
+			want := all[0]
+			upsert := want.Clone().With(repos.Opt.RepoID(0))
+			if err = tx.UpsertRepos(ctx, upsert); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+			if upsert.ID == 0 {
+				t.Fatalf("Repo ID is zero")
+			}
+
+			if have, err = tx.ListRepos(ctx, repos.StoreListReposArgs{}); err != nil {
+				t.Fatalf("ListRepos error: %s", err)
+			}
+			if diff := pretty.Compare(have, want); diff != "" {
+				t.Fatalf("ListRepos:\n%s", diff)
+			}
+		}))
 	}
 }
 

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -716,12 +716,12 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 			}
 
 			// Insert one of the previously soft-deleted repos. Ensure ID on upserted repo is set and we get back the same ID.
-			want := all[0]
+			want := repos.Repos{all[0]}
 			upsert := want.Clone().With(repos.Opt.RepoID(0))
-			if err = tx.UpsertRepos(ctx, upsert); err != nil {
+			if err = tx.UpsertRepos(ctx, upsert...); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
 			}
-			if upsert.ID == 0 {
+			if upsert[0].ID == 0 {
 				t.Fatalf("Repo ID is zero")
 			}
 

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -410,8 +410,8 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				),
 				store: s,
 				stored: repos.Repos{
-					tc.repo.With(repos.Opt.RepoName("old-name")), // same external id as sourced
-					tc.repo.With(repos.Opt.RepoExternalID("")),   // same name as sourced
+					tc.repo.With(repos.Opt.RepoName("old-name")),  // same external id as sourced
+					tc.repo.With(repos.Opt.RepoExternalID("bar")), // same name as sourced
 				}.With(repos.Opt.RepoCreatedAt(clock.Time(1))),
 				now: clock.Now,
 				diff: repos.Diff{

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -717,6 +717,14 @@ func (r *Repo) Less(s *Repo) bool {
 	return sortedSliceLess(sourcesKeys(r.Sources), sourcesKeys(s.Sources))
 }
 
+func (r *Repo) String() string {
+	eid := fmt.Sprintf("{%s %s %s}", r.ExternalRepo.ServiceID, r.ExternalRepo.ServiceType, r.ExternalRepo.ID)
+	if r.IsDeleted() {
+		return fmt.Sprintf("Repo{ID: %d, Name: %q, EID: %s, IsDeleted: true}", r.ID, r.Name, eid)
+	}
+	return fmt.Sprintf("Repo{ID: %d, Name: %q, EID: %s}", r.ID, r.Name, eid)
+}
+
 func sourcesKeys(m map[string]*SourceInfo) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
Rather than using fancy SQL, we update our code to issue a SELECT after we
have gone through updating and inserting into the repo table. This is pretty
fool-proof and much easier to understand.

We also remove the coupling between i and ordinality in the scanAll
closure. Instead we can return the ordinality so we always update the correct
position.

This does send along the full repo struct for listing, when all we actually
need is the external repo spec. This could be optimized in the future if it
shows up as a hotspot, but for simplicity we reuse the existing batch
functionality.

Also included in this commit is a minor optimization around skipping ops with
no repos to change. Additionally we fix a test case which created bad data
(missing external repo id). We also assert we set ID in DBStore.UpsertRepos.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7750