### PR TITLE
a8n: Rename previewCampaignPlan to createCampaignPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- The GraphQL mutation `previewCampaignPlan` has been renamed to `createCampaignPlan`. This mutation is part of Automation, which is still in beta and behind a feature flag and thus subject to possible breaking changes while we still work on it.
+
 ### Fixed
 
 ### Removed

--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -38,7 +38,7 @@ type UpdateCampaignArgs struct {
 	}
 }
 
-type PreviewCampaignPlanArgs struct {
+type CreateCampaignPlanArgs struct {
 	Specification struct {
 		Type      string
 		Arguments JSONCString
@@ -106,7 +106,7 @@ type A8NResolver interface {
 
 	AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error)
 
-	PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error)
+	CreateCampaignPlan(ctx context.Context, args CreateCampaignPlanArgs) (CampaignPlanResolver, error)
 	CreateCampaignPlanFromPatches(ctx context.Context, args CreateCampaignPlanFromPatchesArgs) (CampaignPlanResolver, error)
 	CampaignPlanByID(ctx context.Context, id graphql.ID) (CampaignPlanResolver, error)
 	CancelCampaignPlan(ctx context.Context, args CancelCampaignPlanArgs) (*EmptyResponse, error)
@@ -123,11 +123,11 @@ func (r *schemaResolver) AddChangesetsToCampaign(ctx context.Context, args *AddC
 	return EnterpriseResolvers.a8nResolver.AddChangesetsToCampaign(ctx, args)
 }
 
-func (r *schemaResolver) PreviewCampaignPlan(ctx context.Context, args PreviewCampaignPlanArgs) (CampaignPlanResolver, error) {
+func (r *schemaResolver) CreateCampaignPlan(ctx context.Context, args CreateCampaignPlanArgs) (CampaignPlanResolver, error) {
 	if EnterpriseResolvers.a8nResolver == nil {
 		return nil, a8nOnlyInEnterprise
 	}
-	return EnterpriseResolvers.a8nResolver.PreviewCampaignPlan(ctx, args)
+	return EnterpriseResolvers.a8nResolver.CreateCampaignPlan(ctx, args)
 }
 
 func (r *schemaResolver) CreateCampaignPlanFromPatches(ctx context.Context, args CreateCampaignPlanFromPatchesArgs) (CampaignPlanResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -41,12 +41,14 @@ type Mutation {
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
     # Create a campaign in a namespace. The newly created campaign is returned.
     createCampaign(input: CreateCampaignInput!): Campaign!
-    # Preview the plan for a campaign, including its diff.
+    # Create and preview the plan for a campaign. A plan is a collection of
+    # patches the Campaign would create as changesets on code hosts once
+    # created.
     # The returned CampaignPlan can be referred to when creating the campaign.
     # It is cached with a short TTL.
     # The campaign plan is computed asynchronously.
     # Check its status property and query it by its id to see its latest state.
-    previewCampaignPlan(
+    createCampaignPlan(
         specification: CampaignPlanSpecification!
         # Whether to wait to finish computing the plan before returning.
         # If false, callers must poll the CampaignPlan using its node ID to track progress and get results.
@@ -63,7 +65,7 @@ type Mutation {
         # created from this campaign plan.
         patches: [CampaignPlanPatch!]!
     ): CampaignPlan!
-    # Cancel a campaign plan that is being generated.
+    # Cancel the creation of a campaign plan.
     # Cancellation expresses a desinterest in the campaign plan and is best-effort.
     # It may not be relied upon.
     # The return of this mutation does not mean the plan was fully cancelled yet,
@@ -477,7 +479,7 @@ input CreateCampaignInput {
     # If null, existing changesets can be added manually.
     # If set, no changesets can be added manually, they will be created by Sourcegraph
     # after creating the campaign according to the precomputed campaign plan.
-    # Will error if the plan has been purged already and needs to be recomputed by another call to previewCampaignPlan.
+    # Will error if the plan has been purged already and needs to be recomputed by another call to createCampaignPlan.
     # Will error if the plan is not completed yet.
     # Using a campaign plan for a campaign will retain it for the lifetime of the campaign and prevents it from being purged.
     plan: ID
@@ -507,7 +509,8 @@ input UpdateCampaignInput {
     plan: ID
 }
 
-# A preview of changes that will be applied by a campaign.
+# A collection of proposed changesets with patches that will be turned into
+# real changesets on code hosts by a Campaign.
 # It is chached and addressable by its ID for a limited amount of time.
 type CampaignPlan implements Node {
     # The unique ID of this campaign plan.

--- a/doc/dev/automation_development.md
+++ b/doc/dev/automation_development.md
@@ -32,7 +32,7 @@ Automation introduces a lot of new names, GraphQL queries and mutations and data
 1. Read through `./cmd/frontend/graphqlbackend/a8n.go` to get an overview of the Automation GraphQL API.
 1. Read through `./internal/a8n/types.go` to see all Automation related type definitions.
 1. Compare that with the GraphQL definitions in `./cmd/frontend/graphqlbackend/schema.graphql`.
-1. Start reading through `./enterprise/internal/a8n/resolvers/resolver.go` to see how the main mutation are implemented (look at `previewCampaignPlan` and `createCampaign` to see how the two main operations are implemented).
+1. Start reading through `./enterprise/internal/a8n/resolvers/resolver.go` to see how the main mutation are implemented (look at `createCampaignPlan` and `createCampaign` to see how the two main operations are implemented).
 1. Then start from the other end, `enterprise/cmd/repo-updater/main.go`, and see how the enterprise `repo-updater` uses `a8n.Syncer` to sync `Changesets`.
 
 ## GitHub testing account

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -469,9 +469,9 @@ func (r *Resolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionA
 	}, nil
 }
 
-func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.PreviewCampaignPlanArgs) (graphqlbackend.CampaignPlanResolver, error) {
+func (r *Resolver) CreateCampaignPlan(ctx context.Context, args graphqlbackend.CreateCampaignPlanArgs) (graphqlbackend.CampaignPlanResolver, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "Resolver.PreviewCampaignPlan", args.Specification.Type)
+	tr, ctx := trace.New(ctx, "Resolver.CreateCampaignPlan", args.Specification.Type)
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -15,7 +15,7 @@ import {
     updateCampaign,
     deleteCampaign,
     createCampaign,
-    previewCampaignPlan,
+    createCampaignPlan,
     fetchCampaignPlanById,
     CampaignType,
     retryCampaign,
@@ -153,15 +153,15 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         return unblockHistoryRef.current
     }, [campaignID, history])
 
-    const previewCampaignPlans = useMemo(() => new Subject<GQL.ICampaignPlanSpecification | GQL.ID>(), [])
-    const nextPreviewCampaignPlan = useCallback(previewCampaignPlans.next.bind(previewCampaignPlans), [
-        previewCampaignPlans,
+    const createCampaignPlans = useMemo(() => new Subject<GQL.ICampaignPlanSpecification | GQL.ID>(), [])
+    const nextCreateCampaignPlan = useCallback(createCampaignPlans.next.bind(createCampaignPlans), [
+        createCampaignPlans,
     ])
     const [isLoadingPreview, setIsLoadingPreview] = useState<boolean>(false)
     useObservable(
         useMemo(
             () =>
-                previewCampaignPlans.pipe(
+                createCampaignPlans.pipe(
                     tap(() => {
                         setAlertError(undefined)
                         setIsLoadingPreview(true)
@@ -170,7 +170,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                     switchMap(plan =>
                         typeof plan === 'string'
                             ? fetchCampaignPlanById(plan)
-                            : previewCampaignPlan(plan, false).pipe(
+                            : createCampaignPlan(plan, false).pipe(
                                   tap(() => {
                                       setIsLoadingPreview(false)
                                   }),
@@ -201,16 +201,16 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         }
                     })
                 ),
-            [previewCampaignPlans, nextChangesetUpdate]
+            [createCampaignPlans, nextChangesetUpdate]
         )
     )
 
     const planID: GQL.ID | null = new URLSearchParams(location.search).get('plan')
     useEffect(() => {
         if (planID) {
-            nextPreviewCampaignPlan(planID)
+            nextCreateCampaignPlan(planID)
         }
-    }, [nextPreviewCampaignPlan, planID])
+    }, [nextCreateCampaignPlan, planID])
 
     // Tracks if a refresh of the campaignPlan is required before the campaign can be created
     const previewRefreshNeeded = useMemo(() => {
@@ -517,7 +517,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                     type="button"
                                     className="btn btn-primary mr-1 e2e-preview-campaign"
                                     disabled={!previewRefreshNeeded}
-                                    onClick={() => nextPreviewCampaignPlan(campaignPlanSpec)}
+                                    onClick={() => nextCreateCampaignPlan(campaignPlanSpec)}
                                 >
                                     {isLoadingPreview && <LoadingSpinner className="icon-inline mr-1" />}
                                     Preview changes

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -172,14 +172,14 @@ export async function createCampaign(input: ICreateCampaignInput): Promise<ICamp
     return dataOrThrowErrors(result).createCampaign
 }
 
-export function previewCampaignPlan(
+export function createCampaignPlan(
     specification: ICampaignPlanSpecification,
     wait: boolean = false
 ): Observable<ICampaignPlan> {
     return mutateGraphQL(
         gql`
-            mutation PreviewCampaignPlan($specification: CampaignPlanSpecification!, $wait: Boolean!) {
-                previewCampaignPlan(specification: $specification, wait: $wait) {
+            mutation CreateCampaignPlan($specification: CampaignPlanSpecification!, $wait: Boolean!) {
+                createCampaignPlan(specification: $specification, wait: $wait) {
                     ...CampaignPlanFields
                 }
             }
@@ -188,7 +188,7 @@ export function previewCampaignPlan(
         { specification, wait }
     ).pipe(
         map(dataOrThrowErrors),
-        map(mutation => mutation.previewCampaignPlan)
+        map(mutation => mutation.createCampaignPlan)
     )
 }
 


### PR DESCRIPTION
This is a breaking change I'm proposing to make understanding the API a
lot easier.

I ran into the problem of having to explain what "previewing a campaign
plan" means multiple times in the past few days. First, when explaining
Automation-related concepts to Ryan and Kevin, and then when working on
`src-cli` to add the ability to create `CampaignPlan`s and `Campaign`s.

In the end I realized that `previewCampaignPlan` is simply not as clear
as `createCampaignPlan`, which is what the mutation actually does: it
creates a `CampaignPlan` that can then be shared, previewed and used to
create a `Campaign`.

As I wrote in the CHANGELOG.md: I think we should use the time we're
still in beta and behind a feature flag to make these changes.

I might have more changes like this coming up.