### PR TITLE
subscriptions: fail if we can't set source on custUpdateParams

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -262,7 +262,9 @@ func (ProductSubscriptionLicensingResolver) CreatePaidProductSubscription(ctx co
 	custUpdateParams := &stripe.CustomerParams{
 		Params: stripe.Params{Context: ctx},
 	}
-	custUpdateParams.SetSource(args.PaymentToken)
+	if err := custUpdateParams.SetSource(args.PaymentToken); err != nil {
+		return nil, err
+	}
 	if _, err := customer.Update(custID, custUpdateParams); err != nil {
 		return nil, err
 	}
@@ -341,7 +343,9 @@ func (ProductSubscriptionLicensingResolver) UpdatePaidProductSubscription(ctx co
 	custUpdateParams := &stripe.CustomerParams{
 		Params: stripe.Params{Context: ctx},
 	}
-	custUpdateParams.SetSource(args.PaymentToken)
+	if err := custUpdateParams.SetSource(args.PaymentToken); err != nil {
+		return nil, err
+	}
 	if _, err := customer.Update(custID, custUpdateParams); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We didn't handle this error, which could potentially lead to bad data. Found
with errcheck.
