### PR TITLE
Batch-fetch GitLab Project visibility when computing permissions

### DIFF
--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -58,3 +58,18 @@ const (
 	ProviderBitbucketServer ProviderType = bitbucketserver.ServiceType
 	ProviderSourcegraph     ProviderType = "sourcegraph"
 )
+
+// RepoPermsSort sorts a slice of RepoPerms to guarantee a stable ordering.
+type RepoPermsSort []RepoPerms
+
+func (s RepoPermsSort) Len() int      { return len(s) }
+func (s RepoPermsSort) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s RepoPermsSort) Less(i, j int) bool {
+	if s[i].Repo.ID != s[j].Repo.ID {
+		return s[i].Repo.ID < s[j].Repo.ID
+	}
+	if s[i].Repo.ExternalRepo.ID != s[j].Repo.ExternalRepo.ID {
+		return s[i].Repo.ExternalRepo.ID < s[j].Repo.ExternalRepo.ID
+	}
+	return s[i].Repo.Name < s[j].Repo.Name
+}

--- a/enterprise/cmd/frontend/authz_test.go
+++ b/enterprise/cmd/frontend/authz_test.go
@@ -102,8 +102,10 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
-						BaseURL:  mustURLParse(t, "https://gitlab.mine"),
-						CacheTTL: 48 * time.Hour,
+						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
+						CacheTTL:          48 * time.Hour,
+						MinBatchThreshold: 200,
+						MaxBatchRequests:  300,
 					},
 				},
 			),
@@ -203,14 +205,18 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
-						BaseURL:  mustURLParse(t, "https://gitlab.mine"),
-						CacheTTL: 3 * time.Hour,
+						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
+						CacheTTL:          3 * time.Hour,
+						MinBatchThreshold: 200,
+						MaxBatchRequests:  300,
 					},
 				},
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
-						BaseURL:  mustURLParse(t, "https://gitlab.com"),
-						CacheTTL: 3 * time.Hour,
+						BaseURL:           mustURLParse(t, "https://gitlab.com"),
+						CacheTTL:          3 * time.Hour,
+						MinBatchThreshold: 200,
+						MaxBatchRequests:  300,
 					},
 				},
 			),

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -3,7 +3,9 @@ package gitlab
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -53,6 +55,9 @@ type mockGitLab struct {
 
 	// madeGetProject records what GetProject calls have been made. It's a map from oauth token -> GetProjectOp -> count.
 	madeGetProject map[string]map[gitlab.GetProjectOp]int
+
+	// madeListProjects records what ListProjects calls have been made. It's a map from oauth token -> string (urlStr) -> count.
+	madeListProjects map[string]map[string]int
 
 	// madeListTree records what ListTree calls have been made. It's a map from oauth token -> ListTreeOp -> count.
 	madeListTree map[string]map[gitlab.ListTreeOp]int
@@ -120,6 +125,60 @@ func newMockGitLab(op mockGitLabOp) mockGitLab {
 		madeListTree:   map[string]map[gitlab.ListTreeOp]int{},
 		madeUsers:      map[string]map[string]int{},
 	}
+}
+
+func (m *mockGitLab) ListProjects(c *gitlab.Client, ctx context.Context, urlStr string) (projs []*gitlab.Project, nextPageURL *string, err error) {
+	if _, ok := m.madeListProjects[c.OAuthToken]; !ok {
+		m.madeListProjects[c.OAuthToken] = map[string]int{}
+	}
+	m.madeListProjects[c.OAuthToken][urlStr]++
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, nil, err
+	}
+	query := u.Query()
+	if query.Get("pagination") == "keyset" {
+		return nil, nil, errors.New("This mock does not support keyset pagination")
+	}
+	perPage, err := strconv.Atoi(query.Get("per_page"))
+	if err != nil {
+		return nil, nil, err
+	}
+	page := 1
+	if p := query.Get("page"); p != "" {
+		page, err = strconv.Atoi(p)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	acctID := m.getAcctID(c)
+	for _, proj := range m.projs {
+		if proj.Visibility == gitlab.Public || (proj.Visibility == gitlab.Internal && acctID != 0) {
+			projs = append(projs, proj)
+		}
+	}
+	for _, pid := range m.privateGuest[acctID] {
+		projs = append(projs, m.projs[pid])
+	}
+	for _, pid := range m.privateRepo[acctID] {
+		projs = append(projs, m.projs[pid])
+	}
+
+	sort.Sort(projSort(projs))
+	if (page-1)*perPage >= len(projs) {
+		return nil, nil, nil
+	}
+	if page*perPage < len(projs) {
+		nextURL, _ := url.Parse(urlStr)
+		q := nextURL.Query()
+		q.Set("page", strconv.Itoa(page+1))
+		nextURL.RawQuery = q.Encode()
+		nextURLStr := nextURL.String()
+		return projs[(page-1)*perPage : page*perPage], &nextURLStr, nil
+	}
+	return projs[(page-1)*perPage:], nil, nil
 }
 
 func (m *mockGitLab) GetProject(c *gitlab.Client, ctx context.Context, op gitlab.GetProjectOp) (*gitlab.Project, error) {
@@ -381,3 +440,10 @@ func getIntOrDefault(str string, def int) (int, error) {
 	}
 	return strconv.Atoi(str)
 }
