### PR TITLE
repo-updater: race condition on multierror.Error.ErrorFormat

### DIFF
--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -148,8 +148,12 @@ type SourceError struct {
 
 func (s *SourceError) Error() string {
 	if multiErr, ok := s.Err.(*multierror.Error); ok {
-		multiErr.ErrorFormat = sourceErrorFormatFunc
-		return multiErr.Error()
+		// Create new Error with custom formatter. Do not mutate otherwise can
+		// race with other callers of Error.
+		return (&multierror.Error{
+			Errors:      multiErr.Errors,
+			ErrorFormat: sourceErrorFormatFunc,
+		}).Error()
 	}
 	return s.Err.Error()
 }


### PR DESCRIPTION
Noticed this while running in dev with race detection turned on.