### PR TITLE
frontend: Return StatusUnauthorized for anonymous requests to raw endpoint

### DIFF
--- a/cmd/frontend/auth/non_public_test.go
+++ b/cmd/frontend/auth/non_public_test.go
@@ -78,6 +78,13 @@ func TestNewUserRequiredAuthzMiddleware(t *testing.T) {
 			location:   "/sign-in?returnTo=%2F",
 		},
 		{
+			name:       "no_auth__raw_route",
+			req:        httptest.NewRequest("GET", "/test-repo/-/raw/README.md", nil),
+			allowed:    false,
+			wantStatus: http.StatusUnauthorized,
+			location:   "/sign-in?returnTo=%2Ftest-repo%2F-%2Fraw%2FREADME.md",
+		},
+		{
 			name:       "no_auth__api_route",
 			req:        httptest.NewRequest("GET", "/.api/graphql", nil),
 			allowed:    false,

--- a/cmd/frontend/internal/app/ui/router/exported_router.go
+++ b/cmd/frontend/internal/app/ui/router/exported_router.go
@@ -14,4 +14,5 @@ const (
 	RouteSignIn        = "sign-in"
 	RouteSignUp        = "sign-up"
 	RoutePasswordReset = "password-reset"
+	RouteRaw           = "raw"
 )


### PR DESCRIPTION
Raw endpoint should be an API endpoint, but lives under the UI for auth in
browser reasons. However, given extensions interact with it we want it to
return API like status codes when a user is not logged in.

This adds special casing in our RequireAuthMiddleware for the raw route. This
is done in a similiar fashion as our anonymous access routes, except it just
affects the HTTP status code returned.

Fixes https://github.com/sourcegraph/sourcegraph/issues/1248
