### PR TITLE
Do not remove LSIF upload files immediately on deletion.

### DIFF
--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -53,7 +53,7 @@ async function main(logger: Logger): Promise<void> {
 
     // Create database connection and entity wrapper classes
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const dumpManager = new DumpManager(connection, settings.STORAGE_ROOT)
+    const dumpManager = new DumpManager(connection)
     const uploadManager = new UploadManager(connection)
     const dependencyManager = new DependencyManager(connection)
     const backend = new Backend(settings.STORAGE_ROOT, dumpManager, dependencyManager, SRC_FRONTEND_INTERNAL)

--- a/lsif/src/shared/paths.ts
+++ b/lsif/src/shared/paths.ts
@@ -44,21 +44,3 @@ export async function ensureDirectory(directoryPath: string): Promise<void> {
         }
     }
 }
-
-/**
- * Delete the file if it exists. Throws errors that are not ENOENT.
- *
- * @param filePath The path to delete.
- */
-export async function tryDeleteFile(filePath: string): Promise<boolean> {
-    try {
-        await fs.unlink(filePath)
-        return true
-    } catch (error) {
-        if (!(error && error.code === 'ENOENT')) {
-            throw error
-        }
-
-        return false
-    }
-}

--- a/lsif/src/shared/store/dumps.ts
+++ b/lsif/src/shared/store/dumps.ts
@@ -349,7 +349,10 @@ export class DumpManager {
     ): Promise<void> {
         // Do not delete the file on disk directly in case we are part of a larger transaction.
         // We can afford to wait for the cleanup task to determine that the file is orphaned
-        // when it cannot find a matching row in the database.
+        // when it cannot find a matching row in the database. For more context, see the
+        // `removeDeadDumps` function performed at the start of the `purgeOldDumps` task that
+        // is run on a schedule in the server context.
+
         await entityManager.getRepository(pgModels.LsifDump).delete(dump.id)
     }
 }

--- a/lsif/src/shared/store/dumps.ts
+++ b/lsif/src/shared/store/dumps.ts
@@ -2,7 +2,6 @@ import * as sharedMetrics from '../database/metrics'
 import * as pgModels from '../models/pg'
 import { getCommitsNear, getHead } from '../gitserver/gitserver'
 import { Brackets, Connection, EntityManager } from 'typeorm'
-import { dbFilename, tryDeleteFile } from '../paths'
 import { logAndTraceCall, TracingContext } from '../tracing'
 import { instrumentQuery, instrumentQueryOrTransaction, withInstrumentedTransaction } from '../database/postgres'
 import { TableInserter } from '../database/inserter'
