### PR TITLE
Fix: race condition for undefined patternTypes in interactive mode

### DIFF
--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -30,6 +30,7 @@ import { SearchResultsList } from './SearchResultsList'
 import { SearchResultTypeTabs } from './SearchResultTypeTabs'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
+import { convertPlainTextToInteractiveQuery } from '../input/helpers'
 
 export interface SearchResultsProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
@@ -96,13 +97,16 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         if (!patternType) {
             // If the patternType query parameter does not exist in the URL or is invalid, redirect to a URL which
             // has patternType=regexp appended. This is to ensure old URLs before requiring patternType still work.
+
+            const q = parseSearchURLQuery(this.props.location.search) || ''
+            const { navbarQuery, filtersInQuery } = convertPlainTextToInteractiveQuery(q)
             const newLoc =
                 '/search?' +
                 buildSearchURLQuery(
-                    this.props.navbarSearchQueryState.query,
+                    navbarQuery,
                     GQL.SearchPatternType.regexp,
                     this.props.caseSensitive,
-                    this.props.filtersInQuery
+                    filtersInQuery
                 )
             window.location.replace(newLoc)
         }

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -102,12 +102,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
             const { navbarQuery, filtersInQuery } = convertPlainTextToInteractiveQuery(q)
             const newLoc =
                 '/search?' +
-                buildSearchURLQuery(
-                    navbarQuery,
-                    GQL.SearchPatternType.regexp,
-                    this.props.caseSensitive,
-                    filtersInQuery
-                )
+                buildSearchURLQuery(navbarQuery, GQL.SearchPatternType.regexp, this.props.caseSensitive, filtersInQuery)
             window.location.replace(newLoc)
         }
 


### PR DESCRIPTION
While looking into https://github.com/sourcegraph/sourcegraph/issues/8161, I noticed a race condition that causes a bug. 

The bug: 
- Go to https://sourcegraph.com/search?q=func+check%28+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40b887ad1+file:updatecheck
- Notice that it will redirect you to https://sourcegraph.com/search?q=&patternType=regexp

The relevant code is in https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b887ad1/-/blob/web/src/search/results/SearchResults.tsx#L96-108. What happens is that the SearchResults page renders, notices there is no patternType, and redirects you to the URL with a patternType. However,  `this.props.navbarSearchQueryState.query` is not defined yet, because it gets set by `InteractiveModeInput` in https://sourcegraph.com/github.com/sourcegraph/sourcegraph@fa/pattern-type-race/-/blob/web/src/search/input/interactive/InteractiveModeInput.tsx#L68:34. But, since interactive mode is behind the `splitSearchModes` feature flag, we need to query the global settings before we render `interactiveModeInput`, so we fail to update the query before the redirect occurs. 

The safe thing to do is to always parse the intended query out of the URL when doing a redirect.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
