### PR TITLE
search: more friendly message for stale permissions

### DIFF
--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -1,6 +1,8 @@
 package authz
 
 import (
+	"fmt"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 )
@@ -72,4 +74,19 @@ func (s RepoPermsSort) Less(i, j int) bool {
 		return s[i].Repo.ExternalRepo.ID < s[j].Repo.ExternalRepo.ID
 	}
 	return s[i].Repo.Name < s[j].Repo.Name
+}
+
+// ErrStalePermissions is returned by LoadPermissions when the stored
+// permissions are stale (e.g. the first time a user needs them and they haven't
+// been fetched yet). Callers should pass this error up to the user and show a
+// more friendly prompt message in the UI.
+type ErrStalePermissions struct {
+	UserID int32
+	Perm   Perms
+	Type   PermType
+}
+
+// Error implements the error interface.
+func (e ErrStalePermissions) Error() string {
+	return fmt.Sprintf("%s:%s permissions for user=%d are stale and being updated", e.Perm, e.Type, e.UserID)
 }

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -56,12 +56,12 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	return &a.proposedQueries
 }
 
-func (r *searchResolver) alertForStalePermissions(_ context.Context) (*searchAlert, error) {
+func (r *searchResolver) alertForStalePermissions(_ context.Context) *searchAlert {
 	return &searchAlert{
 		prometheusType: "no_resolved_repos__stale_permissions",
 		title:          "Permissions syncing in progress",
 		description:    "Permissions are being synced from your code host, please wait for a minute and try again.",
-	}, nil
+	}
 }
 
 func (r *searchResolver) alertForQuotesInQueryInLiteralMode(_ context.Context) (*searchAlert, error) {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -56,7 +56,15 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	return &a.proposedQueries
 }
 
