### PR TITLE
frontend/globals: add nil check in `globals.WatchPermissionsUserMapping`

### DIFF
--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -83,7 +83,9 @@ func WatchPermissionsUserMapping() {
 
 	conf.Watch(func() {
 		after := conf.Get().SiteConfiguration.PermissionsUserMapping
-		if after.BindID != "email" && after.BindID != "username" {
+		if after == nil {
+			return
+		} else if after.BindID != "email" && after.BindID != "username" {
 			log15.Error("globals.PermissionsUserMapping", "BindID", after.BindID, "error", "not a valid value")
 			return
 		}


### PR DESCRIPTION
Add nil check to prevent panic in `globals.WatchPermissionsUserMapping`, this fixes failing e2e test in CI on `master`.