### PR TITLE
Remove all arguments from event logging calls in web.

### DIFF
--- a/web/src/auth/ResetPasswordPage.tsx
+++ b/web/src/auth/ResetPasswordPage.tsx
@@ -212,7 +212,7 @@ interface ResetPasswordPageProps extends RouteComponentProps<{}> {
  */
 export class ResetPasswordPage extends React.PureComponent<ResetPasswordPageProps> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('ResetPassword', {}, false)
+        eventLogger.logViewEvent('ResetPassword', false)
     }
 
     public render(): JSX.Element | null {

--- a/web/src/auth/SignInPage.tsx
+++ b/web/src/auth/SignInPage.tsx
@@ -17,7 +17,7 @@ interface SignInPageProps {
 
 export class SignInPage extends React.Component<SignInPageProps> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SignIn', {}, false)
+        eventLogger.logViewEvent('SignIn', false)
     }
 
     public render(): JSX.Element | null {

--- a/web/src/auth/SignUpForm.tsx
+++ b/web/src/auth/SignUpForm.tsx
@@ -163,13 +163,6 @@ export class SignUpForm extends React.Component<SignUpFormProps, SignUpFormState
                     .catch(error => this.setState({ error: asError(error), loading: false }))
             ).subscribe()
         )
-        eventLogger.log('InitiateSignUp', {
-            signup: {
-                user_info: {
-                    signup_email: this.state.email,
-                    signup_username: this.state.username,
-                },
-            },
-        })
+        eventLogger.log('InitiateSignUp')
     }
 }

