### PR TITLE
search: quote values for lang chips containing spaces

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -261,7 +261,7 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 			language := extensionToLanguageLookup(fileMatchPath)
 			if language != "" {
 				if strings.Contains(language, " ") {
-					language = fmt.Sprintf(`"%s"`, language)
+					language = strconv.Quote(language)
 				}
 				value := fmt.Sprintf(`lang:%s`, language)
 				add(value, value, lineMatchCount, limitHit, "lang")

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -260,6 +260,9 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 		if ext := path.Ext(fileMatchPath); ext != "" {
 			language := extensionToLanguageLookup(fileMatchPath)
 			if language != "" {
+				if strings.Contains(language, " ") {
+					language = fmt.Sprintf(`"%s"`, language)
+				}
 				value := fmt.Sprintf(`lang:%s`, language)
 				add(value, value, lineMatchCount, limitHit, "lang")
 			}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -563,6 +563,11 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		Repo:  repo,
 	}
 
+	ignoreListFileMatch := &FileMatchResolver{
+		JPath: "/.gitignore",
+		Repo:  repo,
+	}
+
 	rev := "develop"
 	fileMatchRev := &FileMatchResolver{
 		JPath:    "/testFile.md",
@@ -625,6 +630,14 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 			descr:                     "no results",
 			searchResults:             []SearchResultResolver{},
 			expectedDynamicFilterStrs: map[string]struct{}{},
+		},
+		{
+			descr:         "values containing spaces are quoted",
+			searchResults: []SearchResultResolver{ignoreListFileMatch},
+			expectedDynamicFilterStrs: map[string]struct{}{
+				`repo:^testRepo$`:    {},
+				`lang:"ignore list"`: {},
+			},
 		},
 	}
 


### PR DESCRIPTION
Addresses #6498. The chips are rendered based on dynamicFilter values that we set in the backend. This change quotes values for `lang` if the value contains spaces. 

![fix-chip2](https://user-images.githubusercontent.com/888624/73803707-d39db180-477e-11ea-9f95-ebd7d7c6f0c7.gif)
