### PR TITLE
Web: Display the indexer that created an LSIF dump

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -61,6 +61,7 @@ type LSIFUploadResolver interface {
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
 	InputCommit() string
 	InputRoot() string
+	InputIndexer() string
 	State() string
 	UploadedAt() DateTime
 	StartedAt() *DateTime

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4262,6 +4262,9 @@ type LSIFUpload implements Node {
     # The original root supplied at upload time.
     inputRoot: String!
 
+    # The original indexer name supplied at upload time.
+    inputIndexer: String!
+
     # The upload's current state.
     state: LSIFUploadState!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4269,6 +4269,9 @@ type LSIFUpload implements Node {
     # The original root supplied at upload time.
     inputRoot: String!
 
+    # The original indexer name supplied at upload time.
+    inputIndexer: String!
+
     # The upload's current state.
     state: LSIFUploadState!
 

--- a/enterprise/internal/codeintel/resolvers/upload.go
+++ b/enterprise/internal/codeintel/resolvers/upload.go
@@ -39,6 +39,10 @@ func (r *lsifUploadResolver) InputRoot() string {
 	return r.lsifUpload.Root
 }
 
+func (r *lsifUploadResolver) InputIndexer() string {
+	return r.lsifUpload.Indexer
+}
+
 func (r *lsifUploadResolver) State() string {
 	return strings.ToUpper(r.lsifUpload.State)
 }

--- a/internal/lsif/types.go
+++ b/internal/lsif/types.go
@@ -12,6 +12,7 @@ type LSIFUpload struct {
 	RepositoryID      api.RepoID `json:"repositoryId"`
 	Commit            string     `json:"commit"`
 	Root              string     `json:"root"`
+	Indexer           string     `json:"indexer"`
 	Filename          string     `json:"filename"`
 	State             string     `json:"state"`
 	UploadedAt        time.Time  `json:"uploadedAt"`

--- a/lsif/docs/api.yaml
+++ b/lsif/docs/api.yaml
@@ -514,6 +514,9 @@ components:
         root:
           type: string
           description: The root argument given on upload.
+        indexer:
+          type: string
+          description: The name of the indexer given on upload.
         filename:
           type: string
           description: The filename where the upload was stored before conversion.

--- a/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
@@ -34,10 +34,20 @@ const LsifUploadNode: FunctionComponent<{ node: GQL.ILSIFUpload }> = ({ node }) 
     <div className="w-100 list-group-item py-2 lsif-data__main">
         <div className="lsif-data__meta">
             <div className="lsif-data__meta-root">
-                <code className="e2e-upload-commit">
-                    {node.projectRoot?.commit.abbreviatedOID || node.inputCommit.substring(0, 7)}
+                Upload for commit
+                <code className="ml-1 mr-1 e2e-upload-commit">
+                    {node.projectRoot ? (
+                        <Link to={node.projectRoot.commit.url}>
+                            <code>{node.projectRoot.commit.abbreviatedOID}</code>
+                        </Link>
+                    ) : (
+                        node.inputCommit.substring(0, 7)
+                    )}
                 </code>
-                <span className="ml-2 e2e-upload-root">
+                indexed by
+                <span className="ml-1 mr-1">{node.inputIndexer}</span>
+                rooted at
+                <span className="ml-1 e2e-upload-root">
                     {node.projectRoot ? (
                         <Link to={node.projectRoot.url}>
                             <strong>{node.projectRoot.path || '/'}</strong>

--- a/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
@@ -50,11 +50,9 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
                             Upload for commit{' '}
                             {uploadOrError.projectRoot
                                 ? uploadOrError.projectRoot.commit.abbreviatedOID
-                                : uploadOrError.inputCommit.substring(0, 7)}
-                            {uploadOrError.inputRoot !== '' &&
-                                ` rooted at ${
-                                    uploadOrError.projectRoot ? uploadOrError.projectRoot.path : uploadOrError.inputRoot
-                                }`}
+                                : uploadOrError.inputCommit.substring(0, 7)}{' '}
+                            indexed by {uploadOrError.inputIndexer} rooted at{' '}
+                            {uploadOrError.projectRoot?.path || uploadOrError.inputRoot || '/'}
                         </h2>
                     </div>
 
@@ -120,6 +118,11 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
                                         uploadOrError.inputRoot || '/'
                                     )}
                                 </td>
+                            </tr>
+
+                            <tr>
+                                <td>Indexer</td>
+                                <td>{uploadOrError.inputIndexer}</td>
                             </tr>
 
                             <tr>

--- a/web/src/enterprise/repo/settings/backend.tsx
+++ b/web/src/enterprise/repo/settings/backend.tsx
@@ -41,12 +41,14 @@ export function fetchLsifUploads({
                                 projectRoot {
                                     commit {
                                         abbreviatedOID
+                                        url
                                     }
                                     path
                                     url
                                 }
                                 inputCommit
                                 inputRoot
+                                inputIndexer
                                 uploadedAt
                                 startedAt
                                 finishedAt
@@ -104,6 +106,7 @@ export function fetchLsifUpload({ id }: { id: string }): Observable<GQL.ILSIFUpl
                         }
                         inputCommit
                         inputRoot
+                        inputIndexer
                         state
                         failure {
                             summary


### PR DESCRIPTION
This adds the indexer field that was recently made available in lsif-server to the GraphQL API and the UI.