### PR TITLE
a8n: Decouple changeset and repo syncing

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	shared.Main(nil, nil)
+	shared.Main(nil)
 }

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"database/sql"
 	"sort"
 	"strconv"
 	"strings"
@@ -12,14 +11,9 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"gopkg.in/inconshreveable/log15.v2"
 )
-
-// NewPreSync takes in dependencies used by the Syncer and returns a function
-// that can then be set on the Syncer as a PreSync.
-type NewPreSync func(*sql.DB, Store, *httpcli.Factory) func(context.Context) error
 
 // A Syncer periodically synchronizes available repositories from all its given Sources
 // with the stored Repositories in Sourcegraph.

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -27,9 +27,6 @@ type Syncer struct {
 	Store   Store
 	Sourcer Sourcer
 
-	// PreSync is called before this Syncer's Sync method.
-	PreSync func(context.Context) error
-
 	// DisableStreaming if true will prevent the syncer from streaming in new
 	// sourced repositories into the store.
 	DisableStreaming bool
@@ -108,12 +105,6 @@ func (s *Syncer) TriggerSync() {
 
 // Sync synchronizes the repositories.
 func (s *Syncer) Sync(ctx context.Context) (err error) {
-	if s.PreSync != nil {
-		if err := s.PreSync(ctx); err != nil && s.Logger != nil {
-			s.Logger.Error("PreSync", "error", err)
-		}
-	}
-
 	var diff Diff
 
 	ctx, save := s.observe(ctx, "Syncer.Sync", "")

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -31,6 +31,8 @@ import (
 
 const port = "3182"
 
+// DependencyCallback is a function that allows external code to be triggered when dependencies
+// created in Main are ready for use.
 type DependencyCallback func(db *sql.DB, store repos.Store, cf *httpcli.Factory)
 
 func Main(callback DependencyCallback) {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -31,11 +31,11 @@ import (
 
 const port = "3182"
 
-// DependencyCallback is a function that allows external code to be triggered when dependencies
+// EnterpriseInit is a function that allows enterprise code to be triggered when dependencies
 // created in Main are ready for use.
-type DependencyCallback func(db *sql.DB, store repos.Store, cf *httpcli.Factory)
+type EnterpriseInit func(db *sql.DB, store repos.Store, cf *httpcli.Factory)
 
-func Main(callback DependencyCallback) {
+func Main(enterpriseInit EnterpriseInit) {
 	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
 
 	ctx := context.Background()
@@ -98,8 +98,8 @@ func Main(callback DependencyCallback) {
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	// All dependencies ready
-	if callback != nil {
-		callback(db, store, cf)
+	if enterpriseInit != nil {
+		enterpriseInit(db, store, cf)
 	}
 
 	var src repos.Sourcer

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -20,30 +21,41 @@ func main() {
 	if debug {
 		log.Println("enterprise edition")
 	}
+	shared.Main(dependencyCallback)
+}
 
-	newPreSync := func(db *sql.DB, rs repos.Store, cf *httpcli.Factory) func(context.Context) error {
-		syncer := &a8n.ChangesetSyncer{
-			Store:       a8n.NewStore(db),
-			ReposStore:  rs,
-			HTTPFactory: cf,
-		}
+var cbOnce sync.Once
 
-		return syncer.Sync
-	}
-
-	dbInitHook := func(db *sql.DB) {
+func dependencyCallback(db *sql.DB, repoStore repos.Store, cf *httpcli.Factory) {
+	cbOnce.Do(func() {
 		ctx := context.Background()
-		store := a8n.NewStore(db)
+		a8nStore := a8n.NewStore(db)
 
-		for {
-			err := store.DeleteExpiredCampaignPlans(ctx)
-			if err != nil {
-				log15.Error("DeleteExpiredCampaignPlans", "error", err)
+		// Set up syncer
+		go func() {
+			syncer := &a8n.ChangesetSyncer{
+				Store:       a8nStore,
+				ReposStore:  repoStore,
+				HTTPFactory: cf,
 			}
+			for {
+				err := syncer.Sync(ctx)
+				if err != nil {
+					log15.Error("Syncing Changesets", "err", err)
+				}
+				time.Sleep(1 * time.Minute)
+			}
+		}()
 
-			time.Sleep(2 * time.Minute)
-		}
-	}
-
-	shared.Main(newPreSync, dbInitHook)
+		// Set up expired campaign deletion
+		go func() {
+			for {
+				err := a8nStore.DeleteExpiredCampaignPlans(ctx)
+				if err != nil {
+					log15.Error("DeleteExpiredCampaignPlans", "error", err)
+				}
+				time.Sleep(2 * time.Minute)
+			}
+		}()
+	})
 }

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -43,7 +43,7 @@ func dependencyCallback(db *sql.DB, repoStore repos.Store, cf *httpcli.Factory) 
 				if err != nil {
 					log15.Error("Syncing Changesets", "err", err)
 				}
-				time.Sleep(1 * time.Minute)
+				time.Sleep(2 * time.Minute)
 			}
 		}()
 

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -21,12 +21,12 @@ func main() {
 	if debug {
 		log.Println("enterprise edition")
 	}
-	shared.Main(dependencyCallback)
+	shared.Main(enterpriseInit)
 }
 
 var cbOnce sync.Once
 
-func dependencyCallback(db *sql.DB, repoStore repos.Store, cf *httpcli.Factory) {
+func enterpriseInit(db *sql.DB, repoStore repos.Store, cf *httpcli.Factory) {
 	cbOnce.Do(func() {
 		ctx := context.Background()
 		a8nStore := a8n.NewStore(db)

--- a/enterprise/internal/a8n/syncer.go
+++ b/enterprise/internal/a8n/syncer.go
@@ -2,8 +2,6 @@ package a8n
 
 import (
 	"context"
-	"database/sql"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -19,22 +17,6 @@ type ChangesetSyncer struct {
 	Store       *Store
 	ReposStore  repos.Store
 	HTTPFactory *httpcli.Factory
-}
-
-func (c *ChangesetSyncer) Init(s *sql.DB, rs repos.Store, f *httpcli.Factory) {
-	c.Store = NewStore(s)
-	c.ReposStore = rs
-	c.HTTPFactory = f
-
-	go func() {
-		ticker := time.NewTicker(1 * time.Minute)
-		for range ticker.C {
-			err := c.Sync(context.Background())
-			if err != nil {
-				log15.Error("Syncing changesets", "err", err)
-			}
-		}
-	}()
 }
 
 // Sync refreshes the metadata of all changesets and updates them in the

--- a/enterprise/internal/a8n/syncer.go
+++ b/enterprise/internal/a8n/syncer.go
@@ -22,13 +22,11 @@ type ChangesetSyncer struct {
 // Sync refreshes the metadata of all changesets and updates them in the
 // database
 func (s *ChangesetSyncer) Sync(ctx context.Context) error {
-	log15.Info("Fetching changesets")
 	cs, err := s.listAllNonDeletedChangesets(ctx)
 	if err != nil {
 		log15.Error("ChangesetSyncer.listAllNonDeletedChangesets", "error", err)
 		return err
 	}
-	log15.Info("Found changesets", "count", len(cs))
 
 	if err := s.SyncChangesets(ctx, cs...); err != nil {
 		log15.Error("ChangesetSyncer", "error", err)


### PR DESCRIPTION
This is just a small change to decouple the syncers before we begin work
on making the changeset syncing more intelligent.



