### PR TITLE
Add additional ctags support for clojure. 

### DIFF
--- a/cmd/symbols/.ctags.d/clojure.ctags
+++ b/cmd/symbols/.ctags.d/clojure.ctags
@@ -1,0 +1,11 @@
+--regex-clojure=/def ([A-Za-z0-9_!?+*<>=-]+)/\1/v,variable/
+--regex-clojure=/defmacro ([A-Za-z0-9_!?+*<>=-]+)/\1/m,macro/
+--regex-clojure=/defprotocol ([A-Za-z0-9_!?+*<>=-]+)/\1/p,protocol/
+--regex-clojure=/defrecord ([A-Za-z0-9_!?+*<>=-]+)/\1/r,record/
+--regex-clojure=/deftype ([A-Za-z0-9_!?+*<>=-]+)/\1/t,type/
+--regex-clojure=/s\/def ([A-Za-z0-9_!?+*<>=-]+)/\1/v,variable/
+--regex-clojure=/s\/defn ([A-Za-z0-9_!?+*<>=-]+)/\1/f,function/
+--regex-clojure=/s\/defmacro ([A-Za-z0-9_!?+*<>=-]+)/\1/m,macro/
+--regex-clojure=/s\/defprotocol ([A-Za-z0-9_!?+*<>=-]+)/\1/p,protocol/
+--regex-clojure=/s\/defrecord ([A-Za-z0-9_!?+*<>=-]+)/\1/r,record/
+--regex-clojure=/s\/deftype ([A-Za-z0-9_!?+*<>=-]+)/\1/t,type/

--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -233,7 +233,7 @@ func filterSymbols(ctx context.Context, db *sqlx.DB, args protocol.SearchArgs) (
 // filenames to prevent a newer version of the symbols service from attempting
 // to read from a database created by an older (and likely incompatible) symbols
 // service. Increment this when you change the database schema.
-const symbolsDBVersion = 2
+const symbolsDBVersion = 3
 
 // symbolInDB is the same as `protocol.Symbol`, but with two additional columns:
 // namelowercase and pathlowercase, which enable indexed case insensitive


### PR DESCRIPTION
ctags has built-in support for `defn` and `clojure.core.defn`. This adds support for `def`, `defprotocol`, `defrecord`, `defmacro`, and `deftype`. It also adds the `s/` variants defined by [schema](https://github.com/plumatic/schema) and used by some customers.