### PR TITLE
db: remove enabled/disabled from ReposListOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+### Removed
+
+- All repository fields related to `enabled` and `disabled` have been removed from the GraphQL API. These fields have been deprecated since 3.4. [#3971](https://github.com/sourcegraph/sourcegraph/pull/3971)
+
 ## 3.12.0 (unreleased)
 
 ### Added

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -54,7 +54,7 @@ func TestReposService_List(t *testing.T) {
 
 	calledList := db.Mocks.Repos.MockList(t, "r1", "r2")
 
-	repos, err := s.List(ctx, db.ReposListOptions{Enabled: true})
+	repos, err := s.List(ctx, db.ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -251,7 +251,7 @@ func TestRepos_List(t *testing.T) {
 
 	want := mustCreate(ctx, t, &types.Repo{Name: "r"})
 
-	repos, err := Repos.List(ctx, ReposListOptions{Enabled: true})
+	repos, err := Repos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,28 +277,28 @@ func TestRepos_List_fork(t *testing.T) {
 	yours := mustCreate(ctx, t, &types.Repo{Name: "b/r", RepoFields: &types.RepoFields{Fork: true}})
 
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{Enabled: true, OnlyForks: true})
+		repos, err := Repos.List(ctx, ReposListOptions{OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, yours, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{Enabled: true, NoForks: true})
+		repos, err := Repos.List(ctx, ReposListOptions{NoForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, mine, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{Enabled: true, NoForks: true, OnlyForks: true})
+		repos, err := Repos.List(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, nil, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{Enabled: true})
+		repos, err := Repos.List(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +345,7 @@ func TestRepos_List_pagination(t *testing.T) {
 		{limit: 4, offset: 4, exp: nil},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Enabled: true, LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
+		repos, err := Repos.List(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -390,7 +390,7 @@ func TestRepos_List_query1(t *testing.T) {
 		{"mno/p", []api.RepoName{"jkl/mno/pqr"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query, Enabled: true})
+		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -436,7 +436,7 @@ func TestRepos_List_query2(t *testing.T) {
 		{"def/m", []api.RepoName{"def/mno"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query, Enabled: true})
+		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -509,7 +509,7 @@ func TestRepos_List_sort(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy, Enabled: true})
+		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -570,7 +570,6 @@ func TestRepos_List_patterns(t *testing.T) {
 		repos, err := Repos.List(ctx, ReposListOptions{
 			IncludePatterns: test.includePatterns,
 			ExcludePattern:  test.excludePattern,
-			Enabled:         true,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -695,7 +694,6 @@ func TestRepos_List_queryPattern(t *testing.T) {
 	for _, test := range tests {
 		repos, err := Repos.List(ctx, ReposListOptions{
 			PatternQuery: test.q,
-			Enabled:      true,
 		})
 		if err != nil {
 			if test.err == "" {
@@ -721,14 +719,14 @@ func TestRepos_List_queryAndPatternsMutuallyExclusive(t *testing.T) {
 	wantErr := "Query and IncludePatterns/ExcludePattern options are mutually exclusive"
 
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
-		_, err := Repos.List(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}, Enabled: true})
+		_, err := Repos.List(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
 	})
 
 	t.Run("Query and ExcludePattern", func(t *testing.T) {
-		_, err := Repos.List(ctx, ReposListOptions{Query: "x", ExcludePattern: "y", Enabled: true})
+		_, err := Repos.List(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -84,7 +84,7 @@ func TestRepos_Count(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if count, err := Repos.Count(ctx, ReposListOptions{Enabled: true}); err != nil {
+	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -94,13 +94,13 @@ func TestRepos_Count(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{Enabled: true}); err != nil {
+	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	repos, err := Repos.List(ctx, ReposListOptions{Enabled: true})
+	repos, err := Repos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestRepos_Count(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{Enabled: true}); err != nil {
+	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -25,8 +25,6 @@ func (r *schemaResolver) Repositories(args *struct {
 	graphqlutil.ConnectionArgs
 	Query           *string
 	Names           *[]string
-	Enabled         bool // deprecated
-	Disabled        bool // deprecated
 	Cloned          bool
 	CloneInProgress bool
 	NotCloned       bool
@@ -35,14 +33,7 @@ func (r *schemaResolver) Repositories(args *struct {
 	OrderBy         string
 	Descending      bool
 }) (*repositoryConnectionResolver, error) {
-	// New call sites don't specify Enable and Disable. Assume if disabled
-	// isn't specified we want Enabled since all repos are enabled.
-	if !args.Disabled {
-		args.Enabled = true
-	}
-
 	opt := db.ReposListOptions{
-		Enabled: args.Enabled,
 		OrderBy: db.RepoListOrderBy{{
 			Field:      toDBRepoListColumn(args.OrderBy),
 			Descending: args.Descending,

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -258,7 +258,7 @@ func (r *schemaResolver) UpdateAllMirrorRepositories(ctx context.Context) (*Empt
 		return nil, err
 	}
 
-	reposList, err := db.Repos.List(ctx, db.ReposListOptions{Enabled: true, Disabled: true})
+	reposList, err := db.Repos.List(ctx, db.ReposListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1163,14 +1163,6 @@ type Query {
         query: String
         # Return repositories whose names are in the list.
         names: [String!]
-        # Include enabled repositories.
-        #
-        # DEPRECATED: All repositories are enabled. Will be removed in 3.6.
-        enabled: Boolean = true
-        # Include disabled repositories.
-        #
-        # DEPRECATED: No repositories are disabled. Will be removed in 3.6.
-        disabled: Boolean = false
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1761,13 +1753,6 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
-    # DEPRECATED: All repositories are enabled. This field will be removed in 3.6.
-    #
-    # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
-    #
-    # NOTE: Disabling a repository does not provide any additional security. This field is merely a
-    # guideline to UI implementations.
-    enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository was created on Sourcegraph.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1170,14 +1170,6 @@ type Query {
         query: String
         # Return repositories whose names are in the list.
         names: [String!]
-        # Include enabled repositories.
-        #
-        # DEPRECATED: All repositories are enabled. Will be removed in 3.6.
-        enabled: Boolean = true
-        # Include disabled repositories.
-        #
-        # DEPRECATED: No repositories are disabled. Will be removed in 3.6.
-        disabled: Boolean = false
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1768,13 +1760,6 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
-    # DEPRECATED: All repositories are enabled. This field will be removed in 3.6.
-    #
-    # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
-    #
-    # NOTE: Disabling a repository does not provide any additional security. This field is merely a
-    # guideline to UI implementations.
-    enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository was created on Sourcegraph.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -503,7 +503,6 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 			OnlyRepoIDs:     true,
 			IncludePatterns: includePatterns,
 			ExcludePattern:  unionRegExps(excludePatterns),
-			Enabled:         true,
 			// List N+1 repos so we can see if there are repos omitted due to our repo limit.
 			LimitOffset:  &db.LimitOffset{Limit: maxRepoListSize + 1},
 			NoForks:      op.noForks,

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -21,7 +21,6 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 
 	// List at most 10 repositories as default suggestions.
 	repos, err := backend.Repos.List(ctx, db.ReposListOptions{
-		Enabled: true,
 		LimitOffset: &db.LimitOffset{
 			Limit: 10,
 		},

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -592,7 +592,7 @@ func (n *numTotalReposCache) get(ctx context.Context) int {
 	n.RUnlock()
 
 	n.Lock()
-	newCount, err := db.Repos.Count(ctx, db.ReposListOptions{Enabled: true})
+	newCount, err := db.Repos.Count(ctx, db.ReposListOptions{})
 	if err != nil {
 		defer n.Unlock()
 		log15.Error("failed to determine numTotalRepos", "error", err)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -72,7 +72,6 @@ func TestSearchResults(t *testing.T) {
 
 			want := db.ReposListOptions{
 				OnlyRepoIDs:     true,
-				Enabled:         true,
 				IncludePatterns: []string{"r", "p"},
 				LimitOffset:     limitOffset,
 			}
@@ -106,7 +105,6 @@ func TestSearchResults(t *testing.T) {
 
 			want := db.ReposListOptions{
 				OnlyRepoIDs: true,
-				Enabled:     true,
 				LimitOffset: limitOffset,
 			}
 
@@ -178,7 +176,6 @@ func TestSearchResults(t *testing.T) {
 
 			want := db.ReposListOptions{
 				OnlyRepoIDs: true,
-				Enabled:     true,
 				LimitOffset: limitOffset,
 			}
 

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -153,7 +153,6 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// Only care about the first found repository.
 		repos, err := backend.Repos.List(ctx, db.ReposListOptions{
 			IncludePatterns: validValues,
-			Enabled:         true,
 			OnlyRepoIDs:     true,
 			LimitOffset: &db.LimitOffset{
 				Limit: 1,

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -66,8 +66,8 @@ func TestSearchSuggestions(t *testing.T) {
 	t.Run("single term", func(t *testing.T) {
 		var calledReposListAll, calledReposListFoo bool
 		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
-			wantFoo := db.ReposListOptions{IncludePatterns: []string{"foo"}, OnlyRepoIDs: true, Enabled: true, LimitOffset: limitOffset} // when treating term as repo: field
-			wantAll := db.ReposListOptions{OnlyRepoIDs: true, Enabled: true, LimitOffset: limitOffset}                                   // when treating term as text query
+			wantFoo := db.ReposListOptions{IncludePatterns: []string{"foo"}, OnlyRepoIDs: true, LimitOffset: limitOffset} // when treating term as repo: field
+			wantAll := db.ReposListOptions{OnlyRepoIDs: true, LimitOffset: limitOffset}                                   // when treating term as text query
 			if reflect.DeepEqual(op, wantAll) {
 				calledReposListAll = true
 				return []*types.Repo{{Name: "bar-repo"}}, nil
@@ -134,8 +134,8 @@ func TestSearchSuggestions(t *testing.T) {
 		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 			mu.Lock()
 			defer mu.Unlock()
-			wantReposInGroup := db.ReposListOptions{IncludePatterns: []string{`^foo-repo1$|^repo3$`}, Enabled: true, LimitOffset: limitOffset}    // when treating term as repo: field
-			wantFooRepo3 := db.ReposListOptions{IncludePatterns: []string{"foo", `^foo-repo1$|^repo3$`}, Enabled: true, LimitOffset: limitOffset} // when treating term as repo: field
+			wantReposInGroup := db.ReposListOptions{IncludePatterns: []string{`^foo-repo1$|^repo3$`}, LimitOffset: limitOffset}    // when treating term as repo: field
+			wantFooRepo3 := db.ReposListOptions{IncludePatterns: []string{"foo", `^foo-repo1$|^repo3$`}, LimitOffset: limitOffset} // when treating term as repo: field
 			if reflect.DeepEqual(op, wantReposInGroup) {
 				calledReposListReposInGroup = true
 				return []*types.Repo{
@@ -211,7 +211,6 @@ func TestSearchSuggestions(t *testing.T) {
 			want := db.ReposListOptions{
 				IncludePatterns: []string{"foo"},
 				OnlyRepoIDs:     true,
-				Enabled:         true,
 				LimitOffset:     limitOffset,
 			}
 			if !reflect.DeepEqual(op, want) {
@@ -255,7 +254,6 @@ func TestSearchSuggestions(t *testing.T) {
 			want := db.ReposListOptions{
 				IncludePatterns: []string{"foo"},
 				OnlyRepoIDs:     true,
-				Enabled:         true,
 				LimitOffset: &db.LimitOffset{
 					Limit: 1,
 				},
@@ -307,7 +305,6 @@ func TestSearchSuggestions(t *testing.T) {
 			want := db.ReposListOptions{
 				IncludePatterns: []string{"foo"},
 				OnlyRepoIDs:     true,
-				Enabled:         true,
 				LimitOffset:     limitOffset,
 			}
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -103,7 +103,7 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.Users.Count failed", "error", err)
 	}
 	q.Set("totalUsers", strconv.Itoa(totalUsers))
-	totalRepos, err := db.Repos.Count(ctx, db.ReposListOptions{Enabled: true, Disabled: true})
+	totalRepos, err := db.Repos.Count(ctx, db.ReposListOptions{})
 	hasRepos := totalRepos > 0
 	if err != nil {
 		logFunc("db.Repos.Count failed", "error", err)

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -260,7 +260,7 @@ func (h *reposListServer) serveIndex(w http.ResponseWriter, r *http.Request) err
 		}
 	} else {
 		trueP := true
-		res, err := h.Repos.List(r.Context(), db.ReposListOptions{Index: &trueP, Enabled: true})
+		res, err := h.Repos.List(r.Context(), db.ReposListOptions{Index: &trueP})
 		if err != nil {
 			return errors.Wrap(err, "listing repos")
 		}


### PR DESCRIPTION
All repos are enabled, so these fields have been noops since 3.4. Had to
update all call sites for listing repos. If it specified `disabled: true` and
not `enabled: true` we know the result set is empty so the code is
updated. Otherwise the filter is a noop so we just remove specifying the
fields.

Part of https://github.com/sourcegraph/sourcegraph/issues/3971