### PR TITLE
remove myself as non-toplevel README.md owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -222,7 +222,7 @@ Dockerfile @sourcegraph/distribution
 /enterprise/cmd/frontend/internal/licensing @sourcegraph/distribution
 
 # Documentation and homepage
-README.md @sqs
+/README.md @sqs
 /doc/ @sourcegraph/distribution @ryan-blunden
 /doc/dev/ @nicksnyder
 


### PR DESCRIPTION
This is so I don't get assigned as a reviewer when files like dev/release/README.md change.