### PR TITLE
frontend: Enforce upgrade policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to Sourcegraph are documented in this file.
 - GitHub labels associated with Automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - When creating a campaign Automation users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
 - Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
-- **Search** Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
 - Our [upgrade policy](https://docs.sourcegraph.com/#upgrading-sourcegraph) is now enforced by the `sourcegraph-frontend` on startup to prevent admins from mistakenly jumping too many versions. [#8157](https://github.com/sourcegraph/sourcegraph/pulls/8157) [#7702](https://github.com/sourcegraph/sourcegraph/issues/7702)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Sourcegraph are documented in this file.
 - GitHub labels associated with Automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - When creating a campaign Automation users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
 - Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
+- **Search** Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
+- Our [upgrade policy](https://docs.sourcegraph.com/#upgrading-sourcegraph) is now enforced by the `sourcegraph-frontend` on startup to prevent admins from mistakenly jumping too many versions. [#8157](https://github.com/sourcegraph/sourcegraph/pulls/8157) [#7702](https://github.com/sourcegraph/sourcegraph/issues/7702)
 
 ### Changed
 

--- a/cmd/frontend/backend/versions.go
+++ b/cmd/frontend/backend/versions.go
@@ -1,0 +1,89 @@
+package backend
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+)
+
+// UpgradeError is returned by UpdateServiceVersion when it faces an
+// upgrade policy violation error.
+type UpgradeError struct {
+	Service  string
+	Previous *semver.Version
+	Latest   *semver.Version
+}
+
+// Error implements the error interface.
+func (e UpgradeError) Error() string {
+	return fmt.Sprintf(
+		"upgrading %q from %q to %q is not allowed, please refer to %s",
+		e.Service,
+		e.Previous,
+		e.Latest,
+		"https://docs.sourcegraph.com/#upgrading-sourcegraph",
+	)
+
+}
+
+// UpdateServiceVersion updates the latest version for the given Sourcegraph
+// service. It enforces our documented upgrade policy.
+// https://docs.sourcegraph.com/#upgrading-sourcegraph
+func UpdateServiceVersion(ctx context.Context, service, version string) error {
+	latest, err := semver.NewVersion(version)
+	if err != nil {
+		return err
+	}
+
+	return dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) (err error) {
+		var v string
+
+		q := sqlf.Sprintf(getVersionQuery, service)
+		row := tx.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		if err = row.Scan(&v); err != nil && err != sql.ErrNoRows {
+			return err
+		}
+
+		var previous *semver.Version
+		if v != "" {
+			previous, err = semver.NewVersion(v)
+			if err != nil {
+				return err
+			}
+		}
+
+		if !IsValidUpgrade(previous, latest) {
+			return &UpgradeError{Service: service, Previous: previous, Latest: latest}
+		}
+
+		q = sqlf.Sprintf(upsertVersionQuery, service, latest.String(), time.Now().UTC())
+		_, err = tx.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		return err
+	})
+}
+
+const getVersionQuery = `SELECT version FROM versions WHERE service = %s`
+
+const upsertVersionQuery = `
+INSERT INTO versions (service, version, updated_at)
+VALUES (%s, %s, %s) ON CONFLICT (service) DO
+UPDATE SET (version, updated_at) =
+	(excluded.version, excluded.updated_at)`
+
+// IsValidUpgrade returns true if the given previous and
+// latest versions comply with our documented upgrade policy.
+//
+// https://docs.sourcegraph.com/#upgrading-sourcegraph
+func IsValidUpgrade(previous, latest *semver.Version) bool {
+	return previous == nil || previous.Equal(latest) ||
+		(previous.Major() == latest.Major() &&
+			previous.Minor() == latest.Minor()-1) ||
+		(latest.Major() == previous.Major()+1 &&
+			latest.Minor() == 0)
+}

