### PR TITLE
Remove deprecated __backcompatContents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - All repository fields related to `enabled` and `disabled` have been removed from the GraphQL API. These fields have been deprecated since 3.4. [#3971](https://github.com/sourcegraph/sourcegraph/pull/3971)
+- The deprecated extension API `Hover.__backcompatContents` was removed.
 
 ## 3.12.0 (unreleased)
 

--- a/packages/@sourcegraph/extension-api-types/src/hover.d.ts
+++ b/packages/@sourcegraph/extension-api-types/src/hover.d.ts
@@ -6,7 +6,7 @@ import { Range } from './location'
  *
  * @see module:sourcegraph.Hover
  */
-export interface Hover extends Pick<sourcegraph.Hover, 'contents' | '__backcompatContents'> {
+export interface Hover extends Pick<sourcegraph.Hover, 'contents'> {
     /** The range that the hover applies to. */
     readonly range?: Range
 }

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -971,9 +971,6 @@ declare module 'sourcegraph' {
          */
         contents: MarkupContent
 
-        /** @deprecated */
-        __backcompatContents?: (MarkupContent | string | { language: string; value: string })[]
-
         /**
          * The range to which this hover applies. When missing, the editor will use the range at the current
          * position or the current position itself.

--- a/shared/src/api/client/types/hover.test.ts
+++ b/shared/src/api/client/types/hover.test.ts
@@ -9,16 +9,6 @@ describe('HoverMerged', () => {
         test('0 hovers', () => expect(fromHoverMerged([])).toBeNull())
         test('empty hovers', () => expect(fromHoverMerged([null, undefined])).toBeNull())
         test('empty string hovers', () => expect(fromHoverMerged([{ contents: { value: '' } }])).toBeNull())
-        test('backcompat {language, value}', () =>
-            expect(
-                fromHoverMerged([{ contents: 'z' as any, __backcompatContents: [{ language: 'l', value: 'x' }] }])
-            ).toEqual({
-                contents: [{ kind: MarkupKind.Markdown, value: '```l\nx\n```\n' }],
-            }))
-        test('backcompat string', () =>
-            expect(fromHoverMerged([{ contents: 'z' as any, __backcompatContents: ['x'] }])).toEqual({
-                contents: [{ kind: MarkupKind.Markdown, value: 'x' }],
-            }))
         test('1 MarkupContent', () =>
             expect(fromHoverMerged([{ contents: { kind: MarkupKind.Markdown, value: 'x' } }])).toEqual({
                 contents: [{ kind: MarkupKind.Markdown, value: 'x' }],

--- a/shared/src/api/client/types/hover.ts
+++ b/shared/src/api/client/types/hover.ts
@@ -4,9 +4,6 @@ import { Badged, Hover, MarkupContent } from 'sourcegraph'
 
 /** A hover that is merged from multiple Hover results and normalized. */
 export interface HoverMerged {
-    /**
-     * @todo Make this type *just* {@link MarkupContent} when all consumers are updated.
-     */
     contents: Badged<MarkupContent>[]
 
     range?: Range
@@ -25,34 +22,10 @@ export function fromHoverMerged(values: (Badged<Hover> | Badged<PlainHover> | nu
                     badge: result.badge,
                 })
             }
-            const __backcompatContents = result.__backcompatContents
-            if (__backcompatContents) {
-                for (const content of Array.isArray(__backcompatContents)
-                    ? __backcompatContents
-                    : [__backcompatContents]) {
-                    if (typeof content === 'string') {
-                        if (content) {
-                            contents.push({ value: content, kind: MarkupKind.Markdown, badge: result.badge })
-                        }
-                    } else if ('language' in content) {
-                        if (content.language && content.value) {
-                            contents.push({
-                                value: toMarkdownCodeBlock(content.language, content.value),
-                                kind: MarkupKind.Markdown,
-                                badge: result.badge,
-                            })
-                        }
-                    }
-                }
-            }
             if (result.range && !range) {
                 range = result.range
             }
         }
     }
     return contents.length === 0 ? null : range ? { contents, range } : { contents }
-}
-
-function toMarkdownCodeBlock(language: string, value: string): string {
-    return '```' + language + '\n' + value + '\n```\n'
 }

--- a/shared/src/api/extension/api/types.ts
+++ b/shared/src/api/extension/api/types.ts
@@ -34,7 +34,6 @@ export function fromLocation(
 export function fromHover(hover: sourcegraph.Badged<sourcegraph.Hover>): sourcegraph.Badged<clientType.Hover> {
     return {
         contents: hover.contents,
-        __backcompatContents: hover.__backcompatContents,
         range: fromRange(hover.range),
         badge: hover.badge,
     }


### PR DESCRIPTION
This has not been used for a long time in any of our extensions and should not need to be considered for features like badges.