### PR TITLE
e2e: do not log componentWillReceiveProps warning

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -597,6 +597,10 @@ export async function createDriverForTest(options: DriverOptions): Promise<Drive
             if (message.text().includes('[HMR]') || message.text().includes('[WDS]')) {
                 return
             }
+            if (message.text().includes('Warning: componentWillReceiveProps has been renamed')) {
+                // This warning applies to our dependencies and leads to logspam on every page.
+                return
+            }
             console.log('Browser console:', util.inspect(message, { colors: true, depth: 2, breakLength: Infinity }))
         })
     }


### PR DESCRIPTION
We do not use it. However, it seems some of our dependencies do. This message is
logged so much it makes viewing the logs unuseable. So it is better to just
supress it.