### PR TITLE
replace test: increase timeout from 2s to 5s for zip fetching

### DIFF
--- a/cmd/replacer/replace/replace_test.go
+++ b/cmd/replacer/replace/replace_test.go
@@ -64,7 +64,7 @@ func main() {
 			URL:                  "u",
 			Commit:               "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			RewriteSpecification: test.arg,
-			FetchTimeout:         "2000ms",
+			FetchTimeout:         "5000ms",
 		}
 		got, err := doReplace(ts.URL, &req)
 		if err != nil {


### PR DESCRIPTION
This is a last-ditch effort to fix a [flakey test](https://buildkite.com/sourcegraph/sourcegraph/builds/54860#6bc04ffe-6eff-41df-94b3-c0eaa9aa3d3c) that relies on creating a new store and then fetching the contents/zip in replacer. The test is flakey because appears to time out during fetching. This PR increases the timeout from 2s to 5s. If this still results in a flakey test, I'll take more drastic measures.

Previous relevant comments/PRs:

- Observation: https://github.com/sourcegraph/sourcegraph/issues/5721#issuecomment-563959437
- Attempt: 500ms -> 2s #7147
- Fix to honor fetch timeout: #7159