@@ -24,9 +23,8 @@ export class DumpManager {
      * Create a new `DumpManager` backed by the given database connection.
      *
      * @param connection The Postgres connection.
-     * @param storageRoot The path where SQLite databases are stored.
      */
-    constructor(private connection: Connection, private storageRoot: string) {}
+    constructor(private connection: Connection) {}
 
     /**
      * Find the dump for the given repository and commit.
@@ -349,16 +347,9 @@ export class DumpManager {
         dump: pgModels.LsifDump,
         entityManager: EntityManager = this.connection.createEntityManager()
     ): Promise<void> {
-        // Delete the SQLite file on disk (ignore errors if the file doesn't exist)
-        const path = dbFilename(this.storageRoot, dump.id)
-        await tryDeleteFile(path)
-
-        // Delete the dump record. Do this AFTER the file is deleted because the retention
-        // policy scans the database for deletion candidates, and we don't want to get into
-        // the situation where the row is gone and the file is there. In this case, we don't
-        // have any process to tell us that the file is okay to delete and will be orphaned
-        // on disk forever.
-
+        // Do not delete the file on disk directly in case we are part of a larger transaction.
+        // We can afford to wait for the cleanup task to determine that the file is orphaned
+        // when it cannot find a matching row in the database.
         await entityManager.getRepository(pgModels.LsifDump).delete(dump.id)
     }
 }

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -255,7 +255,7 @@ export class BackendTestContext {
         const { connection, cleanup } = await createCleanPostgresDatabase()
         this.connection = connection
         this.cleanup = cleanup
-        this.dumpManager = new DumpManager(connection, this.storageRoot)
+        this.dumpManager = new DumpManager(connection)
         this.dependencyManager = new DependencyManager(connection)
         this.backend = new Backend(this.storageRoot, this.dumpManager, this.dependencyManager, '')
     }

--- a/lsif/src/tests/integration/store/dependencies.test.ts
+++ b/lsif/src/tests/integration/store/dependencies.test.ts
@@ -1,6 +1,5 @@
 import * as util from '../integration-test-util'
 import * as pgModels from '../../../shared/models/pg'
-import rmfr from 'rmfr'
 import { Connection } from 'typeorm'
 import { fail } from 'assert'
 import { DumpManager } from '../../../shared/store/dumps'
@@ -9,7 +8,6 @@ import { DependencyManager } from '../../../shared/store/dependencies'
 describe('DependencyManager', () => {
     let connection!: Connection
     let cleanup!: () => Promise<void>
-    let storageRoot!: string
     let dumpManager!: DumpManager
     let dependencyManager!: DependencyManager
 
@@ -18,14 +16,11 @@ describe('DependencyManager', () => {
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await util.createCleanPostgresDatabase())
-        storageRoot = await util.createStorageRoot()
-        dumpManager = new DumpManager(connection, storageRoot)
+        dumpManager = new DumpManager(connection)
         dependencyManager = new DependencyManager(connection)
     })
 
     afterAll(async () => {
-        await rmfr(storageRoot)
-
         if (cleanup) {
             await cleanup()
         }

--- a/lsif/src/tests/integration/store/dumps.test.ts
+++ b/lsif/src/tests/integration/store/dumps.test.ts
@@ -1,7 +1,6 @@
 import * as util from '../integration-test-util'
 import * as pgModels from '../../../shared/models/pg'
 import nock from 'nock'
-import rmfr from 'rmfr'
 import { Connection } from 'typeorm'
 import { DumpManager } from '../../../shared/store/dumps'
 import { fail } from 'assert'
@@ -11,7 +10,6 @@ import { pick } from 'lodash'
 describe('DumpManager', () => {
     let connection!: Connection
     let cleanup!: () => Promise<void>
-    let storageRoot!: string
     let dumpManager!: DumpManager
 
     let counter = 100
@@ -22,13 +20,10 @@ describe('DumpManager', () => {
 
     beforeAll(async () => {
         ;({ connection, cleanup } = await util.createCleanPostgresDatabase())
-        storageRoot = await util.createStorageRoot()
-        dumpManager = new DumpManager(connection, storageRoot)
+        dumpManager = new DumpManager(connection)
     })
 
     afterAll(async () => {
-        await rmfr(storageRoot)
-
         if (cleanup) {
             await cleanup()
         }
@@ -465,7 +460,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const dumpManager = new DumpManager(connection, '')
+            const dumpManager = new DumpManager(connection)
             await util.insertDump(connection, dumpManager, repositoryId, ca, '')
 
             await dumpManager.updateCommits(
@@ -496,7 +491,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const dumpManager = new DumpManager(connection, '')
+            const dumpManager = new DumpManager(connection)
             await util.insertDump(connection, dumpManager, repositoryId, ca, '')
             await dumpManager.updateCommits(
                 repositoryId,
@@ -527,7 +522,7 @@ describe('discoverAndUpdateCommit', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const dumpManager = new DumpManager(connection, '')
+            const dumpManager = new DumpManager(connection)
 
             // This test ensures the following does not make a gitserver request.
             // As we did not register a nock interceptor, any request will result
@@ -569,7 +564,7 @@ describe('discoverAndUpdateTips', () => {
         const { connection, cleanup } = await util.createCleanPostgresDatabase()
 
         try {
-            const dumpManager = new DumpManager(connection, '')
+            const dumpManager = new DumpManager(connection)
             await dumpManager.updateCommits(
                 repositoryId,
                 new Map<string, Set<string>>([

--- a/lsif/src/worker/worker.ts
+++ b/lsif/src/worker/worker.ts
@@ -45,7 +45,7 @@ async function main(logger: Logger): Promise<void> {
 
     // Create database connection and entity wrapper classes
     const connection = await createPostgresConnection(fetchConfiguration(), logger)
-    const dumpManager = new DumpManager(connection, settings.STORAGE_ROOT)
+    const dumpManager = new DumpManager(connection)
     const uploadManager = new UploadManager(connection)
     const dependencyManager = new DependencyManager(connection)
 


### PR DESCRIPTION
This simplifies the deletion path for upload files. We have a task that already removes files that are no longer referenced by an LSIF upload row in the database. The current code is a bit sketchy when it's part of a larger transaction that rollsback - it's possible to get into a state where we remove the file but not the row, causing reference issues later