### PR TITLE
Upgrade postgres 11.6-r0 -> 11.7-r0 in server/Dockerfile (fix e2e tests)

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache \
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/postgresql.md#version-requirements
-    'bash=5.0.0-r0' 'postgresql-contrib=11.6-r0' 'postgresql=11.6-r0' \
+    'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
     'redis=5.0.7-r0' bind-tools ca-certificates git@edge \
     mailcap nginx openssh-client pcre su-exec tini nodejs-current=12.4.0-r0 curl
 


### PR DESCRIPTION
e2 tests have been failing ([example](https://buildkite.com/sourcegraph/e2e/builds/5672#91ab2116-62f0-4240-ab15-2cd848908acb)) because of this:

```
#7 2.216 ERROR: unsatisfiable constraints:
#7 2.281   postgresql-12.2-r0:
#7 2.281     breaks: world[postgresql=11.6-r0]
#7 2.281   postgresql-contrib-12.2-r0:
#7 2.281     breaks: world[postgresql-contrib=11.6-r0]
```

which @unknwon reported in the `#buildkite` channel.

