### PR TITLE
web: include alwaysRender on blob error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - After adding/removing a gitserver replica the admin interface will correctly report that repositories that need to move replicas as cloning. [#7970](https://github.com/sourcegraph/sourcegraph/issues/7970)
+- Show download button for images. [#7924](https://github.com/sourcegraph/sourcegraph/issues/7924)
 
 ### Removed
 

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -193,19 +193,16 @@ export class BlobPage extends React.PureComponent<Props, State> {
     }
 
     public render(): React.ReactNode {
-        if (isErrorLike(this.state.blobOrError)) {
-            return (
-                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={upperFirst(this.state.blobOrError.message)} />
-            )
-        }
-
         let renderMode = ToggleRenderedFileMode.getModeFromURL(this.props.location)
         // If url explicitly asks for a certain rendering mode, renderMode is set to that mode, else it checks:
         // - If file contains richHTML and url does not include a line number: We render in richHTML.
         // - If file does not contain richHTML or the url includes a line number: We render in code view.
         if (!renderMode) {
             renderMode =
-                this.state.blobOrError && this.state.blobOrError.richHTML && !parseHash(this.props.location.hash).line
+                this.state.blobOrError &&
+                !isErrorLike(this.state.blobOrError) &&
+                this.state.blobOrError.richHTML &&
+                !parseHash(this.props.location.hash).line
                     ? 'rendered'
                     : 'code'
         }
@@ -263,6 +260,19 @@ export class BlobPage extends React.PureComponent<Props, State> {
                 />
             </>
         )
+
+        if (isErrorLike(this.state.blobOrError)) {
+            return (
+                <>
+                    {alwaysRender}
+                    <HeroPage
+                        icon={AlertCircleIcon}
+                        title="Error"
+                        subtitle={upperFirst(this.state.blobOrError.message)}
+                    />
+                </>
+            )
+        }
 
         if (!this.state.blobOrError) {
             // Render placeholder for layout before content is fetched.


### PR DESCRIPTION
Not including alwaysRender lead to some toolbar items not showing (such as the
download button). An example of a common error page is we don't render images.
However, we would still like to include the download button.

Note: We rely on the raw endpoint for the download functionality. For security
reasons this will always set the content-type to text/plain. This means when you
download the file it will be downloaded as a txt file. We can't support more
mime-types unless we can serve the assets on a different domain.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7924