### PR TITLE
styling: add horizontal padding to markdown rendered results

### DIFF
--- a/web/src/components/SearchResultMatch.scss
+++ b/web/src/components/SearchResultMatch.scss
@@ -77,8 +77,8 @@
 
     &__code-excerpt {
         padding-top: 0;
-        padding-bottom: 0;
-        padding-left: 0;
+        padding-bottom: 1rem;
+        padding-left: 0.5rem;
         padding-right: 0;
 
         table {
@@ -155,9 +155,6 @@
         }
 
         &__code-excerpt {
-            padding-top: 0;
-            padding-bottom: 1rem;
-
             td.line {
                 display: none;
             }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/7379.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
