### PR TITLE
Fix error in reading config

### DIFF
--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -46,7 +46,7 @@ export const EMPTY_COMPUTED_CONTEXT: ComputedContext = {
 }
 
 const FUNCS: { [name: string]: (...args: any[]) => any } = {
-    get: (obj: any, key: string): any => obj[key],
+    get: (obj: any, key: string): any => obj?.[key],
     json: (obj: any): string => JSON.stringify(obj),
 }
 

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -46,7 +46,7 @@ export const EMPTY_COMPUTED_CONTEXT: ComputedContext = {
 }
 
 const FUNCS: { [name: string]: (...args: any[]) => any } = {
-    get: (obj: any, key: string): any => obj?.[key],
+    get: (obj: any, key: string): any => obj?.[key] ?? undefined,
     json: (obj: any): string => JSON.stringify(obj),
 }
 

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -138,6 +138,7 @@ export class ContributionRegistry {
                     } catch (err) {
                         // An error during evaluation causes all of the contributions in the same entry to be
                         // discarded.
+                        console.log(err)
                         logWarning('Discarding contributions: evaluating expressions or templates failed.', {
                             contributions,
                             err,

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -138,7 +138,6 @@ export class ContributionRegistry {
                     } catch (err) {
                         // An error during evaluation causes all of the contributions in the same entry to be
                         // discarded.
-                        console.log(err)
                         logWarning('Discarding contributions: evaluating expressions or templates failed.', {
                             contributions,
                             err,


### PR DESCRIPTION
Closes #7866

This is a fix for the root cause of the noise reported in #7866 
When reading a config value here: 
`{ action: ACTION_ID, when: 'get(config.experimentalFeatures, "searchStats")' },`
the parser did not account for experimentalFeatures being not an object (here `null`). For properties on objects that don't exist, we return undefined instead now and the errors are gone