### PR TITLE
Stats: add symbol search type to latency tracking

### DIFF
--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -219,6 +219,7 @@ type SearchTypeLatency struct {
 	Repo       *SearchLatency
 	Diff       *SearchLatency
 	Commit     *SearchLatency
+	Symbol     *SearchLatency
 }
 
 type SearchLatency struct {


### PR DESCRIPTION
I missed the `Symbol` type for tracking search stats. @efritz feel free to approve + merge so that it doesn't block updating the types with `Symbol` in #8423