### PR TITLE
auth: enforce minimum password length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a setting `search.hideSuggestions`, which when set to `true`, will hide search suggestions in the search bar.
 - An experimental tool [src-expose](https://docs.sourcegraph.com/admin/external_service/other#experimental-src-expose) to import code from any code host.
 - Experimental: Added new field `certificates` as in `{ "experimentalFeatures" { "tls.external": { "certificates": ["<CERT>"] } } }`. This allows you to add certificates to trust when communicating with a code host (via API or git+http). We expect this to be useful for adding internal certificate authorities/self-signed certificates. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
+- New site configuration option `{ "auth.minPasswordRunes": 12 }` to enforce minimum password length when user sign up and change password.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a setting `search.hideSuggestions`, which when set to `true`, will hide search suggestions in the search bar.
 - An experimental tool [src-expose](https://docs.sourcegraph.com/admin/external_service/other#experimental-src-expose) to import code from any code host.
 - Experimental: Added new field `certificates` as in `{ "experimentalFeatures" { "tls.external": { "certificates": ["<CERT>"] } } }`. This allows you to add certificates to trust when communicating with a code host (via API or git+http). We expect this to be useful for adding internal certificate authorities/self-signed certificates. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
-- New site configuration option `{ "auth.minPasswordLength": 12 }` to enforce minimum password length when user sign up and change password.
+- Added a setting `auth.minPasswordLength`, which when set, causes a minimum password length to be enforced when users sign up or change passwords. [#7521](https://github.com/sourcegraph/sourcegraph/issues/7521)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a setting `search.hideSuggestions`, which when set to `true`, will hide search suggestions in the search bar.
 - An experimental tool [src-expose](https://docs.sourcegraph.com/admin/external_service/other#experimental-src-expose) to import code from any code host.
 - Experimental: Added new field `certificates` as in `{ "experimentalFeatures" { "tls.external": { "certificates": ["<CERT>"] } } }`. This allows you to add certificates to trust when communicating with a code host (via API or git+http). We expect this to be useful for adding internal certificate authorities/self-signed certificates. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
-- New site configuration option `{ "auth.minPasswordRunes": 12 }` to enforce minimum password length when user sign up and change password.
+- New site configuration option `{ "auth.minPasswordLength": 12 }` to enforce minimum password length when user sign up and change password.
 
 ### Changed
 

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -150,8 +150,10 @@ const maxPasswordRunes = 256
 
 // checkPasswordLength returns an error if the password is too long.
 func checkPasswordLength(pw string) error {
-	if utf8.RuneCountInString(pw) > maxPasswordRunes {
-		return errcode.NewPresentationError(fmt.Sprintf("Passwords may not be more than %d characters.", maxPasswordRunes))
+	minPasswordRunes := conf.Get().AuthMinPasswordRunes
+	if utf8.RuneCountInString(pw) < minPasswordRunes ||
+		utf8.RuneCountInString(pw) > maxPasswordRunes {
+		return errcode.NewPresentationError(fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes))
 	}
 	return nil
 }

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -150,9 +150,10 @@ const maxPasswordRunes = 256
 
 // checkPasswordLength returns an error if the password is too long.
 func checkPasswordLength(pw string) error {
-	minPasswordRunes := conf.Get().AuthMinPasswordRunes
-	if utf8.RuneCountInString(pw) < minPasswordRunes ||
-		utf8.RuneCountInString(pw) > maxPasswordRunes {
+	pwLen := utf8.RuneCountInString(pw)
+	minPasswordRunes := conf.Get().AuthMinPasswordLength
+	if pwLen < minPasswordRunes ||
+		pwLen > maxPasswordRunes {
 		return errcode.NewPresentationError(fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes))
 	}
 	return nil

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
@@ -89,19 +91,52 @@ func TestUsers_ValidUsernames(t *testing.T) {
 	}
 }
 
-func TestUsers_LimitPasswordLength(t *testing.T) {
+func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	longPassword := strings.Repeat("x", maxPasswordRunes+1)
-	expectedErr := "Passwords may not be more than 256 characters."
+	minPasswordRunes := 12
+	cfg := conf.Get()
+	cfg.AuthMinPasswordRunes = minPasswordRunes
+	conf.Mock(cfg)
+	defer func() {
+		cfg.AuthMinPasswordRunes = 0
+		conf.Mock(cfg)
+	}()
 
-	_, err := Users.Create(ctx, NewUser{Username: "test", Password: longPassword})
-	if pm := errcode.PresentationMessage(err); pm != expectedErr {
-		t.Fatalf("expected error %q; got %q", expectedErr, pm)
+	expErr := fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes)
+	tests := []struct {
+		name     string
+		password string
+		expErr   string
+	}{
+		{
+			name:     "exceeds maximum",
+			password: strings.Repeat("x", maxPasswordRunes+1),
+			expErr:   expErr,
+		},
+		{
+			name:     "below minimum",
+			password: strings.Repeat("x", minPasswordRunes-1),
+			expErr:   expErr,
+		},
+
+		{
+			name:     "no problem",
+			password: strings.Repeat("x", minPasswordRunes),
+			expErr:   "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Users.Create(ctx, NewUser{Username: "test", Password: test.password})
+			if pm := errcode.PresentationMessage(err); pm != test.expErr {
+				t.Fatalf("err: want %q but got %q", test.expErr, pm)
+			}
+		})
 	}
 }
 

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -100,10 +100,10 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 
 	minPasswordRunes := 12
 	cfg := conf.Get()
-	cfg.AuthMinPasswordRunes = minPasswordRunes
+	cfg.AuthMinPasswordLength = minPasswordRunes
 	conf.Mock(cfg)
 	defer func() {
-		cfg.AuthMinPasswordRunes = 0
+		cfg.AuthMinPasswordLength = 0
 		conf.Mock(cfg)
 	}()
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -836,7 +836,7 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
-	// AuthMinPasswordLength description: The minimum number of UTF-8 runes that a password must contain.
+	// AuthMinPasswordLength description: The minimum number of Unicode code points that a password must contain.
 	AuthMinPasswordLength int `json:"auth.minPasswordLength,omitempty"`
 	// AuthProviders description: The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including G Suite), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
 	AuthProviders []AuthProviders `json:"auth.providers,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -836,6 +836,8 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
+	// AuthMinPasswordRunes description: The minimum number of UTF-8 runes that a password must contain.
+	AuthMinPasswordRunes int `json:"auth.minPasswordRunes,omitempty"`
 	// AuthProviders description: The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including G Suite), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
 	AuthProviders []AuthProviders `json:"auth.providers,omitempty"`
 	// AuthPublic description: WARNING: This option has been removed as of 3.8.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -836,8 +836,8 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
-	// AuthMinPasswordRunes description: The minimum number of UTF-8 runes that a password must contain.
-	AuthMinPasswordRunes int `json:"auth.minPasswordRunes,omitempty"`
+	// AuthMinPasswordLength description: The minimum number of UTF-8 runes that a password must contain.
+	AuthMinPasswordLength int `json:"auth.minPasswordLength,omitempty"`
 	// AuthProviders description: The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including G Suite), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
 	AuthProviders []AuthProviders `json:"auth.providers,omitempty"`
 	// AuthPublic description: WARNING: This option has been removed as of 3.8.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -561,7 +561,7 @@
       "group": "Authentication"
     },
     "auth.minPasswordLength": {
-      "description": "The minimum number of UTF-8 runes that a password must contain.",
+      "description": "The minimum number of Unicode code points that a password must contain.",
       "type": "integer",
       "default": 12,
       "group": "Authentication"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -560,7 +560,7 @@
       "default": false,
       "group": "Authentication"
     },
-    "auth.minPasswordRunes": {
+    "auth.minPasswordLength": {
       "description": "The minimum number of UTF-8 runes that a password must contain.",
       "type": "integer",
       "default": 12,

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -557,7 +557,14 @@
     "auth.enableUsernameChanges": {
       "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "group": "Authentication"
+    },
+    "auth.minPasswordRunes": {
+      "description": "The minimum number of UTF-8 runes that a password must contain.",
+      "type": "integer",
+      "default": 12,
+      "group": "Authentication"
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -566,7 +566,7 @@ const SiteSchemaJSON = `{
       "group": "Authentication"
     },
     "auth.minPasswordLength": {
-      "description": "The minimum number of UTF-8 runes that a password must contain.",
+      "description": "The minimum number of Unicode code points that a password must contain.",
       "type": "integer",
       "default": 12,
       "group": "Authentication"

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -565,7 +565,7 @@ const SiteSchemaJSON = `{
       "default": false,
       "group": "Authentication"
     },
-    "auth.minPasswordRunes": {
+    "auth.minPasswordLength": {
       "description": "The minimum number of UTF-8 runes that a password must contain.",
       "type": "integer",
       "default": 12,

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -562,7 +562,14 @@ const SiteSchemaJSON = `{
     "auth.enableUsernameChanges": {
       "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "group": "Authentication"
+    },
+    "auth.minPasswordRunes": {
+      "description": "The minimum number of UTF-8 runes that a password must contain.",
+      "type": "integer",
+      "default": 12,
+      "group": "Authentication"
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",


### PR DESCRIPTION
This PR adds a new site configuration option `{ "auth.minPasswordLength": 12 }` to enforce minimum password length when user 1) sign up 2) change password.

Fixes #7521.
