### PR TITLE
a8n: Fix updating of a Campaign's name/description

### DIFF
--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -843,6 +843,10 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	// we don't update the CampaignPlan, we don't need to rewire ChangesetJobs,
 	// but only update name/description if they changed.
 	if !updatePlanID && updateAttributes {
+		err := tx.UpdateCampaign(ctx, campaign)
+		if err != nil {
+			return campaign, nil, err
+		}
 		return campaign, nil, tx.ResetChangesetJobs(ctx, campaign.ID)
 	}
 

--- a/enterprise/internal/a8n/service_test.go
+++ b/enterprise/internal/a8n/service_test.go
@@ -659,13 +659,20 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 			}
 			if tt.updateDescription {
 				newDescription := "new campaign description"
-				args.Name = &newDescription
+				args.Description = &newDescription
 			}
 			if tt.updatePlan {
 				args.Plan = &newPlan.ID
 			}
 
-			updatedCampaign, detachedChangesets, err := svc.UpdateCampaign(ctx, args)
+			// We ignore the returned campaign here and load it from the
+			// database again to make sure the changes are persisted
+			_, detachedChangesets, err := svc.UpdateCampaign(ctx, args)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			updatedCampaign, err := store.GetCampaign(ctx, GetCampaignOpts{ID: campaign.ID})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Before this change the code was broken: an attribute-only (name or
description) update to a Campaign was never persisted.

This previously worked but got lost in refactors while working on
"individual updates". The tests also didn't spot the problem, since they
only checked the returned struct.

The change here fixes the tests to load the campaign from the DB and
then fixes the now-failing tests by updating the campaign.