### PR TITLE
docs: Link to <3.12 docs on new Automation docs page

### DIFF
--- a/doc/user/automation.md
+++ b/doc/user/automation.md
@@ -4,6 +4,8 @@
 
 [Sourcegraph automation](https://about.sourcegraph.com/product/automation) allows large-scale code changes across many repositories and different code hosts.
 
+**Important**: If you're on Sourcegraph 3.12 or older, you might also want to look at the old documentation: "[Automation documentation for Sourcegraph 3.12](https://docs.sourcegraph.com/@3.12/user/automation)"
+
 ## Configuration
 
 In order to use the Automation preview, a site-admin of your Sourcegraph instance must enable it in the site configuration settings e.g. `sourcegraph.example.com/site-admin/configuration`


### PR DESCRIPTION
I think it's better to have this link here, even though the new docs also work with Sourcegraph 3.12.
