### PR TITLE
search: structural search regex converter should match multiple lines

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -143,31 +143,31 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 			Name:     "Just a hole",
 			Pattern:  ":[1]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()(?-s:.)*?()")`,
+			Want:     `(and case_regex:"()((?s:.))*?()")`,
 		},
 		{
 			Name:     "Adjacent holes",
 			Pattern:  ":[1]:[2]:[3]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()(?-s:.)*?()(?-s:.)*?()(?-s:.)*?()")`,
+			Want:     `(and case_regex:"()((?s:.))*?()((?s:.))*?()((?s:.))*?()")`,
 		},
 		{
 			Name:     "Substring between holes",
 			Pattern:  ":[1] substring :[2]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()(?-s:.)*?([\\t-\\n\\f-\\r ]+substring[\\t-\\n\\f-\\r ]+)(?-s:.)*?()")`,
+			Want:     `(and case_regex:"()((?s:.))*?([\\t-\\n\\f-\\r ]+substring[\\t-\\n\\f-\\r ]+)((?s:.))*?()")`,
 		},
 		{
 			Name:     "Substring before and after different hole kinds",
 			Pattern:  "prefix :[[1]] :[2.] suffix",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(prefix[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+suffix)")`,
+			Want:     `(and case_regex:"(prefix[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+suffix)")`,
 		},
 		{
 			Name:     "Substrings covering all hole kinds.",
 			Pattern:  `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(1\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+2\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+3\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+4\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+5\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+6\\.[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+done\\.)")`,
+			Want:     `(and case_regex:"(1\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+2\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+3\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+4\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+5\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+6\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+done\\.)")`,
 		},
 		{
 			Name:     "Substrings across multiple lines.",
@@ -179,27 +179,27 @@ func TestStructuralPatToZoektQuery(t *testing.T) {
 			Name:     "Allow alphanumeric identifiers in holes",
 			Pattern:  "sub :[alphanum_ident_123] string",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(sub[\\t-\\n\\f-\\r ]+)(?-s:.)*?([\\t-\\n\\f-\\r ]+string)")`,
+			Want:     `(and case_regex:"(sub[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+string)")`,
 		},
 
 		{
 			Name:     "Whitespace separated holes",
 			Pattern:  ":[1] :[2]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()(?-s:.)*?([\\t-\\n\\f-\\r ]+)(?-s:.)*?()")`,
+			Want:     `(and case_regex:"()((?s:.))*?([\\t-\\n\\f-\\r ]+)((?s:.))*?()")`,
 		},
 		{
 			Name:     "Expect newline separated pattern",
 			Pattern:  "ParseInt(:[stuff], :[x]) if err ",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(ParseInt\\()(?-s:.)*?(,[\\t-\\n\\f-\\r ]+)(?-s:.)*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
+			Want:     `(and case_regex:"(ParseInt\\()((?s:.))*?(,[\\t-\\n\\f-\\r ]+)((?s:.))*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
 		},
 		{
 			Name: "Contiguous whitespace is replaced by regex",
 			Pattern: `ParseInt(:[stuff],    :[x])
              if err `,
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(ParseInt\\()(?-s:.)*?(,[\\t-\\n\\f-\\r ]+)(?-s:.)*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
+			Want:     `(and case_regex:"(ParseInt\\()((?s:.))*?(,[\\t-\\n\\f-\\r ]+)((?s:.))*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
 		},
 	}
 	for _, tt := range cases {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -418,7 +418,7 @@ func StructuralPatToRegexpQuery(pattern string) (zoektquery.Q, error) {
 	if len(pieces) == 0 {
 		return &zoektquery.Const{Value: true}, nil
 	}
-	rs := "(" + strings.Join(pieces, ").*?(") + ")"
+	rs := "(" + strings.Join(pieces, ")(.|\\s)*?(") + ")"
 	re, _ := syntax.Parse(rs, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
 	children = append(children, &zoektquery.Regexp{
 		Regexp:        re,


### PR DESCRIPTION
A structural search pattern like `{:[_]}` implies that a pattern like

```
{

}
```

should match (across multiple lines). The regex converter to approximate this was `\{.*?\}`, but that doesn't match across newlines. So, the regex was underapproximating whether a file could match and missed potential results. This  PR changes the conversion from `.*?` to `(.|\s)*?`, which can also match across newlines. Not sure what the performance implication is (probably negligible compared to what's already there), but it's more important to not miss things at this point.

No new tests--all the existing tests are updated to reflect this behavioral change. An e2e test could capture the change to results, but I don't view it as essential to this PR.