### PR TITLE
continue to display redis-based usage statistics for continuity

### DIFF
--- a/cmd/frontend/graphqlbackend/site_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/site_usage_stats.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestats"
+	usagestatsdeprecated "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
@@ -13,7 +13,7 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 	Weeks  *int32
 	Months *int32
 }) (*siteUsageStatisticsResolver, error) {
-	opt := &usagestats.SiteUsageStatisticsOptions{}
+	opt := &usagestatsdeprecated.SiteUsageStatisticsOptions{}
 	if args.Days != nil {
 		d := int(*args.Days)
 		opt.DayPeriods = &d
@@ -26,7 +26,7 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 		m := int(*args.Months)
 		opt.MonthPeriods = &m
 	}
-	activity, err := usagestats.GetSiteUsageStatistics(ctx, opt)
+	activity, err := usagestatsdeprecated.GetSiteUsageStatistics(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/site_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/site_usage_stats.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	usagestatsdeprecated "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestatsdeprecated"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -21,7 +21,7 @@ func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatistic
 		}
 	}
 
-	stats, err := usagestats.GetByUserID(ctx, r.user.ID)
+	stats, err := usagestatsdeprecated.GetByUserID(r.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestats"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
 func TestUser_UsageStatistics(t *testing.T) {
 	resetMocks()
 	db.Mocks.Users.MockGetByID_Return(t, &types.User{ID: 1, Username: "alice"}, nil)
-	usagestats.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
+	usagestatsdeprecated.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
 		return &types.UserUsageStatistics{
 			SearchQueries: 2,
 		}, nil
 	}
-	defer func() { usagestats.MockGetByUserID = nil }()
+	defer func() { usagestatsdeprecated.MockGetByUserID = nil }()
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: mustParseGraphQLSchema(t),

--- a/cmd/frontend/internal/usagestats/event_handlers.go
+++ b/cmd/frontend/internal/usagestats/event_handlers.go
@@ -87,7 +87,7 @@ func publishSourcegraphDotComEvent(args Event) error {
 
 // logLocalEvent logs users events.
 func logLocalEvent(ctx context.Context, name, url string, userID int32, userCookieID, source string, argument json.RawMessage) error {
-	if name == "SearchSubmitted" {
+	if name == "SearchResultsQueried" {
 		err := logSiteSearchOccurred()
 		if err != nil {
 			return err

--- a/cmd/frontend/internal/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/usagestats/usage_stats.go
@@ -27,7 +27,7 @@ func GetByUserID(ctx context.Context, userID int32) (*types.UserUsageStatistics,
 	if err != nil {
 		return nil, err
 	}
-	searchQueries, err := db.EventLogs.CountByUserIDAndEventName(ctx, userID, "SearchSubmitted")
+	searchQueries, err := db.EventLogs.CountByUserIDAndEventName(ctx, userID, "SearchResultsQueried")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/usagestats/usage_stats_test.go
+++ b/cmd/frontend/internal/usagestats/usage_stats_test.go
@@ -63,7 +63,7 @@ func TestUserUsageStatistics_LogSearchQuery(t *testing.T) {
 	user := types.User{
 		ID: 1,
 	}
-	err := logLocalEvent(context.Background(), "SearchSubmitted", "https://sourcegraph.example.com/", user.ID, "test-cookie-id", "WEB", nil)
+	err := logLocalEvent(context.Background(), "SearchResultsQueried", "https://sourcegraph.example.com/", user.ID, "test-cookie-id", "WEB", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION


After a recent conversation with a customer (https://sourcegraph.slack.com/archives/CMB6K7SMN/p1581876749102400) it struck me that we could face some risk if we switch over our backend usage stats without a more gentle transition. 

Additionally, since beginning to log events internally, at least one customer has disabled that logging (due to perf fears), and at least one user has asked about an option to limit data collected.

Thankfully in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/727dcb2f6ad74f67294c4c07930e172eb2493c02 I left the redis-based stats intact, but deprecated. 

This change simply swaps out what gets shown to site admins. The _new_ data will still be what's included in pings. 

Going forward, I will need to do some thinking about how to make this transition happen.


(Also, I took this opportunity to make the new `usagestats` search counts consistent with the old ones, by replacing `SearchSubmitted` with `SearchResultsQueried`, as is used in `usagestatsdeprecated`: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f00a22fa1b4e570fbd4495487fbfb92651b46af9/-/blob/web/src/tracking/services/serverAdminWrapper.tsx#L33)