### PR TITLE
Support multiple 'closest' LSIF uploads in GraphQL

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -81,7 +81,6 @@ type LSIFUploadConnectionResolver interface {
 }
 
 type LSIFQueryResolver interface {
-	Commit(ctx context.Context) (*GitCommitResolver, error)
 	Definitions(ctx context.Context, args *LSIFQueryPositionArgs) (LocationConnectionResolver, error)
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2794,14 +2794,6 @@ type LSIFQueryResolver {
     # (experimental) The LSIF API may change substantially in the near future as we
     # continue to adjust it for our use cases. Changes will not be documented in the
     # CHANGELOG during this time.
-    # The commit that is being used to power code intelligence. This may be distinct from
-    # the commit of the git blob from which this query resolver came when there is no
-    # LSIF data available for that commit.
-    commit: GitCommit!
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # A list of definitions of the symbol under the given document position.
     definitions(
         # The line on which the symbol occurs (zero-based, inclusive).

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2801,14 +2801,6 @@ type LSIFQueryResolver {
     # (experimental) The LSIF API may change substantially in the near future as we
     # continue to adjust it for our use cases. Changes will not be documented in the
     # CHANGELOG during this time.
-    # The commit that is being used to power code intelligence. This may be distinct from
-    # the commit of the git blob from which this query resolver came when there is no
-    # LSIF data available for that commit.
-    commit: GitCommit!
-
-    # (experimental) The LSIF API may change substantially in the near future as we
-    # continue to adjust it for our use cases. Changes will not be documented in the
-    # CHANGELOG during this time.
     # A list of definitions of the symbol under the given document position.
     definitions(
         # The line on which the symbol occurs (zero-based, inclusive).

--- a/enterprise/internal/codeintel/lsifserver/client/query.go
+++ b/enterprise/internal/codeintel/lsifserver/client/query.go
@@ -16,7 +16,7 @@ func (c *Client) Exists(ctx context.Context, args *struct {
 	RepoID api.RepoID
 	Commit string
 	Path   string
-}) (*lsif.LSIFUpload, error) {
+}) ([]*lsif.LSIFUpload, error) {
 	query := queryValues{}
 	query.SetInt("repositoryId", int64(args.RepoID))
 	query.Set("commit", args.Commit)
@@ -28,7 +28,7 @@ func (c *Client) Exists(ctx context.Context, args *struct {
 	}
 
 	payload := struct {
-		Upload *lsif.LSIFUpload `json:"upload"`
+		Uploads []*lsif.LSIFUpload `json:"uploads"`
 	}{}
 
 	_, err := c.do(ctx, req, &payload)
@@ -36,7 +36,7 @@ func (c *Client) Exists(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	return payload.Upload, nil
+	return payload.Uploads, nil
 }
 
 func (c *Client) Upload(ctx context.Context, args *struct {

--- a/enterprise/internal/codeintel/resolvers/location.go
+++ b/enterprise/internal/codeintel/resolvers/location.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -12,7 +11,7 @@ import (
 
 type locationConnectionResolver struct {
 	locations []*lsif.LSIFLocation
-	nextURL   string
+	endCursor string
 }
 
 var _ graphqlbackend.LocationConnectionResolver = &locationConnectionResolver{}
@@ -43,8 +42,8 @@ func (r *locationConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacken
 }
 
 func (r *locationConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if r.nextURL != "" {
-		return graphqlutil.NextPageCursor(base64.StdEncoding.EncodeToString([]byte(r.nextURL))), nil
+	if r.endCursor != "" {
+		return graphqlutil.NextPageCursor(r.endCursor), nil
 	}
 	return graphqlutil.HasNextPage(false), nil
 }

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/lsifserver/client"
@@ -11,109 +12,172 @@ import (
 )
 
 type lsifQueryResolver struct {
-	repoID api.RepoID
-	commit graphqlbackend.GitObjectID
-	path   string
-	upload *lsif.LSIFUpload
+	repoID  api.RepoID
+	commit  graphqlbackend.GitObjectID
+	path    string
+	uploads []*lsif.LSIFUpload
 }
 
 var _ graphqlbackend.LSIFQueryResolver = &lsifQueryResolver{}
 
-func (r *lsifQueryResolver) Commit(ctx context.Context) (*graphqlbackend.GitCommitResolver, error) {
-	return resolveCommit(ctx, r.repoID, r.upload.Commit)
-}
-
 func (r *lsifQueryResolver) Definitions(ctx context.Context, args *graphqlbackend.LSIFQueryPositionArgs) (graphqlbackend.LocationConnectionResolver, error) {
-	opts := &struct {
-		RepoID    api.RepoID
-		Commit    graphqlbackend.GitObjectID
-		Path      string
-		Line      int32
-		Character int32
-		UploadID  int64
-	}{
-		RepoID:    r.repoID,
-		Commit:    r.commit,
-		Path:      r.path,
-		Line:      args.Line,
-		Character: args.Character,
-		UploadID:  r.upload.ID,
-	}
+	for _, upload := range r.uploads {
+		opts := &struct {
+			RepoID    api.RepoID
+			Commit    graphqlbackend.GitObjectID
+			Path      string
+			Line      int32
+			Character int32
+			UploadID  int64
+		}{
+			RepoID:    r.repoID,
+			Commit:    r.commit,
+			Path:      r.path,
+			Line:      args.Line,
+			Character: args.Character,
+			UploadID:  upload.ID,
+		}
 
-	locations, nextURL, err := client.DefaultClient.Definitions(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &locationConnectionResolver{
-		locations: locations,
-		nextURL:   nextURL,
-	}, nil
-}
-
-func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend.LSIFPagedQueryPositionArgs) (graphqlbackend.LocationConnectionResolver, error) {
-	opts := &struct {
-		RepoID    api.RepoID
-		Commit    graphqlbackend.GitObjectID
-		Path      string
-		Line      int32
-		Character int32
-		UploadID  int64
-		Limit     *int32
-		Cursor    *string
-	}{
-		RepoID:    r.repoID,
-		Commit:    r.commit,
-		Path:      r.path,
-		Line:      args.Line,
-		Character: args.Character,
-		UploadID:  r.upload.ID,
-	}
-	if args.First != nil {
-		opts.Limit = args.First
-	}
-	if args.After != nil {
-		decoded, err := base64.StdEncoding.DecodeString(*args.After)
+		locations, _, err := client.DefaultClient.Definitions(ctx, opts)
 		if err != nil {
 			return nil, err
 		}
-		nextURL := string(decoded)
-		opts.Cursor = &nextURL
+
+		if len(locations) > 0 {
+			return &locationConnectionResolver{
+				locations: locations,
+			}, nil
+		}
 	}
 
-	locations, nextURL, err := client.DefaultClient.References(ctx, opts)
+	return &locationConnectionResolver{locations: nil}, nil
+}
+
+func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend.LSIFPagedQueryPositionArgs) (graphqlbackend.LocationConnectionResolver, error) {
+	// Decode a map of upload ids to the next url that serves
+	// the new page of results. This may not include an entry
+	// for every upload if their result sets have already been
+	// exhausted.
+	nextURLs, err := readCursor(args.After)
+	if err != nil {
+		return nil, err
+	}
+
+	// We need to maintain a symmetric map for the next page
+	// of results that we can encode into the endCursor of
+	// this request.
+	newCursors := map[int64]string{}
+
+	var allLocations []*lsif.LSIFLocation
+	for _, upload := range r.uploads {
+		opts := &struct {
+			RepoID    api.RepoID
+			Commit    graphqlbackend.GitObjectID
+			Path      string
+			Line      int32
+			Character int32
+			UploadID  int64
+			Limit     *int32
+			Cursor    *string
+		}{
+			RepoID:    r.repoID,
+			Commit:    r.commit,
+			Path:      r.path,
+			Line:      args.Line,
+			Character: args.Character,
+			UploadID:  upload.ID,
+		}
+		if args.First != nil {
+			opts.Limit = args.First
+		}
+		if nextURL, ok := nextURLs[upload.ID]; ok {
+			opts.Cursor = &nextURL
+		}
+
+		locations, nextURL, err := client.DefaultClient.References(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		allLocations = append(allLocations, locations...)
+
+		if nextURL != "" {
+			newCursors[upload.ID] = nextURL
+		}
+	}
+
+	endCursor, err := makeCursor(newCursors)
 	if err != nil {
 		return nil, err
 	}
 
 	return &locationConnectionResolver{
-		locations: locations,
-		nextURL:   nextURL,
+		locations: allLocations,
+		endCursor: endCursor,
 	}, nil
 }
 
 func (r *lsifQueryResolver) Hover(ctx context.Context, args *graphqlbackend.LSIFQueryPositionArgs) (graphqlbackend.HoverResolver, error) {
-	text, lspRange, err := client.DefaultClient.Hover(ctx, &struct {
-		RepoID    api.RepoID
-		Commit    graphqlbackend.GitObjectID
-		Path      string
-		Line      int32
-		Character int32
-		UploadID  int64
-	}{
-		RepoID:    r.repoID,
-		Commit:    r.commit,
-		Path:      r.path,
-		Line:      args.Line,
-		Character: args.Character,
-		UploadID:  r.upload.ID,
-	})
+	for _, upload := range r.uploads {
+		text, lspRange, err := client.DefaultClient.Hover(ctx, &struct {
+			RepoID    api.RepoID
+			Commit    graphqlbackend.GitObjectID
+			Path      string
+			Line      int32
+			Character int32
+			UploadID  int64
+		}{
+			RepoID:    r.repoID,
+			Commit:    r.commit,
+			Path:      r.path,
+			Line:      args.Line,
+			Character: args.Character,
+			UploadID:  upload.ID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if text != "" {
+			return &hoverResolver{
+				text:     text,
+				lspRange: lspRange,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// readCursor decodes a cursor into a map from upload ids to URLs that
+// serves the next page of results.
+func readCursor(after *string) (map[int64]string, error) {
+	if after == nil {
+		return nil, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(*after)
 	if err != nil {
 		return nil, err
 	}
 
-	return &hoverResolver{
-		text:     text,
-		lspRange: lspRange,
-	}, nil
+	var cursors map[int64]string
+	if err := json.Unmarshal(decoded, &cursors); err != nil {
+		return nil, err
+	}
+	return cursors, nil
+}
+
+// makeCursor encodes a map from upload ids to URLs that serves the next
+// page of results into a single string that can be sent back for use in
+// cursor pagination.
+func makeCursor(cursors map[int64]string) (string, error) {
+	if len(cursors) == 0 {
+		return "", nil
+	}
+
+	encoded, err := json.Marshal(cursors)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(encoded), nil
 }

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -12,9 +12,11 @@ import (
 )
 
 type lsifQueryResolver struct {
-	repoID  api.RepoID
-	commit  graphqlbackend.GitObjectID
-	path    string
+	repoID api.RepoID
+	// commit is the requested target commit
+	commit graphqlbackend.GitObjectID
+	path   string
+	// uploads are ordered by their commit distance from the target commit
 	uploads []*lsif.LSIFUpload
 }
 

--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -91,7 +91,7 @@ func (r *Resolver) LSIFUploads(ctx context.Context, args *graphqlbackend.LSIFRep
 }
 
 func (r *Resolver) LSIF(ctx context.Context, args *graphqlbackend.LSIFQueryArgs) (graphqlbackend.LSIFQueryResolver, error) {
-	upload, err := client.DefaultClient.Exists(ctx, &struct {
+	uploads, err := client.DefaultClient.Exists(ctx, &struct {
 		RepoID api.RepoID
 		Commit string
 		Path   string
@@ -105,14 +105,14 @@ func (r *Resolver) LSIF(ctx context.Context, args *graphqlbackend.LSIFQueryArgs)
 		return nil, err
 	}
 
-	if upload == nil {
+	if len(uploads) == 0 {
 		return nil, nil
 	}
 
 	return &lsifQueryResolver{
-		repoID: args.Repository.Type().ID,
-		commit: args.Commit,
-		path:   args.Path,
-		upload: upload,
+		repoID:  args.Repository.Type().ID,
+		commit:  args.Commit,
+		path:    args.Path,
+		uploads: uploads,
 	}, nil
 }

--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -107,9 +107,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/Upload'
-                  - type: null
+                - $ref: '#/components/schemas/Uploads'
     post:
       description: Determine if LSIF data exists for a file within a particular commit. This endpoint will return true if there is a nearby commit (direct ancestor or descendant) with LSIF data for the same file if the exact commit does not have available LSIF data.
       tags:
@@ -366,7 +364,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Uploads'
+                $ref: '#/components/schemas/PaginatedUploads'
           headers:
             Link:
               description: If there are more results, this header includes the URL of the next page with relation type *next*. See [RFC 5988](https://tools.ietf.org/html/rfc5988).
@@ -484,6 +482,15 @@ components:
         - id
       additionalProperties: false
     Uploads:
+      type: object
+      description: A wrapper for a list of uploads.
+      properties:
+        uploads:
+          type: array
+          description: A list of uploads.
+          items:
+            $ref: '#/components/schemas/Upload'
+    PaginatedUploads:
       type: object
       description: A paginated wrapper for a list of uploads.
       properties:

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -149,11 +149,7 @@ export function createLsifRouter(
                 const { repositoryId, commit, path }: ExistsQueryArgs = req.query
                 const ctx = createTracingContext(req, { repositoryId, commit })
                 const uploads = await backend.exists(repositoryId, commit, path, ctx)
-
-                // TODO(#8384): Multiple dumps to the GraphQL API. Punting on this for now as
-                // it may cause a non-trivial change in the API shape that may also
-                // affect basic-code-intel.
-                res.json({ upload: uploads[0] })
+                res.json({ uploads })
             }
         )
     )


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/8269 made it possible for there to be many 'closest' uploads for a code intelligence query. This changes returns all of them from lsif-server (instead of just arbitrarily returning the first one), and queries each of them in the GraphQL code intel resolvers.

Definitions and hovers will query each dump sequentially and the one with the first non-empty result will be returned without querying the remaining dumps. All dumps will be queried for reference results and the results will be appended together.