### PR TITLE
a8n: Lower-case campaign name when using as default value for branch

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -21,7 +21,7 @@ interface Props {
     onDelete: (closeChangesets: boolean) => Promise<void>
     onEdit: React.MouseEventHandler
     name: string
-    onNameChange: React.Dispatch<React.SetStateAction<string>>
+    onNameChange: (newName: string) => void
 }
 
 export const CampaignActionsBar: React.FunctionComponent<Props> = ({


### PR DESCRIPTION
This adds the `{ lower: true }` option to the call to `slugify` and reduces the number of times we call `slugify` so we don't have to specify the option every time.