### PR TITLE
ci: Set COMMIT_SHA/DATE env vars when building server image

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -186,7 +186,7 @@ func wait(pipeline *bk.Pipeline) {
 	pipeline.AddWait()
 }
 
-func triggerE2E(c Config) func(*bk.Pipeline) {
+func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	// hardFail if we publish docker images
 	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
@@ -194,11 +194,10 @@ func triggerE2E(c Config) func(*bk.Pipeline) {
 		"BUILDKITE_PULL_REQUEST",
 		"BUILDKITE_PULL_REQUEST_BASE_BRANCH",
 		"BUILDKITE_PULL_REQUEST_REPO",
-
-		"COMMIT_SHA",
-		"DATE",
 	)
-	env["VERSION"] = c.version
+	env["COMMIT_SHA"] = commonEnv["COMMIT_SHA"]
+	env["DATE"] = commonEnv["DATE"]
+	env["VERSION"] = commonEnv["VERSION"]
 	env["TAG"] = candiateImageTag(c)
 
 	return func(pipeline *bk.Pipeline) {


### PR DESCRIPTION
I noticed that when we build a server image in the e2e step we don't
have access to the environment variables of the "main" build that
triggered it.

See "Environment" tab here for example: https://buildkite.com/sourcegraph/e2e/builds/4746#d0b5e174-0c63-4f0c-a0ef-59fa27697a8c

The result was that `COMMIT_SHA` and `DATE` labels weren't set in the server images we built the .

This change here should fix that by only copying from the environment what's already set at runtime and copying from the build config what's set in the "main" build environment.
