### PR TITLE
Enable basic code intel for more languages by default.

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -18,12 +18,14 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/erlang":     true,
 	"sourcegraph/go":         true,
 	"sourcegraph/graphql":    true,
+	"sourcegraph/groovy":     true,
 	"sourcegraph/haskell":    true,
 	"sourcegraph/java":       true,
 	"sourcegraph/kotlin":     true,
 	"sourcegraph/lisp":       true,
 	"sourcegraph/lua":        true,
 	"sourcegraph/ocaml":      true,
+	"sourcegraph/pascal":     true,
 	"sourcegraph/perl":       true,
 	"sourcegraph/php":        true,
 	"sourcegraph/powershell": true,
@@ -35,6 +37,8 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/shell":      true,
 	"sourcegraph/swift":      true,
 	"sourcegraph/typescript": true,
+	"sourcegraph/verilog":    true,
+	"sourcegraph/vhdl":       true,
 }
 
 const singletonDefaultSettingsGQLID = "DefaultSettings"


### PR DESCRIPTION
Included: Groovy, Pascal, Verilog, VHDL.
