### PR TITLE
a8n/core: support updating changesets on bitbucket server

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -200,6 +200,26 @@ func (s BitbucketServerSource) LoadChangesets(ctx context.Context, cs ...*Change
 	return nil
 }
 
+func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset) error {
+	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a Bitbucket Server pull request")
+	}
+
+	updated, err := s.client.UpdatePullRequest(ctx, &bitbucketserver.UpdatePullRequestInput{
+		PullRequestID: strconv.Itoa(pr.ID),
+		Title:         pr.Title,
+		Description:   pr.Description,
+		ToRef:         pr.ToRef,
+	})
+	if err != nil {
+		return err
+	}
+
+	c.Changeset.Metadata = updated
+	return nil
+}
+
 // ExternalServices returns a singleton slice containing the external service.
 func (s BitbucketServerSource) ExternalServices() ExternalServices {
 	return ExternalServices{s.svc}

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -206,12 +206,17 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 		return errors.New("Changeset is not a Bitbucket Server pull request")
 	}
 
-	updated, err := s.client.UpdatePullRequest(ctx, &bitbucketserver.UpdatePullRequestInput{
+	update := &bitbucketserver.UpdatePullRequestInput{
 		PullRequestID: strconv.Itoa(pr.ID),
-		Title:         pr.Title,
-		Description:   pr.Description,
-		ToRef:         pr.ToRef,
-	})
+		Title:         c.Title,
+		Description:   c.Body,
+		Version:       pr.Version,
+	}
+	update.ToRef.ID = c.BaseRef
+	update.ToRef.Repository.Slug = pr.ToRef.Repository.Slug
+	update.ToRef.Repository.Project.Key = pr.ToRef.Repository.Project.Key
+
+	updated, err := s.client.UpdatePullRequest(ctx, update)
 	if err != nil {
 		return err
 	}

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -421,3 +421,77 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 		})
 	}
 }
+
+func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		// The test fixtures and golden files were generated with
+		// this config pointed to bitbucket.sgdev.org
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	pr := &bitbucketserver.PullRequest{ID: 43, Version: 1}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs: &Changeset{
+				Title:     "This is a new title",
+				Body:      "This is a new body",
+				BaseRef:   "refs/heads/master",
+				Changeset: &a8n.Changeset{Metadata: pr},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "BitbucketServerSource_UpdateChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &ExternalService{
+				Kind: "BITBUCKETSERVER",
+				Config: marshalJSON(t, &schema.BitbucketServerConnection{
+					Url:   instanceURL,
+					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				}),
+			}
+
+			bbsSrc, err := NewBitbucketServerSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			err = bbsSrc.UpdateChangeset(ctx, tc.cs)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
+		})
+	}
+}

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -101,10 +101,8 @@ type ChangesetSource interface {
 	// means the appropriate final state on the codehost (e.g. "declined" on
 	// Bitbucket Server).
 	CloseChangeset(context.Context, *Changeset) error
-}
 
-// A UpdateChangesetSource can update Changesets.
-type UpdateChangesetSource interface {
+	// UpdateChangeset can update Changesets.
 	UpdateChangeset(context.Context, *Changeset) error
 }
 

--- a/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_UpdateChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_UpdateChangeset_success
@@ -1,0 +1,53 @@
+{
+  "id": 43,
+  "version": 2,
+  "title": "This is a new title",
+  "description": "This is a new body",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1580213993810,
+  "updatedDate": 1580217091763,
+  "fromRef": {
+   "id": "refs/heads/milton/file1txt-1580213978330",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "milton",
+    "emailAddress": "dev@sourcegraph.com",
+    "id": 1,
+    "displayName": "milton woof",
+    "active": true,
+    "slug": "milton",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/43"
+    }
+   ]
+  }
+ }

--- a/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"version":1,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/43
+    method: PUT
+  response:
+    body: '{"id":43,"version":2,"title":"This is a new title","description":"This
+      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1580213993810,"updatedDate":1580217091763,"fromRef":{"id":"refs/heads/milton/file1txt-1580213978330","displayId":"milton/file1txt-1580213978330","latestCommit":"58301dcfa4b81ac8dcca5c8fad4216532f702237","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"97f8a75319760990c187710c50a957358f663366","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
+      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/43"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 28 Jan 2020 13:11:31 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@1JRK3O7x791x4283914x0'
+      X-Asen:
+      - SEN-11363689
+      X-Asessionid:
+      - 1snwtfj
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -405,12 +405,7 @@ func RunChangesetJob(
 		}
 
 		if outdated {
-			ucs, ok := src.(repos.UpdateChangesetSource)
-			if !ok {
-				return errors.Errorf("updating changesets on code host of repo %q is not implemented", repo.Name)
-			}
-
-			err := ucs.UpdateChangeset(ctx, &cs)
+			err := ccs.UpdateChangeset(ctx, &cs)
 			if err != nil {
 				return errors.Wrap(err, "updating changeset")
 			}

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -410,6 +410,25 @@ func (c *Client) LoadPullRequest(ctx context.Context, pr *PullRequest) error {
 	return c.send(ctx, "GET", path, nil, nil, pr)
 }
 
+type UpdatePullRequestInput struct {
+	PullRequestID string `json:"-"`
+
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	ToRef       Ref    `json:"toRef"`
+}
+
+func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {
+	path := fmt.Sprintf(
+		"rest/api/1.0/projects/%s/repos/%s/pull-requests/%s",
+		in.ToRef.Repository.Project.Key,
+		in.ToRef.Repository.Slug,
+		in.PullRequestID,
+	)
+	pr := &PullRequest{}
+	return pr, c.send(ctx, "POST", path, nil, in, pr)
+}
+
 // ErrAlreadyExists is returned by Client.CreatePullRequest when a Pull Request
 // for the given FromRef and ToRef already exists.
 type ErrAlreadyExists struct {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -412,6 +412,7 @@ func (c *Client) LoadPullRequest(ctx context.Context, pr *PullRequest) error {
 
 type UpdatePullRequestInput struct {
 	PullRequestID string `json:"-"`
+	Version       int    `json:"version"`
 
 	Title       string `json:"title"`
 	Description string `json:"description"`
@@ -425,8 +426,9 @@ func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInp
 		in.ToRef.Repository.Slug,
 		in.PullRequestID,
 	)
+
 	pr := &PullRequest{}
-	return pr, c.send(ctx, "POST", path, nil, in, pr)
+	return pr, c.send(ctx, "PUT", path, nil, in, pr)
 }
 
 // ErrAlreadyExists is returned by Client.CreatePullRequest when a Pull Request


### PR DESCRIPTION
This PR allows reflecting changeset edits made on Sourcegraph onto the Bitbucket Server code host. This closes #7762.