### PR TITLE
CHANGELOG: add missing entry about 3.12 requiring `read:org` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The search query builder now lives on its own page at `/search/query-builder`. The home search page has a link to it.
 - User passwords when using builtin auth are limited to 256 characters. Existing passwords longer than 256 characters will continue to work.
 - GraphQL API: Campaign.changesetCreationStatus has been renamed to Campaign.status to be aligned with CampaignPlan. [#7654](https://github.com/sourcegraph/sourcegraph/pull/7654)
+- When using GitHub as an authentication provider, `read:org` scope is now required. This is used to support the new `allowOrgs` site config setting in the GitHub `auth.providers` configuration, which enables site admins to restrict GitHub logins to members of a specific GitHub organization. This for example allows having a Sourcegraph instance with GitHub sign in configured be exposed to the public internet without allowing everyone with a GitHub account access to your Sourcegraph instance.
 
 ### Fixed
 


### PR DESCRIPTION
A customer noticed `read:org` permissions were now required and it was not explained at all in our changelog why this change was made. I was only able to find out why by locating our requested permissions code, backtracking that to a PR https://github.com/sourcegraph/sourcegraph/pull/7555 and then backtracking that to the actual feature that requires these permissions.

Any time we ask for new permissions **please** document it clearly in the CHANGELOG otherwise it will not be clear to users what we're doing and why -- something that I feel is especially important when altering permissions we request from code-hosts. i.e. simply documenting the feature is not enough, we must also document why we're changing the required permissions / scopes.
