### PR TITLE
Document BBS plugin experimental permission fetching

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -169,6 +169,8 @@ Permissions for each user are cached for the configured `ttl` duration (**3h** b
 
 The default `hardTTL` is **3 days**, after which a user's cached permissions must be updated before any user action can be authorized. While the update is happening an error is returned to the user. The default `hardTTL` value was chosen so that it reduces the chances of users being forced to wait for their permissions to be updated after a weekend of inactivity.
 
+There is also an experimental feature that allows for faster permissions fetching that can be enabled via the [Bitbucket Server Sourcegraph plugin](../../../integration/bitbucket_server.md).
+
 ---
 
 Finally, **save the configuration**. You're done!

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -36,6 +36,21 @@ This involves adding a new add-on to your Bitbucket Server instance and see the 
 }
 ```
 
+### Experimental Faster ACL permissions fetching
+
+The plugin also supports an experimental method of faster ACL permissions fetching that aims to improve search speed. You can enable this in the experimental section of the [site configuration](../admin/config/site_config.md):
+
+```json
+{
+  // ...
+  "experimentalFeatures": {
+    "bitbucketServerFastPerm": "enabled"
+  }
+  // ...
+}
+```
+The speed improvements are subtle and more noticable for larger instances with thousands of repositories. This may remove the occasional slow search that has incurred the overhead of refreshing expired permissions information.
+
 ## Browser extension
 
 The [Sourcegraph browser extension](browser_extension.md) supports Bitbucket Server. When installed in your web browser, it adds hover tooltips, go-to-definition, find-references, and code search to files and pull requests viewed on Bitbucket Server.


### PR DESCRIPTION
This PR documents the experimental ACL permission fetching feature of the Bitbucket Server Sourcegraph plugin.