### PR TITLE
bitbucketcloud: add `apiURL` option

### DIFF
--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -39,6 +39,15 @@ func NewBitbucketCloudSource(svc *ExternalService, cf *httpcli.Factory) (*Bitbuc
 }
 
 func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
+	if c.ApiURL == "" {
+		c.ApiURL = "https://api.bitbucket.org"
+	}
+	apiURL, err := url.Parse(c.ApiURL)
+	if err != nil {
+		return nil, err
+	}
+	apiURL = extsvc.NormalizeBaseURL(apiURL)
+
 	if cf == nil {
 		cf = httpcli.NewExternalHTTPClientFactory()
 	}
@@ -68,7 +77,7 @@ func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConne
 		}
 	}
 
-	client := bitbucketcloud.NewClient(cli)
+	client := bitbucketcloud.NewClient(apiURL, cli)
 	client.Username = c.Username
 	client.AppPassword = c.AppPassword
 

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -313,7 +313,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "BITBUCKETCLOUD",
-			desc:   "invalid git url type",
+			desc:   "bad apiURL scheme",
+			config: `{"apiURL": "badscheme://api.bitbucket.org"}`,
+			assert: includes("apiURL: Does not match pattern '^https?://'"),
+		},
+		{
+			kind:   "BITBUCKETCLOUD",
+			desc:   "invalid gitURLType",
 			config: `{"gitURLType": "bad"}`,
 			assert: includes(`gitURLType: gitURLType must be one of the following: "http", "ssh"`),
 		},

