### PR TITLE
Remove pholcus_lib from repoSlugs in search regression tests

### DIFF
--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -75,7 +75,6 @@ describe('Search regression test suite', () => {
         'antonmedv/expr',
         'ClickHouse/clickhouse-go',
         'xwb1989/sqlparser',
-        'henrylee2cn/pholcus_lib',
         'itcloudy/ERP',
         'iovisor/kubectl-trace',
         'minio/highwayhash',


### PR DESCRIPTION
This repository now 404s: https://github.com/henrylee2cn/pholcus_lib

There may be additional tweaks to the search regression tests needed following this, but opening this PR to call this out as the search regression test's `before()` will time out due to this @beyang 