### PR TITLE
docs: gitlab: add an explanation for required access token scope

### DIFF
--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -67,7 +67,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 ## Access token scopes
 
-Sourcegraph requires an access token with `api` permissions (and `sudo`, if you are using an `external` identity provider type). Below is an explanation for why we require this scope instead of e.g. just `read_user`, and what we may also use the access token for in the future.
+Sourcegraph requires an access token with `api` permissions (and `sudo`, if you are using an `external` identity provider type). These permissions are required for the following reasons:
 
 We are actively collaborating with GitLab to improve our integration (e.g. the [Sourcegraph GitLab native integration](https://docs.gitlab.com/ee/integration/sourcegraph.html) and [better APIs for querying repository permissions](https://gitlab.com/gitlab-org/gitlab/issues/20532)).
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -82,5 +82,5 @@ We are actively collaborating with GitLab to improve our integration (e.g. the [
 Sourcegraph in the future may do more with the provided access token as well, including:
 
 - Enabling Sourcegraph site-admins to perform large-scale code refactors, with Sourcegraph issuing and managing the merge requests on GitLab repositories, company-wide.
-- Using more efficient APIs to get repository and user permissions from GitLab more efficiently. We are actively working with GitLab to make this more efficient and use fewer requests, see https://gitlab.com/gitlab-org/gitlab/issues/20532
+- More efficient usage of GitLab APIs for fetching repository and user permissions, and we are [actively working with GitLab](https://gitlab.com/gitlab-org/gitlab/issues/20532) on these improvements.
 - Improving the GitLab native integration and Sourcegraph browser extension integration: https://docs.gitlab.com/ee/integration/sourcegraph.html

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -81,6 +81,6 @@ We are actively collaborating with GitLab on multiple fronts to improve our inte
 
 Sourcegraph in the future may do more with the provided access token as well, including:
 
-- Allowing your Sourcegraph site-admins to perform large-scale code refactors, with Sourcegraph issuing and managing merge requests against your repositories on GitLab (only at your request as a Sourcegraph admin, of course).
+- Enabling Sourcegraph site-admins to perform large-scale code refactors, with Sourcegraph issuing and managing the merge requests on GitLab repositories, company-wide.
 - Using more efficient APIs to get repository and user permissions from GitLab more efficiently. We are actively working with GitLab to make this more efficient and use fewer requests, see https://gitlab.com/gitlab-org/gitlab/issues/20532
 - Improving the GitLab native integration and Sourcegraph browser extension integration: https://docs.gitlab.com/ee/integration/sourcegraph.html

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -69,7 +69,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 Sourcegraph requires an access token with `api` permissions (and `sudo`, if you are using an `external` identity provider type). Below is an explanation for why we require this scope instead of e.g. just `read_user`, and what we may also use the access token for in the future.
 
-We are actively collaborating with GitLab on multiple fronts to improve our integration with them (e.g. through our [GitLab native integration](https://docs.gitlab.com/ee/integration/sourcegraph.html) and [working torwards better APIs Sourcegraph could use for querying repository permissions](https://gitlab.com/gitlab-org/gitlab/issues/20532)), so if you have any feedback please let us know!
+We are actively collaborating with GitLab to improve our integration (e.g. the [Sourcegraph GitLab native integration](https://docs.gitlab.com/ee/integration/sourcegraph.html) and [better APIs for querying repository permissions](https://gitlab.com/gitlab-org/gitlab/issues/20532)).
 
 | Request Type | Required GitLab scope | Sourcegraph usage |
 |--------------|-----------------------|-------------------|

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -78,9 +78,4 @@ We are actively collaborating with GitLab to improve our integration (e.g. the [
 | [`GET /users/:id`](https://docs.gitlab.com/ee/api/users.html#single-user) | `read_user` or `api` | If using GitLab OAuth, used to fetch user metadata during the OAuth sign in process. |
 | [`GET /projects/:id`](https://docs.gitlab.com/ee/api/projects.html#get-single-project) | `api` | (1) If using GitLab OAuth and repository permissions, used to determine if a user has access to a given _project_; (2) Used to query repository metadata (e.g. description) for display on Sourcegraph. |
 | [`GET /projects/:id/repository/tree`](https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree) | `api` | If using GitLab OAuth and repository permissions, used to verify a given user has access to the file contents of a repository within a project (i.e. does not merely have `Guest` permissions). |
-
-Sourcegraph in the future may do more with the provided access token as well, including:
-
-- Enabling Sourcegraph site-admins to perform large-scale code refactors, with Sourcegraph issuing and managing the merge requests on GitLab repositories, company-wide.
-- More efficient usage of GitLab APIs for fetching repository and user permissions, and we are [actively working with GitLab](https://gitlab.com/gitlab-org/gitlab/issues/20532) on these improvements.
-- Improving the GitLab native integration and Sourcegraph browser extension integration: https://docs.gitlab.com/ee/integration/sourcegraph.html
+| (future) write access | `api` | graph site-admins (only) to perform large-scale code refactors, with Sourcegraph issuing and managing the merge requests on GitLab repositories, company-wide. |


### PR DESCRIPTION
A customer asked me why we need an `api` scoped access token, since according to GitLab's docs this:

> Grants complete read/write access to the API, including all groups and projects, the container registry, and the package registry.

I did a deep dive to find the answers here, and this PR adds a section to our docs that explains it in detail while still remaining future-proof (so hopefully it doesn't become too out of date in the distant future).