### PR TITLE
gitserver: set or update git config recloneTimestamp

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -598,7 +598,7 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 
 // setRecloneTime sets the time a repository is cloned.
 func setRecloneTime(dir GitDir, now time.Time) error {
-	cmd := exec.Command("git", "config", "--add", "sourcegraph.recloneTimestamp", strconv.FormatInt(now.Unix(), 10))
+	cmd := exec.Command("git", "config", "sourcegraph.recloneTimestamp", strconv.FormatInt(now.Unix(), 10))
 	cmd.Dir = string(dir)
 	if _, err := cmd.Output(); err != nil {
 		return errors.Wrap(wrapCmdError(cmd, err), "failed to update recloneTimestamp")


### PR DESCRIPTION
Previously we used "--add" which adds a new config, so recloneTimestamp could
potentially appear multiple times. This was benign, since "--get" would only
return the last value "--add"ed. However, it is more correct for us to
"upsert" the config value.

Spotted while making an unrelated change.
