### PR TITLE
Move escape-hatch /site-config.json -> $HOME/site-config.json

### DIFF
--- a/doc/admin/config/site_config.md
+++ b/doc/admin/config/site_config.md
@@ -41,25 +41,25 @@ If you are having trouble accessing the web UI, you can make edits to your site 
 #### Single-container Docker instances
 
 ```sh
-docker exec -it $CONTAINER -- sh -c 'apk add --no-cache nano && nano /site-config.json'
+docker exec -it $CONTAINER sh -c 'apk add --no-cache nano && nano ~/site-config.json'
 ```
 
 Or if you prefer using a Vim editor:
 
 ```sh
-docker exec -it $CONTAINER -- vi /site-config.json
+docker exec -it $CONTAINER sh -c 'vi ~/site-config.json'
 ```
 
 #### Kubernetes cluster instances
 
 ```sh
-kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano /site-config.json'
+kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano ~/site-config.json'
 ```
 
 Or if you prefer using a Vim editor:
 
 ```sh
-kubectl exec -it $FRONTEND_POD -- vi /site-config.json
+kubectl exec -it $FRONTEND_POD -- sh -c 'vi ~/site-config.json'
 ```
 
 Then simply save your changes (type <kbd>ctrl+x</kbd> and <kbd>y</kbd> to exit `nano` and save your changes). Your changes will be applied immediately in the same was as if you had made them through the web UI.

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -173,7 +173,7 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 // edit computation.
 var FormatOptions = jsonx.FormatOptions{InsertSpaces: true, TabSize: 2, EOL: "\n"}
 
-var siteConfigEscapeHatchPath = env.Get("SITE_CONFIG_ESCAPE_HATCH_PATH", "/site-config.json", "Path where the site-config.json escape-hatch file will be written.")
+var siteConfigEscapeHatchPath = env.Get("SITE_CONFIG_ESCAPE_HATCH_PATH", "$HOME/site-config.json", "Path where the site-config.json escape-hatch file will be written.")
 
 // startSiteConfigEscapeHatchWorker handles ensuring that edits to the ephemeral on-disk
 // site-config.json file are propagated to the persistent DB and vice-versa. This acts as
@@ -181,6 +181,8 @@ var siteConfigEscapeHatchPath = env.Get("SITE_CONFIG_ESCAPE_HATCH_PATH", "/site-
 // cannot access the UI (for example by configuring auth in a way that locks them out)
 // they can simply edit this file in any of the frontend containers to undo the change.
 func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
+	siteConfigEscapeHatchPath = os.ExpandEnv(siteConfigEscapeHatchPath)
+
 	var (
 		ctx                                        = context.Background()
 		lastKnownFileContents, lastKnownDBContents string


### PR DESCRIPTION
This changes the default location of the ephemeral `site-config.json` escape hatch file from `/site-config.json` to `$HOME/site-config.json` which is compatible with running our containers as a non-root user.

Fixes #7873

Before, the file location was incompatible with non-`root` container users:

```
$ docker run -it --entrypoint=sh sourcegraph/frontend:3.11.0 -c "whoami && echo 'test' > /site-config.json"
sourcegraph
sh: can't create /site-config.json: Permission denied
```

After, it is compatible:

```
$ docker run -it --entrypoint=sh sourcegraph/server:3.11.0 -c 'whoami && cd $HOME && pwd && echo "test" > ./site-config.json'
root
/root
```

```
$ docker run -it --entrypoint=sh sourcegraph/frontend:3.11.0 -c 'whoami && cd $HOME && pwd && echo "test" > ./site-config.json'
sourcegraph
/home/sourcegraph
```

- We do not use `/etc/sourcegraph/` since configuration under `/etc` is not usually ephemeral, and because site admins of `server` instances sometimes mount their own directory for SSH configuration into there, and the presence of `site-config.json` would mislead them (they may edit it, only to have it overwritten with the DB contents).
- We do not use another location like `/mnt/cache` (suggested to me by someone else) because the owner would be different in Kubernetes and Server contexts, making the problem more complex.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
