### PR TITLE
Add language mappings for Pascal, Verilog, and VHDL

### DIFF
--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -68,7 +68,7 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	// }
 
 	cmd := exec.Command(ctagsCommand, "--_interactive="+opt, "--fields=*",
-		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,Tcl,typescript,tsx,Verilog,Vim",
+		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,typescript,tsx,Verilog,VHDL,Vim",
 		"--map-CSS=+.scss", "--map-CSS=+.less", "--map-CSS=+.sass",
 	)
 	in, err := cmd.StdinPipe()

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -277,6 +277,11 @@ function getModeFromExtension(ext: string): string | undefined {
         case 're': // reason has the same language server as ocaml
             return 'ocaml'
 
+        // Pascal
+        case 'p':
+        case 'pas':
+            return 'pascal'
+
         // Perl
         case 'pl':
         case 'al':

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -280,6 +280,7 @@ function getModeFromExtension(ext: string): string | undefined {
         // Pascal
         case 'p':
         case 'pas':
+        case 'pp':
             return 'pascal'
 
         // Perl
@@ -421,6 +422,11 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'svh':
         case 'svi':
             return 'verilog'
+
+        // VHDL
+        case 'vhd':
+        case 'vhdl':
+            return 'vhdl'
 
         // VIM
         case 'vim':

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -414,9 +414,12 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'vbs':
             return 'vbscrip'
 
-        // Verilog
+        // Verilog, including SystemVerilog
         case 'v':
         case 'veo':
+        case 'sv':
+        case 'svh':
+        case 'svi':
             return 'verilog'
 
         // VIM


### PR DESCRIPTION
In support of https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/200. 