### PR TITLE
db/authz: revoke permissions at user deletion

### DIFF
--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -33,29 +33,51 @@ type AuthorizedReposArgs struct {
 	Provider authz.ProviderType
 }
 
-// AuthzStore contains methods for assigning user permissions.
+// RevokeUserPermissionsArgs contains required arguments to revoke user permissions, it includes all
+// possible leads to grant or authorize access for a user.
+type RevokeUserPermissionsArgs struct {
+	// The user ID that will be used to revoke effective permissions.
+	UserID int32
+	// The username that will be used to revoke pending permissions.
+	Username string
+	// The list of verified emails that will be used to revoke pending permissions.
+	// Only provide verified emails because that is the definitive way to ensure the email ownership.
+	VerifiedEmails []string
+}
+
+// AuthzStore contains methods for manipulating user permissions.
 type AuthzStore interface {
-	// GrantPendingPermissions grants pending permissions for a user, it is a no-op in the OSS version.
+	// GrantPendingPermissions grants pending permissions for a user. It is a no-op in the OSS version.
 	GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error
 	// AuthorizedRepos checks if a user is authorized to access repositories in the candidate list.
 	// The returned list must be a list of repositories that are authorized to the given user.
 	// It is a no-op in the OSS version.
 	AuthorizedRepos(ctx context.Context, args *AuthorizedReposArgs) ([]*types.Repo, error)
+	// RevokeUserPermissions deletes both effective and pending permissions that could be related to a user.
+	// It is a no-op in the OSS version.
+	RevokeUserPermissions(ctx context.Context, args *RevokeUserPermissionsArgs) error
 }
 
 // authzStore is a no-op placeholder for the OSS version.
 type authzStore struct{}
 
 func (*authzStore) GrantPendingPermissions(ctx context.Context, args *GrantPendingPermissionsArgs) error {
-	if Mocks.Authz.GrantPendingPermissions == nil {
-		return nil
+	if Mocks.Authz.GrantPendingPermissions != nil {
+		return Mocks.Authz.GrantPendingPermissions(ctx, args)
 	}
-	return Mocks.Authz.GrantPendingPermissions(ctx, args)
+	return nil
 }
 
 func (*authzStore) AuthorizedRepos(ctx context.Context, args *AuthorizedReposArgs) ([]*types.Repo, error) {
-	if Mocks.Authz.AuthorizedRepos == nil {
-		return []*types.Repo{}, nil
+	if Mocks.Authz.AuthorizedRepos != nil {
+		return Mocks.Authz.AuthorizedRepos(ctx, args)
 	}
-	return Mocks.Authz.AuthorizedRepos(ctx, args)
+	return []*types.Repo{}, nil
+}
+
+func (*authzStore) RevokeUserPermissions(ctx context.Context, args *RevokeUserPermissionsArgs) error {
+	if Mocks.Authz.RevokeUserPermissions != nil {
+		return Mocks.Authz.RevokeUserPermissions(ctx, args)
+	}
+	return nil
 }

--- a/cmd/frontend/db/authz_mock.go
+++ b/cmd/frontend/db/authz_mock.go
@@ -9,4 +9,5 @@ import (
 type MockAuthz struct {
 	GrantPendingPermissions func(ctx context.Context, args *GrantPendingPermissionsArgs) error
 	AuthorizedRepos         func(ctx context.Context, args *AuthorizedReposArgs) ([]*types.Repo, error)
+	RevokeUserPermissions   func(ctx context.Context, args *RevokeUserPermissionsArgs) error
 }

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -376,6 +376,10 @@ func (u *users) Update(ctx context.Context, id int32, update UserUpdate) error {
 }
 
 func (u *users) Delete(ctx context.Context, id int32) error {
+	if Mocks.Users.Delete != nil {
+		return Mocks.Users.Delete(ctx, id)
+	}
+
 	// Wrap in transaction because we delete from multiple tables.
 	tx, err := dbconn.Global.BeginTx(ctx, nil)
 	if err != nil {
@@ -440,6 +444,10 @@ func (u *users) Delete(ctx context.Context, id int32) error {
 }
 
 func (u *users) HardDelete(ctx context.Context, id int32) error {
+	if Mocks.Users.HardDelete != nil {
+		return Mocks.Users.HardDelete(ctx, id)
+	}
+
 	// Wrap in transaction because we delete from multiple tables.
 	tx, err := dbconn.Global.BeginTx(ctx, nil)
 	if err != nil {

--- a/cmd/frontend/db/users_mock.go
+++ b/cmd/frontend/db/users_mock.go
@@ -10,6 +10,8 @@ import (
 type MockUsers struct {
 	Create               func(ctx context.Context, info NewUser) (newUser *types.User, err error)
 	Update               func(userID int32, update UserUpdate) error
+	Delete               func(ctx context.Context, id int32) error
+	HardDelete           func(ctx context.Context, id int32) error
 	SetIsSiteAdmin       func(id int32, isSiteAdmin bool) error
 	GetByID              func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername        func(ctx context.Context, username string) (*types.User, error)

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -60,6 +60,9 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		}
 	}
 
+	// NOTE: Practically, we don't reuse the ID for any new users, and the situation of left-over pending permissions
+	// is possible but highly unlikely. Therefore, there is no need to roll back user deletion even if this step failed.
+	// This call is purely for the purpose of cleanup.
 	if err := db.Authz.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
 		UserID:         user.ID,
 		Username:       user.Username,

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -55,6 +55,7 @@ func TestDeleteUser(t *testing.T) {
 		}
 	})
 
+	// Mocking all database interactions here, but they are all thoroughly tested in the lower layer in "db" package.
 	resetMocks()
 	db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 		return &types.User{SiteAdmin: true}, nil

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -1,0 +1,141 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go/gqltesting"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+)
+
+func TestDeleteUser(t *testing.T) {
+	t.Run("authenticated as non-admin", func(t *testing.T) {
+		resetMocks()
+		db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{}, nil
+		}
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		result, err := (&schemaResolver{}).DeleteUser(ctx, &struct {
+			User graphql.ID
+			Hard *bool
+		}{
+			User: MarshalUserID(1),
+		})
+		if want := backend.ErrMustBeSiteAdmin; err != want {
+			t.Errorf("err: want %q but got %v", want, err)
+		}
+		if result != nil {
+			t.Errorf("result: want nil but got %v", result)
+		}
+	})
+
+	t.Run("delete current user", func(t *testing.T) {
+		resetMocks()
+		db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{ID: 1, SiteAdmin: true}, nil
+		}
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		_, err := (&schemaResolver{}).DeleteUser(ctx, &struct {
+			User graphql.ID
+			Hard *bool
+		}{
+			User: MarshalUserID(1),
+		})
+		want := "unable to delete current user"
+		if err == nil || err.Error() != want {
+			t.Fatalf("err: want %q but got %v", want, err)
+		}
+	})
+
+	resetMocks()
+	db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+		return &types.User{SiteAdmin: true}, nil
+	}
+	db.Mocks.Users.GetByID = func(_ context.Context, id int32) (*types.User, error) {
+		return &types.User{ID: id, Username: "alice"}, nil
+	}
+	db.Mocks.Users.Delete = func(context.Context, int32) error {
+		return nil
+	}
+	db.Mocks.Users.HardDelete = func(context.Context, int32) error {
+		return nil
+	}
+	db.Mocks.UserEmails.ListByUser = func(context.Context, db.UserEmailsListOptions) ([]*db.UserEmail, error) {
+		return []*db.UserEmail{
+			{Email: "alice@example.com"},
+		}, nil
+	}
+	db.Mocks.Authz.RevokeUserPermissions = func(_ context.Context, args *db.RevokeUserPermissionsArgs) error {
+		if args.UserID != 6 {
+			return fmt.Errorf("args.UserID: want 6 but got %v", args.UserID)
+		} else if args.Username != "alice" {
+			return fmt.Errorf("args.Username: want %q but got %v", "alice", args.UserID)
+		} else if diff := cmp.Diff([]string{"alice@example.com"}, args.VerifiedEmails); diff != "" {
+			return fmt.Errorf("args.VerifiedEmails: %q", diff)
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name     string
+		gqlTests []*gqltesting.Test
+	}{
+		{
+			name: "soft delete a user",
+			gqlTests: []*gqltesting.Test{
+				{
+					Schema: mustParseGraphQLSchema(t, nil),
+					Query: `
+				mutation {
+					deleteUser(user: "VXNlcjo2") {
+						alwaysNil
+					}
+				}
+			`,
+					ExpectedResult: `
+				{
+					"deleteUser": {
+						"alwaysNil": null
+					}
+				}
+			`,
+				},
+			},
+		},
+		{
+			name: "hard delete a user",
+			gqlTests: []*gqltesting.Test{
+				{
+					Schema: mustParseGraphQLSchema(t, nil),
+					Query: `
+				mutation {
+					deleteUser(user: "VXNlcjo2", hard: true) {
+						alwaysNil
+					}
+				}
+			`,
+					ExpectedResult: `
+				{
+					"deleteUser": {
+						"alwaysNil": null
+					}
+				}
+			`,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gqltesting.RunTests(t, test.gqlTests)
+		})
+	}
+}

--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -124,11 +124,7 @@ func (s *authzStore) RevokeUserPermissions(ctx context.Context, args *db.RevokeU
 		errs = multierror.Append(errs, err)
 	}
 
-	bindIDs := make([]string, 1, len(args.VerifiedEmails)+1)
-	bindIDs[0] = args.Username
-	for _, email := range args.VerifiedEmails {
-		bindIDs = append(bindIDs, email)
-	}
+	bindIDs := append([]string{args.Username}, args.VerifiedEmails...)
 	if err := s.store.DeleteAllUserPendingPermissions(ctx, bindIDs); err != nil {
 		errs = multierror.Append(errs, err)
 	}

--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -118,8 +118,6 @@ func (s *authzStore) AuthorizedRepos(ctx context.Context, args *db.AuthorizedRep
 // RevokeUserPermissions deletes both effective and pending permissions that could be related to a user,
 // which implements the db.AuthzStore interface. It proactively clean up left-over pending permissions to
 // prevent accidental reuse (i.e. another user with same username or email address(es) but not the same person).
-// The situation of left-over pending permissions is possible but highly unlikely, so we're doing it at best effort,
-// the removal of effective permissions is much more important.
 func (s *authzStore) RevokeUserPermissions(ctx context.Context, args *db.RevokeUserPermissionsArgs) error {
 	errs := new(multierror.Error)
 	if err := s.store.DeleteAllUserPermissions(ctx, args.UserID); err != nil {

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -2,8 +2,6 @@ package db
 
 import (
 	"context"
-	"testing"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -12,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"testing"
 )
 
 func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
@@ -248,5 +247,64 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 
 			equal(t, "repos", test.expectRepos, repos)
 		})
+	}
+}
+
+func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	s := NewAuthzStore(dbconn.Global, clock).(*authzStore)
+
+	// Set both effective and pending permissions for a user
+	if err := s.store.SetRepoPermissions(ctx, &iauthz.RepoPermissions{
+		RepoID:   1,
+		Perm:     authz.Read,
+		UserIDs:  toBitmap(1),
+		Provider: authz.ProviderSourcegraph,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	bindIDs := []string{"alice", "alice@example.com"}
+	if err := s.store.SetRepoPendingPermissions(ctx, bindIDs, &iauthz.RepoPermissions{
+		RepoID: 1,
+		Perm:   authz.Read,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Revoke all of them
+	if err := s.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
+		UserID:         1,
+		Username:       "alice",
+		VerifiedEmails: []string{"alice@example.com"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The user should not have any permissions now
+	err := s.store.LoadUserPermissions(ctx, &iauthz.UserPermissions{
+		UserID:   1,
+		Perm:     authz.Read,
+		Type:     authz.PermRepos,
+		Provider: authz.ProviderSourcegraph,
+	})
+	if err != ErrPermsNotFound {
+		t.Fatalf("err: want %q but got %v", ErrPermsNotFound, err)
+	}
+
+	for _, bindID := range bindIDs {
+		err = s.store.LoadUserPendingPermissions(ctx, &iauthz.UserPendingPermissions{
+			BindID: bindID,
+			Perm:   authz.Read,
+			Type:   authz.PermRepos,
+		})
+		if err != ErrPermsNotFound {
+			t.Fatalf("[%s] err: want %q but got %v", bindID, ErrPermsNotFound, err)
+		}
 	}
 }

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"testing"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -10,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"testing"
 )
 
 func TestAuthzStore_GrantPendingPermissions(t *testing.T) {

--- a/enterprise/cmd/frontend/db/integration_test.go
+++ b/enterprise/cmd/frontend/db/integration_test.go
@@ -30,6 +30,8 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"PermsStore/SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"PermsStore/ListPendingUsers", testPermsStore_ListPendingUsers(db)},
 		{"PermsStore/GrantPendingPermissions", testPermsStore_GrantPendingPermissions(db)},
+		{"PermsStore/DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
+		{"PermsStore/DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"PermsStore/DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 	} {
 		t.Run(tc.name, tc.test)

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -696,7 +696,7 @@ func (s *PermsStore) GrantPendingPermissions(ctx context.Context, userID int32, 
 	}
 
 	ctx, save := s.observe(ctx, "GrantPendingPermissions", "")
-	defer func() { save(&err, append(p.TracingFields(), otlog.Object("userID", userID))...) }()
+	defer func() { save(&err, append(p.TracingFields(), otlog.Int32("userID", userID))...) }()
 
 	var txs *PermsStore
 	if s.inTx() {
@@ -953,6 +953,41 @@ func (s *PermsStore) ListPendingUsers(ctx context.Context) (bindIDs []string, er
 	}
 
 	return bindIDs, nil
+}
+
+// DeleteAllUserPermissions deletes all rows with given user ID from the "user_permissions" table,
+// which effectively removes access to all repositories for the user.
+func (s *PermsStore) DeleteAllUserPermissions(ctx context.Context, userID int32) (err error) {
+	ctx, save := s.observe(ctx, "DeleteAllUserPermissions", "")
+	defer func() { save(&err, otlog.Int32("userID", userID)) }()
+
+	// NOTE: Practically, we don't need to clean up "repo_permissions" table because the value of "id" column
+	// that is associated with this user will be invalidated automatically by deleting this row.
+	if err = s.execute(ctx, sqlf.Sprintf(`DELETE FROM user_permissions WHERE user_id = %s`, userID)); err != nil {
+		return errors.Wrap(err, "execute delete user permissions query")
+	}
+
+	return nil
+}
+
+// DeleteAllUserPendingPermissions deletes all rows with given bind IDs from the "user_pending_permissions" table.
+// It accepts list of bind IDs because a user has multiple bind IDs, e.g. username and email addresses.
+func (s *PermsStore) DeleteAllUserPendingPermissions(ctx context.Context, bindIDs []string) (err error) {
+	ctx, save := s.observe(ctx, "DeleteAllUserPendingPermissions", "")
+	defer func() { save(&err, otlog.String("bindIDs", strings.Join(bindIDs, ","))) }()
+
+	// NOTE: Practically, we don't need to clean up "repo_pending_permissions" table because the value of "id" column
+	// that is associated with this user will be invalidated automatically by deleting this row.
+	items := make([]*sqlf.Query, len(bindIDs))
+	for i := range bindIDs {
+		items[i] = sqlf.Sprintf("%s", bindIDs[i])
+	}
+	q := sqlf.Sprintf(`DELETE FROM user_pending_permissions WHERE bind_id IN (%s)`, sqlf.Join(items, ","))
+	if err = s.execute(ctx, q); err != nil {
+		return errors.Wrap(err, "execute delete user pending permissions query")
+	}
+
+	return nil
 }
 
 func (s *PermsStore) execute(ctx context.Context, q *sqlf.Query) (err error) {

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -1178,6 +1178,128 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 	}
 }
 
+func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(t *testing.T) {
+	return func(t *testing.T) {
+		s := NewPermsStore(db, clock)
+		defer cleanupPermsTables(t, s)
+
+		ctx := context.Background()
+
+		// Set permissions with different providers for user 1 and 2
+		if err := s.SetRepoPermissions(ctx, &iauthz.RepoPermissions{
+			RepoID:   1,
+			Perm:     authz.Read,
+			UserIDs:  toBitmap(1, 2),
+			Provider: authz.ProviderSourcegraph,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetRepoPermissions(ctx, &iauthz.RepoPermissions{
+			RepoID:   2,
+			Perm:     authz.Read,
+			UserIDs:  toBitmap(1, 2),
+			Provider: authz.ProviderBitbucketServer,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Remove all permissions for the user=1
+		if err := s.DeleteAllUserPermissions(ctx, 1); err != nil {
+			t.Fatal(err)
+		}
+
+		// Check user=1 should not have any permissions now
+		err := s.LoadUserPermissions(ctx, &iauthz.UserPermissions{
+			UserID:   1,
+			Perm:     authz.Read,
+			Type:     authz.PermRepos,
+			Provider: authz.ProviderSourcegraph,
+		})
+		if err != ErrPermsNotFound {
+			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+		}
+
+		err = s.LoadUserPermissions(ctx, &iauthz.UserPermissions{
+			UserID:   1,
+			Perm:     authz.Read,
+			Type:     authz.PermRepos,
+			Provider: authz.ProviderBitbucketServer,
+		})
+		if err != ErrPermsNotFound {
+			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+		}
+
+		// Check user=2 shoud not be affected
+		p := &iauthz.UserPermissions{
+			UserID:   2,
+			Perm:     authz.Read,
+			Type:     authz.PermRepos,
+			Provider: authz.ProviderSourcegraph,
+		}
+		err = s.LoadUserPermissions(ctx, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "p.IDs", []uint32{1}, bitmapToArray(p.IDs))
+
+		p = &iauthz.UserPermissions{
+			UserID:   2,
+			Perm:     authz.Read,
+			Type:     authz.PermRepos,
+			Provider: authz.ProviderBitbucketServer,
+		}
+		err = s.LoadUserPermissions(ctx, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "p.IDs", []uint32{2}, bitmapToArray(p.IDs))
+	}
+}
+
+func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(t *testing.T) {
+	return func(t *testing.T) {
+		s := NewPermsStore(db, clock)
+		defer cleanupPermsTables(t, s)
+
+		ctx := context.Background()
+
+		// Set pending permissions for alice and bob
+		if err := s.SetRepoPendingPermissions(ctx, []string{"alice", "bob"}, &iauthz.RepoPermissions{
+			RepoID: 1,
+			Perm:   authz.Read,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Remove all pending permissions for alice
+		if err := s.DeleteAllUserPendingPermissions(ctx, []string{"alice"}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Check alice should not have any pending permissions now
+		err := s.LoadUserPendingPermissions(ctx, &iauthz.UserPendingPermissions{
+			BindID: "alice",
+			Perm:   authz.Read,
+			Type:   authz.PermRepos,
+		})
+		if err != ErrPermsNotFound {
+			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+		}
+
+		// Check bob shoud not be affected
+		p := &iauthz.UserPendingPermissions{
+			BindID: "bob",
+			Perm:   authz.Read,
+			Type:   authz.PermRepos,
+		}
+		err = s.LoadUserPendingPermissions(ctx, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "p.IDs", []uint32{1}, bitmapToArray(p.IDs))
+	}
+}
+
 func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -1216,7 +1216,7 @@ func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(t *testing.T) {
 			Provider: authz.ProviderSourcegraph,
 		})
 		if err != ErrPermsNotFound {
-			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+			t.Fatalf("err: want %q but got %v", ErrPermsNotFound, err)
 		}
 
 		err = s.LoadUserPermissions(ctx, &iauthz.UserPermissions{
@@ -1226,7 +1226,7 @@ func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(t *testing.T) {
 			Provider: authz.ProviderBitbucketServer,
 		})
 		if err != ErrPermsNotFound {
-			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+			t.Fatalf("err: want %q but got %v", ErrPermsNotFound, err)
 		}
 
 		// Check user=2 shoud not be affected
@@ -1283,7 +1283,7 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(t *testing.
 			Type:   authz.PermRepos,
 		})
 		if err != ErrPermsNotFound {
-			t.Fatalf("err: want %q got %v", ErrPermsNotFound, err)
+			t.Fatalf("err: want %q but got %v", ErrPermsNotFound, err)
 		}
 
 		// Check bob shoud not be affected


### PR DESCRIPTION
This PRs fixes #7302, which revoke user permissions when a user is deleted (regardless of a hard delete).

Manually tested and unit tests are added.
