### PR TITLE
MonacoQueryInput: fallback to plain query input

### DIFF
--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -1,25 +1,51 @@
 import React, { Suspense } from 'react'
 import { MonacoQueryInputProps } from './MonacoQueryInput'
 import { lazyComponent } from '../../util/lazyComponent'
+import { CaseSensitivityToggle } from './CaseSensitivityToggle'
+import { RegexpToggle } from './RegexpToggle'
 
 const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'MonacoQueryInput')
 
-const ReadonlyQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({ queryState }) => (
-    <div className="query-input2">
-        <input
-            type="text"
-            readOnly={true}
-            className="form-control query-input2__input e2e-query-input"
-            value={queryState.query}
-        />
-    </div>
-)
+/**
+ * A plain query input displayed during lazy-loading of the MonacoQueryInput.
+ * It has no suggestions, but still allows to type in and submit queries.
+ */
+const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
+    queryState,
+    autoFocus,
+    onChange,
+    ...props
+}) => {
+    const onInputChange = React.useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            // cursorPosition is only used for legacy suggestions, it's OK to set it to 0 here.
+            onChange({ query: e.target.value, cursorPosition: 0 })
+        },
+        [onChange]
+    )
+    return (
+        <div className="query-input2 d-flex">
+            <input
+                type="text"
+                autoFocus={autoFocus}
+                className="form-control query-input2__input e2e-query-input"
+                value={queryState.query}
+                onChange={onInputChange}
+                spellCheck={false}
+            />
+            <div className="query-input2__toggle-container">
+                <CaseSensitivityToggle {...props} navbarSearchQuery={queryState.query}></CaseSensitivityToggle>
+                <RegexpToggle {...props} navbarSearchQuery={queryState.query}></RegexpToggle>
+            </div>
+        </div>
+    )
+}
 
 /**
  * A lazily-loaded {@link MonacoQueryInput}, displaying a read-only query field as a fallback during loading.
  */
 export const LazyMonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = props => (
-    <Suspense fallback={<ReadonlyQueryInput {...props} />}>
+    <Suspense fallback={<PlainQueryInput {...props} />}>
         <MonacoQueryInput {...props}></MonacoQueryInput>
     </Suspense>
 )


### PR DESCRIPTION
Closes #7774

Progressive enhancement: displays a simple search input box during lazy-loading of the MonacoQueryInput, that still allows the user to type in a query and submit.
