### PR TITLE
Docs: mention `extension copy`

### DIFF
--- a/doc/admin/extensions/index.md
+++ b/doc/admin/extensions/index.md
@@ -37,7 +37,9 @@ If you want to create extensions that are only visible to users on your Sourcegr
 To publish an extension to your instance's private extension registry:
 
 1. Configure your [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) with the URL and an access token for your Sourcegraph instance.
-1. Run `src extensions publish` in the extension directory.
+1. Depending on whether or not the extension already exists on Sourcegraph.com:
+  - If the extension already exists on Sourcegraph.com, you can copy it to your private extension registry with `src extensions copy -extension-id=... -current-user=...`
+  - If this is a new extension, run `src extensions publish` in the extension directory.
 
 On Sourcegraph Core, the only way to publish extensions is to publish them to the [Sourcegraph.com extension registry](https://sourcegraph.com/extensions), where anyone on the web can view them.
 


### PR DESCRIPTION
`src extension copy` copies an extension from Sourcegraph.com your private extension registry. it was implemented in https://github.com/sourcegraph/src-cli/pull/82