### PR TITLE
Fix browser extension e2e command in CI

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -150,7 +150,7 @@ func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
 			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("pushd browser"),
 			bk.Cmd("yarn -s run build"),
-			bk.Cmd("yarn -s jest --runInBand ./e2e/github.test"),
+			bk.Cmd("yarn -s mocha ./src/e2e/github.test.ts"),
 			bk.Cmd("popd"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 	}


### PR DESCRIPTION
It still referenced Jest, but we now use Mocha.