### PR TITLE
a8n: Don't roll back on RunChangesetJob error

### DIFF
--- a/enterprise/internal/a8n/runner.go
+++ b/enterprise/internal/a8n/runner.go
@@ -253,7 +253,10 @@ func RunChangesetJobs(ctx context.Context, s *Store, clock func() time.Time, git
 		if err != nil {
 			return errors.Wrap(err, "getting campaign")
 		}
-		return RunChangesetJob(ctx, clock, s, gitClient, nil, c, &job)
+		_ = RunChangesetJob(ctx, clock, s, gitClient, nil, c, &job)
+		// We ignore the error here so that we don't roll back the transaction
+		// RunChangesetJob will save the error in the job row
+		return nil
 	}
 	worker := func() {
 		for {

--- a/enterprise/internal/a8n/runner.go
+++ b/enterprise/internal/a8n/runner.go
@@ -263,7 +263,7 @@ func RunChangesetJobs(ctx context.Context, s *Store, clock func() time.Time, git
 			default:
 				didRun, err := s.ProcessPendingChangesetJobs(context.Background(), process)
 				if err != nil {
-					log15.Error("Running campaign job", "err", err)
+					log15.Error("Running changeset job", "err", err)
 				}
 				// Back off on error or when no jobs available
 				if err != nil || !didRun {

--- a/enterprise/internal/a8n/runner_test.go
+++ b/enterprise/internal/a8n/runner_test.go
@@ -30,7 +30,7 @@ type refAndTarget struct {
 	target string
 }
 
-func TestConsumePendingCampaignJobs(t *testing.T) {
+func TestRunCampaignJobs(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
If we roll back the error is never written to the DB and we retry forever.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7759