### PR TITLE
Fix: matches in context lines do not get highlighted

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -47,8 +47,9 @@
                 </span>
             </nav>
             <div id="content-nav" class="content-nav">
-                <form class="search-form form-inline mobile-search large-hidden medium-hidden">
-                    <input name="search" class="nav-search form-control" type="search" placeholder="Search docs..." spellcheck="false">
+                <form class="search-form form-inline mobile-search large-hidden medium-hidden" method="get" action="/search">
+                    <input name="q" class="nav-search form-control" type="search" placeholder="Search docs..." spellcheck="false">
+                    <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
                     <button class="btn btn-primary nav-search-button ml-2" type="submit">Search</button>
                 </form>
                 <ul class="content-nav-section expandable">

--- a/shared/src/components/CodeExcerpt.test.tsx
+++ b/shared/src/components/CodeExcerpt.test.tsx
@@ -42,6 +42,7 @@ describe('CodeExcerpt', () => {
             { line: 1, character: 7, highlightLength: 4 },
             { line: 2, character: 6, highlightLength: 4 },
         ],
+        lastSubsetMatchLineNumber: 2,
         isLightTheme: false,
         className: 'file-match__item-code-excerpt',
         fetchHighlightedFileLines: HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,

--- a/shared/src/components/CodeExcerpt.test.tsx
+++ b/shared/src/components/CodeExcerpt.test.tsx
@@ -130,7 +130,7 @@ describe('CodeExcerpt', () => {
     })
 
     it('displays the correct number of lines, with no highlight matches on the context lines', () => {
-        const fetchHighlightedFileLines = sinon.spy(ctx => of(HL_FILE))
+        const fetchHighlightedFileLines = sinon.spy(ctx => of(HIGHLIGHTED_FILE_LINES_LONG))
         const highlightRanges = [
             { line: 0, character: 0, highlightLength: 1 },
             { line: 1, character: 0, highlightLength: 1 },

--- a/shared/src/components/CodeExcerpt.test.tsx
+++ b/shared/src/components/CodeExcerpt.test.tsx
@@ -28,6 +28,7 @@ import {
     HIGHLIGHTED_FILE_LINES,
     HIGHLIGHTED_FILE_LINES_REQUEST,
     HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
+    HIGHLIGHTED_FILE_LINES_LONG,
 } from '../util/searchTestHelpers'
 
 describe('CodeExcerpt', () => {
@@ -126,5 +127,60 @@ describe('CodeExcerpt', () => {
         )
         sinon.assert.calledOnce(fetchHighlightedFileLines)
         sinon.assert.calledWithMatch(fetchHighlightedFileLines, { disableTimeout: false })
+    })
+
+    it('displays the correct number of lines, with no highlight matches on the context lines', () => {
+        const fetchHighlightedFileLines = sinon.spy(ctx => of(HL_FILE))
+        const highlightRanges = [
+            { line: 0, character: 0, highlightLength: 1 },
+            { line: 1, character: 0, highlightLength: 1 },
+            { line: 2, character: 0, highlightLength: 1 },
+            { line: 4, character: 0, highlightLength: 1 },
+            { line: 7, character: 0, highlightLength: 1 },
+            { line: 10, character: 0, highlightLength: 1 },
+            { line: 11, character: 0, highlightLength: 1 },
+            { line: 16, character: 0, highlightLength: 1 },
+            { line: 17, character: 0, highlightLength: 1 },
+            { line: 19, character: 0, highlightLength: 1 },
+        ]
+        const { container } = render(
+            <CodeExcerpt
+                {...defaultProps}
+                context={2}
+                lastSubsetMatchLineNumber={20}
+                highlightRanges={highlightRanges}
+                fetchHighlightedFileLines={fetchHighlightedFileLines}
+            />
+        )
+        const rows = container.querySelectorAll('tr')
+        expect(rows.length).toBe(22)
+    })
+
+    it('displays the correct number of lines, with matches on the context line', () => {
+        const fetchHighlightedFileLines = sinon.spy(ctx => of(HIGHLIGHTED_FILE_LINES_LONG))
+        const highlightRanges = [
+            { line: 0, character: 0, highlightLength: 1 },
+            { line: 1, character: 0, highlightLength: 1 },
+            { line: 2, character: 0, highlightLength: 1 },
+            { line: 4, character: 0, highlightLength: 1 },
+            { line: 7, character: 0, highlightLength: 1 },
+            { line: 10, character: 0, highlightLength: 1 },
+            { line: 11, character: 0, highlightLength: 1 },
+            { line: 16, character: 0, highlightLength: 1 },
+            { line: 17, character: 0, highlightLength: 1 },
+            { line: 19, character: 0, highlightLength: 1 },
+            { line: 20, character: 0, highlightLength: 1 },
+        ]
+        const { container } = render(
+            <CodeExcerpt
+                {...defaultProps}
+                context={2}
+                lastSubsetMatchLineNumber={19}
+                highlightRanges={highlightRanges}
+                fetchHighlightedFileLines={fetchHighlightedFileLines}
+            />
+        )
+        const rows = container.querySelectorAll('tr')
+        expect(rows.length).toBe(22)
     })
 })

--- a/shared/src/components/CodeExcerpt.test.tsx
+++ b/shared/src/components/CodeExcerpt.test.tsx
@@ -59,6 +59,7 @@ describe('CodeExcerpt', () => {
                 {...defaultProps}
                 context={5}
                 highlightRanges={[{ line: 4, character: 1, highlightLength: 2 }]}
+                lastSubsetMatchLineNumber={4}
             />
         )
         expect(container.querySelectorAll('.code-excerpt tr').length).toBe(10)

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -145,8 +145,8 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
         // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
         // Don't add the context value to calculate the last line if the last highlight match is the highlight range + contextLines
         const lastLine = contextLineHasHighlight
-            ? Math.max(...this.props.highlightRanges.map(r => r.line)) + numberOfcontextLinesToShow
-            : Math.max(...this.props.highlightRanges.map(r => r.line)) + contextLines
+            ? Math.max(...highlightRangeLines) + numberOfcontextLinesToShow
+            : Math.max(...highlightRangeLines) + contextLines
         // If there are lines, take the minimum of lastLine and the number of lines in the file,
         // so we don't try to display a line index beyond the maximum line number in the file.
         return blobLines ? Math.min(lastLine, blobLines.length) : lastLine

--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -72,9 +72,11 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
     // This checks the highest line number amongst the number of matches
     // that we want to show in a collapsed result preview.
     const highestLineNumberWithinSubsetMatches =
-        sortedItems.length > props.subsetMatches
-            ? sortedItems[props.subsetMatches - 1].line
-            : sortedItems[sortedItems.length - 1].line
+        sortedItems.length > 0
+            ? sortedItems.length > props.subsetMatches
+                ? sortedItems[props.subsetMatches - 1].line
+                : sortedItems[sortedItems.length - 1].line
+            : 0
 
     const showItems = sortedItems.filter(
         (item, i) =>

--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -68,6 +68,9 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         }
         return 1
     })
+
+    // This checks the highest line number amongst the number of matches
+    // that we want to show in a collapsed result preview.
     const highestLineNumberWithinSubsetMatches =
         sortedItems.length > props.subsetMatches
             ? sortedItems[props.subsetMatches - 1].line

--- a/shared/src/util/searchTestHelpers.ts
+++ b/shared/src/util/searchTestHelpers.ts
@@ -197,6 +197,33 @@ export const HIGHLIGHTED_FILE_LINES_SIMPLE = [
     '<tr><td class="line" data-line="10"></td><td class="code">tenth</td></tr>',
 ]
 
+export const HIGHLIGHTED_FILE_LINES_LONG = [
+    '<tr><td class="line" data-line="1"></td><td class="code"><div><span style="color:#93a1a1;">// Copyright 2014 The Go Authors. All rights reserved.↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="2"></td><td class="code"><div><span style="color:#93a1a1;">// Use of this source code is governed by a BSD-style↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="3"></td><td class="code"><div><span style="color:#93a1a1;">// license that can be found in the LICENSE file.↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="4"></td><td class="code"><div><span style="color:#657b83;">↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="5"></td><td class="code"><div><span style="color:#859900;">package</span><span style="color:#657b83;"> oauth2_test↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="6"></td><td class="code"><div><span style="color:#657b83;">↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="7"></td><td class="code"><div><span style="color:#cb4b16;">import </span><span style="color:#657b83;">(↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="8"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">context</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="9"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">fmt</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="10"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">log</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="11"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">net/http</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="12"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">time</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="13"></td><td class="code"><div><span style="color:#657b83;">↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="14"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">golang.org/x/oauth2</span><span style="color:#839496;">&#34;↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="15"></td><td class="code"><div><span style="color:#657b83;">)↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="16"></td><td class="code"><div><span style="color:#657b83;">↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="17"></td><td class="code"><div><span style="color:#268bd2;">func </span><span style="color:#b58900;">ExampleConfig</span><span style="color:#657b83;">() {↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="18"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#268bd2;">ctx </span><span style="color:#859900;">:=</span><span style="color:#657b83;"> context.</span><span style="color:#b58900;">Background</span><span style="color:#657b83;">()↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="19"></td><td class="code"><div><span style="color:#657b83;">	</span><span style="color:#268bd2;">conf </span><span style="color:#859900;">:= &amp;</span><span style="color:#657b83;">oauth2.</span><span style="color:#268bd2;">Config</span><span style="color:#657b83;">{↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="20"></td><td class="code"><div><span style="color:#657b83;">		</span><span style="color:#b58900;">ClientID</span><span style="color:#657b83;">:     </span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">YOUR_CLIENT_ID</span><span style="color:#839496;">&#34;</span><span style="color:#657b83;">,↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="21"></td><td class="code"><div><span style="color:#657b83;">		</span><span style="color:#b58900;">ClientSecret</span><span style="color:#657b83;">: </span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">YOUR_CLIENT_SECRET</span><span style="color:#839496;">&#34;</span><span style="color:#657b83;">,↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="22"></td><td class="code"><div><span style="color:#657b83;">		</span><span style="color:#b58900;">Scopes</span><span style="color:#657b83;">:       []</span><span style="color:#268bd2;">string</span><span style="color:#657b83;">{</span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">SCOPE1</span><span style="color:#839496;">&#34;</span><span style="color:#657b83;">, </span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">SCOPE2</span><span style="color:#839496;">&#34;</span><span style="color:#657b83;">},↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="23"></td><td class="code"><div><span style="color:#657b83;">		</span><span style="color:#b58900;">Endpoint</span><span style="color:#657b83;">: oauth2.</span><span style="color:#268bd2;">Endpoint</span><span style="color:#657b83;">{↵</span></div></td></tr>',
+    '<tr><td class="line" data-line="24"></td><td class="code"><div><span style="color:#657b83;">			</span><span style="color:#b58900;">AuthURL</span><span style="color:#657b83;">:  </span><span style="color:#839496;">&#34;</span><span style="color:#2aa198;">https://provider.com/o/oauth2/auth</span><span style="color:#839496;">&#34;</span><span style="color:#657b83;">,↵</span></div></td></tr>',
+]
+
 export const HIGHLIGHTED_FILE_LINES_REQUEST = sinon.fake.returns(of(HIGHLIGHTED_FILE_LINES))
 export const HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST = sinon.fake.returns(of(HIGHLIGHTED_FILE_LINES_SIMPLE))
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/6900. 

This was a little trickier to fix than I thought. 

The reason these lines weren't getting highlighted was that they were context lines, so the matches on these lines were filtered out in `FileMatchChildren`, while we only decide to render the context lines in `CodeExcerpt`.

Why did we decide to filter out the match in the context lines? Something unknown to the user, is that we [limit the number of matches to display in the preview to 10 matches (in a single file)]((https://sourcegraph.com/search?q=const+subsetMatches+%3D+parseInt%28localStorage.getItem%28SUBSET_COUNT_KEY%29+%7C%7C+%27%27%2C+10%29+repo:github.com/sourcegraph/sourcegraph%24&patternType=literal)
). Everything else is viewable and highlighted by clicking "Show x more matches".

In the bugs listed in the issue, those matches we expected to be highlighted were match number 11 in their respective files. Therefore, in `FileMatchChildren`, they were filtered out. In `CodeExcerpt`, when we decide which part of the blob to display, we include the contextLine. Now, if there's a match highlight that appears  the context lines, it will be highlighted. 

However, we don't want to add _more_ context lines if there is now a highlight in one of the context lines. The caveat here is that our users do not know that there's a 10-match limit in the result previews. Therefore, if there are already 10 matches in a result preview, and the 11th appears on a context line, it will look as if we are not providing the correct number of context lines, which may seem like a bug to attentive users. I think this is a reasonable tradeoff. It's less misleading, and is ultimately more "correct" behavior.