### PR TITLE
a8n: Do not report manual Campaigns as unpublished (fix #8009)

### DIFF
--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -125,6 +125,10 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 }
 
 func (r *campaignResolver) PublishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+	if r.Campaign.CampaignPlanID == 0 {
+		return &graphqlbackend.DateTime{Time: r.Campaign.CreatedAt}, nil
+	}
+
 	createdAt, err := r.store.GetLatestChangesetJobCreatedAt(ctx, r.Campaign.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes #8009.

A manual `Campaign` doesn't have `ChangesetJobs` and it's always published, so we can use its `CreatedAt` timestamp as the publication time.