### PR TITLE
gitserver: limit size of stderr rather than truncate

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -198,7 +198,7 @@ var repoRemoteURL = func(ctx context.Context, dir GitDir) (string, error) {
 	return remoteURLs[0], nil
 }
 
-// writeCounter wraps an io.WriterCloser and keeps track of bytes written.
+// writeCounter wraps an io.Writer and keeps track of bytes written.
 type writeCounter struct {
 	w io.Writer
 	// n is the number of bytes written to w
@@ -209,6 +209,30 @@ func (c *writeCounter) Write(p []byte) (n int, err error) {
 	n, err = c.w.Write(p)
 	c.n += int64(n)
 	return
+}
+
+// limitWriter is a io.Writer that writes to an W but discards after N bytes.
+type limitWriter struct {
+	W io.Writer // underling writer
+	N int       // max bytes remaining
+}
+
+func (l *limitWriter) Write(p []byte) (int, error) {
+	if l.N <= 0 {
+		return len(p), nil
+	}
+	origLen := len(p)
+	if len(p) > l.N {
+		p = p[:l.N]
+	}
+	n, err := l.W.Write(p)
+	l.N -= n
+	if l.N <= 0 {
+		// If we have written limit bytes, then we can include the discarded
+		// part of p in the count.
+		n = origLen
+	}
+	return n, err
 }
 
 // flushingResponseWriter is a http.ResponseWriter that flushes all writes


### PR DESCRIPTION
We only look at the first 1024 bytes of stderr. However, we buffer the whole
of stderr into a bytes.Buffer first, and then truncate it. This commit instead
implements a limitWriter (like an io.LimitReader) which discards all writes
after 1024 bytes.
