### PR TITLE
gitserver: override refspecs we mirror

### DIFF
--- a/cmd/gitserver/server/refspecoverrides.go
+++ b/cmd/gitserver/server/refspecoverrides.go
@@ -25,7 +25,7 @@ func useRefspecOverrides() bool {
 //
 // To not clone everything we instead init a bare repo and only add the
 // refspecs we care about. Then we finally do a fetch.
-func refspecOverridesCloneCmd(ctx context.Context, tmpPath, url string) (*exec.Cmd, error) {
+func refspecOverridesCloneCmd(ctx context.Context, url, tmpPath string) (*exec.Cmd, error) {
 	if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
 		return nil, errors.Wrapf(err, "clone failed to create tmp dir")
 	}

--- a/cmd/gitserver/server/refspecoverrides.go
+++ b/cmd/gitserver/server/refspecoverrides.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+// HACK(keegancsmith) workaround to experiment with cloning less in a large
+// monorepo. https://github.com/sourcegraph/customer/issues/19
+var refspecOverrides = strings.Fields(env.Get("SRC_GITSERVER_REFSPECS", "", "EXPERIMENTAL: override refspec we fetch. Space separated."))
+
+// HACK(keegancsmith) workaround to experiment with cloning less in a large
+// monorepo. https://github.com/sourcegraph/customer/issues/19
+func useRefspecOverrides() bool {
+	return len(refspecOverrides) > 0
+}
+
+// HACK(keegancsmith) workaround to experiment with cloning less in a large
+// monorepo. https://github.com/sourcegraph/customer/issues/19
+//
+// To not clone everything we instead init a bare repo and only add the
+// refspecs we care about. Then we finally do a fetch.
+func refspecOverridesCloneCmd(ctx context.Context, tmpPath, url string) (*exec.Cmd, error) {
+	if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
+		return nil, errors.Wrapf(err, "clone failed to create tmp dir")
+	}
+	cmds := [][]string{
+		{"init", "--bare", "."},
+		{"config", "--add", "remote.origin.url", url},
+		{"config", "--add", "remote.origin.mirror", "true"},
+	}
+	for _, refspec := range refspecOverrides {
+		cmds = append(cmds, []string{"config", "--add", "remote.origin.fetch", refspec})
+	}
+	for _, args := range cmds {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = tmpPath
+		if err := cmd.Run(); err != nil {
+			return nil, errors.Wrapf(err, "clone setup failed")
+		}
+	}
+	cmd := exec.CommandContext(ctx, "git", "fetch", "--progress")
+	cmd.Dir = tmpPath
+	return cmd, nil
+}
+
+// HACK(keegancsmith) workaround to experiment with cloning less in a large
+// monorepo. https://github.com/sourcegraph/customer/issues/19
+func refspecOverridesFetchCmd(ctx context.Context, url string) *exec.Cmd {
+	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--prune", url}, refspecOverrides...)...)
+}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -43,6 +43,10 @@ import (
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
+// HACK(keegancsmith) workaround to experiment with cloning less in a large
+// monorepo. https://github.com/sourcegraph/customer/issues/19
+var refspecOverrides = strings.Fields(env.Get("SRC_GITSERVER_REFSPECS", "", "EXPERIMENTAL: override refspec we fetch. Space separated."))
+
 // tempDirName is the name used for the temporary directory under ReposDir.
 const tempDirName = ".tmp"
 
@@ -812,7 +816,37 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 		tmpPath = filepath.Join(tmpPath, ".git")
 		tmp := GitDir(tmpPath)
 
-		cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath)
+		var cmd *exec.Cmd
+		if len(refspecOverrides) > 0 {
+			// HACK(keegancsmith) workaround to experiment with cloning less
+			// in a large monorepo.
+			// https://github.com/sourcegraph/customer/issues/19
+			//
+			// To not clone everything we instead init a bare repo and only
+			// add the refspecs we care about. Then we finally do a fetch.
+			if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
+				return errors.Wrapf(err, "clone failed to create tmp dir")
+			}
+			cmds := [][]string{
+				{"init", "--bare", "."},
+				{"config", "--add", "remote.origin.url", url},
+				{"config", "--add", "remote.origin.mirror", "true"},
+			}
+			for _, refspec := range refspecOverrides {
+				cmds = append(cmds, []string{"config", "--add", "remote.origin.fetch", refspec})
+			}
+			for _, args := range cmds {
+				cmd := exec.CommandContext(ctx, "git", args...)
+				cmd.Dir = tmpPath
+				if err := cmd.Run(); err != nil {
+					return errors.Wrapf(err, "clone setup failed")
+				}
+			}
+			cmd = exec.CommandContext(ctx, "git", "fetch", "--progress")
+			cmd.Dir = tmpPath
+		} else {
+			cmd = exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath)
+		}
 		// see issue #7322: skip LFS content in repositories with Git LFS configured
 		cmd.Env = append(cmd.Env, "GIT_LFS_SKIP_SMUDGE=1")
 		log15.Info("cloning repo", "repo", repo, "tmp", tmpPath, "dst", dstPath)
@@ -1292,7 +1326,14 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "fetch", "--prune", url, "+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*", "+refs/pull/*:refs/pull/*", "+refs/sourcegraph/*:refs/sourcegraph/*")
+	var cmd *exec.Cmd
+	if len(refspecOverrides) > 0 {
+		// HACK(keegancsmith) workaround to experiment with cloning less in a
+		// large monorepo. https://github.com/sourcegraph/customer/issues/19
+		cmd = exec.CommandContext(ctx, "git", append([]string{"fetch", "--prune", url}, refspecOverrides...)...)
+	} else {
+		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url, "+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*", "+refs/pull/*:refs/pull/*", "+refs/sourcegraph/*:refs/sourcegraph/*")
+	}
 	cmd.Dir = string(dir)
 
 	// drop temporary pack files after a fetch. this function won't

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -814,7 +814,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 
 		var cmd *exec.Cmd
 		if useRefspecOverrides() {
-			cmd, err = refspecOverridesCloneCmd(ctx, tmpPath, url)
+			cmd, err = refspecOverridesCloneCmd(ctx, url, tmpPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This is an experiment for a potential customer with a large number of
branches. It adds the environment variable "SRC_GITSERVER_REFSPECS" which
allows an administrator to restrict the references we fetch. By default we
fetch all refs on clone, and then for future refs we fetch a hardcoded
whitelist. This is a temporary measure to adjust this list. It is a space
seperated list of refspecs. IE the values you would put in the fetch config
for a git remote. An example which fetches just the master and dev branch is

  env SRC_GITSERVER_REFSPECS="+refs/heads/master:refs/heads/master +refs/heads/dev:refs/heads/dev"

Tested by setting the environment variable in local development mode and
exploring which branches were cloned.

NOTE: This is not a documented approach. If we do keep this code around, we
will design a clearer and consistent way for administrators to configure
this. For now specify an environment variable on an insider build should be
sufficient.

Part of https://github.com/sourcegraph/customer/issues/19