### PR TITLE
Browser extension: update GitHub DOM selectors

### DIFF
--- a/browser/src/e2e/github.test.ts
+++ b/browser/src/e2e/github.test.ts
@@ -167,8 +167,8 @@ describe(`Sourcegraph ${startCase(BROWSER)} extension`, () => {
     })
 
     const tokens = {
-        base: { text: 'matchHost', selector: 'span.pl-v' },
-        head: { text: 'typ', selector: 'span.pl-v' },
+        base: { text: 'matchHost', selector: 'span.pl-s1' },
+        head: { text: 'typ', selector: 'span.pl-s1' },
     }
 
     for (const diffType of ['unified', 'split']) {


### PR DESCRIPTION
This fixes bext e2e tests

- https://sourcegraph.slack.com/archives/C07KZF47K/p1579132860098900 
- https://buildkite.com/sourcegraph/sourcegraph/builds/53854#e6966353-8fc7-4e7f-96e6-cee45c0f00b7