### PR TITLE
Remove code intel fields from pings until we update the bigquery schema.

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -244,7 +244,6 @@ type pingPayload struct {
 	HasUpdate            string           `json:"has_update"`
 	UniqueUsersToday     string           `json:"unique_users_today"`
 	SiteActivity         *json.RawMessage `json:"site_activity"`
-	CodeIntelUsage       *json.RawMessage `json:"code_intel_usage"`
 	InstallerEmail       string           `json:"installer_email"`
 	AuthProviders        string           `json:"auth_providers"`
 	ExtServices          string           `json:"ext_services"`
@@ -274,7 +273,6 @@ func logPing(r *http.Request, pr *pingRequest, hasUpdate bool) {
 		HasUpdate:            strconv.FormatBool(hasUpdate),
 		UniqueUsersToday:     strconv.FormatInt(int64(pr.UniqueUsers), 10),
 		SiteActivity:         pr.Activity,
-		CodeIntelUsage:       pr.CodeIntelUsage,
 		InstallerEmail:       pr.InitialAdminEmail,
 		AuthProviders:        strings.Join(pr.AuthProviders, ","),
 		ExtServices:          strings.Join(pr.ExternalServices, ","),


### PR DESCRIPTION
Reverts the changes to Pub/Sub payload until we can change the BigQuery schema to support the new data.

Fields originally added in https://github.com/sourcegraph/sourcegraph/pull/7942. See [this slack thread](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1580857256072300) for context on missing data.

This is definitely it: https://console.cloud.google.com/errors/CMGR3IHZ3a2MTg?time=PT1H&project=telligentsourcegraph&authuser=1&folder&organizationId
