### PR TITLE
gitserver: custom fetch command by domain/path

### DIFF
--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -21,7 +21,6 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 	}
 
 	cgm := map[string][]string{}
-
 	for _, mapping := range c {
 		parts := strings.Fields(mapping.Fetch)
 

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -34,7 +34,7 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 	return cgm
 }
 
-func domainPath(urlVal string) (string, error) {
+func extractDomainPath(cloneURL string) (string, error) {
 	gitURL, err := url.Parse(urlVal)
 	if err != nil {
 		return "", err

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -53,7 +53,6 @@ func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
 	}
 
 	cmdParts := cgm[dp]
-
 	if len(cmdParts) == 0 {
 		return nil
 	}

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -41,7 +41,7 @@ func extractDomainPath(cloneURL string) (string, error) {
 func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
 	dp, err := extractDomainPath(urlVal)
 	if err != nil {
-		log15.Error("failed to extract domain and path from %s: %v", urlVal, err)
+		log15.Error("failed to extract domain and path", "url", urlVal, "err", err)
 		return nil
 	}
 

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -44,7 +44,7 @@ func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
 
 	dp, err := extractDomainPath(urlVal)
 	if err != nil {
-		log15.Error("failed to extract domain and path from %s", urlVal)
+		log15.Error("failed to extract domain and path from %s: %v", urlVal, err)
 		return nil
 	}
 

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -23,8 +23,7 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 
 	cgm := map[string][]string{}
 	for _, mapping := range c {
-		parts := strings.Fields(mapping.Fetch)
-		cgm[mapping.DomainPath] = parts
+		cgm[mapping.DomainPath] = strings.Fields(mapping.Fetch)
 	}
 
 	return cgm
@@ -40,14 +39,13 @@ func extractDomainPath(cloneURL string) (string, error) {
 }
 
 func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
-	cgm := customGitFetch().(map[string][]string)
-
 	dp, err := extractDomainPath(urlVal)
 	if err != nil {
 		log15.Error("failed to extract domain and path from %s: %v", urlVal, err)
 		return nil
 	}
 
+	cgm := customGitFetch().(map[string][]string)
 	cmdParts := cgm[dp]
 	if len(cmdParts) == 0 {
 		return nil

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -39,13 +39,16 @@ func extractDomainPath(cloneURL string) (string, error) {
 }
 
 func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
+	cgm := customGitFetch().(map[string][]string)
+	if len(cgm) == 0 {
+		return nil
+	}
+
 	dp, err := extractDomainPath(urlVal)
 	if err != nil {
 		log15.Error("failed to extract domain and path", "url", urlVal, "err", err)
 		return nil
 	}
-
-	cgm := customGitFetch().(map[string][]string)
 	cmdParts := cgm[dp]
 	if len(cmdParts) == 0 {
 		return nil

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -35,7 +35,7 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 }
 
 func domainPath(urlVal string) (string, error) {
-	gitUrl, err := url.Parse(urlVal)
+	gitURL, err := url.Parse(urlVal)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestEmptyCustomGitFetch(t *testing.T) {
+	customGitFetch = func() interface{} {
+		return buildCustomFetchMappings(nil)
+	}
+
+	customCmd := customFetchCmd(context.Background(), "git@github.com:sourcegraph/sourcegraph.git")
+
+	if customCmd != nil {
+		t.Errorf("expected nil custom cmd for empty configuration, got %+v", customCmd)
+	}
+}
+
+func TestCustomGitFetch(t *testing.T) {
+	mappings := []*schema.CustomGitFetchMapping{
+		{
+			DomainPath: "github.com/foo/normal/one",
+			Fetch:      "echo normal one",
+		},
+		{
+			DomainPath: "github.com/foo/normal/two",
+			Fetch:      "echo normal two",
+		},
+		{
+			DomainPath: "git@github.com:foo/faulty",
+			Fetch:      "",
+		},
+	}
+
+	tests := []struct {
+		Url            string
+		ExpectedCustom bool
+		ExpectedArgs   []string
+	}{
+		{
+			Url:            "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116d@github.com/foo/normal/one",
+			ExpectedCustom: true,
+			ExpectedArgs:   []string{"echo", "normal", "one"},
+		},
+		{
+			Url:            "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116d@github.com/foo/normal/two",
+			ExpectedCustom: true,
+			ExpectedArgs:   []string{"echo", "normal", "two"},
+		},
+		{
+			Url:            "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116d@github.com/foo/faulty",
+			ExpectedCustom: false,
+		},
+		{
+			Url:            "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116dgit@github.com/bar/notthere",
+			ExpectedCustom: false,
+		},
+	}
+
+	customGitFetch = func() interface{} {
+		return buildCustomFetchMappings(mappings)
+	}
+
+	for _, test := range tests {
+		customCmd := customFetchCmd(context.Background(), test.Url)
+
+		if test.ExpectedCustom {
+			if customCmd == nil {
+				t.Errorf("expected custom command for url %s", test.Url)
+			} else {
+				if !reflect.DeepEqual(customCmd.Args, test.ExpectedArgs) {
+					t.Errorf("expected custom command args %v for url %s, got %v", test.ExpectedArgs, test.Url,
+						customCmd.Args)
+				}
+			}
+		} else {
+			if customCmd != nil {
+				t.Errorf("expected no custom command for url %s, got %s", test.Url, customCmd.Path)
+			}
+		}
+	}
+}

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -14,7 +14,6 @@ func TestEmptyCustomGitFetch(t *testing.T) {
 	}
 
 	customCmd := customFetchCmd(context.Background(), "git@github.com:sourcegraph/sourcegraph.git")
-
 	if customCmd != nil {
 		t.Errorf("expected nil custom cmd for empty configuration, got %+v", customCmd)
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1302,8 +1302,8 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 
 	configRemoteOpts := true
 	var cmd *exec.Cmd
-	if useCustomFetch() {
-		cmd = customFetchCmd(ctx)
+	if customCmd := customFetchCmd(ctx, url); customCmd != nil {
+		cmd = customCmd
 		configRemoteOpts = false
 	} else if useRefspecOverrides() {
 		cmd = refspecOverridesFetchCmd(ctx, url)

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache \
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/postgresql.md#version-requirements
-    'bash=5.0.0-r0' 'postgresql-contrib=11.6-r0' 'postgresql=11.6-r0' \
+    'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
     'redis=5.0.7-r0' bind-tools ca-certificates git@edge \
     mailcap nginx openssh-client pcre su-exec tini nodejs-current=12.4.0-r0 curl
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -284,6 +284,14 @@ type CloneURLToRepositoryName struct {
 	To string `json:"to"`
 }
 
+// CustomGitFetchMapping description: Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.
+type CustomGitFetchMapping struct {
+	// DomainPath description: Git clone URL domain/path
+	DomainPath string `json:"domainPath"`
+	// Fetch description: Git fetch command
+	Fetch string `json:"fetch"`
+}
+
 // DebugLog description: Turns on debug logging for specific debugging scenarios.
 type DebugLog struct {
 	// ExtsvcGitlab description: Log GitLab API requests.
@@ -344,6 +352,8 @@ type ExperimentalFeatures struct {
 	Automation string `json:"automation,omitempty"`
 	// BitbucketServerFastPerm description: Enables fetching Bitbucket Server permissions through the roaring bitmap endpoint. This requires the installation of the Bitbucket Server Sourcegraph plugin. Warning: there may be performance degradation under significant load.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
+	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.
+	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// Discussions description: Enables the code discussions experiment.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -138,7 +138,19 @@
                 "minLength": 1
               }
             }
-          }
+          },
+          "examples": [
+            [
+              {
+                "domainPath": "somecodehost.com/path/to/repo",
+                "fetch": "customgitbinary someflag"
+              },
+              {
+                "domainPath": "somecodehost.com/path/to/anotherrepo",
+                "fetch": "customgitbinary someflag anotherflag"
+              }
+            ]
+          ]
         }
       },
       "group": "Experimental",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -134,7 +134,8 @@
               },
               "fetch": {
                 "description": "Git fetch command",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -117,6 +117,27 @@
               }
             }
           }
+        },
+        "customGitFetch": {
+          "description": "JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.",
+          "type": "array",
+          "items": {
+            "title": "CustomGitFetchMapping",
+            "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["domainPath", "fetch"],
+            "properties": {
+              "domainPath": {
+                "description": "Git clone URL domain/path",
+                "type": "string"
+              },
+              "fetch": {
+                "description": "Git fetch command",
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -122,6 +122,27 @@ const SiteSchemaJSON = `{
               }
             }
           }
+        },
+        "customGitFetch": {
+          "description": "JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.",
+          "type": "array",
+          "items": {
+            "title": "CustomGitFetchMapping",
+            "description": "Mapping from Git clone URl domain/path to git fetch command. The ` + "`" + `domainPath` + "`" + ` field contains the Git clone URL domain/path part. The ` + "`" + `fetch` + "`" + ` field contains the custom git fetch command.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["domainPath", "fetch"],
+            "properties": {
+              "domainPath": {
+                "description": "Git clone URL domain/path",
+                "type": "string"
+              },
+              "fetch": {
+                "description": "Git fetch command",
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -139,7 +139,8 @@ const SiteSchemaJSON = `{
               },
               "fetch": {
                 "description": "Git fetch command",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -143,7 +143,19 @@ const SiteSchemaJSON = `{
                 "minLength": 1
               }
             }
-          }
+          },
+          "examples": [
+            [
+              {
+                "domainPath": "somecodehost.com/path/to/repo",
+                "fetch": "customgitbinary someflag"
+              },
+              {
+                "domainPath": "somecodehost.com/path/to/anotherrepo",
+                "fetch": "customgitbinary someflag anotherflag"
+              }
+            ]
+          ]
         }
       },
       "group": "Experimental",


### PR DESCRIPTION
Changed the experimental feature of custom git fetch commands to support custom commands keyed off code host domain/path key.

Implements https://github.com/sourcegraph/sourcegraph/issues/8434