### PR TITLE
Fix Phabricator convertToDetails()

### DIFF
--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -362,10 +362,10 @@ async function convertConduitRepoToRepoDetails(repo: ConduitRepo): Promise<Phabr
 function convertToDetails(repo: ConduitRepo): PhabricatorRepoDetails | null {
     const enabledURIs = repo.attachments.uris.uris
         // Filter out disabled URIs
-        .filter(({fields}) => !fields.uri.disabled)
+        .filter(({ fields }) => !fields.uri.disabled)
         .map(({ fields }) => ({
             isExternalURI: !fields.uri.normalized.replace('\\', '').startsWith(window.location.host + '/'),
-            rawURI: fields.uri.raw
+            rawURI: fields.uri.raw,
         }))
     if (enabledURIs.length === 0) {
         return null

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -371,7 +371,7 @@ function convertToDetails(repo: ConduitRepo): PhabricatorRepoDetails | null {
         return null
     }
     // Use the external URI if there is one, otherwise use the first enabled URI.
-    const { rawURI } = enabledURIs.find(({ isExternalURI }) => isExternalURI) || enabledURIs[0]
+    const { rawURI } = enabledURIs.find(({ isExternalURI }) => isExternalURI) ?? enabledURIs[0]
     const rawRepoName = normalizeRepoName(rawURI)
     return { callsign: repo.fields.callsign, rawRepoName }
 }

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -27,6 +27,7 @@ interface ConduitURI extends PhabEntity {
             display: string // e.g. https://secure.phabricator.com/source/phabricator.git",
             effective: string // e.g. https://secure.phabricator.com/source/phabricator.git",
             normalized: string // e.g. secure.phabricator.com/source/phabricator",
+            disabled: boolean
         }
     }
 }
@@ -359,19 +360,18 @@ async function convertConduitRepoToRepoDetails(repo: ConduitRepo): Promise<Phabr
 }
 
 function convertToDetails(repo: ConduitRepo): PhabricatorRepoDetails | null {
-    let uri: ConduitURI | undefined
-    for (const u of repo.attachments.uris.uris) {
-        const normalPath = u.fields.uri.normalized.replace('\\', '')
-        if (normalPath.startsWith(window.location.host + '/')) {
-            continue
-        }
-        uri = u
-        break
-    }
-    if (!uri) {
+    const enabledURIs = repo.attachments.uris.uris
+        // Filter out disabled URIs
+        .filter(({fields}) => !fields.uri.disabled)
+        .map(({ fields }) => ({
+            isExternalURI: !fields.uri.normalized.replace('\\', '').startsWith(window.location.host + '/'),
+            rawURI: fields.uri.raw
+        }))
+    if (!enabledURIs.length) {
         return null
     }
-    const rawURI = uri.fields.uri.raw
+    // Use the external URI if there is one, otherwise use the first enabled URI.
+    const { rawURI } = enabledURIs.find(({ isExternalURI }) => isExternalURI) || enabledURIs[0]
     const rawRepoName = normalizeRepoName(rawURI)
     return { callsign: repo.fields.callsign, rawRepoName }
 }

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -367,7 +367,7 @@ function convertToDetails(repo: ConduitRepo): PhabricatorRepoDetails | null {
             isExternalURI: !fields.uri.normalized.replace('\\', '').startsWith(window.location.host + '/'),
             rawURI: fields.uri.raw
         }))
-    if (!enabledURIs.length) {
+    if (enabledURIs.length === 0) {
         return null
     }
     // Use the external URI if there is one, otherwise use the first enabled URI.

--- a/browser/src/libs/phabricator/file_info.test.ts
+++ b/browser/src/libs/phabricator/file_info.test.ts
@@ -179,7 +179,7 @@ describe('Phabricator file info', () => {
     })
 
     describe('resolveDiffusionFileInfo()', () => {
-        test('Diffusion - single file code view', async () => {
+        test('Resolves file info for a Diffusion code view', async () => {
             expect(
                 await resolveFileInfoFromFixture(
                     {
@@ -196,7 +196,7 @@ describe('Phabricator file info', () => {
             })
         })
 
-        test('Diffusion - single file code view - ignores disabled URIs', async () => {
+        test('Ignores disabled URIs', async () => {
             expect(
                 await resolveFileInfoFromFixture(
                     {
@@ -249,7 +249,7 @@ describe('Phabricator file info', () => {
             })
         })
 
-        test('Diffusion - single file code view - hosted on phabricator instance', async () => {
+        test('Repository hosted on phabricator instance', async () => {
             expect(
                 await resolveFileInfoFromFixture(
                     {


### PR DESCRIPTION
Fixes #8275

convertToDetails() had two issues:
- It failed to account for the fact that some repositories are hosted on the Phabricator instance, _not_ remotely.
- It didn't ignore disabled URIs.