### PR TITLE
Show warning if admin accesses Sourcegraph over HTTP

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -67,6 +67,12 @@ func init() {
 		}
 		return problems
 	})
+	conf.ContributeWarning(func(c conf.Unified) (problems conf.Problems) {
+		if globals.ExternalURL().Scheme == "http" {
+			problems = append(problems, conf.NewSiteProblem("Your connection is not private. We recommend [configuring Sourcegraph to use HTTPS/SSL](https://docs.sourcegraph.com/admin/nginx)"))
+		}
+		return problems
+	})
 
 	// Warn about invalid site configuration.
 	AlertFuncs = append(AlertFuncs, func(args AlertFuncArgs) []*Alert {


### PR DESCRIPTION
Closes #8160 
I am checking the externalURL and if it is HTTP, I am adding a warning to the website. A sample of how it looks is below:
<img width="1679" alt="Screenshot 2020-02-03 at 1 02 56 AM" src="https://user-images.githubusercontent.com/7762605/73631415-e8673180-4626-11ea-9288-7dc836319118.png">
Let me know if there is something to be changed in this.
I also changed the alert type from `AlertTypeWarning` to `AlertTypeError` for critical problems, I am not sure if this was a bug or was intentional.