### PR TITLE
vcs/git: restructure test to avoid crashing ctrlflow analysis

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -18,4 +18,4 @@ go install -tags=dev -buildmode=archive ${pkgs}
 
 echo "--- lint"
 
-golangci-lint run -v ${pkgs} --deadline 5m
+golangci-lint run ${pkgs}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -34,6 +34,16 @@ func TestMain(m *testing.M) {
 		log15.Root().SetHandler(log15.DiscardHandler())
 	}
 
+	code := m.Run()
+
+	_ = os.RemoveAll(root)
+
+	os.Exit(code)
+}
+
+// done in init since the go vet analysis "ctrlflow" is tripped up if this is
+// done as part of TestMain.
+func init() {
 	// Ignore users configuration in tests
 	os.Setenv("GIT_CONFIG_NOSYSTEM", "true")
 	os.Setenv("HOME", "/dev/null")
@@ -60,12 +70,6 @@ func TestMain(m *testing.M) {
 	gitserver.DefaultClient.Addrs = func(ctx context.Context) []string {
 		return []string{l.Addr().String()}
 	}
-
-	code := m.Run()
-
-	_ = os.RemoveAll(root)
-
-	os.Exit(code)
 }
 
 func AsJSON(v interface{}) string {


### PR DESCRIPTION
golangci-lint is flaky at the moment due to it sometimes crashing on analysing
the `internal/vcs/git.test` package.

This is a stab at the dark for why it is failing. The other likely reason is
this package mixes both xtest and test. That is attempted in https://github.com/sourcegraph/sourcegraph/pull/7857