### PR TITLE
Clear uploads for the correct repository in codeintel regression test.

### DIFF
--- a/web/src/regression/codeintel.test.ts
+++ b/web/src/regression/codeintel.test.ts
@@ -251,7 +251,7 @@ describe('Code intelligence regression test suite', () => {
 
             for (const { repository } of repoCommits) {
                 // First, remove all existing uploads for the repository
-                await clearUploads(gqlClient, repository)
+                await clearUploads(gqlClient, `github.com/sourcegraph-testing/${repository}`)
             }
 
             const uploadUrls = []
@@ -270,7 +270,7 @@ describe('Code intelligence regression test suite', () => {
                 )
 
                 innerResourceManager.add('LSIF upload', `${repository} upload`, () =>
-                    clearUploads(gqlClient, repository)
+                    clearUploads(gqlClient, `github.com/sourcegraph-testing/${repository}`)
                 )
             }
 


### PR DESCRIPTION
I don't know how it ever worked like this.