### PR TITLE
Remove mention of "external services" and use "sync" consistently

### DIFF
--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -214,7 +214,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                 </DropdownToggle>
 
                 <DropdownMenu right={true} className="status-messages-nav-item__dropdown-menu">
-                    <h3>External service status</h3>
+                    <h3>Code host status</h3>
                     {isErrorLike(this.state.messagesOrError) ? (
                         <ErrorAlert
                             className="status-messages-nav-item__entry mb-0"
@@ -226,10 +226,10 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     ) : (
                         <StatusMessagesNavItemEntry
                             title="Repositories up to date"
-                            text="All repositories hosted on the configured code hosts are cloned."
+                            text="All repositories hosted on the configured code hosts are synced."
                             showLink={this.props.isSiteAdmin}
                             linkTo="/site-admin/external-services"
-                            linkText="Configure synced repositories"
+                            linkText="Manage repositories"
                             linkOnClick={this.toggleIsOpen}
                             entryType="success"
                         />

--- a/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-success"
@@ -36,7 +36,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
         Repositories up to date
       </h4>
       <p>
-        All repositories hosted on the configured code hosts are cloned.
+        All repositories hosted on the configured code hosts are synced.
       </p>
     </div>
   </div>
@@ -67,7 +67,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-progress"
@@ -110,7 +110,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-progress"
@@ -163,7 +163,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"
@@ -206,7 +206,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"
@@ -259,7 +259,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"
@@ -302,7 +302,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
     tabIndex="-1"
   >
     <h3>
-      External service status
+      Code host status
     </h3>
     <div
       className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -154,8 +154,8 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
                     <h2 className="mb-0">Repositories</h2>
                 </div>
                 <p>
-                    Repositories are mirrored from connected{' '}
-                    <Link to="/site-admin/external-services">external services</Link>.
+                    Repositories are synced from connected{' '}
+                    <Link to="/site-admin/external-services">code host connections</Link>.
                 </p>
                 <FilteredRepositoryConnection
                     className="list-group list-group-flush mt-3"


### PR DESCRIPTION
These were two things that caught my eye after the introducing of the
new "Manage repositories" entry in the sidebar with the changed naming,
where "external services" doesn't show up.

Changes:

- Use "Code host"/"Code host connection" instead of "External service"
- Use "sync" consistently (we had a stray "mirror") somewhere
- Use "Manage repositories" (as it's called in the admin side bar) instead of "Configure synced repositories"

Before:

<img width="1214" alt="Screen Shot 2020-01-22 at 11 42 35" src="https://user-images.githubusercontent.com/1185253/72887856-c4dde600-3d0c-11ea-8426-9049c4d6302c.png">

After:

<img width="1004" alt="Screen Shot 2020-01-22 at 11 43 25" src="https://user-images.githubusercontent.com/1185253/72887872-cc04f400-3d0c-11ea-948c-324cb92939d4.png">
