### PR TITLE
Interactive mode: handle all filters

### DIFF
--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -30,6 +30,9 @@ export enum FilterTypes {
     fork = 'fork',
     archived = 'archived',
     case = 'case',
+    type = 'type',
+    before = 'before',
+    after = 'after',
 }
 
 export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterTypes[]

--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -33,6 +33,8 @@ export enum FilterTypes {
     type = 'type',
     before = 'before',
     after = 'after',
+    author = 'author',
+    message = 'message',
 }
 
 export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterTypes[]

--- a/shared/src/search/parser/filters.ts
+++ b/shared/src/search/parser/filters.ts
@@ -75,7 +75,7 @@ export const FILTERS: readonly FilterDefinition[] = [
     {
         aliases: ['type'],
         description: 'Limit results to the specified type.',
-        discreteValues: ['code', 'diff', 'commit', 'symbol'],
+        discreteValues: ['code', 'diff', 'commit', 'symbol', 'repo', 'path'],
     },
     {
         aliases: ['case'],
@@ -114,6 +114,18 @@ export const FILTERS: readonly FilterDefinition[] = [
         aliases: ['patterntype'],
         discreteValues: ['regexp', 'literal', 'structural'],
         description: 'The pattern type (regexp, literal, structural) in use',
+    },
+    {
+        aliases: ['author'],
+        description: 'The author of a commit',
+    },
+    {
+        aliases: ['after'],
+        description: 'Commits made after a certain date',
+    },
+    {
+        aliases: ['before'],
+        description: 'Commits made before a certain date',
     },
 ]
 

--- a/shared/src/search/suggestions/util.ts
+++ b/shared/src/search/suggestions/util.ts
@@ -14,6 +14,10 @@ export enum SuggestionTypes {
     timeout = 'timeout',
     dir = 'dir',
     symbol = 'symbol',
+    before = 'before',
+    after = 'after',
+    author = 'author',
+    message = 'message',
 }
 
 export const suggestionTypeKeys: SuggestionTypes[] = Object.keys(SuggestionTypes) as SuggestionTypes[]

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -1,7 +1,7 @@
 import * as H from 'history'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { buildSearchURLQuery } from '../../../shared/src/util/url'
+import { buildSearchURLQuery, generateFiltersQuery } from '../../../shared/src/util/url'
 import { eventLogger } from '../tracking/eventLogger'
 import { SearchType } from './results/SearchResults'
 import { SearchFilterSuggestions } from './searchFilterSuggestions'
@@ -113,7 +113,7 @@ export function toggleSearchType(query: string, searchType: SearchType): string 
     if (!match) {
         return searchType ? `${query} type:${searchType}` : query
     }
-
+    console.log('match[0]', match[0])
     if (match[0] === `type:${searchType}`) {
         /** Query already contains correct search type */
         return query

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -1,7 +1,7 @@
 import * as H from 'history'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { buildSearchURLQuery, generateFiltersQuery } from '../../../shared/src/util/url'
+import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { eventLogger } from '../tracking/eventLogger'
 import { SearchType } from './results/SearchResults'
 import { SearchFilterSuggestions } from './searchFilterSuggestions'
@@ -113,7 +113,7 @@ export function toggleSearchType(query: string, searchType: SearchType): string 
     if (!match) {
         return searchType ? `${query} type:${searchType}` : query
     }
-    console.log('match[0]', match[0])
+
     if (match[0] === `type:${searchType}`) {
         /** Query already contains correct search type */
         return query

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -18,6 +18,8 @@ export function isTextFilter(filter: FilterTypes): boolean {
         'timeout',
         'before',
         'after',
+        'message',
+        'author',
         '-repo',
         '-repohasfile',
         '-file',
@@ -92,5 +94,7 @@ export const FilterTypesToProseNames: Record<FilterTypes, string> = {
     case: 'Case sensitive',
     after: 'Committed after',
     before: 'Committed before',
+    message: 'Commit message contains',
+    author: 'Commit author',
     type: 'Type',
 }

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -4,7 +4,7 @@ import { assign } from 'lodash/fp'
 import { FilterTypes } from '../../../../../shared/src/search/interactive/util'
 
 /** FilterTypes which have a finite number of valid options. */
-export type FiniteFilterTypes = FilterTypes.archived | FilterTypes.fork
+export type FiniteFilterTypes = FilterTypes.archived | FilterTypes.fork | FilterTypes.type
 
 export function isTextFilter(filter: FilterTypes): boolean {
     const validTextFilters = [
@@ -16,6 +16,8 @@ export function isTextFilter(filter: FilterTypes): boolean {
         'lang',
         'count',
         'timeout',
+        'before',
+        'after',
         '-repo',
         '-repohasfile',
         '-file',
@@ -48,10 +50,25 @@ export const finiteFilters: Record<
             })
         ),
     },
+    type: {
+        default: 'code',
+        values: [
+            { value: 'code' },
+            { value: 'commit' },
+            { value: 'diff' },
+            { value: 'repo' },
+            { value: 'path' },
+            { value: 'symbols' },
+        ].map(
+            assign({
+                type: SuggestionTypes.type,
+            })
+        ),
+    },
 }
 
 export const isFiniteFilter = (filter: FilterTypes): filter is FiniteFilterTypes =>
-    ['archived', 'fork'].includes(filter)
+    ['archived', 'fork', 'type'].includes(filter)
 
 /**
  * Some filter types should have their suggestions searched without influence
@@ -73,4 +90,7 @@ export const FilterTypesToProseNames: Record<FilterTypes, string> = {
     fork: 'Forks',
     archived: 'Archived repos',
     case: 'Case sensitive',
+    after: 'Committed after',
+    before: 'Committed before',
+    type: 'Type',
 }

--- a/web/src/search/results/SearchResultTab.tsx
+++ b/web/src/search/results/SearchResultTab.tsx
@@ -3,7 +3,7 @@ import * as H from 'history'
 import { SearchType } from './SearchResults'
 import { NavLink } from 'react-router-dom'
 import { toggleSearchType } from '../helpers'
-import { buildSearchURLQuery } from '../../../../shared/src/util/url'
+import { buildSearchURLQuery, generateFiltersQuery } from '../../../../shared/src/util/url'
 import { constant } from 'lodash'
 import { PatternTypeProps, CaseSensitivityProps } from '..'
 import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
@@ -31,8 +31,9 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
     patternType,
     caseSensitive,
 }) => {
-    const q = toggleSearchType(query, type)
-    const builtURLQuery = buildSearchURLQuery(q, patternType, caseSensitive, filtersInQuery)
+    const fullQuery = [query, generateFiltersQuery(filtersInQuery)].filter(query => query.length > 0).join(' ')
+    const q = toggleSearchType(fullQuery, type)
+    const builtURLQuery = buildSearchURLQuery(q, patternType, caseSensitive)
 
     const isActiveFunc = constant(location.search === `?${builtURLQuery}`)
     return (

--- a/web/src/search/searchFilterSuggestions.ts
+++ b/web/src/search/searchFilterSuggestions.ts
@@ -78,6 +78,18 @@ export const searchFilterSuggestions: SearchFilterSuggestions = {
                 value: 'timeout:',
                 description: '"string specifying time duration" (duration before timeout)',
             },
+            {
+                value: 'after:',
+                description: '"string specifying time frame" (time frame to match commits after)',
+            },
+            {
+                value: 'before:',
+                description: '"string specifying time frame" (time frame to match commits before)',
+            },
+            {
+                value: 'message:',
+                description: 'commit message contents',
+            },
         ].map(
             assign({
                 type: SuggestionTypes.filters,
@@ -157,6 +169,22 @@ export const searchFilterSuggestions: SearchFilterSuggestions = {
             assign({
                 type: SuggestionTypes.timeout,
             })
+        ),
+    },
+    author: {
+        values: [],
+    },
+    message: {
+        values: [],
+    },
+    before: {
+        values: [{ value: '"1 week ago"' }, { value: '"1 day ago"' }, { value: '"last thursday"' }].map(
+            assign({ type: SuggestionTypes.before })
+        ),
+    },
+    after: {
+        values: [{ value: '"1 week ago"' }, { value: '"1 day ago"' }, { value: '"last thursday"' }].map(
+            assign({ type: SuggestionTypes.after })
         ),
     },
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8119 by adding type, before, after, author, and message as recognized filters, and making `SearchResultTabHeader` component use the `filtersInQuery` prop.