### PR TITLE
graphqlbackend: once parse schema once for all tests

### DIFF
--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -2,18 +2,27 @@ package graphqlbackend
 
 import (
 	"database/sql"
+	"sync"
 	"testing"
 
 	graphql "github.com/graph-gophers/graphql-go"
 )
 
+var (
+	parseSchemaOnce sync.Once
+	parseSchemaErr  error
+	parsedSchema    *graphql.Schema
+)
+
 func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
 	t.Helper()
 
-	schema, err := NewSchema(nil, nil, nil)
-	if err != nil {
-		t.Fatal(err)
+	parseSchemaOnce.Do(func() {
+		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil)
+	})
+	if parseSchemaErr != nil {
+		t.Fatal(parseSchemaErr)
 	}
 
-	return schema
+	return parsedSchema
 }


### PR DESCRIPTION
This PRs adds `sync.Once` to only parse GraphQL schema once for all tests in the `cmd/frontend/graphqlbackend` package, given we don't modify the schema in tests so it stays the same.

Addresses https://github.com/sourcegraph/sourcegraph/pull/8063#discussion_r371254377.