### PR TITLE
ci: golangci-lint all errors

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -17,13 +17,5 @@ echo "--- go install"
 go install -tags=dev -buildmode=archive ${pkgs}
 
 echo "--- lint"
-if [ -n "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
-    git fetch origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
-    base="origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-else
-    git fetch origin master
-    base="HEAD~"
-fi
 
-rev=$(git merge-base ${base} HEAD)
-golangci-lint run --build-tags=dev -v ${pkgs} --new-from-rev ${rev} --deadline 5m
+golangci-lint run -v ${pkgs} --deadline 5m


### PR DESCRIPTION
The new-from-rev doesn't seem to be that trustworthy, since there are
instances of new code getting through. I have been sending out commits which
make us golangci-lint clean. We should be now be able to just run lint on
everything. Doing the cleanup found legitimate bugs, so this was a worthwhile
pursuit.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
