### PR TITLE
search: introduce content: field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a setting `auth.minPasswordLength`, which when set, causes a minimum password length to be enforced when users sign up or change passwords. [#7521](https://github.com/sourcegraph/sourcegraph/issues/7521)
 - GitHub labels associated with Automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - When creating a campaign Automation users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
+- GitHub labels associated with automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
+- **Search** Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a setting `auth.minPasswordLength`, which when set, causes a minimum password length to be enforced when users sign up or change passwords. [#7521](https://github.com/sourcegraph/sourcegraph/issues/7521)
 - GitHub labels associated with Automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - When creating a campaign Automation users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
-- GitHub labels associated with automation campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - **Search** Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
 
 ### Changed

--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -27,7 +27,7 @@ This section documents the available search pattern syntax and interpretation in
 
 ### Literal search (default)
 
-Literal search interprets search patterns literally to simplify searching for words or punctuation. 
+Literal search interprets search patterns literally to simplify searching for words or punctuation.
 
 | Search pattern syntax | Description |
 | --- | --- | 
@@ -70,6 +70,7 @@ The following keywords can be used on all searches (using [RE2 syntax](https://g
 | **repogroup:group-name** <br> _alias: g_ | Only include results from the named group of repositories (defined by the server admin). Same as using a repo: keyword that matches all of the group's repositories. Use repo: unless you know that the group exists. | |
 | **file:regexp-pattern** <br> _alias: f_ | Only include results in files whose full path matches the regexp. | [`file:\.js$ httptest`](https://sourcegraph.com/search?q=file:%5C.js%24+httptest) <br> [`file:internal/ httptest`](https://sourcegraph.com/search?q=file:internal/+httptest) |
 | **-file:regexp-pattern** <br> _alias: -f_ | Exclude results from files whose full path matches the regexp. | [`file:\.js$ -file:test http`](https://sourcegraph.com/search?q=file:%5C.js%24+-file:test+http) |
+| **content:"pattern" | Explicitly override the [search pattern](#search-pattern-syntax). Useful for explicitly delineating the pattern to search for if it clashes with other parts of the query. | [`repo:sourcegraph "repo:sourcegraph"`](https://sourcegraph.com/search?q=repo:sourcegraph+content:"repo:sourcegraph"&patternType=literal) |
 | **lang:language-name** <br> _alias: l_ | Only include results from files in the specified programming language. | [`lang:typescript encoding`](https://sourcegraph.com/search?q=lang:typescript+encoding) |
 | **-lang:language-name** <br> _alias: -l_ | Exclude results from files in the specified programming language. | [`-lang:typescript encoding`](https://sourcegraph.com/search?q=-lang:typescript+encoding) |
 | **type:symbol** | Perform a symbol search. | [`type:symbol path`](https://sourcegraph.com/search?q=type:symbol+path)  ||

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -23,6 +23,7 @@ const (
 	FieldRepoHasFile        = "repohasfile"
 	FieldRepoHasCommitAfter = "repohascommitafter"
 	FieldPatternType        = "patterntype"
+	FieldContent            = "content"
 
 	// For diff and commit search only:
 	FieldBefore    = "before"
@@ -56,6 +57,7 @@ var (
 			FieldLang:        {Literal: types.StringType, Quoted: types.StringType, Negatable: true},
 			FieldType:        stringFieldType,
 			FieldPatternType: {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldContent:     {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 
 			FieldRepoHasFile:        regexpNegatableFieldType,
 			FieldRepoHasCommitAfter: {Literal: types.StringType, Quoted: types.StringType, Singular: true},


### PR DESCRIPTION
Stacked on #8395.

This adds an optional singleton `content:` field that overrides the default search pattern when specified.  This will be useful for AND/OR queries later, but the immediate win is that it gives a way to express currently inexpressible search patterns in literal mode (addresses #6490). 

Note on behavior:

The `content:...` search patterns are interpreted the same way as they would be along the current search code path for [case "file", "path"](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@920001ddf24d97e8b720426c3f146b953dd06182/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1115). 

This means that the query `type:path content:"search"` is valid and will return matching file paths for the pattern `search`. That's not really the intention, but it doesn't look like our existing code has a clean way to separate that casing. I am OK with this until we can restructure the search code, since using `content:` should be rare, and using it in conjunction with `type:path` is quite unlikely.
