### PR TITLE
Thread event properties to logEvent graphql call.

### DIFF
--- a/browser/src/shared/backend/userEvents.tsx
+++ b/browser/src/shared/backend/userEvents.tsx
@@ -49,7 +49,7 @@ export const logUserEvent = (
  * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
  */
 export const logEvent = (
-    event: { name: string; userCookieID: string; url: string },
+    event: { name: string; userCookieID: string; url: string; argument?: string },
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
     // Only send the request if this is a private, self-hosted Sourcegraph instance.
@@ -59,8 +59,14 @@ export const logEvent = (
 
     requestGraphQL<GQL.IMutation>({
         request: gql`
-            mutation logEvent($name: String!, $userCookieID: String!, $url: String!, $source: EventSource!) {
-                logEvent(event: $name, userCookieID: $userCookieID, url: $url, source: $source) {
+            mutation logEvent(
+                $name: String!
+                $userCookieID: String!
+                $url: String!
+                $source: EventSource!
+                $argument: String
+            ) {
+                logEvent(event: $name, userCookieID: $userCookieID, url: $url, source: $source, argument: $argument) {
                     alwaysNil
                 }
             }
@@ -68,6 +74,7 @@ export const logEvent = (
         variables: {
             ...event,
             source: GQL.EventSource.CODEHOSTINTEGRATION,
+            argument: event.argument && JSON.stringify(event.argument),
         },
         mightContainPrivateInfo: false,
     }).subscribe({

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -70,11 +70,18 @@ export class EventLogger implements TelemetryService {
      *
      * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
      */
-    public async logCodeIntelligenceEvent(event: string, userEvent: GQL.UserEvent): Promise<void> {
+    public async logCodeIntelligenceEvent(
+        event: string,
+        userEvent: GQL.UserEvent,
+        eventProperties?: any
+    ): Promise<void> {
         const anonUserId = await this.getAnonUserID()
         const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
         logUserEvent(userEvent, anonUserId, sourcegraphURL, this.requestGraphQL)
-        logEvent({ name: event, userCookieID: anonUserId, url: sourcegraphURL }, this.requestGraphQL)
+        logEvent(
+            { name: event, userCookieID: anonUserId, url: sourcegraphURL, argument: eventProperties },
+            this.requestGraphQL
+        )
     }
 
     /**
@@ -89,10 +96,10 @@ export class EventLogger implements TelemetryService {
             case 'goToDefinition':
             case 'goToDefinition.preloaded':
             case 'hover':
-                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATION)
+                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATION, eventProperties)
                 break
             case 'findReferences':
-                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATIONREFS)
+                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATIONREFS, eventProperties)
                 break
         }
     }

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -62,7 +62,7 @@ export class EventLogger implements TelemetryService {
         if ((window.context && window.context.userAgentIsBot) || !eventLabel) {
             return
         }
-        serverAdmin.trackAction(eventLabel)
+        serverAdmin.trackAction(eventLabel, eventProperties)
         this.logToConsole(eventLabel, eventProperties)
     }
 

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -30,7 +30,7 @@ class ServerAdminWrapper {
         logEvent(eventAction)
     }
 
-    public trackAction(eventAction: string): void {
+    public trackAction(eventAction: string, eventProperties?: any): void {
         if (this.isAuthenicated) {
             if (eventAction === 'SearchResultsQueried') {
                 logUserEvent(GQL.UserEvent.SEARCHQUERY)
@@ -47,7 +47,7 @@ class ServerAdminWrapper {
                 logUserEvent(GQL.UserEvent.STAGEMONITOR)
             }
         }
-        logEvent(eventAction)
+        logEvent(eventAction, eventProperties)
     }
 }
 

--- a/web/src/user/settings/backend.tsx
+++ b/web/src/user/settings/backend.tsx
@@ -124,16 +124,28 @@ export function logUserEvent(event: GQL.UserEvent): void {
  *
  * Not used at all for public/sourcegraph.com usage.
  */
-export function logEvent(event: string): void {
+export function logEvent(event: string, eventProperties?: any): void {
     mutateGraphQL(
         gql`
-            mutation logEvent($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!) {
-                logEvent(event: $event, userCookieID: $userCookieID, url: $url, source: $source) {
+            mutation logEvent(
+                $event: String!
+                $userCookieID: String!
+                $url: String!
+                $source: EventSource!
+                $argument: String
+            ) {
+                logEvent(event: $event, userCookieID: $userCookieID, url: $url, source: $source, argument: $argument) {
                     alwaysNil
                 }
             }
         `,
-        { event, userCookieID: eventLogger.getAnonUserID(), url: window.location.href, source: GQL.EventSource.WEB }
+        {
+            event,
+            userCookieID: eventLogger.getAnonUserID(),
+            url: window.location.href,
+            source: GQL.EventSource.WEB,
+            argument: eventProperties && JSON.stringify(eventProperties),
+        }
     )
         .pipe(map(dataOrThrowErrors))
         .subscribe()


### PR DESCRIPTION
Send a JSON-serialized `eventProperties` payload to the `logEvent` mutation as the argument field.