### PR TITLE
search only file contents for structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -980,6 +980,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	options := &getPatternInfoOptions{}
 	if r.patternType == SearchTypeStructural {
 		options = &getPatternInfoOptions{performStructuralSearch: true}
+		forceOnlyResultType = "file"
 	}
 	p, err := r.getPatternInfo(options)
 


### PR DESCRIPTION
Structural search should only run on "file" (content) type. Before this change, an error would appear when searching repos for a pattern that is interpreted as regex but isn't, particularly when the structural search pattern is malformed (missing `]`):

<img width="653" alt="Screen Shot 2020-02-06 at 5 05 30 PM" src="https://user-images.githubusercontent.com/888624/73989472-17b9bf00-4903-11ea-8cc9-7270b9eea346.png">

This PR results in "No results". There may be ways to make the error more helpful (malformed structural syntax pattern), but I'd like to get this fix in ASAP.

<img width="611" alt="Screen Shot 2020-02-06 at 5 08 39 PM" src="https://user-images.githubusercontent.com/888624/73989534-56e81000-4903-11ea-9ad4-000e8fcf0e40.png">

Testing: verified manually. This happens in the hard-to-test `doResults` function, so unit test is difficult unless we restructure. This change isn't big enough to warrant an e2e test IMO.