### PR TITLE
fix docker-compose docs styling

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -119,6 +119,14 @@
                                             <li><a href="/admin/install/docker/google_cloud">Install Sourcegraph with Docker on Google Cloud</a></li>
                                         </ul>
                                     </li>
+                                    <li><a href="/admin/install/docker">Install Sourcegraph with Docker Compose</a></li>
+                                    <li class="content-nav-no-hover" data-sub-section-item="Install Sourcegraph with Docker Compose" )>
+                                        <ul>
+                                            <li><a href="/admin/install/docker-compose/aws">Install Sourcegraph with Docker Compose on AWS</a></li>
+                                            <li><a href="/admin/install/docker-compose/digitalocean">Install Sourcegraph with Docker Compose on DigitalOcean</a></li>
+                                            <li><a href="/admin/install/docker-compose/google_cloud">Install Sourcegraph with Docker Compose on Google Cloud</a></li>
+                                        </ul>
+                                    </li>
                                     <li><a href="/admin/install/cluster">Installing Sourcegraph on a cluster</a></li>
                                 </ul>
                             </li>

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -5,6 +5,7 @@ Site administrators are the admins responsible for deploying, managing, and conf
 ## [Install Sourcegraph](install/index.md)
 
 - [Install Sourcegraph with Docker](install/docker/index.md)
+- [Install Sourcegraph with Docker Compose](install/docker-compose/index.md)
 - [Install Sourcegraph on a cluster](install/cluster.md)
   
 ## Management, deployment, and configuration

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -8,113 +8,108 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
 ## Run Sourcegraph on a Digital Ocean Droplet
 
-1. [Create a new Digital Ocean Droplet](https://cloud.digitalocean.com/droplets/new).
+* [Create a new Digital Ocean Droplet](https://cloud.digitalocean.com/droplets/new).
 
-    * Set the operating system to be **Ubuntu 18.04**.
-    * For droplet size: we recommend at least `8` CPU and `32` GB RAM , but you may need more depending on team size and number of repositories.
-    * (**optional, recommended**) Set up SSH access (Authentication > SSH keys) for convenient access to the droplet.
-    * (**optional, recommended**) Check the "Enable backups" checkbox to enable weekly backups of all your data.
+  * Set the operating system to be **Ubuntu 18.04**.
+  * For droplet size: we recommend at least `8` CPU and `32` GB RAM , but you may need more depending on team size and number of repositories.
+  * (**optional, recommended**) Set up SSH access (Authentication > SSH keys) for convenient access to the droplet.
+  * (**optional, recommended**) Check the "Enable backups" checkbox to enable weekly backups of all your data.
 
-1. In the "Select additional options" section of the Droplet creation page, select the "User Data" and "Monitoring" boxes,
+* In the "Select additional options" section of the Droplet creation page, select the "User Data" and "Monitoring" boxes,
    and paste the following script in the "`Enter user data here...`" text box:
 
-    ```bash
-    #!/usr/bin/env bash
+```bash
+#!/usr/bin/env bash
 
-    set -euxo pipefail
+set -euxo pipefail
 
-    PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
-    DOCKER_DATA_ROOT='/mnt/docker-data'
+PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
+DOCKER_DATA_ROOT='/mnt/docker-data'
 
-    DOCKER_COMPOSE_VERSION='1.25.3'
-    SOURCEGRAPH_VERSION='v3.12.5'
-    DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+DOCKER_COMPOSE_VERSION='1.25.3'
+SOURCEGRAPH_VERSION='v3.12.5'
+DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
-    # Install git
-    sudo apt-get update -y
-    sudo apt-get install -y git
+# Install git
+sudo apt-get update -y
+sudo apt-get install -y git
 
-    # Clone Docker Compose definition
-    git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-    cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-    git checkout ${SOURCEGRAPH_VERSION}
+# Clone Docker Compose definition
+git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git checkout ${SOURCEGRAPH_VERSION}
 
-    # Format (if necessary) and mount DO persistent disk
-    device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
-    if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
-    then
-        sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
-    fi
-    sudo mkdir -p "${DOCKER_DATA_ROOT}"
-    sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
+# Format (if necessary) and mount DO persistent disk
+device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
+if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
+then
+    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
+fi
+sudo mkdir -p "${DOCKER_DATA_ROOT}"
+sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
 
-    # Mount DO disk on reboots
-    DISK_UUID=$(sudo blkid -s UUID -o value "${PERSISTENT_DISK_DEVICE_NAME}")
-    sudo echo "UUID=${DISK_UUID}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" >> '/etc/fstab'
-    umount "${DOCKER_DATA_ROOT}"
-    mount -a
+# Mount DO disk on reboots
+DISK_UUID=$(sudo blkid -s UUID -o value "${PERSISTENT_DISK_DEVICE_NAME}")
+sudo echo "UUID=${DISK_UUID}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" >> '/etc/fstab'
+umount "${DOCKER_DATA_ROOT}"
+mount -a
 
-    # Install Docker
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt-get update -y
-    apt-cache policy docker-ce
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+# Install Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update -y
+apt-cache policy docker-ce
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
-    # Install jq for scripting
-    sudo apt-get update -y
-    sudo apt-get install -y jq
+# Install jq for scripting
+sudo apt-get update -y
+sudo apt-get install -y jq
 
-    # Edit Docker storage directory to mounted volume
-    DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
+# Edit Docker storage directory to mounted volume
+DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
 
-    ## initialize the config file with empty json if it doesn't exist
-    if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]
-    then
-        mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
-        echo '{}' > "${DOCKER_DAEMON_CONFIG_FILE}"
-    fi
+## initialize the config file with empty json if it doesn't exist
+if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]
+then
+    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
+    echo '{}' > "${DOCKER_DAEMON_CONFIG_FILE}"
+fi
 
