### PR TITLE
Update versions in dev-sourcegraph-server.sh.

### DIFF
--- a/dev/dev-sourcegraph-server.sh
+++ b/dev/dev-sourcegraph-server.sh
@@ -7,6 +7,6 @@ set -ex
 # that this image is not exactly identical to the published sourcegraph/server
 # images, as those include Sourcegraph Enterprise features.
 time cmd/server/pre-build.sh
-IMAGE=sourcegraph/server:$USER-dev VERSION=$USER-dev time cmd/server/build.sh
+IMAGE=sourcegraph/server:0.0.0-DEVELOPMENT VERSION=0.0.0-DEVELOPMENT time cmd/server/build.sh
 
-IMAGE=sourcegraph/server:$USER-dev dev/run-server-image.sh
+IMAGE=sourcegraph/server:0.0.0-DEVELOPMENT dev/run-server-image.sh

--- a/enterprise/dev/dev-sourcegraph-server.sh
+++ b/enterprise/dev/dev-sourcegraph-server.sh
@@ -6,6 +6,6 @@ set -ex
 # Build a Sourcegraph server docker image with private code built in to run for
 # development purposes
 time cmd/server/pre-build.sh
-IMAGE=sourcegraph/server:$USER-dev-enterprise VERSION=$USER-dev-enterprise time cmd/server/build.sh
+IMAGE=sourcegraph/server:0.0.0-ENTERPRISE-DEVELOPMENT VERSION=0.0.0-ENTERPRISE-DEVELOPMENT time cmd/server/build.sh
 
-IMAGE=sourcegraph/server:$USER-dev-enterprise ../dev/run-server-image.sh
+IMAGE=sourcegraph/server:0.0.0-ENTERPRISE-DEVELOPMENT ../dev/run-server-image.sh


### PR DESCRIPTION
Alternate solution to https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/195.

Fixes an issue in basic code intel that expects a certain format for version strings: https://github.com/sourcegraph/sourcegraph/issues/7971.