+
+// projSort sorts Projects in order of ID
+type projSort []*gitlab.Project
+
+func (p projSort) Len() int           { return len(p) }
+func (p projSort) Less(i, j int) bool { return p[i].ID < p[j].ID }
+func (p projSort) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -78,9 +78,19 @@ func newAuthzProvider(a *schema.GitLabAuthorization, instanceURL, token string, 
 			return nil, fmt.Errorf("Did not find authentication provider matching %q. Check the [**site configuration**](/site-admin/configuration) to verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for %s.", instanceURL, instanceURL)
 		}
 
+		minBatchThreshold := 200
+		if idp.Oauth.MinBatchingThreshold > 0 {
+			minBatchThreshold = idp.Oauth.MinBatchingThreshold
+		}
+		maxBatchRequests := 300
+		if idp.Oauth.MaxBatchRequests > 0 {
+			maxBatchRequests = idp.Oauth.MaxBatchRequests
+		}
 		return NewOAuthProvider(OAuthAuthzProviderOp{
-			BaseURL:  glURL,
-			CacheTTL: ttl,
+			BaseURL:           glURL,
+			CacheTTL:          ttl,
+			MinBatchThreshold: minBatchThreshold,
+			MaxBatchRequests:  maxBatchRequests,
 		}), nil
 	case idp.Username != nil:
 		return NewSudoProvider(SudoProviderOp{

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -268,7 +268,7 @@ const (
 
 // batchProjVisSize is the number of projects to request visibility for in each batch request issued
 // by fetchProjVisBatch
-var batchProjVisSize = 100
+const batchProjVisSize = 100
 
 // fetchProjVisBatch returns the list of repositories best-effort sorted into groups. The visiblity
 // results are valid even if err is non-nil.

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 
+// >>> NEXT: run this test with minBatchThreshold set to 200 and 1
+
 func Test_GitLab_RepoPerms(t *testing.T) {
 	type call struct {
 		description string

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -12,8 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 
-// >>> NEXT: run this test with minBatchThreshold set to 200 and 1
-
+// Test_GitLab_RepoPerms checks for correctness and cache-correctness
 func Test_GitLab_RepoPerms(t *testing.T) {
 	type call struct {
 		description string
@@ -23,8 +23,13 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 	}
 	type test struct {
 		description string
-		op          OAuthAuthzProviderOp
-		calls       []call
+
+		// Configures the provider. Do NOT set the MaxBatchRequests and MinBatchThreshold fields in
+		// the test struct declarations, as these are set to a range of values in the test logic,
+		// itself.
+		op OAuthAuthzProviderOp
+
+		calls []call
 	}
 
 	// Mock the following scenario:
@@ -72,6 +77,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 		},
 	})
 	gitlab.MockGetProject = gitlabMock.GetProject
+	gitlab.MockListProjects = gitlabMock.ListProjects
 	gitlab.MockListTree = gitlabMock.ListTree
 
 	repos := map[string]*types.Repo{
@@ -170,23 +176,31 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			for _, c := range test.calls {
-				t.Logf("Call %q", c.description)
+				for _, batchingThreshold := range [][2]int{
+					{0, 0},     // should NOT trigger batch-fetching visibility
+					{1, 300},   // should trigger batch-fetching visibility
+					{200, 300}, // should NOT trigger batch-fetching visibility
+				} {
+					t.Logf("Call %q, batchingThreshold %d", c.description, batchingThreshold)
 
-				// Recreate the authz provider cache every time, before running twice (once uncached, once cached)
-				ctx := context.Background()
-				op := test.op
-				op.MockCache = make(mockCache)
-				authzProvider := newOAuthProvider(op)
-
-				for i := 0; i < 2; i++ {
-					t.Logf("iter %d", i)
-					perms, err := authzProvider.RepoPerms(ctx, c.account, c.repos)
-					if err != nil {
-						t.Errorf("unexpected error: %v", err)
-						continue
-					}
-					if !reflect.DeepEqual(perms, c.expPerms) {
-						t.Errorf("expected %s, but got %s", asJSON(t, c.expPerms), asJSON(t, perms))
+					// Recreate the authz provider cache every time, before running twice (once uncached, once cached)
+					ctx := context.Background()
+					op := test.op
+					op.MinBatchThreshold, op.MaxBatchRequests = batchingThreshold[0], batchingThreshold[1]
+					op.MockCache = make(mockCache)
+					authzProvider := newOAuthProvider(op)
+					for i := 0; i < 2; i++ {
+						t.Logf("iter %d", i)
+						perms, err := authzProvider.RepoPerms(ctx, c.account, c.repos)
+						if err != nil {
+							t.Errorf("unexpected error: %v", err)
+							continue
+						}
+						sort.Sort(authz.RepoPermsSort(perms))
+						sort.Sort(authz.RepoPermsSort(c.expPerms))
+						if !reflect.DeepEqual(perms, c.expPerms) {
+							t.Errorf("expected %s, but got %s", asJSON(t, c.expPerms), asJSON(t, perms))
+						}
 					}
 				}
 			}
@@ -194,6 +208,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 	}
 }
 
+// Test_GitLab_RepoPerms_cache tests for cache-effectiveness (we cache what we expect to cache).
 func Test_GitLab_RepoPerms_cache(t *testing.T) {
 	gitlabMock := newMockGitLab(mockGitLabOp{
 		t: t,
@@ -309,5 +324,153 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 		}; !reflect.DeepEqual(exp, actual) {
 			t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 		}
+	}
+}
+
+// Test_GitLab_RepoPerms_batchVisibility tests that Project visibility is fetched in batch (for
+// performance reasons)
+func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
+	gitlabMockOp := mockGitLabOp{
+		t: t,
+		publicProjs: []int{ // public projects
+			991,
+		},
+		internalProjs: []int{ // internal projects
+			981,
+		},
+		privateProjs: map[int][2][]int32{ // private projects
+			10: {
+				{ // guests
+					2,
+				},
+				{ // content ("full access")
+					1,
+					3,
+				},
+			},
+			20: {
+				{
+					3,
+				},
+				{
+					2,
+				},
+			},
+		},
+		oauthToks: map[string]int32{
+			"oauth-u1": 1,
+			"oauth-u2": 2,
+			"oauth-u3": 3,
+		},
+	}
+	repos := map[string]*types.Repo{
+		"u1/repo1":       repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"),
+		"u2/repo1":       repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"),
+		"internal/repo1": repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"),
+		"public/repo1":   repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"),
+	}
+	repoSlice := make([]*types.Repo, 0, len(repos))
+	for _, r := range repos {
+		repoSlice = append(repoSlice, r)
+	}
+
+	{
+		gitlabMock := newMockGitLab(gitlabMockOp)
+		gitlab.MockGetProject = gitlabMock.GetProject
+		gitlab.MockListProjects = gitlabMock.ListProjects
+		gitlab.MockListTree = gitlabMock.ListTree
+
+		ctx := context.Background()
+		authzProvider := newOAuthProvider(OAuthAuthzProviderOp{
+			BaseURL:           mustURL(t, "https://gitlab.mine"),
+			MockCache:         make(mockCache),
+			CacheTTL:          3 * time.Hour,
+			MinBatchThreshold: 1,
+			MaxBatchRequests:  300,
+		})
+		expPerms := []authz.RepoPerms{
+			{Repo: repos["u1/repo1"], Perms: authz.Read},
+			{Repo: repos["internal/repo1"], Perms: authz.Read},
+			{Repo: repos["public/repo1"], Perms: authz.Read},
+		}
+		expMadeGetProject := map[string]map[gitlab.GetProjectOp]int{
+			"oauth-u1": {
+				{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1,
+				{ID: 20, CommonOp: gitlab.CommonOp{NoCache: true}}: 1,
+			},
+		}
+		expMadeListProjects := map[string]map[string]int{
+			"oauth-u1": {"projects?per_page=100": 1},
+		}
+
+		perms, err := authzProvider.RepoPerms(ctx, acct(t, 1, "gitlab", "https://gitlab.mine/", "1", "oauth-u1"), repoSlice)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Sort(authz.RepoPermsSort(perms))
+		sort.Sort(authz.RepoPermsSort(expPerms))
+		if !reflect.DeepEqual(perms, expPerms) {
+			t.Errorf("expected %s, but got %s", asJSON(t, expPerms), asJSON(t, perms))
+		}
+		if !reflect.DeepEqual(expMadeGetProject, gitlabMock.madeGetProject) {
+			t.Errorf("expected madeGetProject calls to be %v, but got %v", expMadeGetProject, gitlabMock.madeGetProject)
+		}
+		if !reflect.DeepEqual(expMadeListProjects, gitlabMock.madeListProjects) {
+			t.Errorf("expected madeListProjects calls to be %v, but got %v", expMadeListProjects, gitlabMock.madeListProjects)
+		}
+
+		gitlab.MockGetProject = nil
+		gitlab.MockListProjects = nil
+		gitlab.MockListTree = nil
+	}
+
+	{
+		gitlabMock := newMockGitLab(gitlabMockOp)
+		gitlab.MockGetProject = gitlabMock.GetProject
+		gitlab.MockListProjects = gitlabMock.ListProjects
+		gitlab.MockListTree = gitlabMock.ListTree
+
+		ctx := context.Background()
+		authzProvider := newOAuthProvider(OAuthAuthzProviderOp{
+			BaseURL:           mustURL(t, "https://gitlab.mine"),
+			MockCache:         make(mockCache),
+			CacheTTL:          3 * time.Hour,
+			MinBatchThreshold: 200,
+			MaxBatchRequests:  300,
+		})
+		expPerms := []authz.RepoPerms{
+			{Repo: repos["u1/repo1"], Perms: authz.Read},
+			{Repo: repos["internal/repo1"], Perms: authz.Read},
+			{Repo: repos["public/repo1"], Perms: authz.Read},
+		}
+		expMadeGetProject := map[string]map[gitlab.GetProjectOp]int{
+			"oauth-u1": {
+				{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}:  1,
+				{ID: 20, CommonOp: gitlab.CommonOp{NoCache: true}}:  1,
+				{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1,
+				{ID: 991, CommonOp: gitlab.CommonOp{NoCache: true}}: 1,
+			},
+		}
+		expMadeListProjects := map[string]map[string]int{}
+
+		perms, err := authzProvider.RepoPerms(ctx, acct(t, 1, "gitlab", "https://gitlab.mine/", "1", "oauth-u1"), repoSlice)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Sort(authz.RepoPermsSort(perms))
+		sort.Sort(authz.RepoPermsSort(expPerms))
+		if !reflect.DeepEqual(perms, expPerms) {
+			t.Errorf("expected %s, but got %s", asJSON(t, expPerms), asJSON(t, perms))
+		}
+		if !reflect.DeepEqual(expMadeGetProject, gitlabMock.madeGetProject) {
+			t.Errorf("expected madeGetProject calls to be %v, but got %v", expMadeGetProject, gitlabMock.madeGetProject)
+		}
+		if !reflect.DeepEqual(expMadeListProjects, gitlabMock.madeListProjects) {
+			t.Errorf("expected madeListProjects calls to be %v, but got %v", expMadeListProjects, gitlabMock.madeListProjects)
+		}
+
+		gitlab.MockGetProject = nil
+		gitlab.MockListProjects = nil
+		gitlab.MockListTree = nil
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -199,8 +200,8 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 						}
 						sort.Sort(authz.RepoPermsSort(perms))
 						sort.Sort(authz.RepoPermsSort(c.expPerms))
-						if !reflect.DeepEqual(perms, c.expPerms) {
-							t.Errorf("expected %s, but got %s", asJSON(t, c.expPerms), asJSON(t, perms))
+						if diff := cmp.Diff(perms, c.expPerms); diff != "" {
+							t.Errorf("perms != c.expPerms:\n%s", diff)
 						}
 					}
 				}
@@ -376,6 +377,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 	}
 
 	{
+		// Test case 1: batching threshold hit, { MinBatchThreshold: 1, MaxBatchRequests: 300 }
 		gitlabMock := newMockGitLab(gitlabMockOp)
 		gitlab.MockGetProject = gitlabMock.GetProject
 		gitlab.MockListProjects = gitlabMock.ListProjects
@@ -410,14 +412,14 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 		}
 		sort.Sort(authz.RepoPermsSort(perms))
 		sort.Sort(authz.RepoPermsSort(expPerms))
-		if !reflect.DeepEqual(perms, expPerms) {
-			t.Errorf("expected %s, but got %s", asJSON(t, expPerms), asJSON(t, perms))
+		if diff := cmp.Diff(expPerms, perms); diff != "" {
+			t.Errorf("expPerms != perms:\n%s", diff)
 		}
-		if !reflect.DeepEqual(expMadeGetProject, gitlabMock.madeGetProject) {
-			t.Errorf("expected madeGetProject calls to be %v, but got %v", expMadeGetProject, gitlabMock.madeGetProject)
+		if diff := cmp.Diff(expMadeGetProject, gitlabMock.madeGetProject); diff != "" {
+			t.Errorf("expMadeGetProject != gitlabMock.madeGetProject:\n%s", diff)
 		}
-		if !reflect.DeepEqual(expMadeListProjects, gitlabMock.madeListProjects) {
-			t.Errorf("expected madeListProjects calls to be %v, but got %v", expMadeListProjects, gitlabMock.madeListProjects)
+		if diff := cmp.Diff(expMadeListProjects, gitlabMock.madeListProjects); diff != "" {
+			t.Errorf("expMadeListProjects != gitlabMock.madeListProjects:\n%s", diff)
 		}
 
 		gitlab.MockGetProject = nil
@@ -426,6 +428,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 	}
 
 	{
+		// Test case 2: batching threshold NOT hit { MinBatchThreshold: 200, MaxBatchRequests: 300 }
 		gitlabMock := newMockGitLab(gitlabMockOp)
 		gitlab.MockGetProject = gitlabMock.GetProject
 		gitlab.MockListProjects = gitlabMock.ListProjects
@@ -460,14 +463,14 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 		}
 		sort.Sort(authz.RepoPermsSort(perms))
 		sort.Sort(authz.RepoPermsSort(expPerms))
-		if !reflect.DeepEqual(perms, expPerms) {
-			t.Errorf("expected %s, but got %s", asJSON(t, expPerms), asJSON(t, perms))
+		if diff := cmp.Diff(perms, expPerms); diff != "" {
+			t.Errorf("perms != expPerms:\n%s", diff)
 		}
-		if !reflect.DeepEqual(expMadeGetProject, gitlabMock.madeGetProject) {
-			t.Errorf("expected madeGetProject calls to be %v, but got %v", expMadeGetProject, gitlabMock.madeGetProject)
+		if diff := cmp.Diff(expMadeGetProject, gitlabMock.madeGetProject); diff != "" {
+			t.Errorf("expMadeGetProject != gitlabMock.madeGetProject:\n%s", diff)
 		}
-		if !reflect.DeepEqual(expMadeListProjects, gitlabMock.madeListProjects) {
-			t.Errorf("expected madeListProjects calls to be %v, but got %v", expMadeListProjects, gitlabMock.madeListProjects)
+		if diff := cmp.Diff(expMadeListProjects, gitlabMock.madeListProjects); diff != "" {
+			t.Errorf("expMadeListProjects != gitlabMock.madeListProjects:\n%s", diff)
 		}
 
 		gitlab.MockGetProject = nil

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -179,6 +179,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 				for _, batchingThreshold := range [][2]int{
 					{0, 0},     // should NOT trigger batch-fetching visibility
 					{1, 300},   // should trigger batch-fetching visibility
+					{1, 1},     // should trigger batch-fetching visibility, but hit maximum
 					{200, 300}, // should NOT trigger batch-fetching visibility
 				} {
 					t.Logf("Call %q, batchingThreshold %d", c.description, batchingThreshold)

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -15,13 +15,37 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
-var requestCounter = metrics.NewRequestMeter("gitlab", "Total number of requests sent to the GitLab API.")
+var (
+	requestCounter = metrics.NewRequestMeter("gitlab", "Total number of requests sent to the GitLab API.")
+
+	// Whether debug nlogging is turned on
+	trace bool
+)
+
+func init() {
+	go func() {
+		conf.Watch(func() {
+			exp := conf.Get().ExperimentalFeatures
+			if exp == nil {
+				trace = false
+				return
+			}
+			if debugLog := exp.DebugLog; debugLog == nil || !debugLog.ExtsvcGitlab {
+				trace = false
+				return
+			}
+			trace = true
+		})
+	}()
+}
 
 // ClientProvider creates GitLab API clients. Each client has separate authentication creds and a
 // separate cache, but they share an underlying HTTP client and rate limiter. Callers who want a simple
@@ -198,9 +222,16 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 	resp, err = c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
+		if trace {
+			log15.Info("TRACE: GitLab API error", "method", req.Method, "url", req.URL.String(), "err", err)
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if trace {
+		log15.Info("TRACE: GitLab API", "method", req.Method, "url", req.URL.String(), "respCode", resp.StatusCode)
+	}
+
 	c.RateLimit.Update(resp.Header)
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Wrap(httpError(resp.StatusCode), fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -169,6 +169,16 @@
         "type": {
           "type": "string",
           "const": "oauth"
+        },
+        "minBatchingThreshold": {
+          "description": "The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.",
+          "type": "integer",
+          "default": 200
+        },
+        "maxBatchRequests": {
+          "description": "The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.",
+          "type": "integer",
+          "default": 300
         }
       }
     },

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -174,6 +174,16 @@ const GitLabSchemaJSON = `{
         "type": {
           "type": "string",
           "const": "oauth"
+        },
+        "minBatchingThreshold": {
+          "description": "The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.",
+          "type": "integer",
+          "default": 200
+        },
+        "maxBatchRequests": {
+          "description": "The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.",
+          "type": "integer",
+          "default": 300
         }
       }
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -632,7 +632,11 @@ type Notice struct {
 	Message string `json:"message"`
 }
 type OAuthIdentity struct {
-	Type string `json:"type"`
+	// MaxBatchRequests description: The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.
+	MaxBatchRequests int `json:"maxBatchRequests,omitempty"`
+	// MinBatchingThreshold description: The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.
+	MinBatchingThreshold int    `json:"minBatchingThreshold,omitempty"`
+	Type                 string `json:"type"`
 }
 
 // OpenIDConnectAuthProvider description: Configures the OpenID Connect authentication provider for SSO.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -284,6 +284,12 @@ type CloneURLToRepositoryName struct {
 	To string `json:"to"`
 }
 
+// DebugLog description: Turns on debug logging for specific debugging scenarios.
+type DebugLog struct {
+	// ExtsvcGitlab description: Log GitLab API requests.
+	ExtsvcGitlab bool `json:"extsvc.gitlab,omitempty"`
+}
+
 // Discussions description: Configures Sourcegraph code discussions.
 type Discussions struct {
 	// AbuseEmails description: Email addresses to notify of e.g. new user reports about abusive comments. Otherwise emails will not be sent.
@@ -338,6 +344,8 @@ type ExperimentalFeatures struct {
 	Automation string `json:"automation,omitempty"`
 	// BitbucketServerFastPerm description: Enables fetching Bitbucket Server permissions through the roaring bitmap endpoint. This requires the installation of the Bitbucket Server Sourcegraph plugin. Warning: there may be performance degradation under significant load.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
+	// DebugLog description: Turns on debug logging for specific debugging scenarios.
+	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// Discussions description: Enables the code discussions experiment.
 	Discussions string `json:"discussions,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -61,6 +61,18 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "debug.log": {
+          "description": "Turns on debug logging for specific debugging scenarios.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extsvc.gitlab": {
+              "description": "Log GitLab API requests.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
         "automation": {
           "description": "Enables the experimental code automation features.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -66,6 +66,18 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "debug.log": {
+          "description": "Turns on debug logging for specific debugging scenarios.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extsvc.gitlab": {
+              "description": "Log GitLab API requests.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
         "automation": {
           "description": "Enables the experimental code automation features.",
           "type": "string",


### PR DESCRIPTION
This PR adds an optimization to the GitLab OAuth authz implementation, wherein permissions for GitLab projects ("project" is what GitLab calls a repository) are fetched in batches of 100 in certain cases, instead of individually. These certain cases are those in which the projects we're fetching have visibility `public` or `internal` (i.e., not `private`). This should make permissions fetching much faster for customers using GitLab OAuth authz and have predominantly `internal` or `public` repositories on Sourcegraph.

This also adds a site config option `experimentalFeatures > debug.log > extsvc.gitlab` that can be set to `true` to turn on debug tracing of GitLab API requests in a running Sourcegraph instance. This should help with future debugging of permissions performance issues.

Please see my inline comments for more explanation of what's in this PR.

**Post-merge TODOs**
- [ ] Cut patch release for customer
- [ ] Update CHANGEOG