### PR TITLE
e2e tests: exit process on setup error

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -359,7 +359,7 @@ describe('e2e test suite', () => {
     })
 
     describe('Visual tests', () => {
-        test('Repositories list', async () => {
+        test.only('Repositories list', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/site-admin/repositories?query=gorilla%2Fmux')
             await driver.page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
             await percySnapshot(driver.page, 'Repositories list')


### PR DESCRIPTION
This doesn't work. I have no idea what I'm doing, but what I'm _trying_ to do is to exit the node process or the browser when we run into an error.