### PR TITLE
Remove webkit inset style tag

### DIFF
--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -45,25 +45,4 @@
 	{{.Injected.BodyBottom}}
 </body>
 
-{{ if .Context.SourcegraphDotComMode }}
-<style ignore-csp>
-	/* Support webkit inset devices */
-	@supports (padding: max(0px)) {
-
-		.global-navbar,
-		.main-page .row,
-		.search-row {
-			padding-left: max(12px, env(safe-area-inset-left));
-			padding-right: max(12px, env(safe-area-inset-right));
-		}
-
-		.modal-open .row .row {
-			padding-left: 0;
-			padding-right: 0;
-		}
-
-	}
-</style>
-{{ end }}
-
 </html>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/7953. This styling was overriding our .global-navbar class styling, and it appears it was only added for a very old version of the homepage (see https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/97eb44ea2c9c143262010d36a37390f633a972c6)
