### PR TITLE
add docker-compose documentation for deploying on aws/gcp/digital ocean

### DIFF
--- a/doc/admin/external_database.md
+++ b/doc/admin/external_database.md
@@ -82,11 +82,12 @@ Most standard PostgreSQL environment variables may be specified (`PGPORT`, etc).
 
 ## Using your own Redis server
 
-Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can add the `REDIS_ENDPOINT` environment variable to your Sourcegraph deployment files and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT` or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`).
+**Version requirements**: We support any version *starting from 5.0*.
 
-### sourcegraph/server
+Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can do the following:
 
-Add the following to your `docker run` command:
+Add the `REDIS_ENDPOINT` environment variable to your `docker run` command and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT`
+or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`). For example:
 
 <!--
   DO NOT CHANGE THIS TO A CODEBLOCK.
@@ -94,57 +95,6 @@ Add the following to your `docker run` command:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 <pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.12.5</code></pre>
-
-### Docker Compose
-
-1. Add/modify the following environment variables to all of the `sourcegraph-frontend-*` services and the `sourcegraph-frontend-internal` service in ` [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml): 
-
-    ```yaml
-    sourcegraph-frontend-0:
-      # ...
-      environment:
-        # ...
-        - 'PGHOST=psql.mycompany.org'
-        - 'PGUSER=sourcegraph'
-        - 'PGPASSWORD=secret'
-        - 'PGDATABASE=sourcegraph'
-        - 'PGSSLMODE=require'
-      # ...
-    ```
-
-    - See ["Environment variables in Compose"](https://docs.docker.com/compose/environment-variables/) for other ways to pass these environment variables to the relevant services (including from the command line, a `.env` file, etc.).
-
-1. Comment out / remove the internal `pgsql` service in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml) since Sourcegraph is using the external one now.
-
-    ```yaml
-    # # Description: PostgreSQL database for various data.
-    # #
-    # # Disk: 128GB / persistent SSD
-    # # Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
-    # # Ports exposed to the public internet: none
-    # #
-    # pgsql:
-    # container_name: pgsql
-    # image: 'index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297'
-    # cpus: 4
-    # mem_limit: '2g'
-    # healthcheck:
-    #    test: '/liveness.sh'
-    #    interval: 10s
-    #    timeout: 1s
-    #    retries: 3
-    #    start_period: 15s
-    # volumes:
-    #    - 'pgsql:/data/'
-    # networks:
-    #     - sourcegraph
-    # restart: always
-    ```
-### Version requirements
-
-We support any version **starting from 5.0**.
-
-### Caveats 
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
 

--- a/doc/admin/external_database.md
+++ b/doc/admin/external_database.md
@@ -9,11 +9,11 @@ Sourcegraph by default provides its own PostgreSQL and Redis databases for data 
 
 You can use your own PostgreSQL v9.6+ server with Sourcegraph if you wish. For example, you may prefer this if you already have existing backup infrastructure around your own PostgreSQL server, wish to use Amazon RDS, etc.
 
-Simply add the standard PostgreSQL environment variables to your `docker run` command and Sourcegraph will use that PostgreSQL server instead of its built-in one. For example:
+Simply add the standard PostgreSQL environment variables to your Sourcegraph deployment files and Sourcegraph will use that PostgreSQL server instead of its built-in one.
 
-### Version requirements
+### sourcegraph/server
 
-Please refer to our [Postgres](https://docs.sourcegraph.com/admin/postgres) documentation to learn about version requirements.
+Add the following to your `docker run` command:
 
 <!--
   DO NOT CHANGE THIS TO A CODEBLOCK.
@@ -21,6 +21,58 @@ Please refer to our [Postgres](https://docs.sourcegraph.com/admin/postgres) docu
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 <pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.12.5</code></pre>
+
+### Docker Compose
+
+1. Add/modify the following environment variables to all of the `sourcegraph-frontend-*` services and the `sourcegraph-frontend-internal` service in ` [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml): 
+
+    ```yaml
+    sourcegraph-frontend-0:
+      # ...
+      environment:
+        # ...
+        - 'PGHOST=psql.mycompany.org'
+        - 'PGUSER=sourcegraph'
+        - 'PGPASSWORD=secret'
+        - 'PGDATABASE=sourcegraph'
+        - 'PGSSLMODE=require'
+      # ...
+    ```
+
+    - See ["Environment variables in Compose"](https://docs.docker.com/compose/environment-variables/) for other ways to pass these environment variables to the relevant services (including from the command line, a `.env` file, etc.).
+
+1. Comment out / remove the internal `pgsql` service in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml) since Sourcegraph is using the external one now.
+
+    ```yaml
+    # # Description: PostgreSQL database for various data.
+    # #
+    # # Disk: 128GB / persistent SSD
+    # # Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
+    # # Ports exposed to the public internet: none
+    # #
+    # pgsql:
+    # container_name: pgsql
+    # image: 'index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297'
+    # cpus: 4
+    # mem_limit: '2g'
+    # healthcheck:
+    #    test: '/liveness.sh'
+    #    interval: 10s
+    #    timeout: 1s
+    #    retries: 3
+    #    start_period: 15s
+    # volumes:
+    #    - 'pgsql:/data/'
+    # networks:
+    #     - sourcegraph
+    # restart: always
+    ```
+
+### Version requirements
+
+Please refer to our [Postgres](https://docs.sourcegraph.com/admin/postgres) documentation to learn about version requirements.
+
+### Caveats
 
 > NOTE: If your PostgreSQL server does not support SSL, set `PGSSLMODE=disable` instead of `PGSSLMODE=require`. Note that this is potentially insecure.
 
@@ -30,14 +82,11 @@ Most standard PostgreSQL environment variables may be specified (`PGPORT`, etc).
 
 ## Using your own Redis server
 
-Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can do the following:
+Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can add the `REDIS_ENDPOINT` environment variable to your Sourcegraph deployment files and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT` or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`).
 
