### PR TITLE
gitserver: ListCloned filters out repos that do not belong on shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- After adding/removing a gitserver replica the admin interface will correctly report that repositories that need to move replicas as cloning. [#7970](https://github.com/sourcegraph/sourcegraph/issues/7970)
+
 ### Removed
 
 - All repository fields related to `enabled` and `disabled` have been removed from the GraphQL API. These fields have been deprecated since 3.4. [#3971](https://github.com/sourcegraph/sourcegraph/pull/3971)


### PR DESCRIPTION
When rebalancing repositories across shards we can have a repository appearing
on a shard which doesn't belong there. ListCloned is used to report to Admins
which repos need to clone. This leads to not reporting any repos as needing
cloning when rebalancing. This commit updates ListCloned to filter out repos
that do not belong on a shard.

Note: Follow-up work is required to make our Purge job shard aware as well as
gracefully handle rebalancing.

Part of https://github.com/sourcegraph/sourcegraph/issues/2485
Fixes https://github.com/sourcegraph/sourcegraph/issues/7970