### PR TITLE
search: add tests for "case:" in TestSearchRepositories

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -52,15 +52,15 @@ func TestSearchRepositories(t *testing.T) {
 		q    string
 		want []string
 	}{{
-		name: "search for all repositories",
+		name: "all",
 		q:    "type:repo",
 		want: []string{"bar/one", "foo/no-match", "foo/one"},
 	}, {
-		name: "search for all repositories where the repo name includes 'foo/one'",
+		name: "pattern filter",
 		q:    "type:repo foo/one",
 		want: []string{"foo/one"},
 	}, {
-		name: "search for all repositories where the repo name includes 'foo' and the repo has a file path matching 'f.go'",
+		name: "repohasfile",
 		q:    "foo type:repo repohasfile:f.go",
 		want: []string{"foo/one"},
 	}}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -63,6 +63,18 @@ func TestSearchRepositories(t *testing.T) {
 		name: "repohasfile",
 		q:    "foo type:repo repohasfile:f.go",
 		want: []string{"foo/one"},
+	}, {
+		name: "case yes match",
+		q:    "foo case:yes",
+		want: []string{"foo/no-match", "foo/one"},
+	}, {
+		name: "case no match",
+		q:    "Foo case:no",
+		want: []string{"foo/no-match", "foo/one"},
+	}, {
+		name: "case exclude all",
+		q:    "Foo case:yes",
+		want: []string{},
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This PR first refactors TestSearchRepositories to be data driven. This leads to making it much easier to add tests and see what exactly they are testing.

Best reviewed commit by commit. Extraction of getPatternInfo happened in #7807 

Follow-up from #7724.