### PR TITLE
Handle GitHub's ReviewDismissed events and events in dismissed state

### DIFF
--- a/enterprise/internal/a8n/counts.go
+++ b/enterprise/internal/a8n/counts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/a8n"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 // ChangesetCounts represents the states in which a given set of Changesets was
@@ -261,7 +262,8 @@ func computeCounts(c *ChangesetCounts, csEvents Events) error {
 				// the same author.
 				lastReview, ok := lastReviewByAuthor[author]
 				if !ok || lastReview != a8n.ChangesetReviewStateApproved {
-					return errors.New("Bitbucket Server Unapproval not following an Approval")
+					log15.Warn("Bitbucket Server Unapproval not following an Approval", "event", e)
+					continue
 				}
 			}
 
@@ -270,7 +272,8 @@ func computeCounts(c *ChangesetCounts, csEvents Events) error {
 				// the author of the review included in the event.
 				_, ok := lastReviewByAuthor[author]
 				if !ok {
-					return errors.New("GitHub review dismissal not following a review")
+					log15.Warn("GitHub review dismissal not following a review", "event", e)
+					continue
 				}
 			}
 

--- a/enterprise/internal/a8n/counts_test.go
+++ b/enterprise/internal/a8n/counts_test.go
@@ -1167,7 +1167,7 @@ func TestCalcCounts(t *testing.T) {
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				ghReview(1, daysAgo(1), "user2", "CHANGES_REQUESTED"),
-				ghReview(1, daysAgo(0), "user3", "user2"),
+				ghReviewDismissed(1, daysAgo(0), "user3", "user2"),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 1, Open: 1, OpenApproved: 1},

--- a/enterprise/internal/a8n/counts_test.go
+++ b/enterprise/internal/a8n/counts_test.go
@@ -1125,6 +1125,56 @@ func TestCalcCounts(t *testing.T) {
 				{Time: daysAgo(0), Total: 2, Closed: 2},
 			},
 		},
+		{
+			codehosts: "github",
+			name:      "single changeset with changes-requested then reviewevent by same person with dismissed state",
+			changesets: []*a8n.Changeset{
+				ghChangeset(1, daysAgo(1)),
+			},
+			start: daysAgo(1),
+			events: []Event{
+				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
+				ghReview(1, daysAgo(0), "user1", "DISMISSED"),
+			},
+			want: []*ChangesetCounts{
+				{Time: daysAgo(1), Total: 1, Open: 1, OpenChangesRequested: 1},
+				{Time: daysAgo(0), Total: 1, Open: 1, OpenPending: 1},
+			},
+		},
+		{
+			codehosts: "github",
+			name:      "single changeset with changes-requested then dismissed event by same person with dismissed state",
+			changesets: []*a8n.Changeset{
+				ghChangeset(1, daysAgo(1)),
+			},
+			start: daysAgo(1),
+			events: []Event{
+				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
+				ghReviewDismissed(1, daysAgo(0), "user2", "user1"),
+			},
+			want: []*ChangesetCounts{
+				{Time: daysAgo(1), Total: 1, Open: 1, OpenChangesRequested: 1},
+				{Time: daysAgo(0), Total: 1, Open: 1, OpenPending: 1},
+			},
+		},
+		{
+			codehosts: "github",
+			name:      "single changeset with approval by one person, changes-requested by another, then dismissal of changes-requested",
+			changesets: []*a8n.Changeset{
+				ghChangeset(1, daysAgo(2)),
+			},
+			start: daysAgo(2),
+			events: []Event{
+				ghReview(1, daysAgo(2), "user1", "APPROVED"),
+				ghReview(1, daysAgo(1), "user2", "CHANGES_REQUESTED"),
+				ghReview(1, daysAgo(0), "user3", "user2"),
+			},
+			want: []*ChangesetCounts{
+				{Time: daysAgo(2), Total: 1, Open: 1, OpenApproved: 1},
+				{Time: daysAgo(1), Total: 1, Open: 1, OpenChangesRequested: 1},
+				{Time: daysAgo(0), Total: 1, Open: 1, OpenApproved: 1},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1188,6 +1238,22 @@ func ghReview(id int64, t time.Time, login, state string) *a8n.ChangesetEvent {
 			State:     state,
 			Author: github.Actor{
 				Login: login,
+			},
+		},
+	}
+}
+
+func ghReviewDismissed(id int64, t time.Time, login, reviewer string) *a8n.ChangesetEvent {
+	return &a8n.ChangesetEvent{
+		ChangesetID: id,
+		Kind:        a8n.ChangesetEventKindGitHubReviewDismissed,
+		Metadata: &github.ReviewDismissedEvent{
+			CreatedAt: t,
+			Actor:     github.Actor{Login: login},
+			Review: github.PullRequestReview{
+				Author: github.Actor{
+					Login: reviewer,
+				},
 			},
 		},
 	}

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -589,9 +589,7 @@ func (ce ChangesetEvents) ReviewState() (ChangesetReviewState, error) {
 			ChangesetReviewStateChangesRequested:
 			reviewsByAuthor[author] = s
 		case ChangesetReviewStateDismissed:
-			if _, ok := reviewsByAuthor[author]; ok {
-				delete(reviewsByAuthor, author)
-			}
+			delete(reviewsByAuthor, author)
 		}
 	}
 

