### PR TITLE
tracking-issue: Improve performance with GraphQL search API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,9 @@ require (
 	github.com/segmentio/fasthash v1.0.1
 	github.com/sergi/go-diff v1.1.0
 	github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470
+	github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0
 	github.com/shurcooL/go v0.0.0-20191216061654-b114cc39af9f // indirect
+	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 // indirect
 	github.com/shurcooL/highlight_go v0.0.0-20191220045850-130f78146f9c // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.sum
+++ b/go.sum
@@ -738,11 +738,15 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470 h1:qb9IthCFBmROJ6YBS31BEMeSYjOscSiG+EO+JVNTz64=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
+github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0 h1:T9uus1QvcPgeLShS30YOnnzk3r9Vvygp45muhlrufgY=
+github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go v0.0.0-20191216061654-b114cc39af9f h1:gvOuVMIvQ0Ca/afBH/YBfp5f2RWb92DbAI5EjwoFLuc=
 github.com/shurcooL/go v0.0.0-20191216061654-b114cc39af9f/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f h1:tygelZueB1EtXkPI6mQ4o9DQ0+FKW41hTbunoXZCTqk=
+github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 h1:KaKXZldeYH73dpQL+Nr38j1r5BgpAYQjYvENOUpIZDQ=
 github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480/go.mod h1:ZpfEhSmds4ytuByIcDnOLkTHGUI6KNqRNPDLHDk+mUU=
 github.com/shurcooL/highlight_go v0.0.0-20191220045850-130f78146f9c h1:O967zvqM56fcJfmohoeysshVu6MP5MJdjPKG4jMXRO4=

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -109,7 +109,7 @@ func estimate(labels []string) string {
 }
 
 func state(state string) string {
-	if state == "closed" {
+	if strings.EqualFold(state, "closed") {
 		return "x"
 	}
 	return " "
@@ -145,12 +145,23 @@ func categories(issue *Issue) map[string]string {
 }
 
 func emojis(categories map[string]string) string {
+	sorted := make([]string, 0, len(categories))
+	length := 0
+
+	for _, emoji := range categories {
+		sorted = append(sorted, emoji)
+		length += len(emoji)
+	}
+
+	sort.Strings(sorted)
+
 	// Generous four bytes for each emoji. We don't have
 	// to be precise, since append will allocate more if needed.
-	s := make([]byte, 0, 4*len(categories))
-	for _, emoji := range categories {
+	s := make([]byte, 0, length)
+	for _, emoji := range sorted {
 		s = append(s, emoji...)
 	}
+
 	return string(s)
 }
 

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v28/github"
+	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
@@ -32,13 +32,13 @@ func main() {
 
 func run(token, org, milestone, labels string) (err error) {
 	ctx := context.Background()
-	cli := github.NewClient(
+	cli := githubv4.NewClient(
 		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		)),
 	)
 
-	issues, err := listIssues(ctx, cli, org, strings.Split(labels, ",")...)
+	issues, err := listIssues(ctx, cli, org, milestone, strings.Split(labels, ","))
 	if err != nil {
 		return err
 	}
@@ -50,21 +50,17 @@ func run(token, org, milestone, labels string) (err error) {
 	)
 
 	for _, issue := range issues {
-		if !partOf(milestone, issue) {
-			continue
-		}
-
 		state := state(issue.State)
 		estimate := estimate(issue.Labels)
 		categories := categories(issue)
-		assignee := assignee(issue.Assignee)
+		assignee := assignee(issue.Assignees)
 		title := title(issue)
 
 		item := fmt.Sprintf("- [%s] %s [#%d](%s) __%s__ %s\n",
 			state,
 			title,
-			*issue.Number,
-			*issue.HTMLURL,
+			issue.Number,
+			issue.URL,
 			estimate,
 			emojis(categories),
 		)
@@ -90,16 +86,11 @@ func run(token, org, milestone, labels string) (err error) {
 	return nil
 }
 
-func title(issue *github.Issue) string {
-	if *issue.Repository.Private {
-		return *issue.Repository.FullName
+func title(issue *Issue) string {
+	if issue.Private {
+		return issue.Repository
 	}
-	return *issue.Title
-}
-
-func partOf(milestone string, issue *github.Issue) bool {
-	return milestone != "" && issue.Milestone != nil &&
-		*issue.Milestone.Title == milestone
+	return issue.Title
 }
 
 func days(estimate string) float64 {
@@ -107,30 +98,30 @@ func days(estimate string) float64 {
 	return d
 }
 
-func estimate(labels []github.Label) string {
+func estimate(labels []string) string {
 	const prefix = "estimate/"
-	for _, l := range labels {
-		if strings.HasPrefix(*l.Name, prefix) {
-			return (*l.Name)[len(prefix):]
+	for _, label := range labels {
+		if strings.HasPrefix(label, prefix) {
+			return label[len(prefix):]
 		}
 	}
 	return "?d"
 }
 
-func state(state *string) string {
-	if state != nil && *state == "closed" {
+func state(state string) string {
+	if state == "closed" {
 		return "x"
 	}
 	return " "
 }
 
-func categories(issue *github.Issue) map[string]string {
+func categories(issue *Issue) map[string]string {
 	categories := make(map[string]string, len(issue.Labels))
 
-	for _, l := range issue.Labels {
+	for _, label := range issue.Labels {
 		var emoji string
 
-		switch *l.Name {
+		switch label {
 		case "customer":
 			emoji = customer(issue)
 		case "roadmap":
@@ -146,7 +137,7 @@ func categories(issue *github.Issue) map[string]string {
 		}
 
 		if emoji != "" {
-			categories[*l.Name] = emoji
+			categories[label] = emoji
 		}
 	}
 
@@ -165,48 +156,117 @@ func emojis(categories map[string]string) string {
 
 var matcher = regexp.MustCompile(`https://app\.hubspot\.com/contacts/2762526/company/\d+`)
 
-func customer(issue *github.Issue) string {
-	if issue == nil || issue.Body == nil {
-		return ""
-	}
-
-	customer := matcher.FindString(*issue.Body)
+func customer(issue *Issue) string {
+	customer := matcher.FindString(issue.Body)
 	if customer == "" {
 		return "👩"
 	}
-
 	return "[👩](" + customer + ")"
 }
 
-func assignee(user *github.User) string {
-	if user == nil || user.Login == nil {
+func assignee(assignees []string) string {
+	if len(assignees) == 0 {
 		return "Unassigned"
 	}
-	return "@" + *user.Login
+	return "@" + assignees[0]
 }
 
-func listIssues(ctx context.Context, cli *github.Client, org string, labels ...string) (issues []*github.Issue, _ error) {
-	opt := &github.IssueListOptions{
-		Filter:      "all",
-		State:       "all",
-		Labels:      labels,
-		ListOptions: github.ListOptions{PerPage: 100},
+type Issue struct {
+	Title      string
+	Body       string
+	Number     int
+	URL        string
+	State      string
+	Repository string
+	Private    bool
+	Labels     []string
+	Assignees  []string
+	Milestone  string
+}
+
+func listIssues(ctx context.Context, cli *githubv4.Client, org, milestone string, labels []string) (issues []*Issue, _ error) {
+	type issue struct {
+		Title      string
+		Body       string
+		State      string
+		Number     int
+		URL        string
+		Repository struct {
+			NameWithOwner string
+			IsPrivate     bool
+		}
+		Assignees struct{ Nodes []struct{ Login string } } `graphql:"assignees(first: 25)"`
+		Labels    struct{ Nodes []struct{ Name string } }  `graphql:"labels(first:25)"`
+		Milestone struct{ Title string }
+	}
+
+	var q struct {
+		Search struct {
+			PageInfo struct {
+				EndCursor   githubv4.String
+				HasNextPage bool
+			}
+			Nodes []struct {
+				issue `graphql:"... on Issue"`
+			}
+		} `graphql:"search(first: 100, type: ISSUE, after: $cursor, query: $query)"`
+	}
+
+	variables := map[string]interface{}{
+		"cursor": (*githubv4.String)(nil),
+		"query":  githubv4.String(listIssuesSearchQuery(org, milestone, labels)),
 	}
 
 	for {
-		page, resp, err := cli.Issues.ListByOrg(ctx, org, opt)
+		err := cli.Query(ctx, &q, variables)
 		if err != nil {
 			return nil, err
 		}
 
-		issues = append(issues, page...)
+		for _, n := range q.Search.Nodes {
+			i := n.issue
 
-		if resp.NextPage == 0 {
+			issue := &Issue{
+				Title:      i.Title,
+				Body:       i.Body,
+				State:      i.State,
+				Number:     i.Number,
+				URL:        i.URL,
+				Repository: i.Repository.NameWithOwner,
+				Private:    i.Repository.IsPrivate,
+				Assignees:  make([]string, 0, len(i.Assignees.Nodes)),
+				Labels:     make([]string, 0, len(i.Labels.Nodes)),
+				Milestone:  i.Milestone.Title,
+			}
+
+			for _, assignee := range i.Assignees.Nodes {
+				issue.Assignees = append(issue.Assignees, assignee.Login)
+			}
+
+			for _, label := range i.Labels.Nodes {
+				issue.Labels = append(issue.Labels, label.Name)
+			}
+
+			issues = append(issues, issue)
+		}
+
+		if !q.Search.PageInfo.HasNextPage {
 			break
 		}
 
-		opt.Page = resp.NextPage
+		variables["cursor"] = githubv4.NewString(q.Search.PageInfo.EndCursor)
 	}
 
 	return issues, nil
+}
+
+func listIssuesSearchQuery(org, milestone string, labels []string) string {
+	var q strings.Builder
+
+	fmt.Fprintf(&q, "org:%q milestone:%q", org, milestone)
+	for _, label := range labels {
+		fmt.Fprintf(&q, " label:%q", label)
+	}
+
+	return q.String()
 }

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -272,9 +272,18 @@ func listIssues(ctx context.Context, cli *githubv4.Client, org, milestone string
 func listIssuesSearchQuery(org, milestone string, labels []string) string {
 	var q strings.Builder
 
-	fmt.Fprintf(&q, "org:%q milestone:%q", org, milestone)
+	if org != "" {
+		fmt.Fprintf(&q, "org:%q", org)
+	}
+
+	if milestone != "" {
+		fmt.Fprintf(&q, " milestone:%q", milestone)
+	}
+
 	for _, label := range labels {
-		fmt.Fprintf(&q, " label:%q", label)
+		if label != "" {
+			fmt.Fprintf(&q, " label:%q", label)
+		}
 	}
 
 	return q.String()

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -155,8 +155,6 @@ func emojis(categories map[string]string) string {
 
 	sort.Strings(sorted)
 
-	// Generous four bytes for each emoji. We don't have
-	// to be precise, since append will allocate more if needed.
 	s := make([]byte, 0, length)
 	for _, emoji := range sorted {
 		s = append(s, emoji...)


### PR DESCRIPTION
This commit changes `cmd/tracking-issue` to use the search API through
GraphQL. This massively speeds up the runtime of this command since
we're able to filter issues by milestone at the source.

```
sourcegraph:tracking-issue/graphql λ time go run ./internal/cmd/tracking-issue/main.go -milestone=3.13 -labels=team/core-services > /dev/null

0.97user 0.23system 0:02.08elapsed

sourcegraph:tracking-issue/graphql λ g co master
sourcegraph:master λ time go run ./internal/cmd/tracking-issue/main.go -milestone=3.13 -labels=team/core-services > /dev/null

1.07user 0.19system 0:11.00elapsed
```