### PR TITLE
fix: make content and message filters always quoted

### DIFF
--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -39,3 +39,11 @@ export function sanitizeClass(value: string): string {
 export function dedupeWhitespace(value: string): string {
     return value.replace(/\s+/g, ' ')
 }
+
+/**
+ * Checkes whether a given string is quoted.
+ * @param value string to check against
+ */
+export function isQuoted(value: string): boolean {
+    return value.startsWith('"') && value.endsWith('"') && value !== '"'
+}

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -28,7 +28,7 @@ import {
     validFilterAndValueBeforeCursor,
     filterStaticSuggestions,
 } from '../../helpers'
-import { dedupeWhitespace } from '../../../../../shared/src/util/strings'
+import { dedupeWhitespace, isQuoted } from '../../../../../shared/src/util/strings'
 import {
     FiltersToTypeAndValue,
     FilterTypes,
@@ -281,8 +281,15 @@ export class FilterInput extends React.Component<Props, State> {
 
         if (this.state.inputValue !== '' || this.props.filterType === FilterTypes.type) {
             // Don't allow empty filters, unless it's the type filter.
+            let inputValue = this.state.inputValue
+
+            if (this.props.filterType === FilterTypes.content || this.props.filterType === FilterTypes.message) {
+                // The content and message filters should always be quoted.
+                inputValue = isQuoted(inputValue) ? inputValue : JSON.stringify(inputValue)
+            }
+
             // Update the top-level filtersInQueryMap with the new value for this filter.
-            this.props.onFilterEdited(this.props.mapKey, this.state.inputValue)
+            this.props.onFilterEdited(this.props.mapKey, inputValue)
         }
     }
 


### PR DESCRIPTION
The new `content` filter should always be quoted, and the `message` filter requires quotes whenever there's more than one word being matched (and is not harmed when it's a single word and quoted). This makes sure that these filters are always quoted when using the interactive mode filters.