### PR TITLE
ci: golangci-lint with default verbosity

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -18,4 +18,4 @@ go install -tags=dev -buildmode=archive ${pkgs}
 
 echo "--- lint"
 
-golangci-lint run -v ${pkgs} --deadline 5m
+golangci-lint run ${pkgs}


### PR DESCRIPTION
The verbose output detracts from issues it finds / is log spam. Additionally
the deadline flag is deprecated and not needed anymore. In the earlier days
golangci-lint had a tendency to run for too long.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
