### PR TITLE
auth: only enforce password length for built-in auth

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -5,7 +5,7 @@ env:
   FORCE_COLOR: "3"
   GO111MODULE: "on"
   IMAGE: us.gcr.io/sourcegraph-dev/server:$TAG
-  TEST_USER_PASSWORD: "test"
+  TEST_USER_PASSWORD: "SuperSecurePassword"
 
 steps:
 - command:

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -103,9 +103,9 @@ type NewUser struct {
 	// (2) any other user account already exists.
 	FailIfNotInitialUser bool `json:"-"` // forbid this field being set by JSON, just in case
 
-	// EnforePasswordLength is whether should enforce minimum and maximum password length requirement.
+	// EnforcePasswordLength is whether should enforce minimum and maximum password length requirement.
 	// Users created by non-builtin auth providers do not have a password thus no need to check.
-	EnforePasswordLength bool `json:"-"` // forbid this field being set by JSON, just in case
+	EnforcePasswordLength bool `json:"-"` // forbid this field being set by JSON, just in case
 }
 
 // Create creates a new user in the database.
@@ -170,7 +170,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		return Mocks.Users.Create(ctx, info)
 	}
 
-	if info.EnforePasswordLength {
+	if info.EnforcePasswordLength {
 		if err := checkPasswordLength(info.Password); err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -102,6 +102,10 @@ type NewUser struct {
 	// user if at least one of the following is true: (1) the site has already been initialized or
 	// (2) any other user account already exists.
 	FailIfNotInitialUser bool `json:"-"` // forbid this field being set by JSON, just in case
+
+	// EnforePasswordLength is whether should enforce minimum and maximum password length requirement.
+	// Users created by non-builtin auth providers do not have a password thus no need to check.
+	EnforePasswordLength bool `json:"-"` // forbid this field being set by JSON, just in case
 }
 
 // Create creates a new user in the database.
@@ -151,7 +155,7 @@ const maxPasswordRunes = 256
 // checkPasswordLength returns an error if the password is too long.
 func checkPasswordLength(pw string) error {
 	pwLen := utf8.RuneCountInString(pw)
-	minPasswordRunes := conf.Get().AuthMinPasswordLength
+	minPasswordRunes := conf.AuthMinPasswordLength()
 	if pwLen < minPasswordRunes ||
 		pwLen > maxPasswordRunes {
 		return errcode.NewPresentationError(fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes))
@@ -166,8 +170,10 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		return Mocks.Users.Create(ctx, info)
 	}
 
-	if err := checkPasswordLength(info.Password); err != nil {
-		return nil, err
+	if info.EnforePasswordLength {
+		if err := checkPasswordLength(info.Password); err != nil {
+			return nil, err
+		}
 	}
 
 	if info.Email != "" && info.EmailVerificationCode == "" && !info.EmailIsVerified {

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -108,31 +108,46 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 		expErr   string
 	}{
 		{
-			name:     "exceeds maximum",
+			name:     "below minimum",
 			username: "user1",
-			password: strings.Repeat("x", maxPasswordRunes+1),
+			password: strings.Repeat("x", minPasswordRunes-1),
 			enforce:  true,
 			expErr:   expErr,
 		},
 		{
-			name:     "below minimum",
+			name:     "exceeds maximum",
 			username: "user2",
-			password: strings.Repeat("x", minPasswordRunes-1),
+			password: strings.Repeat("x", maxPasswordRunes+1),
 			enforce:  true,
 			expErr:   expErr,
 		},
 
 		{
-			name:     "no problem",
+			name:     "no problem at exact minimum",
 			username: "user3",
 			password: strings.Repeat("x", minPasswordRunes),
 			enforce:  true,
 			expErr:   "",
 		},
 		{
-			name:     "does not enforce",
+			name:     "no problem at exact maximum",
 			username: "user4",
-			password: strings.Repeat("x", minPasswordRunes),
+			password: strings.Repeat("x", maxPasswordRunes),
+			enforce:  true,
+			expErr:   "",
+		},
+
+		{
+			name:     "does not enforce and below minimum",
+			username: "user5",
+			password: strings.Repeat("x", minPasswordRunes-1),
+			enforce:  false,
+			expErr:   "",
+		},
+		{
+			name:     "does not enforce and exceeds maximum",
+			username: "user6",
+			password: strings.Repeat("x", maxPasswordRunes+1),
 			enforce:  false,
 			expErr:   "",
 		},

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -102,32 +102,47 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	expErr := fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes)
 	tests := []struct {
 		name     string
+		username string
 		password string
+		enforce  bool
 		expErr   string
 	}{
 		{
 			name:     "exceeds maximum",
+			username: "user1",
 			password: strings.Repeat("x", maxPasswordRunes+1),
+			enforce:  true,
 			expErr:   expErr,
 		},
 		{
 			name:     "below minimum",
+			username: "user2",
 			password: strings.Repeat("x", minPasswordRunes-1),
+			enforce:  true,
 			expErr:   expErr,
 		},
 
 		{
 			name:     "no problem",
+			username: "user3",
 			password: strings.Repeat("x", minPasswordRunes),
+			enforce:  true,
+			expErr:   "",
+		},
+		{
+			name:     "does not enforce",
+			username: "user4",
+			password: strings.Repeat("x", minPasswordRunes),
+			enforce:  false,
 			expErr:   "",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Users.Create(ctx, NewUser{
-				Username:             "test",
+				Username:             test.username,
 				Password:             test.password,
-				EnforePasswordLength: true,
+				EnforePasswordLength: test.enforce,
 			})
 			if pm := errcode.PresentationMessage(err); pm != test.expErr {
 				t.Fatalf("err: want %q but got %q", test.expErr, pm)

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -140,9 +140,9 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Users.Create(ctx, NewUser{
-				Username:             test.username,
-				Password:             test.password,
-				EnforePasswordLength: test.enforce,
+				Username:              test.username,
+				Password:              test.password,
+				EnforcePasswordLength: test.enforce,
 			})
 			if pm := errcode.PresentationMessage(err); pm != test.expErr {
 				t.Fatalf("err: want %q but got %q", test.expErr, pm)

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -98,15 +98,7 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	minPasswordRunes := 12
-	cfg := conf.Get()
-	cfg.AuthMinPasswordLength = minPasswordRunes
-	conf.Mock(cfg)
-	defer func() {
-		cfg.AuthMinPasswordLength = 0
-		conf.Mock(cfg)
-	}()
-
+	minPasswordRunes := conf.AuthMinPasswordLength()
 	expErr := fmt.Sprintf("Passwords may not be less than %d or be more than %d characters.", minPasswordRunes, maxPasswordRunes)
 	tests := []struct {
 		name     string
@@ -132,7 +124,11 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := Users.Create(ctx, NewUser{Username: "test", Password: test.password})
+			_, err := Users.Create(ctx, NewUser{
+				Username:             "test",
+				Password:             test.password,
+				EnforePasswordLength: true,
+			})
 			if pm := errcode.PresentationMessage(err); pm != test.expErr {
 				t.Fatalf("err: want %q but got %q", test.expErr, pm)
 			}

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -28,10 +28,11 @@ func (*schemaResolver) CreateUser(ctx context.Context, args *struct {
 
 	// The new user will be created with a verified email address.
 	user, err := db.Users.Create(ctx, db.NewUser{
-		Username:        args.Username,
-		Email:           email,
-		EmailIsVerified: true,
-		Password:        backend.MakeRandomHardToGuessPassword(),
+		Username:             args.Username,
+		Email:                email,
+		EmailIsVerified:      true,
+		Password:             backend.MakeRandomHardToGuessPassword(),
+		EnforePasswordLength: true,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -28,11 +28,10 @@ func (*schemaResolver) CreateUser(ctx context.Context, args *struct {
 
 	// The new user will be created with a verified email address.
 	user, err := db.Users.Create(ctx, db.NewUser{
-		Username:             args.Username,
-		Email:                email,
-		EmailIsVerified:      true,
-		Password:             backend.MakeRandomHardToGuessPassword(),
-		EnforePasswordLength: true,
+		Username:        args.Username,
+		Email:           email,
+		EmailIsVerified: true,
+		Password:        backend.MakeRandomHardToGuessPassword(),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -81,6 +81,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 		Username:             creds.Username,
 		Password:             creds.Password,
 		FailIfNotInitialUser: failIfNewUserIsNotInitialSiteAdmin,
+		EnforePasswordLength: true,
 	}
 	if failIfNewUserIsNotInitialSiteAdmin {
 		// The email of the initial site admin is considered to be verified.

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -77,11 +77,11 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 	// of doServeSignUp checks it, or else that failIfNewUserIsNotInitialSiteAdmin == true (in which
 	// case the only signup allowed is that of the initial site admin).
 	newUserData := db.NewUser{
-		Email:                creds.Email,
-		Username:             creds.Username,
-		Password:             creds.Password,
-		FailIfNotInitialUser: failIfNewUserIsNotInitialSiteAdmin,
-		EnforePasswordLength: true,
+		Email:                 creds.Email,
+		Username:              creds.Username,
+		Password:              creds.Password,
+		FailIfNotInitialUser:  failIfNewUserIsNotInitialSiteAdmin,
+		EnforcePasswordLength: true,
 	}
 	if failIfNewUserIsNotInitialSiteAdmin {
 		// The email of the initial site admin is considered to be verified.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -301,3 +301,13 @@ func ExperimentalFeatures() schema.ExperimentalFeatures {
 	}
 	return *val
 }
+
+// AuthMinPasswordLength returns the value of minimum password length requirement.
+// If not set, it returns the default value 12.
+func AuthMinPasswordLength() int {
+	val := Get().AuthMinPasswordLength
+	if val <= 0 {
+		return 12
+	}
+	return val
+}


### PR DESCRIPTION
This PR changes the password length check to be only applied for built-in auth users. 

Addresses https://github.com/sourcegraph/sourcegraph/pull/8148#discussion_r373596183.