### PR TITLE
Split precise codeintel telemetry

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/codeintel_usage_stats.go
@@ -83,12 +83,16 @@ type codeIntelEventCategoryStatisticsResolver struct {
 	CodeIntelEventCategoryStatistics *types.CodeIntelEventCategoryStatistics
 }
 
-func (s *codeIntelEventCategoryStatisticsResolver) Precise() *codeIntelEventStatisticsResolver {
-	return &codeIntelEventStatisticsResolver{codeIntelEventStatistics: s.CodeIntelEventCategoryStatistics.Precise}
+func (s *codeIntelEventCategoryStatisticsResolver) LSIF() *codeIntelEventStatisticsResolver {
+	return &codeIntelEventStatisticsResolver{codeIntelEventStatistics: s.CodeIntelEventCategoryStatistics.LSIF}
 }
 
-func (s *codeIntelEventCategoryStatisticsResolver) Fuzzy() *codeIntelEventStatisticsResolver {
-	return &codeIntelEventStatisticsResolver{codeIntelEventStatistics: s.CodeIntelEventCategoryStatistics.Fuzzy}
+func (s *codeIntelEventCategoryStatisticsResolver) LSP() *codeIntelEventStatisticsResolver {
+	return &codeIntelEventStatisticsResolver{codeIntelEventStatistics: s.CodeIntelEventCategoryStatistics.LSP}
+}
+
+func (s *codeIntelEventCategoryStatisticsResolver) Search() *codeIntelEventStatisticsResolver {
+	return &codeIntelEventStatisticsResolver{codeIntelEventStatistics: s.CodeIntelEventCategoryStatistics.Search}
 }
 
 type codeIntelEventStatisticsResolver struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3905,10 +3905,12 @@ type CodeIntelUsagePeriod {
 
 # Statistics about aparticular family of code intel features in a given timestan.
 type CodeIntelEventCategoryStatistics {
-    # Recent precise event statistics.
-    precise: CodeIntelEventStatistics!
-    # Recent fuzzy event statistics.
-    fuzzy: CodeIntelEventStatistics!
+    # Recent LSIF-based code intel event statistics.
+    lsif: CodeIntelEventStatistics!
+    # Recent LSP-based code intel event statistics.
+    lsp: CodeIntelEventStatistics!
+    # Recent search-based code intel event statistics.
+    search: CodeIntelEventStatistics!
 }
 
 # Statistics about a particular code intel feature in a given timespan.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3912,10 +3912,12 @@ type CodeIntelUsagePeriod {
 
 # Statistics about aparticular family of code intel features in a given timestan.
 type CodeIntelEventCategoryStatistics {
-    # Recent precise event statistics.
-    precise: CodeIntelEventStatistics!
-    # Recent fuzzy event statistics.
-    fuzzy: CodeIntelEventStatistics!
+    # Recent lsif-based code intel event statistics.
+    lsif: CodeIntelEventStatistics!
+    # Recent lsif-based code intel event statistics.
+    lsp: CodeIntelEventStatistics!
+    # Recent search-based code intel event statistics.
+    search: CodeIntelEventStatistics!
 }
 
 # Statistics about a particular code intel feature in a given timespan.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3912,9 +3912,9 @@ type CodeIntelUsagePeriod {
 
 # Statistics about aparticular family of code intel features in a given timestan.
 type CodeIntelEventCategoryStatistics {
-    # Recent lsif-based code intel event statistics.
+    # Recent LSIF-based code intel event statistics.
     lsif: CodeIntelEventStatistics!
-    # Recent lsif-based code intel event statistics.
+    # Recent LSP-based code intel event statistics.
     lsp: CodeIntelEventStatistics!
     # Recent search-based code intel event statistics.
     search: CodeIntelEventStatistics!

--- a/cmd/frontend/internal/usagestats/codeintel.go
+++ b/cmd/frontend/internal/usagestats/codeintel.go
@@ -83,12 +83,15 @@ func codeIntelActivity(ctx context.Context, periodType db.PeriodType, periods in
 	}
 
 	eventStatisticByName := map[string]func(p *usagePeriod) *eventStatistics{
-		"codeintel.hover.precise":       func(p *usagePeriod) *eventStatistics { return p.Hover.Precise },
-		"codeintel.hover.fuzzy":         func(p *usagePeriod) *eventStatistics { return p.Hover.Fuzzy },
-		"codeintel.definitions.precise": func(p *usagePeriod) *eventStatistics { return p.Definitions.Precise },
-		"codeintel.definitions.fuzzy":   func(p *usagePeriod) *eventStatistics { return p.Definitions.Fuzzy },
-		"codeintel.references.precise":  func(p *usagePeriod) *eventStatistics { return p.References.Precise },
-		"codeintel.references.fuzzy":    func(p *usagePeriod) *eventStatistics { return p.References.Fuzzy },
+		"codeintel.lsifHover":         func(p *usagePeriod) *eventStatistics { return p.Hover.LSIF },
+		"codeintel.lspHover":          func(p *usagePeriod) *eventStatistics { return p.Hover.LSP },
+		"codeintel.searchHover":       func(p *usagePeriod) *eventStatistics { return p.Hover.Search },
+		"codeintel.lsifDefinitions":   func(p *usagePeriod) *eventStatistics { return p.Definitions.LSIF },
+		"codeintel.lspDefinitions":    func(p *usagePeriod) *eventStatistics { return p.Definitions.LSP },
+		"codeintel.searchDefinitions": func(p *usagePeriod) *eventStatistics { return p.Definitions.Search },
+		"codeintel.lsifReferences":    func(p *usagePeriod) *eventStatistics { return p.References.LSIF },
+		"codeintel.lspReferences":     func(p *usagePeriod) *eventStatistics { return p.References.LSP },
+		"codeintel.searchReferences":  func(p *usagePeriod) *eventStatistics { return p.References.Search },
 	}
 
 	for eventName, getEventStatistic := range eventStatisticByName {
@@ -141,7 +144,8 @@ func codeIntelActivity(ctx context.Context, periodType db.PeriodType, periods in
 
 func newEventCategory() *eventCategoryStatistics {
 	return &eventCategoryStatistics{
-		Precise: &eventStatistics{EventLatencies: &eventLatencies{}},
-		Fuzzy:   &eventStatistics{EventLatencies: &eventLatencies{}},
+		LSIF:   &eventStatistics{EventLatencies: &eventLatencies{}},
+		LSP:    &eventStatistics{EventLatencies: &eventLatencies{}},
+		Search: &eventStatistics{EventLatencies: &eventLatencies{}},
 	}
 }

--- a/cmd/frontend/internal/usagestats/codeintel.go
+++ b/cmd/frontend/internal/usagestats/codeintel.go
@@ -74,7 +74,7 @@ func codeIntelActivity(ctx context.Context, periodType db.PeriodType, periods in
 	}
 
 	activityPeriods := []*types.CodeIntelUsagePeriod{}
-	for i := 0; i <= periods; i++ {
+	for i := 0; i < periods; i++ {
 		activityPeriods = append(activityPeriods, &usagePeriod{
 			Hover:       newEventCategory(),
 			Definitions: newEventCategory(),

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -157,8 +157,9 @@ type CodeIntelUsagePeriod struct {
 }
 
 type CodeIntelEventCategoryStatistics struct {
-	Precise *CodeIntelEventStatistics
-	Fuzzy   *CodeIntelEventStatistics
+	LSIF   *CodeIntelEventStatistics
+	LSP    *CodeIntelEventStatistics
+	Search *CodeIntelEventStatistics
 }
 
 type CodeIntelEventStatistics struct {


### PR DESCRIPTION
Split code intel telemtry from precise into lsif and lsp. One is MUCH slower and shouldn't affect the latencies of the fast path.