### PR TITLE
Add field for isLatestForRepo on LSIF upload page.

### DIFF
--- a/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
@@ -123,7 +123,20 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
                             </tr>
 
                             <tr>
-                                <td>Queued</td>
+                                <td>Is latest for repo</td>
+                                <td>
+                                    {uploadOrError.finishedAt ? (
+                                        <span className="e2e-is-latest-for-repo">
+                                            {uploadOrError.isLatestForRepo ? 'yes' : 'no'}
+                                        </span>
+                                    ) : (
+                                        <span className="text-muted">Upload has not yet completed.</span>
+                                    )}
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td>Uploaded</td>
                                 <td>
                                     <Timestamp date={uploadOrError.uploadedAt} noAbout={true} />
                                 </td>

--- a/web/src/enterprise/repo/settings/backend.tsx
+++ b/web/src/enterprise/repo/settings/backend.tsx
@@ -111,6 +111,7 @@ export function fetchLsifUpload({ id }: { id: string }): Observable<GQL.ILSIFUpl
                         uploadedAt
                         startedAt
                         finishedAt
+                        isLatestForRepo
                     }
                 }
             }


### PR DESCRIPTION
We aren't displaying this field, so the only way to determine this is what list it happens to be in on the list page.