### PR TITLE
search: refactor parse-check-validate pipeline and alerts

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	rxsyntax "regexp/syntax"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,6 +30,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+	querytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
 	searchquerytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -64,6 +67,72 @@ type SearchImplementer interface {
 	Stats(context.Context) (*searchResultsStats, error)
 }
 
+func alertForParseError(err error, queryString string) *searchAlert {
+	switch e := err.(type) {
+	case *syntax.ParseError:
+		return &searchAlert{
+			prometheusType:  "parse_syntax_error",
+			title:           capFirst(e.Msg),
+			description:     "Quoting the query may help if you want a literal match.",
+			proposedQueries: proposedQuotedQueries(queryString),
+		}
+	}
+	return &searchAlert{
+		prometheusType: "parse_syntax_error",
+		title:          "Query Parse Error",
+		description:    capFirst(err.Error()),
+	}
+}
+
+func alertForTypecheckError(err error, queryString string) *searchAlert {
+	switch e := err.(type) {
+	case *querytypes.TypeError:
+		switch e := e.Err.(type) {
+		case *rxsyntax.Error:
+			return &searchAlert{
+				prometheusType:  "typecheck_regex_syntax_error",
+				title:           capFirst(e.Error()),
+				description:     "Quoting the query may help if you want a literal match instead of a regular expression match.",
+				proposedQueries: proposedQuotedQueries(queryString),
+			}
+		}
+	}
+	return &searchAlert{
+		prometheusType: "typecheck_error",
+		title:          "Query Typecheck Error",
+		description:    capFirst(err.Error()),
+	}
+}
+
+// processQuery runs the processing pipeline that parses, type checks, and
+// validates search queries. Errors are converted to descriptive alerts or
+// suggestions that surface in the client.
+//
+// TODO(rvantonder): this function should belong to
+// the internal/search/query package, once alerts can be constructed in
+// internal/search.
+func processQuery(queryString string, searchType query.SearchType) (*query.Query, *searchAlert) {
+	parseTree, err := query.Parse(queryString)
+	if err != nil {
+		return nil, alertForParseError(err, queryString)
+	}
+
+	q, err := query.Check(parseTree)
+	if err != nil {
+		return nil, alertForTypecheckError(err, queryString)
+	}
+
+	err = query.Validate(q, searchType)
+	if err != nil {
+		return nil, &searchAlert{
+			title:       "Invalid Query",
+			description: capFirst(err.Error()),
+		}
+	}
+
+	return q, nil
+}
+
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	tr, _ := trace.New(context.Background(), "graphql.schemaResolver", "Search")
@@ -71,7 +140,7 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 
 	searchType, err := detectSearchType(args.Version, args.PatternType, args.Query)
 	if err != nil {
-		return &didYouMeanQuotedResolver{query: args.Query, err: err}, nil
+		return nil, err
 	}
 
 	if searchType == query.SearchTypeStructural && !conf.StructuralSearchEnabled() {
@@ -85,13 +154,9 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 		queryString = args.Query
 	}
 
-	q, err := query.ParseAndCheck(queryString)
-	if err != nil {
-		return &didYouMeanQuotedResolver{query: args.Query, err: err}, nil
-	}
-	err = query.Validate(q, searchType)
-	if err != nil {
-		return searchAlert{title: "Invalid Query", description: capFirst(err.Error())}, nil
+	q, alert := processQuery(queryString, searchType)
+	if alert != nil {
+		return alert, nil
 	}
 
 	// If the request is a paginated one, decode those arguments now.

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -444,8 +444,11 @@ func addQueryRegexpField(query *query.Query, field, pattern string) syntax.Parse
 
 func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 	alert := &searchAlert{
-		title:       a.title,
-		description: a.description,
+		prometheusType:  a.prometheusType,
+		title:           a.title,
+		description:     a.description,
+		patternType:     a.patternType,
+		proposedQueries: a.proposedQueries,
 	}
 	return &SearchResultsResolver{alert: alert}, nil
 }

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
@@ -1,12 +1,8 @@
 package graphqlbackend
 
 import (
-	"context"
 	"reflect"
-	"strings"
 	"testing"
-
-	"github.com/sourcegraph/sourcegraph/internal/search/query"
 
 	"github.com/davecgh/go-spew/spew"
 )
@@ -68,75 +64,6 @@ func Test_proposedQuotedQueries(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_didYouMeanQuotedResolver_Results(t *testing.T) {
-	t.Run("regex error", func(t *testing.T) {
-		raw := "*"
-		_, err := query.ParseAndCheck(raw)
-		if err == nil {
-			t.Fatalf(`error returned from syntax.Parse("%s") is nil`, raw)
-		}
-		dymqr := didYouMeanQuotedResolver{query: raw, err: err}
-		srr, err := dymqr.Results(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		alert := srr.alert
-		if !strings.Contains(strings.ToLower(alert.title), "regexp") {
-			t.Errorf("title is '%s', want it to contain 'regexp'", alert.title)
-		}
-		if !strings.Contains(alert.description, "regular expression") {
-			t.Errorf("description is '%s', want it to contain 'regular expression'", alert.description)
-		}
-	})
-
-	t.Run("type error that is not a regex error should show a suggestion", func(t *testing.T) {
-		raw := "-foobar"
-		_, err := query.ParseAndCheck(raw)
-		if err == nil {
-			t.Fatalf(`error returned from syntax.Parse("%s") is nil`, raw)
-		}
-		dymqr := didYouMeanQuotedResolver{query: raw, err: err}
-		_, err = dymqr.Results(context.Background())
-		if err == nil {
-			t.Errorf("got nil error")
-		}
-	})
-
-	t.Run("query parse error", func(t *testing.T) {
-		raw := ":"
-		_, err := query.ParseAndCheck(raw)
-		dymqr := didYouMeanQuotedResolver{query: raw, err: err}
-		srr, err := dymqr.Results(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		alert := srr.alert
-		if strings.Contains(strings.ToLower(alert.title), "regexp") {
-			t.Errorf("title is '%s', want it not to contain 'regexp'", alert.title)
-		}
-		if strings.Contains(alert.description, "regular expression") {
-			t.Errorf("description is '%s', want it not to contain 'regular expression'", alert.description)
-		}
-	})
-
-	t.Run("negated file field with an invalid regex", func(t *testing.T) {
-		raw := "-f:(a"
-		_, err := query.ParseAndCheck(raw)
-		if err == nil {
-			t.Fatal("ParseAndCheck failed to detect the invalid regex in the f: field")
-		}
-		dymqr := didYouMeanQuotedResolver{query: raw, err: err}
-		srr, err := dymqr.Results(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		alert := srr.alert
-		if len(alert.proposedQueries) != 1 {
-			t.Fatalf("got %d proposed queries (%v), want exactly 1", len(alert.proposedQueries), alert.proposedQueries)
-		}
-	})
 }
 
 func Test_capFirst(t *testing.T) {


### PR DESCRIPTION
Goals:
- Start implementing the pipeline where we do parse -> check (AST) -> validate (legal search queries). See RFC 75 for reference.
- Each stage in the pipeline promotes errors to friendly alerts that surface on the client side
- Get rid of `didYouMeanQuotedResolver`. Use `searchAlert` to surface the alerts and suggestions for this logic. I removed most of this and migrated into the pipeline for alerts, and then migrated the tests into `search_test.go`

I will do more moving things around but don't want to create rebase hell with the other outstanding PRs.
