### PR TITLE
gitserver: always update reclone time when recloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - After adding/removing a gitserver replica the admin interface will correctly report that repositories that need to move replicas as cloning. [#7970](https://github.com/sourcegraph/sourcegraph/issues/7970)
 - Show download button for images. [#7924](https://github.com/sourcegraph/sourcegraph/issues/7924)
+- gitserver backoffs trying to re-clone repositories if they fail to clone. In the case of large monorepos that failed this lead to gitserver constantly cloning them and using many resources. [#7804](https://github.com/sourcegraph/sourcegraph/issues/7804)
 
 ### Removed
 


### PR DESCRIPTION
If a repo fails to clone due to being large, we will constantly be doing a
clone which uses up lots of resources. The reclone is best effort, so not
doing it again soon is fine. Deciding if we need to reclone is based on the
"recloneTime", which is a timestamp in the repo which is set to the time of
cloning. This commit will always adjust the reclone time to halfway between
the old time and now. So if the reclone fails, we will only try again in the
future. In the case of normal reclone it will be 45/2=22.5 days, in the case
of git.gc it will be 2/2=1 day.

This kind of behaves like a back-off, but not exactly. This behaviour was chosen since it avoids introducing new state.

We also increase the time between git gc clones to be less aggressive. This is
because it is too aggressive for monorepos.

Fixes https://github.com/sourcegraph/sourcegraph/issues/7804