### PR TITLE
goroutine: Deterministic test

### DIFF
--- a/cmd/frontend/internal/goroutine/goroutine_test.go
+++ b/cmd/frontend/internal/goroutine/goroutine_test.go
@@ -2,13 +2,21 @@ package goroutine
 
 import "testing"
 
+type closeOnError chan bool
+
+func (e closeOnError) Error() string {
+	close(e)
+	return "will be caught and test will not fail"
+}
+
 func TestGo(t *testing.T) {
 	done := make(chan bool)
 	Go(func() {
-		defer func() {
-			done <- true
-		}()
-		panic("will be caught and test will not fail")
+		// The recover handler for Go logs the value we pass to panic. When it
+		// does log this closeOnError.Error is called which will close
+		// done. This is to ensure we actually run the recover path before
+		// returning from the test.
+		panic(closeOnError(done))
 	})
 	<-done
 }


### PR DESCRIPTION
The previous test didn't actually ensure that the panic handler ran inside of
goroutine.Go. Previously when we close the done channel, we hadn't yet handled
the error in goroutine.Go. We now sneakily close it when the error is logged,
which is inside of the panic handler.

This does seem a bit brittle, but if it does break the test will timeout.
Additionally this will prevent some non-determinism I regarding test coverage
and this package.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
