### PR TITLE
http: set samesite cookie attribute to value none

### DIFF
--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -26,6 +26,7 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 			csrf.CookieName("sg_csrf_token"),
 			csrf.Path("/"),
 			csrf.Secure(secure),
+			csrf.SameSite(csrf.SameSiteStrictMode),
 		)(next)}
 	}
 

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -26,7 +26,8 @@ func CSRFMiddleware(next http.Handler, isSecure func() bool) http.Handler {
 			csrf.CookieName("sg_csrf_token"),
 			csrf.Path("/"),
 			csrf.Secure(secure),
-			csrf.SameSite(csrf.SameSiteStrictMode),
+			// see https://github.com/sourcegraph/sourcegraph/issues/6167
+			csrf.SameSite(csrf.SameSiteNoneMode),
 		)(next)}
 	}
 

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -103,7 +103,8 @@ func NewRedisStore(secureCookie func() bool) sessions.Store {
 	rstore.Options.Path = "/"
 	rstore.Options.Secure = secureCookie()
 	rstore.Options.HttpOnly = true
-	rstore.Options.SameSite = http.SameSiteStrictMode
+	// see issue https://github.com/sourcegraph/sourcegraph/issues/6167
+	rstore.Options.SameSite = http.SameSiteNoneMode
 
 	return &sessionsStore{
 		Store:  rstore,

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -103,6 +103,7 @@ func NewRedisStore(secureCookie func() bool) sessions.Store {
 	rstore.Options.Path = "/"
 	rstore.Options.Secure = secureCookie()
 	rstore.Options.HttpOnly = true
+	rstore.Options.SameSite = http.SameSiteStrictMode
 
 	return &sessionsStore{
 		Store:  rstore,


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/6167

When a local instance installs an extension it talks to a remote registry (for example sourcegraph.com).  With the change in browser behavior regarding the SameSite cookie attribute (nicely described here: https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/) the session cookies from sourcegraph.com won't be sent to sourcegraph.com by the browser during the extension installation flow on the local instance. This is ok, the extension still installs (it gets the bundle). The only downside is the message in the console (as far as I can tell).

This PR sets the attribute value explicitly instead of relying on default value and behavior.  The assumption is that having explicit value will get rid of the message in the console. I haven't been able to confirm that yet, still setting up my test.

We could go with value Strict or Lax (see https://web.dev/samesite-cookies-explained/). Lax is the new default when attribute is not explicitly set (it used to be None before Chrome 80).