### PR TITLE
authz: always check config conflicts first

### DIFF
--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -58,6 +58,10 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.Grant
 }
 
 func (s *authzStore) AuthorizedRepos(ctx context.Context, args *db.AuthorizedReposArgs) ([]*types.Repo, error) {
+	if len(args.Repos) == 0 {
+		return args.Repos, nil
+	}
+
 	s.init()
 
 	p := &iauthz.UserPermissions{


### PR DESCRIPTION
Always perform config conflict check before the "len(repos) == 0" as explained in the code comments:

>🚨 SECURITY: This "smart" check must happen after checking globals.PermissionsUserMapping().Enabled. Otherwise, we could leak the existence of repositories that a user has no access to by returning an error (resulted in 500), and returning nil (resulted in 404) for non-existent repositories.