### PR TITLE
a8n: Fix flaky test

### DIFF
--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -2539,10 +2539,10 @@ func testProcessCampaignJob(db *sql.DB) func(*testing.T) {
 			for i := 0; i < 2; i++ {
 				go func() {
 					ran, err := s.ProcessPendingCampaignJob(ctx, process)
-					errChan <- err
 					if ran {
 						atomic.AddInt64(&runCount, 1)
 					}
+					errChan <- err
 				}()
 			}
 			for i := 0; i < 2; i++ {


### PR DESCRIPTION
We should update the counter before sending on the channel or there's a
chance that the code checking for the result will run before the counter
has been incremented.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
