### PR TITLE
web: clean up and reorganize site admin sidebar

### DIFF
--- a/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/web/src/enterprise/site-admin/sidebaritems.ts
@@ -1,21 +1,7 @@
 import HeartIcon from 'mdi-react/HeartIcon'
-import PuzzleIcon from 'mdi-react/PuzzleIcon'
-import { authGroup, otherGroup, siteAdminSidebarGroups } from '../../site-admin/sidebaritems'
+import { otherGroup, siteAdminSidebarGroups, usersGroup, overviewGroup } from '../../site-admin/sidebaritems'
 import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
-
-const registryGroup: SiteAdminSideBarGroup = {
-    header: {
-        label: 'Registry',
-        icon: PuzzleIcon,
-    },
-    items: [
-        {
-            label: 'Extensions',
-            to: '/site-admin/registry/extensions',
-        },
-    ],
-}
 
 /**
  * Sidebar items that are only used on Sourcegraph.com.
@@ -45,44 +31,58 @@ const dotcomGroup: SiteAdminSideBarGroup = {
 export const enterpriseSiteAdminSidebarGroups: SiteAdminSideBarGroups = siteAdminSidebarGroups.reduce<
     SiteAdminSideBarGroups
 >((enterpriseGroups, group) => {
-    if (group === authGroup) {
+    if (group === overviewGroup) {
         return [
             ...enterpriseGroups,
-            // Extend auth group items
+            // Extend overview group items
             {
                 ...group,
                 items: [
+                    ...group.items,
                     {
-                        label: 'Providers',
+                        label: 'License',
+                        to: '/site-admin/license',
+                    },
+                ],
+            },
+        ]
+    }
+    if (group === usersGroup) {
+        return [
+            ...enterpriseGroups,
+            // Extend users group items
+            {
+                ...group,
+                items: [
+                    ...group.items,
+                    {
+                        label: 'Auth providers',
                         to: '/site-admin/auth/providers',
                     },
                     {
                         label: 'External accounts',
                         to: '/site-admin/auth/external-accounts',
                     },
-                    ...group.items,
                 ],
             },
-            // Insert registry group after auth group
-            registryGroup,
         ]
     }
     if (group === otherGroup) {
         return [
             ...enterpriseGroups,
-            // Insert dotcom group before other group (on Sourcegraph.com)
-            dotcomGroup,
             // Extend other group items
             {
                 ...group,
                 items: [
-                    {
-                        label: 'License',
-                        to: '/site-admin/license',
-                    },
                     ...group.items,
+                    {
+                        label: 'Extensions',
+                        to: '/site-admin/registry/extensions',
+                    },
                 ],
             },
+            // Insert dotcom group after other group (on Sourcegraph.com)
+            dotcomGroup,
         ]
     }
     return [...enterpriseGroups, group]

--- a/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -279,8 +279,8 @@ export class SiteAdminSurveyResponsesPage extends React.Component<Props, State> 
     public render(): JSX.Element | null {
         return (
             <div className="site-admin-survey-responses-page">
-                <PageTitle title="Survey Responses - Admin" />
-                <h2>Survey responses</h2>
+                <PageTitle title="User feedback survey - Admin" />
+                <h2>User feedback survey</h2>
                 <p>
                     After using Sourcegraph for a few days, users are presented with a request to answer "How likely is
                     it that you would recommend Sourcegraph to a friend?" on a scale from 0–10 and to provide some

--- a/web/src/site-admin/sidebaritems.ts
+++ b/web/src/site-admin/sidebaritems.ts
@@ -1,9 +1,10 @@
-import LockIcon from 'mdi-react/LockIcon'
 import ServerIcon from 'mdi-react/ServerIcon'
+import UsersIcon from 'mdi-react/UsersIcon'
 import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from './SiteAdminSidebar'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import SettingsIcon from 'mdi-react/SettingsIcon'
 
-export const primaryGroup: SiteAdminSideBarGroup = {
+export const overviewGroup: SiteAdminSideBarGroup = {
     header: {
         label: 'Site admin',
         icon: ServerIcon,
@@ -15,21 +16,25 @@ export const primaryGroup: SiteAdminSideBarGroup = {
             exact: true,
         },
         {
-            label: 'Configuration',
-            to: '/site-admin/configuration',
+            label: 'Usage stats',
+            to: '/site-admin/usage-statistics',
+        },
+        {
+            label: 'Feedback survey',
+            to: '/site-admin/surveys',
         },
     ],
 }
 
-export const secondaryGroup: SiteAdminSideBarGroup = {
+const configurationGroup: SiteAdminSideBarGroup = {
+    header: {
+        label: 'Configuration',
+        icon: SettingsIcon,
+    },
     items: [
         {
-            label: 'Users',
-            to: '/site-admin/users',
-        },
-        {
-            label: 'Organizations',
-            to: '/site-admin/organizations',
+            label: 'Site configuration',
+            to: '/site-admin/configuration',
         },
         {
             label: 'Global settings',
@@ -55,12 +60,20 @@ const repositoriesGroup: SiteAdminSideBarGroup = {
     ],
 }
 
-export const authGroup: SiteAdminSideBarGroup = {
+export const usersGroup: SiteAdminSideBarGroup = {
     header: {
-        label: 'Auth',
-        icon: LockIcon,
+        label: 'Users & auth',
+        icon: UsersIcon,
     },
     items: [
+        {
+            label: 'Users',
+            to: '/site-admin/users',
+        },
+        {
+            label: 'Organizations',
+            to: '/site-admin/organizations',
+        },
         {
             label: 'Access tokens',
             to: '/site-admin/tokens',
@@ -75,14 +88,6 @@ export const otherGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/updates',
         },
         {
-            label: 'Usage stats',
-            to: '/site-admin/usage-statistics',
-        },
-        {
-            label: 'User surveys',
-            to: '/site-admin/surveys',
-        },
-        {
             label: 'Pings',
             to: '/site-admin/pings',
         },
@@ -94,9 +99,9 @@ export const otherGroup: SiteAdminSideBarGroup = {
 }
 
 export const siteAdminSidebarGroups: SiteAdminSideBarGroups = [
-    primaryGroup,
-    secondaryGroup,
+    overviewGroup,
+    configurationGroup,
     repositoriesGroup,
-    authGroup,
+    usersGroup,
     otherGroup,
 ]


### PR DESCRIPTION
- Moves site config and global settings into its own new group
- Moves all user- and auth-related items into a "Users & auth" group
- Moves up usage stats, surveys, and license into the top (overview group)
- Removes singleton extensions group (item is moved to unlabeled existing "Other" group at bottom)
- Renames "User surveys" to "Feedback survey" for clarity

## new

<img src=https://user-images.githubusercontent.com/1976/73142200-e575ab00-4040-11ea-9f55-bb656dedd6f0.png width=150>


## old

<img src=https://user-images.githubusercontent.com/1976/73142083-a561f880-403f-11ea-8871-82ed9bbdf4dd.png width=150>