### PR TITLE
Remove splitSearchModes option from site config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- experimentalFeatures.splitSearchModes was removed as a site configuration option. It should be set in global/org/user settings.
+
 ### Fixed
 
 - After adding/removing a gitserver replica the admin interface will correctly report that repositories that need to move replicas as cloning. [#7970](https://github.com/sourcegraph/sourcegraph/issues/7970)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -342,8 +342,6 @@ type ExperimentalFeatures struct {
 	EventLogging string `json:"eventLogging,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
-	// SplitSearchModes description: Enables toggling between the current omni search mode, and experimental interactive search mode.
-	SplitSearchModes string `json:"splitSearchModes,omitempty"`
 	// StructuralSearch description: Enables structural search.
 	StructuralSearch string `json:"structuralSearch,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -73,12 +73,6 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
-        "splitSearchModes": {
-          "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "disabled"
-        },
         "bitbucketServerFastPerm": {
           "description": "Enables fetching Bitbucket Server permissions through the roaring bitmap endpoint. This requires the installation of the Bitbucket Server Sourcegraph plugin. Warning: there may be performance degradation under significant load.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -78,12 +78,6 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
-        "splitSearchModes": {
-          "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "disabled"
-        },
         "bitbucketServerFastPerm": {
           "description": "Enables fetching Bitbucket Server permissions through the roaring bitmap endpoint. This requires the installation of the Bitbucket Server Sourcegraph plugin. Warning: there may be performance degradation under significant load.",
           "type": "string",


### PR DESCRIPTION
We only use `splitSearchModes` from the settings cascade.