--- a/web/src/auth/SignUpPage.tsx
+++ b/web/src/auth/SignUpPage.tsx
@@ -17,7 +17,7 @@ interface SignUpPageProps {
 
 export class SignUpPage extends React.Component<SignUpPageProps> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SignUp', {}, false)
+        eventLogger.logViewEvent('SignUp', false)
     }
 
     public render(): JSX.Element | null {

--- a/web/src/extensions/ExtensionToggle.tsx
+++ b/web/src/extensions/ExtensionToggle.tsx
@@ -50,7 +50,7 @@ export class ExtensionToggle extends React.PureComponent<Props> {
                             return EMPTY
                         }
 
-                        eventLogger.log('ExtensionToggled', { extension_id: this.props.extension.id })
+                        eventLogger.log('ExtensionToggled')
 
                         return from(
                             this.props.platformContext.updateSettings(highestPrecedenceSubject.subject.id, {

--- a/web/src/extensions/ExtensionToggle.tsx
+++ b/web/src/extensions/ExtensionToggle.tsx
@@ -50,7 +50,7 @@ export class ExtensionToggle extends React.PureComponent<Props> {
                             return EMPTY
                         }
 
-                        eventLogger.log('ExtensionToggled')
+                        eventLogger.log('ExtensionToggled', { extension_id: this.props.extension.id })
 
                         return from(
                             this.props.platformContext.updateSettings(highestPrecedenceSubject.subject.id, {

--- a/web/src/marketing/BrowserExtensionToast.tsx
+++ b/web/src/marketing/BrowserExtensionToast.tsx
@@ -101,6 +101,5 @@ export class ChromeExtensionToast extends React.Component {
         )
     }
 
-    private onClickInstall = (): void =>
-        eventLogger.log('BrowserExtInstallClicked', { marketing: { browser: 'Chrome' } })
+    private onClickInstall = (): void => eventLogger.log('BrowserExtInstallClicked')
 }

--- a/web/src/marketing/ServerBanner.tsx
+++ b/web/src/marketing/ServerBanner.tsx
@@ -3,7 +3,7 @@ import { DismissibleAlert } from '../components/DismissibleAlert'
 import { eventLogger } from '../tracking/eventLogger'
 
 const onClickInstall = (): void => {
-    eventLogger.log('InstallSourcegraphServerCTAClicked', { location_on_page: 'banner' })
+    eventLogger.log('InstallSourcegraphServerCTAClicked')
 }
 
 export const ServerBanner: React.FunctionComponent = () => (

--- a/web/src/marketing/SurveyToast.tsx
+++ b/web/src/marketing/SurveyToast.tsx
@@ -43,7 +43,7 @@ export class SurveyCTA extends React.PureComponent<SurveyCTAProps> {
     }
 
     private onClick = (score: number): void => {
-        eventLogger.log('SurveyButtonClicked', { marketing: { nps_score: score } })
+        eventLogger.log('SurveyButtonClicked')
         if (this.props.onClick) {
             this.props.onClick(score)
         }
@@ -65,7 +65,7 @@ export class SurveyToast extends React.Component<Props, State> {
             visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 60 === 3,
         }
         if (this.state.visible) {
-            eventLogger.log('SurveyReminderViewed', { marketing: { sessionCount: daysActiveCount } })
+            eventLogger.log('SurveyReminderViewed')
         } else if (daysActiveCount % 60 === 0) {
             // Reset toast dismissal 3 days before it will be shown
             localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'false')

--- a/web/src/marketing/SurveyToast.tsx
+++ b/web/src/marketing/SurveyToast.tsx
@@ -43,7 +43,7 @@ export class SurveyCTA extends React.PureComponent<SurveyCTAProps> {
     }
 
     private onClick = (score: number): void => {
-        eventLogger.log('SurveyButtonClicked')
+        eventLogger.log('SurveyButtonClicked', { score })
         if (this.props.onClick) {
             this.props.onClick(score)
         }

--- a/web/src/org/area/OrgMembersPage.tsx
+++ b/web/src/org/area/OrgMembersPage.tsx
@@ -146,7 +146,7 @@ export class OrgMembersPage extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('OrgMembers', { organization: { org_name: this.props.org.name } })
+        eventLogger.logViewEvent('OrgMembers')
 
         this.subscriptions.add(
             this.componentUpdates

--- a/web/src/org/backend.tsx
+++ b/web/src/org/backend.tsx
@@ -93,7 +93,7 @@ export function updateOrganization(id: GQL.ID, displayName: string): Observable<
             displayName,
         }
     ).pipe(
-        map(({ errors }) => {
+        map(({ data, errors }) => {
             if (!data || (errors && errors.length > 0)) {
                 eventLogger.log('UpdateOrgSettingsFailed')
                 throw createAggregateError(errors)

--- a/web/src/org/backend.tsx
+++ b/web/src/org/backend.tsx
@@ -33,12 +33,7 @@ export function createOrganization(args: {
                 eventLogger.log('NewOrgFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('NewOrgCreated', {
-                organization: {
-                    org_id: data.createOrganization.id,
-                    org_name: data.createOrganization.name,
-                },
-            })
+            eventLogger.log('NewOrgCreated')
             return concat(refreshAuthenticatedUser(), [data.createOrganization])
         })
     )
@@ -65,20 +60,12 @@ export function removeUserFromOrganization(args: {
         `,
         args
     ).pipe(
-        mergeMap(({ data, errors }) => {
-            const eventData = {
-                organization: {
-                    remove: {
-                        user_id: args.user,
-                    },
-                    org_id: args.organization,
-                },
-            }
+        mergeMap(({ errors }) => {
             if (errors && errors.length > 0) {
-                eventLogger.log('RemoveOrgMemberFailed', eventData)
+                eventLogger.log('RemoveOrgMemberFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('OrgMemberRemoved', eventData)
+            eventLogger.log('OrgMemberRemoved')
             // Reload user data
             return concat(refreshAuthenticatedUser(), [undefined])
         })
@@ -106,20 +93,12 @@ export function updateOrganization(id: GQL.ID, displayName: string): Observable<
             displayName,
         }
     ).pipe(
-        map(({ data, errors }) => {
-            const eventData = {
-                organization: {
-                    update: {
-                        display_name: displayName,
-                    },
-                    org_id: id,
-                },
-            }
+        map(({ errors }) => {
             if (!data || (errors && errors.length > 0)) {
-                eventLogger.log('UpdateOrgSettingsFailed', eventData)
+                eventLogger.log('UpdateOrgSettingsFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('OrgSettingsUpdated', eventData)
+            eventLogger.log('OrgSettingsUpdated')
             return
         })
     )

--- a/web/src/org/invite/InviteForm.tsx
+++ b/web/src/org/invite/InviteForm.tsx
@@ -34,20 +34,12 @@ function inviteUserToOrganization(
             organization,
         }
     ).pipe(
-        map(({ data, errors }) => {
-            const eventData = {
-                organization: {
-                    invite: {
-                        username,
-                    },
-                    org_id: organization,
-                },
-            }
+        map(({ errors }) => {
             if (!data || !data.inviteUserToOrganization || (errors && errors.length > 0)) {
-                eventLogger.log('InviteOrgMemberFailed', eventData)
+                eventLogger.log('InviteOrgMemberFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('OrgMemberInvited', eventData)
+            eventLogger.log('OrgMemberInvited')
             return data.inviteUserToOrganization
         })
     )
@@ -149,16 +141,7 @@ export class InviteForm extends React.PureComponent<Props, State> {
                 .pipe(
                     tap(e => e.preventDefault()),
                     withLatestFrom(orgChanges, this.usernameChanges),
-                    tap(([, orgId, username]) =>
-                        eventLogger.log('InviteOrgMemberClicked', {
-                            organization: {
-                                invite: {
-                                    username,
-                                },
-                                org_id: orgId,
-                            },
-                        })
-                    ),
+                    tap(() => eventLogger.log('InviteOrgMemberClicked')),
                     mergeMap(([, { orgID }, username]) =>
                         inviteUserToOrganization(username, orgID).pipe(
                             tap(() => this.props.onOrganizationUpdate()),

--- a/web/src/org/invite/InviteForm.tsx
+++ b/web/src/org/invite/InviteForm.tsx
@@ -34,7 +34,7 @@ function inviteUserToOrganization(
             organization,
         }
     ).pipe(
-        map(({ errors }) => {
+        map(({ data, errors }) => {
             if (!data || !data.inviteUserToOrganization || (errors && errors.length > 0)) {
                 eventLogger.log('InviteOrgMemberFailed')
                 throw createAggregateError(errors)

--- a/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -46,7 +46,7 @@ export class OrgSettingsProfilePage extends React.PureComponent<Props, State> {
                     distinctUntilKeyChanged('id')
                 )
                 .subscribe(org => {
-                    eventLogger.logViewEvent('OrgSettingsProfile', { organization: { org_name: org.name } })
+                    eventLogger.logViewEvent('OrgSettingsProfile')
                 })
         )
 

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -575,12 +575,7 @@ export function createOrganization(
                 eventLogger.log('NewOrgFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('NewOrgCreated', {
-                organization: {
-                    org_id: data.createOrganization.id,
-                    org_name: data.createOrganization.name,
-                },
-            })
+            eventLogger.log('NewOrgCreated')
             return concat([data.createOrganization])
         })
     )
@@ -696,11 +691,7 @@ export function addExternalService(
                 eventLogger.log('AddExternalServiceFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('AddExternalServiceSucceeded', {
-                externalService: {
-                    kind: data.addExternalService.kind,
-                },
-            })
+            eventLogger.log('AddExternalServiceSucceeded')
             return data.addExternalService
         })
     )

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -129,7 +129,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
     }
 
     private logViewEvent(): void {
-        eventLogger.logViewEvent('Blob', { fileShown: true })
+        eventLogger.logViewEvent('Blob')
     }
 
     public componentDidMount(): void {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -27,7 +27,7 @@ export function submitSearch(
 
     // Go to search results page
     const path = '/search?' + searchQueryParam
-    eventLogger.log('SearchSubmitted')
+    eventLogger.log('SearchSubmitted', { query: navbarQuery, source })
     history.push(path, { ...history.location.state, query: navbarQuery })
     if (activation) {
         activation.update({ DidSearch: true })

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -27,13 +27,7 @@ export function submitSearch(
 
     // Go to search results page
     const path = '/search?' + searchQueryParam
-    eventLogger.log('SearchSubmitted', {
-        code_search: {
-            pattern: navbarQuery,
-            query: navbarQuery,
-            source,
-        },
-    })
+    eventLogger.log('SearchSubmitted')
     history.push(path, { ...history.location.state, query: navbarQuery })
     if (activation) {
         activation.update({ DidSearch: true })

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -496,7 +496,7 @@ export class QueryInput extends React.Component<Props, State> {
             }
 
             // 🚨 PRIVACY: never provide any private data in { code_search: { suggestion: { type } } }.
-            eventLogger.log('SearchSuggestionSelected')
+            eventLogger.log('SearchSuggestionSelected', { type: suggestion.type })
 
             // if separate word is being typed and suggestion with url is selected
             if (

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -496,13 +496,7 @@ export class QueryInput extends React.Component<Props, State> {
             }
 
             // 🚨 PRIVACY: never provide any private data in { code_search: { suggestion: { type } } }.
-            eventLogger.log('SearchSuggestionSelected', {
-                code_search: {
-                    suggestion: {
-                        type: suggestion.type,
-                    },
-                },
-            })
+            eventLogger.log('SearchSuggestionSelected')
 
             // if separate word is being typed and suggestion with url is selected
             if (

--- a/web/src/search/input/SearchScopes.tsx
+++ b/web/src/search/input/SearchScopes.tsx
@@ -33,11 +33,7 @@ export const SearchScopes: React.FunctionComponent<Props> = ({
 
     const onSearchScopeClicked = useCallback(
         (value: string): void => {
-            eventLogger.log('SearchScopeClicked', {
-                search_filter: {
-                    value,
-                },
-            })
+            eventLogger.log('SearchScopeClicked')
 
             const newQuery = toggleSearchFilter(query, value)
 

--- a/web/src/search/input/SearchScopes.tsx
+++ b/web/src/search/input/SearchScopes.tsx
@@ -33,7 +33,7 @@ export const SearchScopes: React.FunctionComponent<Props> = ({
 
     const onSearchScopeClicked = useCallback(
         (value: string): void => {
-            eventLogger.log('SearchScopeClicked')
+            eventLogger.log('SearchScopeClicked', { search_filter: value })
 
             const newQuery = toggleSearchFilter(query, value)
 

--- a/web/src/search/results/CommitSearchResult.tsx
+++ b/web/src/search/results/CommitSearchResult.tsx
@@ -35,9 +35,6 @@ interface Props {
 }
 
 export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props) => {
-    const telemetryData: { [key: string]: any } = {
-        preview_type: props.result.diffPreview ? 'diff' : 'message',
-    }
     const logClickOnPerson = (): void => {
         eventLogger.log('CommitSearchResultClicked')
     }

--- a/web/src/search/results/CommitSearchResult.tsx
+++ b/web/src/search/results/CommitSearchResult.tsx
@@ -35,22 +35,7 @@ interface Props {
 }
 
 export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props) => {
-    const logClickOnPerson = (): void => {
-        eventLogger.log('CommitSearchResultClicked')
-    }
-    const logClickOnMessage = (): void => {
-        eventLogger.log('CommitSearchResultClicked')
-    }
-    const logClickOnTag = (): void => {
-        eventLogger.log('CommitSearchResultClicked')
-    }
-    const logClickOnCommitID = (): void => {
-        eventLogger.log('CommitSearchResultClicked')
-    }
-    const logClickOnTimestamp = (): void => {
-        eventLogger.log('CommitSearchResultClicked')
-    }
-    const logClickOnText = (): void => {
+    const logClick = (): void => {
         eventLogger.log('CommitSearchResultClicked')
     }
 
@@ -68,7 +53,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
                 to={props.result.commit.url}
                 className="commit-search-result__title-person"
                 onClick={stopPropagationToCollapseOrExpand}
-                onMouseDown={logClickOnPerson}
+                onMouseDown={logClick}
             >
                 <UserAvatar user={props.result.commit.author.person} size={32} className="mr-1 icon-inline" />
                 {props.result.commit.author.person.displayName}
@@ -77,28 +62,24 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
                 to={props.result.commit.url}
                 className="commit-search-result__title-message"
                 onClick={stopPropagationToCollapseOrExpand}
-                onMouseDown={logClickOnMessage}
+                onMouseDown={logClick}
             >
                 {commitMessageSubject(props.result.commit.message) || '(empty commit message)'}
             </Link>
             <span className="commit-search-result__title-signature">
                 {uniqueRefs([...props.result.refs, ...props.result.sourceRefs]).map((ref, i) => (
-                    <GitRefTag key={i} gitRef={ref} onMouseDown={logClickOnTag} />
+                    <GitRefTag key={i} gitRef={ref} onMouseDown={logClick} />
                 ))}
                 <code>
                     <Link
                         to={props.result.commit.url}
                         onClick={stopPropagationToCollapseOrExpand}
-                        onMouseDown={logClickOnCommitID}
+                        onMouseDown={logClick}
                     >
                         {props.result.commit.abbreviatedOID}
                     </Link>
                 </code>{' '}
-                <Link
-                    to={props.result.commit.url}
-                    onClick={stopPropagationToCollapseOrExpand}
-                    onMouseDown={logClickOnTimestamp}
-                >
+                <Link to={props.result.commit.url} onClick={stopPropagationToCollapseOrExpand} onMouseDown={logClick}>
                     {formatDistance(parseISO(props.result.commit.author.date), new Date(), {
                         addSuffix: true,
                     })}
@@ -117,7 +98,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
                 value={props.result.messagePreview.value.split('\n')}
                 highlights={props.result.messagePreview.highlights}
                 lineClasses={[{ line: 1, className: 'strong' }]}
-                onMouseDown={logClickOnText}
+                onMouseDown={logClick}
             />
         )
     }
@@ -220,7 +201,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
                 value={lines}
                 highlights={props.result.diffPreview.highlights}
                 lineClasses={lineClasses}
-                onMouseDown={logClickOnText}
+                onMouseDown={logClick}
             />
         )
     }

--- a/web/src/search/results/CommitSearchResult.tsx
+++ b/web/src/search/results/CommitSearchResult.tsx
@@ -39,32 +39,22 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
         preview_type: props.result.diffPreview ? 'diff' : 'message',
     }
     const logClickOnPerson = (): void => {
-        eventLogger.log('CommitSearchResultClicked', { commit_search_result: { ...telemetryData, target: 'person' } })
+        eventLogger.log('CommitSearchResultClicked')
     }
     const logClickOnMessage = (): void => {
-        eventLogger.log('CommitSearchResultClicked', {
-            commit_search_result: { ...telemetryData, target: 'message' },
-        })
+        eventLogger.log('CommitSearchResultClicked')
     }
     const logClickOnTag = (): void => {
-        eventLogger.log('CommitSearchResultClicked', {
-            commit_search_result: { ...telemetryData, target: 'tag' },
-        })
+        eventLogger.log('CommitSearchResultClicked')
     }
     const logClickOnCommitID = (): void => {
-        eventLogger.log('CommitSearchResultClicked', {
-            commit_search_result: { ...telemetryData, target: 'commit-id' },
-        })
+        eventLogger.log('CommitSearchResultClicked')
     }
     const logClickOnTimestamp = (): void => {
-        eventLogger.log('CommitSearchResultClicked', {
-            commit_search_result: { ...telemetryData, target: 'timestamp' },
-        })
+        eventLogger.log('CommitSearchResultClicked')
     }
     const logClickOnText = (): void => {
-        eventLogger.log('CommitSearchResultClicked', {
-            commit_search_result: { ...telemetryData, target: 'text' },
-        })
+        eventLogger.log('CommitSearchResultClicked')
     }
 
     const title: React.ReactChild = (

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -237,7 +237,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
             label,
             id,
             run: editor => {
-                eventLogger.log('SiteConfigurationActionExecuted', { id })
+                eventLogger.log('SiteConfigurationActionExecuted')
                 editor.focus()
                 editor.pushUndoStop()
                 const { edits, selectText, cursorOffset } = run(editor.getValue())

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -185,11 +185,7 @@ export function addExternalService(
                 eventLogger.log('AddExternalServiceFailed')
                 throw createAggregateError(errors)
             }
-            eventLogger.log('AddExternalServiceSucceeded', {
-                externalService: {
-                    kind: data.addExternalService.kind,
-                },
-            })
+            eventLogger.log('AddExternalServiceSucceeded')
             return data.addExternalService
         })
     )

--- a/web/src/tracking/analyticsUtils.tsx
+++ b/web/src/tracking/analyticsUtils.tsx
@@ -117,10 +117,3 @@ function stripURLParameters(url: string, paramsToRemove: string[] = []): void {
     }
     window.history.replaceState(window.history.state, window.document.title, parsedUrl.href)
 }
-
-function camelCaseToUnderscore(input: string): string {
-    if (input.startsWith('_')) {
-        input = input.substring(1)
-    }
-    return input.replace(/([A-Z])/g, $1 => `_${$1.toLowerCase()}`)
-}

--- a/web/src/tracking/analyticsUtils.tsx
+++ b/web/src/tracking/analyticsUtils.tsx
@@ -78,21 +78,17 @@ export function pageViewQueryParameters(url: string): EventQueryParameters {
  */
 export function handleQueryEvents(url: string): void {
     const parsedUrl = new URL(url)
-    const eventParameters: { [key: string]: string } = {}
-    for (const [key, val] of parsedUrl.searchParams.entries()) {
-        eventParameters[camelCaseToUnderscore(key)] = val
-    }
     const eventName = parsedUrl.searchParams.get('_event')
     const isBadgeRedirect = !!parsedUrl.searchParams.get('badge')
     if (eventName || isBadgeRedirect) {
         if (isBadgeRedirect) {
-            eventLogger.log('RepoBadgeRedirected', eventParameters)
+            eventLogger.log('RepoBadgeRedirected')
         } else if (eventName === 'CompletedAuth0SignIn') {
-            eventLogger.log('CompletedAuth0SignIn', eventParameters)
+            eventLogger.log('CompletedAuth0SignIn')
         } else if (eventName === 'SignupCompleted') {
-            eventLogger.log('SignupCompleted', eventParameters)
+            eventLogger.log('SignupCompleted')
         } else if (eventName) {
-            eventLogger.log(eventName, eventParameters)
+            eventLogger.log(eventName)
         }
     }
 

--- a/web/src/tracking/analyticsUtils.tsx
+++ b/web/src/tracking/analyticsUtils.tsx
@@ -5,12 +5,7 @@ import { eventLogger } from './eventLogger'
 interface EventQueryParameters {
     utm_campaign?: string
     utm_source?: string
-    utm_product_name?: string
-    utm_product_version?: string
-    /**
-     *  Editor machine_id property for syncing editor <-> webapp
-     */
-    editor_machine_id?: string
+    utm_medium?: string
 }
 
 /**
@@ -66,8 +61,7 @@ export function pageViewQueryParameters(url: string): EventQueryParameters {
     return {
         utm_campaign: parsedUrl.searchParams.get('utm_campaign') || undefined,
         utm_source: parsedUrl.searchParams.get('utm_source') || undefined,
-        utm_product_name: parsedUrl.searchParams.get('utm_product_name') || undefined,
-        utm_product_version: parsedUrl.searchParams.get('utm_product_version') || undefined,
+        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
     }
 }
 
@@ -78,31 +72,12 @@ export function pageViewQueryParameters(url: string): EventQueryParameters {
  */
 export function handleQueryEvents(url: string): void {
     const parsedUrl = new URL(url)
-    const eventName = parsedUrl.searchParams.get('_event')
     const isBadgeRedirect = !!parsedUrl.searchParams.get('badge')
-    if (eventName || isBadgeRedirect) {
-        if (isBadgeRedirect) {
-            eventLogger.log('RepoBadgeRedirected')
-        } else if (eventName === 'CompletedAuth0SignIn') {
-            eventLogger.log('CompletedAuth0SignIn')
-        } else if (eventName === 'SignupCompleted') {
-            eventLogger.log('SignupCompleted')
-        } else if (eventName) {
-            eventLogger.log(eventName)
-        }
+    if (isBadgeRedirect) {
+        eventLogger.log('RepoBadgeRedirected')
     }
 
-    stripURLParameters(url, [
-        '_event',
-        '_source',
-        'utm_campaign',
-        'utm_source',
-        'utm_product_name',
-        'utm_product_version',
-        'badge',
-        'mid',
-        'toast',
-    ])
+    stripURLParameters(url, ['utm_campaign', 'utm_source', 'utm_medium', 'badge'])
 }
 
 /**

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -35,17 +35,15 @@ export class EventLogger implements TelemetryService {
      * Log a pageview.
      * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
      */
-    public logViewEvent(pageTitle: string, eventProperties?: any, logAsActiveUser = true): void {
+    public logViewEvent(pageTitle: string, logAsActiveUser = true): void {
         if ((window.context && window.context.userAgentIsBot) || !pageTitle) {
             return
         }
         pageTitle = `View${pageTitle}`
 
-        const decoratedProps = {
-            ...pageViewQueryParameters(window.location.href),
-        }
+        const props = pageViewQueryParameters(window.location.href)
         serverAdmin.trackPageView(pageTitle, logAsActiveUser)
-        this.logToConsole(pageTitle, decoratedProps)
+        this.logToConsole(pageTitle, props)
 
         // Use flag to ensure URL query params are only stripped once
         if (!this.hasStrippedQueryParameters) {


### PR DESCRIPTION
Remove all current arguments from event logging in web.

This is *actually* what @dan asked for this before merging https://github.com/sourcegraph/sourcegraph/pull/7988.