### PR TITLE
a8n: Send campaigns count in usage pings

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -166,7 +166,7 @@ type pingRequest struct {
 	HasRepos             bool             `json:"repos"`
 	EverSearched         bool             `json:"searched"`
 	EverFindRefs         bool             `json:"refs"`
-	TotalCampaigns       int32            `json:"totalCampaigns"`
+	AutomationUsage      *json.RawMessage `json:"automationUsage"`
 }
 
 // readPingRequest reads the ping request payload from the request. If the

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -166,6 +166,7 @@ type pingRequest struct {
 	HasRepos             bool             `json:"repos"`
 	EverSearched         bool             `json:"searched"`
 	EverFindRefs         bool             `json:"refs"`
+	TotalCampaigns       int32            `json:"totalCampaigns"`
 }
 
 // readPingRequest reads the ping request payload from the request. If the

--- a/cmd/frontend/internal/usagestats/automation.go
+++ b/cmd/frontend/internal/usagestats/automation.go
@@ -1,0 +1,22 @@
+package usagestats
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+)
+
+// GetAutomationUsageStatistics returns the current site's automation usage.
+func GetAutomationUsageStatistics(ctx context.Context) (*types.AutomationUsageStatistics, error) {
+	const q = "SELECT COUNT(*) FROM campaigns;"
+
+	var count int
+	if err := dbconn.Global.QueryRowContext(ctx, q).Scan(&count); err != nil {
+		return nil, err
+	}
+
+	return &types.AutomationUsageStatistics{
+		CampaignsCount: count,
+	}, nil
+}

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -194,3 +194,7 @@ type Event struct {
 	Version         string
 	Timestamp       time.Time
 }
+
+type AutomationUsageStatistics struct {
+	CampaignsCount int
+}


### PR DESCRIPTION
Fixes #7711 - This adds the total number of Automation campaigns in the database to
the update ping.

This is just one number by design, since for now we only want to capture the number of campaigns per customer.

That's also why I simply defined one function in this package that queries the database directly. instead of using the `a8n.Store`. Because that would require moving the `Store` out of the `enterprise/internal/a8n` into the `internal/a8n` package. So I went for this tradeoff (duplicate mention of `campaigns` table here and in the store code).

What do you think?