### PR TITLE
Improve changeset form UX

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -94,7 +94,7 @@ $table-border-color-light: #e4e9f1;
 $progress-height: auto;
 
 // Collapsible
-$collapsible-expand-btn-width: 20px;
+$collapsible-expand-btn-width: 1.25rem;
 
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -93,6 +93,9 @@ $table-border-color-light: #e4e9f1;
 // Progress
 $progress-height: auto;
 
+// Collapsible
+$collapsible-expand-btn-width: 20px;
+
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
@@ -248,6 +251,7 @@ body,
 @import './user/area/UserArea';
 @import './org/OrgsArea';
 @import './components/AnimatedAlert';
+@import './components/Collapsible';
 @import './components/DismissibleAlert';
 @import './marketing/SurveyPage';
 @import './components/SingleValueCard';

--- a/web/src/components/Collapsible.scss
+++ b/web/src/components/Collapsible.scss
@@ -1,0 +1,5 @@
+.collapsible {
+    &__expand-btn {
+        width: $collapsible-expand-btn-width;
+    }
+}

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -59,7 +59,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
             >
                 <button
                     type="button"
-                    className={classNames('btn btn-icon', wholeTitleClickable && 'stretched-link')}
+                    className={classNames('btn btn-icon collapsible__expand-btn', wholeTitleClickable && 'stretched-link')}
                     aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                     onClick={toggleIsExpanded}
                 >

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -59,7 +59,10 @@ export const Collapsible: React.FunctionComponent<Props> = ({
             >
                 <button
                     type="button"
-                    className={classNames('btn btn-icon collapsible__expand-btn', wholeTitleClickable && 'stretched-link')}
+                    className={classNames(
+                        'btn btn-icon collapsible__expand-btn',
+                        wholeTitleClickable && 'stretched-link'
+                    )}
                     aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                     onClick={toggleIsExpanded}
                 >

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -88,33 +88,80 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
         },
         [campaignID, externalID, onAdd, repoName, setError]
     )
