### PR TITLE
Fix: navbar doesn't update when searching from tree page in interactive mode

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1556,7 +1556,7 @@ describe('e2e test suite', () => {
         })
     })
 
-    describe.only('Interactive search mode (feature flagged)', () => {
+    describe('Interactive search mode (feature flagged)', () => {
         let previousExperimentalFeatures: any
 
         before(async () => {

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1556,7 +1556,7 @@ describe('e2e test suite', () => {
         })
     })
 
-    describe('Interactive search mode (feature flagged)', () => {
+    describe.only('Interactive search mode (feature flagged)', () => {
         let previousExperimentalFeatures: any
 
         before(async () => {
@@ -1680,6 +1680,31 @@ describe('e2e test suite', () => {
             await driver.page.keyboard.type('/mux')
             await driver.page.click('.e2e-search-button')
             await driver.assertWindowLocation('/search?q=repo:%5Egithub%5C.com/gorilla/mux%24&patternType=literal')
+        })
+
+        test('Interactive search mode updates query when on searching from directory page', async () => {
+            await driver.page.goto(sourcegraphBaseUrl + '/github.com/sourcegraph/jsonrpc2')
+            await driver.page.waitForSelector('.tree-page__section-search .e2e-query-input')
+            await driver.page.click('.tree-page__section-search .e2e-query-input')
+            await driver.page.type('.tree-page__section-search .e2e-query-input', 'test')
+            await driver.page.click('.tree-page__section-search .e2e-search-button')
+            await driver.assertWindowLocation(
+                '/search?q=repo:%5Egithub%5C.com/sourcegraph/jsonrpc2%24+test&patternType=literal'
+            )
+            await driver.page.waitForSelector('.e2e-query-input')
+            const queryInputValue = () =>
+                driver.page.evaluate(() => {
+                    const input = document.querySelector<HTMLInputElement>('.e2e-query-input')
+                    return input ? input.value : null
+                })
+            assert.strictEqual(await queryInputValue(), 'test')
+            await driver.page.waitForSelector('.filter-input')
+            const filterInputValue = () =>
+                driver.page.evaluate(() => {
+                    const filterInput = document.querySelector<HTMLButtonElement>('.filter-input__button-text')
+                    return filterInput ? filterInput.textContent : null
+                })
+            assert.strictEqual(await filterInputValue(), 'repo:^github\\.com/sourcegraph/jsonrpc2$')
         })
 
         test('Interactive search mode filter dropdown and finite-option filter inputs', async () => {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -26,6 +26,7 @@ import { InteractiveModeInput } from '../search/input/interactive/InteractiveMod
 import { FiltersToTypeAndValue } from '../../../shared/src/search/interactive/util'
 import { SearchModeToggle } from '../search/input/interactive/SearchModeToggle'
 import { Link } from '../../../shared/src/components/Link'
+import { convertPlainTextToInteractiveQuery } from '../search/input/helpers'
 
 interface Props
     extends SettingsCascadeProps,
@@ -105,8 +106,18 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
     public componentDidUpdate(prevProps: Props): void {
         if (prevProps.location.search !== this.props.location.search) {
             const query = parseSearchURLQuery(this.props.location.search || '')
-            if (query && !this.props.interactiveSearchMode) {
-                this.props.onNavbarQueryChange({ query, cursorPosition: query.length })
+            if (query) {
+                if (this.props.interactiveSearchMode) {
+                    let filtersInQuery: FiltersToTypeAndValue = {}
+                    const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
+                    filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
+                    this.props.onNavbarQueryChange({ query: navbarQuery, cursorPosition: navbarQuery.length })
+
+                    this.props.onFiltersInQueryChange(filtersInQuery)
+                } else {
+                    this.props.onNavbarQueryChange({ query, cursorPosition: query.length })
+                }
+
             }
         }
     }

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -117,7 +117,6 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 } else {
                     this.props.onNavbarQueryChange({ query, cursorPosition: query.length })
                 }
-
             }
         }
     }


### PR DESCRIPTION
Fixes a new issue where doing a search from the directory/repo tree page would not correctly update the query input in interactive mode. 

Added e2e tests to ensure the correct behavior.