### PR TITLE
docs: mention nodejs version management with nvm

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -52,7 +52,7 @@ The following are two recommendations for installing these dependencies:
     brew cask install docker
     ```
 
-3.  Install Go, Node, PostgreSQL, Redis, Git, nginx, golang-migrate, Comby, and SQLite tools with the following command:
+3.  Install Go, Node Version Manager, PostgreSQL, Redis, Git, nginx, golang-migrate, Comby, and SQLite tools with the following command:
 
     ```bash
     brew install go nvm yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -27,7 +27,7 @@ Sourcegraph has the following dependencies:
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (v2.18 or higher)
 - [Go](https://golang.org/doc/install) (v1.13 or higher)
-- [Node JS](https://nodejs.org/en/download/) (see current recommended version in [.nvmrc](../../.nvmrc))
+- [Node JS](https://nodejs.org/en/download/) (see current recommended version in [.nvmrc](https://github.com/sourcegraph/sourcegraph/blob/master/.nvmrc))
 - [make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/engine/installation/) (v18 or higher)
   - For macOS we recommend using Docker for Mac instead of `docker-machine`

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -27,7 +27,7 @@ Sourcegraph has the following dependencies:
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (v2.18 or higher)
 - [Go](https://golang.org/doc/install) (v1.13 or higher)
-- [Node JS](https://nodejs.org/en/download/) (version 8 or 10)
+- [Node JS](https://nodejs.org/en/download/) (see current recommended version in [.nvmrc](../../.nvmrc))
 - [make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/engine/installation/) (v18 or higher)
   - For macOS we recommend using Docker for Mac instead of `docker-machine`
@@ -55,10 +55,16 @@ The following are two recommendations for installing these dependencies:
 3.  Install Go, Node, PostgreSQL, Redis, Git, nginx, golang-migrate, Comby, and SQLite tools with the following command:
 
     ```bash
-    brew install go node yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
+    brew install go nvm yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
     ```
 
-4.  Configure PostgreSQL and Redis to start automatically
+4. Install the current recommended version of Node JS using:
+
+    ```bash
+    nvm install
+    ```
+
+5.  Configure PostgreSQL and Redis to start automatically
 
     ```bash
     brew services start postgresql
@@ -67,7 +73,7 @@ The following are two recommendations for installing these dependencies:
 
     (You can stop them later by calling `stop` instead of `start` above.)
 
-5.  Ensure `psql`, the PostgreSQL command line client, is on your `$PATH`.
+6.  Ensure `psql`, the PostgreSQL command line client, is on your `$PATH`.
     Homebrew does not put it there by default. Homebrew gives you the command to run to insert `psql` in your path in the "Caveats" section of `brew info postgresql`. Alternatively, you can use the command below. It might need to be adjusted depending on your Homebrew prefix (`/usr/local` below) and shell (bash below).
 
     ```bash
@@ -75,7 +81,7 @@ The following are two recommendations for installing these dependencies:
     source ~/.bash_profile
     ```
 
-6.  Open a new Terminal window to ensure `psql` is now on your `$PATH`.
+7.  Open a new Terminal window to ensure `psql` is now on your `$PATH`.
 
 ### Ubuntu
 
@@ -93,9 +99,6 @@ The following are two recommendations for installing these dependencies:
     # Yarn
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-
-    # Node.js
-    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
     ```
 
 2. Update repositories:
@@ -107,13 +110,19 @@ The following are two recommendations for installing these dependencies:
 3. Install dependencies:
 
     ```bash
-    sudo apt install -y make git-all postgresql postgresql-contrib redis-server nginx libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io nodejs yarn
+    sudo apt install -y make git-all postgresql postgresql-contrib redis-server nginx libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io yarn
 
     # install golang-migrate (you must move the extracted binary into your $PATH)
     curl -L https://github.com/golang-migrate/migrate/releases/download/v4.7.0/migrate.linux-amd64.tar.gz | tar xvz
 
     # install comby (you must move the extracted binary into your $PATH)
     curl -L https://github.com/comby-tools/comby/releases/download/0.11.3/comby-0.11.3-x86_64-linux.tar.gz | tar xvz
+
+    # nvm (to manage Node.js)
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+
+    # in repo dir: install current recommendend version of Node JS
+    nvm install
     ```
 
 4. Configure startup services


### PR DESCRIPTION
Since we recently introduced a renovate-managed `.nvmrc` file, which is also the source of truth for CI, I think it's good to recommend using it in the local dev env either