### PR TITLE
Fixes for interactive mode type filter

### DIFF
--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -261,6 +261,12 @@ export class FilterInput extends React.Component<Props, State> {
         this.setFiniteFilterDefault.next()
     }
 
+    public componentDidUpdate(prevProps: Props): void {
+        if (isFiniteFilter(this.props.filterType) && this.props.value !== prevProps.value) {
+            this.inputValues.next(this.props.value)
+        }
+    }
+
     public componentWillUnmount(): void {
         this.subscriptions.unsubscribe()
     }

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -273,8 +273,8 @@ export class FilterInput extends React.Component<Props, State> {
         e.preventDefault()
         e.stopPropagation()
 
-        if (this.state.inputValue !== '') {
-            // Don't allow empty filters.
+        if (this.state.inputValue !== '' || this.props.filterType === FilterTypes.type) {
+            // Don't allow empty filters, unless it's the type filter.
             // Update the top-level filtersInQueryMap with the new value for this filter.
             this.props.onFilterEdited(this.props.mapKey, this.state.inputValue)
         }
@@ -511,7 +511,7 @@ export class FilterInput extends React.Component<Props, State> {
                                         autoFocus={true}
                                     />
                                     <label htmlFor={val.value} tabIndex={0} className="filter-input__radio-label">
-                                        {startCase(val.value)}
+                                        {val.displayValue ? startCase(val.displayValue) : startCase(val.value)}
                                     </label>
                                 </div>
                             ))}

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -53,13 +53,13 @@ export const finiteFilters: Record<
         ),
     },
     type: {
-        default: 'code',
+        default: '',
         values: [
-            { value: 'code' },
+            { displayValue: 'code', value: '' },
             { value: 'commit' },
             { value: 'diff' },
             { value: 'repo' },
-            { value: 'path' },
+            { displayValue: 'filenames', value: 'path' },
             { value: 'symbols' },
         ].map(
             assign({

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -59,7 +59,7 @@ export const finiteFilters: Record<
             { value: 'commit' },
             { value: 'diff' },
             { value: 'repo' },
-            { displayValue: 'filenames', value: 'path' },
+            { value: 'path' },
             { value: 'symbols' },
         ].map(
             assign({


### PR DESCRIPTION
Fixes a couple of bugs I found with the `type` filter when doing QA for interactive mode:
- The type filter input had an option for `code`, and it would actually input `type:code`, which is invalid. This PR fixes it by removing the `type:` filter. 
- The `type:` filter chips did not update when clicking one of the search type tabs, which updates the `type` value of the query.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
