### PR TITLE
a8n: go vet warning about composite literal in test

### DIFF
--- a/internal/a8n/types_test.go
+++ b/internal/a8n/types_test.go
@@ -121,15 +121,15 @@ func TestChangesetEvents(t *testing.T) {
 				ID: 23,
 				Metadata: &github.PullRequest{
 					TimelineItems: []github.TimelineItem{
-						{"AssignedEvent", assignedEvent},
-						{"PullRequestReviewThread", &github.PullRequestReviewThread{
+						{Type: "AssignedEvent", Item: assignedEvent},
+						{Type: "PullRequestReviewThread", Item: &github.PullRequestReviewThread{
 							Comments: reviewComments[:2],
 						}},
-						{"UnassignedEvent", unassignedEvent},
-						{"PullRequestReviewThread", &github.PullRequestReviewThread{
+						{Type: "UnassignedEvent", Item: unassignedEvent},
+						{Type: "PullRequestReviewThread", Item: &github.PullRequestReviewThread{
 							Comments: reviewComments[2:],
 						}},
-						{"ClosedEvent", closedEvent},
+						{Type: "ClosedEvent", Item: closedEvent},
 					},
 				},
 			},


### PR DESCRIPTION
github.TimelineItem composite literal uses unkeyed fields (govet)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
