### PR TITLE
docs: Fixed page hierarchy, removing inline h1 headings

### DIFF
--- a/doc/admin/monitoring/slack_alert_channel.md
+++ b/doc/admin/monitoring/slack_alert_channel.md
@@ -33,9 +33,7 @@ the web hook.
 > earlier). Set the environment variable `GF_SERVER_ROOT_URL` to your Sourcegraph instance external URL followed
 > by the path `/-/debug/grafana`.
 
-# Other alert channel types
+## Other alert channel types
 
 Other alert channel types are configured in a way similar to the Slack alert channel type described above. Choose the
-appropriate channel type and provide the necessary information for that type. 
- 
-    
+appropriate channel type and provide the necessary information for that type.

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -4,7 +4,7 @@ This document describes the exact changes needed to update a [pure-Docker Source
 
 Each section comprehensively describes the changes needed in Docker images, environment variables, and added/removed services.
 
-# v3.12.2 → v3.12.5 changes
+## v3.12.2 → v3.12.5 changes
 
 ### Confirm file permissions
 
@@ -38,7 +38,7 @@ Also change the follow which are not versioned alongside Sourcegraph currently:
 | zoekt-indexserver | index.docker.io/sourcegraph/zoekt-indexserver:0.0.20200124185115-83b89a5@sha256:efd1fb37fc62bfab963f12e95f69778b0e2e6a253caed5be9025840072ea85b5 |
 | zoekt-webserver   | index.docker.io/sourcegraph/zoekt-webserver:0.0.20200124185328-83b89a5@sha256:cde27ee7db0fe6c293a8c9df47b529fb01b5a898e6cbeea4c18d80fe218563db |
 
-# v3.12.1 → v3.12.2 changes
+## v3.12.1 → v3.12.2 changes
 
 ### Update image tags
 
@@ -63,7 +63,7 @@ Also change the follow which are not versioned alongside Sourcegraph currently:
 |-------------------|-------------------------------------------------|
 | prometheus        | index.docker.io/sourcegraph/prometheus:10.0.7@sha256:22d54f27c7df8733a06c7ae8c2e851b61b1ed42f1f5621d493ef58ebd8d815e0 |
 
-# v3.10.4 → v3.12.1 changes
+## v3.10.4 → v3.12.1 changes
 
 ### Management console removal
 
@@ -107,7 +107,7 @@ Also change the follow which are not versioned alongside Sourcegraph currently:
 | redis-cache (no change if using external Redis) | index.docker.io/sourcegraph/redis-cache:19-04-16_6891de82@sha256:4cbfac8af0abb673899250d4fd859cc477d6426de519e9deb71e454e18322499 |
 | redis-store (no change if using external Redis) | index.docker.io/sourcegraph/redis-store:19-04-16_6891de821@sha256:56426d601ce1f6d63088fea1cefa61f69a2e809c7d90fc1d157cca63cf81b277 |
 
-# v3.10.4 → v3.12.5 changes
+## v3.10.4 → v3.12.5 changes
 
 ### Confirm file permissions
 

--- a/doc/dev/architecture/search-pagination.md
+++ b/doc/dev/architecture/search-pagination.md
@@ -20,7 +20,7 @@ Next, the actual pagination begins when `paginatedResults` is called: https://so
 
 For the purposes of clarity in this document, we will use the following terms:
 
-#### "search backend"
+### "search backend"
 
 We use the term "search backend" to describe a function which performs a search for a specific result `type:`. The function can perform an indexed (e.g. zoekt text search or symbol search) or unindexed (e.g. commit/diff search). The list of these at the time of writing are:
 
@@ -31,7 +31,7 @@ We use the term "search backend" to describe a function which performs a search 
 - `searchCommitLogInRepos` for finding `type:commit` results.
 - `performCodemod` for code modification find/replace (read-only) results.
 
-#### "cursor"
+### "cursor"
 
 The cursor is a base64 opaque string from a clients point of view. It contains metadata that is passed back and forth between the client and the server in order for the server to know where the client left off and where the server should begin looking for more results. Its actual definition in code is [here](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph+type+searchCursor+struct).
 
@@ -42,7 +42,7 @@ Our cursors are considered to be:
 
 Note: "cursor-based pagination" is an established concept and you can find resources describing different cursor-based pagination approaches elsewhere online.
 
-# How search pagination works
+## How search pagination works
 
 ### Shared backends
 

--- a/doc/dev/postgresql.md
+++ b/doc/dev/postgresql.md
@@ -12,7 +12,7 @@ Our minimum supported version is `9.6` which means you must use that for develop
 For Ubuntu 18.04, you will need to add a repository source. Use the
 [PostgreSQL.org official repo and instructions.](https://www.postgresql.org/download/linux/ubuntu/)
 
-# Initializing PostgreSQL
+## Initializing PostgreSQL
 
 Sourcegraph assumes it has a dedicated PostgreSQL server, or at least that you
 can make global configuration changes, such as changing the timezone. If you
@@ -40,7 +40,7 @@ timezone = 'UTC'
 Finally, restart your database server (mac: `brew services restart postgresql`, recent linux
 probably `service postgresql restart`)
 
-# Configuring PostgreSQL
+## Configuring PostgreSQL
 
 The Sourcegraph server reads PostgreSQL connection configuration from
 the
@@ -73,17 +73,17 @@ on local sockets, which provides reliable identification but must
 be specially configured to authenticate you as a user with a name
 different from your account name.)
 
-# Migrations
+## Migrations
 
 Migrations get applied automatically at application startup - you
 shouldn't need to run anything by hand. For full documentation see
 [migrations/README.md](https://github.com/sourcegraph/sourcegraph/blob/master/migrations/README.md)
 
-# Style guide
+## Style guide
 
 Here is the preferred style going forward. Existing tables may be inconsistent with this style.
 
-## Avoiding nullable columns
+### Avoiding nullable columns
 
 Use a `NOT NULL` constraint whenever possible to enforce having a value on every column. `NULL` values can easily introduce errors when not handled correctly, and for many fields it makes sense to always have a value anyways.
 
@@ -103,7 +103,7 @@ if s.Valid {
 }
 ```
 
-## Recommended columns for all tables
+### Recommended columns for all tables
 
 - `id` auto increment primary key.
 - `created_at` not null default `now()` set when a row is first inserted and never updated after that.
@@ -124,7 +124,7 @@ CREATE TABLE "widgets" (
 );
 ```
 
-## Hard vs soft deletes
+### Hard vs soft deletes
 
 Definitions:
 
@@ -185,7 +185,7 @@ Alternatively, we could remove the unique constraint on `user_id` and `org_id` a
 
 The decision here can be made on a table by table basis.
 
-## Use foreign keys
+### Use foreign keys
 
 If you have a column that references another column in the database, add a foreign key constraint.
 
@@ -201,17 +201,17 @@ Foreign key constraints should not cascade deletes for a few reasons:
 
 Instead of cascading deletes, applications should explicitly delete the rows that would otherwise get deleted if cascading deletes were enabled.
 
-## Table names
+### Table names
 
 Tables are plural (e.g. repositories, users, comments, etc.).
 
 Join tables should be named based on the two tables being joined (e.g. `foo_bar` joins `foo` and `bar`).
 
-## Validation
+### Validation
 
 To the extent that certain fields require validation (e.g. username) we should perform that validation in client AND EITHER the database when possible, OR the graphql api. This results in the best experience for the client, and protects us from corrupt data.
 
-## Triggers
+### Triggers
 
 Because a trigger resides in the database and anyone who has the required privilege can use it, a trigger lets you write a set of SQL statements that multiple applications can use. It lets you avoid redundant code when multiple programs need to perform the same database operation.
 
@@ -232,4 +232,3 @@ A test like this ought to exercise your data access module, regardless of the de
 Here's an example of how you could [structure such tests](https://github.com/sourcegraph/sourcegraph/blob/da3743ece358fbe6709f07e95d5fd97bd554e047/cmd/repo-updater/repos/integration_test.go#L17).
 
 If you're uncertain about using triggers as part of your work, do some research before committing to a solution and don't hesitate to discuss it with your peers.
-

--- a/doc/integration/lightstep.md
+++ b/doc/integration/lightstep.md
@@ -9,13 +9,13 @@ Feature | Supported?
 For users: [View live traces for your code](#view-live-traces-for-your-code) | ✅
 For site admins: [Monitoring a self-hosted Sourcegraph instance](#instrumenting-a-self-hosted-sourcegraph-instance) | ✅
 
-# View live traces for your code
+## View live traces for your code
 
 Any user can [enable the LightStep extension for Sourcegraph](https://sourcegraph.com/extensions/sourcegraph/lightstep) to view live traces for OpenTracing spans in their own code.
 
 ![Screenshot](https://storage.googleapis.com/sourcegraph-assets/LightStep_Sourcegraph.png)
 
-# Monitoring a self-hosted Sourcegraph instance
+## Monitoring a self-hosted Sourcegraph instance
 
 In the site configuration, site admins can [configure LightStep tracing](../admin/config/site_config.md) using the `lightstepAccessToken` and `lightstepProject` configuration properties.
 


### PR DESCRIPTION
Fixes page content linking issues caused by using h1 level headings instead of h2.

![ScreenFlow](https://user-images.githubusercontent.com/133014/73582425-dd05f000-44d8-11ea-91ef-1cefac10eeda.gif)
