### PR TITLE
site_alert: only show HTTP warning in non-dev deployment

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -64,11 +64,7 @@ func init() {
 	conf.ContributeWarning(func(c conf.Unified) (problems conf.Problems) {
 		if c.ExternalURL == "" {
 			problems = append(problems, conf.NewSiteProblem("`externalURL` is required to be set for many features of Sourcegraph to work correctly."))
-		}
-		return problems
-	})
-	conf.ContributeWarning(func(c conf.Unified) (problems conf.Problems) {
-		if globals.ExternalURL().Scheme == "http" {
+		} else if conf.DeployType() != conf.DeployDev && strings.HasPrefix(c.ExternalURL, "http://") {
 			problems = append(problems, conf.NewSiteProblem("Your connection is not private. We recommend [configuring Sourcegraph to use HTTPS/SSL](https://docs.sourcegraph.com/admin/nginx)"))
 		}
 		return problems


### PR DESCRIPTION
A followup PR of https://github.com/sourcegraph/sourcegraph/pull/8234, which disables warning in dev setup.