### PR TITLE
fix: search result match border missing

### DIFF
--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -24,6 +24,7 @@
 
         &-code-wrapper {
             position: relative;
+            border-bottom: solid 1px var(--border-color);
         }
 
         &-badge-row {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/7958

