### PR TITLE
Add missing badge attachment styles in browser package.

### DIFF
--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -7,6 +7,7 @@
 @import '../../shared/src/extensions/ExtensionStatus';
 @import '../../shared/src/notifications/NotificationItem';
 @import '../../shared/src/notifications/Notifications';
+@import '../../shared/src/components/BadgeAttachment';
 
 $body-color-light: #2b3750;
 $body-color-dark: #f2f4f8;

--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -71,10 +71,3 @@ $body-color-dark: #f2f4f8;
 .line-decoration-attachment {
     margin-left: 0.25rem;
 }
-
-.badge-decoration-attachment {
-    &__contents {
-        // Always apply light theme styles
-        background-color: rgba(255, 255, 255, 0.8);
-    }
-}

--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -24,7 +24,7 @@ $body-color-dark: #f2f4f8;
 .command-palette-button {
     align-self: center;
 
-    > .command-list-popover-button {
+    >.command-list-popover-button {
         user-select: none;
         position: relative;
     }
@@ -62,6 +62,7 @@ $body-color-dark: #f2f4f8;
 .toggle--off::-webkit-slider-runnable-track {
     color: #eeeeee;
 }
+
 .toggle--off::-webkit-slider-thumb {
     background-color: #000000;
     opacity: 0.2;
@@ -69,4 +70,11 @@ $body-color-dark: #f2f4f8;
 
 .line-decoration-attachment {
     margin-left: 0.25rem;
+}
+
+.badge-decoration-attachment {
+    &__contents {
+        // Always apply light theme styles
+        background-color: rgba(255, 255, 255, 0.8);
+    }
 }

--- a/shared/src/components/BadgeAttachment.tsx
+++ b/shared/src/components/BadgeAttachment.tsx
@@ -13,7 +13,9 @@ export const BadgeAttachment: React.FunctionComponent<{
 
     return (
         <LinkOrSpan
-            className="badge-decoration-attachment"
+            // Ensure theme-light exists as an ascendent of the img below, otherwise the
+            // browser extension will always render with a dark theme background. It's bad.
+            className={'badge-decoration-attachment ' + isLightTheme ? 'theme-light' : ''}
             to={attachment.linkURL}
             data-tooltip={attachment.hoverMessage}
             // Use target to open external URLs

--- a/shared/src/components/BadgeAttachment.tsx
+++ b/shared/src/components/BadgeAttachment.tsx
@@ -15,7 +15,7 @@ export const BadgeAttachment: React.FunctionComponent<{
         <LinkOrSpan
             // Ensure theme-light exists as an ascendent of the img below, otherwise the
             // browser extension will always render with a dark theme background. It's bad.
-            className={'badge-decoration-attachment ' + isLightTheme ? 'theme-light' : ''}
+            className={`badge-decoration-attachment ${isLightTheme ? 'theme-light' : ''}`}
             to={attachment.linkURL}
             data-tooltip={attachment.hoverMessage}
             // Use target to open external URLs


### PR DESCRIPTION
lo-frickin-l

This _should_ fix it. Testing it locally now

<img width="860" alt="Screen Shot 2020-01-15 at 6 13 34 PM" src="https://user-images.githubusercontent.com/103087/72484438-d897c280-37c9-11ea-9e59-3c47ff915481.png">
