### PR TITLE
revert^2: experimental tls.external site setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Add button to download file in code view. [#5478](https://github.com/sourcegraph/sourcegraph/issues/5478)
 - The new `allowOrgs` site config setting in GitHub `auth.providers` enables admins to restrict GitHub logins to members of specific GitHub organizations. [#4195](https://github.com/sourcegraph/sourcegraph/issues/4195)
 - Skip LFS content when cloning git repositories. [#7322](https://github.com/sourcegraph/sourcegraph/issues/7322)
+- An experimental site setting `experimentalFeatures/tls.external` which allows you to configure SSL/TLS settings for Sourcegraph contacting your code hosts. Currently just supports turning off TLS/SSL verification. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
 - Experimental: To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. To search all branches, use `repo:myrepo@*refs/heads/`. Requires the site configuration value `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }`. Previously this was only supported for diff and commit searches.
 - Support case field in repository search. [#7671](https://github.com/sourcegraph/sourcegraph/issues/7671)
 - Hover tooltips and _Find Reference_ results now display a badge to indicate when a result is search-based. These indicators can be disabled by adding `{ "experimentalFeatures": { "showBadgeAttachments": false } }` in global settings.

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -54,7 +54,7 @@ func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnect
 	}
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer(func(c *http.Client) error {

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -243,3 +243,9 @@ func (t stubBadHTTPRedirectTransport) RoundTrip(r *http.Request) (*http.Response
 
 	return resp, err
 }
+
+// UnwrappableTransport signals that this transport can't be wrapped. In
+// particular this means we won't respect global external
+// settings. https://github.com/sourcegraph/sourcegraph/issues/71 and
+// https://github.com/sourcegraph/sourcegraph/issues/7738
+func (stubBadHTTPRedirectTransport) UnwrappableTransport() {}

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -40,7 +40,7 @@ func NewBitbucketCloudSource(svc *ExternalService, cf *httpcli.Factory) (*Bitbuc
 
 func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer()

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -47,7 +47,7 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 	baseURL = NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	var opts []httpcli.Opt

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -61,7 +61,7 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 	apiURL, githubDotCom := github.APIRoot(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	opts := []httpcli.Opt{

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -46,7 +46,7 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 	baseURL = NormalizeBaseURL(baseURL)
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	var opts []httpcli.Opt

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -32,7 +32,7 @@ func NewOtherSource(svc *ExternalService, cf *httpcli.Factory) (*OtherSource, er
 	}
 
 	if cf == nil {
-		cf = httpcli.NewHTTPClientFactory()
+		cf = httpcli.NewExternalHTTPClientFactory()
 	}
 
 	cli, err := cf.Doer()

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -181,7 +181,7 @@ func (s *PhabricatorSource) client(ctx context.Context) (*phabricator.Client, er
 
 // RunPhabricatorRepositorySyncWorker runs the worker that syncs repositories from Phabricator to Sourcegraph
 func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 
 	for {
 		phabs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -342,7 +342,7 @@ func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceS
 		Kind:        req.ExternalService.Kind,
 		DisplayName: req.ExternalService.DisplayName,
 		Config:      req.ExternalService.Config,
-	}, httpcli.NewHTTPClientFactory())
+	}, httpcli.NewExternalHTTPClientFactory())
 	if err != nil {
 		return err
 	}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -95,7 +95,7 @@ func Main(newPreSync repos.NewPreSync, dbInitHook func(db *sql.DB)) {
 		)
 	}
 
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 	var src repos.Sourcer
 	{
 		m := repos.NewSourceMetrics()

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -39,7 +39,7 @@ func TestService(t *testing.T) {
 	}
 
 	gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 
 	u, err := db.Users.Create(ctx, testUser)
 	if err != nil {
@@ -352,7 +352,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 	}
 
 	gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
-	cf := httpcli.NewHTTPClientFactory()
+	cf := httpcli.NewExternalHTTPClientFactory()
 
 	u, err := db.Users.Create(ctx, testUser)
 	if err != nil {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -57,14 +57,18 @@ type Factory struct {
 	common []Opt
 }
 
-// NewHTTPClientFactory returns an httpcli.Factory with common
-// options and middleware pre-set.
-func NewHTTPClientFactory() *Factory {
+// NewExternalHTTPClientFactory returns an httpcli.Factory with common options
+// and middleware pre-set for communicating to external services.
+func NewExternalHTTPClientFactory() *Factory {
 	return NewFactory(
 		// TODO(tsenart): Use middle for Prometheus instrumentation later.
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
+		// ExternalTransportOpt needs to be before TracedTransportOpt and
+		// NewCachedTransportOpt since it wants to extract a http.Transport,
+		// not a generic http.RoundTripper.
+		ExternalTransportOpt,
 		TracedTransportOpt,
 		NewCachedTransportOpt(httputil.Cache, true),
 	)
@@ -154,6 +158,19 @@ func ContextErrorMiddleware(cli Doer) Doer {
 //
 // Common Opts
 //
+
+// ExternalTransportOpt returns an Opt that ensures the http.Client.Transport
+// can contact non-Sourcegraph services. For example Admins can configure
+// TLS/SSL settings.
+func ExternalTransportOpt(cli *http.Client) error {
+	tr, err := getTransportForMutation(cli)
+	if err != nil {
+		return errors.Wrap(err, "httpcli.ExternalTransportOpt")
+	}
+
+	cli.Transport = &externalTransport{base: tr}
+	return nil
+}
 
 // NewCertPoolOpt returns a Opt that sets the RootCAs pool of an http.Client's
 // transport.

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -176,6 +176,10 @@ func ExternalTransportOpt(cli *http.Client) error {
 // transport.
 func NewCertPoolOpt(certs ...string) Opt {
 	return func(cli *http.Client) error {
+		if len(certs) == 0 {
+			return nil
+		}
+
 		tr, err := getTransportForMutation(cli)
 		if err != nil {
 			return errors.Wrap(err, "httpcli.NewCertPoolOpt")

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -254,7 +254,7 @@ func getTransportForMutation(cli *http.Client) (*http.Transport, error) {
 
 	tr, ok := cli.Transport.(*http.Transport)
 	if !ok {
-		return nil, errors.New("http.Client.Transport is not an *http.Transport")
+		return nil, errors.Errorf("http.Client.Transport is not an *http.Transport: %T", cli.Transport)
 	}
 
 	tr = tr.Clone()

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -169,27 +169,10 @@ func TestNewCertPool(t *testing.T) {
 		err    string
 	}{
 		{
-			name: "sets default transport if nil",
-			cli:  &http.Client{},
-			assert: func(t testing.TB, cli *http.Client) {
-				if cli.Transport == nil {
-					t.Fatal("transport wasn't set")
-				}
-			},
-		},
-		{
-			name: "fails if transport isn't an http.Transport",
-			cli:  &http.Client{Transport: bogusTransport{}},
-			err:  "httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
-		},
-		{
-			name: "sets TLSClientConfig if nil",
-			cli:  &http.Client{Transport: &http.Transport{}},
-			assert: func(t testing.TB, cli *http.Client) {
-				if cli.Transport.(*http.Transport).TLSClientConfig == nil {
-					t.Fatal("TLSClientConfig wasn't set")
-				}
-			},
+			name:  "fails if transport isn't an http.Transport",
+			cli:   &http.Client{Transport: bogusTransport{}},
+			certs: []string{cert},
+			err:   "httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name:  "pool is set to what is given",

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -180,7 +180,7 @@ func TestNewCertPool(t *testing.T) {
 		{
 			name: "fails if transport isn't an http.Transport",
 			cli:  &http.Client{Transport: bogusTransport{}},
-			err:  "httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport",
+			err:  "httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name: "sets TLSClientConfig if nil",
@@ -246,7 +246,7 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 		{
 			name: "fails if transport isn't an http.Transport",
 			cli:  &http.Client{Transport: bogusTransport{}},
-			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport is not an *http.Transport",
+			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name:    "IdleConnTimeout is set to what is given",

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -1,0 +1,52 @@
+package httpcli
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type externalTransport struct {
+	base *http.Transport
+
+	mu        sync.RWMutex
+	config    *schema.TlsExternal
+	effective *http.Transport
+}
+
+func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.RLock()
+	config, effective := t.config, t.effective
+	t.mu.RUnlock()
+
+	if current := conf.Get().ExperimentalFeatures.TlsExternal; current == nil {
+		return t.base.RoundTrip(r)
+	} else if reflect.DeepEqual(config, current) {
+		return effective.RoundTrip(r)
+	}
+
+	effective = t.update()
+	return effective.RoundTrip(r)
+}
+
+func (t *externalTransport) update() *http.Transport {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	config := conf.Get().ExperimentalFeatures.TlsExternal
+	effective := t.base.Clone()
+
+	if effective.TLSClientConfig == nil {
+		effective.TLSClientConfig = new(tls.Config)
+	}
+
+	effective.TLSClientConfig.InsecureSkipVerify = config.InsecureSkipVerify
+
+	t.config = config
+	t.effective = effective
+	return effective
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -346,6 +346,8 @@ type ExperimentalFeatures struct {
 	SplitSearchModes string `json:"splitSearchModes,omitempty"`
 	// StructuralSearch description: Enables structural search.
 	StructuralSearch string `json:"structuralSearch,omitempty"`
+	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
+	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.
@@ -934,6 +936,13 @@ type SiteConfiguration struct {
 	// 1. `kubectl port-forward $(kubectl get pods | grep jaeger-query | awk '{ print $1 }') 16686`
 	// 1. Go to http://localhost:16686 to view the Jaeger dashboard.
 	UseJaeger bool `json:"useJaeger,omitempty"`
+}
+
+// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
+type TlsExternal struct {
+	// InsecureSkipVerify description: insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -90,6 +90,18 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "tls.external": {
+          "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "insecureSkipVerify": {
+              "description": "insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.\nIf InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.",
+              "type": "boolean",
+              "default": false
+            }
+          }
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -95,6 +95,18 @@ const SiteSchemaJSON = `{
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "tls.external": {
+          "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "insecureSkipVerify": {
+              "description": "insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.\nIf InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.",
+              "type": "boolean",
+              "default": false
+            }
+          }
         }
       },
       "group": "Experimental",


### PR DESCRIPTION
reverting the revert https://github.com/sourcegraph/sourcegraph/pull/7741

AWS Code Commit broke with two commits: https://github.com/sourcegraph/sourcegraph/pull/7651 and https://github.com/sourcegraph/sourcegraph/pull/7648

The first broke it because previously NewCertOpt would not be run for it, now it always would be. The second broke it further because that PR can't wrap non-http.Transport RoundTrippers. This PR introduces a marker interface to let us skip that.

The effect is AWS Code Commit won't respect the new tls.external site setting. This is fine for now, since the setting is experimental.

Test Plan: Run e2e tests on enterprise dev.

Part of https://github.com/sourcegraph/sourcegraph/issues/71

Fixes https://github.com/sourcegraph/sourcegraph/issues/7745
Fixes https://github.com/sourcegraph/sourcegraph/issues/7744
Fixes https://github.com/sourcegraph/sourcegraph/issues/7738