### PR TITLE
regression-e2e: remove case:yes from search filters test

### DIFF
--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -503,7 +503,6 @@ describe('Search regression test suite', () => {
 
         test('Search filters', async () => {
             const filterToToken = [
-                ['case:yes', 'case:yes'],
                 ['lang:go', 'lang:go'],
                 ['-file:_test\\.go$', '-file:_test\\.go$'],
             ]


### PR DESCRIPTION
Removes `case:yes` filter from the search filters regression test. With the new case sensitivity toggle, `case:yes` gets removed from the raw query in the search bar, so this test would fail.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
