### PR TITLE
a8n: Use simple header for campaign pages

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -123,7 +123,9 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const isSiteInit = props.location.pathname === '/site-admin/init'
 
     const hideGlobalSearchInput: GlobalNavbar['props']['hideGlobalSearchInput'] =
-        props.location.pathname === '/stats' || props.location.pathname === '/search/query-builder'
+        props.location.pathname === '/stats' ||
+        props.location.pathname === '/search/query-builder' ||
+        props.location.pathname.startsWith('/campaigns')
 
     useScrollToLocationHash(props.location)
     // Remove trailing slash (which is never valid in any of our URLs).


### PR DESCRIPTION
I think it looks good and takes off some visual complexity of this already very packed UI

![image](https://user-images.githubusercontent.com/19534377/73387840-6fd43e00-42d1-11ea-8e43-37d014693c24.png)

![image](https://user-images.githubusercontent.com/19534377/73387877-7d89c380-42d1-11ea-946f-bf128b6c6a71.png)

Closes #7868 