### PR TITLE
all: ignore most warnings from errcheck

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -31,7 +31,7 @@ func serveReposGetByName(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+	_, _ = w.Write(data)
 	return nil
 }
 
@@ -50,7 +50,7 @@ func servePhabricatorRepoCreate(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+	_, _ = w.Write(data)
 	return nil
 }
 
@@ -362,7 +362,7 @@ func serveSavedQueriesSetInfo(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "SavedQueries.Set")
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 	return nil
 }
 
@@ -377,7 +377,7 @@ func serveSavedQueriesDeleteInfo(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "SavedQueries.Delete")
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 	return nil
 }
 
@@ -500,7 +500,7 @@ func serveGitResolveRevision(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(commitID))
+	_, _ = w.Write([]byte(commitID))
 	return nil
 }
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -592,7 +592,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 				}
 
 				if honey.Enabled() {
-					ev.Send()
+					_ = ev.Send()
 				}
 				if traceLogs {
 					log15.Debug("TRACE gitserver exec", mapToLog15Ctx(ev.Fields())...)
@@ -660,7 +660,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// to a persistent failure mode where every exec takes > 10s, which is disastrous for gitserver performance.
 	if len(req.Args) == 2 && req.Args[0] == "rev-parse" && req.Args[1] == "HEAD" {
 		if resolved, err := quickRevParseHead(dir); err == nil && git.IsAbsoluteRevision(resolved) {
-			w.Write([]byte(resolved))
+			_, _ = w.Write([]byte(resolved))
 			w.Header().Set("X-Exec-Error", "")
 			w.Header().Set("X-Exec-Exit-Status", "0")
 			w.Header().Set("X-Exec-Stderr", "")
@@ -1372,7 +1372,7 @@ func (s *Server) ensureRevision(ctx context.Context, repo api.RepoName, url, rev
 		return false
 	}
 	// Revision not found, update before returning.
-	s.doRepoUpdate(ctx, repo, url)
+	_ = s.doRepoUpdate(ctx, repo, url)
 	return true
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -122,8 +122,8 @@ func TestRequest(t *testing.T) {
 	runCommandMock = func(ctx context.Context, cmd *exec.Cmd) (int, error) {
 		switch cmd.Args[1] {
 		case "testcommand":
-			cmd.Stdout.Write([]byte("teststdout"))
-			cmd.Stderr.Write([]byte("teststderr"))
+			_, _ = cmd.Stdout.Write([]byte("teststdout"))
+			_, _ = cmd.Stderr.Write([]byte("teststderr"))
 			return 42, nil
 		case "testerror":
 			return 0, errors.New("testerror")

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -196,7 +196,7 @@ func TestProgressWriter(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			var w progressWriter
 			for _, write := range testCase.writes {
-				w.Write([]byte(write))
+				_, _ = w.Write([]byte(write))
 			}
 			if actual := w.String(); testCase.text != actual {
 				t.Fatalf("\ngot:\n%s\nwant:\n%s\n", actual, testCase.text)

--- a/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
@@ -28,7 +28,7 @@ func TestMiddleware(t *testing.T) {
 	const mockUserID = 123
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("got through"))
+		_, _ = w.Write([]byte("got through"))
 	})
 	authedHandler := http.NewServeMux()
 	authedHandler.Handle("/.api/", Middleware.API(h))

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -90,7 +90,7 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 		data = sourceMappingURLLineRegex.ReplaceAll(bundle, []byte{})
 	}
-	w.Write(data)
+	_, _ = w.Write(data)
 
 	if !wantSourceMap && sourceMap != nil {
 		// Append `//# sourceMappingURL=` directive to JS bundle if we have a source map. It is

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -111,7 +111,7 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 			registryRequestsErrorCounter.Inc()
 			ev.AddField("error", err.Error())
 		}
-		ev.Send()
+		_ = ev.Send()
 	}()
 
 	// Identify this response as coming from the registry API.
@@ -184,7 +184,7 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 	if err != nil {
 		return err
 	}
-	w.Write(data)
+	_, _ = w.Write(data)
 	return nil
 }
 

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -353,7 +353,7 @@ func (c *internalClient) post(ctx context.Context, route string, reqBody, respBo
 func checkAPIResponse(resp *http.Response) error {
 	if 200 > resp.StatusCode || resp.StatusCode > 299 {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
+		_, _ = buf.ReadFrom(resp.Body)
 		b := buf.Bytes()
 		errString := string(b)
 		if errString != "" {

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -74,7 +74,7 @@ func Start(extra ...Endpoint) {
 
 	pp := http.NewServeMux()
 	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`
+		_, _ = w.Write([]byte(`
 				<a href="vars">Vars</a><br>
 				<a href="debug/pprof/">PProf</a><br>
 				<a href="metrics">Metrics</a><br>
@@ -84,7 +84,7 @@ func Start(extra ...Endpoint) {
 		for _, e := range extra {
 			fmt.Fprintf(w, `<a href="%s">%s</a><br>`, strings.TrimPrefix(e.Path, "/"), e.Name)
 		}
-		w.Write([]byte(`
+		_, _ = w.Write([]byte(`
 				<br>
 				<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>
 				<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>

--- a/internal/goreman/log.go
+++ b/internal/goreman/log.go
@@ -41,7 +41,7 @@ func (l *clogger) writeBuffers(line []byte) {
 	fmt.Printf("%s %*s | ", now, maxProcNameLength, l.proc)
 	ct.ResetColor()
 	l.buffers = append(l.buffers, line)
-	l.buffers.WriteTo(os.Stdout)
+	_, _ = l.buffers.WriteTo(os.Stdout)
 	l.buffers = l.buffers[0:0]
 	mutex.Unlock()
 }

--- a/internal/goreman/proc.go
+++ b/internal/goreman/proc.go
@@ -83,7 +83,7 @@ func startProc(proc string) error {
 // startProcs starts the processes.
 func startProcs() {
 	for proc := range procs {
-		startProc(proc)
+		_ = startProc(proc)
 	}
 }
 
@@ -128,7 +128,7 @@ func stopProcs(kill bool) {
 		wg.Add(1)
 		go func(proc string) {
 			defer wg.Done()
-			stopProc(proc, kill)
+			_ = stopProc(proc, kill)
 		}(proc)
 	}
 	wg.Wait()

--- a/internal/goreman/rpc.go
+++ b/internal/goreman/rpc.go
@@ -31,7 +31,9 @@ func (Goreman) RestartAll(args struct{}, ret *string) (err error) {
 
 // start rpc server.
 func startServer(addr string) error {
-	rpc.Register(Goreman{})
+	if err := rpc.Register(Goreman{}); err != nil {
+		return err
+	}
 	server, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err

--- a/internal/httputil/cache_control_transport_test.go
+++ b/internal/httputil/cache_control_transport_test.go
@@ -64,7 +64,7 @@ func TestCacheControlTransport(t *testing.T) {
 	noCCTransport := NewCacheControlTransport("", recorder, nil)
 	for _, meth := range []string{"GET", "PUT", "PATCH", "DELETE", "POST"} {
 		req, _ := http.NewRequest(meth, url1, bytes.NewBuffer(nil))
-		noCCTransport.RoundTrip(req)
+		_, _ = noCCTransport.RoundTrip(req)
 		if cc := recorder.req.Header.Get("Cache-Control"); cc != "" {
 			t.Errorf("expected no cache control on %s (because none set on transport), but got %s", meth, cc)
 		}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -51,7 +51,11 @@ func TestMain(m *testing.M) {
 	srv := &http.Server{Handler: (&server.Server{
 		ReposDir: filepath.Join(root, "repos"),
 	}).Handler()}
-	go srv.Serve(l)
+	go func() {
+		if err := srv.Serve(l); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	gitserver.DefaultClient.Addrs = func(ctx context.Context) []string {
 		return []string{l.Addr().String()}

--- a/internal/vcs/util/keyfile.go
+++ b/internal/vcs/util/keyfile.go
@@ -14,7 +14,7 @@ import (
 // the returned File when done using it.
 func WriteKeyTempFile(namePrefix string, keyData []byte) (filename string, tmp *os.File, err error) {
 	hasher := sha256.New()
-	hasher.Write([]byte(namePrefix))
+	_, _ = hasher.Write([]byte(namePrefix))
 	hash := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 
 	tmpfile, err := ioutil.TempFile("", "go-vcs-"+hash+"-")


### PR DESCRIPTION
These are mostly calls to Write that we can't do anything with if they
fail. Logging the failures is usually noisy since the most common reason for
failure is the client has gone away. This just marks us ignoring the error as
explicit.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
