### PR TITLE
Fix GitHub enterprise detection in site admin

### DIFF
--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -1,3 +1,4 @@
+import { parse as parseJSONC } from '@sqs/jsonc-parser'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -12,7 +13,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { ExternalServiceCard } from '../components/ExternalServiceCard'
 import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
 import { ErrorAlert } from '../components/alerts'
-import { defaultExternalServices } from './externalServices'
+import { defaultExternalServices, codeHostExternalServices } from './externalServices'
 
 interface Props extends RouteComponentProps<{ id: GQL.ID }> {
     isLightTheme: boolean
@@ -109,7 +110,14 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 this.state.externalServiceOrError) ||
             undefined
 
-        const externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
+        let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
+        if (externalService && externalService.kind === GQL.ExternalServiceKind.GITHUB) {
+            const parsedConfig = parseJSONC(externalService.config)
+            // we have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the url
+            if (!parsedConfig.url.match(/^https:\/\/github\.com/)) {
+                externalServiceCategory = codeHostExternalServices.ghe
+            }
+        }
 
         return (
             <div className="site-admin-configuration-page mt-3">
@@ -123,9 +131,9 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 {isErrorLike(this.state.externalServiceOrError) && (
                     <ErrorAlert className="mb-3" error={this.state.externalServiceOrError} />
                 )}
-                {externalService && (
+                {externalServiceCategory && (
                     <div className="mb-3">
-                        <ExternalServiceCard {...defaultExternalServices[externalService.kind]} />
+                        <ExternalServiceCard {...externalServiceCategory} />
                     </div>
                 )}
                 {externalService && externalServiceCategory && (

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -114,7 +114,11 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
         if (externalService && externalService.kind === GQL.ExternalServiceKind.GITHUB) {
             const parsedConfig = parseJSONC(externalService.config)
             // we have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the url
-            if (!parsedConfig.url.match(/^https:\/\/github\.com/)) {
+            if (
+                parsedConfig?.url &&
+                typeof parsedConfig.url === 'string' &&
+                !parsedConfig.url.match(/^https:\/\/github\.com/)
+            ) {
                 externalServiceCategory = codeHostExternalServices.ghe
             }
         }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/8265

We don't have a distinction in the API after creation between GitHub.com and GitHub Enterprise, so we have to do this check on the url 🤔 

If anyone knows of a better way to detect this, happy to adopt it. This is more a dirty fix 