### PR TITLE
docs: Improve a8n docs & document "Find leaked credentials" campaign

### DIFF
--- a/doc/user/automation.md
+++ b/doc/user/automation.md
@@ -35,9 +35,9 @@ Automation requires that your [external service](../admin/external_service.md) i
 Automation is still in beta and currently has some limitations to keep in mind:
 
 - We currently only support GitHub and Bitbucket Server code hosts in Automation.
-- The maximum number of repositories over which an Automation campaign is 200.
+- The maximum number of repositories which an Automation campaign can process is 200.
 
-If you have a specific automation workflow in mind that is not covered by our current feature set or exceeds our repository limit, let us know us at <support@sourcegraph.com>.
+If you have a specific automation workflow in mind that is not covered by our current feature set or exceeds our repository limit, let us know at <support@sourcegraph.com>.
 
 ## Supported campaign types and functionality
 

--- a/doc/user/automation.md
+++ b/doc/user/automation.md
@@ -16,13 +16,32 @@ In order to use the Automation preview, a site-admin of your Sourcegraph instanc
 }
 ```
 
+## Creating a new campaign
+
+1. After enabling the feature flag, navigate to `sourcegraph.example.com/campaigns` or simply click the "Campaigns" entry in the navigation bar at the top.
+1. Click `Create new campaign`.
+1. Enter the name and an optional description for your campaign.
+1. Select the type of campaign to run. See the list of supported campaign types and functionality below.
+1. Configure the campaign type by editing its parameters.
+1. Now generate a preview of the changes that would be made by the campaign by clicking `Preview changes`. Wait for all repositories to be processed. This might take a while when the the campaign runs over hundreds of repositories.
+1. Once the preview is fully computed, you'll see a list of patches that would be turned into changesets (i.e. pull requests on GitHub) on the code hosts associated with each repository.
+1. Feel free to change the arguments and create a new preview.
+1. When you're happy with the proposed changes click `Create`. **This will asynchronously create the changesets (i.e. pull requests) on the code hosts**. Once created, changeset progress (e.g., `open`, `merged`) can be tracked in the campaign view.
+
 Automation requires that your [external service](../admin/external_service.md) is using a token with **write access** in order to create changesets on your code host.
+
+## Current limitations
+
+Automation is still in beta and currently has some limitations to keep in mind:
+
+- We currently only support GitHub and Bitbucket Server code hosts in Automation.
+- The maximum number of repositories over which an Automation campaign is 200.
+
+If you have a specific automation workflow in mind that is not covered by our current feature set or exceeds our repository limit, let us know us at <support@sourcegraph.com>.
 
 ## Supported campaign types and functionality
 
-Our focus is to deliver _general_ functionality (e.g., centralized monitoring of a large set of pull requests on different code hosts) as well as _tailored_ solutions for large-scale code changes and workflows (e.g., detect leaked NPM credentials). If you have a specific automation workflow in mind that is not covered by our current feature set, please reach out to us at <support@sourcegraph.com>.
-
-We currently support GitHub and Bitbucket Server code hosts. A maximum of 200 repositories can be processed at a time (please reach out to us if you have a use case that exceeds this number).
+Our focus is to deliver _general_ functionality (e.g., centralized monitoring of a large set of pull requests on different code hosts) as well as _tailored_ solutions for large-scale code changes and workflows (e.g., detect leaked NPM credentials).
 
 ### Regex search and replace
 
@@ -48,19 +67,32 @@ Parameters:
 
 Note: the `scopeQuery` filter for `comby` narrows the set of repositories and will currently run on _all_ files in the repository. Future improvements will allow to restrict changes using the `file:` filter.
 
+### Finding leaked credentials
+
+This campaign type finds possibly leaked credentials across your codebase and creates changesets that remove or replace the credentials.
+
+Parameters:
+
+| Name            | Description                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| scopeQuery      | Search query to narrow down repositories to be included in this campaign.                      |
+| matchers        | A list of credential "matchers" that are run.                                                  |
+
+Properties of a `matcher`:
+
+| Name            | Description                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| type            | The type of the matcher. Currently supported: `"npm"`                   .                      |
+| replaceWith     | An optional string that the credentials are replaced with.                                     |
+
+
+The currently available matcher types:
+
+1. `npm`: finds (and optionally replaces) NPM registry tokens and passwords in `.npmrc` files.
+
 ### Manual changeset monitoring
 
 Manual campaigns keep track of existing changesets from various code hosts. You can manually add each changeset you would like to track (such as a GitHub pull request), and can track them to completion.
-
-## Creating a new campaign
-
-1. Navigate to `sourcegraph.example.com/campaigns` or simply click the "Campaigns" entry in the top navbar. (It will only appear when correctly configured).
-1. Click `Create new campaign`.
-1. Enter the title and an optional description for your campaign.
-1. Select the type of campaign to run. For example, enter regex patterns to match and replace text using the JSON editor. Note: special characters like `\` and `"` need to be escaped inside the string.
-1. To generate a preview campaign, click `Preview changes` and wait for all repositories to be processed. When the preview is ready, you'll see a list of diffs.
-1. Feel free to change the search and replace patterns to create a new preview.
-1. Once the preview looks good, click `create`. **This will create a pull request of the changset on your code host**. Once created, changeset progress (e.g., `open`, `merged`) can be tracked in the campaign view.
 
 ---
 


### PR DESCRIPTION
Various improvements, reordering and, finally, documentation for the NPM credentials campaign type.

This might be the first of many PRs (or I might add to this one until approved)