### PR TITLE
gitserver: log git error lines on dot-com

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -115,6 +116,10 @@ type Server struct {
 
 	// DiskSizer tells how much disk is free and how large the disk is.
 	DiskSizer DiskSizer
+
+	// TODO(keegancsmith) remove! Temporary logging to understand errors in
+	// production. https://github.com/sourcegraph/sourcegraph/issues/6676
+	StderrErrorLog *log.Logger
 
 	// skipCloneForTests is set by tests to avoid clones.
 	skipCloneForTests bool
@@ -682,6 +687,10 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	status = strconv.Itoa(exitStatus)
 	stdoutN = stdoutW.n
 	stderrN = stderrW.n
+
+	if s.StderrErrorLog != nil {
+		logErrors(s.StderrErrorLog.Printf, req.Repo, stderrBuf.Bytes())
+	}
 
 	// write trailer
 	w.Header().Set("X-Exec-Error", errorString(execErr))


### PR DESCRIPTION
We are unsure of how often and when git will include this output. So we are
going to log when it happens on Sourcegraph.com to get a feeling on our very
large cluster. From that we can move forward with a heuristic around automatic
repair.

Part of https://github.com/sourcegraph/sourcegraph/issues/6676