### PR TITLE
search: add validation and alert functions

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -90,6 +90,10 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	if err != nil {
 		return &didYouMeanQuotedResolver{query: args.Query, err: err}, nil
 	}
+	err = query.Validate(q, searchType)
+	if err != nil {
+		return searchAlert{title: "Invalid Query", description: capFirst(err.Error())}, nil
+	}
 
 	// If the request is a paginated one, decode those arguments now.
 	var pagination *searchPaginationInfo

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -441,3 +441,16 @@ func addQueryRegexpField(query *query.Query, field, pattern string) syntax.Parse
 	}
 	return expr
 }
+
+func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
+	alert := &searchAlert{
+		title:       a.title,
+		description: a.description,
+	}
+	return &SearchResultsResolver{alert: alert}, nil
+}
+
+func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
+	return nil, nil
+}
+func (searchAlert) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -3,6 +3,7 @@
 package query
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
@@ -151,6 +152,17 @@ func parseAndCheck(conf *types.Config, input string) (*Query, error) {
 		return nil, err
 	}
 	return &Query{conf: conf, Query: checkedQuery}, nil
+}
+
+// Validate validates legal combinations of fields and search patterns of a
+// successfully parsed query.
+func Validate(q *Query, searchType SearchType) error {
+	if searchType == SearchTypeStructural {
+		if q.Fields[FieldCase] != nil {
+			return errors.New(`the parameter "case:" is not valid for structural search, matching is always case-sensitive`)
+		}
+	}
+	return nil
 }
 
 // BoolValue returns the last boolean value (yes/no) for the field. For example, if the query is


### PR DESCRIPTION
Stacked on #8485. Addresses #7293. The more important part of this PR is the changes around the fix. If you are interested in some low level details about search and alerts interaction, read on. Otherwise, just review the diff.

---

- Currently, we do a lot of potential alert raising _after_ performing search, and also return results. Most alerts happen in `search_results.go`. Some alerts are raised _after_ trying to search, but have no bearing on search results (e.g., checking for quotes in the query). These checks happen far too late in the pipeline.
- When we do parsing/checking and return an error earlier in the pipeline (`search.go`), we go through a layer of indirection in the `didYouMeanQuotedResolver` business and wrapper, which is generally hard to reason about.
- We need a more direct way to return alerts (not just errors) earlier, before computing results. So I added code where `searchAlert` now implements the GQL type, and a helper function `newAlert` to make this smoother.
- With the helper setup, I  can now move alerts to the right places, tidy up some ugly resolver type business, and overall make query validation a separate, smooth process.