### PR TITLE
Add fix for #8009 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A regression in 3.12.0 which caused [Automation find-leaked-credentials campaigns](https://docs.sourcegraph.com/user/automation#finding-leaked-credentials) to not return any results for private repositories. [#7914](https://github.com/sourcegraph/sourcegraph/issues/7914)
 - A regression in 3.12.0 which removed the horizontal bar between search result matches.
+- Manual Automation campaigns were wrongly displayed as being in draft mode. [#8009](https://github.com/sourcegraph/sourcegraph/issues/8009)
 
 ## 3.12.1
 


### PR DESCRIPTION
Adding the fix for https://github.com/sourcegraph/sourcegraph/issues/8009 to the CHANGELOG so it can be released in 3.12.2 later today.