### PR TITLE
search: remove resolver dependency for simple alerts

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -54,7 +54,7 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	return &a.proposedQueries
 }
 
-func (r *searchResolver) alertForStalePermissions(_ context.Context) *searchAlert {
+func alertForStalePermissions() *searchAlert {
 	return &searchAlert{
 		prometheusType: "no_resolved_repos__stale_permissions",
 		title:          "Permissions syncing in progress",
@@ -62,16 +62,16 @@ func (r *searchResolver) alertForStalePermissions(_ context.Context) *searchAler
 	}
 }
 
-func (r *searchResolver) alertForQuotesInQueryInLiteralMode(_ context.Context) (*searchAlert, error) {
+func alertForQuotesInQueryInLiteralMode(query *query.Query) *searchAlert {
 	return &searchAlert{
 		prometheusType: "no_results__suggest_quotes",
 		title:          "No results. Did you mean to use quotes?",
 		description:    "Your search is interpreted literally and contains quotes. Did you mean to search for quotes?",
 		proposedQueries: []*searchQueryDescription{{
 			description: "Remove quotes",
-			query:       syntax.ExprString(omitQuotes(r.query)),
+			query:       syntax.ExprString(omitQuotes(query)),
 		}},
-	}, nil
+	}
 }
 
 func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAlert, error) {
@@ -335,7 +335,7 @@ outer:
 	return alert, nil
 }
 
-func (r *searchResolver) alertForMissingRepoRevs(missingRepoRevs []*search.RepositoryRevisions) *searchAlert {
+func alertForMissingRepoRevs(patternType query.SearchType, missingRepoRevs []*search.RepositoryRevisions) *searchAlert {
 	var description string
 	if len(missingRepoRevs) == 1 {
 		if len(missingRepoRevs[0].RevSpecs()) == 1 {
@@ -354,7 +354,7 @@ func (r *searchResolver) alertForMissingRepoRevs(missingRepoRevs []*search.Repos
 		prometheusType: "missing_repo_revs",
 		title:          "Some repositories could not be searched",
 		description:    description,
-		patternType:    r.patternType,
+		patternType:    patternType,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -192,7 +192,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	var alert *searchAlert
 
 	if len(missingRepoRevs) > 0 {
-		alert = r.alertForMissingRepoRevs(missingRepoRevs)
+		alert = alertForMissingRepoRevs(r.patternType, missingRepoRevs)
 	}
 
 	log15.Info("next cursor for paginated search request",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -919,7 +919,7 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 	if err != nil {
 		if errors.Is(err, authz.ErrStalePermissions{}) {
 			log15.Debug("searchResolver.determineRepos", "err", err)
-			alert := r.alertForStalePermissions(ctx)
+			alert := alertForStalePermissions()
 			return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 		}
 		return nil, nil, nil, err
@@ -1337,11 +1337,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	if len(missingRepoRevs) > 0 {
-		alert = r.alertForMissingRepoRevs(missingRepoRevs)
+		alert = alertForMissingRepoRevs(r.patternType, missingRepoRevs)
 	}
 
 	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == query.SearchTypeLiteral {
-		alert, err = r.alertForQuotesInQueryInLiteralMode(ctx)
+		alert = alertForQuotesInQueryInLiteralMode(r.query)
 	}
 
 	// If we have some results, only log the error instead of returning it,


### PR DESCRIPTION
Rationale behind this change:
- `alertForStalePermissions` doesn't need anything from `r *searchResolver`
- `alertForQuotesInQueryInLiteralMode` can't fail, no need to return an error type.