### PR TITLE
Bump sourcegraph version.

### DIFF
--- a/packages/sourcegraph-extension-api/package.json
+++ b/packages/sourcegraph-extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "23.0.1",
+  "version": "23.1.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",
   "bugs": {


### PR DESCRIPTION
I never bumped this version after adding badge indicators, so basic code intel type declarations can't be explicit in new changes.