### PR TITLE
bitbucketserver: fail if SetOAuth fails

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -105,10 +105,13 @@ func NewClientWithConfig(c *schema.BitbucketServerConnection) (*Client, error) {
 	client.Password = c.Password
 	client.Token = c.Token
 	if c.Authorization != nil {
-		client.SetOAuth(
+		err := client.SetOAuth(
 			c.Authorization.Oauth.ConsumerKey,
 			c.Authorization.Oauth.SigningKey,
 		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return client, nil
 }


### PR DESCRIPTION
We ignored this error. Found with errcheck.