### PR TITLE
Atomic migrations

### DIFF
--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -127,12 +126,7 @@ func InjectVersionUpdate(f bindata.AssetFunc) bindata.AssetFunc {
 		if err != nil {
 			return nil, err
 		}
-		versionParts := strings.Split(path.Base(name), "_")
-		if len(versionParts) < 2 {
-			return nil, errors.New("expected migration filename to be of the form <version>_<name>")
-		}
-		version := versionParts[0]
-		newContents := strings.Replace(string(oldContents), "COMMIT;", fmt.Sprintf("UPDATE schema_migrations SET version='%s', dirty=false;\nCOMMIT;", version), 1)
+		newContents := strings.Replace(string(oldContents), "COMMIT;", fmt.Sprintf("UPDATE schema_migrations SET dirty=false;\nCOMMIT;"), 1)
 		return []byte(newContents), nil
 	}
 }

--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -111,7 +111,7 @@ func NewDB(dsn, app string) (*sql.DB, error) {
 	return db, nil
 }
 
-// InjectVersionUpdate fixes the dirty state (set by golang-migrate) after a
+// injectVersionUpdate fixes the dirty state (set by golang-migrate) after a
 // successful migration. If the frontend starts a migration that will turn out
 // to be successful but does not stay alive for the duration of the query due to
 // a startup timeout, there will be no chance to set the new version or unset
@@ -120,7 +120,7 @@ func NewDB(dsn, app string) (*sql.DB, error) {
 // once the migration is committed.
 //
 // See https://github.com/golang-migrate/migrate/issues/325.
-func InjectVersionUpdate(f bindata.AssetFunc) bindata.AssetFunc {
+func injectVersionUpdate(f bindata.AssetFunc) bindata.AssetFunc {
 	return func(name string) ([]byte, error) {
 		oldContents, err := f(name)
 		if err != nil {
@@ -132,7 +132,7 @@ func InjectVersionUpdate(f bindata.AssetFunc) bindata.AssetFunc {
 }
 
 func NewMigrationSourceLoader(dataSource string) *bindata.AssetSource {
-	return bindata.Resource(migrations.AssetNames(), InjectVersionUpdate(migrations.Asset))
+	return bindata.Resource(migrations.AssetNames(), injectVersionUpdate(migrations.Asset))
 }
 
 func NewMigrate(db *sql.DB, dataSource string) (*migrate.Migrate, error) {

--- a/internal/db/dbutil/dbutil_test.go
+++ b/internal/db/dbutil/dbutil_test.go
@@ -67,3 +67,15 @@ func TestPostgresDSN(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectVersionUpdate(t *testing.T) {
+	gotContents, err := injectVersionUpdate(func(name string) ([]byte, error) { return []byte("BEGIN;\n-- some statements...\nCOMMIT;"), nil })("migrations/100_dummy.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotContents)
+	want := "BEGIN;\n-- some statements...\nUPDATE schema_migrations SET dirty=false;\nCOMMIT;"
+	if got != want {
+		t.Errorf("incorrect contents: got != want\ngot:  %v\nwant: %v", got, want)
+	}
+}


### PR DESCRIPTION
**tl;dr** this makes migrations atomic, which ensures that successful migrations always leave the DB in a clean state.

**Prior to this change**, it was possible for the frontend to disconnect from Postgres halfway through a migration (e.g. when the migration takes [>5 minutes and k8s kills the frontend because it's not responding](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/78d19bd4f013a7193ddcf3e8739086a922452eb5/base/frontend/sourcegraph-frontend.Deployment.yaml#L66)), leaving the DB marked as being in a dirty state despite the migration eventually succeeding.

**After this change**, each migration will set `dirty=false` within the transaction to guarantee that when a migration succeeds the DB will be in a clean state.

More context:

- Motivating prod error https://sourcegraph.slack.com/archives/C0J618TTM/p1579282575001900
- Investigation https://sourcegraph.slack.com/archives/C07KZF47K/p1579287343014500
- Filed issue https://github.com/golang-migrate/migrate/issues/325 (and submitted a PR https://github.com/golang-migrate/migrate/pull/326, probably won't get merged soon)
- Problem statement and alternatives https://sourcegraph.slack.com/archives/C07KZF47K/p1579546621063800

A few alternatives:

- Accept that migrations can fail in this way and document how to fix the DB when this happens
- Use my patched version of golang-migrate until a satisfactory solution has been upstreamed
- Mitigation: increase the timeout for DB migrations
- Don't merge slow migrations into master, somehow check perf before merging
- Workaround 1: SET version=..., dirty=false at the end of each migration in our migrations/ directory
- Workaround 2 (implemented in this PR): splice that statement into the migration at runtime by intercepting the migration loader
- Workaround 3: inline the ~40 lines of relevant code from golang-migrate and patch that in our source

3 teammates [supported](https://sourcegraph.slack.com/archives/C07KZF47K/p1579547161066000?thread_ts=1579546621.063800&cid=C07KZF47K) workaround 3:

> I vote for workaround 3, since we’re postgres only and the value-add from that lib is not that high. We can also do more postgres specific things if we go workaround 3 route and do stuff more tailored towards our exact needs.

Upon further consideration, it became more clear to me that [workaround 2 would be better](https://sourcegraph.slack.com/archives/C07KZF47K/p1579563038077500?thread_ts=1579546621.063800&cid=C07KZF47K):

> @eric and I chatted about this in depth and realized that workaround 3 is not very desirable because it would not play well with the `migrate` command line tool.
> 
> Workaround 2 is more compatible and doesn't change the control flow as much.
> 
> Given that, we plan to proceed with workaround 2.

This PR is based on https://github.com/sourcegraph/sourcegraph/pull/7905, which is expected to be merged before this PR.