### PR TITLE
internal/rcache: skip nil values from MGET

### DIFF
--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -65,14 +65,19 @@ func (r *Cache) GetMulti(keys ...string) [][]byte {
 		log15.Warn("failed to execute redis command", "cmd", "MGET", "error", err)
 	}
 
-	strVals := make([][]byte, len(vals))
-	for i, val := range vals {
+	strVals := make([][]byte, 0, len(vals))
+	for _, val := range vals {
+		// MGET returns nil as not found.
+		if val == nil {
+			continue
+		}
+
 		b, err := redis.Bytes(val, nil)
 		if err != nil {
 			log15.Warn("failed to parse bytes from Redis value", "value", val)
 			continue
 		}
-		strVals[i] = b
+		strVals = append(strVals, b)
 	}
 	return strVals
 }

--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -94,7 +94,7 @@ func TestCache_multi(t *testing.T) {
 
 	c := New("some_prefix")
 	vals := c.GetMulti("k0", "k1", "k2")
-	if got, exp := vals, [][]byte{nil, nil, nil}; !reflect.DeepEqual(exp, got) {
+	if got, exp := vals, [][]byte{}; !reflect.DeepEqual(exp, got) {
 		t.Errorf("Expected %v on initial fetch, got %v", exp, got)
 	}
 
@@ -132,7 +132,7 @@ func TestCache_multi(t *testing.T) {
 	}
 
 	c.Delete("k0")
-	if got, exp := c.GetMulti("k0", "k1", "k2"), [][]byte{nil, []byte("y"), []byte("z")}; !reflect.DeepEqual(exp, got) {
+	if got, exp := c.GetMulti("k0", "k1", "k2"), [][]byte{[]byte("y"), []byte("z")}; !reflect.DeepEqual(exp, got) {
 		t.Errorf("Expected %v, but got %v", exp, got)
 	}
 }


### PR DESCRIPTION
This PR add a nil-check to `GetMulti` method, which simply skips to the next value. Also changed implementation to not include `nil`s in the returned results list.

Fixes #7912.