### PR TITLE
comment: pkg/redispool -> internal/redispool

### DIFF
--- a/cmd/server/shared/redis.go
+++ b/cmd/server/shared/redis.go
@@ -45,7 +45,7 @@ func maybeRedisCacheProcFile() (string, error) {
 }
 
 func maybeRedisProcFile(c redisProcfileConfig) (string, error) {
-	// Redis is already configured. See envvars used in pkg/redispool.
+	// Redis is already configured. See envvars used in internal/redispool.
 	if os.Getenv("REDIS_ENDPOINT") != "" {
 		return "", nil
 	}


### PR DESCRIPTION
The `pkg` folder was renamed to `internal` a while ago. 