### PR TITLE
Clean old lsif redis-store data on startup.

### DIFF
--- a/lsif/src/server/server.ts
+++ b/lsif/src/server/server.ts
@@ -127,8 +127,11 @@ async function migrateFilenames(): Promise<void> {
  */
 async function clearOldRedisData(logger: Logger): Promise<void> {
     const script = `
-        local keys = redis.call('keys', 'bull:*')
-        for i, key in ipairs(keys) do
+        for i, key in ipairs(redis.call('keys', 'lsif:*')) do
+            redis.call('del', key)
+        end
+
+        for i, key in ipairs(redis.call('keys', 'bull:*')) do
             redis.call('del', key)
         end
     `


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/8137 had cleaned up all bull data, but did not clean up the node-resque data that came before that.