### PR TITLE
Update badge attachment styles.

### DIFF
--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -1,5 +1,10 @@
 // CSS for components shared with the webapp
 
+// Set this to override the icon background color in badge attachments.
+// The web's light-theme background color is slightly off-white, but the
+// box that renders the tooltip on GitHub is pure white.
+$body-bg-color-light: #ffffff;
+
 @import '../../shared/src/actions/ActionItem';
 @import '../../shared/src/commandPalette/CommandList';
 @import '../../shared/src/components/completion/CompletionWidget.scss';
@@ -11,11 +16,6 @@
 
 $body-color-light: #2b3750;
 $body-color-dark: #f2f4f8;
-
-// Set this to override the icon background color in badge attachments.
-// The web's light-theme background color is slightly off-white, but the
-// box that renders the tooltip on GitHub is pure white.
-$body-bg-color-light: #ffffff;
 
 :root {
     --body-bg: #ffffff;

--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -12,6 +12,11 @@
 $body-color-light: #2b3750;
 $body-color-dark: #f2f4f8;
 
+// Set this to override the icon background color in badge attachments.
+// The web's light-theme background color is slightly off-white, but the
+// box that renders the tooltip on GitHub is pure white.
+$body-bg-color-light: #ffffff;
+
 :root {
     --body-bg: #ffffff;
     --text-muted: #{$color-light-text-2};

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -7,7 +7,7 @@
         z-index: 1;
         border: none;
         border-radius: 1rem;
-        background-color: transparentize($body-bg-color-dark, 0.2);
+        background-color: rgba($body-bg-color-dark, 0.8);
     }
 
     width: 100%;
@@ -17,7 +17,7 @@
 .theme-light {
     .badge-decoration-attachment {
         &__contents {
-            background-color: transparentize($body-bg-color-light, 0.2);
+            background-color: rgba($body-bg-color-light, 0.8);
         }
     }
 }

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -7,7 +7,7 @@
         z-index: 1;
         border: none;
         border-radius: 1rem;
-        background-color: rgba(0, 0, 0, 0.8);
+        background-color: transparentize($body-bg-color-dark, 0.2);
     }
 
     width: 100%;
@@ -17,7 +17,7 @@
 .theme-light {
     .badge-decoration-attachment {
         &__contents {
-            background-color: rgba(255, 255, 255, 0.8);
+            background-color: transparentize($body-bg-color-light, 0.2);
         }
     }
 }

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -6,7 +6,7 @@
         background: transparent;
         z-index: 1;
         border: none;
-        border-radius: 1rem;
+        border-radius: 100%;
         background-color: rgba($body-bg-color-dark, 0.8);
     }
 

--- a/shared/src/global-styles/colors.scss
+++ b/shared/src/global-styles/colors.scss
@@ -103,6 +103,9 @@ $text-muted: var(--text-muted);
 $body-color-light: $gray-19;
 $body-color-dark: $white;
 
+$body-bg-color-light: #fbfdff;
+$body-bg-color-dark: #04070e;
+
 :root {
     --primary: #{$primary};
     --secondary: #{$secondary-light};
@@ -112,7 +115,7 @@ $body-color-dark: $white;
     --danger: #{$danger};
     --merged: #{$merged};
     --body-color: #{$body-color-light};
-    --body-bg: #fbfdff;
+    --body-bg: #{$body-bg-color-light};
     --text-muted: #{$color-light-text-2};
     --link-color: #{$gray-13};
     --link-active-color: #{$gray-18};
@@ -123,7 +126,7 @@ $body-color-dark: $white;
     --secondary: #{$secondary};
     --color-border: #{$color-border};
     --body-color: #{$body-color-dark};
-    --body-bg: #04070e;
+    --body-bg: #{$body-bg-color-dark};
     --text-muted: #{$color-text-1};
     --link-color: #{$gray-07};
     --link-active-color: #{$gray-02};

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -17,7 +17,7 @@
         top: 1px;
         right: 1px;
         padding: 0.25rem;
-        border-radius: 1rem;
+        border-radius: 100%;
         background: transparent;
         z-index: 1;
         border: none;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -14,8 +14,8 @@
 
     &__close-button {
         position: absolute;
-        top: 0;
-        right: 0;
+        top: 1px;
+        right: 1px;
         padding: 0.25rem;
         border-radius: 0;
         background: transparent;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -17,10 +17,11 @@
         top: 1px;
         right: 1px;
         padding: 0.25rem;
-        border-radius: 0;
+        border-radius: 1rem;
         background: transparent;
         z-index: 1;
         border: none;
+        background-color: transparentize($body-bg-color-dark, 0.2);
         opacity: 0;
         transition: opacity $animation-duration ease-in-out;
     }
@@ -87,8 +88,8 @@
 
     &__badge {
         position: absolute;
-        top: 0;
-        right: 0;
+        top: 1px;
+        right: 1px;
         width: 100%;
         text-align: right;
     }
@@ -130,5 +131,13 @@
     &__alert-below {
         margin: 0;
         overflow-y: auto;
+    }
+}
+
+.theme-light {
+    .hover-overlay {
+        &__close-button {
+            background-color: transparentize($body-bg-color-light, 0.2);
+        }
     }
 }

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -21,7 +21,7 @@
         background: transparent;
         z-index: 1;
         border: none;
-        background-color: transparentize($body-bg-color-dark, 0.2);
+        background-color: rgba($body-bg-color-dark, 0.8);
         opacity: 0;
         transition: opacity $animation-duration ease-in-out;
     }
@@ -137,7 +137,7 @@
 .theme-light {
     .hover-overlay {
         &__close-button {
-            background-color: transparentize($body-bg-color-light, 0.2);
+            background-color: rgba($body-bg-color-light, 0.8);
         }
     }
 }


### PR DESCRIPTION
Update the background color of the icon background to more closely match the background of the light/dark themes. Also makes the icon background less obvious in the extension on GitHub.

Dark:
<img width="126" alt="Screen Shot 2020-01-16 at 9 45 58 AM" src="https://user-images.githubusercontent.com/103087/72539801-84cabf00-3845-11ea-8f40-16b68754671f.png">

Light:
<img width="126" alt="Screen Shot 2020-01-16 at 9 45 53 AM" src="https://user-images.githubusercontent.com/103087/72539800-84cabf00-3845-11ea-9d3a-3fe0190508d7.png">

GitHub:
<img width="126" alt="Screen Shot 2020-01-16 at 9 45 37 AM" src="https://user-images.githubusercontent.com/103087/72539798-84cabf00-3845-11ea-8575-313f9c2156bf.png">