### PR TITLE
Add content filter as valid filter in webapp

### DIFF
--- a/shared/src/search/interactive/util.ts
+++ b/shared/src/search/interactive/util.ts
@@ -35,6 +35,7 @@ export enum FilterTypes {
     after = 'after',
     author = 'author',
     message = 'message',
+    content = 'content',
 }
 
 export const filterTypeKeys: FilterTypes[] = Object.keys(FilterTypes) as FilterTypes[]

--- a/shared/src/search/parser/filters.ts
+++ b/shared/src/search/parser/filters.ts
@@ -127,6 +127,11 @@ export const FILTERS: readonly FilterDefinition[] = [
         aliases: ['before'],
         description: 'Commits made before a certain date',
     },
+    {
+        aliases: ['content'],
+        description:
+            'Explicitly overrides the search pattern. Used for explicitly delineating the search pattern to search for in case of clashes.',
+    },
 ]
 
 /**

--- a/shared/src/search/suggestions/util.ts
+++ b/shared/src/search/suggestions/util.ts
@@ -18,6 +18,7 @@ export enum SuggestionTypes {
     after = 'after',
     author = 'author',
     message = 'message',
+    content = 'content',
 }
 
 export const suggestionTypeKeys: SuggestionTypes[] = Object.keys(SuggestionTypes) as SuggestionTypes[]

--- a/web/src/search/input/interactive/filters.ts
+++ b/web/src/search/input/interactive/filters.ts
@@ -79,4 +79,5 @@ export const FilterTypesToProseNames: Record<FilterTypes, string> = {
     message: 'Commit message contains',
     author: 'Commit author',
     type: 'Type',
+    content: 'Content',
 }

--- a/web/src/search/searchFilterSuggestions.ts
+++ b/web/src/search/searchFilterSuggestions.ts
@@ -90,6 +90,10 @@ export const searchFilterSuggestions: SearchFilterSuggestions = {
                 value: 'message:',
                 description: 'commit message contents',
             },
+            {
+                value: 'content:',
+                description: 'override the search pattern',
+            },
         ].map(
             assign({
                 type: SuggestionTypes.filters,
@@ -186,5 +190,8 @@ export const searchFilterSuggestions: SearchFilterSuggestions = {
         values: [{ value: '"1 week ago"' }, { value: '"1 day ago"' }, { value: '"last thursday"' }].map(
             assign({ type: SuggestionTypes.after })
         ),
+    },
+    content: {
+        values: [],
     },
 }


### PR DESCRIPTION
Adds the new `content` filter as a valid filter in our webapp, meaning it's recognized in our frontend parser, and will be correctly handled in interactive mode.

Also adds it to the interactive mode filter dropdown.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
