### PR TITLE
Set 3.10.2 as minimum version of src-cli

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.10.0"
+const MinimumVersion = "3.10.2"


### PR DESCRIPTION
3.10.0 does not include the now advertised src actions command



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
