### PR TITLE
a8n: Remove published_at from ChangesetJobs

### DIFF
--- a/enterprise/internal/a8n/integration_test.go
+++ b/enterprise/internal/a8n/integration_test.go
@@ -20,10 +20,9 @@ func TestIntegration(t *testing.T) {
 	defer cleanup()
 
 	t.Run("Store", testStore(db))
+	t.Run("GitHubWebhook", testGitHubWebhook(db))
 
-	// The following two tests need to be separate because testStore above wraps everything in a global transaction
+	// The following tests need to be separate because testStore above wraps everything in a global transaction
 	t.Run("StoreLocking", testStoreLocking(db))
 	t.Run("ProcessCampaignJob", testProcessCampaignJob(db))
-
-	t.Run("GitHubWebhook", testGitHubWebhook(db))
 }

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -128,14 +128,14 @@ func (r *campaignResolver) PublishedAt(ctx context.Context) (*graphqlbackend.Dat
 	if !r.Campaign.PublishedAt.IsZero() {
 		return &graphqlbackend.DateTime{Time: r.Campaign.PublishedAt}, nil
 	}
-	publishedAt, err := r.store.GetLatestChangesetJobPublishedAt(ctx, r.Campaign.ID)
+	createdAt, err := r.store.GetLatestChangesetJobCreatedAt(ctx, r.Campaign.ID)
 	if err != nil {
 		return nil, err
 	}
-	if publishedAt.IsZero() {
+	if createdAt.IsZero() {
 		return nil, nil
 	}
-	return &graphqlbackend.DateTime{Time: publishedAt}, nil
+	return &graphqlbackend.DateTime{Time: createdAt}, nil
 }
 
 func (r *campaignResolver) Changesets(ctx context.Context, args struct {

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -635,10 +635,9 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs []*a8n.Changeset) 
 	return syncer.SyncChangesetsWithSources(ctx, bySource)
 }
 
-// PublishChangesetJobForCampaignJob creates or updates a ChangesetJob for the
+// PublishChangesetJobForCampaignJob creates a ChangesetJob for the
 // CampaignJob with the given ID. The CampaignJob has to belong to a
-// CampaignPlan that was attached to a Campaign. It will ensure that the
-// ChangesetJob is published, even if it already exists.
+// CampaignPlan that was attached to a Campaign.
 func (s *Service) PublishChangesetJobForCampaignJob(ctx context.Context, campaignJobID int64) (err error) {
 	traceTitle := fmt.Sprintf("campaignJob: %d", campaignJobID)
 	tr, ctx := trace.New(ctx, "service.PublishChangesetJobForCampaignJob", traceTitle)
@@ -670,23 +669,13 @@ func (s *Service) PublishChangesetJobForCampaignJob(ctx context.Context, campaig
 	if err != nil && err != ErrNoResults {
 		return err
 	}
-	if existing != nil && !existing.PublishedAt.IsZero() && err == nil {
-		// No need to update
-		return nil
-	}
-
 	if existing != nil {
-		existing.PublishedAt = s.clock()
-		err = tx.UpdateChangesetJob(ctx, existing)
-		if err != nil {
-			return err
-		}
+		// Already exists
 		return nil
 	}
 	changesetJob := &a8n.ChangesetJob{
 		CampaignID:    campaign.ID,
 		CampaignJobID: job.ID,
-		PublishedAt:   s.clock(),
 	}
 	err = tx.CreateChangesetJob(ctx, changesetJob)
 	if err != nil {

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -262,69 +262,6 @@ func TestService(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateChangesetJobForCampaignJobWhenNotAlreadyPublished", func(t *testing.T) {
-		plan := &a8n.CampaignPlan{CampaignType: "test", Arguments: `{}`}
-		err = store.CreateCampaignPlan(ctx, plan)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		campaignJob := testCampaignJob(plan.ID, rs[0].ID, now)
-		err := store.CreateCampaignJob(ctx, campaignJob)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		campaign := testCampaign(u.ID, plan.ID)
-		err = store.CreateCampaign(ctx, campaign)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
-		err = svc.PublishChangesetJobForCampaignJob(ctx, campaignJob.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		haveJob, err := store.GetChangesetJob(ctx, GetChangesetJobOpts{
-			CampaignID:    campaign.ID,
-			CampaignJobID: campaignJob.ID,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if haveJob.PublishedAt.IsZero() {
-			t.Fatalf("PublishedAt is not set")
-		}
-
-		// Reset published at to null
-		haveJob.PublishedAt = time.Time{}
-		err = store.UpdateChangesetJob(ctx, haveJob)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Try to create again, should not fail
-		err = svc.PublishChangesetJobForCampaignJob(ctx, campaignJob.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Get again and make sure PublishedAt has been set
-		haveJob, err = store.GetChangesetJob(ctx, GetChangesetJobOpts{
-			CampaignID:    campaign.ID,
-			CampaignJobID: campaignJob.ID,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if haveJob.PublishedAt.IsZero() {
-			t.Fatalf("PublishedAt is not set")
-		}
-	})
-
 	t.Run("UpdateCampaignWithUnprocessedChangesetJobs", func(t *testing.T) {
 		subTests := []struct {
 			name  string

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -63,7 +63,7 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 }
 
 // ProcessPendingChangesetJobs attempts to fetch one pending changeset job.
-// A pending job is one that has never been started, its campaign is published and its plan is not cancelled.
+// A pending job is one that has never been started and its plan is not cancelled.
 // If found, 'process' is called. We guarantee that if process is called it will have exclusive global access to
 // the job. All operations on the job should be done using the supplied store as they will run in a transaction.
 // Returning an error will roll back the transaction.
@@ -100,7 +100,6 @@ UPDATE changeset_jobs j SET started_at = now() WHERE id = (
 	JOIN campaign_plans p ON p.id = c.campaign_plan_id
 	WHERE j.started_at IS NULL
 	AND p.canceled_at IS NULL
-	AND (c.published_at IS NOT NULL OR j.published_at IS NOT NULL)
 	ORDER BY j.id ASC
 	FOR UPDATE SKIP LOCKED LIMIT 1
 )
@@ -112,8 +111,7 @@ RETURNING j.id,
   j.started_at,
   j.finished_at,
   j.created_at,
-  j.updated_at,
-  j.published_at
+  j.updated_at
 `
 
 // ProcessPendingCampaignJob attempts to fetch one pending campaign job. If found, 'process'
@@ -2097,10 +2095,9 @@ INSERT INTO changeset_jobs (
   started_at,
   finished_at,
   created_at,
-  updated_at,
-  published_at
+  updated_at
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   campaign_id,
@@ -2110,8 +2107,7 @@ RETURNING
   started_at,
   finished_at,
   created_at,
-  updated_at,
-  published_at
+  updated_at
 `
 
 func (s *Store) createChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error) {
@@ -2133,7 +2129,6 @@ func (s *Store) createChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error
 		nullTimeColumn(c.FinishedAt),
 		c.CreatedAt,
 		c.UpdatedAt,
-		nullTimeColumn(c.PublishedAt),
 	), nil
 }
 
@@ -2160,9 +2155,8 @@ SET (
   error,
   started_at,
   finished_at,
-  updated_at,
-  published_at
-) = (%s, %s, %s, %s, %s, %s, %s, %s)
+  updated_at
+) = (%s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -2173,8 +2167,7 @@ RETURNING
   started_at,
   finished_at,
   created_at,
-  updated_at,
-  published_at
+  updated_at
 `
 
 func (s *Store) updateChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error) {
@@ -2189,7 +2182,6 @@ func (s *Store) updateChangesetJobQuery(c *a8n.ChangesetJob) (*sqlf.Query, error
 		nullTimeColumn(c.StartedAt),
 		nullTimeColumn(c.FinishedAt),
 		c.UpdatedAt,
-		nullTimeColumn(c.PublishedAt),
 		c.ID,
 	), nil
 }
@@ -2245,28 +2237,37 @@ func countChangesetJobsQuery(opts *CountChangesetJobsOpts) *sqlf.Query {
 	return sqlf.Sprintf(countChangesetJobsQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
-func (s *Store) GetLatestChangesetJobPublishedAt(ctx context.Context, campaignID int64) (time.Time, error) {
-	q := sqlf.Sprintf(getLatestChangesetJobPublishedAtFmtstr, campaignID, campaignID)
-	var publishedAt time.Time
+// GetLatestChangesetJobCreatedAt returns the most recent created_at time for all changeset jobs
+// for a campaign iff they have all been created
+func (s *Store) GetLatestChangesetJobCreatedAt(ctx context.Context, campaignID int64) (time.Time, error) {
+	q := sqlf.Sprintf(getLatestChangesetJobPublishedAtFmtstr, campaignID, campaignID, campaignID)
+	var createdAt time.Time
 	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
-		err = sc.Scan(&dbutil.NullTime{Time: &publishedAt})
+		err = sc.Scan(&dbutil.NullTime{Time: &createdAt})
 		if err != nil {
 			return 0, 0, err
 		}
 		return 0, 1, nil
 	})
 	if err != nil {
-		return publishedAt, err
+		return createdAt, err
 	}
-	return publishedAt, nil
+	return createdAt, nil
 }
 
 var getLatestChangesetJobPublishedAtFmtstr = `
-SELECT max(published_at)
-FROM changeset_jobs
-WHERE campaign_id = %d
-AND NOT EXISTS
-  (SELECT id FROM changeset_jobs WHERE campaign_id = %d AND published_at IS NULL)
+SELECT CASE
+         WHEN (SELECT count(campaign_jobs.id)
+               FROM   campaign_jobs
+                      JOIN campaigns c
+                        ON campaign_jobs.campaign_plan_id = c.campaign_plan_id
+               WHERE  c.id = %s) = (SELECT count(id)
+                                   FROM   changeset_jobs
+                                   WHERE  campaign_id = %s) THEN
+         (SELECT max(created_at)
+          FROM   changeset_jobs
+          WHERE  campaign_id = %s)
+       END
 `
 
 // GetChangesetJobOpts captures the query options needed for getting a ChangesetJob
@@ -2307,8 +2308,7 @@ SELECT
   started_at,
   finished_at,
   created_at,
-  updated_at,
-  published_at
+  updated_at
 FROM changeset_jobs
 WHERE %s
 LIMIT 1
@@ -2381,8 +2381,7 @@ SELECT
   changeset_jobs.started_at,
   changeset_jobs.finished_at,
   changeset_jobs.created_at,
-  changeset_jobs.updated_at,
-  changeset_jobs.published_at
+  changeset_jobs.updated_at
 FROM changeset_jobs
 `
 
@@ -2630,7 +2629,6 @@ func scanChangesetJob(c *a8n.ChangesetJob, s scanner) error {
 		&dbutil.NullTime{Time: &c.FinishedAt},
 		&c.CreatedAt,
 		&c.UpdatedAt,
-		&dbutil.NullTime{Time: &c.PublishedAt},
 	)
 }
 

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -215,8 +215,6 @@ type ChangesetJob struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
-
-	PublishedAt time.Time
 }
 
 // Clone returns a clone of a ChangesetJob.

--- a/migrations/1528395637_remove_published_at_from_changeset_job.down.sql
+++ b/migrations/1528395637_remove_published_at_from_changeset_job.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs ADD COLUMN published_at timestamptz;
+
+COMMIT;

--- a/migrations/1528395637_remove_published_at_from_changeset_job.up.sql
+++ b/migrations/1528395637_remove_published_at_from_changeset_job.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE changeset_jobs DROP COLUMN IF EXISTS published_at;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -66,6 +66,8 @@
 // 1528395635_check_campaign_name_not_blank.up.sql (189B)
 // 1528395636_add_published_at_to_changeset_jobs.down.sql (80B)
 // 1528395636_add_published_at_to_changeset_jobs.up.sql (81B)
+// 1528395637_remove_published_at_from_changeset_job.down.sql (81B)
+// 1528395637_remove_published_at_from_changeset_job.up.sql (80B)
 
 package migrations
 
@@ -1454,6 +1456,46 @@ func _1528395636_add_published_at_to_changeset_jobsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395637_remove_published_at_from_changeset_jobDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x89\xcf\xca\x4f\x2a\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\x51\x28\xc9\xcc\x4d\x2d\x2e\x49\xcc\x2d\x28\xa9\xb2\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x86\xae\x59\x0b\x51\x00\x00\x00")
+
+func _1528395637_remove_published_at_from_changeset_jobDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395637_remove_published_at_from_changeset_jobDownSql,
+		"1528395637_remove_published_at_from_changeset_job.down.sql",
+	)
+}
+
+func _1528395637_remove_published_at_from_changeset_jobDownSql() (*asset, error) {
+	bytes, err := _1528395637_remove_published_at_from_changeset_jobDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395637_remove_published_at_from_changeset_job.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x78, 0xd5, 0xc6, 0x78, 0x4f, 0x88, 0xb3, 0x8a, 0x2c, 0xe1, 0xc0, 0x53, 0x17, 0xa3, 0xc3, 0xc4, 0x7b, 0xc0, 0x66, 0xf4, 0x86, 0x40, 0xf6, 0xa7, 0x21, 0xdf, 0xa, 0xb2, 0xb4, 0xb3, 0xb2, 0x67}}
+	return a, nil
+}
+
+var __1528395637_remove_published_at_from_changeset_jobUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x89\xcf\xca\x4f\x2a\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x28\x4d\xca\xc9\x2c\xce\x48\x4d\x89\x4f\x2c\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xcb\x01\x9f\x51\x50\x00\x00\x00")
+
+func _1528395637_remove_published_at_from_changeset_jobUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395637_remove_published_at_from_changeset_jobUpSql,
+		"1528395637_remove_published_at_from_changeset_job.up.sql",
+	)
+}
+
+func _1528395637_remove_published_at_from_changeset_jobUpSql() (*asset, error) {
+	bytes, err := _1528395637_remove_published_at_from_changeset_jobUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395637_remove_published_at_from_changeset_job.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x69, 0x4e, 0x1, 0x24, 0xcf, 0x1a, 0x32, 0x3f, 0x2e, 0xb5, 0x62, 0x47, 0x70, 0xc5, 0x97, 0x23, 0x9c, 0x7, 0xd1, 0xa5, 0xad, 0x8e, 0xef, 0xd9, 0x54, 0x32, 0x36, 0xbf, 0xbe, 0xfd, 0x1f, 0x1d}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1611,6 +1653,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395635_check_campaign_name_not_blank.up.sql":                    _1528395635_check_campaign_name_not_blankUpSql,
 	"1528395636_add_published_at_to_changeset_jobs.down.sql":             _1528395636_add_published_at_to_changeset_jobsDownSql,
 	"1528395636_add_published_at_to_changeset_jobs.up.sql":               _1528395636_add_published_at_to_changeset_jobsUpSql,
+	"1528395637_remove_published_at_from_changeset_job.down.sql":         _1528395637_remove_published_at_from_changeset_jobDownSql,
+	"1528395637_remove_published_at_from_changeset_job.up.sql":           _1528395637_remove_published_at_from_changeset_jobUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1720,6 +1764,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395635_check_campaign_name_not_blank.up.sql":                    {_1528395635_check_campaign_name_not_blankUpSql, map[string]*bintree{}},
 	"1528395636_add_published_at_to_changeset_jobs.down.sql":             {_1528395636_add_published_at_to_changeset_jobsDownSql, map[string]*bintree{}},
 	"1528395636_add_published_at_to_changeset_jobs.up.sql":               {_1528395636_add_published_at_to_changeset_jobsUpSql, map[string]*bintree{}},
+	"1528395637_remove_published_at_from_changeset_job.down.sql":         {_1528395637_remove_published_at_from_changeset_jobDownSql, map[string]*bintree{}},
+	"1528395637_remove_published_at_from_changeset_job.up.sql":           {_1528395637_remove_published_at_from_changeset_jobUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
It can be assumed that once a ChangesetJob has been created it should be
processed. Following this invariant, we no longer need the published_at
field on a ChangesetJob.

ChangesetJobs are created from CampaignJobs in one of two ways:

1. A Campaign is published leading to all CampaignJobs being created
along with their corresponding ChangesetJobs.

2. A ChangesetJob can be manually created by publishing an indivdual
campaign job.

This part of https://github.com/sourcegraph/sourcegraph/issues/7782

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
