### PR TITLE
Allow changing the overlay mount location

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -470,6 +470,28 @@ function initCodeIntelligence({
     return { hoverifier, subscription }
 }
 
+/**
+ * Returns an Observable that emits the element where
+ * the hover overlay mount should be appended, taking account
+ * mutations and {@link CodeHost#getHoverOverlayMountLocation}.
+ *
+ * The caller is responsible for removing the previous mount if it exists.
+ *
+ * This is useful to mount the hover overlay to a different container than document.body,
+ * so that it is affected by the visibility changes of that container.
+ *
+ * Related issue: https://gitlab.com/gitlab-org/gitlab/issues/193433
+ *
+ * Example use case on GitLab:
+ * 1. User visits https://gitlab.com/gitlab-org/gitaly/-/merge_requests/1575. div.tab-pane.diffs doesn't exist yet (it'll be lazy-loaded)
+ *      -> Mount the  hover overlay is to document.body.
+ * 2. User visits the 'Changes' tab
+ *      -> Unmount from document.body, mount to div.tab-pane.diffs
+ * 3. User visits the 'Overview' tab again
+ *      -> div.tab-pane.diffs is hidden, and as a result so is the hover overlay.
+ * 4. User navigates away from the merge request (soft-reload), div.tab-pane.diffs is removed
+ *      -> Mount to document.body again
+ */
 export function observeHoverOverlayMountLocation(
     getMountLocationSelector: NonNullable<CodeHost['getHoverOverlayMountLocation']>,
     mutations: Observable<MutationRecordLike[]>

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -182,4 +182,12 @@ export const gitlabCodeHost = subTypeOf<CodeHost>()({
         errorAlertClassName: notificationClassNames[NotificationType.Error],
     },
     codeViewsRequireTokenization: true,
+    getHoverOverlayMountLocation: (): string | null => {
+        const { pageKind } = getPageInfo()
+        // On merge request pages only, mount the hover overlay to the diffs tab container.
+        if (pageKind === GitLabPageKind.MergeRequest) {
+            return 'div.tab-pane.diffs'
+        }
+        return null
+    },
 })


### PR DESCRIPTION
Rel https://github.com/sourcegraph/sourcegraph/issues/3228#issuecomment-481174882

On GitLab merge request pages, the diff tab is always present. As a result, when switching tabs, the hover overlay remains visible, since it is by default mounted to `document.body`, and as such is not affected by the change in visibility of the diff tab.

This PR introduces the ability to customize the hover overlay mount location, through `CodeHost.getHoverOverlayMountLocation()`. If `CodeHost.getHoverOverlayMountLocation()` is unspecified, or if it returns `null`, the hover overlay will be mounted to document.body. If the custom mount location is removed from the DOM, the hover overlay will be mounted to document.body again.
