### PR TITLE
search: record inferred file extensions in metrics

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -163,22 +163,22 @@ func lookupMatcher(language string) string {
 	return ""
 }
 
+// languageMetric takes an extension and list of include patterns and returns a
+// label that describes which language is inferred for structural matching.
 func languageMetric(matcher string, includePatterns *[]string) string {
-	if matcher == "" {
-		var extension string
-		if len(*includePatterns) > 0 {
-			extension = filepath.Ext((*includePatterns)[0])
-			if extension == "" {
-				return "inferred:.generic"
-			} else {
-				return fmt.Sprintf("inferred:%s", extension)
-			}
-		} else {
-			return "inferred:.generic"
-		}
-	} else {
+	if matcher != "" {
 		return matcher
 	}
+
+	var extension string
+	if len(*includePatterns) > 0 {
+		extension = filepath.Ext((*includePatterns)[0])
+		if extension == "" {
+			return "inferred:.generic"
+		}
+		return fmt.Sprintf("inferred:%s", extension)
+	}
+	return "inferred:.generic"
 }
 
 func structuralSearch(ctx context.Context, zipPath, pattern, rule string, languages, includePatterns []string, repo api.RepoName) (matches []protocol.FileMatch, limitHit bool, err error) {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -173,10 +173,10 @@ func languageMetric(matcher string, includePatterns *[]string) string {
 	var extension string
 	if len(*includePatterns) > 0 {
 		extension = filepath.Ext((*includePatterns)[0])
-		if extension == "" {
-			return "inferred:.generic"
+		if extension != "" {
+			return fmt.Sprintf("inferred:%s", extension)
 		}
-		return fmt.Sprintf("inferred:%s", extension)
+		return "inferred:.generic"
 	}
 	return "inferred:.generic"
 }

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -175,7 +175,6 @@ func languageMetric(matcher string, includePatterns *[]string) string {
 		if extension != "" {
 			return fmt.Sprintf("inferred:%s", extension)
 		}
-		return "inferred:.generic"
 	}
 	return "inferred:.generic"
 }

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -170,9 +170,8 @@ func languageMetric(matcher string, includePatterns *[]string) string {
 		return matcher
 	}
 
-	var extension string
 	if len(*includePatterns) > 0 {
-		extension = filepath.Ext((*includePatterns)[0])
+		extension := filepath.Ext((*includePatterns)[0])
 		if extension != "" {
 			return fmt.Sprintf("inferred:%s", extension)
 		}

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -132,6 +132,49 @@ func foo(real string) {}
 	}
 }
 
+func TestRecordMetrics(t *testing.T) {
+	cases := []struct {
+		name            string
+		matcher         string
+		includePatterns *[]string
+		want            string
+	}{
+		{
+			name:            "Empty values",
+			matcher:         "",
+			includePatterns: &[]string{},
+			want:            "inferred:.generic",
+		},
+		{
+			name:            "Include patterns no extension",
+			matcher:         "",
+			includePatterns: &[]string{"foo", "bar.go"},
+			want:            "inferred:.generic",
+		},
+		{
+			name:            "Include patterns first extension",
+			matcher:         "",
+			includePatterns: &[]string{"foo.c", "bar.go"},
+			want:            "inferred:.c",
+		},
+		{
+			name:            "Non-empty matcher",
+			matcher:         ".xml",
+			includePatterns: &[]string{"foo.c", "bar.go"},
+			want:            ".xml",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := languageMetric(tt.matcher, tt.includePatterns)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // Tests that includePatterns works. includePatterns serve a similar role in
 // structural search compared to regex search, but is interpreted _differently_.
 // includePatterns cannot be a regex expression (as in traditional search), but

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -168,8 +169,8 @@ func TestRecordMetrics(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			got := languageMetric(tt.matcher, tt.includePatterns)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("got %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}


### PR DESCRIPTION
Current prometheus metrics record the file extension for structural search, or 'inferred' if `lang:` is not specified. I'd like to know what gets inferred, which is based on the file extension of the first `includePattern`, if it exists. This PR adds the logic to record inferred languages/extensions.