### PR TITLE
graphqlbackend: remove unused `db` argument in `mustParseGraphQLSchema`

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -42,7 +42,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-				Schema:  mustParseGraphQLSchema(t, nil),
+				Schema:  mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					createAccessToken(user: "` + uid1GQLID + `", scopes: ["user:all"], note: "n") {
@@ -108,7 +108,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-				Schema:  mustParseGraphQLSchema(t, nil),
+				Schema:  mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					createAccessToken(user: "` + uid1GQLID + `", scopes: ["user:all", "site-admin:sudo"], note: "n") {
@@ -141,7 +141,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
-				Schema:  mustParseGraphQLSchema(t, nil),
+				Schema:  mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					createAccessToken(user: "` + uid1GQLID + `", scopes: ["user:all"], note: "n") {
@@ -230,7 +230,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				Schema:  mustParseGraphQLSchema(t, nil),
+				Schema:  mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					deleteAccessToken(byID: "` + string(token1GQLID) + `") {
@@ -261,7 +261,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
-				Schema:  mustParseGraphQLSchema(t, nil),
+				Schema:  mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					deleteAccessToken(byID: "` + string(token1GQLID) + `") {

--- a/cmd/frontend/graphqlbackend/discussion_comments_test.go
+++ b/cmd/frontend/graphqlbackend/discussion_comments_test.go
@@ -25,7 +25,7 @@ func TestDiscussionComment_Get(t *testing.T) {
 	t.Run("by ID", func(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
                                 query ($id: ID!) {
                                         node(id: $id) {
@@ -87,7 +87,7 @@ func TestDiscussionsMutations_UpdateComment(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Context: backend.WithAuthzBypass(context.Background()),
-			Schema:  mustParseGraphQLSchema(t, nil),
+			Schema:  mustParseGraphQLSchema(t),
 			Query: `
                                 mutation($contents: String!) {
                                         discussions {

--- a/cmd/frontend/graphqlbackend/discussion_threads_test.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads_test.go
@@ -26,7 +26,7 @@ func TestDiscussionThread_Get(t *testing.T) {
 	t.Run("by ID", func(t *testing.T) {
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
                                 query ($id: ID!) {
                                         node(id: $id) {
@@ -169,7 +169,7 @@ func TestDiscussionsMutations_UpdateThread(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Context: backend.WithAuthzBypass(context.Background()),
-			Schema:  mustParseGraphQLSchema(t, nil),
+			Schema:  mustParseGraphQLSchema(t),
 			Query: `
                                 mutation($title: String!) {
                                         discussions {

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -59,7 +59,7 @@ func TestGitTree(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -20,7 +20,7 @@ func TestRepository(t *testing.T) {
 	db.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -23,7 +23,7 @@ func TestNamespace(t *testing.T) {
 		}
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
 				{
 					namespace(id: "VXNlcjoz") {
@@ -55,7 +55,7 @@ func TestNamespace(t *testing.T) {
 		}
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
 				{
 					namespace(id: "T3JnOjM=") {
@@ -80,7 +80,7 @@ func TestNamespace(t *testing.T) {
 		resetMocks()
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
 				{
 					namespace(id: "aW52YWxpZDoz") {

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -17,7 +17,7 @@ func TestOrganization(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					organization(name: "acme") {
@@ -42,7 +42,7 @@ func TestNode_Org(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					node(id: "T3JnOjE=") {

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -20,7 +20,7 @@ func TestOrgs(t *testing.T) {
 	db.Mocks.Orgs.Count = func(context.Context, db.OrgsListOptions) (int, error) { return 2, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					organizations {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -14,7 +14,7 @@ func TestRepositories(t *testing.T) {
 	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 3, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repositories {
@@ -39,7 +39,7 @@ func TestRepositories(t *testing.T) {
 			`,
 		},
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repositories(first: 2) {

--- a/cmd/frontend/graphqlbackend/repository_mirror_test.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror_test.go
@@ -53,7 +53,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					checkMirrorRepositoryConnection(repository: "UmVwb3NpdG9yeToxMjM=") {
@@ -109,7 +109,7 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query: `
 				mutation {
 					checkMirrorRepositoryConnection(name: "my/repo") {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -30,7 +30,7 @@ func TestRepository_Commit(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -33,7 +33,7 @@ func TestSettingsMutation_EditSettings(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-			Schema:  mustParseGraphQLSchema(t, nil),
+			Schema:  mustParseGraphQLSchema(t),
 			Query: `
 				mutation($value: JSONValue) {
 					settingsMutation(input: {subject: "VXNlcjox", lastID: 1}) {
@@ -77,7 +77,7 @@ func TestSettingsMutation_OverwriteSettings(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-			Schema:  mustParseGraphQLSchema(t, nil),
+			Schema:  mustParseGraphQLSchema(t),
 			Query: `
 				mutation($contents: String!) {
 					settingsMutation(input: {subject: "VXNlcjox", lastID: 1}) {

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -93,7 +93,7 @@ func TestDeleteUser(t *testing.T) {
 			name: "soft delete a user",
 			gqlTests: []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				mutation {
 					deleteUser(user: "VXNlcjo2") {
@@ -115,7 +115,7 @@ func TestDeleteUser(t *testing.T) {
 			name: "hard delete a user",
 			gqlTests: []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				mutation {
 					deleteUser(user: "VXNlcjo2", hard: true) {

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -77,7 +77,7 @@ func TestStatusMessages(t *testing.T) {
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query:  graphqlQuery,
 				ExpectedResult: `
 				{
@@ -124,7 +124,7 @@ func TestStatusMessages(t *testing.T) {
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, nil),
+				Schema: mustParseGraphQLSchema(t),
 				Query:  graphqlQuery,
 				ExpectedResult: `
 					{

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -1,7 +1,6 @@
 package graphqlbackend
 
 import (
-	"database/sql"
 	"sync"
 	"testing"
 
@@ -14,7 +13,7 @@ var (
 	parsedSchema    *graphql.Schema
 )
 
-func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
+func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -27,7 +27,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			name: "set an email to be verified",
 			gqlTests: []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				mutation {
 					setUserEmailVerified(user: "VXNlcjox", email: "alice@example.com", verified: true) {
@@ -50,7 +50,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			name: "set an email to be unverified",
 			gqlTests: []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				mutation {
 					setUserEmailVerified(user: "VXNlcjox", email: "alice@example.com", verified: false) {

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -18,7 +18,7 @@ func TestUser(t *testing.T) {
 			t.Helper()
 			gqltesting.RunTests(t, []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				{
 					user(username: "alice") {
@@ -72,7 +72,7 @@ func TestUser(t *testing.T) {
 				t.Helper()
 				gqltesting.RunTests(t, []*gqltesting.Test{
 					{
-						Schema: mustParseGraphQLSchema(t, nil),
+						Schema: mustParseGraphQLSchema(t),
 						Query: `
 				{
 					user(email: "alice@example.com") {
@@ -107,7 +107,7 @@ func TestUser(t *testing.T) {
 		t.Run("allowed on non-Sourcegraph.com", func(t *testing.T) {
 			gqltesting.RunTests(t, []*gqltesting.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, nil),
+					Schema: mustParseGraphQLSchema(t),
 					Query: `
 				{
 					user(email: "alice@example.com") {
@@ -134,7 +134,7 @@ func TestNode_User(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					node(id: "VXNlcjox") {

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -20,7 +20,7 @@ func TestUser_UsageStatistics(t *testing.T) {
 	defer func() { usagestats.MockGetByUserID = nil }()
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					node(id: "VXNlcjox") {

--- a/cmd/frontend/graphqlbackend/users_create_test.go
+++ b/cmd/frontend/graphqlbackend/users_create_test.go
@@ -26,7 +26,7 @@ func TestCreateUser(t *testing.T) {
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				mutation {
 					createUser(username: "alice") {

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -20,7 +20,7 @@ func TestUsers(t *testing.T) {
 	db.Mocks.Users.Count = func(context.Context, *db.UsersListOptions) (int, error) { return 2, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: mustParseGraphQLSchema(t, nil),
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					users {


### PR DESCRIPTION
This PR removes an unused argument `db *sql.DB` passed to `mustParseGraphQLSchema`, seems like a left-over from a refactoring at some point.