### PR TITLE
Fix GitHub private repo detection

### DIFF
--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -291,8 +291,7 @@ export const githubCodeHost: CodeHost = {
     textFieldResolvers: [commentTextFieldResolver],
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: () => {
-        const header = document.querySelector('.repohead-details-container')
-        const repoHeaderHasPrivateMarker = !!header?.querySelector('.private')
+        const repoHeaderHasPrivateMarker = !!document.querySelector('.repohead .private')
         return {
             ...parseURL(),
             privateRepository: window.location.hostname !== 'github.com' || repoHeaderHasPrivateMarker,


### PR DESCRIPTION
GitHub's DOM has changed, breaking our detection of private repositories in the browser extension, which caused https://github.com/codecov/sourcegraph-codecov/issues/44.
