### PR TITLE
Use golangci-lint as lint tool in VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,4 +67,5 @@
       "changeProcessCWD": true,
     },
   ],
+  "go.lintTool": "golangci-lint",
 }


### PR DESCRIPTION
This is the linter we use on CI and which we follow.