--- a/cmd/frontend/backend/versions.go
+++ b/cmd/frontend/backend/versions.go
@@ -65,8 +65,8 @@ func UpdateServiceVersion(ctx context.Context, service, version string) error {
 		q = sqlf.Sprintf(
 			upsertVersionQuery,
 			service,
-			latest.String(),
-			previous.String(),
+			versionString(latest),
+			versionString(previous),
 			time.Now().UTC(),
 		)
 		_, err = tx.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
@@ -82,6 +82,13 @@ VALUES (%s, %s, %s) ON CONFLICT (service) DO
 UPDATE SET (version, updated_at) =
 	(excluded.version, excluded.updated_at)
 WHERE version = %s`
+
+func versionString(v *semver.Version) string {
+	if v == nil {
+		return ""
+	}
+	return v.String()
+}
 
 // IsValidUpgrade returns true if the given previous and
 // latest versions comply with our documented upgrade policy.

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+func TestIsValidUpgrade(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		previous string
+		latest   string
+		want     bool
+	}{{
+		name:     "no versions",
+		previous: "",
+		latest:   "",
+		want:     true,
+	}, {
+		name:     "no previous version",
+		previous: "",
+		latest:   "v3.13.0",
+		want:     true,
+	}, {
+		name:     "same version",
+		previous: "v3.13.0",
+		latest:   "v3.13.0",
+		want:     true,
+	}, {
+		name:     "one minor version up",
+		previous: "v3.12.4",
+		latest:   "v3.13.1",
+		want:     true,
+	}, {
+		name:     "one major version up",
+		previous: "v3.13.1",
+		latest:   "v4.0.0",
+		want:     true,
+	}, {
+		name:     "more than one minor version up",
+		previous: "v3.9.4",
+		latest:   "v3.11.0",
+		want:     false,
+	}, {
+		name:     "major jump",
+		previous: "v3.9.4",
+		latest:   "v4.1.0",
+		want:     false,
+	},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previous, _ := semver.NewVersion(tc.previous)
+			latest, _ := semver.NewVersion(tc.latest)
+
+			if got := IsValidUpgrade(previous, latest); got != tc.want {
+				t.Errorf(
+					"IsValidUpgrade(previous: %s, latest: %s) = %t, want %t",
+					tc.latest,
+					tc.latest,
+					got,
+					tc.want,
+				)
+			}
+		})
+	}
+}

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -119,7 +119,7 @@ func TestIsValidUpgrade(t *testing.T) {
 			if got := IsValidUpgrade(previous, latest); got != tc.want {
 				t.Errorf(
 					"IsValidUpgrade(previous: %s, latest: %s) = %t, want %t",
-					tc.latest,
+					tc.previous,
 					tc.latest,
 					got,
 					tc.want,

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -32,6 +32,7 @@ func TestUpdateServiceVersion(t *testing.T) {
 			Previous: semver.MustParse("1.0.0"),
 			Latest:   semver.MustParse("2.1.0"),
 		}},
+		{"0.3.0", nil}, // rollback
 	} {
 		have := UpdateServiceVersion(ctx, "service", tc.version)
 		want := tc.err
@@ -70,6 +71,16 @@ func TestIsValidUpgrade(t *testing.T) {
 		latest:   "v3.13.1",
 		want:     true,
 	}, {
+		name:     "one patch version up",
+		previous: "v3.12.4",
+		latest:   "v3.12.5",
+		want:     true,
+	}, {
+		name:     "two patch versions up",
+		previous: "v3.12.4",
+		latest:   "v3.12.6",
+		want:     true,
+	}, {
 		name:     "one major version up",
 		previous: "v3.13.1",
 		latest:   "v4.0.0",
@@ -84,6 +95,21 @@ func TestIsValidUpgrade(t *testing.T) {
 		previous: "v3.9.4",
 		latest:   "v4.1.0",
 		want:     false,
+	}, {
+		name:     "major rollback",
+		previous: "v4.1.0",
+		latest:   "v3.9.4",
+		want:     true,
+	}, {
+		name:     "minor rollback",
+		previous: "v4.1.0",
+		latest:   "v4.0.4",
+		want:     true,
+	}, {
+		name:     "patch rollback",
+		previous: "v4.1.4",
+		latest:   "v4.1.3",
+		want:     true,
 	},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -33,6 +33,13 @@ func TestUpdateServiceVersion(t *testing.T) {
 			Latest:   semver.MustParse("2.1.0"),
 		}},
 		{"0.3.0", nil}, // rollback
+		{"non-semantic-version-is-always-valid", nil},
+		{"1.0.0", nil}, // back to semantic version is allowed
+		{"2.1.0", &UpgradeError{
+			Service:  "service",
+			Previous: semver.MustParse("1.0.0"),
+			Latest:   semver.MustParse("2.1.0"),
+		}}, // upgrade policy violation returns
 	} {
 		have := UpdateServiceVersion(ctx, "service", tc.version)
 		want := tc.err
@@ -60,6 +67,11 @@ func TestIsValidUpgrade(t *testing.T) {
 		name:     "no previous version",
 		previous: "",
 		latest:   "v3.13.0",
+		want:     true,
+	}, {
+		name:     "no latest version",
+		previous: "v3.13.0",
+		latest:   "",
 		want:     true,
 	}, {
 		name:     "same version",

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -44,6 +44,7 @@ func TestUpdateServiceVersion(t *testing.T) {
 		t.Logf("version = %q", tc.version)
 	}
 }
+
 func TestIsValidUpgrade(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -971,3 +971,15 @@ Referenced by:
     TABLE "user_external_accounts" CONSTRAINT "user_external_accounts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
 
 ```
+
+# Table "public.versions"
+```
+   Column   |           Type           |       Modifiers        
+------------+--------------------------+------------------------
+ service    | text                     | not null
+ version    | text                     | not null
+ updated_at | timestamp with time zone | not null default now()
+Indexes:
+    "versions_pkey" PRIMARY KEY, btree (service)
+
+```

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -98,6 +98,10 @@ func generate(log *log.Logger) (string, error) {
 		return "", fmt.Errorf("ConnectToDB: %w", err)
 	}
 
+	if err := dbconn.MigrateDB(dbconn.Global, dataSource); err != nil {
+		return "", fmt.Errorf("MigrateDB: %w", err)
+	}
+
 	db, err := dbconn.Open(dataSource)
 	if err != nil {
 		return "", fmt.Errorf("Open: %w", err)

--- a/cmd/frontend/internal/app/ui/help_test.go
+++ b/cmd/frontend/internal/app/ui/help_test.go
@@ -19,7 +19,7 @@ func TestServeHelp(t *testing.T) {
 		}
 		{
 			orig := version.Version()
-			version.Mock("dev")
+			version.Mock("0.0.0+dev")
 			defer version.Mock(orig) // reset
 		}
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/tmpfriend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/httpapi"
@@ -28,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/confdb"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/processrestart"
@@ -79,15 +81,42 @@ func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
 	return &url.URL{Scheme: "http", Host: hostPort}
 }
 
+// InitDB initializes the global database connection and sets the
+// version of the frontend in our versions table.
+func InitDB() error {
+	if err := dbconn.ConnectToDB(""); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	migrate := true
+
+	for {
+		err := backend.UpdateServiceVersion(ctx, "frontend", version.Version())
+		if err != nil && !dbutil.IsPostgresError(err, "undefined_table") {
+			return err
+		}
+
+		if !migrate {
+			return nil
+		}
+
+		if err := dbconn.MigrateDB(dbconn.Global, ""); err != nil {
+			return err
+		}
+
+		migrate = false
+	}
+}
+
 // Main is the main entrypoint for the frontend server program.
 func Main(githubWebhook, bitbucketServerWebhook http.Handler) error {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
 	if dbconn.Global == nil {
-		// Connect to the database and start the configuration server.
-		if err := dbconn.ConnectToDB(""); err != nil {
-			log.Fatal(err)
+		if err := InitDB(); err != nil {
+			log.Fatalf("ERROR: %v", err)
 		}
 	}
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -92,6 +92,10 @@ func InitDB() error {
 	migrate := true
 
 	for {
+		// We need this loop so that we handle the missing versions table,
+		// which would be added by running the migrations. Once we detect that
+		// it's missing, we run the migrations and try to update the version again.
+
 		err := backend.UpdateServiceVersion(ctx, "frontend", version.Version())
 		if err != nil && !dbutil.IsPostgresError(err, "undefined_table") {
 			return err

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -25,3 +25,11 @@ func Main(githubWebhook, bitbucketServerWebhook http.Handler) {
 		os.Exit(1)
 	}
 }
+
+// InitDB initializes the global frontend database connection and sets the
+// version of the frontend in our versions table.
+//
+// It is exposed as function in a package so that it can be called by other
+// main package implementations such as Sourcegraph Enterprise, which import
+// proprietary/private code.
+func InitDB() error { return cli.InitDB() }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -39,8 +39,8 @@ func main() {
 	initLSIFEndpoints()
 
 	// Connect to the database.
-	if err := dbconn.ConnectToDB(""); err != nil {
-		log.Fatal(err)
+	if err := shared.InitDB(); err != nil {
+		log.Fatalf("FATAL: %v", err)
 	}
 	initAuthz(dbconn.Global)
 

--- a/internal/db/dbconn/dbconn.go
+++ b/internal/db/dbconn/dbconn.go
@@ -62,14 +62,17 @@ func ConnectToDB(dataSource string) error {
 	registerPrometheusCollector(Global, "_app")
 	configureConnectionPool(Global)
 
-	m, err := dbutil.NewMigrate(Global, dataSource)
+	return nil
+}
+
+func MigrateDB(db *sql.DB, dataSource string) error {
+	m, err := dbutil.NewMigrate(db, dataSource)
 	if err != nil {
 		return err
 	}
 	if err := dbutil.DoMigrate(m); err != nil {
 		return errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 	}
-
 	return nil
 }
 

--- a/internal/db/dbtesting/dbtesting.go
+++ b/internal/db/dbtesting/dbtesting.go
@@ -141,5 +141,9 @@ func initTest(nameSuffix string) error {
 		}
 	}
 
-	return dbconn.ConnectToDB("dbname=" + dbname)
+	if err := dbconn.ConnectToDB("dbname=" + dbname); err != nil {
+		return err
+	}
+
+	return dbconn.MigrateDB(dbconn.Global, "dbname="+dbname)
 }

--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	// Register driver
+	"github.com/lib/pq"
 	_ "github.com/lib/pq"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -170,6 +171,11 @@ func (stdoutLogger) Printf(format string, v ...interface{}) {
 }
 func (logger stdoutLogger) Verbose() bool {
 	return true
+}
+
+func IsPostgresError(err error, codename string) bool {
+	e, ok := errors.Cause(err).(*pq.Error)
+	return ok && e.Code.Name() == codename
 }
 
 // NullTime represents a time.Time that may be null. nullTime implements the

--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -13,7 +13,6 @@ import (
 
 	// Register driver
 	"github.com/lib/pq"
-	_ "github.com/lib/pq"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const devVersion = "dev" // version string for unreleased development builds
+const devVersion = "0.0.0+dev" // version string for unreleased development builds
 
 // version is configured at build time via ldflags like this:
 // -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=1.2.3"

--- a/migrations/1528395650_add_versions_table.down.sql
+++ b/migrations/1528395650_add_versions_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS versions;
+
+COMMIT;

--- a/migrations/1528395650_add_versions_table.up.sql
+++ b/migrations/1528395650_add_versions_table.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS versions (
+  service text PRIMARY KEY,
+  version text NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -66,6 +66,8 @@
 // 1528395648_add_external_branch_to_changesets.up.sql (444B)
 // 1528395649_add_campaign_branch.down.sql (126B)
 // 1528395649_add_campaign_branch.up.sql (820B)
+// 1528395650_add_versions_table.down.sql (48B)
+// 1528395650_add_versions_table.up.sql (159B)
 
 package migrations
 
@@ -1454,6 +1456,46 @@ func _1528395649_add_campaign_branchUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395650_add_versions_tableDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x4b\x2d\x2a\xce\xcc\xcf\x2b\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xae\xf3\xa9\xdf\x30\x00\x00\x00")
+
+func _1528395650_add_versions_tableDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395650_add_versions_tableDownSql,
+		"1528395650_add_versions_table.down.sql",
+	)
+}
+
+func _1528395650_add_versions_tableDownSql() (*asset, error) {
+	bytes, err := _1528395650_add_versions_tableDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395650_add_versions_table.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0xe3, 0xb5, 0x83, 0xfe, 0xb7, 0xc2, 0x6f, 0x54, 0x5f, 0x4b, 0xd1, 0x76, 0x8d, 0x32, 0xd0, 0xdd, 0x29, 0x23, 0x5b, 0x1a, 0xbc, 0xcd, 0xc1, 0x90, 0xe6, 0x28, 0x3c, 0x23, 0x57, 0x22, 0x33}}
+	return a, nil
+}
+
+var __1528395650_add_versions_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x3c\xce\xbd\xaa\x83\x40\x10\xc5\xf1\x7e\x9f\xe2\x94\x0a\xf7\x0d\xac\xd6\x9b\x31\x2c\x59\x35\xe8\x08\xb1\x0a\x12\xa7\xb0\xf0\x03\x77\x62\x42\x9e\x3e\x48\x48\xea\xff\x8f\xc3\x49\xe9\xe8\x8a\xc4\x98\xff\x8a\x2c\x13\xd8\xa6\x9e\xe0\x32\x14\x25\x83\x2e\xae\xe6\x1a\x9b\xac\x61\x98\xa7\x80\xc8\x00\x41\xd6\x6d\xb8\x09\x54\x9e\x8a\x73\xe5\x72\x5b\xb5\x38\x51\xfb\x67\xf0\x85\x9f\xb6\x0f\x14\x8d\xf7\x7b\xb8\x2f\x7d\xa7\xd2\x5f\x3b\x85\x0e\xa3\x04\xed\xc6\x45\x5f\x3f\x82\x03\x65\xb6\xf1\x8c\x69\x7e\x44\xb1\x89\xf7\x3b\x65\x9e\x3b\x4e\xcc\x3b\x00\x00\xff\xff\x19\x44\x08\xa5\x9f\x00\x00\x00")
+
+func _1528395650_add_versions_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395650_add_versions_tableUpSql,
+		"1528395650_add_versions_table.up.sql",
+	)
+}
+
+func _1528395650_add_versions_tableUpSql() (*asset, error) {
+	bytes, err := _1528395650_add_versions_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395650_add_versions_table.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x24, 0x25, 0x9a, 0x4d, 0x70, 0x32, 0xbc, 0x62, 0x2e, 0xf, 0x17, 0x2d, 0x23, 0x9c, 0xac, 0x8a, 0xc5, 0x68, 0xf2, 0x12, 0xc2, 0x7e, 0xeb, 0x17, 0x86, 0xaf, 0xfe, 0xb5, 0xc0, 0xfc, 0x37, 0x49}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1611,6 +1653,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395648_add_external_branch_to_changesets.up.sql":              _1528395648_add_external_branch_to_changesetsUpSql,
 	"1528395649_add_campaign_branch.down.sql":                          _1528395649_add_campaign_branchDownSql,
 	"1528395649_add_campaign_branch.up.sql":                            _1528395649_add_campaign_branchUpSql,
+	"1528395650_add_versions_table.down.sql":                           _1528395650_add_versions_tableDownSql,
+	"1528395650_add_versions_table.up.sql":                             _1528395650_add_versions_tableUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1720,6 +1764,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395648_add_external_branch_to_changesets.up.sql":              {_1528395648_add_external_branch_to_changesetsUpSql, map[string]*bintree{}},
 	"1528395649_add_campaign_branch.down.sql":                          {_1528395649_add_campaign_branchDownSql, map[string]*bintree{}},
 	"1528395649_add_campaign_branch.up.sql":                            {_1528395649_add_campaign_branchUpSql, map[string]*bintree{}},
+	"1528395650_add_versions_table.down.sql":                           {_1528395650_add_versions_tableDownSql, map[string]*bintree{}},
+	"1528395650_add_versions_table.up.sql":                             {_1528395650_add_versions_tableUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This commit changes the frontend to enforce our upgrade policy on
startup. A `versions` table is introduced, where the latest seen version
of a service in the Sourcegraph architecture is stored.

For the frontend, this is done on startup, before database migrations
are run. If an admin violates our upgrade policy, the frontend will
shutdown with a descriptive error, pointing to our documentation.

In a future PR, we'll ensure our upgrade policy is respected by
other services. This will be done by sending the service's version
along to the frontend on calls to `api.InternalClient.WaitForFrontend`
during a service's startup procedure, and having the frontend respond
with an error if the upgrade is invalid, which the service should handle
by logging and shutting itself down.

Fixes #7702
Follow-up in #8382