### PR TITLE
web: remove unneeded narrow-width route prop

### DIFF
--- a/web/src/Layout.scss
+++ b/web/src/Layout.scss
@@ -11,42 +11,6 @@
         display: flex;
         overflow: auto;
         -webkit-overflow-scrolling: touch;
-
-        &--restricted {
-            padding: 0 2.5rem;
-
-            @media (max-width: $media-md) {
-                width: 100%;
-                padding: 0;
-            }
-
-            @media (min-width: $media-md) {
-                // stylelint-disable-next-line declaration-property-unit-whitelist
-                width: 720px;
-            }
-
-            @media (max-width: $media-lg) {
-                width: 100%;
-                padding: 0;
-            }
-
-            @media (min-width: $media-lg) {
-                // stylelint-disable-next-line declaration-property-unit-whitelist
-                width: 960px;
-            }
-
-            @media (min-width: $media-xl) {
-                // stylelint-disable-next-line declaration-property-unit-whitelist
-                width: 1140px;
-            }
-        }
-
-        &--full-width {
-            @media (max-width: $media-md) {
-                padding: 0;
-            }
-
-            width: 100%;
-        }
+        width: 100%;
     }
 }

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -161,30 +161,21 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 <Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                     <Switch>
                         {/* eslint-disable react/jsx-no-bind */}
-                        {props.routes.map(({ render, condition = () => true, ...route }) => {
-                            const isFullWidth = !route.forceNarrowWidth
-                            return (
+                        {props.routes.map(
+                            ({ render, condition = () => true, ...route }) =>
                                 condition(props) && (
                                     <Route
                                         {...route}
                                         key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                         component={undefined}
                                         render={routeComponentProps => (
-                                            <div
-                                                className={[
-                                                    'layout__app-router-container',
-                                                    `layout__app-router-container--${
-                                                        isFullWidth ? 'full-width' : 'restricted'
-                                                    }`,
-                                                ].join(' ')}
-                                            >
+                                            <div className="layout__app-router-container">
                                                 {render({ ...props, ...routeComponentProps })}
                                             </div>
                                         )}
                                     />
                                 )
-                            )
-                        })}
+                        )}
                         {/* eslint-enable react/jsx-no-bind */}
                     </Switch>
                 </Suspense>

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -24,11 +24,6 @@ export interface LayoutRouteProps<Params extends { [K in keyof Params]?: string 
      * @default () => true
      */
     condition?: (props: LayoutRouteComponentProps<Params>) => boolean
-
-    /**
-     * Whether or not to force the width of the page to be narrow.
-     */
-    forceNarrowWidth?: boolean
 }
 
 /**
@@ -67,13 +62,11 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/sign-in',
         render: lazyComponent(() => import('./auth/SignInPage'), 'SignInPage'),
         exact: true,
-        forceNarrowWidth: true,
     },
     {
         path: '/sign-up',
         render: lazyComponent(() => import('./auth/SignUpPage'), 'SignUpPage'),
         exact: true,
-        forceNarrowWidth: true,
     },
     {
         path: '/settings',
@@ -96,7 +89,6 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/site-admin/init',
         exact: true,
         render: lazyComponent(() => import('./site-admin/SiteInitPage'), 'SiteInitPage'),
-        forceNarrowWidth: false,
     },
     {
         path: '/site-admin',
@@ -113,7 +105,6 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/password-reset',
         render: lazyComponent(() => import('./auth/ResetPasswordPage'), 'ResetPasswordPage'),
         exact: true,
-        forceNarrowWidth: true,
     },
     {
         path: '/explore',


### PR DESCRIPTION
None of the pages whose routes specified forceNarrowWidth actually needed it; their own styles all properly rendered the pages with a custom (smaller) narrow width.

Also fixes a problem where vertical scrollbars (on systems that show scrollbars, ie not macOS) would appear to the right of the signup/sign-in form instead of flush right.