### PR TITLE
ctags: enable basic support for Groovy files

### DIFF
--- a/cmd/symbols/.ctags.d/groovy.ctags
+++ b/cmd/symbols/.ctags.d/groovy.ctags
@@ -1,0 +1,10 @@
+--langdef=Groovy
+--langmap=Groovy:.groovy
+--regex-groovy=/^[ \t]*package[ \t]+([a-zA-Z0-9.-_]+)/\1/p,package/
+--regex-groovy=/^[ \t]*((private|public)[ \t]*)?(abstract|final|static)?[ \t]*class[ \t]+([A-Za-z0-9_]+)/\4/c,class/
+--regex-groovy=/^[ \t]*((private|public)[ \t]*)?interface[ \t]+([A-Za-z0-9_]+)/\3/n,interface/
+--regex-groovy=/^[ \t]*((private|public)[ \t]*)?trait[ \t]+([A-Za-z0-9_]+)/\3/t,trait/
+--regex-groovy=/^[ \t]*((private|public)[ \t]*)?enum[ \t]+([A-Za-z0-9_]+)/\3/e,enum/
+--regex-groovy=/^[ \t]*(public|private|protected[ \t]*)*([a-zA-Z0-9_]{3,})\([A-Za-z0-9 _,]*\)[ \t]+/\2/r,constructor/
+--regex-groovy=/^[ \t]*((abstract|final|public|private|protected|static)[ \t]*)*(def|void|byte|int|short|long|float|double|boolean|char|[A-Z][a-zA-Z0-9_]*)[ \t]+([a-zA-Z0-9_]+)\(/\4/m,method/
+--regex-groovy=/^[ \t]*((final|public|private|protected|static|synchronized)[ \t]*)*(def|byte|int|short|long|float|double|boolean|char|[A-Z][A-Za-z0-9_]*)[ \t]+([a-zA-Z0-9_]+)[ \t]*([\/]+.*)?$/\4/v,field/

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -68,7 +68,7 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	// }
 
 	cmd := exec.Command(ctagsCommand, "--_interactive="+opt, "--fields=*",
-		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,GraphQL,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,typescript,tsx,Verilog,VHDL,Vim",
+		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,GraphQL,Groovy,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,typescript,tsx,Verilog,VHDL,Vim",
 		"--map-CSS=+.scss", "--map-CSS=+.less", "--map-CSS=+.sass",
 	)
 	in, err := cmd.StdinPipe()

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -163,6 +163,10 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'graphql':
             return 'graphql'
 
+        // Groovy
+        case 'groovy':
+            return 'groovy'
+
         // HAML
         case 'haml':
             return 'haml'


### PR DESCRIPTION
Add a language definition and regex rules based on the vim-gradle plugin at https://bitbucket.org/sw-samuraj/vim-gradle. The rules from the plugin have been modified as follows:

- Remove duplicate tag usage and fix labels not valid in universal-ctags.
- Remove prefixes and type tag decorations on method/constructor names.
- Consolidate rules for different visibilities.
- Fix some overlapping matches on different kinds.
- Fix incorrect regexp usage