### PR TITLE
refuse to create changesets for campaign with plan

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -184,6 +184,10 @@ func (s *Service) CreateCampaign(ctx context.Context, c *a8n.Campaign, draft boo
 var ErrNoCampaignJobs = errors.New("cannot create or update a Campaign without any changesets")
 
 func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store, c *a8n.Campaign) error {
+	if c.CampaignPlanID == 0 {
+		return errors.New("cannot create changesets for campaign with no campaign plan")
+	}
+
 	jobs, _, err := store.ListCampaignJobs(ctx, ListCampaignJobsOpts{
 		CampaignPlanID:            c.CampaignPlanID,
 		Limit:                     -1,


### PR DESCRIPTION
This guards against a potentially dangerous and unexpected operation: if `c.CampaignPlanID` is 0 (because the campaign has no plan, ie it is a manual plan) and a GraphQL API client requested that campaign to be published, then *ALL* campaign plans' changesets will be published. This is because `c.CampaignPlanID == 0`, so it is considered to be "no constraint" when generating the query.

It was possible to trigger this because of another bug https://github.com/sourcegraph/sourcegraph/issues/8009. Even when that is fixed, it is still good to guard against this.

Blocks tomorrow's rollout at https://app.hubspot.com/contacts/2762526/company/608245740 cc @christinaforney 