### PR TITLE
LSIF: Make a custom TypeORM logger.

### DIFF
--- a/lsif/src/server/backend/cache.ts
+++ b/lsif/src/server/backend/cache.ts
@@ -4,6 +4,7 @@ import promClient from 'prom-client'
 import Yallist from 'yallist'
 import { Connection, EntityManager } from 'typeorm'
 import { createSqliteConnection } from '../../shared/database/sqlite'
+import { Logger } from 'winston'
 
 /**
  * A wrapper around a cache value promise.
@@ -331,6 +332,7 @@ export class ConnectionCache extends GenericCache<string, Connection> {
      *
      * @param database The database filename.
      * @param entities The set of entities to create on a new connection.
+     * @param logger The logger instance.
      * @param callback The function invoke with the SQLite connection.
      */
     public withConnection<T>(
@@ -338,9 +340,10 @@ export class ConnectionCache extends GenericCache<string, Connection> {
         // Decorators are not possible type check
         // eslint-disable-next-line @typescript-eslint/ban-types
         entities: Function[],
+        logger: Logger,
         callback: (connection: Connection) => Promise<T>
     ): Promise<T> {
-        return this.withValue(database, () => createSqliteConnection(database, entities), callback)
+        return this.withValue(database, () => createSqliteConnection(database, entities, logger), callback)
     }
 
     /**
@@ -349,6 +352,7 @@ export class ConnectionCache extends GenericCache<string, Connection> {
      *
      * @param database The database filename.
      * @param entities The set of entities to create on a new connection.
+     * @param logger The logger instance.
      * @param callback The function invoke with a SQLite transaction connection.
      */
     public withTransactionalEntityManager<T>(
@@ -356,9 +360,10 @@ export class ConnectionCache extends GenericCache<string, Connection> {
         // Decorators are not possible type check
         // eslint-disable-next-line @typescript-eslint/ban-types
         entities: Function[],
+        logger: Logger,
         callback: (entityManager: EntityManager) => Promise<T>
     ): Promise<T> {
-        return this.withConnection(database, entities, connection => connection.transaction(callback))
+        return this.withConnection(database, entities, logger, connection => connection.transaction(callback))
     }
 }
 

--- a/lsif/src/server/routes/lsif.ts
+++ b/lsif/src/server/routes/lsif.ts
@@ -80,9 +80,9 @@ export function createLsifRouter(
             validation.validateInt('repositoryId'),
             validation.validateNonEmptyString('commit').matches(commitPattern),
             validation.validateOptionalString('root'),
+            validation.validateOptionalString('indexerName'),
             validation.validateOptionalBoolean('blocking'),
             validation.validateOptionalInt('maxWait'),
-            validation.validateOptionalString('indexerName'),
         ]),
         wrap(
             async (req: express.Request, res: express.Response): Promise<void> => {
@@ -90,9 +90,9 @@ export function createLsifRouter(
                     repositoryId,
                     commit,
                     root: rootRaw,
+                    indexerName,
                     blocking,
                     maxWait,
-                    indexerName,
                 }: UploadQueryArgs = req.query
 
                 const root = sanitizeRoot(rootRaw)

--- a/lsif/src/shared/database/logger.ts
+++ b/lsif/src/shared/database/logger.ts
@@ -1,0 +1,47 @@
+import { Logger as TypeORMLogger } from 'typeorm'
+import { PlatformTools } from 'typeorm/platform/PlatformTools'
+import { Logger as WinstonLogger } from 'winston'
+
+/**
+ * A custom TypeORM logger that only logs slow database queries.
+ *
+ * We had previously set the TypeORM logging config to `['warn', 'error']`.
+ * This caused some issues as it would print the entire parameter set for large
+ * batch inserts to stdout. These parameters often included gzipped json payloads,
+ * which would lock up the terminal where the server was running.
+ *
+ * This logger will only print slow database queries. Any other error condition
+ * will be printed with the query, parameters, and underlying constraint violation
+ * as part of a thrown error, making it unnecessary to log here.
+ */
+export class DatabaseLogger implements TypeORMLogger {
+    constructor(private logger: WinstonLogger) {}
+
+    public logQuerySlow(time: number, query: string, parameters?: unknown[]): void {
+        this.logger.warn('Slow database query', {
+            query: PlatformTools.highlightSql(query),
+            parameters,
+            executionTime: time,
+        })
+    }
+
+    public logQuery(): void {
+        /* no-op */
+    }
+
+    public logSchemaBuild(): void {
+        /* no-op */
+    }
+
+    public logMigration(): void {
+        /* no-op */
+    }
+
+    public logQueryError(): void {
+        /* no-op */
+    }
+
+    public log(): void {
+        /* no-op */
+    }
+}

--- a/lsif/src/shared/database/postgres.ts
+++ b/lsif/src/shared/database/postgres.ts
@@ -8,6 +8,7 @@ import { Logger } from 'winston'
 import { PostgresConnectionCredentialsOptions } from 'typeorm/driver/postgres/PostgresConnectionCredentialsOptions'
 import { readEnvInt } from '../settings'
 import { TlsOptions } from 'tls'
+import { DatabaseLogger } from './logger'
 
 /**
  * The minimum migration version required by this instance of the LSIF process.
@@ -89,7 +90,7 @@ function connect(connectionOptions: PostgresConnectionCredentialsOptions, logger
     return pRetry(
         () => {
             logger.debug('Connecting to Postgres')
-            return connectPostgres(connectionOptions, '')
+            return connectPostgres(connectionOptions, '', logger)
         },
         {
             factor: 1,
@@ -105,16 +106,18 @@ function connect(connectionOptions: PostgresConnectionCredentialsOptions, logger
  *
  * @param connectionOptions The connection options.
  * @param suffix The database suffix (used for testing).
+ * @param logger The logger instance
  */
 export function connectPostgres(
     connectionOptions: PostgresConnectionCredentialsOptions,
-    suffix: string
+    suffix: string,
+    logger: Logger
 ): Promise<Connection> {
     return _createConnection({
         type: 'postgres',
         name: `lsif${suffix}`,
         entities: pgModels.entities,
-        logging: ['warn', 'error'],
+        logger: new DatabaseLogger(logger),
         maxQueryExecutionTime: 1000,
         ...connectionOptions,
     })

--- a/lsif/src/shared/database/sqlite.ts
+++ b/lsif/src/shared/database/sqlite.ts
@@ -1,16 +1,20 @@
 import { Connection, createConnection as _createConnection } from 'typeorm'
+import { Logger } from 'winston'
+import { DatabaseLogger } from './logger'
 
 /**
  * Create a SQLite connection from the given filename.
  *
  * @param database The database filename.
  * @param entities The set of expected entities present in this schema.
+ * @param logger The logger instance.
  */
 export function createSqliteConnection(
     database: string,
     // Decorators are not possible type check
     // eslint-disable-next-line @typescript-eslint/ban-types
-    entities: Function[]
+    entities: Function[],
+    logger: Logger
 ): Promise<Connection> {
     return _createConnection({
         type: 'sqlite',
@@ -18,7 +22,7 @@ export function createSqliteConnection(
         database,
         entities,
         synchronize: true,
-        logging: ['warn', 'error'],
+        logger: new DatabaseLogger(logger),
         maxQueryExecutionTime: 1000,
     })
 }

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -15,6 +15,7 @@ import { userInfo } from 'os'
 import { InternalLocation } from '../../server/backend/database'
 import { DumpManager } from '../../shared/store/dumps'
 import { DependencyManager } from '../../shared/store/dependencies'
+import { createSilentLogger } from '../../shared/logging'
 
 /**
  * Create a temporary directory with a subdirectory for dbs.
@@ -93,7 +94,11 @@ export async function createCleanPostgresDatabase(): Promise<{ connection: Conne
     try {
         // Run migrations then connect to database
         await child_process.exec(migrateCommand, { env })
-        connection = await connectPostgres({ host, port, username, password, database, ssl: false }, suffix)
+        connection = await connectPostgres(
+            { host, port, username, password, database, ssl: false },
+            suffix,
+            createSilentLogger()
+        )
         return { connection, cleanup }
     } catch (error) {
         // We made a database but can't use it - try to clean up


### PR DESCRIPTION
This fixes some massive dumps taken on the terminal by the default typeorm logger. It prints all parameters to failed queries, which can be massive gzipped buffers when encoding sqlite data.