### PR TITLE
docker-images: explicitly create storage folders in Dockerfile…

### DIFF
--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -15,6 +15,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 ENV CONFIGURATION_MODE=server PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg PUBLIC_REPO_REDIRECTS=true CACHE_DIR=/mnt/cache/frontend
+RUN mkdir -p ${CACHE_DIR} && chown -R sourcegraph:sourcegraph ${CACHE_DIR}
 USER sourcegraph
 CMD ["serve"]
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/frontend"]

--- a/cmd/replacer/Dockerfile
+++ b/cmd/replacer/Dockerfile
@@ -18,6 +18,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 ENV CACHE_DIR=/mnt/cache/replacer
+RUN mkdir -p ${CACHE_DIR} && chown -R sourcegraph:sourcegraph ${CACHE_DIR}
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/replacer"]
 COPY replacer /usr/local/bin/

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -23,6 +23,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 ENV CACHE_DIR=/mnt/cache/searcher
+RUN mkdir -p ${CACHE_DIR} && chown -R sourcegraph:sourcegraph ${CACHE_DIR}
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/searcher"]
 COPY searcher /usr/local/bin/

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /
 COPY .ctags.d /.ctags.d
 
 ENV CACHE_DIR=/mnt/cache/symbols
+RUN mkdir -p ${CACHE_DIR}
 EXPOSE 3184
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/symbols"]
 COPY symbols /usr/local/bin/

--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -1,13 +1,34 @@
-FROM prom/prometheus:v2.15.2@sha256:35c52c0c2b76433bbfc44a5a7abc294c2f032ed80250be02b441db5dd91b203a
+# This Dockerfile is adapted from https://github.com/prometheus/prometheus/blob/v2.15.2/Dockerfile with
+# our own customizations.
+#
+# When upgrading prometheus, be sure to check https://github.com/prometheus/prometheus/blob/master/Dockerfile
+# (replacing master with the version number) to see if any changes (added/removed files, etc.) need to be
+# synchronized with this derivative Dockerfile.
+FROM prom/prometheus:v2.15.2@sha256:35c52c0c2b76433bbfc44a5a7abc294c2f032ed80250be02b441db5dd91b203a AS upstream
+
+# hadolint ignore=DL3007
+FROM quay.io/prometheus/busybox-linux-amd64:latest
 
 LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
-LABEL com.sourcegraph.prometheus.version=v2.12.0
+LABEL com.sourcegraph.prometheus.version=v2.15.2
+
+COPY --from=upstream /bin/prometheus /bin/prometheus
+COPY --from=upstream /bin/promtool /bin/promtoool
+COPY --from=upstream /etc/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
+COPY --from=upstream /usr/share/prometheus/console_libraries/ /usr/share/prometheus/console_libraries/
+COPY --from=upstream /usr/share/prometheus/consoles/ /usr/share/prometheus/consoles/
+COPY --from=upstream /LICENSE /LICENSE
+COPY --from=upstream /NOTICE /NOTICE
+# hadolint ignore=DL3010
+COPY --from=upstream /npm_licenses.tar.bz2 /npm_licenses.tar.bz2
+
+RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 
 # TODO(uwe): remove "USER root" line once https://github.com/prometheus/prometheus/issues/3441 is resolved
 #
-# This is needed currently because the base image has us running as "nobody"
+# This is needed currently because the upstream image has us running as "nobody"
 # which cannot create the sourcegraph user below.
 USER root
 # Add the sourcegraph group, user, and create the home directory.
@@ -18,6 +39,7 @@ USER root
 #
 # Note: This mirrors what we do in e.g. our base alpine image: https://github.com/sourcegraph/sourcegraph/blob/master/docker-images/alpine/Dockerfile#L10-L15
 RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/sourcegraph sourcegraph
+RUN mkdir -p /prometheus && chown -R sourcegraph:sourcegraph /prometheus
 USER sourcegraph
 
 COPY config/*_rules.yml /sg_config_prometheus/
@@ -26,3 +48,7 @@ COPY config/prometheus.yml /sg_config_prometheus/
 COPY entry.sh /
 
 ENTRYPOINT ["/entry.sh"]
+# Note that upstream's 'VOLUME' directive was deliberately removed. Including it makes it impossible
+# to chmod the directory to our 'sourcegraph' user.
+WORKDIR    /prometheus
+EXPOSE     9090

--- a/enterprise/cmd/frontend/Dockerfile
+++ b/enterprise/cmd/frontend/Dockerfile
@@ -15,6 +15,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 ENV CONFIGURATION_MODE=server PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg PUBLIC_REPO_REDIRECTS=true
+RUN mkdir -p /mnt/cache/frontend && chown -R sourcegraph:sourcegraph /mnt/cache/frontend
 USER sourcegraph
 CMD ["serve"]
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/frontend"]


### PR DESCRIPTION
Part of #7829 

See also https://github.com/sourcegraph/infrastructure/pull/1792

Many of our docker images write to external volumes for caches, data storage, etc. The file system permissions are identical from both the container's and host's POV. 

For example, let's say you mount a folder (`/data`) into a container and on the host, only uid `11` has r/w access to it. If the container is running as some other unprivileged user (say uid `22`) then the container process can't access the folder. This is the source of all the permission issues/container crashes in #7829. 

There are [multiple ways to mount volumes](https://docs.docker.com/storage/) in Docker: 

- When using [bind mounts](https://docs.docker.com/storage/bind-mounts/), what we currently tell people to do by default, if the host folder that's being mounted has mismatched file permissions you're forced to run `chmod` commands as a workaround. This is hacky, brittle, and might not be possible to run in every environment. 

- When using ['named' volumes](https://docs.docker.com/storage/volumes/), the method that's recommended in the official documentation, [the volume's initial contents **and permissions** are propagated from the container](https://github.com/docker/compose/issues/3270#issuecomment-543603959). However, this only applies if the path in the container that the volume is being attached to existed beforehand (otherwise, the volume will be attached with root permissions).  

This PR ensures that **all** of the storage paths in our docker images are created ahead of time in their respective Dockerfiles with permissions that are accessible to our "sourcegraph" user. 

There was one complication with https://github.com/sourcegraph/sourcegraph/tree/master/docker-images/prometheus. The upstream image that we inherit from [explicitly declares a `VOLUME` in the Dockerfile with permissions that are only writeable via their default "nobody" user](https://github.com/prometheus/prometheus/blob/fafb7940b1cdb24cada28a713fbcc01ed1e2d585/Dockerfile#L23). It is [not possible to change the permissions on this volume](https://stackoverflow.com/a/26145444) with a Dockerfile that inherits from this image. (Note that using explicit `VOLUME`'s in Dockerfiles has been a long-standing complaint of many base images: https://github.com/docker-library/postgres/issues/404, https://github.com/moby/moby/issues/3465, https://github.com/moby/moby/issues/3465). The workaround used here is to effectively copy the upstream Dockerfile's assets into our own Dockerfile that deliberately omits that `VOLUME` directive. We'll need to ensure that our Dockerfile is kept in sync whenever we need to upgrade the Prometheus version, but https://github.com/prometheus/prometheus/commits/master/Dockerfile doesn't change all that often in practice. 

--- Test plan

I'm pretty confident our users won't need to do any manual migration due to this change. (Our k8s configuration still runs all our images as root, and anyone still using bind mounts shouldn't have to do anything since the existing host folder's permissions still override anything that's set in the container). 

However, just to be sure, we'll need to test a fresh kubernetes deployment, the kubernetes upgrade path, and a fresh docker-compose deployment( note that https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/permission depends on changes from this PR).  This change doesn't affect sourcegraph/server. 
