### PR TITLE
search: erase structural patterntype alert suggestion

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -45,9 +45,7 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 			case SearchTypeLiteral:
 				proposedQuery.query = proposedQuery.query + " patternType:literal"
 			case SearchTypeStructural:
-				// Don't append patternType:structural, it is not erased from the query like
-				// patterntype:regexp and patterntype:literal.
-				// TODO(RVT): Making this consistent requires a change on the UI side.
+				proposedQuery.query = proposedQuery.query + " patternType:structural"
 			default:
 				panic("unreachable")
 			}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -39,11 +39,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "Some query description",
-						query:       "repo:github.com/sourcegraph/sourcegraph patterntype:structural",
+						query:       "repo:github.com/sourcegraph/sourcegraph",
 					},
 				},
 			},
-			Want: "repo:github.com/sourcegraph/sourcegraph patterntype:structural",
+			Want: "repo:github.com/sourcegraph/sourcegraph patternType:structural",
 		},
 	}
 


### PR DESCRIPTION
The web side erases `patterntype`, so alert suggestions need the parameter in the query, if needed. The exception was `patterntype:structural`, but the exception was removed with the UI changes in one of #7267 or #8233. I think it was #7267.