### PR TITLE
Default-enable the protobuf basic code intel extension.

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -29,6 +29,7 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/perl":       true,
 	"sourcegraph/php":        true,
 	"sourcegraph/powershell": true,
+	"sourcegraph/protobuf":   true,
 	"sourcegraph/python":     true,
 	"sourcegraph/r":          true,
 	"sourcegraph/ruby":       true,


### PR DESCRIPTION
Added in https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/241 et seq.