### PR TITLE
registry: use more efficient json.Unmarshal on manifest

### DIFF
--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -35,7 +35,7 @@ func getExtensionManifestWithBundleURL(ctx context.Context, extensionID string, 
 	if release != nil {
 		// Add URL to bundle if necessary.
 		var o map[string]interface{}
-		if err := jsonc.Unmarshal(release.Manifest, &o); err != nil {
+		if err := json.Unmarshal([]byte(release.Manifest), &o); err != nil {
 			return nil, time.Time{}, fmt.Errorf("parsing extension manifest for extension with ID %d (release tag %q): %s", registryExtensionID, releaseTag, err)
 		}
 		if o == nil {


### PR DESCRIPTION
I took a random trace of sourcegraph.com, and this was the largest use of
CPU. There are more optimizations we can make here, but the simple change is
to just use a more efficient unmarshaller. I validated that all data in
postgres is normal json (instead of jsonc). Additionally the column type is
jsonb, so it should always be conformant json.

I also checked how often we need to blend in the URL (the purpose of this
function). The answer is most of the time.

Part of https://github.com/sourcegraph/sourcegraph/issues/7544