### PR TITLE
a8n: Temporarily disable the credentials campaign type

### DIFF
--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -487,6 +487,9 @@ func (r *Resolver) PreviewCampaignPlan(ctx context.Context, args graphqlbackend.
 	if typeName == "" {
 		return nil, errors.New("cannot create CampaignPlan without Type")
 	}
+	if typeName == "credentials" {
+		return nil, errors.New("unsupported campaign type")
+	}
 	campaignType, err := ee.NewCampaignType(typeName, specArgs, r.httpFactory)
 	if err != nil {
 		return nil, err

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -19,7 +19,7 @@ import {
 import { DiffStatFields, FileDiffHunkRangeFields, PreviewFileDiffFields, FileDiffFields } from '../../../backend/diff'
 import { Connection } from '../../../components/FilteredConnection'
 
-export type CampaignType = 'comby' | 'credentials'
+export type CampaignType = 'comby'
 
 const campaignFragment = gql`
     fragment CampaignFields on Campaign {

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
 import combyJsonSchema from '../../../../../../schema/campaign-types/comby.schema.json'
-import credentialsJsonSchema from '../../../../../../schema/campaign-types/credentials.schema.json'
 import { ThemeProps } from '../../../../../../shared/src/theme'
 import { MonacoSettingsEditor } from '../../../../settings/MonacoSettingsEditor'
 import { CampaignType } from '../backend'

--- a/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
+++ b/web/src/enterprise/campaigns/detail/form/CampaignPlanSpecificationFields.tsx
@@ -28,7 +28,6 @@ interface Props extends ThemeProps {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const jsonSchemaByType: { [K in CampaignType]: any } = {
     comby: combyJsonSchema,
-    credentials: credentialsJsonSchema,
 }
 
 const defaultInputByType: { [K in CampaignType]: string } = {
@@ -36,10 +35,6 @@ const defaultInputByType: { [K in CampaignType]: string } = {
     "scopeQuery": "repo:github.com/foo/bar",
     "matchTemplate": "",
     "rewriteTemplate": ""
-}`,
-    credentials: `{
-    "scopeQuery": "repo:github.com/foo/bar",
-    "matchers": [{ "type": "npm" }]
 }`,
 }
 

--- a/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/form/__snapshots__/CampaignPlanSpecificationFields.test.tsx.snap
@@ -29,11 +29,6 @@ exports[`CampaignPlanSpecificationFields has initial value and calls onChange 1`
         >
           Comby search and replace
         </option>
-        <option
-          value="credentials"
-        >
-          Find leaked credentials
-        </option>
       </select>
       <small
         className="ml-1"
@@ -132,11 +127,6 @@ exports[`CampaignPlanSpecificationFields manual type editable 1`] = `
           >
             Comby search and replace
           </option>
-          <option
-            value="credentials"
-          >
-            Find leaked credentials
-          </option>
         </select>
       </React.Fragment>
     </div>
@@ -196,11 +186,6 @@ exports[`CampaignPlanSpecificationFields non-manual type editable 1`] = `
             value="comby"
           >
             Comby search and replace
-          </option>
-          <option
-            value="credentials"
-          >
-            Find leaked credentials
           </option>
         </select>
         <small

--- a/web/src/enterprise/campaigns/detail/presentation.ts
+++ b/web/src/enterprise/campaigns/detail/presentation.ts
@@ -8,5 +8,4 @@ export const MANUAL_CAMPAIGN_TYPE = 'manual' as const
 export const campaignTypeLabels: Record<CampaignType | typeof MANUAL_CAMPAIGN_TYPE, string> = {
     [MANUAL_CAMPAIGN_TYPE]: 'Manual',
     comby: 'Comby search and replace',
-    credentials: 'Find leaked credentials',
 }


### PR DESCRIPTION
This change is intended to only be included in a patch release to work
around https://github.com/sourcegraph/sourcegraph/issues/7914


