### PR TITLE
redispool: Wait SRC_REDIS_WAIT_FOR before quitting sysreq check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - experimentalFeatures.splitSearchModes was removed as a site configuration option. It should be set in global/org/user settings.
+- Sourcegraph now waits for `90s` instead of `5s` for Redis to be available before quitting. This duration is configurable with the new `SRC_REDIS_WAIT_FOR` environment variable.
 
 ### Fixed
 

--- a/internal/redispool/sysreq.go
+++ b/internal/redispool/sysreq.go
@@ -6,6 +6,7 @@ import (
 
 	"fmt"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 )
@@ -13,14 +14,19 @@ import (
 var timeout, _ = time.ParseDuration(env.Get("SRC_REDIS_WAIT_FOR", "90s", "Duration to wait for Redis to become ready before quitting"))
 
 func init() {
-	sysreq.AddCheck("Redis", func(ctx context.Context) (problem, fix string, err error) {
-		c := Store.Get()
-		defer c.Close()
+	sysreq.AddCheck("Redis Store", redisCheck("Store", addrStore, timeout, Store))
+	sysreq.AddCheck("Redis Cache", redisCheck("Cache", addrCache, timeout, Cache))
+}
 
+func redisCheck(name, addr string, timeout time.Duration, pool *redis.Pool) sysreq.CheckFunc {
+	return func(ctx context.Context) (problem, fix string, err error) {
 		deadline := time.Now().Add(timeout)
 
 		for time.Now().Before(deadline) {
+			c := pool.Get()
 			_, err = c.Do("PING")
+			c.Close()
+
 			if err == nil {
 				// Success
 				return "", "", nil
@@ -28,8 +34,9 @@ func init() {
 			// Try again
 			time.Sleep(250 * time.Millisecond)
 		}
-		return "Redis is unavailable or misconfigured",
-			fmt.Sprintf("Start a Redis server listening at port %s", addrStore),
+
+		return fmt.Sprintf("Redis %q is unavailable or misconfigured", name),
+			fmt.Sprintf("Start a Redis server listening at port %s", addr),
 			err
-	})
+	}
 }


### PR DESCRIPTION
This commit makes our `redispool` sysreq check wait for `90s` by
default instead of `5s` and allows admins to set a `SRC_REDIS_WAIT_FOR`
environment variable to control this timeout if it turns out the new
default isn't enough.

Addresses part of #2904. The next step is make Redis start-up faster by
ensuring it maintains a small AOF file that is short to process on
startup (#3300).

Additionally, repo-updater also uses redis, but doesn't currently
integrate with the sysreq package. I'll be reviewing whether we still need
to use redis at all in it (it's currently used for caching GitHub API
responses). If we still need it, I'll run sysreq checks in repo-updater,
otherwise, I'll get rid of the redis dependency there.
