### PR TITLE
fix: update broken link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@ Unless you feel confident your change will be accepted (trivial bug fixes, code 
 ## Code of Conduct
 
 All interactions with the Sourcegraph open source project are governed by the
-[Sourcegraph Code of Conduct](./doc/dev/conduct.md).
+[Sourcegraph Code of Conduct](https://about.sourcegraph.com/community/code_of_conduct).


### PR DESCRIPTION
The code of conduct lives in the [about repository](https://github.com/sourcegraph/about) since c15a3db4. Point to the Handbook site rather than the source file.