### PR TITLE
search: do not panic in query string function

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -187,7 +187,7 @@ func asString(v *searchquerytypes.Value) string {
 	case v.Regexp != nil:
 		return v.Regexp.String()
 	default:
-		panic("unable to get value as string")
+		return "<unable to get seearchquerytypes.Value as string>"
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -187,7 +187,7 @@ func asString(v *searchquerytypes.Value) string {
 	case v.Regexp != nil:
 		return v.Regexp.String()
 	default:
-		return "<unable to get seearchquerytypes.Value as string>"
+		return "<unable to get searchquerytypes.Value as string>"
 	}
 }
 


### PR DESCRIPTION
This `asString` function is dangerous. It doesn't do exhaustive checking on the states of `*searchquerytypes.Value`.  The field values `v.String`, `v.Regexp`, `v.Bool` could all be nil, or `v` could be nil, etc. I'm not fixing up all of that, instead, let's just return a string and not panic.

The uses for `asString` appear luckily safe for now, and I ran into this while changing some parser logic, so we are potentially one small change away from nil panicking without this PR.