### PR TITLE
Take patternType into account for  diagnostics

### DIFF
--- a/shared/src/search/parser/diagnostics.test.ts
+++ b/shared/src/search/parser/diagnostics.test.ts
@@ -1,10 +1,14 @@
 import { getDiagnostics } from './diagnostics'
 import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { SearchPatternType } from '../../graphql/schema'
 
 describe('getDiagnostics()', () => {
     test('invalid filter type', () => {
         expect(
-            getDiagnostics((parseSearchQuery('repos:^github.com/sourcegraph') as ParseSuccess<Sequence>).token)
+            getDiagnostics(
+                (parseSearchQuery('repos:^github.com/sourcegraph') as ParseSuccess<Sequence>).token,
+                SearchPatternType.literal
+            )
         ).toStrictEqual([
             {
                 endColumn: 6,
@@ -18,7 +22,9 @@ describe('getDiagnostics()', () => {
     })
 
     test('invalid filter value', () => {
-        expect(getDiagnostics((parseSearchQuery('case:maybe') as ParseSuccess<Sequence>).token)).toStrictEqual([
+        expect(
+            getDiagnostics((parseSearchQuery('case:maybe') as ParseSuccess<Sequence>).token, SearchPatternType.literal)
+        ).toStrictEqual([
             {
                 endColumn: 5,
                 endLineNumber: 1,
@@ -30,14 +36,53 @@ describe('getDiagnostics()', () => {
         ])
     })
 
-    test('search query containing colon', () => {
+    test('search query containing colon, regexp pattern type', () => {
         expect(
-            getDiagnostics((parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token)
+            getDiagnostics(
+                (parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token,
+                SearchPatternType.regexp
+            )
         ).toStrictEqual([
             {
                 endColumn: 28,
                 endLineNumber: 1,
                 message: 'Quoting the query may help if you want a literal match.',
+                severity: 4,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        ])
+    })
+
+    test('search query containing colon, literal pattern type', () => {
+        expect(
+            getDiagnostics(
+                (parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token,
+                SearchPatternType.literal
+            )
+        ).toStrictEqual([])
+    })
+
+    test('search query containing quoted token, regexp pattern type', () => {
+        expect(
+            getDiagnostics(
+                (parseSearchQuery('"Configuration::doStuff(...)"') as ParseSuccess<Sequence>).token,
+                SearchPatternType.regexp
+            )
+        ).toStrictEqual([])
+    })
+
+    test('search query containing quoted token, literal pattern type', () => {
+        expect(
+            getDiagnostics(
+                (parseSearchQuery('"Configuration::doStuff(...)"') as ParseSuccess<Sequence>).token,
+                SearchPatternType.literal
+            )
+        ).toStrictEqual([
+            {
+                endColumn: 30,
+                endLineNumber: 1,
+                message: 'Your search is interpreted literally and contains quotes. Did you mean to search for quotes?',
                 severity: 4,
                 startColumn: 1,
                 startLineNumber: 1,


### PR DESCRIPTION
Closes #7698

Matches the behaviour of the backend by:
- Warning the user that quotes might be useful if the query contains a colon in regexp search.
- Not warning the user if the query contains a colon in literal search.
- Warning the user about literally interpreted queries containing quotes in literal search.
- Not warning the user when using quoted strings in regexp search.

![Kapture 2020-02-03 at 12 44 10](https://user-images.githubusercontent.com/1741180/73650692-0793ac80-4683-11ea-9fef-0aef3140e99e.gif)


