### PR TITLE
Do not throw error on nil repository in resolver.

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -355,7 +355,7 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 		return nil, err
 	}
 	if resolver == nil {
-		return nil, errors.New("repository not found")
+		return nil, nil
 	}
 	return resolver.repo, nil
 }


### PR DESCRIPTION
The change added https://github.com/sourcegraph/sourcegraph/commit/5861ade4b66ab6a8e1670c3e89cc1e097a9e1763 will return an unexpected error from the Repository resolver, when nil is an acceptable result (the schema is not a required repository). This was breaking most of the regression tests ([context](https://sourcegraph.slack.com/archives/CHPC7UX16/p1582142038251300)) as the retry loop wasn't expecting a non-formatted error.

@sourcegraph/core-services : is this now the correct respond type (nil repository, no error) or should it be different (nil repository, formatted error with correct code)?

_Update_: it appears it should be nil, nil: https://github.com/sourcegraph/sourcegraph/blame/9bde612d46032964ecee8e586194a48b3279676d/cmd/frontend/graphqlbackend/graphqlbackend.go#L412