### PR TITLE
github-proxy: Use identical access token rate limit quota

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -906,9 +906,9 @@ type SiteConfiguration struct {
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`
 	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently to update repositories.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
-	// GithubClientID description: Client ID for GitHub.
+	// GithubClientID description: Client ID for GitHub. (DEPRECATED)
 	GithubClientID string `json:"githubClientID,omitempty"`
-	// GithubClientSecret description: Client secret for GitHub.
+	// GithubClientSecret description: Client secret for GitHub. (DEPRECATED)
 	GithubClientSecret string `json:"githubClientSecret,omitempty"`
 	// HtmlBodyBottom description: HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts
 	HtmlBodyBottom string `json:"htmlBodyBottom,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -175,13 +175,13 @@
       "group": "External services"
     },
     "githubClientID": {
-      "description": "Client ID for GitHub.",
+      "description": "Client ID for GitHub. (DEPRECATED)",
       "type": "string",
       "group": "Internal",
       "hide": true
     },
     "githubClientSecret": {
-      "description": "Client secret for GitHub.",
+      "description": "Client secret for GitHub. (DEPRECATED)",
       "type": "string",
       "group": "Internal",
       "hide": true

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -180,13 +180,13 @@ const SiteSchemaJSON = `{
       "group": "External services"
     },
     "githubClientID": {
-      "description": "Client ID for GitHub.",
+      "description": "Client ID for GitHub. (DEPRECATED)",
       "type": "string",
       "group": "Internal",
       "hide": true
     },
     "githubClientSecret": {
-      "description": "Client secret for GitHub.",
+      "description": "Client secret for GitHub. (DEPRECATED)",
       "type": "string",
       "group": "Internal",
       "hide": true


### PR DESCRIPTION
This commit deprecates the site config settings `githubClientID` and
`githubClientSecret` and removes the code that used them in `github-proxy`.

They were originally meant to be used by sourcegraph.com to increase the
available rate limit quota against github.com. However, recent changes
to GitHub deprecate OAuth authentication as an app via `client_id` and
`client_secret` URL query parameters.

In search for a solution, I looked into whether it would make sense to
convert this mechanism to the new GitHub App authentication, but stopped
short of it because I verified that the existing available rate limit
quota for the OAuth app is the same as for the personal access token we
already authenticate requests with (i.e. 5000 request / hour).

```console
$ curl -I 'https://api.github.com/user?client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&access_token=$ACCESS_TOKEN' |
   grep 'X-RateLimit-Limit'
X-RateLimit-Limit: 5000

$ curl -I 'https://api.github.com/user?access_token=$ACCESS_TOKEN' |
   grep 'X-RateLimit-Limit'
X-RateLimit-Limit: 5000
```

In light of this finding, I chose to instead remove the usage of these
OAuth credentials altogether and rely only on the already present
personal access token.

Fixes #8310