--- a/internal/conf/reposource/bitbucketcloud_test.go
+++ b/internal/conf/reposource/bitbucketcloud_test.go
@@ -10,23 +10,42 @@ func TestBitbucketCloud_cloneURLToRepoName(t *testing.T) {
 	tests := []struct {
 		conn schema.BitbucketCloudConnection
 		urls []urlToRepoName
-	}{{
-		conn: schema.BitbucketCloudConnection{
-			Url: "https://bitbucket.org",
-		},
-		urls: []urlToRepoName{
-			{"git@bitbucket.org:gorilla/mux.git", "bitbucket.org/gorilla/mux"},
-			{"git@bitbucket.org:/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
-			{"git+https://bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
-			{"https://bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
-			{"https://www.bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
-			{"https://oauth2:ACCESS_TOKEN@bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+	}{
+		{
+			conn: schema.BitbucketCloudConnection{
+				Url: "https://bitbucket.org",
+			},
+			urls: []urlToRepoName{
+				{"git@bitbucket.org:gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+				{"git@bitbucket.org:/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+				{"git+https://bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+				{"https://bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+				{"https://www.bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
+				{"https://oauth2:ACCESS_TOKEN@bitbucket.org/gorilla/mux.git", "bitbucket.org/gorilla/mux"},
 
-			{"git@asdf.com:gorilla/mux.git", ""},
-			{"https://asdf.com/gorilla/mux.git", ""},
-			{"https://oauth2:ACCESS_TOKEN@asdf.com/gorilla/mux.git", ""},
+				{"git@asdf.com:gorilla/mux.git", ""},
+				{"https://asdf.com/gorilla/mux.git", ""},
+				{"https://oauth2:ACCESS_TOKEN@asdf.com/gorilla/mux.git", ""},
+			},
 		},
-	}}
+		{
+			conn: schema.BitbucketCloudConnection{
+				Url: "https://staging.bitbucket.org",
+			},
+			urls: []urlToRepoName{
+				{"git@staging.bitbucket.org:gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+				{"git@staging.bitbucket.org:/gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+				{"git+https://staging.bitbucket.org/gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+				{"https://staging.bitbucket.org/gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+				{"https://www.staging.bitbucket.org/gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+				{"https://oauth2:ACCESS_TOKEN@staging.bitbucket.org/gorilla/mux.git", "staging.bitbucket.org/gorilla/mux"},
+
+				{"git@asdf.com:gorilla/mux.git", ""},
+				{"https://asdf.com/gorilla/mux.git", ""},
+				{"https://oauth2:ACCESS_TOKEN@asdf.com/gorilla/mux.git", ""},
+			},
+		},
+	}
 
 	for _, test := range tests {
 		for _, u := range test.urls {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -53,9 +53,10 @@ type Client struct {
 	RateLimit *rate.Limiter
 }
 
-// NewClient creates a new Bitbucket Cloud API client. If a nil
-// httpClient is provided, http.DefaultClient will be used.
-func NewClient(httpClient httpcli.Doer) *Client {
+// NewClient creates a new Bitbucket Cloud API client with given apiURL. If a nil httpClient
+// is provided, http.DefaultClient will be used. Both Username and AppPassword fields are
+// required to be set before calling any APIs.
+func NewClient(apiURL *url.URL, httpClient httpcli.Doer) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
@@ -72,7 +73,7 @@ func NewClient(httpClient httpcli.Doer) *Client {
 
 	return &Client{
 		httpClient: httpClient,
-		URL:        &url.URL{Scheme: "https", Host: "api.bitbucket.org"},
+		URL:        apiURL,
 		RateLimit:  rate.NewLimiter(rateLimitRequestsPerSecond, RateLimitMaxBurstRequests),
 	}
 }

--- a/internal/extsvc/bitbucketcloud/client_test.go
+++ b/internal/extsvc/bitbucketcloud/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ import (
 var update = flag.Bool("update", false, "update testdata")
 
 func TestClient_Repos(t *testing.T) {
-	cli, save := NewTestClient(t, "Repos", *update)
+	cli, save := NewTestClient(t, "Repos", *update, &url.URL{Scheme: "https", Host: "api.bitbucket.org"})
 	defer save()
 
 	timeout, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))

--- a/internal/extsvc/bitbucketcloud/testing.go
+++ b/internal/extsvc/bitbucketcloud/testing.go
@@ -1,6 +1,7 @@
 package bitbucketcloud
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func GetenvTestBitbucketCloudUsername() string {
 
 // NewTestClient returns a bitbucketcloud.Client that records its interactions
 // to testdata/vcr/.
-func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
+func NewTestClient(t testing.TB, name string, update bool, apiURL *url.URL) (*Client, func()) {
 	t.Helper()
 
 	cassete := filepath.Join("testdata/vcr/", normalize(name))
@@ -34,7 +35,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 		t.Fatal(err)
 	}
 
-	cli := NewClient(hc)
+	cli := NewClient(apiURL, hc)
 	cli.Username = GetenvTestBitbucketCloudUsername()
 	cli.AppPassword = os.Getenv("BITBUCKET_CLOUD_APP_PASSWORD")
 

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/google/go-cmp/cmp"
 )
 
 func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
@@ -27,9 +27,7 @@ func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
 		t.Fatalf("failed to read golden file %q: %s", path, err)
 	}
 
-	if have, want := string(data), string(golden); have != want {
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(have, want, false)
-		t.Error(dmp.DiffPrettyText(diffs))
+	if diff := cmp.Diff(string(golden), string(data)); diff != "" {
+		t.Error(diff)
 	}
 }

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -9,7 +9,7 @@
   "required": ["url", "username", "appPassword"],
   "properties": {
     "url": {
-      "description": "URL of Bitbucket Cloud, such as https://bitbucket.org.",
+      "description": "URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
       "type": "string",
       "not": {
         "type": "string",
@@ -18,6 +18,17 @@
       "pattern": "^https?://",
       "format": "uri",
       "examples": ["https://bitbucket.org"]
+    },
+    "apiURL": {
+      "description": "The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
+      "type": "string",
+      "not": {
+        "type": "string",
+        "pattern": "example\\.com"
+      },
+      "pattern": "^https?://",
+      "format": "uri",
+      "examples": ["https://api.bitbucket.org"]
     },
     "username": {
       "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",

--- a/schema/bitbucket_cloud_stringdata.go
+++ b/schema/bitbucket_cloud_stringdata.go
@@ -14,7 +14,7 @@ const BitbucketCloudSchemaJSON = `{
   "required": ["url", "username", "appPassword"],
   "properties": {
     "url": {
-      "description": "URL of Bitbucket Cloud, such as https://bitbucket.org.",
+      "description": "URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
       "type": "string",
       "not": {
         "type": "string",
@@ -23,6 +23,17 @@ const BitbucketCloudSchemaJSON = `{
       "pattern": "^https?://",
       "format": "uri",
       "examples": ["https://bitbucket.org"]
+    },
+    "apiURL": {
+      "description": "The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
+      "type": "string",
+      "not": {
+        "type": "string",
+        "pattern": "example\\.com"
+      },
+      "pattern": "^https?://",
+      "format": "uri",
+      "examples": ["https://api.bitbucket.org"]
     },
     "username": {
       "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -113,6 +113,8 @@ func (v *AuthProviders) UnmarshalJSON(data []byte) error {
 
 // BitbucketCloudConnection description: Configuration for a connection to Bitbucket Cloud.
 type BitbucketCloudConnection struct {
+	// ApiURL description: The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
+	ApiURL string `json:"apiURL,omitempty"`
 	// AppPassword description: The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.
 	AppPassword string `json:"appPassword"`
 	// Exclude description: A list of repositories to never mirror from Bitbucket Cloud. Takes precedence over "teams" configuration.
@@ -135,7 +137,7 @@ type BitbucketCloudConnection struct {
 	RepositoryPathPattern string `json:"repositoryPathPattern,omitempty"`
 	// Teams description: An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.
 	Teams []string `json:"teams,omitempty"`
-	// Url description: URL of Bitbucket Cloud, such as https://bitbucket.org.
+	// Url description: URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
 	Url string `json:"url"`
 	// Username description: The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding "appPassword" field.
 	Username string `json:"username"`


### PR DESCRIPTION
This PR adds a `apiURL` external config option to support custom API endpoint. Unit tests are also updated to make sure we respect the config option in all places.

Manually tested to prevent regressions.

Fixes #7990.