### PR TITLE
web: properly render password reset item in profile sidebar

### DIFF
--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -147,6 +147,15 @@ func Providers() []Provider {
 	return providers
 }
 
+func BuiltinAuthEnabled() bool {
+	for _, p := range Providers() {
+		if p.Config().Builtin != nil {
+			return true
+		}
+	}
+	return false
+}
+
 type sortProviders []Provider
 
 func (p sortProviders) Len() int {

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -700,7 +700,7 @@ func (u *users) getOneBySQL(ctx context.Context, query string, args ...interface
 
 // getBySQL returns users matching the SQL query, if any exist.
 func (*users) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*types.User, error) {
-	rows, err := dbconn.Global.QueryContext(ctx, "SELECT u.id, u.username, u.display_name, u.avatar_url, u.created_at, u.updated_at, u.site_admin, u.tags FROM users u "+query, args...)
+	rows, err := dbconn.Global.QueryContext(ctx, "SELECT u.id, u.username, u.display_name, u.avatar_url, u.created_at, u.updated_at, u.site_admin, u.passwd IS NOT NULL, u.tags FROM users u "+query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +710,7 @@ func (*users) getBySQL(ctx context.Context, query string, args ...interface{}) (
 	for rows.Next() {
 		var u types.User
 		var displayName, avatarURL sql.NullString
-		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, pq.Array(&u.Tags))
+		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.Builtin, pq.Array(&u.Tags))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -278,6 +278,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 		SiteAdmin:   siteAdmin,
+		Builtin:     info.Password != "",
 	}, nil
 }
 

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -278,7 +278,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 		SiteAdmin:   siteAdmin,
-		Builtin:     info.Password != "",
+		BuiltinAuth: info.Password != "",
 	}, nil
 }
 
