### PR TITLE
gitserver: mark potential corrupt repos based on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When creating a campaign Automation users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
 - Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
 - Our [upgrade policy](https://docs.sourcegraph.com/#upgrading-sourcegraph) is now enforced by the `sourcegraph-frontend` on startup to prevent admins from mistakenly jumping too many versions. [#8157](https://github.com/sourcegraph/sourcegraph/pulls/8157) [#7702](https://github.com/sourcegraph/sourcegraph/issues/7702)
+- Repositories with bad object packs or bad objects are automatically repaired. We now detect suspect output of git commands to mark a repository for repair. [#6676](https://github.com/sourcegraph/sourcegraph/issues/6676)
 
 ### Changed
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -598,10 +598,9 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 
 // setRecloneTime sets the time a repository is cloned.
 func setRecloneTime(dir GitDir, now time.Time) error {
-	cmd := exec.Command("git", "config", "sourcegraph.recloneTimestamp", strconv.FormatInt(now.Unix(), 10))
-	cmd.Dir = string(dir)
-	if _, err := cmd.Output(); err != nil {
-		return errors.Wrap(wrapCmdError(cmd, err), "failed to update recloneTimestamp")
+	err := gitConfigSet(dir, "sourcegraph.recloneTimestamp", strconv.FormatInt(now.Unix(), 10))
+	if err != nil {
+		return errors.Wrap(err, "failed to update recloneTimestamp")
 	}
 	return nil
 }
@@ -618,18 +617,15 @@ func getRecloneTime(dir GitDir) (time.Time, error) {
 		return now, setRecloneTime(dir, now)
 	}
 
-	cmd := exec.Command("git", "config", "--get", "sourcegraph.recloneTimestamp")
-	cmd.Dir = string(dir)
-	out, err := cmd.Output()
+	value, err := gitConfigGet(dir, "sourcegraph.recloneTimestamp")
 	if err != nil {
-		// Exit code 1 means the key is not set.
-		if ee, ok := err.(*exec.ExitError); ok && ee.Sys().(syscall.WaitStatus).ExitStatus() == 1 {
-			return update()
-		}
-		return time.Unix(0, 0), errors.Wrap(wrapCmdError(cmd, err), "failed to determine clone timestamp")
+		return time.Unix(0, 0), errors.Wrap(err, "failed to determine clone timestamp")
+	}
+	if value == "" {
+		return update()
 	}
 
-	sec, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 0)
+	sec, err := strconv.ParseInt(strings.TrimSpace(value), 10, 0)
 	if err != nil {
 		// If the value is bad update it to the current time
 		now, err2 := update()
@@ -640,6 +636,30 @@ func getRecloneTime(dir GitDir) (time.Time, error) {
 	}
 
 	return time.Unix(sec, 0), nil
+}
+
+func gitConfigGet(dir GitDir, key string) (string, error) {
+	cmd := exec.Command("git", "config", "--get", key)
+	cmd.Dir = string(dir)
+	out, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 means the key is not set.
+		if ee, ok := err.(*exec.ExitError); ok && ee.Sys().(syscall.WaitStatus).ExitStatus() == 1 {
+			return "", nil
+		}
+		return "", errors.Wrapf(wrapCmdError(cmd, err), "failed to get git config %s", key)
+	}
+	return string(out), nil
+}
+
+func gitConfigSet(dir GitDir, key, value string) error {
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Dir = string(dir)
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrapf(wrapCmdError(cmd, err), "failed to set git config %s", key)
+	}
+	return nil
 }
 
 // jitterDuration returns a duration between [0, d) based on key. This is like

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -688,6 +688,9 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	stdoutN = stdoutW.n
 	stderrN = stderrW.n
 
+	stderr := stderrBuf.String()
+	checkMaybeCorruptRepo(req.Repo, dir, stderr)
+
 	if s.StderrErrorLog != nil {
 		logErrors(s.StderrErrorLog.Printf, req.Repo, stderrBuf.Bytes())
 	}
@@ -695,7 +698,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// write trailer
 	w.Header().Set("X-Exec-Error", errorString(execErr))
 	w.Header().Set("X-Exec-Exit-Status", status)
-	w.Header().Set("X-Exec-Stderr", stderrBuf.String())
+	w.Header().Set("X-Exec-Stderr", stderr)
 }
 
 // setGitAttributes writes our global gitattributes to


### PR DESCRIPTION
There are cases were repos become corrupted, but we don't detect them since it
only happens when trying to read specific objects. For a few weeks we added
some stderr logging/parsing on Sourcegraph.com and investigated all errors
reported. This commit contains a whitelist of error messages which could point
to repository corruption.

When we believe a repository is corrupted we mark it as corrupt. The reclone
janitor job will then reclone the repository. The janitor job runs
regularly (every minute by default), which means we will quickly converge to a
fixed uncorrupted repository. Note: we prefer cloning to expensive git
gc/repack operations.

Fixes https://github.com/sourcegraph/sourcegraph/issues/6676