### PR TITLE
[ci] db backcompat: install .tool-versions from `OLD` commit

### DIFF
--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -33,6 +33,7 @@ echo ""
 
 # Recreate the test DB and run TestMigrations once to ensure that the schema version is the latest.
 set -ex
+asdf install # in case the go version has changed in between these two commits
 go test -count=1 -v ./cmd/frontend/db/  -run=TestMigrations
 HEAD="$HEAD" OLD="${COMMIT_BEFORE_LAST_MIGRATION}" ./dev/ci/db-backcompat.sh
 set +ex

--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -33,7 +33,6 @@ echo ""
 
 # Recreate the test DB and run TestMigrations once to ensure that the schema version is the latest.
 set -ex
-asdf install # in case the go version has changed in between these two commits
 go test -count=1 -v ./cmd/frontend/db/  -run=TestMigrations
 HEAD="$HEAD" OLD="${COMMIT_BEFORE_LAST_MIGRATION}" ./dev/ci/db-backcompat.sh
 set +ex

--- a/dev/ci/db-backcompat.sh
+++ b/dev/ci/db-backcompat.sh
@@ -51,6 +51,7 @@ function runTest() {
     (
         set -ex
         git checkout "$OLD"
+        asdf install # in case the go version has changed in between these two commits
         set +ex
 
         NOW_LATEST_SCHEMA=$(getLatestMigrationVersion)
@@ -87,6 +88,7 @@ EXIT_CODE="$?"
 
 set -x
 git checkout "$HEAD"
+asdf install # in case the go version has changed in between these two commits
 set +x
 echo "Restored HEAD commit: $HEAD: $(git rev-parse HEAD)"
 


### PR DESCRIPTION
During our DB backward compatibility tests, an `OLD` version of Sourcegraph is checked out. If that `OLD` version is using a version of Go other than the one that's in the `HEAD` https://github.com/sourcegraph/sourcegraph/blob/master/.tool-versions, the script will fail and [asdf](https://github.com/asdf-vm/asdf) (rightly) complains that the Go version specified in the older commit isn't installed on the machine.

Running `asdf install` after each checkout fixes the issue. 