### PR TITLE
web: standardize top margin in site admin area

### DIFF
--- a/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -76,9 +76,7 @@ export class SiteAdminAuthenticationProvidersPage extends React.Component<Props>
         return (
             <div className="site-admin-authentication-page">
                 <PageTitle title="Authentication providers - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Authentication providers</h2>
-                </div>
+                <h2>Authentication providers</h2>
                 <p>
                     Authentication providers allow users to sign into Sourcegraph. See{' '}
                     <a href="https://docs.sourcegraph.com/admin/auth">authentication documentation</a> about configuring

--- a/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
@@ -54,7 +54,7 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
         return (
             <div className="user-settings-external-accounts-page">
                 <PageTitle title="External accounts" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">External user accounts</h2>
                     <Link to="/site-admin/auth/providers" className="btn btn-secondary">
                         View auth providers

--- a/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -169,7 +169,7 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
         return (
             <div className="registry-extensions-page">
                 <PageTitle title="Registry extensions" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Registry extensions</h2>
                     <div>
                         <Link className="btn btn-link mr-sm-2" to="/extensions">

--- a/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
@@ -78,7 +78,7 @@ export class SiteAdminProductCustomersPage extends React.Component<Props> {
         return (
             <div className="site-admin-customers-page">
                 <PageTitle title="Customers" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
+                <div className="d-flex justify-content-between align-items-center mb-1">
                     <h2 className="mb-0">Customers</h2>
                 </div>
                 <p>User accounts may be linked to a customer on the billing system.</p>

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicensesPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicensesPage.tsx
@@ -46,9 +46,7 @@ export class SiteAdminProductLicensesPage extends React.Component<Props> {
         return (
             <div className="site-admin-product-subscriptions-page">
                 <PageTitle title="Product subscriptions" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">License key lookup</h2>
-                </div>
+                <h2>License key lookup</h2>
                 <p>Find matching licenses and their associated product subscriptions.</p>
                 <FilteredProductLicenseConnection
                     className="list-group list-group-flush mt-3"

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -47,7 +47,7 @@ export class SiteAdminProductSubscriptionsPage extends React.Component<Props> {
         return (
             <div className="site-admin-product-subscriptions-page">
                 <PageTitle title="Product subscriptions" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Product subscriptions</h2>
                     <Link to="/site-admin/dotcom/product/subscriptions/new" className="btn btn-primary">
                         <AddIcon className="icon-inline" />

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -311,7 +311,7 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
         return (
             <div className="site-admin-all-users-page">
                 <PageTitle title="Users - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Users</h2>
                     <div>
                         <Link to="/site-admin/users/new" className="btn btn-primary">

--- a/web/src/site-admin/SiteAdminArea.tsx
+++ b/web/src/site-admin/SiteAdminArea.tsx
@@ -63,7 +63,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<SiteAdminAreaProps> = 
     }
 
     return (
-        <div className="site-admin-area d-flex container">
+        <div className="site-admin-area d-flex container my-3">
             <SiteAdminSidebar className="flex-0 mr-3" groups={props.sideBarGroups} />
             <div className="flex-1">
                 <ErrorBoundary location={props.location}>

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -408,9 +408,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         return (
             <div className="site-admin-configuration-page">
                 <PageTitle title="Configuration - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Site configuration</h2>
-                </div>
+                <h2>Site configuration</h2>
                 <p>
                     View and edit the Sourcegraph site configuration. See{' '}
                     <Link to="/help/admin/config/site_config">documentation</Link> for more information.

--- a/web/src/site-admin/SiteAdminExternalServicesPage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicesPage.tsx
@@ -196,7 +196,7 @@ export class SiteAdminExternalServicesPage extends React.PureComponent<Props, St
         return (
             <div className="site-admin-external-services-page">
                 <PageTitle title="Manage repositories - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Manage repositories</h2>
                     <Link
                         className="btn btn-primary e2e-goto-add-external-service-page"

--- a/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -143,7 +143,7 @@ export class SiteAdminOrgsPage extends React.Component<Props, State> {
         return (
             <div className="site-admin-orgs-page">
                 <PageTitle title="Organizations - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Organizations</h2>
                     <Link to="/organizations/new" className="btn btn-primary">
                         <AddIcon className="icon-inline" /> Create organization

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -105,7 +105,7 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
             setupPercentage = percentageDone(this.props.activation.completed)
         }
         return (
-            <div className="site-admin-overview-page py-3">
+            <div className="site-admin-overview-page">
                 <PageTitle title="Overview - Admin" />
                 {this.props.overviewComponents.length > 0 && (
                     <div className="mb-4">

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -29,9 +29,7 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
         return (
             <div className="site-admin-pings-page">
                 <PageTitle title="Pings - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Pings</h2>
-                </div>
+                <h2>Pings</h2>
                 <p>
                     Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and customer teams. It
                     sends only the high-level data below. It never sends code, repository names, usernames, or any other

--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -87,9 +87,7 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
     return (
         <div>
             <PageTitle title="Report a bug - Admin" />
-            <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                <h2 className="mb-0">Report a bug</h2>
-            </div>
+            <h2>Report a bug</h2>
             <p>
                 Create an issue on the{' '}
                 <a target="_blank" rel="noopener noreferrer" href="https://github.com/sourcegraph/sourcegraph/issues">

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -150,9 +150,7 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
         return (
             <div className="site-admin-repositories-page">
                 <PageTitle title="Repositories - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Repositories</h2>
-                </div>
+                <h2>Repositories</h2>
                 <p>
                     Repositories are synced from connected{' '}
                     <Link to="/site-admin/external-services">code host connections</Link>.

--- a/web/src/site-admin/SiteAdminSettingsPage.tsx
+++ b/web/src/site-admin/SiteAdminSettingsPage.tsx
@@ -19,7 +19,6 @@ export const SiteAdminSettingsPage: React.FunctionComponent<Props> = props => (
             {...props}
             subject={props.site}
             authenticatedUser={props.authenticatedUser}
-            className="mt-3"
             extraHeader={
                 <p>
                     Global settings apply to all organizations and users. Settings for a user or organization override

--- a/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/web/src/site-admin/SiteAdminSidebar.tsx
@@ -24,7 +24,7 @@ export interface SiteAdminSidebarProps {
  * Sidebar for the site admin area.
  */
 export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = ({ className, groups }) => (
-    <div className={`mt-3 site-admin-sidebar ${className}`}>
+    <div className={`site-admin-sidebar ${className}`}>
         {groups.map(
             ({ header, items, condition = () => true }, i) =>
                 condition({}) && (

--- a/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -280,9 +280,7 @@ export class SiteAdminSurveyResponsesPage extends React.Component<Props, State> 
         return (
             <div className="site-admin-survey-responses-page">
                 <PageTitle title="Survey Responses - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Survey responses</h2>
-                </div>
+                <h2>Survey responses</h2>
                 <p>
                     After using Sourcegraph for a few days, users are presented with a request to answer "How likely is
                     it that you would recommend Sourcegraph to a friend?" on a scale from 0–10 and to provide some

--- a/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -45,7 +45,7 @@ export class SiteAdminTokensPage extends React.PureComponent<Props, State> {
         return (
             <div className="user-settings-tokens-page">
                 <PageTitle title="Access tokens - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Access tokens</h2>
                     <LinkOrSpan
                         title={accessTokensEnabled ? '' : 'Access token creation is disabled in site configuration'}

--- a/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -60,9 +60,7 @@ export class SiteAdminUpdatesPage extends React.Component<Props, State> {
         return (
             <div className="site-admin-updates-page">
                 <PageTitle title="Updates - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Updates</h2>
-                </div>
+                <h2>Updates</h2>
                 {this.state.error && (
                     <p className="site-admin-updates-page__error">Error: {upperFirst(this.state.error)}</p>
                 )}

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.scss
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.scss
@@ -1,7 +1,6 @@
 @import '../components/d3/BarChart';
 
 .site-admin-usage-statistics-page {
-    padding: 1rem;
     &__date-column {
         width: 40%;
     }

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -237,9 +237,7 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
         return (
             <div className="site-admin-usage-statistics-page">
                 <PageTitle title="Usage statistics - Admin" />
-                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                    <h2 className="mb-0">Usage statistics</h2>
-                </div>
+                <h2>Usage statistics</h2>
                 {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
                 {this.state.stats && (
                     <>


### PR DESCRIPTION
Previously, most (but not all) site admin pages specified mt-3 or equivalent for a margin-top. Some pages did not, which meant that the were incorrectly flush with the global nav. Instead of having each site admin page specify mt-3, this changes it to just specify that in the parent component.