### PR TITLE
automation: make regex search replace the default campaign

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -267,7 +267,7 @@ func (c *comby) generateDiff(ctx context.Context, repo api.RepoName, commit api.
 
 type regexSearchReplaceArgs struct {
 	ScopeQuery  string `json:"scopeQuery"`
-	RegexMatch  string `json:"regexMatch"`
+	RegexpMatch string `json:"regexpMatch"`
 	TextReplace string `json:"textReplace"`
 }
 
@@ -281,16 +281,16 @@ func (c *regexSearchReplace) searchQuery() string {
 	// We add the regexMatch because without it search may only return a
 	// truncated list of file matches. We also add count:10000 to have a
 	// higher chance of finding all matches.
-	return fmt.Sprintf("%s %s count:10000", c.args.ScopeQuery, c.args.RegexMatch)
+	return fmt.Sprintf("%s %s count:10000", c.args.ScopeQuery, c.args.RegexpMatch)
 }
 
 func (c *regexSearchReplace) searchQueryForRepo(n api.RepoName) string {
-	return fmt.Sprintf("repo:%s %s %s count:10000", regexp.QuoteMeta(string(n)), c.args.ScopeQuery, c.args.RegexMatch)
+	return fmt.Sprintf("repo:%s %s %s count:10000", regexp.QuoteMeta(string(n)), c.args.ScopeQuery, c.args.RegexpMatch)
 }
 
 func (c *regexSearchReplace) generateDiff(ctx context.Context, repo api.RepoName, commit api.CommitID) (string, string, error) {
 	// check that the regex is valid before doing any work.
-	re, err := regexp.Compile(c.args.RegexMatch)
+	re, err := regexp.Compile(c.args.RegexpMatch)
 	if err != nil {
 		return "", "", err
 	}

--- a/enterprise/internal/a8n/campaign_type_test.go
+++ b/enterprise/internal/a8n/campaign_type_test.go
@@ -259,7 +259,7 @@ func TestCampaignType_RegexSearchAndReplace(t *testing.T) {
 			name: "simple search replace",
 			args: regexSearchReplaceArgs{
 				ScopeQuery:  "repo:github",
-				RegexMatch:  "foo",
+				RegexpMatch: "foo",
 				TextReplace: "bar",
 			},
 			searchResultsContents: map[string]string{
@@ -278,7 +278,7 @@ func TestCampaignType_RegexSearchAndReplace(t *testing.T) {
 			name: "search replace with match groups",
 			args: regexSearchReplaceArgs{
 				ScopeQuery:  "repo:github",
-				RegexMatch:  "(foo)",
+				RegexpMatch: "(foo)",
 				TextReplace: "$1${1}bar",
 			},
 			searchResultsContents: map[string]string{

--- a/schema/campaign-types/regex_search_replace.schema.json
+++ b/schema/campaign-types/regex_search_replace.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "regex-search-replace-spec.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Schema for regex search replace",
+  "description": "Schema for regexp search replace",
   "type": "object",
   "properties": {
     "scopeQuery": {
@@ -9,16 +9,16 @@
       "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     },
-    "regexMatch": {
+    "regexpMatch": {
       "type": "string",
       "minLength": 1,
       "description": "Match this regular expression. RE2 syntax is supported: https://github.com/google/re2/wiki/Syntax"
     },
     "textReplace": {
       "type": "string",
-      "description": "Replace the regexMatch text with this text. You may refer to match groups in regexMatch using $id or ${id} syntax."
+      "description": "Replace the regexpMatch text with this text. You may refer to match groups in regexpMatch using $id or ${id} syntax."
     }
   },
-  "required": ["scopeQuery", "regexMatch", "textReplace"],
+  "required": ["scopeQuery", "regexpMatch", "textReplace"],
   "additionalProperties": false
 }

--- a/schema/campaign-types/regex_search_replace_stringdata.go
+++ b/schema/campaign-types/regex_search_replace_stringdata.go
@@ -6,7 +6,7 @@ package schema
 const RegexSearchReplaceCampaignTypeSchemaJSON = `{
   "$id": "regex-search-replace-spec.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Schema for regex search replace",
+  "description": "Schema for regexp search replace",
   "type": "object",
   "properties": {
     "scopeQuery": {
@@ -14,17 +14,17 @@ const RegexSearchReplaceCampaignTypeSchemaJSON = `{
       "minLength": 1,
       "description": "Define a scope to narrow down repositories affected by this change. Only GitHub and Bitbucket Server are supported."
     },
-    "regexMatch": {
+    "regexpMatch": {
       "type": "string",
       "minLength": 1,
       "description": "Match this regular expression. RE2 syntax is supported: https://github.com/google/re2/wiki/Syntax"
     },
     "textReplace": {
       "type": "string",
-      "description": "Replace the regexMatch text with this text. You may refer to match groups in regexMatch using $id or ${id} syntax."
+      "description": "Replace the regexpMatch text with this text. You may refer to match groups in regexpMatch using $id or ${id} syntax."
     }
   },
-  "required": ["scopeQuery", "regexMatch", "textReplace"],
+  "required": ["scopeQuery", "regexpMatch", "textReplace"],
   "additionalProperties": false
 }
 `

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1578,7 +1578,7 @@ describe('e2e test suite', () => {
         test('Create campaign preview for regexp campaign type', async () => {
             await createCampaignPreview({
                 specification: JSON.stringify({
-                    regexMatch: 'this is file ([0-9]+)',
+                    regexpMatch: 'this is file ([0-9]+)',
                     textReplace: 'file $1 this is',
                     scopeQuery: 'repo:github.com/sourcegraph-testing/automation-e2e-test',
                 }),

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.test.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.test.tsx
@@ -22,7 +22,7 @@ describe('CampaignPlanSpecificationFields', () => {
         expect(component).toMatchSnapshot()
 
         expect(onChange.calledOnce).toBe(true)
-        expect(onChange.firstCall.args[0].type).toBe('comby')
+        expect(onChange.firstCall.args[0].type).toBe('regexSearchReplace')
         expect(onChange.firstCall.args[0].arguments).toMatch(/scopeQuery/)
     })
 

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
@@ -45,7 +45,7 @@ const defaultInputByType: { [K in CampaignType]: string } = {
 }`,
     regexSearchReplace: `{
     "scopeQuery": "repo:github.com/foo/bar file:.*",
-    "regexMatch": "foo",
+    "regexpMatch": "foo",
     "textReplace": "bar"
 }`,
 }
@@ -61,7 +61,9 @@ export const CampaignPlanSpecificationFields: React.FunctionComponent<Props> = (
     isLightTheme,
 }) => {
     const value: CampaignPlanSpecificationFormData =
-        rawValue !== undefined ? rawValue : { type: 'comby', arguments: defaultInputByType.comby }
+        rawValue !== undefined
+            ? rawValue
+            : { type: 'regexSearchReplace', arguments: defaultInputByType.regexSearchReplace }
     useEffect(() => {
         if (rawValue === undefined) {
             onChange(value)

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`CampaignPlanSpecificationFields has initial value and calls onChange 1`
         className="form-control w-auto d-inline-block e2e-campaign-type"
         onChange={[Function]}
         placeholder="Select campaign type"
-        value="comby"
+        value="regexSearchReplace"
       >
         <option
           value="manual"
@@ -37,21 +37,9 @@ exports[`CampaignPlanSpecificationFields has initial value and calls onChange 1`
         <option
           value="regexSearchReplace"
         >
-          Regex search and replace
+          Regexp search and replace
         </option>
       </select>
-      <small
-        className="ml-1"
-      >
-        <a
-          href="https://comby.dev/#match-syntax"
-          rel="noopener noreferrer"
-          tabIndex={-1}
-          target="_blank"
-        >
-          Learn about comby syntax
-        </a>
-      </small>
     </div>
   </div>
   <div
@@ -68,18 +56,14 @@ exports[`CampaignPlanSpecificationFields has initial value and calls onChange 1`
       isLightTheme={true}
       jsonSchema={
         Object {
-          "$id": "comby-spec.json#",
+          "$id": "regex-search-replace-spec.json#",
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
-          "description": "Schema for comby options",
+          "description": "Schema for regexp search replace",
           "properties": Object {
-            "matchTemplate": Object {
-              "description": "See https://comby.dev/#match-syntax for syntax",
+            "regexpMatch": Object {
+              "description": "Match this regular expression. RE2 syntax is supported: https://github.com/google/re2/wiki/Syntax",
               "minLength": 1,
-              "type": "string",
-            },
-            "rewriteTemplate": Object {
-              "description": "See https://comby.dev/#match-syntax for syntax",
               "type": "string",
             },
             "scopeQuery": Object {
@@ -87,20 +71,24 @@ exports[`CampaignPlanSpecificationFields has initial value and calls onChange 1`
               "minLength": 1,
               "type": "string",
             },
+            "textReplace": Object {
+              "description": "Replace the regexpMatch text with this text. You may refer to match groups in regexpMatch using $id or \${id} syntax.",
+              "type": "string",
+            },
           },
           "required": Array [
             "scopeQuery",
-            "matchTemplate",
-            "rewriteTemplate",
+            "regexpMatch",
+            "textReplace",
           ],
           "type": "object",
         }
       }
       onChange={[Function]}
       value="{
-    \\"scopeQuery\\": \\"repo:github.com/foo/bar\\",
-    \\"matchTemplate\\": \\"\\",
-    \\"rewriteTemplate\\": \\"\\"
+    \\"scopeQuery\\": \\"repo:github.com/foo/bar file:.*\\",
+    \\"regexpMatch\\": \\"foo\\",
+    \\"textReplace\\": \\"bar\\"
 }"
     />
   </div>
@@ -145,7 +133,7 @@ exports[`CampaignPlanSpecificationFields manual type editable 1`] = `
           <option
             value="regexSearchReplace"
           >
-            Regex search and replace
+            Regexp search and replace
           </option>
         </select>
       </React.Fragment>
@@ -215,7 +203,7 @@ exports[`CampaignPlanSpecificationFields non-manual type editable 1`] = `
           <option
             value="regexSearchReplace"
           >
-            Regex search and replace
+            Regexp search and replace
           </option>
         </select>
         <small

--- a/web/src/enterprise/campaigns/detail/presentation.ts
+++ b/web/src/enterprise/campaigns/detail/presentation.ts
@@ -9,5 +9,5 @@ export const campaignTypeLabels: Record<CampaignType | typeof MANUAL_CAMPAIGN_TY
     [MANUAL_CAMPAIGN_TYPE]: 'Manual',
     comby: 'Comby search and replace',
     credentials: 'Find leaked credentials',
-    regexSearchReplace: 'Regex search and replace',
+    regexSearchReplace: 'Regexp search and replace',
 }


### PR DESCRIPTION
Stacked on #7790. 

Proposal: make regex the default campaign selection. Why? New users are being introduced to a potentially unfamiliar concept with "campaigns", and definitely a new UI. Regex is a broadly familiar concept, so let's reduce the "newness" exposure and not throw them too far into the deep end. On first exposure users should not initially feel obliged to figure out what `comby` is in addition to the the campaign workflow/UI.