### PR TITLE
MonacoQueryInput styling tweaks

### DIFF
--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -1,19 +1,15 @@
 .monaco-query-input-container {
     position: relative;
     border: 1px solid $input-border-color;
-    box-sizing: border-box;
+    // Match padding from the regular query input.
+    padding-left: 0.75rem;
+    background-color: #0e121b;
+    display: flex;
+    align-items: center;
     &:focus-within {
         border: 1px solid $input-focus-border-color;
         box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
     }
-
-    &__toggles {
-        position: absolute;
-        right: 0.25rem;
-        top: 0.25rem;
-        display: flex;
-    }
-
     .monaco-editor {
         // stylelint-disable-next-line selector-class-pattern
         .decorationsOverviewRuler {
@@ -31,9 +27,25 @@
             width: 100% !important;
         }
         .monaco-editor-hover-content {
+            padding: 0.25rem;
             .status-bar {
                 display: none;
             }
         }
+        // Override our :focus-visible style, which gets applied to the textarea
+        // Monaco uses for accessibility, and displays a tiny box shadow above the cursor otherwise.
+        .inputarea.focus-visible {
+            box-shadow: none;
+        }
+    }
+
+    &__regexp-toggle {
+        padding-right: 0.25rem;
+    }
+}
+
+.theme-light {
+    .monaco-query-input-container {
+        background-color: #ffffff;
     }
 }

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -54,41 +54,50 @@ function addSouregraphSearchCodeIntelligence(
     // Register themes and handle theme change
     monaco.editor.defineTheme('sourcegraph-dark', {
         base: 'vs-dark',
-        inherit: true,
+        inherit: false,
         colors: {
+            background: '#0E121B',
+            'textLink.activeBackground': '#2a3a51',
             'editor.background': '#0E121B',
-            'editor.foreground': '#ffffff',
+            'editor.foreground': '#f2f4f8',
             'editorCursor.foreground': '#ffffff',
-            'editor.selectionBackground': '#1C7CD650',
-            'editor.selectionHighlightBackground': '#1C7CD625',
-            'editor.inactiveSelectionBackground': '#1C7CD625',
             'editorSuggestWidget.background': '#1c2736',
             'editorSuggestWidget.foreground': '#F2F4F8',
+            'editorSuggestWidget.highlightForeground': '#569cd6',
+            'editorSuggestWidget.selectedBackground': '#2a3a51',
+            'list.hoverBackground': '#2a3a51',
             'editorSuggestWidget.border': '#2b3750',
             'editorHoverWidget.background': '#1c2736',
             'editorHoverWidget.foreground': '#F2F4F8',
             'editorHoverWidget.border': '#2b3750',
         },
-        rules: [],
+        rules: [
+            { token: 'identifier', foreground: '#f2f4f8' },
+            { token: 'keyword', foreground: '#569cd6' },
+        ],
     })
     monaco.editor.defineTheme('sourcegraph-light', {
         base: 'vs',
-        inherit: true,
+        inherit: false,
         colors: {
+            background: '#ffffff',
             'editor.background': '#ffffff',
             'editor.foreground': '#2b3750',
             'editorCursor.foreground': '#2b3750',
-            'editor.selectionBackground': '#1C7CD650',
-            'editor.selectionHighlightBackground': '#1C7CD625',
-            'editor.inactiveSelectionBackground': '#1C7CD625',
             'editorSuggestWidget.background': '#ffffff',
             'editorSuggestWidget.foreground': '#2b3750',
             'editorSuggestWidget.border': '#cad2e2',
+            'editorSuggestWidget.highlightForeground': '#268bd2',
+            'editorSuggestWidget.selectedBackground': '#f2f4f8',
+            'list.hoverBackground': '#f2f4f8',
             'editorHoverWidget.background': '#ffffff',
             'editorHoverWidget.foreground': '#2b3750',
             'editorHoverWidget.border': '#cad2e2',
         },
-        rules: [],
+        rules: [
+            { token: 'identifier', foreground: '#2b3750' },
+            { token: 'keyword', foreground: '#268bd2' },
+        ],
     })
     subscriptions.add(
         themeChanges.subscribe(theme => {
@@ -152,7 +161,9 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
         const options: Monaco.editor.IEditorOptions = {
             readOnly: false,
             lineNumbers: 'off',
-            lineHeight: 32,
+            lineHeight: 16,
+            // Match the query input's height for suggestion items line height.
+            suggestLineHeight: 34,
             minimap: {
                 enabled: false,
             },
@@ -171,31 +182,34 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
             quickSuggestions: false,
             fixedOverflowWidgets: true,
             contextmenu: false,
+            // Display the cursor as a 1px line.
+            cursorStyle: 'line',
+            cursorWidth: 1,
         }
         return (
             <div ref={this.setContainerRef} className="monaco-query-input-container flex-1">
-                <MonacoEditor
-                    id="monaco-query-input"
-                    language={SOURCEGRAPH_SEARCH}
-                    value={this.props.queryState.query}
-                    height={34}
-                    theme="sourcegraph-dark"
-                    editorWillMount={this.editorWillMount}
-                    onEditorCreated={this.onEditorCreated}
-                    options={options}
-                    border={false}
-                ></MonacoEditor>
-                <div className="monaco-query-input-container__toggles">
-                    <CaseSensitivityToggle
-                        {...this.props}
-                        navbarSearchQuery={this.props.queryState.query}
-                    ></CaseSensitivityToggle>
-                    <RegexpToggle
-                        {...this.props}
-                        navbarSearchQuery={this.props.queryState.query}
-                        className="monaco-query-input-container__regexp-toggle"
-                    ></RegexpToggle>
+                <div className="flex-1">
+                    <MonacoEditor
+                        id="monaco-query-input"
+                        language={SOURCEGRAPH_SEARCH}
+                        value={this.props.queryState.query}
+                        height={16}
+                        theme="sourcegraph-dark"
+                        editorWillMount={this.editorWillMount}
+                        onEditorCreated={this.onEditorCreated}
+                        options={options}
+                        border={false}
+                    ></MonacoEditor>
                 </div>
+                <CaseSensitivityToggle
+                    {...this.props}
+                    navbarSearchQuery={this.props.queryState.query}
+                ></CaseSensitivityToggle>
+                <RegexpToggle
+                    {...this.props}
+                    navbarSearchQuery={this.props.queryState.query}
+                    className="monaco-query-input-container__regexp-toggle"
+                ></RegexpToggle>
             </div>
         )
     }

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -33,7 +33,7 @@ export class SearchNavbarItem extends React.PureComponent<Props> {
     public render(): React.ReactNode {
         return (
             <Form
-                className="search search--navbar-item d-flex align-items-start flex-grow-1"
+                className="search search--navbar-item d-flex align-items-flex-start flex-grow-1"
                 onSubmit={this.onFormSubmit}
             >
                 {this.props.smartSearchField ? (


### PR DESCRIPTION
Some UI polish on the Monaco query input. Screenshots in `Details`.

- Use the keyword color from our regular syntax highlighting themes to highlight filters, and the regular query input color for the rest of the text.
- Tweak suggestions widget colors to better match our light and dark themes.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/72883352-70366d00-3d04-11ea-87c4-6e653a139bfa.png"/>
    <img src="https://user-images.githubusercontent.com/1741180/72883363-74fb2100-3d04-11ea-8843-16591cc5ac67.png"/>
    <img src="https://user-images.githubusercontent.com/1741180/72883366-775d7b00-3d04-11ea-93f5-b76c8b12ceb5.png"/>
    <img src="https://user-images.githubusercontent.com/1741180/72883373-7a586b80-3d04-11ea-812e-dda8868dbf4c.png"/>
</details>

- Fix off-by-1px height difference between the query input and surrounding UI elements.
- Match padding-left from the regular query input (previously had no padding).
- Cursor is thinner, and longer takes the full height of the input.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/72883289-54cb6200-3d04-11ea-8cf0-558ff2e55f80.png"/>
    <img src="https://user-images.githubusercontent.com/1741180/72883312-5eed6080-3d04-11ea-847a-aaa2ac2ff81e.png"/>
</details>

- Don't use absolute positioning for in-field toggles to avoids conflict with query text.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/72883239-411ffb80-3d04-11ea-8d6d-8bcd0c076249.png"/>
</details>

- Don't display a box shadow around Monaco's `.inputarea` element, fixes a small visual blip above the cursor position.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/72883253-4715dc80-3d04-11ea-95b3-89db32feb579.png"/>
</details>