### PR TITLE
ctags: enable basic support for GraphQL schema files

### DIFF
--- a/cmd/symbols/.ctags.d/graphql.ctags
+++ b/cmd/symbols/.ctags.d/graphql.ctags
@@ -1,0 +1,10 @@
+--langdef=GraphQL
+--langmap=GraphQL:.graphql
+--regex-graphql=/^[ \t]*([_A-Za-z][_A-Za-z0-9]*)[\(:]/\1/v,field/
+--regex-graphql=/^[ \t]*enum[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/e,enum/
+--regex-graphql=/^[ \t]*fragment[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/f,fragment/
+--regex-graphql=/^[ \t]*input[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/i,input/
+--regex-graphql=/^[ \t]*interface[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/n,interface/
+--regex-graphql=/^[ \t]*mutation[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/m,mutation/
+--regex-graphql=/^[ \t]*query[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/q,query/
+--regex-graphql=/^[ \t]*type[ \t]+([_A-Za-z][_0-9A-Za-z]*)/\1/t,type/

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -68,7 +68,7 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	// }
 
 	cmd := exec.Command(ctagsCommand, "--_interactive="+opt, "--fields=*",
-		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,typescript,tsx,Verilog,VHDL,Vim",
+		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,GraphQL,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,typescript,tsx,Verilog,VHDL,Vim",
 		"--map-CSS=+.scss", "--map-CSS=+.less", "--map-CSS=+.sass",
 	)
 	in, err := cmd.StdinPipe()

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -159,6 +159,10 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'go':
             return 'go'
 
+        // GraphQL
+        case 'graphql':
+            return 'graphql'
+
         // HAML
         case 'haml':
             return 'haml'


### PR DESCRIPTION
Add a language definition and regex rules based on some examples proposed in
https://gist.github.com/hoop33/b0a33cf8fdcf4d64689f58efed75c15e.
