### PR TITLE
Interactive mode: add filter negation

### DIFF
--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -30,10 +30,6 @@ export enum FilterTypes {
     fork = 'fork',
     archived = 'archived',
     case = 'case',
-    // '-repo' = '-repo',
-    // '-file' = '-file',
-    // '-lang' = '-lang',
-    // '-repohasfile' = '-repohasfile',
 }
 
 export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterTypes[]

--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -13,7 +13,7 @@ export interface FiltersToTypeAndValue {
         value: string
         // `editable` is whether the corresponding filter input is currently editable in the UI.
         editable: boolean
-
+        // `negated` is whether the filter is negated. Optional because some filters are non-negatable.
         negated?: boolean
     }
 }
@@ -42,9 +42,9 @@ export enum NegatedFilters {
 }
 
 /** The list of filters that are able to be negated. */
-export type NegatableFilters = FilterTypes.repo | FilterTypes.file | FilterTypes.repohasfile | FilterTypes.lang
+export type NegatableFilter = FilterTypes.repo | FilterTypes.file | FilterTypes.repohasfile | FilterTypes.lang
 
-export const isNegatableFilter = (filter: FilterTypes): filter is NegatableFilters =>
+export const isNegatableFilter = (filter: FilterTypes): filter is NegatableFilter =>
     Object.keys(NegatedFilters).includes(filter)
 
 /** The list of all negated filters. i.e. all valid filters that have `-` as a suffix. */
@@ -53,11 +53,11 @@ export const negatedFilters = Object.values(NegatedFilters)
 export const isNegatedFilter = (filter: string): filter is NegatedFilters =>
     negatedFilters.includes(filter as NegatedFilters)
 
-const negatedFilterToNegatableFilter: { [key: string]: NegatableFilters } = {
+const negatedFilterToNegatableFilter: { [key: string]: NegatableFilter } = {
     '-repo': FilterTypes.repo,
     '-file': FilterTypes.file,
     '-lang': FilterTypes.lang,
     '-repohasfile': FilterTypes.repohasfile,
 }
 
-export const resolveNegatedFilter = (filter: NegatedFilters): NegatableFilters => negatedFilterToNegatableFilter[filter]
+export const resolveNegatedFilter = (filter: NegatedFilters): NegatableFilter => negatedFilterToNegatableFilter[filter]

--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -13,6 +13,8 @@ export interface FiltersToTypeAndValue {
         value: string
         // `editable` is whether the corresponding filter input is currently editable in the UI.
         editable: boolean
+
+        negated?: boolean
     }
 }
 
@@ -28,6 +30,38 @@ export enum FilterTypes {
     fork = 'fork',
     archived = 'archived',
     case = 'case',
+    // '-repo' = '-repo',
+    // '-file' = '-file',
+    // '-lang' = '-lang',
+    // '-repohasfile' = '-repohasfile',
 }
 
 export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterTypes[]
+
+export enum NegatedFilters {
+    repo = '-repo',
+    file = '-file',
+    lang = '-lang',
+    repohasfile = '-repohasfile',
+}
+
+/** The list of filters that are able to be negated. */
+export type NegatableFilters = FilterTypes.repo | FilterTypes.file | FilterTypes.repohasfile | FilterTypes.lang
+
+export const isNegatableFilter = (filter: FilterTypes): filter is NegatableFilters =>
+    Object.keys(NegatedFilters).includes(filter)
+
+/** The list of all negated filters. i.e. all valid filters that have `-` as a suffix. */
+export const negatedFilters = Object.values(NegatedFilters)
+
+export const isNegatedFilter = (filter: string): filter is NegatedFilters =>
+    negatedFilters.includes(filter as NegatedFilters)
+
+const negatedFilterToNegatableFilter: { [key: string]: NegatableFilters } = {
+    '-repo': FilterTypes.repo,
+    '-file': FilterTypes.file,
+    '-lang': FilterTypes.lang,
+    '-repohasfile': FilterTypes.repohasfile,
+}
+
+export const resolveNegatedFilter = (filter: NegatedFilters): NegatableFilters => negatedFilterToNegatableFilter[filter]

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -1,7 +1,7 @@
 import { Position, Range, Selection } from '@sourcegraph/extension-api-types'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { SearchPatternType } from '../graphql/schema'