-### Version requirements
+### sourcegraph/server
 
-We support any version **starting from 5.0**.
-
-Add the `REDIS_ENDPOINT` environment variable to your `docker run` command and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT`
-or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`). For example:
+Add the following to your `docker run` command:
 
 <!--
   DO NOT CHANGE THIS TO A CODEBLOCK.
@@ -45,6 +94,57 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 <pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.12.5</code></pre>
+
+### Docker Compose
+
+1. Add/modify the following environment variables to all of the `sourcegraph-frontend-*` services and the `sourcegraph-frontend-internal` service in ` [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml): 
+
+    ```yaml
+    sourcegraph-frontend-0:
+      # ...
+      environment:
+        # ...
+        - 'PGHOST=psql.mycompany.org'
+        - 'PGUSER=sourcegraph'
+        - 'PGPASSWORD=secret'
+        - 'PGDATABASE=sourcegraph'
+        - 'PGSSLMODE=require'
+      # ...
+    ```
+
+    - See ["Environment variables in Compose"](https://docs.docker.com/compose/environment-variables/) for other ways to pass these environment variables to the relevant services (including from the command line, a `.env` file, etc.).
+
+1. Comment out / remove the internal `pgsql` service in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.12.5/docker-compose/docker-compose.yaml) since Sourcegraph is using the external one now.
+
+    ```yaml
+    # # Description: PostgreSQL database for various data.
+    # #
+    # # Disk: 128GB / persistent SSD
+    # # Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
+    # # Ports exposed to the public internet: none
+    # #
+    # pgsql:
+    # container_name: pgsql
+    # image: 'index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297'
+    # cpus: 4
+    # mem_limit: '2g'
+    # healthcheck:
+    #    test: '/liveness.sh'
+    #    interval: 10s
+    #    timeout: 1s
+    #    retries: 3
+    #    start_period: 15s
+    # volumes:
+    #    - 'pgsql:/data/'
+    # networks:
+    #     - sourcegraph
+    # restart: always
+    ```
+### Version requirements
+
+We support any version **starting from 5.0**.
+
+### Caveats 
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
 

--- a/doc/admin/install/cluster.md
+++ b/doc/admin/install/cluster.md
@@ -1,10 +1,10 @@
 # Installing Sourcegraph on a cluster
 
-| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+| Deployment Type                                       | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker Compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 For cluster deployments, we recommend installing Sourcegraph on Kubernetes. See the [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph) for more information.
 

--- a/doc/admin/install/cluster.md
+++ b/doc/admin/install/cluster.md
@@ -1,5 +1,11 @@
 # Installing Sourcegraph on a cluster
 
+| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+
 For cluster deployments, we recommend installing Sourcegraph on Kubernetes. See the [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph) for more information.
 
 If you cannot use Kubernetes or prefer using your own container infrastructure, check out our [pure-Docker deployment reference](https://github.com/sourcegraph/deploy-sourcegraph-docker).

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -2,10 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) to a single EC2 instance on AWS.
 
-When running Sourcegraph in production, deploying Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) is the default installation method that we recommend. However:
-
-* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
-* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -28,7 +28,7 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
     # Format (if necessary) and mount EBS volume
     device_fs=$(lsblk "${EBS_VOLUME_DEVICE_NAME}" --noheadings --output fsType)
-    if [ "${device_fs}" == ""] ## only format the volume if it isn't already formatted
+    if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
     then
       mkfs -t xfs "${EBS_VOLUME_DEVICE_NAME}"
     fi

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -26,6 +26,15 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
     SOURCEGRAPH_VERSION='v3.12.5'
     DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
 
+    # Install git
+    yum update -y
+    yum install git -y
+
+    # Clone Docker Compose definition
+    git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+    cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+    git checkout "${SOURCEGRAPH_VERSION}"
+
     # Format (if necessary) and mount EBS volume
     device_fs=$(lsblk "${EBS_VOLUME_DEVICE_NAME}" --noheadings --output fsType)
     if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
@@ -76,15 +85,8 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
     chmod +x /usr/local/bin/docker-compose
     curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
 
-    # Install git
-    yum install git -y
-
-    # Clone Docker Compose definition
-    git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-    cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
-    git checkout "${SOURCEGRAPH_VERSION}"
-
     # Run Sourcegraph. Restart the containers upon reboot.
+    cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
     docker-compose up -d
     ```
 

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -1,0 +1,83 @@
+# Install Sourcegraph with Docker on AWS
+
+This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AWS.
+
+* If you're just starting out, we recommend [running Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features.
+* If you need scalability and high-availability beyond what a docker-compose deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+---
+
+## Deploy to EC2
+
+- Click **Launch Instance** from your [EC2 dashboard](https://console.aws.amazon.com/ec2/v2/home).
+- Select the Amazon Linux 2 AMI (HVM), SSD Volume Type.
+- Select an appropriate instance size (we recommend `t2.2xlarge` or larger, depending on team size and number of repositories/languages enabled), then **Next: Configure Instance Details**
+- Ensure the **Auto-assign Public IP** option is "Enable". This ensures your instance is accessible to the Internet.
+- Add the following user data (as text) in the **Advanced Details** section:
+
+   ```yaml
+   #cloud-config
+   repo_update: true
+   repo_upgrade: all
+
+   runcmd:
+   # Create the directory structure for Sourcegraph data
+   - mkdir -p /home/ec2-user/.sourcegraph/config
+   - mkdir -p /home/ec2-user/.sourcegraph/data
+
+   # Install, configure, and enable Docker
+   - yum update -y
+   - amazon-linux-extras install docker
+   - systemctl enable --now --no-block docker
+   - sed -i -e 's/1024/10240/g' /etc/sysconfig/docker
+   - sed -i -e 's/4096/40960/g' /etc/sysconfig/docker
+   - usermod -a -G docker ec2-user
+
+   # Install docker-compose
+   - curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   - chmod +x /usr/local/bin/docker-compose
+   - curl -L https://raw.githubusercontent.com/docker/compose/1.25.3/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+   
+   # Install git, clone docker-compose definition
+   - yum install git -y
+   - git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git /home/ec2-user/deploy-sourcegraph-docker
+   - cd /home/ec2-user/deploy-sourcegraph-docker/docker-compose
+   - git checkout "v3.12.3"
+
+   # Run Sourcegraph. Restart the containers upon reboots.
+   - docker-compose up -d
+   ```
+
+- Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:
+  - Default **HTTP** rule: port range `80`, source `0.0.0.0/0, ::/0`
+  - Default **HTTPS** rule: port range `443`, source `0.0.0.0/0, ::/0`<br>(NOTE: additional work will be required later on to [configure NGINX to support SSL](../../../admin/nginx.md#nginx-ssl-https-configuration))
+- Launch your instance, then navigate to its public IP in your browser. (This can be found by navigating to the instance page on EC2 and looking in the "Description" panel for the "IPv4 Public IP" value.) You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the EC2 instance and viewing the logs:
+
+     ```
+     docker-compose logs sourcegraph-frontend-0
+     ```
+- If you have configured a domain name to point to the IP, configure `externalURL` to reflect that.
+
+
+  <!-- - mention you might have to wait a bit for the Docker container to fully spin up (include instructions for checking logs for health) -->
+
+---
+
+## Update your Sourcegraph version
+
+To update to the most recent version of Sourcegraph (X.Y.Z), SSH into your instance and run the following:
+
+```bash
+cd /home/ec2-user/deploy-sourcerph-docker/docker-compose
+git pull
+git checkout vX.Y.Z
+docker-compose up -d
+```
+
+---
+
+## Using an external database for persistence
+
+The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) and [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/).
+
+> NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -49,7 +49,7 @@ When running Sourcegraph in production, deploying Sourcegraph via [Docker Compos
 1. Select **Next: Add Storage**
 1. Select the following settings for the Root volume:
 
-    * **Size (GiB)**: `200` GB minimum *(As a rule of thumb, Sourcegraph needs at least as much space as all your repositories combined take up. Allocating as much disk space as you can upfront helps you avoid [resizing your boot disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd) later on.)*
+    * **Size (GiB)**: `200` GB minimum *(As a rule of thumb, Sourcegraph needs at least as much space as all your repositories combined take up. Allocating as much disk space as you can upfront helps you avoid [resizing your root volume](https://aws.amazon.com/premiumsupport/knowledge-center/expand-root-ebs-linux/) later on.)*
     * **Volume Type**: General Purpose SSD (gp2)
 
 1. Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:
@@ -90,7 +90,7 @@ docker-compose up -d
 
 The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount). There are a few different back ways to backup this data:
 
-* (**default, recommended**) The most straightfoward method backup to backup this data is to [snapshot the entire disk that the EC2 instance is using](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-snapshot.html) on an [automatic, scheduled basis](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
+* (**default, recommended**) The most straightfoward method to backup this data is to [snapshot the entire disk that the EC2 instance is using](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-snapshot.html) on an [automatic, scheduled basis](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 
 * Using an external Postgres instance (see below) lets a service such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) take care of backing up all of Sourcegraph's user data for you. If the EC2 instance running Sourcegraph ever dies or is destroyed, creating a fresh instance that's connected to that external Postgres will leave Sourcegraph in the same state that it was before.
 
@@ -98,6 +98,6 @@ The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deplo
 
 ## Using an external database for persistence
 
-The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) and [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/).
+The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external databases](../../external_database.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) and [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/).
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -134,7 +134,7 @@ docker-compose up -d
 
 ## Storage and Backups
 
-The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. The script above [configures Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) to store all Docker data on the additional EBS volume that was attached to the instance (mounted at `/mnt/docker-data` - the volumes themselves are stored under `/mnt/docker-data/volumes`) There are a few different back ways to backup this data:
+The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. The script above [configures Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) to store all Docker data on the additional EBS volume that was attached to the instance (mounted at `/mnt/docker-data` - the volumes themselves are stored under `/mnt/docker-data/volumes`) There are a few different ways to backup this data:
 
 * (**recommended**) The most straightfoward method to backup this data is to [snapshot the entire `/mnt/docker-data` EBS disk](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-snapshot.html) on an [automatic, scheduled basis](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -122,7 +122,7 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 To update to the most recent version of Sourcegraph (X.Y.Z), SSH into your instance and run the following:
 
 ```bash
-cd /home/ec2-user/deploy-sourcerph-docker/docker-compose
+cd /home/ec2-user/deploy-sourcegraph-docker/docker-compose
 git pull
 git checkout vX.Y.Z
 docker-compose up -d

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -49,7 +49,7 @@ When running Sourcegraph in production, deploying Sourcegraph via [Docker Compos
 - Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:
   - Default **HTTP** rule: port range `80`, source `0.0.0.0/0, ::/0`
   - Default **HTTPS** rule: port range `443`, source `0.0.0.0/0, ::/0`<br>(NOTE: additional work will be required later on to [configure NGINX to support SSL](../../../admin/nginx.md#nginx-ssl-https-configuration))
-- Launch your instance, then navigate to its public IP in your browser. (This can be found by navigating to the instance page on EC2 and looking in the "Description" panel for the "IPv4 Public IP" value.) 1. You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the instance and viewing the logs:
+- Launch your instance, then navigate to its public IP in your browser. (This can be found by navigating to the instance page on EC2 and looking in the "Description" panel for the "IPv4 Public IP" value.) You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the instance and viewing the logs:
 
   - Following the status of the user data script that you provided earlier:
     

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -43,7 +43,6 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
     device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
     if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
     then
-        echo "--- ${PERSISTENT_DISK_DEVICE_NAME} is already formatted, skipping..."
         sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
     fi
     sudo mkdir -p "${DOCKER_DATA_ROOT}"

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -2,10 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) to a single Droplet running on DigitalOcean.
 
-When running Sourcegraph in production, deploying Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) is the default installation method that we recommend. However:
-
-* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
-* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -1,0 +1,91 @@
+# Install Sourcegraph with Docker Compose on DigitalOcean
+
+This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) to a single Droplet running on DigitalOcean.
+
+When running Sourcegraph in production, deploying Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) is the default installation method that we recommend. However:
+
+* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
+* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+---
+
+## Run Sourcegraph on a Digital Ocean Droplet
+
+1. [Create a new Digital Ocean Droplet](https://cloud.digitalocean.com/droplets/new). Set the
+   operating system to be Ubuntu 18.04. For droplet size, we recommend at least 8 CPU and 32 GB RAM ,
+   but you may need more depending on team size and number of repositories. We recommend you set up
+   SSH access (Authentication > SSH keys) for convenient access to the droplet.
+1. In the "Select additional options" section of the Droplet creation page, select the "User Data" and "Monitoring" boxes,
+   and paste the following script in the "`Enter user data here...`" text box:
+
+   ```bash
+   #!/usr/bin/env bash
+
+   set -euxo pipefail
+
+   DOCKER_COMPOSE_VERSION='1.25.3'
+   SOURCEGRAPH_VERSION='v3.12.5'
+   DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+  
+   # Install Docker
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+   sudo apt-get update
+   apt-cache policy docker-ce
+   apt-get install -y docker-ce docker-ce-cli containerd.io
+  
+   # Install Docker Compose
+   curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   chmod +x /usr/local/bin/docker-compose
+   curl -L https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+
+   # Install git
+   sudo apt-get update
+   sudo apt-get install -y git
+
+   # Clone Docker Compose definition
+   git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}
+   cd ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}/docker-compose
+   git checkout ${SOURCEGRAPH_VERSION}
+
+   # Run Sourcegraph. Restart the containers upon reboot.
+   docker-compose up -d
+   ```
+
+1. You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the Droplet and viewing the logs:
+
+  - Following the status of the user data script that you provided earlier:
+    
+    ```bash
+    tail -f /var/log/cloud-init-output.log
+    ```
+
+  - (Once the user data script completes) monitoring the health of the `sourcegraph-frontend` container:
+
+     ```bash
+     docker ps --filter="name=sourcegraph-frontend-0"
+     ```
+
+1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
+   DNS entry for the IP, configure `externalURL` to reflect that.
+
+### After initialization
+
+After initial setup, we recommend you do the following:
+
+* Restrict the accessibility of ports other than `80` and `443` via [Cloud
+  Firewalls](https://www.digitalocean.com/docs/networking/firewalls/quickstart/).
+* Set up [TLS/SSL](../../nginx.md#nginx-ssl-https-configuration) in the NGINX configuration.
+
+---
+
+## Update your Sourcegraph version
+
+To update to the most recent version of Sourcegraph (X.Y.Z), SSH into your instance and run the following:
+
+```bash
+cd /root/deploy-sourcerph-docker/docker-compose
+git pull
+git checkout vX.Y.Z
+docker-compose up -d
+```

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -1,4 +1,4 @@
-# Install Sourcegraph with Docker Compose on DigitalOcean
+# Install Sourcegraph with Docker Compose on Digital Ocean
 
 This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) to a single Droplet running on DigitalOcean.
 

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -139,7 +139,7 @@ docker-compose up -d
 
 ## Storage and Backups
 
-The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount). There are a few different back ways to backup this data:
+The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. The script above [configures Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) to store all Docker data on the additional block storage volume that was attached to the droplet (mounted at `/mnt/docker-data` - the volumes themselves are stored under `/mnt/docker-data/volumes`) There are a few different ways to backup this data:
 
 * (**recommended**) The most straightfoward method to backup this data is to [snapshot the entire `/mnt/docker-data` block storage volume on an automatic scheduled basis](https://www.digitalocean.com/docs/images/snapshots/).
 

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -2,8 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/)to a single node running on Google Cloud.
 
-* If you're just starting out, we recommend [running Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features.
-* If you need scalability and high-availability beyond what a docker-compose deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -89,7 +89,7 @@ docker-compose up -d
 
 The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount). There are a few different back ways to backup this data:
 
-* (**default, recommended**) The most straightfoward method backup to backup this data is to [snapshot the entire disk that the GCP instance is using](https://cloud.google.com/compute/docs/disks/create-snapshots) on an [automatic, scheduled basis](https://cloud.google.com/compute/docs/disks/scheduled-snapshots).
+* (**default, recommended**) The most straightfoward method to backup this data is to [snapshot the entire disk that the GCP instance is using](https://cloud.google.com/compute/docs/disks/create-snapshots) on an [automatic, scheduled basis](https://cloud.google.com/compute/docs/disks/scheduled-snapshots).
 
 * Using an external Postgres instance (see below) lets a service such as [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) take care of backing up all of Sourcegraph's user data for you. If the VM instance running Sourcegraph ever dies or is destroyed, creating a fresh instance that's connected to that external Postgres will leave Sourcegraph in the same state that it was before.
 

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -137,7 +137,7 @@ docker-compose up -d
 
 ## Storage and Backups
 
-The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. The script above [configures Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) to store all Docker data on the additional persistent disk that was attached to the instance (mounted at `/mnt/docker-data` - the volumes themselves are stored under `/mnt/docker-data/volumes`) There are a few different back ways to backup this data:
+The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. The script above [configures Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) to store all Docker data on the additional persistent disk that was attached to the instance (mounted at `/mnt/docker-data` - the volumes themselves are stored under `/mnt/docker-data/volumes`) There are a few different ways to backup this data:
 
 * (**recommended**) The most straightfoward method to backup this data is to [snapshot the entire `/mnt/docker-data` persistsent disk](https://cloud.google.com/compute/docs/disks/create-snapshots) on an [automatic, scheduled basis](https://cloud.google.com/compute/docs/disks/scheduled-snapshots). The directions above tell you how to set up this schedule when the instance is first created, but you can also [create the schedule afterwards](https://cloud.google.com/compute/docs/disks/scheduled-snapshots).
 

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -17,35 +17,55 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Go
 
   ```bash
   #!/usr/bin/env bash
-  
-  # Install docker
+
+  set -euxo pipefail
+
+  DOCKER_COMPOSE_VERSION='1.25.3'
+  SOURCEGRAPH_VERSION='v3.12.5'
+  DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+
+  # Install Docker
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   sudo apt-get update
   apt-cache policy docker-ce
   apt-get install -y docker-ce docker-ce-cli containerd.io
 
-  # Install docker-compose
-  curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  # Install Docker Compose
+  curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
-  curl -L https://raw.githubusercontent.com/docker/compose/1.25.3/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+  curl -L https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
 
   # Install git
   sudo apt-get update
   sudo apt-get install -y git
 
-  # Clone docker-compose definition
-  git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git /root/deploy-sourcegraph-docker
-  cd /root/deploy-sourcegraph-docker/docker-compose
-  git checkout "v3.12.3"
+  # Clone Docker Compose definition
+  git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}
+  cd ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}/docker-compose
+  git checkout ${SOURCEGRAPH_VERSION}
 
