### PR TITLE
auth: dynamic request scopes for GitHub OAuth provider

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config_test.go
@@ -1,7 +1,6 @@
 package githuboauth
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -42,6 +41,7 @@ func Test_parseConfig(t *testing.T) {
 						DisplayName:  "GitHub",
 						Type:         "github",
 						Url:          "https://github.com",
+						AllowOrgs:    []string{"myorg"},
 					},
 				}},
 			}}},
@@ -53,6 +53,7 @@ func Test_parseConfig(t *testing.T) {
 						DisplayName:  "GitHub",
 						Type:         "github",
 						Url:          "https://github.com",
+						AllowOrgs:    []string{"myorg"},
 					},
 					Provider: provider("https://github.com/", oauth2.Config{
 						ClientID:     "my-client-id",
@@ -61,7 +62,7 @@ func Test_parseConfig(t *testing.T) {
 							AuthURL:  "https://github.com/login/oauth/authorize",
 							TokenURL: "https://github.com/login/oauth/access_token",
 						},
-						Scopes: []string{"repo", "user:email", "read:org"},
+						Scopes: []string{"user:email", "repo", "read:org"},
 					}),
 				},
 			},
@@ -76,6 +77,7 @@ func Test_parseConfig(t *testing.T) {
 						DisplayName:  "GitHub",
 						Type:         "github",
 						Url:          "https://github.com",
+						AllowOrgs:    []string{"myorg"},
 					},
 				}, {
 					Github: &schema.GitHubAuthProvider{
@@ -95,6 +97,7 @@ func Test_parseConfig(t *testing.T) {
 						DisplayName:  "GitHub",
 						Type:         "github",
 						Url:          "https://github.com",
+						AllowOrgs:    []string{"myorg"},
 					},
 					Provider: provider("https://github.com/", oauth2.Config{
 						ClientID:     "my-client-id",
@@ -103,7 +106,7 @@ func Test_parseConfig(t *testing.T) {
 							AuthURL:  "https://github.com/login/oauth/authorize",
 							TokenURL: "https://github.com/login/oauth/access_token",
 						},
-						Scopes: []string{"repo", "user:email", "read:org"},
+						Scopes: []string{"user:email", "repo", "read:org"},
 					}),
 				},
 				{
@@ -121,7 +124,7 @@ func Test_parseConfig(t *testing.T) {
 							AuthURL:  "https://mycompany.com/login/oauth/authorize",
 							TokenURL: "https://mycompany.com/login/oauth/access_token",
 						},
-						Scopes: []string{"repo", "user:email", "read:org"},
+						Scopes: []string{"user:email", "repo"},
 					}),
 				},
 			},
@@ -141,11 +144,11 @@ func Test_parseConfig(t *testing.T) {
 					q.SourceConfig = schema.AuthProviders{Github: p.GitHubAuthProvider}
 				}
 			}
-			if !reflect.DeepEqual(gotProviders, tt.wantProviders) {
-				t.Error(cmp.Diff(gotProviders, tt.wantProviders))
+			if diff := cmp.Diff(tt.wantProviders, gotProviders); diff != "" {
+				t.Errorf("providers: %s", diff)
 			}
-			if !reflect.DeepEqual(gotProblems.Messages(), tt.wantProblems) {
-				t.Errorf("parseConfig() gotProblems = %v, want %v", gotProblems, tt.wantProblems)
+			if diff := cmp.Diff(tt.wantProblems, gotProblems.Messages()); diff != "" {
+				t.Errorf("problems: %s", diff)
 			}
 		})
 	}

--- a/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
@@ -117,7 +117,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitHubCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "repo user:email read:org"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "user:email repo read:org"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -150,7 +150,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGHE.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "repo user:email read:org"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "user:email repo read:org"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -183,7 +183,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitHubCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "repo user:email read:org"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "user:email repo read:org"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -280,6 +280,7 @@ func newMockProvider(t *testing.T, clientID, clientSecret, baseURL string) *Mock
 		Url:          baseURL,
 		ClientSecret: clientSecret,
 		ClientID:     clientID,
+		AllowOrgs:    []string{"myorg"},
 	}}
 	mp.Provider, problems = parseProvider(cfg.Github, cfg)
 	if len(problems) > 0 {

--- a/enterprise/cmd/frontend/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider.go
@@ -29,7 +29,7 @@ func parseProvider(p *schema.GitHubAuthProvider, sourceCfg schema.AuthProviders)
 	oauth2Cfg := oauth2.Config{
 		ClientID:     p.ClientID,
 		ClientSecret: p.ClientSecret,
-		Scopes:       requestedScopes(),
+		Scopes:       requestedScopes(p),
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  codeHost.BaseURL.ResolveReference(&url.URL{Path: "/login/oauth/authorize"}).String(),
 			TokenURL: codeHost.BaseURL.ResolveReference(&url.URL{Path: "/login/oauth/access_token"}).String(),
@@ -56,15 +56,15 @@ func parseProvider(p *schema.GitHubAuthProvider, sourceCfg schema.AuthProviders)
 	}), nil
 }
 
-func requestedScopes() []string {
-	scopes := []string{
-		"repo",
-		"user:email",
-		"read:org",
+func requestedScopes(p *schema.GitHubAuthProvider) []string {
+	scopes := []string{"user:email"}
+	if !envvar.SourcegraphDotComMode() {
+		scopes = append(scopes, "repo")
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		return scopes[1:]
+	// Needs extra scope to check organization membership
+	if len(p.AllowOrgs) > 0 {
+		scopes = append(scopes, "read:org")
 	}
 
 	return scopes

--- a/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
@@ -1,0 +1,60 @@
+package githuboauth
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func Test_requestedScopes(t *testing.T) {
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	tests := []struct {
+		dotComMode bool
+		schema     *schema.GitHubAuthProvider
+		expScopes  []string
+	}{
+		{
+			dotComMode: false,
+			schema: &schema.GitHubAuthProvider{
+				AllowOrgs: nil,
+			},
+			expScopes: []string{"repo", "user:email"},
+		},
+		{
+			dotComMode: false,
+			schema: &schema.GitHubAuthProvider{
+				AllowOrgs: []string{"myorg"},
+			},
+			expScopes: []string{"read:org", "repo", "user:email"},
+		},
+
+		{
+			dotComMode: true,
+			schema: &schema.GitHubAuthProvider{
+				AllowOrgs: nil,
+			},
+			expScopes: []string{"user:email"},
+		},
+		{
+			dotComMode: true,
+			schema: &schema.GitHubAuthProvider{
+				AllowOrgs: []string{"myorg"},
+			},
+			expScopes: []string{"read:org", "user:email"},
+		},
+	}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			envvar.MockSourcegraphDotComMode(test.dotComMode)
+			scopes := requestedScopes(test.schema)
+			sort.Strings(scopes)
+			if diff := cmp.Diff(test.expScopes, scopes); diff != "" {
+				t.Fatalf("scopes: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements dynamic request scopes for GitHub OAuth provider, which tries to request the minimum scopes we need. In particular, if `allowOrgs` is not configured, the scope will not include `read:org`, and vice versa.

I manually tested and can confirm once the scopes are changed (i.e. admin changed the site configuration), the user could re-sign in to Sourcegraph and see the "Authorize application" page from GitHub to see what new scopes are requested.

Unit tests are also added.

Fixes https://github.com/sourcegraph/sourcegraph/issues/8163.