### PR TITLE
search: fix scaling factor of indexed search result count

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -28,6 +28,48 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+func TestZoektResultCountFactor(t *testing.T) {
+	cases := []struct {
+		name     string
+		numRepos int
+		pattern  *search.TextPatternInfo
+		want     int
+	}{
+		{
+			name:     "One repo implies max scaling factor",
+			numRepos: 1,
+			pattern:  &search.TextPatternInfo{},
+			want:     100,
+		},
+		{
+			name:     "Eleven repos implies a scaling factor between min and max",
+			numRepos: 11,
+			pattern:  &search.TextPatternInfo{},
+			want:     8,
+		},
+		{
+			name:     "More than 500 repos implies a min scaling factor",
+			numRepos: 501,
+			pattern:  &search.TextPatternInfo{},
+			want:     1,
+		},
+		{
+			name:     "Setting a count greater than defautl max results (30) adapts scaling factor",
+			numRepos: 501,
+			pattern:  &search.TextPatternInfo{FileMatchLimit: 100},
+			want:     10,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := zoektResultCountFactor(tt.numRepos, tt.pattern)
+			if tt.want != got {
+				t.Fatalf("Want scaling factor %d but got %d", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestQueryToZoektQuery(t *testing.T) {
 	cases := []struct {
 		Name    string

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -28,18 +28,18 @@ func zoektResultCountFactor(numRepos int, query *search.TextPatternInfo) int {
 	// arbitrary.
 	k := 1
 	switch {
-	case numRepos <= 500:
-		k = 2
-	case numRepos <= 100:
-		k = 3
-	case numRepos <= 50:
-		k = 5
-	case numRepos <= 25:
-		k = 8
-	case numRepos <= 10:
-		k = 10
 	case numRepos <= 5:
 		k = 100
+	case numRepos <= 10:
+		k = 10
+	case numRepos <= 25:
+		k = 8
+	case numRepos <= 50:
+		k = 5
+	case numRepos <= 100:
+		k = 3
+	case numRepos <= 500:
+		k = 2
 	}
 	if query.FileMatchLimit > defaultMaxSearchResults {
 		k = int(float64(k) * 3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))


### PR DESCRIPTION
We use a scaling factor in indexed search set how many matches/results we want to see based on how many repos are matched. The intuition is:

- low number of repos to search -> give us more results -> set a higher scaling factor `k`
- high number of repos to search -> give us fewer results -> set a lower scaling factor `k`

Snippet of the code:

```go
        k := 1                                                                                                                                                          
        switch {                                                                                                                                                        
        case numRepos <= 500:                                                                                                                                           
                k = 2                                                                                                                                                   
        case numRepos <= 100:   // unreachable                                                                                                                                        
                k = 3                                                                                                                                                   
        case numRepos <= 50:    // unreachable                                                                                                                                        
                k = 5                                                                                                                                                   
        case numRepos <= 25:    // ... etc.                                                                                                                                         
                k = 8                                                                                                                                                   
        case numRepos <= 10:                                                                                                                                            
                k = 10                                                                                                                                                  
        case numRepos <= 5:                                                                                                                                             
                k = 100                                                                                                                                                 
        }  
```

Since this is Go code, not C, there is no fallthrough. `k` is basically always 2, unless numRepos > 500 in which case it is 1. So we basically always ask for very few results for small number of repos.

I have some concern that the intended scaling factor hasn't been validated very well (I mean validated empirically, as in, users have been exposed to this behavior) since it has basically never worked. It's worth fixing to the intended meaning and seeing how things go, because it does solve some existing issues. 

I discovered this because I'm using indexed search for structural search and this issue affects it also. This fix does help with managing some results behavior there, and I checked that this also addresses #7596 and therefore pretty confident this is one significant underlying issue affecting weird behaviors in unindexed search.
