### PR TITLE
httpcli: only call effective.RoundTrip once

### DIFF
--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -25,11 +25,10 @@ func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	if current := conf.Get().ExperimentalFeatures.TlsExternal; current == nil {
 		return t.base.RoundTrip(r)
-	} else if reflect.DeepEqual(config, current) {
-		return effective.RoundTrip(r)
+	} else if !reflect.DeepEqual(config, current) {
+		effective = t.update()
 	}
 
-	effective = t.update()
 	return effective.RoundTrip(r)
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/sourcegraph/sourcegraph/pull/7765/files/21e45a4df0de4254787edb1ae775ca4c7fccc9a8#r366952276