### PR TITLE
Improve filter identification, and don't parse invalid filters in interactive mode

### DIFF
--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -42,6 +42,8 @@ export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterT
 export enum NegatedFilters {
     repo = '-repo',
     file = '-file',
+    r = '-r',
+    f = '-f',
     lang = '-lang',
     repohasfile = '-repohasfile',
 }
@@ -61,6 +63,8 @@ export const isNegatedFilter = (filter: string): filter is NegatedFilters =>
 const negatedFilterToNegatableFilter: { [key: string]: NegatableFilter } = {
     '-repo': FilterTypes.repo,
     '-file': FilterTypes.file,
+    '-r': FilterTypes.repo,
+    '-f': FilterTypes.file,
     '-lang': FilterTypes.lang,
     '-repohasfile': FilterTypes.repohasfile,
 }

--- a/web/src/search/input/helpers.test.ts
+++ b/web/src/search/input/helpers.test.ts
@@ -42,5 +42,27 @@ describe('Search input helpers', () => {
                         }
             )
         })
+
+        test('converts query with invalid filters, without adding invalid filters to filtersInQuery', () => {
+            const newQuery = convertPlainTextToInteractiveQuery('foo case:yes archived:no asdf:no')
+            expect(
+                newQuery.navbarQuery === 'foo asdf:no' &&
+                    newQuery.filtersInQuery ===
+                        {
+                            case: {
+                                type: 'case' as const,
+                                value: 'yes',
+                                editable: false,
+                                negated: false,
+                            },
+                            archived: {
+                                type: 'archived' as const,
+                                value: 'no',
+                                editable: false,
+                                negated: false,
+                            },
+                        }
+            )
+        })
     })
 })

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -2,32 +2,10 @@ import { SuggestionTypes } from '../../../../../shared/src/search/suggestions/ut
 import { Suggestion } from '../Suggestion'
 import { assign } from 'lodash/fp'
 import { FilterTypes } from '../../../../../shared/src/search/interactive/util'
+import { getFilterDefinition } from '../../../../../shared/src/search/parser/filters'
 
 /** FilterTypes which have a finite number of valid options. */
 export type FiniteFilterTypes = FilterTypes.archived | FilterTypes.fork | FilterTypes.type
-
-export function isTextFilter(filter: FilterTypes): boolean {
-    const validTextFilters = [
-        'repo',
-        'repogroup',
-        'repohasfile',
-        'repohascommitafter',
-        'file',
-        'lang',
-        'count',
-        'timeout',
-        'before',
-        'after',
-        'message',
-        'author',
-        '-repo',
-        '-repohasfile',
-        '-file',
-        '-lang',
-    ]
-
-    return validTextFilters.includes(filter)
-}
 
 export const finiteFilters: Record<
     FiniteFilterTypes,
@@ -70,7 +48,11 @@ export const finiteFilters: Record<
 }
 
 export const isFiniteFilter = (filter: FilterTypes): filter is FiniteFilterTypes =>
-    ['archived', 'fork', 'type'].includes(filter)
+    !!getFilterDefinition(filter) && ['fork', 'archived', 'type'].includes(filter)
+
+export function isTextFilter(filter: FilterTypes): boolean {
+    return !!getFilterDefinition(filter) && !isFiniteFilter(filter)
+}
 
 /**
  * Some filter types should have their suggestions searched without influence


### PR DESCRIPTION
This PR improves identifying text filters in interactive mode. Previously, we didn't check whether a parsed filter was actually valid, we only checked that it was not a finite filter. Now, we check to make sure the filter is valid in `isTextFilter`, so that when we parse filters in interactive mode, invalid filters will not appear in the selected filters bar.

This PR also properly identifies aliases. Previously, the shorthand `f:` and `r:` filters didn't work. Now, since we're ensuring the filter is validated using the aliases list in the parser, we won't miss out on any aliases. Also added `-r` and `-f` as identified negated filters.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
