### PR TITLE
feat: add hideSuggestions setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Experimental: the search query input now provides syntax highlighting, hover tooltips, and diagnostics on filters in search queries. Requires the global settings value `{ "experimentalFeatures": { "smartSearchField": true } }`.
+- Added a setting `search.hideSuggestions`, which when set to `false`, will hide search suggestions in the search bar.
 
 ### Changed
 

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -204,5 +204,11 @@
         }
       }
     }
+  },
+  "search.hideSuggestions": {
+    "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
+    "type": "boolean",
+    "default": false,
+    "!go": { "pointer": true }
   }
 }

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -209,6 +209,12 @@ const SettingsSchemaJSON = `{
         }
       }
     }
+  },
+  "search.hideSuggestions": {
+    "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
+    "type": "boolean",
+    "default": false,
+    "!go": { "pointer": true }
   }
 }
 `

--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -5,6 +5,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { ThemePreference } from '../theme'
 import { GlobalNavbar } from './GlobalNavbar'
 import { createLocation, createMemoryHistory } from 'history'
+import { NOOP_SETTINGS_CASCADE } from '../../../shared/src/util/searchTestHelpers'
 
 const PROPS: GlobalNavbar['props'] = {
     authenticatedUser: null,
@@ -25,7 +26,7 @@ const PROPS: GlobalNavbar['props'] = {
     caseSensitive: false,
     setCaseSensitivity: () => undefined,
     platformContext: {} as any,
-    settingsCascade: {} as any,
+    settingsCascade: NOOP_SETTINGS_CASCADE,
     showCampaigns: false,
     telemetryService: {} as any,
     hideNavLinks: true, // used because reactstrap Popover is incompatible with react-test-renderer

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -156,7 +156,7 @@ export class QueryInput extends React.Component<Props, State> {
             props.settingsCascade.final &&
             props.settingsCascade.final['search.hideSuggestions']
 
-        if (!this.props.withoutSuggestions || hideSuggestionsSetting) {
+        if (!hideSuggestionsSetting && !this.props.withoutSuggestions) {
             // Show suggestions on input change.
             this.subscriptions.add(
                 this.inputValues.subscribe(() => {

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -38,6 +38,7 @@ import { dedupeWhitespace } from '../../../../shared/src/util/strings'
 import { SuggestionTypes } from '../../../../shared/src/search/suggestions/util'
 import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
 import { CaseSensitivityToggle } from './CaseSensitivityToggle'
+import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 
 /**
  * The query input field is clobbered and updated to contain this subject's values, as
@@ -45,7 +46,7 @@ import { CaseSensitivityToggle } from './CaseSensitivityToggle'
  */
 export const queryUpdates = new Subject<string>()
 
-interface Props extends PatternTypeProps, CaseSensitivityProps {
+interface Props extends PatternTypeProps, CaseSensitivityProps, SettingsCascadeProps {
     location: H.Location
     history: H.History
 
@@ -150,7 +151,12 @@ export class QueryInput extends React.Component<Props, State> {
         // (will be used in next PR to push to queryHistory (undo/redo))
         this.subscriptions.add(this.inputValues.subscribe(queryState => this.props.onChange(queryState)))
 
-        if (!this.props.withoutSuggestions) {
+        const hideSuggestionsSetting =
+            isSettingsValid(props.settingsCascade) &&
+            props.settingsCascade.final &&
+            props.settingsCascade.final['search.hideSuggestions']
+
+        if (!this.props.withoutSuggestions || hideSuggestionsSetting) {
             // Show suggestions on input change.
             this.subscriptions.add(
                 this.inputValues.subscribe(() => {
@@ -354,8 +360,14 @@ export class QueryInput extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        const hideSuggestionsSetting =
+            isSettingsValid(this.props.settingsCascade) &&
+            this.props.settingsCascade.final &&
+            this.props.settingsCascade.final['search.hideSuggestions']
+
         const showSuggestions =
             !this.props.withoutSuggestions &&
+            !hideSuggestionsSetting &&
             this.state.showSuggestions &&
             (this.state.suggestions.values.length > 0 || this.state.loadingSuggestions)
 

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -8,8 +8,15 @@ import { PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '.
 import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { QueryInput } from './QueryInput'
 import { ThemeProps } from '../../../../shared/src/theme'
+import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 
-interface Props extends ActivationProps, PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps, ThemeProps {
+interface Props
+    extends ActivationProps,
+        PatternTypeProps,
+        CaseSensitivityProps,
+        SmartSearchFieldProps,
+        SettingsCascadeProps,
+        ThemeProps {
     location: H.Location
     history: H.History
     navbarSearchState: QueryState

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -251,6 +251,7 @@ export class InteractiveModeInput extends React.Component<InteractiveModeProps, 
                             <div className="d-flex align-items-start">
                                 <SearchModeToggle {...this.props} interactiveSearchMode={true} />
                                 <QueryInput
+                                    {...this.props}
                                     location={this.props.location}
                                     history={this.props.history}
                                     value={this.props.navbarSearchState}


### PR DESCRIPTION
Adds a `search.hideSuggestions` setting. When set to `true`, it does not display search suggestions. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/8042. 