### PR TITLE
refactor: use pattern type only in query alert suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -20,11 +20,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: searchAlert{
 				title:       "An alert for regex",
 				description: "An alert for regex",
-				patternType: query.SearchTypeRegex,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "Some query description",
 						query:       "repo:github.com/sourcegraph/sourcegraph",
+						patternType: query.SearchTypeRegex,
 					},
 				},
 			},
@@ -35,11 +35,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: searchAlert{
 				title:       "An alert for structural",
 				description: "An alert for structural",
-				patternType: query.SearchTypeStructural,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "Some query description",
 						query:       "repo:github.com/sourcegraph/sourcegraph",
+						patternType: query.SearchTypeStructural,
 					},
 				},
 			},
@@ -50,7 +50,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			got := tt.Alert.ProposedQueries()
-			if !reflect.DeepEqual((*got)[0].query, tt.Want) {
+			if !reflect.DeepEqual((*got)[0].Query(), tt.Want) {
 				t.Errorf("got: %s, want: %s", (*got)[0].query, tt.Want)
 			}
 		})

--- a/cmd/frontend/graphqlbackend/search_query.go
+++ b/cmd/frontend/graphqlbackend/search_query.go
@@ -1,14 +1,33 @@
 package graphqlbackend
 
+import "github.com/sourcegraph/sourcegraph/internal/search/query"
+
 type searchQueryDescription struct {
 	description string
 	query       string
+	patternType query.SearchType
 }
 
-func (q searchQueryDescription) Query() string { return q.query }
+func (q searchQueryDescription) Query() string {
+	if q.description != "Remove quotes" {
+		switch q.patternType {
+		case query.SearchTypeRegex:
+			return q.query + " patternType:regexp"
+		case query.SearchTypeLiteral:
+			return q.query + " patternType:literal"
+		case query.SearchTypeStructural:
+			return q.query + " patternType:structural"
+		default:
+			panic("unreachable")
+		}
+	}
+	return q.query
+}
+
 func (q searchQueryDescription) Description() *string {
 	if q.description == "" {
 		return nil
 	}
+
 	return &q.description
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -528,11 +528,11 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 				prometheusType: "timed_out",
 				title:          "Timed out while searching",
 				description:    fmt.Sprintf("We weren't able to find any results in %s.", roundStr(dt.String())),
-				patternType:    r.patternType,
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "query with longer timeout",
 						query:       fmt.Sprintf("timeout:%v %s", dt2, omitQueryFields(r, query.FieldTimeout)),
+						patternType: r.patternType,
 					},
 				},
 			},


### PR DESCRIPTION
The `patternType` is only needed when an alert has suggestions. It is now part of 

```
proposedQueries []*searchQueryDescription
```

instead of the alert type. This change removes all the places that `patternType` is needlessly specified when constructing alerts, and adds it explicitly when constructing suggestions.

This change also makes it possible to construct multiple suggestions per alert with different pattern types. E.g., "You did this in literal search? Suggest this query in regex search or structural search". 