### PR TITLE
rename (in docs and settings): automation -> campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- The "automation" feature was renamed to "campaigns".
+  - `campaigns.readAccess.enabled` replaces the deprecated site configuration property `automation.readAccess.enabled`.
+  - The experimental feature flag was not renamed (because it will go away soon) and remains `{"experimentalFeatures": {"automation": "enabled"}}`.
+
 ### Fixed
 
 ### Removed
@@ -30,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Experimental: Added new field `certificates` as in `{ "experimentalFeatures" { "tls.external": { "certificates": ["<CERT>"] } } }`. This allows you to add certificates to trust when communicating with a code host (via API or git+http). We expect this to be useful for adding internal certificate authorities/self-signed certificates. [#71](https://github.com/sourcegraph/sourcegraph/issues/71)
 - Added a setting `auth.minPasswordLength`, which when set, causes a minimum password length to be enforced when users sign up or change passwords. [#7521](https://github.com/sourcegraph/sourcegraph/issues/7521)
 - GitHub labels associated with code change campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
+- GitHub labels associated with campaigns are now displayed. [#8115](https://github.com/sourcegraph/sourcegraph/pull/8115)
 - When creating a campaign, users can now specify the branch name that will be used on code host. This is also a breaking change for users of the GraphQL API since the `branch` attribute is now required in `CreateCampaignInput` when a `plan` is also specified. [#7646](https://github.com/sourcegraph/sourcegraph/issues/7646)
 - Added an optional `content:` parameter for specifying a search pattern. This parameter overrides any other search patterns in a query. Useful for unambiguously specifying what to search for when search strings clash with other query syntax. [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490)
 - Interactive search mode, which helps users construct queries using UI elements, is now made available to users by default. A dropdown to the left of the search bar allows users to toggle between interactive and plain text modes. The option to use interactive search mode can be disabled by adding `{ "experimentalFeatures": { "splitSearchModes": false } }` in global settings. [#8461](https://github.com/sourcegraph/sourcegraph/pull/8461)
@@ -45,6 +50,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The Sourcegraph Docker image optimized its use of Redis to make start-up significantly faster in certain scenarios (e.g when container restarts were frequent). ([#3300](https://github.com/sourcegraph/sourcegraph/issues/3300), [#2904](https://github.com/sourcegraph/sourcegraph/issues/2904))
 - Upgrading Sourcegraph is officially supported for one minor version increment (e.g., 3.12 -> 3.13). Previously, upgrades from 2 minor versions previous were supported. Please reach out to support@sourcegraph.com if you would like assistance upgrading from a much older version of Sourcegraph.
 - The GraphQL mutation `previewCampaignPlan` has been renamed to `createCampaignPlan`. This mutation is part of campaigns, which is still in beta and behind a feature flag and thus subject to possible breaking changes while we still work on it.
+- The GraphQL mutation `previewCampaignPlan` has been renamed to `createCampaignPlan`. This mutation is part of the campaigns feature, which is still in beta and behind a feature flag and thus subject to possible breaking changes while we still work on it.
 - The GraphQL field `CampaignPlan.changesets` has been deprecated and will be removed in 3.15. A new field called `CampaignPlan.changesetPlans` has been introduced to make the naming more consistent with the `Campaign.changesetPlans` field. Please use that instead. [#7966](https://github.com/sourcegraph/sourcegraph/pull/7966)
 - Long lines (>2000 bytes) are no longer highlighted, in order to prevent performance issues in browser rendering. [#6489](https://github.com/sourcegraph/sourcegraph/issues/6489)
 - No longer requires `read:org` permissions for GitHub OAuth if `allowOrgs` is not enabled in the site configuration. [#8163](https://github.com/sourcegraph/sourcegraph/issues/8163)
@@ -96,11 +102,16 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
-- Experimental: The site configuration field `automation.readAccess.enabled` allows site-admins to give read-only access for code change campaigns to non-site-admins. This is a setting for the experimental feature campaigns and will only have an effect when campaigns are enabled under `experimentalFeatures`. [#8013](https://github.com/sourcegraph/sourcegraph/issues/8013)
+- Experimental: The site configuration field `campaigns.readAccess.enabled` allows site-admins to give read-only access for code change campaigns to non-site-admins. This is a setting for the experimental feature campaigns and will only have an effect when campaigns are enabled under `experimentalFeatures`. [#8013](https://github.com/sourcegraph/sourcegraph/issues/8013)
 
 ### Fixed
 
 - A regression in 3.12.0 which caused [find-leaked-credentials campaigns](https://docs.sourcegraph.com/user/campaigns#finding-leaked-credentials) to not return any results for private repositories. [#7914](https://github.com/sourcegraph/sourcegraph/issues/7914)
+- Experimental: The site configuration field `campaigns.readAccess.enabled` allows site-admins to give read-only access for campaigns to non-site-admins. This is a setting for the experimental campaigns feature and will only have an effect when campaigns is enabled under `experimentalFeatures`. [#8013](https://github.com/sourcegraph/sourcegraph/issues/8013)
+
+### Fixed
+
+- A regression in 3.12.0 which caused find-leaked-credentials campaigns to not return any results for private repositories. [#7914](https://github.com/sourcegraph/sourcegraph/issues/7914)
 - A regression in 3.12.0 which removed the horizontal bar between search result matches.
 - Manual campaigns were wrongly displayed as being in draft mode. [#8009](https://github.com/sourcegraph/sourcegraph/issues/8009)
 - Manual campaigns could be published and create the wrong changesets on code hosts, even though the campaign was never in draft mode (see line above). [#8012](https://github.com/sourcegraph/sourcegraph/pull/8012)
@@ -166,6 +177,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - The syncing process for newly created campaign changesets has been fixed again after they have erroneously been marked as deleted in the database. [#7522](https://github.com/sourcegraph/sourcegraph/pull/7522)
+- The syncing process for newly created changesets (in campaigns) has been fixed again after they have erroneously been marked as deleted in the database. [#7522](https://github.com/sourcegraph/sourcegraph/pull/7522)
 
 ## 3.11.0
 
@@ -262,6 +274,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `ZOEKT_HOST` environment variable has been deprecated. Please use `INDEXED_SEARCH_SERVERS` instead. `ZOEKT_HOST` will be removed in 3.12.
 - Directory names on the repository tree page are now shown in bold to improve readability.
 - Added support for Bitbucket Server pull request activity to the [campaign](https://about.sourcegraph.com/product/code-change-management/) burndown chart. When used, this feature leads to more requests being sent to Bitbucket Server, since Sourcegraph needs to keep track of how a pull request's state changes over time. With [the instance scoped webhooks](https://docs.google.com/document/d/1I3Aq1WSUh42BP8KvKr6AlmuCfo8tXYtJu40WzdNT6go/edit) in our [Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/pull/10) as well as up-coming [heuristical syncing changes](#6389), this additional load will be significantly reduced in the future.
+- Added support for Bitbucket Server pull request activity to the campaign burndown chart. When used, this feature leads to more requests being sent to Bitbucket Server, since Sourcegraph needs to keep track of how a pull request's state changes over time. With [the instance scoped webhooks](https://docs.google.com/document/d/1I3Aq1WSUh42BP8KvKr6AlmuCfo8tXYtJu40WzdNT6go/edit) in our [Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/pull/10) as well as up-coming [heuristical syncing changes](#6389), this additional load will be significantly reduced in the future.
 
 ### Fixed
 
@@ -318,6 +331,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Old URLs without a patternType URL parameter will be redirected to the same URL with
     patternType=regexp appended to preserve intended behavior.
 - Added support for GitHub organization webhooks to enable faster updates of metadata used by [campaigns](https://about.sourcegraph.com/product/code-change-management/), such as pull requests or issue comments. See the [GitHub webhook documentation](https://docs.sourcegraph.com/admin/external_service/github#webhooks) for instructions on how to enable webhooks.
+- Added support for GitHub organization webhooks to enable faster updates of changeset metadata used by campaigns. See the [GitHub webhook documentation](https://docs.sourcegraph.com/admin/external_service/github#webhooks) for instructions on how to enable webhooks.
 - Added burndown chart to visualize progress of campaigns.
 - Added ability to edit campaign titles and descriptions.
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -188,9 +188,9 @@ func publicSiteConfiguration() schema.SiteConfiguration {
 		updateChannel = "release"
 	}
 	return schema.SiteConfiguration{
-		AutomationReadAccessEnabled: c.AutomationReadAccessEnabled,
-		AuthPublic:                  c.AuthPublic,
-		UpdateChannel:               updateChannel,
+		CampaignsReadAccessEnabled: c.CampaignsReadAccessEnabled,
+		AuthPublic:                 c.AuthPublic,
+		UpdateChannel:              updateChannel,
 	}
 }
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -104,12 +104,12 @@ func getAndMarshalCodeIntelUsageJSON(ctx context.Context) (*json.RawMessage, err
 	return &message, nil
 }
 
-func getAndMarshalAutomationUsageJSON(ctx context.Context) (*json.RawMessage, error) {
-	automationUsage, err := usagestats.GetAutomationUsageStatistics(ctx)
+func getAndMarshalCampaignsUsageJSON(ctx context.Context) (*json.RawMessage, error) {
+	usage, err := usagestats.GetCampaignsUsageStatistics(ctx)
 	if err != nil {
 		return nil, err
 	}
-	contents, err := json.Marshal(automationUsage)
+	contents, err := json.Marshal(usage)
 	if err != nil {
 		return nil, err
 	}
@@ -169,9 +169,9 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 	if err != nil {
 		logFunc("externalServicesKinds failed", "error", err)
 	}
-	automationUsage, err := getAndMarshalAutomationUsageJSON(ctx)
+	campaignsUsage, err := getAndMarshalCampaignsUsageJSON(ctx)
 	if err != nil {
-		logFunc("getAndMarshalAutomationUsageJSON failed", "error", err)
+		logFunc("getAndMarshalCampaignsUsageJSON failed", "error", err)
 	}
 
 	contents, err := json.Marshal(&pingRequest{
@@ -190,7 +190,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		HasRepos:             hasRepos,
 		EverSearched:         hasRepos && searchOccurred, // Searches only count if repos have been added.
 		EverFindRefs:         findRefsOccurred,
-		AutomationUsage:      automationUsage,
+		AutomationUsage:      campaignsUsage,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/internal/usagestats/automation.go
+++ b/cmd/frontend/internal/usagestats/automation.go
@@ -7,8 +7,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
-// GetAutomationUsageStatistics returns the current site's automation usage.
-func GetAutomationUsageStatistics(ctx context.Context) (*types.AutomationUsageStatistics, error) {
+// GetCampaignsUsageStatistics returns the current site's campaigns usage.
+func GetCampaignsUsageStatistics(ctx context.Context) (*types.CampaignsUsageStatistics, error) {
 	const q = "SELECT COUNT(*) FROM campaigns;"
 
 	var count int
@@ -16,7 +16,7 @@ func GetAutomationUsageStatistics(ctx context.Context) (*types.AutomationUsageSt
 		return nil, err
 	}
 
-	return &types.AutomationUsageStatistics{
+	return &types.CampaignsUsageStatistics{
 		CampaignsCount: count,
 	}, nil
 }

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -196,7 +196,7 @@ type Event struct {
 	Timestamp       time.Time
 }
 
-type AutomationUsageStatistics struct {
+type CampaignsUsageStatistics struct {
 	CampaignsCount int
 }
 

--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -70,3 +70,5 @@
 /team/roadmap https://about.sourcegraph.com/direction 308
 /team/style_guide https://about.sourcegraph.com/handbook/communication/style_guide 308
 /adopt/comp https://about.sourcegraph.com/workflow 308
+/user/automation /user/campaigns 308
+/dev/automation_development /dev/campaigns_development 308

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -91,7 +91,7 @@
                             <li><a href="/user/repository">Repositories</a></li>
                             <li><a href="/user/tour">Sourcegraph tour</a></li>
                             <li><a href="/user/markdown">Sourcegraph-flavored Markdown</a></li>
-                            <li><a href="/user/automation">Automation <span class="badge badge-primary">preview</span></a></li>
+                            <li><a href="/user/campaigns">Campaigns <span class="badge badge-primary">preview</span></a></li>
                             <li><a href="/user/usage_statistics">Usage statistics</a></li>
                             <li><a href="/user/user_surveys">User surveys</a></li>
                         </ul>
@@ -305,7 +305,7 @@
                     <li class="content-nav-no-hover">
                         <a class="content-nav-section-header" href="/dev">Open source development documentation</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/dev/automation_development">Developing automation</a></li>
+                            <li><a href="/dev/campaigns_development">Developing campaigns</a></li>
                             <li><a href="/dev/graphql_api">Developing the Sourcegraph GraphQL API</a></li>
                             <li><a href="/dev/web_app">Developing the Sourcegraph web app</a></li>
                             <li><a href="/dev/local_development">Getting started with developing Sourcegraph</a></li>

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -66,7 +66,7 @@
                             <ul class="nav flex-column">
                                 <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-search-navigation">Code search</a></li>
                                 <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-review">Code review</a></li>
-                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-alerts-automation">Code alerts &amp; automation</a></li>
+                                <li class="nav-item"><a href="https://about.sourcegraph.com/product/code-change-management">Code change management</a></li>
                             </ul>
                         </div>
                         <div class="col-sm-6 col-md-3 col-lg-2 mb-3">

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -19,6 +19,6 @@ Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and
 - Aggregate counts of current users by product feature (site management, code search and navigation, code review, saved searches, diff searches)
 - Aggregate daily, weekly, and monthly latencies (in ms) of certain events (e.g., hover tooltips)
 - Aggregate daily, weekly, and monthly total counts of certain events (e.g., hover tooltips)
-- Total count of Automation campaigns created
+- Total count of code campaigns created
 
 To disable pings, please [contact support](https://about.sourcegraph.com/contact/).

--- a/doc/dev/campaigns_development.md
+++ b/doc/dev/campaigns_development.md
@@ -1,26 +1,26 @@
-# Developing Automation
+# Developing campaigns
 
-## What is Automation?
+## What are code campaigns?
 
-Before diving into the technical part of Automation, make sure to read up on what Automation is, what it's not and what we want it to be:
+Before diving into the technical part of campaigns, make sure to read up on what code campaigns are, what it's not and what we want it to be:
 
-1. Start by reading through the [Automation product landingpage](https://about.sourcegraph.com/product/automation/)
-1. **IMPORTANT:** Watch the Automation videos! At the bottom of the landingpage, you'll find two demo videos that showcase the original prototype for Automation. A lot of our work aims to reproduce what you can see in these videos — in a scalable way that supports multiple code hosts. **Make sure to watch these videos!**
-1. Take a look at the [Automation sequence of milestones](https://docs.google.com/document/d/1TDsjrCy55UTZA_NyofVssnBotTyPP6Hvbrsp__aUCfM/edit#heading=h.go9qqwdnhiyu) to get a high-level overview of what we did so far and what still needs to be done
-1. Read through the [user documentation on Automation](../user/automation.md).
+1. Start by reading through the [code change management product page](https://about.sourcegraph.com/product/code-change-management/)
+1. **IMPORTANT:** Watch the videos! At the bottom of that page, you'll find two demo videos. A lot of our work aims to reproduce what you can see in these videos — in a scalable way that supports multiple code hosts. **Make sure to watch these videos!**
+1. Take a look at the [sequence of milestones](https://docs.google.com/document/d/1TDsjrCy55UTZA_NyofVssnBotTyPP6Hvbrsp__aUCfM/edit#heading=h.go9qqwdnhiyu) to get a high-level overview of what we did so far and what still needs to be done
+1. Read through the [user documentation](../user/campaigns.md).
 
 ## Starting up your environment
 
 1. Run `./enterprise/dev/start.sh` — Wait until all repositories are cloned.
-2. Follow the [user guide on creating campaigns](../user/automation.md). **Remember:** If you create a campaign, you're opening real PRs on GitHub. Make sure only [testing repositories](#github-testing-account) are affected. If you create a large campaign, it takes a while to preview/create but also helps a lot with finding bugs/errors, etc.
+2. Follow the [user guide on creating campaigns](../user/campaigns.md). **Remember:** If you create a campaign, you're opening real PRs on GitHub. Make sure only [testing repositories](#github-testing-account) are affected. If you create a large campaign, it takes a while to preview/create but also helps a lot with finding bugs/errors, etc.
 
 ## Glossary
 
-Automation introduces a lot of new names, GraphQL queries and mutations and database tables. This section tries to explain the most common names and provide a mapping between the GraphQL types and their internal counterpart in the Go backend.
+The code campaigns feature introduces a lot of new names, GraphQL queries and mutations and database tables. This section tries to explain the most common names and provide a mapping between the GraphQL types and their internal counterpart in the Go backend.
 
 | GraphQL type        | Go type              | Database table     | Description |
 | ------------------- | -------------------- | -------------------| ----------- |
-| `Campaign`          | `a8n.Campaign`       | `campaigns`        | A campaign is a collection of changesets on code hosts. The central entity in Automation. |
+| `Campaign`          | `a8n.Campaign`       | `campaigns`        | A campaign is a collection of changesets on code hosts. The central entity. |
 | `ExternalChangeset` | `a8n.Changeset`      | `changesets`       | Changeset is the unified name for pull requests/merge requests/etc. on code hosts.        |
 | `CampaignPlan`      | `a8n.CampaignPlan`   | `campaign_plans`   | A campaign plan is a collection of changes (think: patches/diffs) that will be applied by running a Campaign. A campaign *has one* campaign plan. |
 | `ChangesetPlan`     | `a8n.CampaignJob`    | `campaign_jobs`    | A *plan* for a changeset. It represents a patch per repository that *can* be a changeset. It belongs to a campaign plan, which has multiple changeset plans, one per repository. |
@@ -29,20 +29,20 @@ Automation introduces a lot of new names, GraphQL queries and mutations and data
 
 ## Diving into the code as a backend developer
 
-1. Read through `./cmd/frontend/graphqlbackend/a8n.go` to get an overview of the Automation GraphQL API.
-1. Read through `./internal/a8n/types.go` to see all Automation related type definitions.
+1. Read through `./cmd/frontend/graphqlbackend/a8n.go` to get an overview of the campaigns GraphQL API.
+1. Read through `./internal/a8n/types.go` to see all campaigns-related type definitions.
 1. Compare that with the GraphQL definitions in `./cmd/frontend/graphqlbackend/schema.graphql`.
 1. Start reading through `./enterprise/internal/a8n/resolvers/resolver.go` to see how the main mutation are implemented (look at `createCampaignPlanFromPatches` and `createCampaign` to see how the two main operations are implemented).
 1. Then start from the other end, `enterprise/cmd/repo-updater/main.go`, and see how the enterprise `repo-updater` uses `a8n.Syncer` to sync `Changesets`.
 
 ## GitHub testing account
 
-Automation features require creating changesets (PRs) on code hosts. If you are not part of the Sourcegraph organization, we recommend you create dummy projects to safely test changes on so you do not spam real repositories with your tests. If you _are_ part of the Sourcegraph organization, we have an account set up for this purpose.
+The campaigns feature requires creating changesets (PRs) on code hosts. If you are not part of the Sourcegraph organization, we recommend you create dummy projects to safely test changes on so you do not spam real repositories with your tests. If you _are_ part of the Sourcegraph organization, we have an account set up for this purpose.
 
 To use this account, follow these steps:
 
 1. Find the GitHub `sd9` user in 1Password
-2. Copy the Automation Testing Token
+2. Copy the Campaigns Testing Token
 3. Change your `dev-private/enterprise/dev/external-services-config.json` to only contain a GitHub external service config with the token, like this:
 
 ```json

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -18,7 +18,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 - [Developing the web app](web_app.md)
 - [Developing the GraphQL API](graphql_api.md)
 - [Developing indexed search](zoekt.md)
-- [Developing automation](automation_development.md)
+- [Developing campaigns](campaigns_development.md)
 - [Using PostgreSQL](postgresql.md)
 - [Testing](testing.md)
 - [Go style guide](https://about.sourcegraph.com/handbook/engineering/go_style_guide)

--- a/doc/user/campaigns.md
+++ b/doc/user/campaigns.md
@@ -1,14 +1,14 @@
-# Automation
+# Campaigns
 
-> Automation is currently available in private beta for select enterprise customers.
+> Campaigns are currently available in private beta for select enterprise customers.
 
-[Sourcegraph automation](https://about.sourcegraph.com/product/automation) allows large-scale code changes across many repositories and different code hosts.
+[Sourcegraph code change management](https://about.sourcegraph.com/product/code-change-management) lets you make large-scale code changes across many repositories and different code hosts.
 
 **Important**: If you're on Sourcegraph 3.12 or older, you might also want to look at the old documentation: "[Automation documentation for Sourcegraph 3.12](https://docs.sourcegraph.com/@3.12/user/automation)"
 
 ## Configuration
 
-In order to use the Automation preview, a site-admin of your Sourcegraph instance must enable it in the site configuration settings e.g. `sourcegraph.example.com/site-admin/configuration`
+In order to use code campaigns, a site-admin of your Sourcegraph instance must enable it in the site configuration settings e.g. `sourcegraph.example.com/site-admin/configuration`
 
 ```json
 {
@@ -18,20 +18,20 @@ In order to use the Automation preview, a site-admin of your Sourcegraph instanc
 }
 ```
 
-Without any further configuration Automation is **only be accessible to site-admins.** If you want to grant read-only access to non-site-admins, use the following site configuration setting:
+Without any further configuration, campaigns are **only accessible to site-admins.** If you want to grant read-only access to non-site-admins, use the following site configuration setting:
 
 ```json
 {
-  "automation.readAccess.enabled": true
+  "campaigns.readAccess.enabled": true
 }
 ```
 
 ## Usage
 
-There are two types of Automation campaigns:
+There are two types of campaigns:
 
 - Manual campaigns to which you can manually add changesets (pull requests) and track their progress.
-- Campaigns created from a set of patches. With the `src` CLI tool you can not only create the campaign from an existing set of patches, but you can also _generate the patches_ for a number of repositories.
+- Campaigns created from a set of patches. With the `src` CLI tool, you can not only create the campaign from an existing set of patches, but you can also _generate the patches_ for a number of repositories.
 
 ### Creating a manual campaign
 
@@ -416,6 +416,6 @@ This uses `/cache` as the `YARN_CACHE_FOLDER` and `NPM_CONFIG_CACHE` folder. It 
 
 Subsequent action steps that use this preamble in their `Dockerfile` will run faster because they can leverage the cache folder.
 
-## Note for Automation developers
+## Note for developers
 
-If you are looking to run automation on a larger scale in the local dev environment, follow the [guide on automation development](../dev/automation_development.md).
+If you are looking to use campaigns in your local dev environment, follow the [guide on campaigns development](../dev/campaigns_development.md).

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -32,7 +32,7 @@ All features:
 - [Usage statistics](usage_statistics.md)
 - [User surveys](user_surveys.md)
 - [Color themes](themes.md)
-- [Automation preview](automation.md)
+- [Campaigns](campaigns.md)
 - [Quick links](quick_links.md)
 
 ## What is Sourcegraph?

--- a/enterprise/internal/a8n/resolvers/resolver.go
+++ b/enterprise/internal/a8n/resolvers/resolver.go
@@ -38,7 +38,7 @@ func NewResolver(db *sql.DB) graphqlbackend.A8NResolver {
 }
 
 func allowReadAccess(ctx context.Context) error {
-	if readAccess := conf.AutomationReadAccessEnabled(); readAccess {
+	if readAccess := conf.CampaignsReadAccessEnabled(); readAccess {
 		return nil
 	}
 
@@ -420,7 +420,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	for _, r := range rs {
 		if !a8n.IsRepoSupported(&r.ExternalRepo) {
 			err = errors.Errorf(
-				"External service type %s of repository %q is currently not supported in Automation features",
+				"External service type %s of repository %q is currently not supported for use with campaigns",
 				r.ExternalRepo.ServiceType,
 				r.Name,
 			)

--- a/enterprise/internal/a8n/service.go
+++ b/enterprise/internal/a8n/service.go
@@ -318,7 +318,7 @@ func RunChangesetJob(
 		CommitInfo: protocol.PatchCommitInfo{
 			Message:     c.Name,
 			AuthorName:  "Sourcegraph Bot",
-			AuthorEmail: "automation@sourcegraph.com",
+			AuthorEmail: "campaigns@sourcegraph.com",
 			Date:        job.CreatedAt,
 		},
 		// We use unified diffs, not git diffs, which means they're missing the

--- a/enterprise/internal/a8n/webhooks.go
+++ b/enterprise/internal/a8n/webhooks.go
@@ -525,7 +525,7 @@ func (*GitHubWebhook) checkRunEvent(cr *gh.CheckRun) *github.CheckRun {
 	}
 }
 
-// Upsert ensures the creation of the BitbucketServer automation webhook.
+// Upsert ensures the creation of the BitbucketServer campaigns webhook.
 // This happens periodically at the specified interval.
 func (h *BitbucketServerWebhook) Upsert(every time.Duration) {
 	for {

--- a/internal/a8n/config.go
+++ b/internal/a8n/config.go
@@ -1,0 +1,14 @@
+package a8n
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+func init() {
+	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
+		if c.AutomationReadAccessEnabled != nil {
+			problems = append(problems, conf.NewSiteProblem("The `automation.readAccess.enabled` property was renamed to `campaigns.readAccess.enabled`. Use that new property name instead. The old name is deprecated and will be removed in a future release."))
+		}
+		return
+	})
+}

--- a/internal/a8n/types.go
+++ b/internal/a8n/types.go
@@ -14,7 +14,7 @@ import (
 )
 
 // SupportedExternalServices are the external service types currently supported
-// by Automation features. Repos that are associated with external services
+// by the campaigns feature. Repos that are associated with external services
 // whose type is not in this list will simply be filtered out from the search
 // results.
 var SupportedExternalServices = map[string]struct{}{
@@ -23,7 +23,7 @@ var SupportedExternalServices = map[string]struct{}{
 }
 
 // IsRepoSupported returns whether the given ExternalRepoSpec is supported by
-// Automation features, based on the external service type.
+// the campaigns feature, based on the external service type.
 func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
 	_, ok := SupportedExternalServices[spec.ServiceType]
 	return ok

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -211,10 +211,16 @@ func SymbolIndexEnabled() bool {
 	return enabled
 }
 
-func AutomationReadAccessEnabled() bool {
+func CampaignsReadAccessEnabled() bool {
+	if v := Get().CampaignsReadAccessEnabled; v != nil {
+		return *v
+	}
+
+	// DEPRECATED property name.
 	if v := Get().AutomationReadAccessEnabled; v != nil {
 		return *v
 	}
+
 	return false
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -361,7 +361,7 @@ type ExcludedGitoliteRepo struct {
 
 // ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type ExperimentalFeatures struct {
-	// Automation description: Enables the experimental code automation features.
+	// Automation description: Enables the experimental code change management campaigns feature. NOTE: The automation feature was renamed to campaigns, but this experimental feature flag name was not changed (because the feature flag will go away soon anyway).
 	Automation string `json:"automation,omitempty"`
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
@@ -893,12 +893,14 @@ type SiteConfiguration struct {
 	AuthSessionExpiry string `json:"auth.sessionExpiry,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`
-	// AutomationReadAccessEnabled description: Enables read-only access to Automation campaigns for non-site-admin users. This is a setting for the experimental feature Automation. These will only have an effect when Automation is enabled under experimentalFeatures
+	// AutomationReadAccessEnabled description: DEPRECATED: The automation feature was renamed to campaigns. Use `campaigns.readAccess.enabled` instead.
 	AutomationReadAccessEnabled *bool `json:"automation.readAccess.enabled,omitempty"`
 	// Branding description: Customize Sourcegraph homepage logo and search icon.
 	//
 	// Only available in Sourcegraph Enterprise.
 	Branding *Branding `json:"branding,omitempty"`
+	// CampaignsReadAccessEnabled description: Enables read-only access to campaigns for non-site-admin users. This is a setting for the experimental campaigns feature. These will only have an effect when campaigns is enabled with `{"experimentalFeatures": {"automation": "enabled"}}`.
+	CampaignsReadAccessEnabled *bool `json:"campaigns.readAccess.enabled,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
 	CorsOrigin string `json:"corsOrigin,omitempty"`
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -74,7 +74,7 @@
           }
         },
         "automation": {
-          "description": "Enables the experimental code automation features.",
+          "description": "Enables the experimental code change management campaigns feature. NOTE: The automation feature was renamed to campaigns, but this experimental feature flag name was not changed (because the feature flag will go away soon anyway).",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
@@ -157,10 +157,16 @@
       "hide": true
     },
     "automation.readAccess.enabled": {
-      "description": "Enables read-only access to Automation campaigns for non-site-admin users. This is a setting for the experimental feature Automation. These will only have an effect when Automation is enabled under experimentalFeatures",
+      "description": "DEPRECATED: The automation feature was renamed to campaigns. Use `campaigns.readAccess.enabled` instead.",
       "type": "boolean",
       "!go": { "pointer": true },
-      "group": "Automation"
+      "group": "Campaigns"
+    },
+    "campaigns.readAccess.enabled": {
+      "description": "Enables read-only access to campaigns for non-site-admin users. This is a setting for the experimental campaigns feature. These will only have an effect when campaigns is enabled with `{\"experimentalFeatures\": {\"automation\": \"enabled\"}}`.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Campaigns"
     },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -79,7 +79,7 @@ const SiteSchemaJSON = `{
           }
         },
         "automation": {
-          "description": "Enables the experimental code automation features.",
+          "description": "Enables the experimental code change management campaigns feature. NOTE: The automation feature was renamed to campaigns, but this experimental feature flag name was not changed (because the feature flag will go away soon anyway).",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
@@ -162,10 +162,16 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "automation.readAccess.enabled": {
-      "description": "Enables read-only access to Automation campaigns for non-site-admin users. This is a setting for the experimental feature Automation. These will only have an effect when Automation is enabled under experimentalFeatures",
+      "description": "DEPRECATED: The automation feature was renamed to campaigns. Use ` + "`" + `campaigns.readAccess.enabled` + "`" + ` instead.",
       "type": "boolean",
       "!go": { "pointer": true },
-      "group": "Automation"
+      "group": "Campaigns"
+    },
+    "campaigns.readAccess.enabled": {
+      "description": "Enables read-only access to campaigns for non-site-admin users. This is a setting for the experimental campaigns feature. These will only have an effect when campaigns is enabled with ` + "`" + `{\"experimentalFeatures\": {\"automation\": \"enabled\"}}` + "`" + `.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Campaigns"
     },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -378,7 +378,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                         !window.context.sourcegraphDotComMode &&
                                         !!authenticatedUser &&
                                         (authenticatedUser.siteAdmin ||
-                                            !!window.context.site['automation.readAccess.enabled'])
+                                            !!window.context.site['campaigns.readAccess.enabled'])
                                     }
                                     // Theme
                                     isLightTheme={this.isLightTheme()}

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -77,7 +77,7 @@ interface SourcegraphContext
      */
     site: Pick<
         import('./schema/site.schema').SiteConfiguration,
-        'auth.public' | 'update.channel' | 'automation.readAccess.enabled'
+        'auth.public' | 'update.channel' | 'campaigns.readAccess.enabled'
     >
 
     /** Whether access tokens are enabled. */

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -67,7 +67,7 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                         Aggregate daily, weekly, and monthly latencies (in ms) of certain events (e.g., hover tooltips)
                     </li>
                     <li>Aggregate daily, weekly, and monthly total counts of certain events (e.g., hover tooltips)</li>
-                    <li>Total count of Automation campaigns created</li>
+                    <li>Total count of code campaigns created</li>
                 </ul>
                 {!pingsEnabled ? (
                     <p>Pings are disabled.</p>


### PR DESCRIPTION
See https://github.com/sourcegraph/about/pull/583 for info on the rename.
    
This only performs the rename in documentation and settings; it does not rename all instances in code (e.g., the `a8n` Go package is not renamed).