-func (r *searchResolver) alertForQuotesInQueryInLiteralMode(ctx context.Context) (*searchAlert, error) {
+func (r *searchResolver) alertForStalePermissions(_ context.Context) (*searchAlert, error) {
+	return &searchAlert{
+		prometheusType: "no_resolved_repos__stale_permissions",
+		title:          "Permissions syncing in progress",
+		description:    "Permissions are being synced from your code host, please wait for a minute and refresh the page.",
+	}, nil
+}
+
+func (r *searchResolver) alertForQuotesInQueryInLiteralMode(_ context.Context) (*searchAlert, error) {
 	return &searchAlert{
 		prometheusType: "no_results__suggest_quotes",
 		title:          "No results. Did you mean to use quotes?",

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -60,7 +60,7 @@ func (r *searchResolver) alertForStalePermissions(_ context.Context) (*searchAle
 	return &searchAlert{
 		prometheusType: "no_resolved_repos__stale_permissions",
 		title:          "Permissions syncing in progress",
-		description:    "Permissions are being synced from your code host, please wait for a minute and refresh the page.",
+		description:    "Permissions are being synced from your code host, please wait for a minute and try again.",
 	}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -862,8 +863,16 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceO
 func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (repos, missingRepoRevs []*search.RepositoryRevisions, res *SearchResultsResolver, err error) {
 	repos, missingRepoRevs, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
+		if errors.Is(err, authz.ErrStalePermissions{}) {
+			alert, err := r.alertForStalePermissions(ctx)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
+		}
 		return nil, nil, nil, err
 	}
+
 	tr.LazyPrintf("searching %d repos, %d missing", len(repos), len(missingRepoRevs))
 	if len(repos) == 0 {
 		alert, err := r.alertForNoResolvedRepos(ctx)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -864,10 +864,8 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 	repos, missingRepoRevs, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		if errors.Is(err, authz.ErrStalePermissions{}) {
-			alert, err := r.alertForStalePermissions(ctx)
-			if err != nil {
-				return nil, nil, nil, err
-			}
+			log15.Debug("searchResolver.determineRepos", "err", err)
+			alert := r.alertForStalePermissions(ctx)
 			return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 		}
 		return nil, nil, nil, err

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
@@ -119,7 +119,11 @@ func (s *store) UpdatePermissions(
 
 		// No valid permissions available yet or hard TTL expired.
 		if p.UpdatedAt.IsZero() || p.Expired(s.hardTTL, now) {
-			return &authz.ErrStalePermissions{p.UserID, p.Perm, p.Type}
+			return &authz.ErrStalePermissions{
+				UserID: p.UserID,
+				Perm:   p.Perm,
+				Type:   p.Type,
+			}
 		}
 
 		return nil
@@ -130,7 +134,11 @@ func (s *store) UpdatePermissions(
 	case err == nil:
 	case err == errLockNotAvailable:
 		if p.Expired(s.hardTTL, now) {
-			return &authz.ErrStalePermissions{p.UserID, p.Perm, p.Type}
+			return &authz.ErrStalePermissions{
+				UserID: p.UserID,
+				Perm:   p.Perm,
+				Type:   p.Type,
+			}
 		}
 	default:
 		return err

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
@@ -12,7 +12,8 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/segmentio/fasthash/fnv1"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -33,7 +34,7 @@ type store struct {
 	hardTTL time.Duration
 	clock   func() time.Time
 	block   bool // Perform blocking updates if true.
-	updates chan *authz.UserPermissions
+	updates chan *iauthz.UserPermissions
 }
 
 func newStore(db dbutil.DB, ttl, hardTTL time.Duration, clock func() time.Time) *store {
@@ -51,7 +52,7 @@ func newStore(db dbutil.DB, ttl, hardTTL time.Duration, clock func() time.Time) 
 
 // DefaultHardTTL is the default hard TTL used in the permissions store, after which
 // cached permissions for a given user MUST be updated, and previously cached permissions
-// can no longer be used, resulting in a call to LoadPermissions returning a StalePermissionsError.
+// can no longer be used, resulting in a call to LoadPermissions returning a ErrStalePermissions.
 const DefaultHardTTL = 3 * 24 * time.Hour
 
 // PermissionsUpdateFunc fetches updated permissions from a source of truth,
@@ -70,7 +71,7 @@ type PermissionsUpdateFunc func(context.Context) (
 // returned.
 func (s *store) LoadPermissions(
 	ctx context.Context,
-	p *authz.UserPermissions,
+	p *iauthz.UserPermissions,
 	update PermissionsUpdateFunc,
 ) (err error) {
 	if s == nil || p == nil {
@@ -98,7 +99,7 @@ func (s *store) LoadPermissions(
 // to fetch fresh data from the source of truth.
 func (s *store) UpdatePermissions(
 	ctx context.Context,
-	p *authz.UserPermissions,
+	p *iauthz.UserPermissions,
 	update PermissionsUpdateFunc,
 ) (err error) {
 	ctx, save := s.observe(ctx, "UpdatePermissions", "")
@@ -109,7 +110,7 @@ func (s *store) UpdatePermissions(
 	expired.IDs = nil
 
 	if !s.block { // Non blocking code path
-		go func(expired *authz.UserPermissions) {
+		go func(expired *iauthz.UserPermissions) {
 			err := s.update(ctx, expired, update)
 			if err != nil && err != errLockNotAvailable {
 				log15.Error("bitbucketserver.authz.store.UpdatePermissions", "error", err)
@@ -118,7 +119,7 @@ func (s *store) UpdatePermissions(
 
 		// No valid permissions available yet or hard TTL expired.
 		if p.UpdatedAt.IsZero() || p.Expired(s.hardTTL, now) {
-			return &StalePermissionsError{UserPermissions: p}
+			return &authz.ErrStalePermissions{p.UserID, p.Perm, p.Type}
 		}
 
 		return nil
@@ -129,7 +130,7 @@ func (s *store) UpdatePermissions(
 	case err == nil:
 	case err == errLockNotAvailable:
 		if p.Expired(s.hardTTL, now) {
-			return &StalePermissionsError{UserPermissions: p}
+			return &authz.ErrStalePermissions{p.UserID, p.Perm, p.Type}
 		}
 	default:
 		return err
@@ -139,25 +140,12 @@ func (s *store) UpdatePermissions(
 	return nil
 }
 
-// StalePermissionsError is returned by LoadPermissions when the stored
-// permissions are stale (e.g. the first time a user needs them and they haven't
-// been fetched yet). Callers should pass this error up to the user and show it
-// in the UI.
-type StalePermissionsError struct {
-	*authz.UserPermissions
-}
-
-// Error implements the error interface.
-func (e StalePermissionsError) Error() string {
-	return fmt.Sprintf("%s:%s permissions for user=%d are stale and being updated", e.Perm, e.Type, e.UserID)
-}
-
 var errLockNotAvailable = errors.New("lock not available")
 
 // lock uses Postgres advisory locks to acquire an exclusive lock over the
 // given UserPermissions. Concurrent processes that call this method while a lock is
 // already held by another process will have errLockNotAvailable returned.
-func (s *store) lock(ctx context.Context, p *authz.UserPermissions) (err error) {
+func (s *store) lock(ctx context.Context, p *iauthz.UserPermissions) (err error) {
 	ctx, save := s.observe(ctx, "lock", "")
 	defer func() { save(&err, p.TracingFields()...) }()
 
@@ -195,7 +183,7 @@ func (s *store) lock(ctx context.Context, p *authz.UserPermissions) (err error) 
 
 var lockNamespace = int32(fnv1.HashString32("perms"))
 
-func lockQuery(p *authz.UserPermissions) *sqlf.Query {
+func lockQuery(p *iauthz.UserPermissions) *sqlf.Query {
 	// Postgres advisory lock ids are a global namespace within one database.
 	// It's very unlikely that another part of our application uses a lock
 	// namespace identically to this one. It's equally unlikely that there are
@@ -216,7 +204,7 @@ const lockQueryFmtStr = `
 SELECT pg_try_advisory_xact_lock(%s, %s)
 `
 
-func (s *store) load(ctx context.Context, p *authz.UserPermissions) (err error) {
+func (s *store) load(ctx context.Context, p *iauthz.UserPermissions) (err error) {
 	ctx, save := s.observe(ctx, "load", "")
 	defer func() { save(&err, p.TracingFields()...) }()
 
@@ -313,7 +301,7 @@ func (s *store) loadRepoIDs(ctx context.Context, c *extsvc.CodeHost, externalIDs
 	return ids, nil
 }
 
-func loadQuery(p *authz.UserPermissions) *sqlf.Query {
+func loadQuery(p *iauthz.UserPermissions) *sqlf.Query {
 	return sqlf.Sprintf(
 		loadQueryFmtStr,
 		p.UserID,
@@ -333,7 +321,7 @@ AND object_type = %s
 AND provider = %s
 `
 
-func (s *store) update(ctx context.Context, p *authz.UserPermissions, update PermissionsUpdateFunc) (err error) {
+func (s *store) update(ctx context.Context, p *iauthz.UserPermissions, update PermissionsUpdateFunc) (err error) {
 	_, save := s.observe(ctx, "update", "")
 	defer func() { save(&err, p.TracingFields()...) }()
 
@@ -418,7 +406,7 @@ func (s *store) tx(ctx context.Context) (*sql.Tx, error) {
 	}
 }
 
-func (s *store) upsert(ctx context.Context, p *authz.UserPermissions) (err error) {
+func (s *store) upsert(ctx context.Context, p *iauthz.UserPermissions) (err error) {
 	ctx, save := s.observe(ctx, "upsert", "")
 	defer func() { save(&err, p.TracingFields()...) }()
 
@@ -436,7 +424,7 @@ func (s *store) upsert(ctx context.Context, p *authz.UserPermissions) (err error
 	return rows.Close()
 }
 
-func (s *store) upsertQuery(p *authz.UserPermissions) (*sqlf.Query, error) {
+func (s *store) upsertQuery(p *iauthz.UserPermissions) (*sqlf.Query, error) {
 	ids, err := p.IDs.ToBytes()
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -147,7 +147,11 @@ func testStore(db *sql.DB) func(*testing.T) {
 		{
 			// No permissions cached.
 			ps, err := load(s)
-			equal(t, "err", err, &authz.ErrStalePermissions{ps.UserID, ps.Perm, ps.Type})
+			equal(t, "err", err, &authz.ErrStalePermissions{
+				UserID: ps.UserID,
+				Perm:   ps.Perm,
+				Type:   ps.Type,
+			})
 			equal(t, "ids", array(ps.IDs), []uint32(nil))
 		}
 
@@ -158,7 +162,11 @@ func testStore(db *sql.DB) func(*testing.T) {
 			atomic.AddInt64(&now, int64(hardTTL))
 
 			ps, err := load(s)
-			equal(t, "err", err, &authz.ErrStalePermissions{ps.UserID, ps.Perm, ps.Type})
+			equal(t, "err", err, &authz.ErrStalePermissions{
+				UserID: ps.UserID,
+				Perm:   ps.Perm,
+				Type:   ps.Type,
+			})
 			equal(t, "ids", array(ps.IDs), ids)
 		}
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -147,7 +147,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 		{
 			// No permissions cached.
 			ps, err := load(s)
-			equal(t, "err", err, &StalePermissionsError{UserPermissions: ps})
+			equal(t, "err", err, &authz.ErrStalePermissions{ps.UserID, ps.Perm, ps.Type})
 			equal(t, "ids", array(ps.IDs), []uint32(nil))
 		}
 
@@ -158,7 +158,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 			atomic.AddInt64(&now, int64(hardTTL))
 
 			ps, err := load(s)
-			equal(t, "err", err, &StalePermissionsError{UserPermissions: ps})
+			equal(t, "err", err, &authz.ErrStalePermissions{ps.UserID, ps.Perm, ps.Type})
 			equal(t, "ids", array(ps.IDs), ids)
 		}
 


### PR DESCRIPTION
This PR prompts a more friendly message for stale permissions when the user performs a search for the first time, which kicks off the permissions syncing process for the user.

Before:
![image](https://user-images.githubusercontent.com/2946214/74220612-00a41400-4ceb-11ea-919b-1b997d2a1be7.png)

After:
![image](https://user-images.githubusercontent.com/2946214/74220618-04379b00-4ceb-11ea-8aab-6e070d1844b6.png)

Implements [RFC 109: More friendly onboarding process for user permissions](https://docs.google.com/document/d/1gy2oqA55_EOcr5F0mbd7AWHS8UaPssC2HhIrl9HTXno/edit#)