### PR TITLE
e2e tests: Ensure repos are cloned before starting test suite

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -302,7 +302,7 @@ export class Driver {
                 await this.page.goto(`${this.sourcegraphBaseUrl}/${slug}`)
 
                 if (slug.toLowerCase() === 'github.com/sourcegraphtest/alwayscloningtest') {
-                    continue;
+                    continue
                 }
 
                 // We wait for the revision element to show up, which only shows

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -300,6 +300,16 @@ export class Driver {
                 await this.page.waitForSelector(`.repository-node[data-e2e-repository='${slug}']`, { visible: true })
                 // Workaround for https://github.com/sourcegraph/sourcegraph/issues/5286
                 await this.page.goto(`${this.sourcegraphBaseUrl}/${slug}`)
+
+                if (slug.toLowerCase().includes('alwayscloningtest')) {
+                    continue;
+                }
+
+                // We wait for the revision element to show up, which only shows
+                // up when the repository has been cloned.
+                await retry(async () => {
+                    await this.page.waitForSelector('.e2e-revision', { visible: true })
+                })
             }
         }
     }

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -301,7 +301,7 @@ export class Driver {
                 // Workaround for https://github.com/sourcegraph/sourcegraph/issues/5286
                 await this.page.goto(`${this.sourcegraphBaseUrl}/${slug}`)
 
-                if (slug.toLowerCase() === 'sourcegraphtest/alwayscloningtest') {
+                if (slug.toLowerCase() === 'github.com/sourcegraphtest/alwayscloningtest') {
                     continue;
                 }
 

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -301,7 +301,7 @@ export class Driver {
                 // Workaround for https://github.com/sourcegraph/sourcegraph/issues/5286
                 await this.page.goto(`${this.sourcegraphBaseUrl}/${slug}`)
 
-                if (slug.toLowerCase().includes('alwayscloningtest')) {
+                if (slug.toLowerCase() === 'sourcegraphtest/alwayscloningtest') {
                     continue;
                 }
 


### PR DESCRIPTION
I have a hunch that not waiting for repos to be fully cloned is the
cause for the majority of our e2e flakiness (excluding
infrastructure-related flakiness).

I don't know whether this check was already there and got removed or
whether the architecture changed in the meantime (repos are added and
cloned async now), but the comment (`// Clone the repositories`) makes
it sound like this is what's supposed to happen in `ensureRepos`.

The test I use is to check for the revision selector to show up.