### PR TITLE
ci: include job log on failure of parallel_run

### DIFF
--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -11,11 +11,7 @@ cleanup() {
 trap cleanup EXIT
 
 parallel_run() {
-    log_file=$(mktemp)
-    trap "rm -rf $log_file" EXIT
-
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
-    cat $log_file
+    ./dev/ci/parallel_run.sh "$@"
 }
 export -f parallel_run
 

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -4,12 +4,7 @@ set -ex
 cd $(dirname "${BASH_SOURCE[0]}")
 
 parallel_run() {
-    log_file=$(mktemp)
-    trap "rm -rf $log_file" EXIT
-
-    parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
-    echo "--- done - displaying job log:"
-    cat $log_file
+    ../ci/parallel_run.sh "$@"
 }
 
 go version

--- a/dev/ci/parallel_run.sh
+++ b/dev/ci/parallel_run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+log_file=$(mktemp)
+trap "rm -rf $log_file" EXIT
+
+parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
+echo "--- done - displaying job log:"
+cat $log_file

--- a/dev/ci/parallel_run.sh
+++ b/dev/ci/parallel_run.sh
@@ -3,6 +3,9 @@
 log_file=$(mktemp)
 trap "rm -rf $log_file" EXIT
 
+# Remove parallel citation log spam.
+echo 'will cite' | parallel --citation &>/dev/null
+
 parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
 code=$?
 

--- a/dev/ci/parallel_run.sh
+++ b/dev/ci/parallel_run.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-set -e
-
 log_file=$(mktemp)
 trap "rm -rf $log_file" EXIT
 
 parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
+code=$?
+
 echo "--- done - displaying job log:"
 cat $log_file
+
+exit $code

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -5,12 +5,7 @@ unset CDPATH
 cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 
 parallel_run() {
-    log_file=$(mktemp)
-    trap "rm -rf $log_file" EXIT
-
-    parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
-    echo "--- done - displaying job log:"
-    cat $log_file
+    ./dev/ci/parallel_run.sh "$@"
 }
 
 export ARGS="$@"
@@ -34,15 +29,6 @@ export -f run_command
 
 if [[ "${CI:-"false"}" == "true" ]]; then
     echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"
-
-    parallel_run() {
-        log_file=$(mktemp)
-        trap "rm -rf $log_file" EXIT
-
-        parallel --jobs 4 --keep-order --line-buffer --joblog $log_file "$@"
-        echo "--- done - displaying job log:"
-        cat $log_file
-    }
 
     parallel_run run_command {} ::: "${DIRS[@]}"
 else

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -4,11 +4,7 @@ set -exuo pipefail
 cd $(dirname "${BASH_SOURCE[0]}")/../../..
 
 parallel_run() {
-    log_file=$(mktemp)
-    trap "rm -rf $log_file" EXIT
-
-    parallel --jobs 4 --keep-order --line-buffer --tag --joblog $log_file "$@"
-    cat $log_file
+    ./dev/ci/parallel_run.sh "$@"
 }
 
 echo "--- yarn root"


### PR DESCRIPTION
If parallel_run fails we never say why since since the shellopt `set -e` causes us to exist before catting the job log. This PR moves parallel_run into its own script which has better control over shellopts to ensure we always output the job log.

For example when lint fails it was hard to know which step. Now we know :)