### PR TITLE
all: fix some errcheck warnings

### DIFF
--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -151,7 +151,9 @@ func main() {
 		log.Fatal(err)
 	}
 	if len(os.Args) > 1 {
-		ioutil.WriteFile(os.Args[1], []byte(out), 0644)
+		if err := ioutil.WriteFile(os.Args[1], []byte(out), 0644); err != nil {
+			log.Fatal(err)
+		}
 	} else {
 		fmt.Print(out)
 	}

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -67,7 +67,7 @@ func NewHandler() http.Handler {
 
 	r.Get(router.DebugHeaders).Handler(trace.TraceRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Header.Del("Cookie")
-		r.Header.Write(w)
+		_ = r.Header.Write(w)
 	})))
 	addDebugHandlers(r.Get(router.Debug).Subrouter())
 

--- a/cmd/frontend/internal/app/misc_handlers.go
+++ b/cmd/frontend/internal/app/misc_handlers.go
@@ -30,7 +30,7 @@ func robotsTxtHelper(w io.Writer, allowRobots bool) {
 		fmt.Fprintln(&buf, "Disallow: /")
 	}
 	fmt.Fprintln(&buf)
-	buf.WriteTo(w)
+	_, _ = buf.WriteTo(w)
 }
 
 func favicon(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/app/sign_out.go
+++ b/cmd/frontend/internal/app/sign_out.go
@@ -58,7 +58,7 @@ func renderSignoutPageTemplate(w http.ResponseWriter, r *http.Request, signoutUR
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	buf.WriteTo(w)
+	_, _ = buf.WriteTo(w)
 }
 
 var signoutPageTemplate = template.Must(template.New("").Parse(`

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -129,7 +129,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 	}
 
 	// Write the session cookie
-	if session.SetActor(w, r, actor, 0); err != nil {
+	if err := session.SetActor(w, r, actor, 0); err != nil {
 		httpLogAndError(w, "Could not create new user session", http.StatusInternalServerError)
 	}
 
@@ -184,7 +184,7 @@ func HandleSignIn(w http.ResponseWriter, r *http.Request) {
 	actor := &actor.Actor{UID: usr.ID}
 
 	// Write the session cookie
-	if session.SetActor(w, r, actor, 0); err != nil {
+	if err := session.SetActor(w, r, actor, 0); err != nil {
 		httpLogAndError(w, "Could not create new user session", http.StatusInternalServerError)
 		return
 	}

--- a/cmd/frontend/internal/pkg/handlerutil/handler.go
+++ b/cmd/frontend/internal/pkg/handlerutil/handler.go
@@ -54,8 +54,8 @@ func (h HandlerWithErrorReturn) ServeHTTP(w http.ResponseWriter, r *http.Request
 			stack := make([]byte, 1024*1024)
 			n := runtime.Stack(stack, false)
 			stack = stack[:n]
-			io.WriteString(os.Stderr, "\nstack trace:\n")
-			os.Stderr.Write(stack)
+			_, _ = io.WriteString(os.Stderr, "\nstack trace:\n")
+			_, _ = os.Stderr.Write(stack)
 
 			err := fmt.Errorf("panic: %v\n\nstack trace:\n%s", e, stack)
 			status := http.StatusInternalServerError

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -153,12 +153,12 @@ func main() {
 		}
 		w.WriteHeader(resp.StatusCode)
 		if resp.StatusCode < 400 || !logRequests {
-			io.Copy(w, resp.Body)
+			_, _ = io.Copy(w, resp.Body)
 			return
 		}
 		b, err := ioutil.ReadAll(resp.Body)
 		log15.Warn("proxy error", "status", resp.StatusCode, "body", string(b), "bodyErr", err)
-		io.Copy(w, bytes.NewReader(b))
+		_, _ = io.Copy(w, bytes.NewReader(b))
 	})
 	if logRequests {
 		h = handlers.LoggingHandler(os.Stdout, h)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -613,7 +613,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	if cloneInProgress {
 		status = "clone-in-progress"
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(&protocol.NotFoundPayload{
+		_ = json.NewEncoder(w).Encode(&protocol.NotFoundPayload{
 			CloneInProgress: true,
 			CloneProgress:   cloneProgress,
 		})
@@ -1233,8 +1233,8 @@ func computeRefHash(dir GitDir) ([]byte, error) {
 	})
 	hasher := sha256.New()
 	for _, b := range lines {
-		hasher.Write(b)
-		hasher.Write([]byte("\n"))
+		_, _ = hasher.Write(b)
+		_, _ = hasher.Write([]byte("\n"))
 	}
 	hash := make([]byte, hex.EncodedLen(hasher.Size()))
 	hex.Encode(hash, hasher.Sum(nil))

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -72,7 +72,7 @@ func main() {
 			// For cluster liveness and readiness probes
 			if r.URL.Path == "/healthz" {
 				w.WriteHeader(200)
-				w.Write([]byte("ok"))
+				_, _ = w.Write([]byte("ok"))
 				return
 			}
 			handler.ServeHTTP(w, r)

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -115,9 +115,9 @@ type ctagsProcess struct {
 }
 
 func (p *ctagsProcess) Close() {
-	p.cmd.Process.Kill()
-	p.outPipe.Close()
-	p.in.Close()
+	_ = p.cmd.Process.Kill()
+	_ = p.outPipe.Close()
+	_ = p.in.Close()
 }
 
 func (p *ctagsProcess) read(rep *reply) error {

--- a/enterprise/cmd/frontend/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/middleware_test.go
@@ -46,7 +46,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 
 	s.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(providerJSON{
+		_ = json.NewEncoder(w).Encode(providerJSON{
 			Issuer:      oidcProvider.Issuer,
 			AuthURL:     oidcProvider.Issuer + "/oauth2/v1/authorize",
 			TokenURL:    oidcProvider.Issuer + "/oauth2/v1/token",
@@ -72,7 +72,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 			t.Errorf("got redirect_uri %v, want %v", redirectURI, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(fmt.Sprintf(`{
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
 			"access_token": "aaaaa",
 			"token_type": "Bearer",
 			"expires_in": 3600,
@@ -91,7 +91,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 			t.Fatalf("No bearer token found in authz header %q", authzHeader)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(fmt.Sprintf(`{
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
 			"sub": %q,
 			"profile": "This is a profile",
 			"email": "`+email+`",

--- a/enterprise/cmd/frontend/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/auth/saml/middleware.go
@@ -97,7 +97,7 @@ func samlSPHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			traceLog(fmt.Sprintf("Service Provider metadata: %s", p.ConfigID().ID), string(buf))
 			w.Header().Set("Content-Type", "application/samlmetadata+xml; charset=utf-8")
-			w.Write(buf)
+			_, _ = w.Write(buf)
 			return
 
 		case "/login":

--- a/enterprise/cmd/frontend/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/saml/middleware_test.go
@@ -219,9 +219,9 @@ func TestMiddleware(t *testing.T) {
 	authedHandler.Handle("/", Middleware.App(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/":
-			w.Write([]byte("This is the home"))
+			_, _ = w.Write([]byte("This is the home"))
 		case "/page":
-			w.Write([]byte("This is a page"))
+			_, _ = w.Write([]byte("This is a page"))
 		case "/require-authn":
 			actr := actor.FromContext(r.Context())
 			if actr.UID == 0 {
@@ -229,7 +229,7 @@ func TestMiddleware(t *testing.T) {
 			} else if actr.UID != mockedUserID {
 				t.Errorf("in authn expected-endpoint, actor with incorrect UID was set; %d != %d", actr.UID, mockedUserID)
 			}
-			w.Write([]byte("Authenticated"))
+			_, _ = w.Write([]byte("Authenticated"))
 		default:
 			http.Error(w, "", http.StatusNotFound)
 		}

--- a/internal/db/dbtesting/dbtesting.go
+++ b/internal/db/dbtesting/dbtesting.go
@@ -26,12 +26,12 @@ func useFastPasswordMocks() {
 	// We can't care about security in tests, we care about speed.
 	MockHashPassword = func(password string) (sql.NullString, error) {
 		h := fnv.New64()
-		io.WriteString(h, password)
+		_, _ = io.WriteString(h, password)
 		return sql.NullString{Valid: true, String: strconv.FormatUint(h.Sum64(), 16)}, nil
 	}
 	MockValidPassword = func(hash, password string) bool {
 		h := fnv.New64()
-		io.WriteString(h, password)
+		_, _ = io.WriteString(h, password)
 		return hash == strconv.FormatUint(h.Sum64(), 16)
 	}
 }
@@ -94,7 +94,9 @@ func emptyDBPreserveSchema(t testing.TB, d *sql.DB) {
 	var tables []string
 	for rows.Next() {
 		var table string
-		rows.Scan(&table)
+		if err := rows.Scan(&table); err != nil {
+			t.Fatal(err)
+		}
 		tables = append(tables, table)
 	}
 	if err := rows.Close(); err != nil {

--- a/internal/httputil/cache_control_transport_test.go
+++ b/internal/httputil/cache_control_transport_test.go
@@ -30,29 +30,33 @@ func TestCacheControlTransport(t *testing.T) {
 		return !(r.URL.String() == url3)
 	})
 
-	// Cache-control round-tripper
-	ccTransport.RoundTrip(getReq)
-	if cc := recorder.req.Header.Get("Cache-Control"); cc != "max-age=0" {
+	cacheControl := func(r *http.Request) string {
+		t.Helper()
+
+		// Cache-control round-tripper
+		if _, err := ccTransport.RoundTrip(r); err != nil {
+			t.Fatal(err)
+		}
+		return recorder.req.Header.Get("Cache-Control")
+	}
+
+	if cc := cacheControl(getReq); cc != "max-age=0" {
 		t.Errorf("expected cache control header on GET, but got none")
 	}
 
-	ccTransport.RoundTrip(getReq)
-	if cc := recorder.req.Header.Get("Cache-Control"); cc != "" {
+	if cc := cacheControl(getReq); cc != "" {
 		t.Errorf("expected no cache control header on 2nd GET, but got %s", cc)
 	}
 
-	ccTransport.RoundTrip(getReq2)
-	if cc := recorder.req.Header.Get("Cache-Control"); cc != "max-age=0" {
+	if cc := cacheControl(getReq2); cc != "max-age=0" {
 		t.Errorf("expected cache control header on GET to new URL, but got none")
 	}
 
-	ccTransport.RoundTrip(getReq3)
-	if cc := recorder.req.Header.Get("Cache-Control"); cc != "" {
+	if cc := cacheControl(getReq3); cc != "" {
 		t.Errorf("expected no cache control header on GET to long-lived URL, but got %s", cc)
 	}
 
-	ccTransport.RoundTrip(postReq)
-	if cc := recorder.req.Header.Get("Cache-Control"); cc != "" {
+	if cc := cacheControl(postReq); cc != "" {
 		t.Errorf("expected no cache control header on POST, but got %s", cc)
 	}
 

--- a/internal/store/zipcache.go
+++ b/internal/store/zipcache.go
@@ -37,7 +37,7 @@ type zipCacheShard struct {
 
 func (c *ZipCache) shardFor(path string) *zipCacheShard {
 	h := fnv.New32()
-	io.WriteString(h, path)
+	_, _ = io.WriteString(h, path)
 	return &c.shards[h.Sum32()%uint32(len(c.shards))]
 }
 


### PR DESCRIPTION
A new meditation for yuppie software engineers. Run errcheck on our codebase
and fix some of the warnings. 5 minutes a day will lead to a better, happier
and examined life.

Most fixes are just explicitly marking we are ignoring the error. This is the
case often since we are writing a response and there is no reasonable recourse
if it fails. Some changes handle the error.