### PR TITLE
LSIF: Add stats endpoint to lsif-server.

### DIFF
--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -15,6 +15,18 @@ tags:
   - name: Uploads
     description: Upload operations
 paths:
+  /stats:
+    get:
+      description: Get common usage statistics.
+      tags:
+        - Stats
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stats'
   /upload:
     post:
       description: Upload LSIF data for a particular commit and directory. Exactly one file must be uploaded, and it is assumed to be the gzipped output of an LSIF indexer.
@@ -405,6 +417,30 @@ paths:
           description: Not Found
 components:
   schemas:
+    Stats:
+      type: object
+      description: Common usage statistics.
+      properties:
+        mostRecentUploads:
+          type: array
+          description: A list of upload dates for each distinct repository.
+          items:
+            type: object
+            description: The most recent upload date for each distinct repository.
+            properties:
+              repositoryId:
+                type: number
+                description: The repository identifier.
+              uploadedAt:
+                type: string
+                description: An ISO 8601-formatted time that the upload was uploaded.
+            required:
+              - repositoryId
+              - uploadedAt
+            additionalProperties: false
+      required:
+        - mostRecentUploads
+      additionalProperties: false
     Position:
       type: object
       description: A cursor position in a source file.

--- a/lsif/src/server/routes/meta.ts
+++ b/lsif/src/server/routes/meta.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import promClient from 'prom-client'
 
 /**
- * Create a router containing health endpoint.
+ * Create a router containing the health and metric endpoints.
  */
 export function createMetaRouter(): express.Router {
     const router = express.Router()

--- a/lsif/src/server/routes/stats.ts
+++ b/lsif/src/server/routes/stats.ts
@@ -1,0 +1,16 @@
+import express from 'express'
+import { UploadManager } from '../../shared/store/uploads'
+
+/**
+ * Create a router containing the stats endpoint.
+ *
+ * @param uploadManager The uploads manager instance.
+ */
+export function createStatsRouter(uploadManager: UploadManager): express.Router {
+    const router = express.Router()
+    router.get('/stats', async (_, res) => {
+        res.send({ mostRecentUploads: await uploadManager.mostRecentUploads() })
+    })
+
+    return router
+}

--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -24,6 +24,7 @@ import { waitForConfiguration } from '../shared/config/config'
 import { DumpManager } from '../shared/store/dumps'
 import { DependencyManager } from '../shared/store/dependencies'
 import { SRC_FRONTEND_INTERNAL } from '../shared/config/settings'
+import { createStatsRouter } from './routes/stats'
 
 /**
  * Runs the HTTP server that accepts LSIF dump uploads and responds to LSIF requests.
@@ -84,6 +85,7 @@ async function main(logger: Logger): Promise<void> {
 
     // Register endpoints
     app.use(createMetaRouter())
+    app.use(createStatsRouter(uploadManager))
     app.use(createUploadRouter(uploadManager))
     app.use(createLsifRouter(backend, uploadManager, logger, tracer))
 

--- a/lsif/src/shared/store/uploads.ts
+++ b/lsif/src/shared/store/uploads.ts
@@ -38,6 +38,19 @@ export class UploadManager {
     }
 
     /**
+     * Return the most recent upload date for an LSIF for every repository.
+     */
+    public mostRecentUploads(): Promise<{ repositoryId: number; uploadedAt: Date }[]> {
+        return this.connection
+            .getRepository(pgModels.LsifUpload)
+            .createQueryBuilder()
+            .select('repository_id', 'repositoryId')
+            .addSelect('max(uploaded_at)', 'uploadedAt')
+            .groupBy('repository_id')
+            .getRawMany()
+    }
+
+    /**
      * Get the uploads in the given state.
      *
      * @param repositoryId The repository identifier.


### PR DESCRIPTION
Add a /stats endpoint to the lsif-server that returns (for now) the time of latest activity for each repository. This will be used in the frontend to implement pings for [RFC 100](https://docs.google.com/document/d/1YVCpWhjWx0fn304vBcsqPkG3ckGNykR1fqWgXv1ckwI).