+    const onChangeRepoName = (repoName: string): void => {
+        try {
+            const url = new URL(repoName)
+            // match for github and bitbucket pr urls
+            const githubRegex = /\/pull\/([0-9]+).*$/
+            const bitbucketRegex = /\/pull-requests\/([0-9]+).*$/
+            const githubMatches = githubRegex.exec(url.pathname)
+            if (githubMatches) {
+                setRepoName(url.hostname + url.pathname.substring(0, url.pathname.indexOf('/pull/')))
+                if (githubMatches[1]) {
+                    setExternalID(githubMatches[1])
+                }
+            } else {
+                const bitbucketMatches = bitbucketRegex.exec(url.pathname)
+                if (bitbucketMatches) {
+                    setRepoName(url.hostname + url.pathname.substring(0, url.pathname.indexOf('/pull-requests/')))
+                    if (bitbucketMatches[1]) {
+                        setExternalID(bitbucketMatches[1])
+                    }
+                } else {
+                    setRepoName(repoName)
+                }
+            }
+        } catch {
+            setRepoName(repoName)
+        }
+    }
     return (
         <>
-            <Form className="form-inline" onSubmit={submit}>
-                <input
-                    required={true}
-                    type="text"
-                    size={35}
-                    className="form-control mr-1"
-                    placeholder="Repository name"
-                    value={repoName}
-                    onChange={event => setRepoName(event.target.value)}
-                />
-                <input
-                    required={true}
-                    type="text"
-                    size={16}
-                    className="form-control mr-1"
-                    placeholder="Changeset number"
-                    value={externalID}
-                    onChange={event => setExternalID(event.target.value)}
-                />
+            <Form onSubmit={submit}>
+                <div className="d-flex">
+                    <div className="form-group mr-3 mb-0">
+                        <label htmlFor="changeset-repo">
+                            <h3>Repository name</h3>
+                        </label>
+                        <input
+                            required={true}
+                            name="changeset-repo"
+                            type="text"
+                            size={35}
+                            className="form-control mr-1"
+                            placeholder="Repository name"
+                            value={repoName}
+                            onChange={event => onChangeRepoName(event.target.value)}
+                        />
+                        <p className="form-text text-muted">
+                            Name of the repository in Sourcegraph {window.location.protocol}//{window.location.host}
+                            /$REPOSITORY_NAME
+                        </p>
+                    </div>
+                    <div className="form-group mr-3 mb-0">
+                        <label htmlFor="changeset-number">
+                            <h3>Changeset number</h3>
+                        </label>
+                        <input
+                            required={true}
+                            name="changeset-number"
+                            type="number"
+                            min={1}
+                            step={1}
+                            size={16}
+                            className="form-control mr-1"
+                            placeholder="Changeset number"
+                            value={externalID}
+                            onChange={event => setExternalID(event.target.value + '')}
+                        />
+                    </div>
+                </div>
                 <button type="submit" className="btn btn-primary mr-1">
                     Add changeset
+                    {isLoading && <LoadingSpinner className="ml-2 icon-inline" />}
                 </button>
-                {isLoading && <LoadingSpinner className="icon-inline" />}
             </Form>
-            {error && <ErrorAlert error={error} />}
+            {error && <ErrorAlert error={error} className="mt-3" />}
         </>
     )
 }

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -117,6 +117,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
     }
     return (
         <>
+            <h3>Track changeset</h3>
             <Form onSubmit={submit}>
                 <div className="d-flex">
                     <div className="form-group mr-3 mb-0">
@@ -131,10 +132,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                             value={repoName}
                             onChange={event => onChangeRepoName(event.target.value)}
                         />
-                        <p className="form-text text-muted">
-                            Name of the repository in Sourcegraph {window.location.protocol}//{window.location.host}
-                            /$REPOSITORY_NAME
-                        </p>
+                        <p className="form-text text-muted">e.g., codehost/organization/repository</p>
                     </div>
                     <div className="form-group mr-3 mb-0">
                         <label htmlFor="changeset-number">Changeset number</label>

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -7,7 +7,6 @@ import { RepoNotFoundError } from '../../../../../shared/src/backend/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
-import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 
 async function addChangeset({
     campaignID,

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -120,9 +120,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
             <Form onSubmit={submit}>
                 <div className="d-flex">
                     <div className="form-group mr-3 mb-0">
-                        <label htmlFor="changeset-repo">
-                            <h3>Repository name</h3>
-                        </label>
+                        <label htmlFor="changeset-repo">Repository name</label>
                         <input
                             required={true}
                             name="changeset-repo"
@@ -139,9 +137,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                         </p>
                     </div>
                     <div className="form-group mr-3 mb-0">
-                        <label htmlFor="changeset-number">
-                            <h3>Changeset number</h3>
-                        </label>
+                        <label htmlFor="changeset-number">Changeset number</label>
                         <input
                             required={true}
                             name="changeset-number"

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -7,6 +7,7 @@ import { RepoNotFoundError } from '../../../../../shared/src/backend/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
+import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 
 async function addChangeset({
     campaignID,
@@ -88,33 +89,6 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
         },
         [campaignID, externalID, onAdd, repoName, setError]
     )
-    const onChangeRepoName = (repoName: string): void => {
-        try {
-            const url = new URL(repoName)
-            // match for github and bitbucket pr urls
-            const githubRegex = /\/pull\/([0-9]+).*$/
-            const bitbucketRegex = /\/pull-requests\/([0-9]+).*$/
-            const githubMatches = githubRegex.exec(url.pathname)
-            if (githubMatches) {
-                setRepoName(url.hostname + url.pathname.substring(0, url.pathname.indexOf('/pull/')))
-                if (githubMatches[1]) {
-                    setExternalID(githubMatches[1])
-                }
-            } else {
-                const bitbucketMatches = bitbucketRegex.exec(url.pathname)
-                if (bitbucketMatches) {
-                    setRepoName(url.hostname + url.pathname.substring(0, url.pathname.indexOf('/pull-requests/')))
-                    if (bitbucketMatches[1]) {
-                        setExternalID(bitbucketMatches[1])
-                    }
-                } else {
-                    setRepoName(repoName)
-                }
-            }
-        } catch {
-            setRepoName(repoName)
-        }
-    }
     return (
         <>
             <h3>Track changeset</h3>
@@ -130,9 +104,12 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                             className="form-control mr-1"
                             placeholder="Repository name"
                             value={repoName}
-                            onChange={event => onChangeRepoName(event.target.value)}
+                            onChange={event => setRepoName(event.target.value)}
                         />
-                        <p className="form-text text-muted">e.g., codehost/organization/repository</p>
+                        <p className="form-text text-muted">
+                            Find the Sourcegraph repository name in the URL (e.g., {window.location.protocol}//
+                            {window.location.host}/<strong>&lt;REPOSITORY_NAME&gt;</strong>)
+                        </p>
                     </div>
                     <div className="form-group mr-3 mb-0">
                         <label htmlFor="changeset-number">Changeset number</label>

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -97,7 +97,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                         <label htmlFor="changeset-repo">Repository name</label>
                         <input
                             required={true}
-                            name="changeset-repo"
+                            id="changeset-repo"
                             type="text"
                             size={35}
                             className="form-control mr-1"
@@ -114,7 +114,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                         <label htmlFor="changeset-number">Changeset number</label>
                         <input
                             required={true}
-                            name="changeset-number"
+                            id="changeset-number"
                             type="number"
                             min={1}
                             step={1}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
@@ -15,9 +15,7 @@ exports[`AddChangesetForm renders the form 1`] = `
       <label
         htmlFor="changeset-repo"
       >
-        <h3>
-          Repository name
-        </h3>
+        Repository name
       </label>
       <input
         className="form-control mr-1"
@@ -45,9 +43,7 @@ exports[`AddChangesetForm renders the form 1`] = `
       <label
         htmlFor="changeset-number"
       >
-        <h3>
-          Changeset number
-        </h3>
+        Changeset number
       </label>
       <input
         className="form-control mr-1"

--- a/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
@@ -1,69 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AddChangesetForm renders the form 1`] = `
-<form
-  className=" "
-  onInvalid={[Function]}
-  onSubmit={[Function]}
->
-  <div
-    className="d-flex"
+Array [
+  <h3>
+    Track changeset
+  </h3>,
+  <form
+    className=" "
+    onInvalid={[Function]}
+    onSubmit={[Function]}
   >
     <div
-      className="form-group mr-3 mb-0"
+      className="d-flex"
     >
-      <label
-        htmlFor="changeset-repo"
+      <div
+        className="form-group mr-3 mb-0"
       >
-        Repository name
-      </label>
-      <input
-        className="form-control mr-1"
-        name="changeset-repo"
-        onChange={[Function]}
-        placeholder="Repository name"
-        required={true}
-        size={35}
-        type="text"
-        value=""
-      />
-      <p
-        className="form-text text-muted"
+        <label
+          htmlFor="changeset-repo"
+        >
+          Repository name
+        </label>
+        <input
+          className="form-control mr-1"
+          name="changeset-repo"
+          onChange={[Function]}
+          placeholder="Repository name"
+          required={true}
+          size={35}
+          type="text"
+          value=""
+        />
+        <p
+          className="form-text text-muted"
+        >
+          e.g., codehost/organization/repository
+        </p>
+      </div>
+      <div
+        className="form-group mr-3 mb-0"
       >
-        Name of the repository in Sourcegraph 
-        http:
-        //
-        localhost
-        /$REPOSITORY_NAME
-      </p>
+        <label
+          htmlFor="changeset-number"
+        >
+          Changeset number
+        </label>
+        <input
+          className="form-control mr-1"
+          min={1}
+          name="changeset-number"
+          onChange={[Function]}
+          placeholder="Changeset number"
+          required={true}
+          size={16}
+          step={1}
+          type="number"
+          value=""
+        />
+      </div>
     </div>
-    <div
-      className="form-group mr-3 mb-0"
+    <button
+      className="btn btn-primary mr-1"
+      type="submit"
     >
-      <label
-        htmlFor="changeset-number"
-      >
-        Changeset number
-      </label>
-      <input
-        className="form-control mr-1"
-        min={1}
-        name="changeset-number"
-        onChange={[Function]}
-        placeholder="Changeset number"
-        required={true}
-        size={16}
-        step={1}
-        type="number"
-        value=""
-      />
-    </div>
-  </div>
-  <button
-    className="btn btn-primary mr-1"
-    type="submit"
-  >
-    Add changeset
-  </button>
-</form>
+      Add changeset
+    </button>
+  </form>,
+]
 `;

--- a/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
@@ -34,7 +34,15 @@ Array [
         <p
           className="form-text text-muted"
         >
-          e.g., codehost/organization/repository
+          Find the Sourcegraph repository name in the URL (e.g., 
+          http:
+          //
+          localhost
+          /
+          <strong>
+            &lt;REPOSITORY_NAME&gt;
+          </strong>
+          )
         </p>
       </div>
       <div

--- a/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
@@ -2,28 +2,67 @@
 
 exports[`AddChangesetForm renders the form 1`] = `
 <form
-  className="form-inline "
+  className=" "
   onInvalid={[Function]}
   onSubmit={[Function]}
 >
-  <input
-    className="form-control mr-1"
-    onChange={[Function]}
-    placeholder="Repository name"
-    required={true}
-    size={35}
-    type="text"
-    value=""
-  />
-  <input
-    className="form-control mr-1"
-    onChange={[Function]}
-    placeholder="Changeset number"
-    required={true}
-    size={16}
-    type="text"
-    value=""
-  />
+  <div
+    className="d-flex"
+  >
+    <div
+      className="form-group mr-3 mb-0"
+    >
+      <label
+        htmlFor="changeset-repo"
+      >
+        <h3>
+          Repository name
+        </h3>
+      </label>
+      <input
+        className="form-control mr-1"
+        name="changeset-repo"
+        onChange={[Function]}
+        placeholder="Repository name"
+        required={true}
+        size={35}
+        type="text"
+        value=""
+      />
+      <p
+        className="form-text text-muted"
+      >
+        Name of the repository in Sourcegraph 
+        http:
+        //
+        localhost
+        /$REPOSITORY_NAME
+      </p>
+    </div>
+    <div
+      className="form-group mr-3 mb-0"
+    >
+      <label
+        htmlFor="changeset-number"
+      >
+        <h3>
+          Changeset number
+        </h3>
+      </label>
+      <input
+        className="form-control mr-1"
+        min={1}
+        name="changeset-number"
+        onChange={[Function]}
+        placeholder="Changeset number"
+        required={true}
+        size={16}
+        step={1}
+        type="number"
+        value=""
+      />
+    </div>
+  </div>
   <button
     className="btn btn-primary mr-1"
     type="submit"

--- a/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/AddChangesetForm.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
         </label>
         <input
           className="form-control mr-1"
-          name="changeset-repo"
+          id="changeset-repo"
           onChange={[Function]}
           placeholder="Repository name"
           required={true}
@@ -55,8 +55,8 @@ Array [
         </label>
         <input
           className="form-control mr-1"
+          id="changeset-number"
           min={1}
-          name="changeset-number"
           onChange={[Function]}
           placeholder="Changeset number"
           required={true}

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.scss
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.scss
@@ -1,5 +1,8 @@
 .changeset-node {
     &__content {
+        &--no-collapse {
+            margin-left: $collapsible-expand-btn-width;
+        }
         flex: 1;
         min-width: 0;
     }

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
@@ -165,7 +165,9 @@ export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({
                     ))}
                 </Collapsible>
             ) : (
-                <div className="campaign-node__content flex-fill">{changesetNodeRow}</div>
+                <div className="changeset-node__content changeset-node__content--no-collapse flex-fill">
+                    {changesetNodeRow}
+                </div>
             )}
         </li>
     )

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
@@ -148,7 +148,7 @@ export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({
         <li className="list-group-item e2e-changeset-node">
             {fileDiffNodes ? (
                 <Collapsible
-                    titleClassName="campaign-node__content flex-fill"
+                    titleClassName="changeset-node__content flex-fill"
                     title={changesetNodeRow}
                     wholeTitleClickable={false}
                 >

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
@@ -191,7 +191,7 @@ Object {
         </span>
       </div>
     }
-    titleClassName="campaign-node__content flex-fill"
+    titleClassName="changeset-node__content flex-fill"
     wholeTitleClickable={false}
   >
     <FileDiffNode

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
@@ -17,7 +17,7 @@ Object {
         />
       </div>
       <div
-        className="campaign-node__content flex-fill"
+        className="changeset-node__content flex-fill"
       >
         <h3
           className="m-0"
@@ -70,7 +70,7 @@ Object {
         />
       </div>
       <div
-        className="campaign-node__content flex-fill"
+        className="changeset-node__content flex-fill"
       >
         <h3
           className="m-0"
@@ -145,7 +145,7 @@ Object {
           />
         </div>
         <div
-          className="campaign-node__content flex-fill"
+          className="changeset-node__content flex-fill"
         >
           <h3
             className="m-0"

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ChangesetNode renders a changesetplan with publishing disabled 1`] = `
 Object {
   "children": <div
-    className="campaign-node__content flex-fill"
+    className="changeset-node__content changeset-node__content--no-collapse flex-fill"
   >
     <div
       className="d-flex align-items-center m-1"
@@ -56,7 +56,7 @@ Object {
 exports[`ChangesetNode renders a changesetplan with publishing enabled 1`] = `
 Object {
   "children": <div
-    className="campaign-node__content flex-fill"
+    className="changeset-node__content changeset-node__content--no-collapse flex-fill"
   >
     <div
       className="d-flex align-items-center m-1"


### PR DESCRIPTION
Closes #8027 

I also added some regex parsing to the pasted content, so it'll split bitbucket and github urls properly now and paste in what is expected. Lmk if you like that behavior or if it feels weird (see screencast below)

![image](https://user-images.githubusercontent.com/19534377/73089240-20a79b00-3ed6-11ea-85b8-20fedacdaadc.png)

![2020-01-24 18 20 20](https://user-images.githubusercontent.com/19534377/73089366-58aede00-3ed6-11ea-8559-7c419b9f883b.gif)
