### PR TITLE
Set dbtesting.DBNameSuffix in backend package

### DIFF
--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
+func init() {
+	dbtesting.DBNameSuffix = "backendtestdb"
+}
+
 func TestUpdateServiceVersion(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 


### PR DESCRIPTION
Without this tests fails:

https://buildkite.com/sourcegraph/sourcegraph/builds/56120#05cf089a-c771-4b61-a33a-80df0bd616bc
