### PR TITLE
gitserver: specify custom fetch command

### DIFF
--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var customFetch = strings.Fields(env.Get("SRC_GITSERVER_CUSTOM_FETCH", "",
+	"EXPERIMENTAL: custom fetch command for unorthodox repo setups."))
+
+func useCustomFetch() bool {
+	return len(customFetch) > 0
+}
+
+func customFetchCmd(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(ctx, customFetch[0], customFetch[1:]...)
+}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1301,7 +1301,9 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 	}
 
 	var cmd *exec.Cmd
-	if useRefspecOverrides() {
+	if useCustomFetch() {
+		cmd = customFetchCmd(ctx)
+	} else if useRefspecOverrides() {
 		cmd = refspecOverridesFetchCmd(ctx, url)
 	} else {
 		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url, "+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*", "+refs/pull/*:refs/pull/*", "+refs/sourcegraph/*:refs/sourcegraph/*")

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1300,9 +1300,11 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 		}
 	}
 
+	configRemoteOpts := true
 	var cmd *exec.Cmd
 	if useCustomFetch() {
 		cmd = customFetchCmd(ctx)
+		configRemoteOpts = false
 	} else if useRefspecOverrides() {
 		cmd = refspecOverridesFetchCmd(ctx, url)
 	} else {
@@ -1316,7 +1318,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 	// when the cleanup happens, just that it does.
 	defer s.cleanTmpFiles(dir)
 
-	if output, err := runWithRemoteOpts(ctx, cmd, nil); err != nil {
+	if output, err := runWith(ctx, cmd, configRemoteOpts, nil); err != nil {
 		log15.Error("Failed to update", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to update")
 	}

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -105,10 +105,16 @@ var tlsExternal = conf.Cached(func() interface{} {
 	}
 })
 
+func runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) ([]byte, error) {
+	return runWith(ctx, cmd, true, progress)
+}
+
 // runWithRemoteOpts runs the command after applying the remote options.
 // If progress is not nil, all output is written to it in a separate goroutine.
-func runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) ([]byte, error) {
-	configureRemoteGitCommand(cmd, tlsExternal().(*tlsConfig))
+func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress io.Writer) ([]byte, error) {
+	if configRemoteOpts {
+		configureRemoteGitCommand(cmd, tlsExternal().(*tlsConfig))
+	}
 
 	var b interface {
 		Bytes() []byte


### PR DESCRIPTION
> NOTE: not intended to be merged. this is to unblock a customer with unorthodox repo setup for a trial experiment. i defer to core team for a more real production solution later.

Adds ability to specify a fetch command from the outside to override git fetch.

