### PR TITLE
a8n: Allow updating individually published Changesets

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -748,7 +748,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		return nil, nil, errors.Wrap(err, "getting latest changesetjob creation time")
 	}
 	allChangesetJobsCreated := !changesetCreation.IsZero()
-	if !allChangesetJobsCreated && status.CompletedCount() == 0 {
+	if !allChangesetJobsCreated && status.Total == 0 {
 		// If the campaign hasn't been published yet and no Changesets have
 		// been individually published (through the `PublishChangeset`
 		// mutation), we can simply update the attributes on the Campaign
@@ -766,7 +766,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	// If we have non-zero number of ChangesetJobs, but the Campaign has not
 	// been fully published yet, we have individually published Changesets we
 	// need to update.
-	partialUpdate := !allChangesetJobsCreated && status.CompletedCount() != 0
+	partialUpdate := !allChangesetJobsCreated && status.Total != 0
 
 	diff, err := computeCampaignUpdateDiff(ctx, tx, campaign, oldPlanID, updateAttributes)
 	if err != nil {


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/7915 with the most straightforward solution:

When updating the CampaignPlan for a Campaign that has been partially published, we _only_ update or close the Changesets/ChangesetJobs that have been published. We don't create new ones.

---

**Example**:

An unpublished Campaign with 4 diffs for 4 repositories, where a subset of the Changesets is already published:

| ID | Repository | Diff | Published (= ChangesetJob/Changeset created)| 
|---| --- | --- | --- |
| `1` | `Repo-A` | `"123"` | No |
| `2` | `Repo-B` | `"456"` | No |
| `3` | `Repo-C` | `"789"` | Yes |
| `4` | `Repo-D` | `"ABC"` | Yes |

(Ignore the syntax of the "Diff", this is just here to illustrate when a diff per repository has changed)

Now we create a new Campaign Plan with 4 diffs for 4 repositories:

| ID | Repository | Diff | 
|---| --- | --- |
| `5` | `Repo-A` | `"123"` | 
| `6` | `Repo-B` | `"UPDATED"` |
| `7` | `Repo-C` | `"UPDATED"` |
| `8` | `Repo-E` | `"NEWNEW"` |

When we update the Campaign to have this new Campaign Plan we want the following to happen:

- The diff for `Repo-A` should stay as it is
- The diff for `Repo-B` should be updated
- The diff for `Repo-C` should be updated **on the codehost** since it's published
- The diff for `Repo-D` should be closed **on the codehost** since it's published and detached from the Campaign
- The diff for `Repo-E` should be added to the list but not created on the codehost

So after we update the Campaign to the new CampaignPlan we get this:

| ID | Repository | Diff | Published (= ChangesetJob/Changeset created)| 
|---| --- | --- | --- |
| `4` | `Repo-A` | `"123"` | No |
| `5` | `Repo-B` | `"UPDATED"` | No |
| `6` | `Repo-C` | `"UPDATED"` | Yes |
| `7` | `Repo-E` | `"NEWNEW"` | No |

And the previously published diff for `Repo-D` has been closed.

---

This was actually easier to implement than I thought it would. At least from a code perspective, I had to do a lot of thinking about this. The realization that made it easy to implement:

When we are in "partial update"-mode we can compute the update-diff (which changesets to update, which to create, which to close on the codehosts) as we normally would, **but ignore the list-of-changesets-to-create and only execute the to-update/to-close list)
