### PR TITLE
Enable postgres-based event logs on Sourcegraph.com

### DIFF
--- a/cmd/frontend/graphqlbackend/site_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/site_usage_stats.go
@@ -2,10 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
-	"errors"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
@@ -15,9 +13,6 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 	Weeks  *int32
 	Months *int32
 }) (*siteUsageStatisticsResolver, error) {
-	if envvar.SourcegraphDotComMode() {
-		return nil, errors.New("site usage statistics are not available on sourcegraph.com")
-	}
 	opt := &usagestats.SiteUsageStatisticsOptions{}
 	if args.Days != nil {
 		d := int(*args.Days)

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -57,9 +56,6 @@ type userConnectionResolver struct {
 func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, int, error) {
 	if r.activePeriod == nil {
 		return nil, 0, errors.New("activePeriod must not be nil")
-	}
-	if r.activePeriod != nil && envvar.SourcegraphDotComMode() {
-		return nil, 0, errors.New("usage statistics are not available on sourcegraph.com")
 	}
 	r.once.Do(func() {
 		var err error

--- a/cmd/frontend/internal/usagestats/event_handlers.go
+++ b/cmd/frontend/internal/usagestats/event_handlers.go
@@ -45,9 +45,8 @@ func LogEvent(ctx context.Context, args Event) error {
 	}
 	if envvar.SourcegraphDotComMode() {
 		return publishSourcegraphDotComEvent(args)
-	} else {
-		return logLocalEvent(ctx, args.EventName, args.URL, args.UserID, args.UserCookieID, args.Source, args.Argument)
 	}
+	return logLocalEvent(ctx, args.EventName, args.URL, args.UserID, args.UserCookieID, args.Source, args.Argument)
 }
 
 type bigQueryEvent struct {

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -9,13 +9,11 @@ class ServerAdminWrapper {
     private isAuthenicated = false
 
     constructor() {
-        if (window.context && !window.context.sourcegraphDotComMode) {
-            authenticatedUser.subscribe(user => {
-                if (user) {
-                    this.isAuthenicated = true
-                }
-            })
-        }
+        authenticatedUser.subscribe(user => {
+            if (user) {
+                this.isAuthenicated = true
+            }
+        })
     }
 
     public trackPageView(eventAction: string, logAsActiveUser: boolean = true): void {

--- a/web/src/user/settings/backend.tsx
+++ b/web/src/user/settings/backend.tsx
@@ -94,9 +94,6 @@ export function setUserEmailVerified(user: GQL.ID, email: string, verified: bool
  * @deprecated Use logEvent
  */
 export function logUserEvent(event: GQL.UserEvent): void {
-    if (window.context && window.context.sourcegraphDotComMode) {
-        return
-    }
     mutateGraphQL(
         gql`
             mutation logUserEvent($event: UserEvent!, $userCookieID: String!) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8032

@unknwon FYI, this will add a significant load (pg insertions and # of API calls) on Sourcegraph.com. Note that I left the browser extension events unlogged, though (since we say we won't capture telemetry from it in our docs: https://docs.sourcegraph.com/integration/browser_extension#privacy

Is it safe to turn this on?