### PR TITLE
src-cli: bump version to 3.10.5

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.10.2"
+const MinimumVersion = "3.10.5"


### PR DESCRIPTION
This PR bumps the src-cli required version to support specifying campaign branches.