-    ## update Docker's 'data-root' to point to our mounted disk
-    tmp_config=$(mktemp)
-    trap "rm -f ${tmp_config}" EXIT
-    sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' > "${tmp_config}"
-    sudo cat "${tmp_config}" > "${DOCKER_DAEMON_CONFIG_FILE}"
+## update Docker's 'data-root' to point to our mounted disk
+tmp_config=$(mktemp)
+trap "rm -f ${tmp_config}" EXIT
+sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' > "${tmp_config}"
+sudo cat "${tmp_config}" > "${DOCKER_DAEMON_CONFIG_FILE}"
 
-    ## finally, restart Docker daemon to pick up our changes
-    sudo systemctl restart --now docker
+## finally, restart Docker daemon to pick up our changes
+sudo systemctl restart --now docker
 
-    # Install Docker Compose
-    curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
-    curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
 
-    # Run Sourcegraph. Restart the containers upon reboot.
-    cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
-    docker-compose up -d
-    ```
+# Run Sourcegraph. Restart the containers upon reboot.
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
+docker-compose up -d
+```
 
-1. Click on "Add Volume" and add new block storage with the following settings:
+* Click on "Add Volume" and add new block storage with the following settings:
 
-    * **Size**: We recommend >> 250 GB. *(As a rule of thumb, Sourcegraph needs at least as much space as all your repositories combined take up. Allocating as much disk space as you can upfront helps you avoid needing to select a droplet with a larger root disk later on.)*
-    * Under **Chose configuration options**, select "Manually Format and Mount"
+  * **Size**: We recommend > 250 GB. *(As a rule of thumb, Sourcegraph needs at least as much space as all your repositories combined take up. Allocating as much disk space as you can upfront helps you avoid needing to select a droplet with a larger root disk later on.)*
+  * Under **Chose configuration options**, select "Manually Format and Mount"
 
-1. You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the Droplet and viewing the logs:
+* You may have to wait a minute or two for the instance to finish initializing before Sourcegraph becomes accessible. You can monitor the status by SSHing into the Droplet and running the following diagnostic commands:
 
-      * Following the status of the user data script that you provided earlier:
+```bash
+# Follow the status of the user data script you provided earlier
+tail -f /var/log/cloud-init-output.log
 
-          ```bash
-          tail -f /var/log/cloud-init-output.log
-          ```
+# (Once the user data script completes) monitor the health of the "sourcegraph-frontend" container
+docker ps --filter="name=sourcegraph-frontend-0"
+```
 
-      * (Once the user data script completes) monitoring the health of the `sourcegraph-frontend` container:
-
-        ```bash
-        docker ps --filter="name=sourcegraph-frontend-0"
-        ```
-
-1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
-   DNS entry for the IP, configure `externalURL` to reflect that.
+* Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
 
 ### After initialization
 


### PR DESCRIPTION
This PR:

1. adds a link to the docker-compose index page to the sidebar (I didn't realize there was a dedicated sidebar template)
1. changes all the lists on the docker compose docs to be unordered, and unindents all the code blocks. Our current markdown parser https://github.com/russross/blackfriday isn't able to correctly render lists with nested code blocks (numbering restarts or is otherwise broken). Switching to unordered lists + unindenting the code blocks hides this issue even though this isn't as readable as it could be. 

Side note: Can we switch from https://github.com/russross/blackfriday to https://github.com/yuin/goldmark/ ? [Hugo even made the switch late last year](https://gohugo.io/news/0.60.0-relnotes/). 