### PR TITLE
DB: Query total event count by period

### DIFF
--- a/cmd/frontend/db/event_logs.go
+++ b/cmd/frontend/db/event_logs.go
@@ -177,7 +177,7 @@ func calcEndDate(startDate time.Time, periods int, periodType PeriodType) (time.
 		return startDate.AddDate(0, periods, 0), true
 	}
 
-	return startDate, false
+	return time.Time{}, false
 }
 
 // CountUniqueUsersOptions provides options for counting unique users.

--- a/cmd/frontend/db/event_logs.go
+++ b/cmd/frontend/db/event_logs.go
@@ -207,11 +207,11 @@ func (l *eventLogs) CountUniquesPerPeriod(ctx context.Context, periodType Period
 
 	var endDate time.Time
 	switch periodType {
-	case "daily":
+	case Daily:
 		endDate = startDate.AddDate(0, 0, periods)
-	case "weekly":
+	case Weekly:
 		endDate = startDate.AddDate(0, 0, 7*periods)
-	case "monthly":
+	case Monthly:
 		endDate = startDate.AddDate(0, periods, 0)
 	default:
 		return nil, fmt.Errorf("periodType must be \"daily\", \"weekly\", or \"monthly\". Got %s", periodType)

--- a/cmd/frontend/db/event_logs.go
+++ b/cmd/frontend/db/event_logs.go
@@ -138,16 +138,16 @@ type UsageValue struct {
 	Count int
 }
 
-// UniqueUserCountType is the type of period in which to count unique users.
-type UniqueUserCountType string
+// PeriodType is the type of period in which to count events and unique.
+type PeriodType string
 
 const (
-	// Daily is used to get a count of unique daily active users.
-	Daily UniqueUserCountType = "daily"
-	// Weekly is used to get a count of unique weekly active users.
-	Weekly UniqueUserCountType = "weekly"
-	// Monthly is used to get a count of unique monthly active users.
-	Monthly UniqueUserCountType = "monthly"
+	// Daily is used to get a count of events or unique active users within a day.
+	Daily PeriodType = "daily"
+	// Weekly is used to get a count of events or unique active users within a week.
+	Weekly PeriodType = "weekly"
+	// Monthly is used to get a count of events or unique active users within a month.
+	Monthly PeriodType = "monthly"
 )
 
 // CountUniquesOptions provides options for counting unique users.
@@ -160,7 +160,7 @@ type CountUniquesOptions struct {
 
 // CountUniquesPerPeriod provides a count of unique active users in a given time span, broken up into periods of a given type.
 // Returns an array array of length `periods`, with one entry for each period in the time span.
-func (l *eventLogs) CountUniquesPerPeriod(ctx context.Context, periodType UniqueUserCountType, startDate time.Time, periods int, opt *CountUniquesOptions) ([]UsageValue, error) {
+func (l *eventLogs) CountUniquesPerPeriod(ctx context.Context, periodType PeriodType, startDate time.Time, periods int, opt *CountUniquesOptions) ([]UsageValue, error) {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opt != nil {
 		if opt.RegisteredOnly {

--- a/cmd/frontend/db/event_logs.go
+++ b/cmd/frontend/db/event_logs.go
@@ -186,12 +186,12 @@ type CountUniqueUsersOptions struct {
 	RegisteredOnly bool
 	// If true, only include code host integration users. Otherwise, include all users.
 	IntegrationOnly bool
-	// If non-nil, only include users that logged an event with a given prefix.
-	ByEventNamePrefix *string
-	// If non-nil, only include users that logged a given event.
-	ByEventName *string
-	// If non-nil, only include users that logged any event that matches a list of given event names
-	ByEventNames *[]string
+	// If set, only include users that logged an event with a given prefix.
+	ByEventNamePrefix string
+	// If set, only include users that logged a given event.
+	ByEventName string
+	// If not empty, only include users that logged any event that matches a list of given event names
+	ByEventNames []string
 }
 
 // CountUniqueUsersPerPeriod provides a count of unique active users in a given time span, broken up into periods of a given type.
@@ -205,15 +205,15 @@ func (l *eventLogs) CountUniqueUsersPerPeriod(ctx context.Context, periodType Pe
 		if opt.IntegrationOnly {
 			conds = append(conds, sqlf.Sprintf("source = %s", integrationSource))
 		}
-		if opt.ByEventNamePrefix != nil {
-			conds = append(conds, sqlf.Sprintf("name LIKE %s", *opt.ByEventNamePrefix+"%"))
+		if opt.ByEventNamePrefix != "" {
+			conds = append(conds, sqlf.Sprintf("name LIKE %s", opt.ByEventNamePrefix+"%"))
 		}
-		if opt.ByEventName != nil {
-			conds = append(conds, sqlf.Sprintf("name = %s", *opt.ByEventName))
+		if opt.ByEventName != "" {
+			conds = append(conds, sqlf.Sprintf("name = %s", opt.ByEventName))
 		}
-		if opt.ByEventNames != nil {
+		if len(opt.ByEventNames) > 0 {
 			items := []*sqlf.Query{}
-			for _, v := range *opt.ByEventNames {
+			for _, v := range opt.ByEventNames {
 				items = append(items, sqlf.Sprintf("%s", v))
 			}
 			conds = append(conds, sqlf.Sprintf("name IN (%s)", sqlf.Join(items, ",")))
@@ -230,27 +230,27 @@ func (l *eventLogs) CountUniqueUsersPerPeriod(ctx context.Context, periodType Pe
 
 // CountEventsOptions provides options for counting events.
 type CountEventsOptions struct {
-	// If non-nil, only include users that logged an event with a given prefix.
-	ByEventNamePrefix *string
-	// If non-nil, only include users that logged a given event.
-	ByEventName *string
-	// If non-nil, only include users that logged any event that matches a list of given event names
-	ByEventNames *[]string
+	// If set, only include users that logged an event with a given prefix.
+	ByEventNamePrefix string
+	// If set, only include users that logged a given event.
+	ByEventName string
+	// If not empty, only include users that logged any event that matches a list of given event names
+	ByEventNames []string
 }
 
 // CountEventsPerPeriod provide a count of events in a given time span, broken up into periods of a given type.
 func (l *eventLogs) CountEventsPerPeriod(ctx context.Context, periodType PeriodType, startDate time.Time, periods int, opt *CountEventsOptions) ([]UsageValue, error) {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opt != nil {
-		if opt.ByEventNamePrefix != nil {
-			conds = append(conds, sqlf.Sprintf("name LIKE %s", *opt.ByEventNamePrefix+"%"))
+		if opt.ByEventNamePrefix != "" {
+			conds = append(conds, sqlf.Sprintf("name LIKE %s", opt.ByEventNamePrefix+"%"))
 		}
-		if opt.ByEventName != nil {
-			conds = append(conds, sqlf.Sprintf("name = %s", *opt.ByEventName))
+		if opt.ByEventName != "" {
+			conds = append(conds, sqlf.Sprintf("name = %s", opt.ByEventName))
 		}
-		if opt.ByEventNames != nil {
+		if len(opt.ByEventNames) > 0 {
 			items := []*sqlf.Query{}
-			for _, v := range *opt.ByEventNames {
+			for _, v := range opt.ByEventNames {
 				items = append(items, sqlf.Sprintf("%s", v))
 			}
 			conds = append(conds, sqlf.Sprintf("name IN (%s)", sqlf.Join(items, ",")))

--- a/cmd/frontend/internal/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/usagestats/usage_stats.go
@@ -141,7 +141,7 @@ func GetSiteUsageStatistics(ctx context.Context, opt *SiteUsageStatisticsOptions
 	}, nil
 }
 
-func startOfPeriod(periodType db.UniqueUserCountType, periodsAgo int) (time.Time, error) {
+func startOfPeriod(periodType db.PeriodType, periodsAgo int) (time.Time, error) {
 	switch periodType {
 	case db.Daily:
 		now := timeNow().UTC()
@@ -156,7 +156,7 @@ func startOfPeriod(periodType db.UniqueUserCountType, periodsAgo int) (time.Time
 }
 
 // activeUsers returns counts of active users in the given number of days, weeks, or months, as selected (including the current, partially completed period).
-func activeUsers(ctx context.Context, periodType db.UniqueUserCountType, periods int) ([]*types.SiteActivityPeriod, error) {
+func activeUsers(ctx context.Context, periodType db.PeriodType, periods int) ([]*types.SiteActivityPeriod, error) {
 	if periods == 0 {
 		return []*types.SiteActivityPeriod{}, nil
 	}

--- a/cmd/frontend/internal/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/usagestats/usage_stats.go
@@ -70,27 +70,27 @@ func GetByUserID(ctx context.Context, userID int32) (*types.UserUsageStatistics,
 func GetUsersActiveTodayCount(ctx context.Context) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.CountUniquesAll(ctx, today, today.AddDate(0, 0, 1))
+	return db.EventLogs.CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
 func ListRegisteredUsersToday(ctx context.Context) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.ListUniquesAll(ctx, start, start.AddDate(0, 0, 1))
+	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersThisWeek returns a list of the registered users that were active this week.
 func ListRegisteredUsersThisWeek(ctx context.Context) ([]int32, error) {
 	start := startOfWeek(0)
-	return db.EventLogs.ListUniquesAll(ctx, start, start.AddDate(0, 0, 7))
+	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 7))
 }
 
 // ListRegisteredUsersThisMonth returns a list of the registered users that were active this month.
 func ListRegisteredUsersThisMonth(ctx context.Context) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.ListUniquesAll(ctx, start, start.AddDate(0, 1, 0))
+	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 1, 0))
 }
 
 // SiteUsageStatisticsOptions contains options for the number of daily, weekly, and monthly periods in
@@ -166,17 +166,17 @@ func activeUsers(ctx context.Context, periodType db.PeriodType, periods int) ([]
 	if err != nil {
 		return nil, err
 	}
-	uniques, err := db.EventLogs.CountUniquesPerPeriod(ctx, periodType, startDate, periods, nil)
+	uniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, startDate, periods, nil)
 	if err != nil {
 		return nil, err
 	}
-	registeredUniques, err := db.EventLogs.CountUniquesPerPeriod(ctx, periodType, startDate, periods, &db.CountUniquesOptions{
+	registeredUniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, startDate, periods, &db.CountUniqueUsersOptions{
 		RegisteredOnly: true,
 	})
 	if err != nil {
 		return nil, err
 	}
-	integrationUniques, err := db.EventLogs.CountUniquesPerPeriod(ctx, periodType, startDate, periods, &db.CountUniquesOptions{
+	integrationUniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, startDate, periods, &db.CountUniqueUsersOptions{
 		IntegrationOnly: true,
 	})
 	if err != nil {
@@ -184,27 +184,27 @@ func activeUsers(ctx context.Context, periodType db.PeriodType, periods int) ([]
 	}
 
 	var activeUsers []*types.SiteActivityPeriod
-	for i, u := range uniques {
-		// Pull out data from each period. Note that CountUniquesPerPeriod will always
-		// return a slice of length `periods` due to the generate_series in the base
-		// query, so it is safe to read the following indices.
+	for i, u := range uniqueUsers {
+		// Pull out data from each period. Note that CountUniqueUsersPerPeriod will
+		// always return a slice of length `periods` due to the generate_series in
+		// the base query, so it is safe to read the following indices.
 		actPer := &types.SiteActivityPeriod{
 			StartTime:            u.Start,
 			UserCount:            int32(u.Count),
-			RegisteredUserCount:  int32(registeredUniques[i].Count),
-			AnonymousUserCount:   int32(u.Count - registeredUniques[i].Count),
-			IntegrationUserCount: int32(integrationUniques[i].Count),
+			RegisteredUserCount:  int32(registeredUniqueUsers[i].Count),
+			AnonymousUserCount:   int32(u.Count - registeredUniqueUsers[i].Count),
+			IntegrationUserCount: int32(integrationUniqueUsers[i].Count),
 			Stages:               nil,
 		}
 		activeUsers = append(activeUsers, actPer)
 	}
 
-	// Count stage uniques For the latest week and month only.
+	// Count stage unique users For the latest week and month only.
 	switch periodType {
 	case db.Weekly:
 		fallthrough
 	case db.Monthly:
-		activeUsers[0].Stages, err = stageUniques(activeUsers[0].StartTime)
+		activeUsers[0].Stages, err = stageUniqueUsers(activeUsers[0].StartTime)
 		if err != nil {
 			return nil, err
 		}
@@ -213,12 +213,12 @@ func activeUsers(ctx context.Context, periodType db.PeriodType, periods int) ([]
 	return activeUsers, nil
 }
 
-var MockStageUniques func(startDate time.Time) (*types.Stages, error)
+var MockStageUniqueUsers func(startDate time.Time) (*types.Stages, error)
 
-// stageUniques returns the count of unique users on this instance in each stage of the Software Development Lifecycle since the given start date.
-func stageUniques(startDate time.Time) (*types.Stages, error) {
-	if MockStageUniques != nil {
-		return MockStageUniques(startDate)
+// stageUniqueUsers returns the count of unique users on this instance in each stage of the Software Development Lifecycle since the given start date.
+func stageUniqueUsers(startDate time.Time) (*types.Stages, error) {
+	if MockStageUniqueUsers != nil {
+		return MockStageUniqueUsers(startDate)
 	}
 
 	ctx := context.Background()
@@ -229,7 +229,7 @@ func stageUniques(startDate time.Time) (*types.Stages, error) {
 	// 1) any activity from a site admin
 	// 2) any usage of an API access token
 
-	manageUniques, err := db.EventLogs.CountUniquesByEventNamePrefix(ctx, startDate, endDate, "ViewSiteAdmin")
+	manageUniqueUsers, err := db.EventLogs.CountUniqueUsersByEventNamePrefix(ctx, startDate, endDate, "ViewSiteAdmin")
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func stageUniques(startDate time.Time) (*types.Stages, error) {
 	// 2) any file, repo, tree views
 	// 3) TODO(Dan): any code host integration usage (other than for code review)
 
-	codeUniques, err := db.EventLogs.CountUniquesByEventNames(ctx, startDate, endDate, []string{"ViewRepository", "ViewBlob", "ViewTree", "SearchResultsQueried"})
+	codeUniqueUsers, err := db.EventLogs.CountUniqueUsersByEventNames(ctx, startDate, endDate, []string{"ViewRepository", "ViewBlob", "ViewTree", "SearchResultsQueried"})
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func stageUniques(startDate time.Time) (*types.Stages, error) {
 	// 2) TODO(Dan): receiving a saved search notification (slack)
 	// 3) clicking a saved search notification (email or slack)
 	// 4) TODO(Dan): having a saved search defined in your user or org settings
-	verifyUniques, err := db.EventLogs.CountUniquesByEventNames(ctx, startDate, endDate, []string{"SavedSearchEmailClicked", "SavedSearchSlackClicked", "SavedSearchEmailNotificationSent"})
+	verifyUniqueUsers, err := db.EventLogs.CountUniqueUsersByEventNames(ctx, startDate, endDate, []string{"SavedSearchEmailClicked", "SavedSearchSlackClicked", "SavedSearchEmailNotificationSent"})
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func stageUniques(startDate time.Time) (*types.Stages, error) {
 	//// MONITOR ////
 	// 1) running a diff search
 	// 2) TODO(Dan): monitoring extension enabled (e.g. LightStep, Sentry, Datadog)
-	monitorUniques, err := db.EventLogs.CountUniquesByEventName(ctx, startDate, endDate, "DiffSearchResultsQueried")
+	monitorUniqueUsers, err := db.EventLogs.CountUniqueUsersByEventName(ctx, startDate, endDate, "DiffSearchResultsQueried")
 	if err != nil {
 		return nil, err
 	}
@@ -284,15 +284,15 @@ func stageUniques(startDate time.Time) (*types.Stages, error) {
 	// none currently
 
 	return &types.Stages{
-		Manage:    int32(manageUniques),
+		Manage:    int32(manageUniqueUsers),
 		Plan:      0,
-		Code:      int32(codeUniques),
+		Code:      int32(codeUniqueUsers),
 		Review:    0,
-		Verify:    int32(verifyUniques),
+		Verify:    int32(verifyUniqueUsers),
 		Package:   0,
 		Deploy:    0,
 		Configure: 0,
-		Monitor:   int32(monitorUniques),
+		Monitor:   int32(monitorUniqueUsers),
 		Secure:    0,
 		Automate:  0,
 	}, nil

--- a/cmd/frontend/internal/usagestats/usage_stats_test.go
+++ b/cmd/frontend/internal/usagestats/usage_stats_test.go
@@ -211,7 +211,7 @@ func TestUserUsageStatistics_getUsersActiveToday(t *testing.T) {
 }
 
 func TestUserUsageStatistics_DAUs_WAUs_MAUs(t *testing.T) {
-	MockStageUniques = func(_ time.Time) (*types.Stages, error) {
+	MockStageUniqueUsers = func(_ time.Time) (*types.Stages, error) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
This functionality will be necessary to query the metrics required by [RFC 100](https://docs.google.com/document/d/1YVCpWhjWx0fn304vBcsqPkG3ckGNykR1fqWgXv1ckwI) once all parties have approved.

This refactors the event log definitions in the db package so that we can add a new type of query that sums events rather than unique users in a time period.

This PR:

- renames occurrences of "uniques" to "uniqueUser" to disambiguate what we're querying
- adds conditions to filter results of `CountUniqueUsersPerPeriod` by event name/prefix
- adds a definition of `CountEventsPerPeriod` that works similarly to `CountUniqueUsersPerPeriod`.

Review by commit may be easiest.

This PR defines but does not yet use this new method.