### PR TITLE
graphql: lazy load commit information in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 - **Monitoring:** Fixed an issue with the **Replacer**, **Repo Updater**, and **Searcher** dashboards would incorrectly report on a metric from the unrelated query-runner service. [#7531](https://github.com/sourcegraph/sourcegraph/issues/7531)
 - Hover tooltips for Perl files now have syntax highlighting. [#8307](https://github.com/sourcegraph/sourcegraph/issues/8307)
 - Deterministic ordering of results from indexed search. Previously when refreshing a page with many results some results may come and go.
+- Fixed an issue with missing commit information in graphql search results. [#8343](https://github.com/sourcegraph/sourcegraph/pull/8343)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -56,9 +56,9 @@ func toGitCommitResolver(repo *RepositoryResolver, commit *git.Commit) *GitCommi
 		includeUserInfo: true,
 		oid:             GitObjectID(commit.ID),
 	}
-	res.consumeCommit(commit)
-
-	res.once.Do(func() {})
+	res.once.Do(func() {
+		res.consumeCommit(commit)
+	})
 	return res
 }
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -80,8 +80,6 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (err error) {
 			return
 		}
 
-		fmt.Printf("%v\n", commit.Author)
-
 		r.author = *toSignatureResolver(&commit.Author, r.long)
 		r.committer = toSignatureResolver(commit.Committer, r.long)
 		r.message = commit.Message

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -15,7 +15,7 @@ type personResolver struct {
 	email string
 
 	// fetch + serve sourcegraph stored user information
-	long bool
+	includeUserInfo bool
 
 	// cache result because it is used by multiple fields
 	once sync.Once
@@ -27,7 +27,7 @@ type personResolver struct {
 // resolved to a user.
 func (r *personResolver) resolveUser(ctx context.Context) (*types.User, error) {
 	r.once.Do(func() {
-		if r.long && r.email != "" {
+		if r.includeUserInfo && r.email != "" {
 			r.user, r.err = db.Users.GetByVerifiedEmail(ctx, r.email)
 			if errcode.IsNotFound(r.err) {
 				r.err = nil

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -14,6 +14,9 @@ type personResolver struct {
 	name  string
 	email string
 
+	// fetch + serve sourcegraph stored user information
+	long bool
+
 	// cache result because it is used by multiple fields
 	once sync.Once
 	user *types.User
@@ -24,7 +27,7 @@ type personResolver struct {
 // resolved to a user.
 func (r *personResolver) resolveUser(ctx context.Context) (*types.User, error) {
 	r.once.Do(func() {
-		if r.email != "" {
+		if r.long && r.email != "" {
 			r.user, r.err = db.Users.GetByVerifiedEmail(ctx, r.email)
 			if errcode.IsNotFound(r.err) {
 				r.err = nil

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -68,7 +68,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	wantCommit := GitCommitResolver{
 		repo:   &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
-		author: *toSignatureResolver(&gitSignatureWithDate),
+		author: *toSignatureResolver(&gitSignatureWithDate, false),
 	}
 
 	if want := []*commitSearchResultResolver{

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/google/go-cmp/cmp"
+	//"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -66,10 +66,12 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 
 	wantCommit := GitCommitResolver{
-		repo:   &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
-		oid:    "c1",
-		author: *toSignatureResolver(&gitSignatureWithDate, false),
+		repo:            &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		oid:             "c1",
+		author:          *toSignatureResolver(&gitSignatureWithDate, true),
+		includeUserInfo: true,
 	}
+	wantCommit.once.Do(func() {}) // mark as done
 
 	if want := []*commitSearchResultResolver{
 		{
@@ -82,7 +84,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
 		},
 	}; !reflect.DeepEqual(results, want) {
-		t.Errorf("results\ngot  %v\nwant %v\ndiff: %v", results, want, cmp.Diff(results, want))
+		t.Errorf("results\ngot  %v\nwant %v", results, want)
 	}
 	if limitHit {
 		t.Error("limitHit")

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -25,7 +25,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	commit := &GitCommitResolver{
 		repo:   &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
-		author: *toSignatureResolver(&gitSignatureWithDate),
+		author: *toSignatureResolver(&gitSignatureWithDate, false),
 	}
 	sr := &searchSymbolResult{symbol, baseURI, "go", commit}
 

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -19,15 +19,15 @@ func (r signatureResolver) Date() string {
 	return r.date.Format(time.RFC3339)
 }
 
-func toSignatureResolver(sig *git.Signature, long bool) *signatureResolver {
+func toSignatureResolver(sig *git.Signature, includeUserInfo bool) *signatureResolver {
 	if sig == nil {
 		return nil
 	}
 	return &signatureResolver{
 		person: &personResolver{
-			name:  sig.Name,
-			email: sig.Email,
-			long:  long,
+			name:            sig.Name,
+			email:           sig.Email,
+			includeUserInfo: includeUserInfo,
 		},
 		date: sig.Date,
 	}

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -19,7 +19,7 @@ func (r signatureResolver) Date() string {
 	return r.date.Format(time.RFC3339)
 }
 
-func toSignatureResolver(sig *git.Signature) *signatureResolver {
+func toSignatureResolver(sig *git.Signature, long bool) *signatureResolver {
 	if sig == nil {
 		return nil
 	}
@@ -27,6 +27,7 @@ func toSignatureResolver(sig *git.Signature) *signatureResolver {
 		person: &personResolver{
 			name:  sig.Name,
 			email: sig.Email,
+			long:  long,
 		},
 		date: sig.Date,
 	}


### PR DESCRIPTION
This PR lazy loads in commit information in search results in the graphql API. This fixes #5335.

I chose to implement the lazy method instead of making the `author` field optional for API feature parity. It made more sense to have `author` remain as a required field of `GitCommit`.