-import { FiltersToTypeAndValue, filterTypeKeys } from '../search/interactive/util'
+import { FiltersToTypeAndValue, filterTypeKeys, negatedFilters, NegatedFilters, isNegatableFilter } from '../search/interactive/util'
 import { isEmpty } from 'lodash'
 
 export interface RepoSpec {
@@ -594,9 +594,15 @@ export function buildSearchURLQuery(
 export function interactiveBuildSearchURLQuery(filtersInQuery: FiltersToTypeAndValue): URLSearchParams {
     const searchParams = new URLSearchParams()
 
-    for (const searchType of filterTypeKeys) {
+    for (const searchType of [...filterTypeKeys, ...negatedFilters]) {
         for (const [, filterValue] of Object.entries(filtersInQuery)) {
             if (filterValue.type === searchType) {
+                if (filterValue.negated) {
+                    if (isNegatableFilter(searchType)) {
+                        searchParams.append(NegatedFilters[searchType], filterValue.value)
+                    }
+                    continue
+                }
                 searchParams.append(searchType, filterValue.value)
             }
         }

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -1,7 +1,13 @@
 import { Position, Range, Selection } from '@sourcegraph/extension-api-types'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { SearchPatternType } from '../graphql/schema'
-import { FiltersToTypeAndValue, filterTypeKeys, negatedFilters, NegatedFilters, isNegatableFilter } from '../search/interactive/util'
+import {
+    FiltersToTypeAndValue,
+    filterTypeKeys,
+    negatedFilters,
+    NegatedFilters,
+    isNegatableFilter,
+} from '../search/interactive/util'
 import { isEmpty } from 'lodash'
 
 export interface RepoSpec {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -163,7 +163,7 @@ interface ValidFilterAndValueMatch extends FilterAndValueMatch {
 /**
  * Tries to resolve the given string into a valid filter type.
  */
-const resolveFilterType = (filter: string = ''): FiltersSuggestionTypes | null => {
+export const resolveFilterType = (filter: string = ''): FiltersSuggestionTypes | null => {
     const absoluteFilter = filter.replace(/^-/, '')
     return filterAliases[absoluteFilter] ?? (isValidFilter(absoluteFilter) ? absoluteFilter : null)
 }
@@ -307,6 +307,9 @@ export const isFuzzyWordSearch = (queryState: QueryState): boolean => {
  */
 export const filterAliasForSearch: Record<string, SuggestionTypes | undefined> = {
     [SuggestionTypes.repohasfile]: SuggestionTypes.file,
+    // [FilterTypes['-repohasfile']]: SuggestionTypes.file,
+    // [FilterTypes['-repo']]: SuggestionTypes.repo,
+    // [FilterTypes['-file']]: SuggestionTypes.file,
 }
 
 /**
@@ -363,7 +366,7 @@ export const formatInteractiveQueryForFuzzySearch = (
     // `repohasfile:` should be converted to `file:`
     const filterSearchAlias = filterAliasForSearch[filterType]
     if (filterSearchAlias) {
-        return `${filterSearchAlias}:${value}`
+        return fullQuery.replace(`${filterType}:${value}`, `${filterSearchAlias}:${value}`)
     }
 
     return isolatedFuzzySearchFiltersFilterType.includes(filterType) ? filterType + ':' + value : fullQuery

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -307,9 +307,6 @@ export const isFuzzyWordSearch = (queryState: QueryState): boolean => {
  */
 export const filterAliasForSearch: Record<string, SuggestionTypes | undefined> = {
     [SuggestionTypes.repohasfile]: SuggestionTypes.file,
-    // [FilterTypes['-repohasfile']]: SuggestionTypes.file,
-    // [FilterTypes['-repo']]: SuggestionTypes.repo,
-    // [FilterTypes['-file']]: SuggestionTypes.file,
 }
 
 /**

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -1,6 +1,11 @@
 import { escapeRegExp } from 'lodash'
 import { SearchPatternType } from '../../../shared/src/graphql/schema'
-import { FiltersToTypeAndValue, filterTypeKeys, FilterTypes } from '../../../shared/src/search/interactive/util'
+import {
+    FiltersToTypeAndValue,
+    filterTypeKeys,
+    FilterTypes,
+    negatedFilters,
+} from '../../../shared/src/search/interactive/util'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -36,7 +41,7 @@ export function parseSearchURLQuery(
 export function interactiveParseSearchURLQuery(query: string): string | undefined {
     const searchParams = new URLSearchParams(query)
     const finalQueryParts = []
-    for (const filterType of filterTypeKeys.filter(key => key !== FilterTypes.case)) {
+    for (const filterType of [...filterTypeKeys, ...negatedFilters].filter(key => key !== FilterTypes.case)) {
         for (const filterValue of searchParams.getAll(filterType)) {
             finalQueryParts.push(`${filterType}:${filterValue}`)
         }

--- a/web/src/search/input/interactive/FilterInput.scss
+++ b/web/src/search/input/interactive/FilterInput.scss
@@ -74,6 +74,22 @@ $filter-input-padding: 0.25rem;
         display: flex;
         align-self: flex-end;
     }
+
+    &__negation-button {
+        border: 1px solid transparent;
+        margin-right: 0.25rem;
+
+        &--active {
+            border: 1px solid $color-border-active;
+            border-radius: 2px;
+            .theme-dark & {
+                background: $color-bg-5;
+            }
+            .theme-light & {
+                background: $color-light-bg-3;
+            }
+        }
+    }
 }
 
 .theme-light {

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Form } from '../../../components/Form'
 import CloseIcon from 'mdi-react/CloseIcon'
+import MinusIcon from 'mdi-react/MinusIcon'
 import { Subscription, Subject, merge, of } from 'rxjs'
 import {
     distinctUntilChanged,
@@ -28,7 +29,11 @@ import {
     filterStaticSuggestions,
 } from '../../helpers'
 import { dedupeWhitespace } from '../../../../../shared/src/util/strings'
-import { FiltersToTypeAndValue, FilterTypes } from '../../../../../shared/src/search/interactive/util'
+import {
+    FiltersToTypeAndValue,
+    FilterTypes,
+    isNegatableFilter,
+} from '../../../../../shared/src/search/interactive/util'
 import { SuggestionTypes } from '../../../../../shared/src/search/suggestions/util'
 import { startCase, isEqual } from 'lodash'
 import { searchFilterSuggestions } from '../../searchFilterSuggestions'
@@ -72,6 +77,11 @@ interface Props {
      */
     editable: boolean
 
+    /**
+     * Whether the current filter is negated
+     */
+    negated?: boolean
+
     isHomepage: boolean
 
     /**
@@ -94,6 +104,8 @@ interface Props {
      * Callback to handle the editable state of this filter.
      */
     toggleFilterEditable: (filterKey: string) => void
+
+    toggleFilterNegated: (filterKey: string) => void
 }
 
 const LOADING: 'loading' = 'loading'
@@ -357,6 +369,10 @@ export class FilterInput extends React.Component<Props, State> {
         }
     }
 
+    private toggleNegation = (): void => {
+        this.props.toggleFilterNegated(this.props.mapKey)
+    }
+
     private downshiftItemToString = (suggestion?: Suggestion): string => (suggestion ? suggestion.value : '')
 
     public render(): JSX.Element | null {
@@ -396,6 +412,18 @@ export class FilterInput extends React.Component<Props, State> {
                         return (
                             <div>
                                 <div className="filter-input__form">
+                                    {isNegatableFilter(this.props.filterType) && this.props.editable && (
+                                        <button
+                                            type="button"
+                                            className={classNames('btn', 'btn-icon', 'filter-input__negation-button', {
+                                                'filter-input__negation-button--active': this.props.negated,
+                                            })}
+                                            onClick={this.toggleNegation}
+                                            data-tooltip={this.props.negated ? 'Include results' : 'Exclude results'}
+                                        >
+                                            <MinusIcon />
+                                        </button>
+                                    )}
                                     <div className="filter-input__input-wrapper">
                                         <input
                                             ref={this.inputEl}
@@ -510,6 +538,7 @@ export class FilterInput extends React.Component<Props, State> {
                     aria-label="Edit filter"
                     tabIndex={0}
                 >
+                    {this.props.negated ? '-' : ''}
                     {this.props.filterType}:{this.state.inputValue}
                 </button>
                 <button

--- a/web/src/search/input/interactive/SelectedFiltersRow.tsx
+++ b/web/src/search/input/interactive/SelectedFiltersRow.tsx
@@ -34,6 +34,9 @@ interface Props {
      */
     toggleFilterEditable: (filterKey: string) => void
 
+    /**
+     * Callback to handle the negation state of a filter.
+     */
     toggleFilterNegated: (filterKey: string) => void
 
     /**

--- a/web/src/search/input/interactive/SelectedFiltersRow.tsx
+++ b/web/src/search/input/interactive/SelectedFiltersRow.tsx
@@ -18,6 +18,7 @@ interface Props {
      * Callback to trigger a search when a filter is submitted.
      */
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
+
     /**
      * Callback to handle a filter's value being updated.
      */
@@ -32,6 +33,8 @@ interface Props {
      * Callback to handle the editable state of a filter.
      */
     toggleFilterEditable: (filterKey: string) => void
+
+    toggleFilterNegated: (filterKey: string) => void
 
     /**
      * Whether we're on the search homepage.
@@ -49,6 +52,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
     onFilterEdited,
     onFilterDeleted,
     toggleFilterEditable,
+    toggleFilterNegated,
     isHomepage,
 }) => {
     const filterKeys = Object.keys(filtersInQuery)
@@ -65,6 +69,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
                                 filterType={filtersInQuery[field].type}
                                 value={filtersInQuery[field].value}
                                 editable={filtersInQuery[field].editable}
+                                negated={filtersInQuery[field].negated}
                                 filtersInQuery={filtersInQuery}
                                 navbarQuery={navbarQuery}
                                 isHomepage={isHomepage}
@@ -72,6 +77,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
                                 onFilterDeleted={onFilterDeleted}
                                 onFilterEdited={onFilterEdited}
                                 toggleFilterEditable={toggleFilterEditable}
+                                toggleFilterNegated={toggleFilterNegated}
                             />
                         ))}
                 </div>

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -16,6 +16,10 @@ export function isTextFilter(filter: FilterTypes): boolean {
         'lang',
         'count',
         'timeout',
+        '-repo',
+        '-repohasfile',
+        '-file',
+        '-lang',
     ]
 
     return validTextFilters.includes(filter)
@@ -69,4 +73,8 @@ export const FilterTypesToProseNames: Record<FilterTypes, string> = {
     fork: 'Forks',
     archived: 'Archived repos',
     case: 'Case sensitive',
+    // '-repo': 'Exclude repos',
+    // '-repohasfile': 'Exclude repos with file',
+    // '-file': 'Exclude files',
+    // '-lang': 'Exclude languages',
 }

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -73,8 +73,4 @@ export const FilterTypesToProseNames: Record<FilterTypes, string> = {
     fork: 'Forks',
     archived: 'Archived repos',
     case: 'Case sensitive',
-    // '-repo': 'Exclude repos',
-    // '-repohasfile': 'Exclude repos with file',
-    // '-file': 'Exclude files',
-    // '-lang': 'Exclude languages',
 }

--- a/web/src/search/searchFilterSuggestions.ts
+++ b/web/src/search/searchFilterSuggestions.ts
@@ -2,6 +2,7 @@ import { Suggestion, FiltersSuggestionTypes } from './input/Suggestion'
 import { assign } from 'lodash/fp'
 import { languageIcons } from '../../../shared/src/components/languageIcons'
 import { SuggestionTypes } from '../../../shared/src/search/suggestions/util'
+import { FilterTypes } from '../../../shared/src/search/interactive/util'
 
 export type SearchFilterSuggestions = Record<
     FiltersSuggestionTypes,

--- a/web/src/search/searchFilterSuggestions.ts
+++ b/web/src/search/searchFilterSuggestions.ts
@@ -2,7 +2,6 @@ import { Suggestion, FiltersSuggestionTypes } from './input/Suggestion'
 import { assign } from 'lodash/fp'
 import { languageIcons } from '../../../shared/src/components/languageIcons'
 import { SuggestionTypes } from '../../../shared/src/search/suggestions/util'
-import { FilterTypes } from '../../../shared/src/search/interactive/util'
 
 export type SearchFilterSuggestions = Record<
     FiltersSuggestionTypes,


### PR DESCRIPTION
This PR adds the ability to negate filters in interactive mode.

It adds a `-` icon in a toggle next to the filter input for filters that are able to be negated.

![2020-01-15 21 32 50](https://user-images.githubusercontent.com/16265452/72438010-f28fd000-37de-11ea-976d-60e0f27b6774.gif)

(Note: PR is based off of the open interactive mode PR)
