### PR TITLE
Fix getPageInfo() for gitlab.com MRs

### DIFF
--- a/browser/src/libs/gitlab/scrape.ts
+++ b/browser/src/libs/gitlab/scrape.ts
@@ -46,7 +46,11 @@ export function getPageInfo(): GitLabInfo {
     let pageKind: GitLabPageKind
     if (window.location.pathname.includes(`${owner}/${projectName}/commit`)) {
         pageKind = GitLabPageKind.Commit
-    } else if (window.location.pathname.includes(`${owner}/${projectName}/merge_requests`)) {
+    } else if (
+        window.location.pathname.includes(`${owner}/${projectName}/merge_requests`) ||
+        // https://github.com/sourcegraph/sourcegraph/issues/8134
+        window.location.pathname.includes(`${owner}/${projectName}/-/merge_requests`)
+    ) {
         pageKind = GitLabPageKind.MergeRequest
     } else if (window.location.pathname.includes(`${owner}/${projectName}/blob`)) {
         pageKind = GitLabPageKind.File


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8134

We should run nightly puppeteer tests against gitlab.com and/or consider adding e2e tests to gitlab's own test suite to catch this type of stuff early.