### PR TITLE
search: remove tooltip that obscured search mode dropdown

### DIFF
--- a/web/src/search/input/interactive/SearchModeToggle.tsx
+++ b/web/src/search/input/interactive/SearchModeToggle.tsx
@@ -18,7 +18,6 @@ export const SearchModeToggle: React.FunctionComponent<Props> = props => {
             <DropdownToggle
                 caret={true}
                 className="search-mode-toggle__button e2e-search-mode-toggle"
-                data-tooltip="Toggle search mode"
                 aria-label="Toggle search mode"
             >
                 {props.interactiveSearchMode ? (


### PR DESCRIPTION
The "Toggle search mode" tooltip covered up the dropdown. I do not think the tooltip is necessary because it can be inferred from the dropdown items.

![image](https://user-images.githubusercontent.com/1976/72583815-8a072880-389c-11ea-9cac-16cfcb40914c.png)