@@ -711,7 +711,7 @@ func (*users) getBySQL(ctx context.Context, query string, args ...interface{}) (
 	for rows.Next() {
 		var u types.User
 		var displayName, avatarURL sql.NullString
-		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.Builtin, pq.Array(&u.Tags))
+		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.BuiltinAuth, pq.Array(&u.Tags))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2923,7 +2923,7 @@ type User implements Node & SettingsSubject & Namespace {
     # Only the user and site admins can access this field.
     siteAdmin: Boolean!
     # Whether the user account uses built in auth.
-    builtin: Boolean!
+    builtinAuth: Boolean!
     # The latest settings for the user.
     #
     # Only the user and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2922,6 +2922,8 @@ type User implements Node & SettingsSubject & Namespace {
     #
     # Only the user and site admins can access this field.
     siteAdmin: Boolean!
+    # Whether the user account uses built in auth.
+    builtin: Boolean!
     # The latest settings for the user.
     #
     # Only the user and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2929,6 +2929,8 @@ type User implements Node & SettingsSubject & Namespace {
     #
     # Only the user and site admins can access this field.
     siteAdmin: Boolean!
+    # Whether the user account uses built in auth.
+    builtin: Boolean!
     # The latest settings for the user.
     #
     # Only the user and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2930,7 +2930,7 @@ type User implements Node & SettingsSubject & Namespace {
     # Only the user and site admins can access this field.
     siteAdmin: Boolean!
     # Whether the user account uses built in auth.
-    builtin: Boolean!
+    builtinAuth: Boolean!
     # The latest settings for the user.
     #
     # Only the user and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -7,6 +7,7 @@ import (
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -115,8 +116,9 @@ func (r *UserResolver) DisplayName() *string {
 	return &r.user.DisplayName
 }
 
-// Builtin returns whether or not the user account was created in Sourcegraph.
-func (r *UserResolver) Builtin() bool { return r.user.Builtin }
+func (r *UserResolver) BuiltinAuth() bool {
+	return r.user.BuiltinAuth && providers.BuiltinAuthEnabled()
+}
 
 func (r *UserResolver) AvatarURL() *string {
 	if r.user.AvatarURL == "" {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -115,6 +115,9 @@ func (r *UserResolver) DisplayName() *string {
 	return &r.user.DisplayName
 }
 
+// Builtin returns whether or not the user account was created in Sourcegraph.
+func (r *UserResolver) Builtin() bool { return r.user.Builtin }
+
 func (r *UserResolver) AvatarURL() *string {
 	if r.user.AvatarURL == "" {
 		return nil

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -77,6 +77,7 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	SiteAdmin   bool
+	Builtin     bool
 	Tags        []string
 }
 

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -77,7 +77,7 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	SiteAdmin   bool
-	Builtin     bool
+	BuiltinAuth bool
 	Tags        []string
 }
 

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -38,7 +38,7 @@ const fetchUser = (args: { username: string }): Observable<GQL.IUser | null> =>
                     avatarURL
                     viewerCanAdminister
                     siteAdmin
-                    builtin
+                    builtinAuth
                     createdAt
                     emails {
                         email

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -38,6 +38,7 @@ const fetchUser = (args: { username: string }): Observable<GQL.IUser | null> =>
                     avatarURL
                     viewerCanAdminister
                     siteAdmin
+                    builtin
                     createdAt
                     emails {
                         email

--- a/web/src/user/settings/UserSettingsArea.tsx
+++ b/web/src/user/settings/UserSettingsArea.tsx
@@ -2,13 +2,10 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import * as React from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import { Subscription } from 'rxjs'
-import { map } from 'rxjs/operators'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
-import { siteFlags } from '../../site/backend'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { RouteDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
@@ -30,15 +27,12 @@ export interface UserSettingsAreaRouteContext extends UserSettingsAreaProps {
      * is viewing another user's account page).
      */
     user: GQL.IUser
-    authProviders: GQL.IAuthProvider[]
     newToken?: GQL.ICreateAccessTokenResult
     onDidCreateAccessToken: (value?: GQL.ICreateAccessTokenResult) => void
     onDidPresentNewToken: (value?: GQL.ICreateAccessTokenResult) => void
 }
 
 interface UserSettingsAreaState {
-    authProviders: GQL.IAuthProvider[]
-
     /**
      * Holds the newly created access token (from UserSettingsCreateAccessTokenPage), if any. After
      * it is displayed to the user, this subject's value is set back to undefined.
@@ -51,20 +45,7 @@ interface UserSettingsAreaState {
  */
 export const UserSettingsArea = withAuthenticatedUser(
     class UserSettingsArea extends React.Component<UserSettingsAreaProps, UserSettingsAreaState> {
-        public state: UserSettingsAreaState = { authProviders: [] }
-        private subscriptions = new Subscription()
-
-        public componentDidMount(): void {
-            this.subscriptions.add(
-                siteFlags.pipe(map(({ authProviders }) => authProviders)).subscribe(({ nodes }) => {
-                    this.setState({ authProviders: nodes })
-                })
-            )
-        }
-
-        public componentWillUnmount(): void {
-            this.subscriptions.unsubscribe()
-        }
+        public state: UserSettingsAreaState = {}
 
         public render(): JSX.Element | null {
             if (!this.props.user) {
@@ -88,17 +69,11 @@ export const UserSettingsArea = withAuthenticatedUser(
                 user: this.props.user,
                 onDidCreateAccessToken: this.setNewToken,
                 onDidPresentNewToken: this.setNewToken,
-                authProviders: this.state.authProviders,
             }
 
             return (
                 <div className="d-flex">
-                    <UserSettingsSidebar
-                        items={this.props.sideBarItems}
-                        authProviders={this.state.authProviders}
-                        {...this.props}
-                        className="flex-0 mr-3"
-                    />
+                    <UserSettingsSidebar items={this.props.sideBarItems} {...this.props} className="flex-0 mr-3" />
                     <div className="flex-1">
                         <ErrorBoundary location={this.props.location}>
                             <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -19,8 +19,7 @@ import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
-    user: Pick<GQL.IUser, 'viewerCanAdminister'>
-    authProviders: GQL.IAuthProvider[]
+    user: Pick<GQL.IUser, 'viewerCanAdminister' | 'builtin'>
 }
 
 export type UserSettingsSidebarItems = Record<
@@ -30,7 +29,6 @@ export type UserSettingsSidebarItems = Record<
 
 export interface UserSettingsSidebarProps extends UserAreaRouteContext, RouteComponentProps<{}> {
     items: UserSettingsSidebarItems
-    authProviders: GQL.IAuthProvider[]
     className?: string
 }
 
@@ -57,7 +55,7 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                 <SidebarGroupItems>
                     {props.items.account.map(
                         ({ label, to, exact, condition = () => true }) =>
-                            condition({ authProviders: props.authProviders, user: props.user }) && (
+                            condition({ user: props.user }) && (
                                 <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
                                     {label}
                                 </SidebarNavItem>

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -19,7 +19,7 @@ import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
-    user: Pick<GQL.IUser, 'viewerCanAdminister' | 'builtin'>
+    user: Pick<GQL.IUser, 'viewerCanAdminister' | 'builtinAuth'>
 }
 
 export type UserSettingsSidebarItems = Record<

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -17,7 +17,7 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             to: '/password',
             exact: true,
             // Only the builtin auth provider has a password.
-            condition: ({ user }) => user.builtin,
+            condition: ({ user }) => user.builtinAuth,
         },
         {
             label: 'Emails',

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -17,7 +17,7 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             to: '/password',
             exact: true,
             // Only the builtin auth provider has a password.
-            condition: ({ authProviders }) => authProviders.some(({ isBuiltin }) => isBuiltin),
+            condition: ({ user }) => user.builtin,
         },
         {
             label: 'Emails',


### PR DESCRIPTION
This PR properly renders the password reset item in the profile sidebar when the user account uses builtin authentication. This fixes #7520. It also removes the existing logic (checking to see if builtin auth provider is enabled) that lead to false positives. 

The builtin is detected when the password field in the users table is not null. (https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/db/users.go#L110)