-  # Run Sourcegraph. Restart the containers upon reboots.
+  # Run Sourcegraph. Restart the containers upon reboot.
   docker-compose up -d
   ```
 
 - Create your VM, then navigate to its public IP address.
 
 - If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
+
+- You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the instance and viewing the logs:
+
+  - Following the status of the startup script that you provided earlier:
+    
+    ```bash
+    tail -f /var/log/cloud-init-output.log
+    ```
+
+  - (Once the user data script completes) monitoring the health of the `sourcegraph-frontend` container:
+
+     ```bash
+     docker ps --filter="name=sourcegraph-frontend-0"
+     ```
 
 ---
 

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -1,0 +1,69 @@
+# Install Sourcegraph with Docker on Google Cloud
+
+This tutorial shows you how to deploy Sourcegraph to a single node running on Google Cloud.
+
+* If you're just starting out, we recommend [running Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features.
+* If you need scalability and high-availability beyond what a docker-compose deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+---
+
+## Deploy to Google Cloud VM
+
+- [Open your Google Cloud console](https://console.cloud.google.com/compute/instances) to create a new VM instance and click **Create Instance**
+- Choose an appropriate machine type (we recommend at least the `n1-standard-8` with 8 vCPUs and 30 GB RAM, more depending on team size and number of repositories/languages enabled)
+- Choose Ubuntu 18.04 LTS as your boot disk
+- Check the boxes for **Allow HTTP traffic** and **Allow HTTPS traffic** in the **Firewall** section
+- Open the **Management, disks, networking, and SSH keys** dropdown section and add the following in the **Startup script** field:
+
+  ```bash
+  #!/usr/bin/env bash
+  
+  # Install docker
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  sudo apt-get update
+  apt-cache policy docker-ce
+  apt-get install -y docker-ce docker-ce-cli containerd.io
+
+  # Install docker-compose
+  curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  curl -L https://raw.githubusercontent.com/docker/compose/1.25.3/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+
+  # Install git
+  sudo apt-get update
+  sudo apt-get install -y git
+
+  # Clone docker-compose definition
+  git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git /root/deploy-sourcegraph-docker
+  cd /root/deploy-sourcegraph-docker/docker-compose
+  git checkout "v3.12.3"
+
+  # Run Sourcegraph. Restart the containers upon reboots.
+  docker-compose up -d
+  ```
+
+- Create your VM, then navigate to its public IP address.
+
+- If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
+
+---
+
+## Update your Sourcegraph version
+
+To update to the most recent version of Sourcegraph (X.Y.Z), SSH into your instance and run the following:
+
+```bash
+cd /root/deploy-sourcerph-docker/docker-compose
+git pull
+git checkout vX.Y.Z
+docker-compose up -d
+```
+
+---
+
+## Using an external database for persistence
+
+The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) and [Cloud Memorystore](https://cloud.google.com/memorystore/).
+
+> NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -1,6 +1,6 @@
-# Install Sourcegraph with Docker on Google Cloud
+# Install Sourcegraph with Docker Compose on Google Cloud
 
-This tutorial shows you how to deploy Sourcegraph to a single node running on Google Cloud.
+This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://docs.docker.com/compose/)to a single node running on Google Cloud.
 
 * If you're just starting out, we recommend [running Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a docker-compose deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
@@ -9,63 +9,66 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Go
 
 ## Deploy to Google Cloud VM
 
-- [Open your Google Cloud console](https://console.cloud.google.com/compute/instances) to create a new VM instance and click **Create Instance**
-- Choose an appropriate machine type (we recommend at least the `n1-standard-8` with 8 vCPUs and 30 GB RAM, more depending on team size and number of repositories/languages enabled)
-- Choose Ubuntu 18.04 LTS as your boot disk
-- Check the boxes for **Allow HTTP traffic** and **Allow HTTPS traffic** in the **Firewall** section
-- Open the **Management, disks, networking, and SSH keys** dropdown section and add the following in the **Startup script** field:
+1. [Open your Google Cloud console](https://console.cloud.google.com/compute/instances) to create a new VM instance and click **Create Instance**
+1. Choose an appropriate machine type (we recommend at least the `n1-standard-8` with `8` vCPUs and `30` GB RAM, more depending on team size and number of repositories/languages enabled)
+1. Under the "Boot Disk" options, select the following:
 
-  ```bash
-  #!/usr/bin/env bash
+    * **Operating System**: Ubuntu
+    * **Version**: Ubuntu 18.04 LTS
+    * **Boot disk type**: SSD persistent disk
+    * **Size**: `200` GB minimum *(As a rule of thumb, Sourcegraph needs at least as much space as all your repositories combined take up. Allocating as much disk space as you can upfront helps you avoid [resizing your boot disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd) later on.)*
 