--- a/internal/a8n/types_test.go
+++ b/internal/a8n/types_test.go
@@ -393,16 +393,31 @@ func TestChangesetEventsReviewState(t *testing.T) {
 			},
 			want: ChangesetReviewStateApproved,
 		},
+		{
+			events: ChangesetEvents{
+				ghReview(daysAgo(1), "user1", "CHANGES_REQUESTED"),
+				ghReview(daysAgo(0), "user1", "DISMISSED"),
+			},
+			want: ChangesetReviewStatePending,
+		},
+		{
+			events: ChangesetEvents{
+				ghReview(daysAgo(2), "user1", "CHANGES_REQUESTED"),
+				ghReview(daysAgo(1), "user1", "DISMISSED"),
+				ghReview(daysAgo(0), "user3", "APPROVED"),
+			},
+			want: ChangesetReviewStateApproved,
+		},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		have, err := tc.events.ReviewState()
 		if err != nil {
 			t.Fatalf("got error: %s", err)
 		}
 
 		if have, want := have, tc.want; have != want {
-			t.Errorf("wrong reviewstate. have=%s, want=%s", have, want)
+			t.Errorf("%d: wrong reviewstate. have=%s, want=%s", i, have, want)
 		}
 	}
 }


### PR DESCRIPTION
This fixes #8370 by handling GitHub's support for dismissing reviews.

There are two ways in which the dismissal of a review can show up in our codebase.

1. As a `ReviewDismissed` event. This is emitted when a review is dimissed (either by the author of the reviewD itself or by another person)
2. As the `DISMISSED` state of a review. When a review is dimissed, the `PullRequestReview` object embedded in a `PullRequestReviewedEvent` is updated and its state is changed to `DISMISSED`.

Here's what these two events look like in our database:

```
-[ RECORD 5 ]+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id           | 23022
changeset_id | 12
kind         | github:reviewed
key          | 357299055
created_at   | 2020-02-12 01:51:10.305031-08
metadata     | {"URL": "https://github.com/sourcegraph/automation-testing/pull/156#pullrequestreview-357299055", "Body": "looks good", "State": "DISMISSED", "Author": {"URL": "https://github.com/mrnugget", "Login": "mrnugget", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "Commit": {"OID": "05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80", "URL": "https://github.com/sourcegraph/automation-testing/commit/05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80", "Status": {"State": "", "Contexts": null}, "Message": "Add foobar.md file", "Committer": {"Name": "Thorsten Ball", "User": {"URL": "https://github.com/mrnugget", "Login": "mrnugget", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "Email": "mrnugget@gmail.com", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "PushedDate": "2019-11-12T13:00:07Z", "CommittedDate": "2019-11-12T12:57:33Z", "MessageHeadline": "Add foobar.md file"}, "CreatedAt": "2020-02-12T09:28:18Z", "UpdatedAt": "2020-02-12T09:28:33Z", "DatabaseID": 357299055, "AuthorAssociation": "MEMBER", "IncludesCreatedEdit": false}
updated_at   | 2020-02-12 04:22:57.021974-08
-[ RECORD 6 ]+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id           | 23023
changeset_id | 12
kind         | github:review_dismissed
key          | ryanslade:357299055:1581499713000000000
created_at   | 2020-02-12 01:51:10.305031-08
metadata     | {"Actor": {"URL": "https://github.com/ryanslade", "Login": "ryanslade", "AvatarURL": "https://avatars3.githubusercontent.com/u/25610?v=4"}, "Review": {"URL": "https://github.com/sourcegraph/automation-testing/pull/156#pullrequestreview-357299055", "Body": "looks good", "State": "DISMISSED", "Author": {"URL": "https://github.com/mrnugget", "Login": "mrnugget", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "Commit": {"OID": "05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80", "URL": "https://github.com/sourcegraph/automation-testing/commit/05e562cc5d8ab50b5fcab8dfd5dfa5db13a48e80", "Status": {"State": "", "Contexts": null}, "Message": "Add foobar.md file", "Committer": {"Name": "Thorsten Ball", "User": {"URL": "https://github.com/mrnugget", "Login": "mrnugget", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "Email": "mrnugget@gmail.com", "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4"}, "PushedDate": "2019-11-12T13:00:07Z", "CommittedDate": "2019-11-12T12:57:33Z", "MessageHeadline": "Add foobar.md file"}, "CreatedAt": "2020-02-12T09:28:18Z", "UpdatedAt": "2020-02-12T09:28:33Z", "DatabaseID": 357299055, "AuthorAssociation": "MEMBER", "IncludesCreatedEdit": false}, "CreatedAt": "2020-02-12T09:28:33Z", "DismissalMessage": "Things"}
updated_at   | 2020-02-12 04:22:57.021974-08
```

The code here handles *both* cases.