### PR TITLE
a8n: Add count:99999 to credentials search query

### DIFF
--- a/enterprise/internal/a8n/campaign_type.go
+++ b/enterprise/internal/a8n/campaign_type.go
@@ -359,12 +359,12 @@ type credentials struct {
 }
 
 func (c *credentials) searchQuery() string {
-	return c.args.ScopeQuery + " " + npmTokenRegexp.String() + " file:.npmrc"
+	return c.args.ScopeQuery + " " + npmTokenRegexp.String() + " file:.npmrc count:99999"
 }
 
 func (c *credentials) searchQueryForRepo(n api.RepoName) string {
 	return fmt.Sprintf(
-		"file:.npmrc repo:%s %s",
+		"file:.npmrc count:99999 repo:%s %s",
 		regexp.QuoteMeta(string(n)),
 		npmTokenRegexp.String(),
 	)


### PR DESCRIPTION
This is a small tweak based on the discussion in
https://github.com/sourcegraph/sourcegraph/pull/7790#discussion_r367276028
to hopefully avoid users running into the current limitations of our
interaction between Automation and Search.

I know that it's hacky because it would break in case the user specifies `count:` in the `scopeQuery`, but that is better than us missing results.

I do want to get this into 3.12 as a small cherry-pick.