### PR TITLE
Use api.RepoID everywhere where a repository ID is used

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -285,7 +285,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 	}
 
 	if !args.Enabled {
-		_, err := repoupdater.DefaultClient.ExcludeRepo(ctx, uint32(repo.repo.ID))
+		_, err := repoupdater.DefaultClient.ExcludeRepo(ctx, repo.repo.ID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "repo-updater.exclude-repos")
 		}

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -35,7 +35,7 @@ func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct 
 		return nil, err
 	}
 
-	svcs, err := repoupdater.DefaultClient.RepoExternalServices(ctx, uint32(r.repo.ID))
+	svcs, err := repoupdater.DefaultClient.RepoExternalServices(ctx, r.repo.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -47,7 +47,7 @@ func (r *repositoryMirrorInfoResolver) repoUpdateSchedulerInfo(ctx context.Conte
 	r.repoUpdateSchedulerInfoOnce.Do(func() {
 		args := repoupdaterprotocol.RepoUpdateSchedulerInfoArgs{
 			RepoName: r.repository.repo.Name,
-			ID:       uint32(r.repository.repo.ID),
+			ID:       r.repository.repo.ID,
 		}
 		r.repoUpdateSchedulerInfoResult, r.repoUpdateSchedulerInfoErr = repoupdater.DefaultClient.RepoUpdateSchedulerInfo(ctx, args)
 	})

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -37,7 +37,7 @@ type StoreListReposArgs struct {
 	// Names of repos to list. When zero-valued, this is omitted from the predicate set.
 	Names []string
 	// IDs of repos to list. When zero-valued, this is omitted from the predicate set.
-	IDs []uint32
+	IDs []api.RepoID
 	// Kinds of repos to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
 	// ExternalRepos of repos to list. When zero-valued, this is omitted from the predicate set.
@@ -59,7 +59,7 @@ type StoreListExternalServicesArgs struct {
 	// IDs of external services to list. When zero-valued, this is omitted from the predicate set.
 	IDs []int64
 	// RepoIDs that the listed external services own.
-	RepoIDs []uint32
+	RepoIDs []api.RepoID
 	// Kinds of external services to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
 }
@@ -526,7 +526,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 		_, _, err = scanAll(rows, func(sc scanner) (last, count int64, err error) {
 			var (
 				i  int
-				id uint32
+				id api.RepoID
 			)
 
 			err = sc.Scan(&i, &id)
@@ -554,7 +554,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 
 func batchReposQuery(fmtstr string, repos []*Repo) (_ *sqlf.Query, err error) {
 	type record struct {
-		ID                  uint32          `json:"id"`
+		ID                  api.RepoID      `json:"id"`
 		Name                string          `json:"name"`
 		URI                 *string         `json:"uri,omitempty"`
 		Description         string          `json:"description"`

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -736,7 +736,7 @@ func hasNoID(r *repos.Repo) bool {
 	return r.ID == 0
 }
 
-func hasID(ids ...uint32) func(r *repos.Repo) bool {
+func hasID(ids ...api.RepoID) func(r *repos.Repo) bool {
 	return func(r *repos.Repo) bool {
 		for _, id := range ids {
 			if r.ID == id {
@@ -946,7 +946,7 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		stored: repositories,
 		args: func(stored repos.Repos) repos.StoreListReposArgs {
 			return repos.StoreListReposArgs{
-				IDs: []uint32{stored[0].ID, stored[1].ID},
+				IDs: []api.RepoID{stored[0].ID, stored[1].ID},
 			}
 		},
 		repos: repos.Assert.ReposEqual(repositories[:2].Clone()...),

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -74,9 +74,9 @@ type FakeStore struct {
 	ListAllRepoNamesError       error // error to be returned in ListAllRepoNames
 
 	svcIDSeq  int64
-	repoIDSeq uint32
+	repoIDSeq api.RepoID
 	svcByID   map[int64]*ExternalService
-	repoByID  map[uint32]*Repo
+	repoByID  map[api.RepoID]*Repo
 	parent    *FakeStore
 }
 
@@ -91,7 +91,7 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 		svcByID[id] = svc.Clone()
 	}
 
-	repoByID := make(map[uint32]*Repo, len(s.repoByID))
+	repoByID := make(map[api.RepoID]*Repo, len(s.repoByID))
 	for _, r := range s.repoByID {
 		clone := r.Clone()
 		repoByID[r.ID] = clone
@@ -224,7 +224,7 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		names[strings.ToLower(name)] = true
 	}
 
-	ids := make(map[uint32]bool, len(args.IDs))
+	ids := make(map[api.RepoID]bool, len(args.IDs))
 	for _, id := range args.IDs {
 		ids[id] = true
 	}
@@ -319,7 +319,7 @@ func (s *FakeStore) UpsertRepos(ctx context.Context, upserts ...*Repo) error {
 	}
 
 	if s.repoByID == nil {
-		s.repoByID = make(map[uint32]*Repo, len(upserts))
+		s.repoByID = make(map[api.RepoID]*Repo, len(upserts))
 	}
 
 	var updates, inserts []*Repo
@@ -461,7 +461,7 @@ var Opt = struct {
 	ExternalServiceID         func(int64) func(*ExternalService)
 	ExternalServiceModifiedAt func(time.Time) func(*ExternalService)
 	ExternalServiceDeletedAt  func(time.Time) func(*ExternalService)
-	RepoID                    func(uint32) func(*Repo)
+	RepoID                    func(api.RepoID) func(*Repo)
 	RepoName                  func(string) func(*Repo)
 	RepoCreatedAt             func(time.Time) func(*Repo)
 	RepoModifiedAt            func(time.Time) func(*Repo)
@@ -487,7 +487,7 @@ var Opt = struct {
 			e.DeletedAt = ts
 		}
 	},
-	RepoID: func(n uint32) func(*Repo) {
+	RepoID: func(n api.RepoID) func(*Repo) {
 		return func(r *Repo) {
 			r.ID = n
 		}

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -531,7 +531,7 @@ func (e *ExternalService) With(opts ...func(*ExternalService)) *ExternalService 
 // Repo represents a source code repository stored in Sourcegraph.
 type Repo struct {
 	// The internal Sourcegraph repo ID.
-	ID uint32
+	ID api.RepoID
 	// Name is the name for this repository (e.g., "github.com/user/repo"). It
 	// is the same as URI, unless the user configures a non-default
 	// repositoryPathPattern.
@@ -757,8 +757,8 @@ func pick(a *Repo, b *Repo) (keep, discard *Repo) {
 type Repos []*Repo
 
 // IDs returns the list of ids from all Repos.
-func (rs Repos) IDs() []uint32 {
-	ids := make([]uint32, len(rs))
+func (rs Repos) IDs() []api.RepoID {
+	ids := make([]api.RepoID, len(rs))
 	for i := range rs {
 		ids[i] = rs[i].ID
 	}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -37,8 +37,8 @@ type Server struct {
 		GetRepo(ctx context.Context, projectWithNamespace string) (*repos.Repo, error)
 	}
 	Scheduler interface {
-		UpdateOnce(id uint32, name api.RepoName, url string)
-		ScheduleInfo(id uint32) *protocol.RepoUpdateSchedulerInfoResult
+		UpdateOnce(id api.RepoID, name api.RepoName, url string)
+		ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedulerInfoResult
 	}
 	GitserverClient interface {
 		ListCloned(context.Context) ([]string, error)
@@ -71,7 +71,7 @@ func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Reque
 	}
 
 	rs, err := s.Store.ListRepos(r.Context(), repos.StoreListReposArgs{
-		IDs: []uint32{req.ID},
+		IDs: []api.RepoID{req.ID},
 	})
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
@@ -114,7 +114,7 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rs, err := s.Store.ListRepos(r.Context(), repos.StoreListReposArgs{
-		IDs: []uint32{req.ID},
+		IDs: []api.RepoID{req.ID},
 	})
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -502,7 +502,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		repoID uint32
+		repoID api.RepoID
 		svcs   []api.ExternalService
 		err    string
 	}{{
@@ -1136,8 +1136,8 @@ func (s *fakeRepoSource) GetRepo(context.Context, string) (*repos.Repo, error) {
 
 type fakeScheduler struct{}
 
-func (s *fakeScheduler) UpdateOnce(_ uint32, _ api.RepoName, _ string) {}
-func (s *fakeScheduler) ScheduleInfo(id uint32) *protocol.RepoUpdateSchedulerInfoResult {
+func (s *fakeScheduler) UpdateOnce(_ api.RepoID, _ api.RepoName, _ string) {}
+func (s *fakeScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedulerInfoResult {
 	return &protocol.RepoUpdateSchedulerInfoResult{}
 }
 

--- a/enterprise/internal/a8n/resolvers/campaign_plans.go
+++ b/enterprise/internal/a8n/resolvers/campaign_plans.go
@@ -86,7 +86,7 @@ type campaignJobsConnectionResolver struct {
 	// cache results because they are used by multiple fields
 	once                         sync.Once
 	jobs                         []*a8n.CampaignJob
-	reposByID                    map[int32]*repos.Repo
+	reposByID                    map[api.RepoID]*repos.Repo
 	changesetJobsByCampaignJobID map[int64]*a8n.ChangesetJob
 	next                         int64
 	err                          error
@@ -124,7 +124,7 @@ func (r *campaignJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlba
 	return resolvers, nil
 }
 
-func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.CampaignJob, map[int32]*repos.Repo, map[int64]*a8n.ChangesetJob, int64, error) {
+func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.CampaignJob, map[api.RepoID]*repos.Repo, map[int64]*a8n.ChangesetJob, int64, error) {
 	r.once.Do(func() {
 		r.jobs, r.next, r.err = r.store.ListCampaignJobs(ctx, r.opts)
 		if r.err != nil {
@@ -132,9 +132,9 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 		}
 
 		reposStore := repos.NewDBStore(r.store.DB(), sql.TxOptions{})
-		repoIDs := make([]uint32, len(r.jobs))
+		repoIDs := make([]api.RepoID, len(r.jobs))
 		for i, j := range r.jobs {
-			repoIDs[i] = uint32(j.RepoID)
+			repoIDs[i] = j.RepoID
 		}
 
 		rs, err := reposStore.ListRepos(ctx, repos.StoreListReposArgs{IDs: repoIDs})
@@ -143,9 +143,9 @@ func (r *campaignJobsConnectionResolver) compute(ctx context.Context) ([]*a8n.Ca
 			return
 		}
 
-		r.reposByID = make(map[int32]*repos.Repo, len(rs))
+		r.reposByID = make(map[api.RepoID]*repos.Repo, len(rs))
 		for _, repo := range rs {
-			r.reposByID[int32(repo.ID)] = repo
+			r.reposByID[repo.ID] = repo
 		}
 
 		cs, _, err := r.store.ListChangesetJobs(ctx, ee.ListChangesetJobsOpts{
@@ -207,7 +207,7 @@ func (r *campaignJobResolver) computeRepoCommit(ctx context.Context) (*graphqlba
 		if r.preloadedRepo != nil {
 			r.repo = newRepositoryResolver(r.preloadedRepo)
 		} else {
-			r.repo, r.err = graphqlbackend.RepositoryByIDInt32(ctx, api.RepoID(r.job.RepoID))
+			r.repo, r.err = graphqlbackend.RepositoryByIDInt32(ctx, r.job.RepoID)
 			if r.err != nil {
 				return
 			}

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -383,8 +383,8 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 		return nil, err
 	}
 
-	var repoIDs []uint32
-	repoSet := map[uint32]*repos.Repo{}
+	var repoIDs []api.RepoID
+	repoSet := map[api.RepoID]*repos.Repo{}
 	cs := make([]*a8n.Changeset, 0, len(args.Input))
 
 	for _, c := range args.Input {
@@ -393,14 +393,13 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 			return nil, err
 		}
 
-		id := uint32(repoID)
-		if _, ok := repoSet[id]; !ok {
-			repoSet[id] = nil
-			repoIDs = append(repoIDs, id)
+		if _, ok := repoSet[repoID]; !ok {
+			repoSet[repoID] = nil
+			repoIDs = append(repoIDs, repoID)
 		}
 
 		cs = append(cs, &a8n.Changeset{
-			RepoID:     int32(id),
+			RepoID:     repoID,
 			ExternalID: c.ExternalID,
 		})
 	}
@@ -439,7 +438,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	}
 
 	for _, c := range cs {
-		c.ExternalServiceType = repoSet[uint32(c.RepoID)].ExternalRepo.ServiceType
+		c.ExternalServiceType = repoSet[c.RepoID].ExternalRepo.ServiceType
 	}
 
 	err = tx.CreateChangesets(ctx, cs...)
@@ -464,7 +463,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 		csr[i] = &changesetResolver{
 			store:         r.store,
 			Changeset:     cs[i],
-			preloadedRepo: repoSet[uint32(cs[i].RepoID)],
+			preloadedRepo: repoSet[cs[i].RepoID],
 		}
 	}
 

--- a/enterprise/internal/a8n/resolvers/resolver_test.go
+++ b/enterprise/internal/a8n/resolvers/resolver_test.go
@@ -777,13 +777,13 @@ func TestChangesetCountsOverTime(t *testing.T) {
 
 	changesets := []*a8n.Changeset{
 		{
-			RepoID:              int32(githubRepo.ID),
+			RepoID:              githubRepo.ID,
 			ExternalID:          "5834",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 			CampaignIDs:         []int64{campaign.ID},
 		},
 		{
-			RepoID:              int32(githubRepo.ID),
+			RepoID:              githubRepo.ID,
 			ExternalID:          "5849",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 			CampaignIDs:         []int64{campaign.ID},
@@ -1198,7 +1198,7 @@ func TestCampaignPlanResolver(t *testing.T) {
 			CampaignPlanID: plan.ID,
 			StartedAt:      now,
 			FinishedAt:     now,
-			RepoID:         int32(repo.ID),
+			RepoID:         repo.ID,
 			Rev:            testingRev,
 			BaseRef:        "master",
 			Diff:           testDiff,

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -97,7 +97,7 @@ func TestService(t *testing.T) {
 		for i, patch := range patches {
 			wantJobs[i] = &a8n.CampaignJob{
 				CampaignPlanID: plan.ID,
-				RepoID:         int32(patch.Repo),
+				RepoID:         patch.Repo,
 				BaseRef:        patch.BaseRevision,
 				Rev:            commit,
 				Diff:           patch.Patch,
@@ -366,7 +366,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reposByID := make(map[uint32]*repos.Repo, len(rs))
+	reposByID := make(map[api.RepoID]*repos.Repo, len(rs))
 	reposByName := make(map[string]*repos.Repo, len(rs))
 	for _, r := range rs {
 		reposByID[r.ID] = r
@@ -570,7 +570,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 						t.Errorf("unrecognized repo name: %s", name)
 					}
 					for _, j := range oldCampaignJobs {
-						if j.RepoID == int32(repo.ID) {
+						if j.RepoID == repo.ID {
 							toPublish[j.ID] = j
 
 							err = svc.CreateChangesetJobForCampaignJob(ctx, j.ID)
@@ -686,7 +686,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 				if !ok {
 					t.Fatalf("ChangesetJob has invalid CampaignJobID: %+v", c)
 				}
-				r, ok := reposByID[uint32(campaignJob.RepoID)]
+				r, ok := reposByID[campaignJob.RepoID]
 				if !ok {
 					t.Fatalf("ChangesetJob has invalid RepoID: %v", c)
 				}
@@ -762,7 +762,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 				}
 
 				for _, c := range oldChangesets {
-					if c.RepoID == int32(r.ID) {
+					if c.RepoID == r.ID {
 						wantIDs = append(wantIDs, c.ID)
 					}
 				}
@@ -884,10 +884,10 @@ func createTestUser(ctx context.Context, t *testing.T) *types.User {
 	return user
 }
 
-func testCampaignJob(plan int64, repo uint32, t time.Time) *a8n.CampaignJob {
+func testCampaignJob(plan int64, repo api.RepoID, t time.Time) *a8n.CampaignJob {
 	return &a8n.CampaignJob{
 		CampaignPlanID: plan,
-		RepoID:         int32(repo),
+		RepoID:         api.RepoID(repo),
 		Rev:            "deadbeef",
 		BaseRef:        "refs/heads/master",
 		Diff:           "cool diff",
@@ -906,7 +906,7 @@ func testCampaign(user int32, plan int64) *a8n.Campaign {
 	}
 }
 
-func testChangeset(repoID int32, campaign int64, changesetJob int64) *a8n.Changeset {
+func testChangeset(repoID api.RepoID, campaign int64, changesetJob int64) *a8n.Changeset {
 	return &a8n.Changeset{
 		RepoID:              repoID,
 		CampaignIDs:         []int64{campaign},

--- a/enterprise/internal/a8n/store.go
+++ b/enterprise/internal/a8n/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/segmentio/fasthash/fnv1"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -386,7 +387,7 @@ func (s *Store) createChangesetsQuery(cs []*a8n.Changeset) (*sqlf.Query, error) 
 func batchChangesetsQuery(fmtstr string, cs []*a8n.Changeset) (*sqlf.Query, error) {
 	type record struct {
 		ID                  int64           `json:"id"`
-		RepoID              int32           `json:"repo_id"`
+		RepoID              api.RepoID      `json:"repo_id"`
 		CreatedAt           time.Time       `json:"created_at"`
 		UpdatedAt           time.Time       `json:"updated_at"`
 		Metadata            json.RawMessage `json:"metadata"`

--- a/enterprise/internal/a8n/store_test.go
+++ b/enterprise/internal/a8n/store_test.go
@@ -1713,7 +1713,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 				for i, j := range tc.jobs {
 					j.CampaignPlanID = plan.ID
-					j.RepoID = int32(i)
+					j.RepoID = api.RepoID(i)
 					j.Rev = api.CommitID(fmt.Sprintf("deadbeef-%d", i))
 					j.BaseRef = "master"
 
@@ -1813,7 +1813,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 				for i, j := range tc.jobs {
 					j.StartedAt = now.Add(-2 * time.Hour)
 					j.CampaignPlanID = plan.ID
-					j.RepoID = int32(i)
+					j.RepoID = api.RepoID(i)
 					j.Rev = api.CommitID(fmt.Sprintf("deadbeef-%d", i))
 					j.BaseRef = "master"
 
@@ -2404,7 +2404,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 				campaignJob := &a8n.CampaignJob{
 					CampaignPlanID: plan.ID,
 					BaseRef:        "x",
-					RepoID:         int32(123),
+					RepoID:         api.RepoID(123),
 				}
 				err = s.CreateCampaignJob(ctx, campaignJob)
 				if err != nil {
@@ -2457,7 +2457,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 				campaignJob = &a8n.CampaignJob{
 					CampaignPlanID: plan.ID,
 					BaseRef:        "x",
-					RepoID:         int32(123),
+					RepoID:         api.RepoID(123),
 				}
 				err = s.CreateCampaignJob(ctx, campaignJob)
 				if err != nil {
@@ -2560,7 +2560,7 @@ func testProcessCampaignJob(db *sql.DB) func(*testing.T) {
 			job := &a8n.CampaignJob{
 				ID:             0,
 				CampaignPlanID: plan.ID,
-				RepoID:         int32(repo.ID),
+				RepoID:         repo.ID,
 				Rev:            "",
 				BaseRef:        "abc",
 				Diff:           "",
@@ -2601,7 +2601,7 @@ func testProcessCampaignJob(db *sql.DB) func(*testing.T) {
 			err = s.CreateCampaignJob(context.Background(), &a8n.CampaignJob{
 				ID:             0,
 				CampaignPlanID: plan.ID,
-				RepoID:         int32(repo.ID),
+				RepoID:         repo.ID,
 				Rev:            "",
 				BaseRef:        "abc",
 				Diff:           "",

--- a/enterprise/internal/a8n/webhooks_test.go
+++ b/enterprise/internal/a8n/webhooks_test.go
@@ -104,7 +104,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 
 		changesets := []*a8n.Changeset{
 			{
-				RepoID:              int32(githubRepo.ID),
+				RepoID:              githubRepo.ID,
 				ExternalID:          "16",
 				ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 				CampaignIDs:         []int64{campaign.ID},

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -61,7 +61,7 @@ type CampaignJob struct {
 	ID             int64
 	CampaignPlanID int64
 
-	RepoID  int32
+	RepoID  api.RepoID
 	Rev     api.CommitID
 	BaseRef string
 
@@ -244,7 +244,7 @@ func (c *ChangesetJob) SuccessfullyCompleted() bool {
 // Campaigns.
 type Changeset struct {
 	ID                  int64
-	RepoID              int32
+	RepoID              api.RepoID
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 	Metadata            interface{}

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -212,7 +212,7 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 
 // RepoExternalServices requests the external services associated with a
 // repository with the given id.
-func (c *Client) RepoExternalServices(ctx context.Context, id uint32) ([]api.ExternalService, error) {
+func (c *Client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api.ExternalService, error) {
 	req := protocol.RepoExternalServicesRequest{ID: id}
 	resp, err := c.httpPost(ctx, "repo-external-services", &req)
 	if err != nil {
@@ -237,7 +237,7 @@ func (c *Client) RepoExternalServices(ctx context.Context, id uint32) ([]api.Ext
 
 // ExcludeRepo adds the repository with the given id to all of the
 // external services exclude lists that match its kind.
-func (c *Client) ExcludeRepo(ctx context.Context, id uint32) (*protocol.ExcludeRepoResponse, error) {
+func (c *Client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.ExcludeRepoResponse, error) {
 	if id == 0 {
 		return &protocol.ExcludeRepoResponse{}, nil
 	}

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -13,7 +13,7 @@ type RepoUpdateSchedulerInfoArgs struct {
 	// XXX(tsenart): Depreacted. Remove after lookup by ID is rolled out.
 	RepoName api.RepoName
 	// The ID of the repo to lookup the schedule for.
-	ID uint32
+	ID api.RepoID
 }
 
 type RepoUpdateSchedulerInfoResult struct {
@@ -38,7 +38,7 @@ type RepoQueueState struct {
 // associated with a repository.
 type RepoExternalServicesRequest struct {
 	// ID of the repository being queried.
-	ID uint32
+	ID api.RepoID
 }
 
 // RepoExternalServicesResponse is returned in response to an
@@ -51,7 +51,7 @@ type RepoExternalServicesResponse struct {
 // being mirrored from any external service of its kind.
 type ExcludeRepoRequest struct {
 	// ID of the repository to be excluded.
-	ID uint32
+	ID api.RepoID
 }
 
 // ExcludeRepoResponse is returned in response to an ExcludeRepoRequest.
@@ -152,7 +152,7 @@ func (a *RepoUpdateRequest) String() string {
 // RepoUpdateResponse is a response type to a RepoUpdateRequest.
 type RepoUpdateResponse struct {
 	// ID of the repo that got an update request.
-	ID uint32 `json:"id"`
+	ID api.RepoID `json:"id"`
 	// Name of the repo that got an update request.
 	Name string `json:"name"`
 	// URL of the repo that got an update request.


### PR DESCRIPTION
Before this change we had three different types all pointing to the same thing:

- api.RepoID
- uint32
- int32

One was more prominent in graphqlbackend, the other in repo-updater and the last one in the a8n packages.

Since `api.RepoID` is an int32 and since it's a database ID and thus technically unsigned they could all be used interchangeably.

But: there were a ton of conversions between the types and it made writing code cumbersome ("cannot use type int32 where uint32 is expected", etc.)

So this PR is my proposal as the **first step** to fix this.

Why the first step? I'd also accept int32 or uint32, but I want a single type to be used consistently. Moving to api.RepoID first makes it easy to search/replace afterwards.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