-  set -euxo pipefail
+1. Check the boxes for **Allow HTTP traffic** and **Allow HTTPS traffic** in the **Firewall** section
+1. Open the **Management, disks, networking, and SSH keys** dropdown section and add the following in the **Startup script** field:
 
-  DOCKER_COMPOSE_VERSION='1.25.3'
-  SOURCEGRAPH_VERSION='v3.12.5'
-  DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
-
-  # Install Docker
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  sudo apt-get update
-  apt-cache policy docker-ce
-  apt-get install -y docker-ce docker-ce-cli containerd.io
-
-  # Install Docker Compose
-  curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose
-  curl -L https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
-
-  # Install git
-  sudo apt-get update
-  sudo apt-get install -y git
-
-  # Clone Docker Compose definition
-  git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}
-  cd ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}/docker-compose
-  git checkout ${SOURCEGRAPH_VERSION}
-
-  # Run Sourcegraph. Restart the containers upon reboot.
-  docker-compose up -d
-  ```
-
-- Create your VM, then navigate to its public IP address.
-
-- If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
-
-- You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the instance and viewing the logs:
-
-  - Following the status of the startup script that you provided earlier:
-    
     ```bash
-    tail -f /var/log/cloud-init-output.log
+    #!/usr/bin/env bash
+
+    set -euxo pipefail
+
+    DOCKER_COMPOSE_VERSION='1.25.3'
+    SOURCEGRAPH_VERSION='v3.12.5'
+    DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+
+    # Install Docker
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get update
+    apt-cache policy docker-ce
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+    # Install Docker Compose
+    curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+    curl -L https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+
+    # Install git
+    sudo apt-get update
+    sudo apt-get install -y git
+
+    # Clone Docker Compose definition
+    git clone https://github.com/sourcegraph/deploy-sourcegraph-docker.git ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}
+    cd ${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}/docker-compose
+    git checkout ${SOURCEGRAPH_VERSION}
+
+    # Run Sourcegraph. Restart the containers upon reboot.
+    docker-compose up -d
     ```
 
-  - (Once the user data script completes) monitoring the health of the `sourcegraph-frontend` container:
+1. Create your VM, then navigate to its public IP address.
+1. If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
+1. You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the instance and:
+    * Following the status of the startup script that you provided earlier:
 
-     ```bash
-     docker ps --filter="name=sourcegraph-frontend-0"
-     ```
+      ```bash
+      tail -f /var/log/cloud-init-output.log
+      ```
+
+    * (Once the user data script completes) monitoring the health of the `sourcegraph-frontend` container:
+
+      ```bash
+      docker ps --filter="name=sourcegraph-frontend-0"
+      ```
 
 ---
 
@@ -82,8 +85,18 @@ docker-compose up -d
 
 ---
 
+## Storage and Backups
+
+The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount). There are a few different back ways to backup this data:
+
+* (**default, recommended**) The most straightfoward method backup to backup this data is to [snapshot the entire disk that the GCP instance is using](https://cloud.google.com/compute/docs/disks/create-snapshots) on an [automatic, scheduled basis](https://cloud.google.com/compute/docs/disks/scheduled-snapshots).
+
+* Using an external Postgres instance (see below) lets a service such as [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) take care of backing up all of Sourcegraph's user data for you. If the VM instance running Sourcegraph ever dies or is destroyed, creating a fresh instance that's connected to that external Postgres will leave Sourcegraph in the same state that it was before.
+
+---
+
 ## Using an external database for persistence
 
-The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) and [Cloud Memorystore](https://cloud.google.com/memorystore/).
+The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external databases](../../external_database.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) and [Cloud Memorystore](https://cloud.google.com/memorystore/).
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -46,6 +46,7 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
       device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
       if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
       then
+          echo "--- ${PERSISTENT_DISK_DEVICE_NAME} is already formatted, skipping..."
           sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
       fi
       sudo mkdir -p "${DOCKER_DATA_ROOT}"

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -46,7 +46,6 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
       device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
       if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
       then
-          echo "--- ${PERSISTENT_DISK_DEVICE_NAME} is already formatted, skipping..."
           sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
       fi
       sudo mkdir -p "${DOCKER_DATA_ROOT}"

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -1,6 +1,10 @@
 # Install Sourcegraph with Docker Compose
 
-When running Sourcegraph in production, deploying Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) is the default installation method that we recommend. However:
+| Deployment Type              | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](#) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](#)          | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](#)              | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 * If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -9,7 +9,7 @@
 * If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
 
-It takes less than 5 minutes to run and install Sourcegraph using Docker Ccompose:
+It takes less than 5 minutes to run and install Sourcegraph using Docker Compose:
 
 ```bash
 git clone git@github.com:sourcegraph/deploy-sourcegraph-docker.git

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -1,0 +1,59 @@
+# Install Sourcegraph with Docker Compose
+
+When running Sourcegraph in production, deploying Sourcegraph via [Docker Compose](https://docs.docker.com/compose/) is the default installation method that we recommend. However:
+
+* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
+* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+
+It takes less than 5 minutes to run and install Sourcegraph using docker-compose:
+
+<!--
+  DO NOT CHANGE THIS TO A CODEBLOCK.
+  We want line breaks for readability, but backslashes to escape them do not work cross-platform.
+  This uses line breaks that are rendered but not copy-pasted to the clipboard.
+-->
+
+```bash
+git clone git@github.com:sourcegraph/deploy-sourcegraph-docker.git
+cd deploy-sourcegraph-docker/docker-compose
+git checkout v3.12.5
+docker-compose up -d
+```
+
+Once the server is ready (the `sourcegraph-frontend-0` service is healthy when running `docker ps`), navigate to the hostname or IP address on port `80`.  Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
+
+<!--
+TODO(ryan): Replace with updated screencast
+<p class="container">
+  <div style="padding:56.25% 0 0 0;position:relative;">
+    <iframe src="https://player.vimeo.com/video/314926561?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+  </div>
+</p>
+-->
+
+For next steps and further configuration options, visit the [site administration documentation](../../index.md).
+
+> NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
+
+## Cloud installation guides
+
+Cloud specific Sourcegraph installation guides for AWS, Google Cloud and Digital Ocean.
+
+- [Install Sourcegraph with Docker Compose on AWS](../../install/docker-dcompose/aws.md)
+- [Install Sourcegraph with Docker Compose on Google Cloud](../../install/docker-compose/google_cloud.md)
+- [Install Sourcegraph with Docker Compose on DigitalOcean](../../install/docker-compose/digitalocean.md)
+
+## Insiders build
+
+To test new development builds of Sourcegraph (triggered by commits to master), change the all semver tags in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) from `3.12.5` to `insiders`.
+
+> WARNING: `insiders` builds may be unstable, so back up Sourcegraph's data and config beforehand.
+
+To keep this up to date, run `docker-compose pull` to pull in the latest images, and run `docker-compose restart` to restart all container to access new changes.
+
+## Next steps
+
+- [Configuring Sourcegraph](../../config/index.md)
+- [Upgrading Sourcegraph](../../updates.md)
+- [Site administration documentation](../../index.md)

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -1,13 +1,15 @@
 # Install Sourcegraph with Docker Compose
 
-| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+| Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 * If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+---
 
 It takes less than 5 minutes to run and install Sourcegraph using Docker Compose:
 
@@ -24,16 +26,15 @@ For next steps and further configuration options, visit the [site administration
 
 > NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
 
-## 
+## Storage
 
-
-By default, Sourcegraph's Docker Compse definition uses [Docker volumes]
+The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount). 
 
 ## Cloud installation guides
 
 Cloud specific Sourcegraph installation guides for AWS, Google Cloud and Digital Ocean.
 
-- [Install Sourcegraph with Docker Compose on AWS](../../install/docker-dcompose/aws.md)
+- [Install Sourcegraph with Docker Compose on AWS](../../install/docker-compose/aws.md)
 - [Install Sourcegraph with Docker Compose on Google Cloud](../../install/docker-compose/google_cloud.md)
 - [Install Sourcegraph with Docker Compose on DigitalOcean](../../install/docker-compose/digitalocean.md)
 

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -3,7 +3,7 @@
 | Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
 |----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
 | [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Docker Compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 * If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -1,22 +1,15 @@
 # Install Sourcegraph with Docker Compose
 
-| Deployment Type              | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](#) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](#)          | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](#)              | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 * If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
 
-
-It takes less than 5 minutes to run and install Sourcegraph using docker-compose:
-
-<!--
-  DO NOT CHANGE THIS TO A CODEBLOCK.
-  We want line breaks for readability, but backslashes to escape them do not work cross-platform.
-  This uses line breaks that are rendered but not copy-pasted to the clipboard.
--->
+It takes less than 5 minutes to run and install Sourcegraph using Docker Ccompose:
 
 ```bash
 git clone git@github.com:sourcegraph/deploy-sourcegraph-docker.git
@@ -27,18 +20,14 @@ docker-compose up -d
 
 Once the server is ready (the `sourcegraph-frontend-0` service is healthy when running `docker ps`), navigate to the hostname or IP address on port `80`.  Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
 
-<!--
-TODO(ryan): Replace with updated screencast
-<p class="container">
-  <div style="padding:56.25% 0 0 0;position:relative;">
-    <iframe src="https://player.vimeo.com/video/314926561?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  </div>
-</p>
--->
-
 For next steps and further configuration options, visit the [site administration documentation](../../index.md).
 
 > NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
+
+## 
+
+
+By default, Sourcegraph's Docker Compse definition uses [Docker volumes]
 
 ## Cloud installation guides
 

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -2,8 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AWS.
 
-* If you're just starting out, we recommend [running Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features.
-* If you need scalability and high-availability beyond what a single-server deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -2,7 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph to a single node running on DigitalOcean.
 
-If you're just starting out, we recommend [installing Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features. If you need scalability and high-availability beyond what a single-server deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -2,7 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph to a single node running on Google Cloud.
 
-If you're just starting out, we recommend [installing Sourcegraph locally](index.md). It takes only a few minutes and lets you try out all of the features. If you need scalability and high-availability beyond what a single-server deployment can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -1,14 +1,6 @@
 # Install Sourcegraph with Docker
 
-| Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker Compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
-
-
-* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
-* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
 
 ---
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -1,10 +1,16 @@
 # Install Sourcegraph with Docker
 
-| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+| Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+
+
+* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
+* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
+
+---
 
 It takes less than a minute to run and install Sourcegraph using Docker:
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -3,7 +3,7 @@
 | Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
 |----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
 | [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Docker Compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -1,6 +1,12 @@
 # Install Sourcegraph with Docker
 
-It takes less than 5 minutes to run and install Sourcegraph using Docker:
+| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+
+It takes less than a minute to run and install Sourcegraph using Docker:
 
 <!--
   DO NOT CHANGE THIS TO A CODEBLOCK.

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -6,6 +6,6 @@
 | [Docker Compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
 
-* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
+* If you're just starting out, we recommend [running Sourcegraph locally](docker/index.md). It takes only a few minutes and lets you try out all of the features.
 
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -5,3 +5,7 @@
 | [Single-container server](../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
 | [Docker Compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+
+* If you're just starting out, we recommend [running Sourcegraph locally](../docker/index.md). It takes only a few minutes and lets you try out all of the features.
+
+* If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -1,7 +1,7 @@
 # Installing Sourcegraph
 
-| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
-| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
-| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
+| Deployment Type                                       | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -3,5 +3,5 @@
 | Deployment Type                                       | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
 |-------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
 | [Single-container server](../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
-| [Docker-compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Docker Compose](../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -1,4 +1,7 @@
 # Installing Sourcegraph
 
-- [Install Sourcegraph with Docker](docker/index.md) **(recommended, easiest)**
-- [Install Sourcegraph on a cluster](cluster.md)
+| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
+|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
+| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
+| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |


### PR DESCRIPTION
# Overview

This PR adds documentation for deploying docker-compose on each of the major cloud providers: AWS, GCP, and Digital Ocean. Each set of instructions gives recommendations on what machine size to choose, how much storage to give the machine, and documentation pointers about how to create backups of their Sourcegraph instance. 

This PR also tells people what deployment option they should choose when they're starting out: 

| Deployment Type                               | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
|-----------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
| [Single-container server](../docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
| [Docker-compose](index.md)                    | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
| [Kubernetes](../cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |

A later PR will give instructions for migrating off of `sourcegraph/server` to Docker Compose. 

## Notes:

### Startup scripts

Each of the cloud provider docs provides a startup script to initialize the instance. Each of the scripts follows this general flow:

1. Install `git`
1. Clone https://github.com/sourcegraph/deploy-sourcegraph-docker to the installation directory (AWS: `/home/ec2-user/deploy-sourcegraph-docker`, GCP/DO: `/root/deploy-sourcegraph-docker`) and checkout the latest [release](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases)
1. Prepare the external disk (used for storing all of Docker's data) and mount it into the file system
	- Using the external disk's device name provided in the startup script, check to see if the disk already has an existing  file system
	   - If it's **unformatted**, then format with `xfs` for AWS, and `ext4` for GCP/DO
       - If the disk **already has a filesystem**, do nothing (this prevents data from being destroyed if the user is using a disk that had a backup restored onto it).  
	   - Notes:
			- The same init script can be used on both the initial install and when spinning up a VM that has existing sourcegraph data on it.
            - Digital Ocean's webUI doesn't allow you to attach an existing volume to a new droplet during the creation process - you can only do so **after** the instance is initialized. I'll need to investigate instructions for how to spin up a backup on DO (simply run the init script after you login for the first time)?
	- Add the external disk's UUID to `/etc/fstab` so that the disk is automatically mounted upon reboots.
       - A lot of cloud provider documentation said that you can't rely on the device name being stable between reboots. Some cloud providers allow you to give names to disks, but the resulting label in `/dev/` wasn't predictable in my experience. I think using the device name is fine for now since it's only used for the initial format and the UUID is what actually gets stored in `/etc/fstab`.
1. Install docker
1. Install jq
1. Use jq modify `/etc/docker/daemon.json` to change the [`data-root`](https://docs.docker.com/engine/reference/commandline/dockerd/) setting to point to `/mnt/docker-data`. 
	- All of docker-compose's data is stored via docker volumes. Telling Docker to store all of its data under `/mnt/docker-data` allows customer's to easily snapshot/backup all of the user data in a similar workflow to what they have with `sourcegraph/server`. 
1. Restore the docker daemon to pickup these changes
1. Install docker-compose 
1. Run `docker-compose up -d` to start the sourcegraph/services and restart them on reboots 



### Backups

Docker Compose doesn't offer any built-in tool to mass backup Docker volumes, and 
[Docker's documentation](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes) only offers instructions for how to create/restore a tarball of a container on the individual container level. (I haven't tested this yet, but going down this route would involve custom scripting and would require managing these tarballs somewhere such as an S3 bucket, etc.)

As mentioned above, most of our customers currently solve this by mounting an external disk to the ~/.sourcegraph directory.  I have replicated this workflow by telling Docker to store all of its data (including volumes) under `/mnt/docker-data`. The docs also contain pointers for how to take snapshots of the external disk. 

In addition to the above method, I also call out that using an external Postgres service is an easy way to backup all of Sourcegraph's user data. 

---

Notes:

I have personally tested these docs for AWS, GCP, and DO. I have also tested restoring backups on AWS and GCP (and not DO for reasons stated above). 

I would still like someone to take an in depth look at this PR, the wording, and actually test out my instructions, but this PR needs to be merged already so that customers and take a look.