### PR TITLE
vcs/git: do not use xtest

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -55,7 +54,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 	ref := req.TargetRef
 	if req.Push {
-		ref = git.EnsureRefPrefix(ref)
+		ref = ensureRefPrefix(ref)
 	}
 
 	// Ensure tmp directory exists
@@ -233,4 +232,13 @@ func cleanUpTmpRepo(path string) {
 	if err != nil {
 		log15.Info("unable to clean up tmp repo", "path", path, "err", err)
 	}
+}
+
+// ensureRefPrefix checks whether the ref is a full ref and contains the
+// "refs/heads" prefix (i.e. "refs/heads/master") or just an abbreviated ref
+// (i.e. "master") and adds the "refs/heads/" prefix if the latter is the case.
+//
+// Copied from git package to avoid cycle import when testing git package.
+func ensureRefPrefix(ref string) string {
+	return "refs/heads/" + strings.TrimPrefix(ref, "refs/heads/")
 }

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -39,7 +39,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -659,7 +658,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// For searches over large repo sets (> 1k), this leads to too many child process execs, which can lead
 	// to a persistent failure mode where every exec takes > 10s, which is disastrous for gitserver performance.
 	if len(req.Args) == 2 && req.Args[0] == "rev-parse" && req.Args[1] == "HEAD" {
-		if resolved, err := quickRevParseHead(dir); err == nil && git.IsAbsoluteRevision(resolved) {
+		if resolved, err := quickRevParseHead(dir); err == nil && isAbsoluteRevision(resolved) {
 			_, _ = w.Write([]byte(resolved))
 			w.Header().Set("X-Exec-Error", "")
 			w.Header().Set("X-Exec-Exit-Status", "0")
@@ -1363,7 +1362,7 @@ func (s *Server) ensureRevision(ctx context.Context, repo api.RepoName, url, rev
 	}
 	// rev-parse on an OID does not check if the commit actually exists, so it
 	// is always works. So we append ^0 to force the check
-	if git.IsAbsoluteRevision(rev) {
+	if isAbsoluteRevision(rev) {
 		rev = rev + "^0"
 	}
 	cmd := exec.Command("git", "rev-parse", rev, "--")
@@ -1385,7 +1384,7 @@ func quickRevParseHead(dir GitDir) (string, error) {
 		return "", err
 	}
 	head = bytes.TrimSpace(head)
-	if h := string(head); git.IsAbsoluteRevision(h) {
+	if h := string(head); isAbsoluteRevision(h) {
 		return h, nil
 	}
 
@@ -1436,4 +1435,24 @@ func errorString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+// IsAbsoluteRevision checks if the revision is a git OID SHA string.
+//
+// Note: This doesn't mean the SHA exists in a repository, nor does it mean it
+// isn't a ref. Git allows 40-char hexadecimal strings to be references.
+//
+// copied from internal/vcs/git to avoid cyclic import
+func isAbsoluteRevision(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		if !(('0' <= r && r <= '9') ||
+			('a' <= r && r <= 'f') ||
+			('A' <= r && r <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -1,4 +1,4 @@
-package git_test
+package git
 
 import (
 	"reflect"
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestRepository_BlameFile(t *testing.T) {
@@ -20,27 +19,27 @@ func TestRepository_BlameFile(t *testing.T) {
 		"git add f",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}
-	gitWantHunks := []*git.Hunk{
+	gitWantHunks := []*Hunk{
 		{
 			StartLine: 1, EndLine: 2, StartByte: 0, EndByte: 6, CommitID: "e6093374dcf5725d8517db0dccbbf69df65dbde0",
-			Message: "foo", Author: git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Message: "foo", Author: Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 		},
 		{
 			StartLine: 2, EndLine: 3, StartByte: 6, EndByte: 12, CommitID: "fad406f4fe02c358a09df0d03ec7a36c2c8a20f1",
-			Message: "foo", Author: git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Message: "foo", Author: Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 		},
 	}
 	tests := map[string]struct {
 		repo gitserver.Repo
 		path string
-		opt  *git.BlameOptions
+		opt  *BlameOptions
 
-		wantHunks []*git.Hunk
+		wantHunks []*Hunk
 	}{
 		"git cmd": {
 			repo: MakeGitRepository(t, gitCommands...),
 			path: "f",
-			opt: &git.BlameOptions{
+			opt: &BlameOptions{
 				NewestCommit: "master",
 			},
 			wantHunks: gitWantHunks,
@@ -48,14 +47,14 @@ func TestRepository_BlameFile(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		newestCommitID, err := git.ResolveRevision(ctx, test.repo, nil, string(test.opt.NewestCommit), nil)
+		newestCommitID, err := ResolveRevision(ctx, test.repo, nil, string(test.opt.NewestCommit), nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on base: %s", label, test.opt.NewestCommit, err)
 			continue
 		}
 
 		test.opt.NewestCommit = newestCommitID
-		hunks, err := git.BlameFile(ctx, test.repo, test.path, test.opt)
+		hunks, err := BlameFile(ctx, test.repo, test.path, test.opt)
 		if err != nil {
 			t.Errorf("%s: BlameFile(%s, %+v): %s", label, test.path, test.opt, err)
 			continue

--- a/internal/vcs/git/blob_test.go
+++ b/internal/vcs/git/blob_test.go
@@ -1,12 +1,10 @@
-package git_test
+package git
 
 import (
 	"context"
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestRead(t *testing.T) {
@@ -54,11 +52,11 @@ func TestRead(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name+"-ReadFile", func(t *testing.T) {
-			data, err := git.ReadFile(ctx, repo, commitID, test.file, test.maxBytes)
+			data, err := ReadFile(ctx, repo, commitID, test.file, test.maxBytes)
 			test.checkFn(t, err, data)
 		})
 		t.Run(name+"-GetFileReader", func(t *testing.T) {
-			rc, err := git.NewFileReader(ctx, repo, commitID, test.file)
+			rc, err := NewFileReader(ctx, repo, commitID, test.file)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -69,7 +67,7 @@ func TestRead(t *testing.T) {
 	}
 
 	t.Run("maxBytes", func(t *testing.T) {
-		data, err := git.ReadFile(ctx, repo, commitID, "file1", 3)
+		data, err := ReadFile(ctx, repo, commitID, "file1", 3)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -1,4 +1,4 @@
-package git_test
+package git
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 var ctx = context.Background()
@@ -20,17 +19,17 @@ func TestRepository_GetCommit(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommit := &git.Commit{
+	wantGitCommit := &Commit{
 		ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-		Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-		Committer: &git.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+		Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+		Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 		Message:   "bar",
 		Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 	}
 	tests := map[string]struct {
 		repo       gitserver.Repo
 		id         api.CommitID
-		wantCommit *git.Commit
+		wantCommit *Commit
 	}{
 		"git cmd": {
 			repo:       MakeGitRepository(t, gitCommands...),
@@ -40,7 +39,7 @@ func TestRepository_GetCommit(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commit, err := git.GetCommit(ctx, test.repo, nil, test.id)
+		commit, err := GetCommit(ctx, test.repo, nil, test.id)
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -51,7 +50,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := git.GetCommit(ctx, test.repo, nil, NonExistentCommitID); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 	}
@@ -125,7 +124,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 		}
 
 		repo := MakeGitRepository(t, gitCommands...)
-		got, err := git.HasCommitAfter(ctx, repo, tc.after, tc.revspec)
+		got, err := HasCommitAfter(ctx, repo, tc.after, tc.revspec)
 		if err != nil || got != tc.want {
 			t.Errorf("got %t hascommitafter, want %t", got, tc.want)
 		}
@@ -141,18 +140,18 @@ func TestRepository_Commits(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommits := []*git.Commit{
+	wantGitCommits := []*Commit{
 		{
 			ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-			Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-			Committer: &git.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 			Message:   "bar",
 			Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 		},
 		{
 			ID:        "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
-			Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-			Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 			Message:   "foo",
 			Parents:   nil,
 		},
@@ -160,7 +159,7 @@ func TestRepository_Commits(t *testing.T) {
 	tests := map[string]struct {
 		repo        gitserver.Repo
 		id          api.CommitID
-		wantCommits []*git.Commit
+		wantCommits []*Commit
 		wantTotal   uint
 	}{
 		"git cmd": {
@@ -172,13 +171,13 @@ func TestRepository_Commits(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commits, err := git.Commits(ctx, test.repo, git.CommitsOptions{Range: string(test.id)})
+		commits, err := Commits(ctx, test.repo, CommitsOptions{Range: string(test.id)})
 		if err != nil {
 			t.Errorf("%s: Commits: %s", label, err)
 			continue
 		}
 
-		total, err := git.CommitCount(ctx, test.repo, git.CommitsOptions{Range: string(test.id)})
+		total, err := CommitCount(ctx, test.repo, CommitsOptions{Range: string(test.id)})
 		if err != nil {
 			t.Errorf("%s: CommitCount: %s", label, err)
 			continue
@@ -193,7 +192,7 @@ func TestRepository_Commits(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *git.Commit
+			var gotC, wantC *Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}
@@ -206,7 +205,7 @@ func TestRepository_Commits(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := git.Commits(ctx, test.repo, git.CommitsOptions{Range: string(NonExistentCommitID)}); !gitserver.IsRevisionNotFound(err) {
+		if _, err := Commits(ctx, test.repo, CommitsOptions{Range: string(NonExistentCommitID)}); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 	}
@@ -220,39 +219,39 @@ func TestRepository_Commits_options(t *testing.T) {
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:08Z git commit --allow-empty -m qux --author='a <a@a.com>' --date 2006-01-02T15:04:08Z",
 	}
-	wantGitCommits := []*git.Commit{
+	wantGitCommits := []*Commit{
 		{
 			ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-			Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-			Committer: &git.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
 			Message:   "bar",
 			Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 		},
 	}
-	wantGitCommits2 := []*git.Commit{
+	wantGitCommits2 := []*Commit{
 		{
 			ID:        "ade564eba4cf904492fb56dcd287ac633e6e082c",
-			Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
-			Committer: &git.Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
+			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
+			Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:08Z")},
 			Message:   "qux",
 			Parents:   []api.CommitID{"b266c7e3ca00b1a17ad0b1449825d0854225c007"},
 		},
 	}
 	tests := map[string]struct {
 		repo        gitserver.Repo
-		opt         git.CommitsOptions
-		wantCommits []*git.Commit
+		opt         CommitsOptions
+		wantCommits []*Commit
 		wantTotal   uint
 	}{
 		"git cmd": {
 			repo:        MakeGitRepository(t, gitCommands...),
-			opt:         git.CommitsOptions{Range: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
+			opt:         CommitsOptions{Range: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
 			wantTotal:   1,
 		},
 		"git cmd Head": {
 			repo: MakeGitRepository(t, gitCommands...),
-			opt: git.CommitsOptions{
+			opt: CommitsOptions{
 				Range: "b266c7e3ca00b1a17ad0b1449825d0854225c007...ade564eba4cf904492fb56dcd287ac633e6e082c",
 			},
 			wantCommits: wantGitCommits2,
@@ -261,13 +260,13 @@ func TestRepository_Commits_options(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commits, err := git.Commits(ctx, test.repo, test.opt)
+		commits, err := Commits(ctx, test.repo, test.opt)
 		if err != nil {
 			t.Errorf("%s: Commits(): %s", label, err)
 			continue
 		}
 
-		total, err := git.CommitCount(ctx, test.repo, test.opt)
+		total, err := CommitCount(ctx, test.repo, test.opt)
 		if err != nil {
 			t.Errorf("%s: CommitCount(): %s", label, err)
 			continue
@@ -282,7 +281,7 @@ func TestRepository_Commits_options(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *git.Commit
+			var gotC, wantC *Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}
@@ -307,24 +306,24 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit2 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m commit3 --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
 	}
-	wantGitCommits := []*git.Commit{
+	wantGitCommits := []*Commit{
 		{
 			ID:        "546a3ef26e581624ef997cb8c0ba01ee475fc1dc",
-			Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-			Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+			Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 			Message:   "commit2",
 			Parents:   []api.CommitID{"a04652fa1998a0a7d2f2f77ecb7021de943d3aab"},
 		},
 	}
 	tests := map[string]struct {
 		repo        gitserver.Repo
-		opt         git.CommitsOptions
-		wantCommits []*git.Commit
+		opt         CommitsOptions
+		wantCommits []*Commit
 		wantTotal   uint
 	}{
 		"git cmd Path 0": {
 			repo: MakeGitRepository(t, gitCommands...),
-			opt: git.CommitsOptions{
+			opt: CommitsOptions{
 				Range: "master",
 				Path:  "doesnt-exist",
 			},
@@ -333,7 +332,7 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		},
 		"git cmd Path 1": {
 			repo: MakeGitRepository(t, gitCommands...),
-			opt: git.CommitsOptions{
+			opt: CommitsOptions{
 				Range: "master",
 				Path:  "file1",
 			},
@@ -343,13 +342,13 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commits, err := git.Commits(ctx, test.repo, test.opt)
+		commits, err := Commits(ctx, test.repo, test.opt)
 		if err != nil {
 			t.Errorf("%s: Commits(): %s", label, err)
 			continue
 		}
 
-		total, err := git.CommitCount(ctx, test.repo, test.opt)
+		total, err := CommitCount(ctx, test.repo, test.opt)
 		if err != nil {
 			t.Errorf("%s: CommitCount: %s", label, err)
 			continue
@@ -364,7 +363,7 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		}
 
 		for i := 0; i < len(commits) || i < len(test.wantCommits); i++ {
-			var gotC, wantC *git.Commit
+			var gotC, wantC *Commit
 			if i < len(commits) {
 				gotC = commits[i]
 			}

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -1,4 +1,4 @@
-package git_test
+package git
 
 import (
 	"reflect"
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestRepository_RawLogDiffSearch(t *testing.T) {
@@ -32,57 +31,57 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 	)
 	tests := []struct {
 		name string
-		opt  git.RawLogDiffSearchOptions
-		want []*git.LogCommitSearchResult
+		opt  RawLogDiffSearchOptions
+		want []*LogCommitSearchResult
 	}{{
 		name: "query",
-		opt: git.RawLogDiffSearchOptions{
-			Query: git.TextSearchOptions{Pattern: "root"},
+		opt: RawLogDiffSearchOptions{
+			Query: TextSearchOptions{Pattern: "root"},
 			Diff:  true,
 		},
-		want: []*git.LogCommitSearchResult{{
-			Commit: git.Commit{
+		want: []*LogCommitSearchResult{{
+			Commit: Commit{
 				ID:        "b9b2349a02271ca96e82c70f384812f9c62c26ab",
-				Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-				Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
 				Message:   "branch1",
 				Parents:   []api.CommitID{"ce72ece27fd5c8180cfbc1c412021d32fd1cda0d"},
 			},
 			Refs:       []string{"refs/heads/branch1"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &git.Diff{Raw: "diff --git a/f b/f\nindex d8649da..1193ff4 100644\n--- a/f\n+++ b/f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
+			Diff:       &Diff{Raw: "diff --git a/f b/f\nindex d8649da..1193ff4 100644\n--- a/f\n+++ b/f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
 		}, {
-			Commit: git.Commit{
+			Commit: Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
-				Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "root",
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &git.Diff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
+			Diff:       &Diff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
 		}},
 	}, {
 		name: "empty-query",
-		opt: git.RawLogDiffSearchOptions{
-			Query: git.TextSearchOptions{Pattern: ""},
+		opt: RawLogDiffSearchOptions{
+			Query: TextSearchOptions{Pattern: ""},
 			Args:  []string{"--grep=branch1|root", "--extended-regexp"},
 		},
-		want: []*git.LogCommitSearchResult{{
-			Commit: git.Commit{
+		want: []*LogCommitSearchResult{{
+			Commit: Commit{
 				ID:        "b9b2349a02271ca96e82c70f384812f9c62c26ab",
-				Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
-				Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
 				Message:   "branch1",
 				Parents:   []api.CommitID{"ce72ece27fd5c8180cfbc1c412021d32fd1cda0d"},
 			},
 			Refs:       []string{"refs/heads/branch1"},
 			SourceRefs: []string{"refs/heads/branch2"},
 		}, {
-			Commit: git.Commit{
+			Commit: Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
-				Author:    git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
-				Committer: &git.Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 				Message:   "root",
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
@@ -90,8 +89,8 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 		}},
 	}, {
 		name: "path",
-		opt: git.RawLogDiffSearchOptions{
-			Paths: git.PathOptions{
+		opt: RawLogDiffSearchOptions{
+			Paths: PathOptions{
 				IncludePatterns: []string{"g"},
 				ExcludePattern:  "f",
 				IsRegExp:        true,
@@ -102,7 +101,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			results, complete, err := git.RawLogDiffSearch(ctx, repo, test.opt)
+			results, complete, err := RawLogDiffSearch(ctx, repo, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -128,13 +127,13 @@ func TestRepository_RawLogDiffSearch_emptyCommit(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo gitserver.Repo
-		want map[*git.RawLogDiffSearchOptions][]*git.LogCommitSearchResult
+		want map[*RawLogDiffSearchOptions][]*LogCommitSearchResult
 	}{
 		"git cmd": {
 			repo: MakeGitRepository(t, gitCommands...),
-			want: map[*git.RawLogDiffSearchOptions][]*git.LogCommitSearchResult{
+			want: map[*RawLogDiffSearchOptions][]*LogCommitSearchResult{
 				{
-					Paths: git.PathOptions{IncludePatterns: []string{"/xyz.txt"}, IsRegExp: true},
+					Paths: PathOptions{IncludePatterns: []string{"/xyz.txt"}, IsRegExp: true},
 				}: nil, // want no matches
 			},
 		},
@@ -142,7 +141,7 @@ func TestRepository_RawLogDiffSearch_emptyCommit(t *testing.T) {
 
 	for label, test := range tests {
 		for opt, want := range test.want {
-			results, complete, err := git.RawLogDiffSearch(ctx, test.repo, *opt)
+			results, complete, err := RawLogDiffSearch(ctx, test.repo, *opt)
 			if err != nil {
 				t.Errorf("%s: %+v: %s", label, *opt, err)
 				continue

--- a/internal/vcs/git/exec_test.go
+++ b/internal/vcs/git/exec_test.go
@@ -1,10 +1,8 @@
-package git_test
+package git
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestExecSafe(t *testing.T) {
@@ -56,7 +54,7 @@ func TestExecSafe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.args), func(t *testing.T) {
-			stdout, stderr, exitCode, err := git.ExecSafe(ctx, repo, test.args)
+			stdout, stderr, exitCode, err := ExecSafe(ctx, repo, test.args)
 			if err == nil && test.wantError {
 				t.Errorf("got error %v, want error %v", err, test.wantError)
 			}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -1,4 +1,4 @@
-package git_test
+package git
 
 import (
 	"bytes"
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -43,7 +42,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("listen failed: %s", err)
 	}
 
-	root, err = ioutil.TempDir("", "git.test")
+	root, err = ioutil.TempDir("", "test")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -124,7 +123,7 @@ func MakeGitRepository(t testing.TB, cmds ...string) gitserver.Repo {
 	return repo
 }
 
-func CommitsEqual(a, b *git.Commit) bool {
+func CommitsEqual(a, b *Commit) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/internal/vcs/git/merge_base_test.go
+++ b/internal/vcs/git/merge_base_test.go
@@ -1,10 +1,9 @@
-package git_test
+package git
 
 import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestMerger_MergeBase(t *testing.T) {
@@ -41,25 +40,25 @@ func TestMerger_MergeBase(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		a, err := git.ResolveRevision(ctx, test.repo, nil, test.a, nil)
+		a, err := ResolveRevision(ctx, test.repo, nil, test.a, nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on a: %s", label, test.a, err)
 			continue
 		}
 
-		b, err := git.ResolveRevision(ctx, test.repo, nil, test.b, nil)
+		b, err := ResolveRevision(ctx, test.repo, nil, test.b, nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on b: %s", label, test.b, err)
 			continue
 		}
 
-		want, err := git.ResolveRevision(ctx, test.repo, nil, test.wantMergeBase, nil)
+		want, err := ResolveRevision(ctx, test.repo, nil, test.wantMergeBase, nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on wantMergeBase: %s", label, test.wantMergeBase, err)
 			continue
 		}
 
-		mb, err := git.MergeBase(ctx, test.repo, a, b)
+		mb, err := MergeBase(ctx, test.repo, a, b)
 		if err != nil {
 			t.Errorf("%s: MergeBase(%s, %s): %s", label, a, b, err)
 			continue

--- a/internal/vcs/git/object_test.go
+++ b/internal/vcs/git/object_test.go
@@ -1,10 +1,9 @@
-package git_test
+package git
 
 import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestGetObject(t *testing.T) {
@@ -19,19 +18,19 @@ func TestGetObject(t *testing.T) {
 		repo           gitserver.Repo
 		objectName     string
 		wantOID        string
-		wantObjectType git.ObjectType
+		wantObjectType ObjectType
 	}{
 		"basic": {
 			repo:           MakeGitRepository(t, gitCommands...),
 			objectName:     "e86b31b62399cfc86199e8b6e21a35e76d0e8b5e^{tree}",
 			wantOID:        "a1dffc7a64c0b2d395484bf452e9aeb1da3a18f2",
-			wantObjectType: git.ObjectTypeTree,
+			wantObjectType: ObjectTypeTree,
 		},
 	}
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			oid, objectType, err := git.GetObject(ctx, test.repo, test.objectName)
+			oid, objectType, err := GetObject(ctx, test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/git/revisions_test.go
+++ b/internal/vcs/git/revisions_test.go
@@ -1,23 +1,22 @@
-package git_test
+package git
 
 import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestIsAbsoluteRevision(t *testing.T) {
 	yes := []string{"8cb03d28ad1c6a875f357c5d862237577b06e57c", "20697a062454c29d84e3f006b22eb029d730cd00"}
 	no := []string{"ref: refs/heads/appsinfra/SHEP-20-review", "master", "HEAD", "refs/heads/master", "20697a062454c29d84e3f006b22eb029d730cd0", "20697a062454c29d84e3f006b22eb029d730cd000", "  20697a062454c29d84e3f006b22eb029d730cd00  ", "20697a062454c29d84e3f006b22eb029d730cd0 "}
 	for _, s := range yes {
-		if !git.IsAbsoluteRevision(s) {
+		if !IsAbsoluteRevision(s) {
 			t.Errorf("%q should be an absolute revision", s)
 		}
 	}
 	for _, s := range no {
-		if git.IsAbsoluteRevision(s) {
+		if IsAbsoluteRevision(s) {
 			t.Errorf("%q should not be an absolute revision", s)
 		}
 	}
@@ -42,7 +41,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := git.ResolveRevision(ctx, test.repo, nil, test.branch, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -73,7 +72,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := git.ResolveRevision(ctx, test.repo, nil, test.branch, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, nil)
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -105,7 +104,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := git.ResolveRevision(ctx, test.repo, nil, test.tag, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, nil)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -136,7 +135,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := git.ResolveRevision(ctx, test.repo, nil, test.tag, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, nil)
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue


### PR DESCRIPTION
This is a stab in the dark for fixing ctrlflow analysis crashing. This is
the more likely fix because we had a cyclic dependency between gitserver and
Union(git.test, git.xtest) which is a very possible bug in ctrlflow.

This manifests itself as the check step in CI failing. This hopefully fixes that.