### PR TITLE
Update LSIF upload warnings.

### DIFF
--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -10,6 +10,8 @@
 
 Follow our [LSIF quickstart guide](lsif_quickstart.md) to manually generate and upload LSIF data for your repository. After you are satisfied with the result, you can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](lsif_in_ci.md), or using [GitHub Actions](lsif_on_github.md).
 
+LSIF support is still a relatively new feature. We recommend you start by uploading a smaller number of key repositories. Once you reach 50 to 100 repositories, we will be able to provide specific recommendations for ensuring stability and performance of your Sourcegraph instance. We are currently working on validating that the feature remains responsive with tens of thousands of repositories.
+
 ## Enabling LSIF on your Sourcegraph instance
 
 Go to your global settings at https://sourcegraph.example.com/site-admin/global-settings and enable LSIF:
@@ -29,15 +31,11 @@ You may occasionally see results from [basic code intelligence](basic_code_intel
 - The current file doesn't exist in the nearest LSIF dump or has been changed between the LSIF dump and the browsing commit.
 - The _Find references_ panel will always include search-based results, but only after all of the precise results have been displayed. This ensures every symbol has code intelligence.
 
-## Data retention policy
+## Cross-repository code intelligence
 
-The bulk of LSIF data is stored on-disk, and as code intelligence data for a commit ages it becomes less useful. Sourcegraph will automatically remove the least recently uploaded data if the amount of disk space falls above a threshold. This value can be changed via the `DBS_DIR_MAXIMUM_SIZE_BYTES` environment variable. The default value of this variable is `10737418240`, which is `1024 * 1024 * 1024 * 10` bytes, or `10` gigabytes.
+Cross-repository code intelligence will only be powered by LSIF when **both** repositories have LSIF data. When the current file has LSIF data and the other repository doesn't, the missing precise results will be supplemented with imprecise search-based code intelligence.
 
-## Warning about uploading too much data
-
-Global find-references is a resource-intensive operation that's sensitive to the number of packages for which you have uploaded LSIF data into your Sourcegraph instance. Improvements to this are planned for Sourcegraph 3.10 (see the [RFC](https://docs.google.com/document/d/1VZB0Y4tWKeOUN1JvdDgo4LHwQn875MPOI9xztzqoSRc/edit#)).
-
-**Do not upload more than 10-40 LSIF dumps to your Sourcegraph instance or you risk harming other parts of Sourcegraph. We are working to validate its performance at scale and eliminate this concern.**
+## Size of upload data
 
 The following table gives a rough estimate for the space and time requirements for indexing and conversion. These repositories are a representative sample of public Go repositories available on GitHub. The working tree size is the size of the clone at the given commit (without git history), the number of files indexed, and the number of lines of Go code in the repository. The index size gives the size of the uncompressed LSIF output of the indexer. The conversion size gives the total amount of disk space occupied after uploading the dump to a Sourcegraph instance.
 
@@ -51,14 +49,9 @@ The following table gives a rough estimate for the space and time requirements f
 | [kubernetes](https://github.com/kubernetes/kubernetes/tree/e680ad7) | 301MB, 4577 files,   1.550m loc |  1.21m | 910MB |  80.06s | 162MB |
 | [aws-sdk-go](https://github.com/aws/aws-sdk-go/tree/18a2d30)        | 119MB, 1759 files,   1.067m loc |  8.20m | 1.3GB | 155.82s | 358MB |
 
+## Data retention policy
 
-
-
-
-
-## Cross-repository code intelligence
-
-Cross-repository code intelligence will only be powered by LSIF when **both** repositories have LSIF data. When the current file has LSIF data and the other repository doesn't, there will be no code intelligence results (we're working on fallback to fuzzy code intelligence for 3.10).
+The bulk of LSIF data is stored on-disk, and as code intelligence data for a commit ages it becomes less useful. Sourcegraph will automatically remove the least recently uploaded data if the amount of disk space falls above a threshold. This value can be changed via the `DBS_DIR_MAXIMUM_SIZE_BYTES` environment variable. The default value of this variable is `10737418240`, which is `1024 * 1024 * 1024 * 10` bytes, or `10` gigabytes.
 
 ## More about LSIF
 

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -51,7 +51,7 @@ The following table gives a rough estimate for the space and time requirements f
 
 ## Data retention policy
 
-The bulk of LSIF data is stored on-disk, and as code intelligence data for a commit ages it becomes less useful. Sourcegraph will automatically remove the least recently uploaded data if the amount of disk space falls above a threshold. This value can be changed via the `DBS_DIR_MAXIMUM_SIZE_BYTES` environment variable. The default value of this variable is `10737418240`, which is `1024 * 1024 * 1024 * 10` bytes, or `10` gigabytes.
+The bulk of LSIF data is stored on-disk, and as code intelligence data for a commit ages it becomes less useful. Sourcegraph will automatically remove the least recently uploaded data if the amount of disk space falls below a configurable threshold. This value defaults to 10 GiB (10⨉2^30 = 10737418240  bytes), and can be changed via the `DBS_DIR_MAXIMUM_SIZE_BYTES` environment variable.
 
 ## More about LSIF
 

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -10,7 +10,7 @@
 
 Follow our [LSIF quickstart guide](lsif_quickstart.md) to manually generate and upload LSIF data for your repository. After you are satisfied with the result, you can upload LSIF data to a Sourcegraph instance using your existing [continuous integration infrastructure](lsif_in_ci.md), or using [GitHub Actions](lsif_on_github.md).
 
-LSIF support is still a relatively new feature. We recommend you start by uploading a smaller number of key repositories. Once you reach 50 to 100 repositories, we will be able to provide specific recommendations for ensuring stability and performance of your Sourcegraph instance. We are currently working on validating that the feature remains responsive with tens of thousands of repositories.
+LSIF support is still a relatively new feature. We are currently working on validating that the feature remains responsive even with tens of thousands of repositories. To get started, we recommend you upload a smaller number of key repositories. Once you reach 50 to 100 repositories, we will be able to provide specific recommendations for ensuring stability and performance of your Sourcegraph instance.
 
 ## Enabling LSIF on your Sourcegraph instance
 


### PR DESCRIPTION
Remove some of the "coming soon to 3.10", rearranged data retention sections, and rephrased the warning that says not to upload more than 10-40 LSIF _dumps_ (which is _far_ too low). We've seen no impact on the dotcom instance running LSIF for two dozen repositories with ~300 active dumps (due to the default disk size).