### PR TITLE
Expose backend.CurrentUser method for 3.12

### DIFF
--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -19,7 +19,7 @@ func CheckOrgAccess(ctx context.Context, orgID int32) error {
 	if hasAuthzBypass(ctx) {
 		return nil
 	}
-	currentUser, err := currentUser(ctx)
+	currentUser, err := CurrentUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -18,7 +18,7 @@ func CheckCurrentUserIsSiteAdmin(ctx context.Context) error {
 	if hasAuthzBypass(ctx) {
 		return nil
 	}
-	user, err := currentUser(ctx)
+	user, err := CurrentUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,9 @@ func CheckSiteAdminOrSameUser(ctx context.Context, subjectUserID int32) error {
 	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as %s or as an admin (%s)", subjectUser.Username, isSiteAdminErr.Error())}
 }
 
-func currentUser(ctx context.Context) (*types.User, error) {
+// CurrentUser gets the current authenticated user
+// It returns nil, nil if no user is found
+func CurrentUser(ctx context.Context) (*types.User, error) {
 	user, err := db.Users.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == db.ErrNoCurrentUser {

--- a/enterprise/internal/a8n/resolvers/campaigns.go
+++ b/enterprise/internal/a8n/resolvers/campaigns.go
@@ -100,6 +100,9 @@ func (r *campaignResolver) ViewerCanAdminister(ctx context.Context) (bool, error
 	if err != nil {
 		return false, err
 	}
+	if currentUser == nil {
+		return false, backend.ErrNotAuthenticated
+	}
 	return currentUser.SiteAdmin, nil
 }
 


### PR DESCRIPTION
A fix in 3.12.2 needs to use this method, but it was only exposed on `master` in a too-large-to-cherry-pick commit.
