### PR TITLE
Stats: search query latency data types

### DIFF
--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -199,3 +199,30 @@ type Event struct {
 type AutomationUsageStatistics struct {
 	CampaignsCount int
 }
+
+type SearchLatencyStatistics struct {
+	Daily   []*SearchLatencyPeriod
+	Weekly  []*SearchLatencyPeriod
+	Monthly []*SearchLatencyPeriod
+}
+
+type SearchLatencyPeriod struct {
+	StartTime time.Time
+	Latencies *SearchTypeLatency
+}
+
+type SearchTypeLatency struct {
+	Literal    *SearchLatency
+	Regexp     *SearchLatency
+	Structural *SearchLatency
+	File       *SearchLatency
+	Repo       *SearchLatency
+	Diff       *SearchLatency
+	Commit     *SearchLatency
+}
+
+type SearchLatency struct {
+	P50 float64
+	P90 float64
+	P99 float64
+}


### PR DESCRIPTION
This is just the (proposed) data types of the search query latency to add. I feel like we can bundle these stats with the description for code intel hovers. @efritz question: are the latencies for hovers, etc. global latencies, or per user? For search we can use either, just want to understand what the choice and rationale is for code intel.

I'm going with the 

```
type SearchEventLatencies struct {
	P50 float64
	P90 float64
	P99 float64
}
```

to use the `PercentilesPerPeriod` utility function consistently (as opposed to just recording `P99`).

@tsenart I propose we break these down by category (`file`, `repo`,...) or it is going to be very hard to see where to prioritize effort for improving perf.