### PR TITLE
Changes section: show <1yo commits initially

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -261,12 +261,14 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query *string
 	Path  *string
+	After *string
 }) (*gitCommitConnectionResolver, error) {
 	return &gitCommitConnectionResolver{
 		revisionRange: string(r.oid),
 		first:         args.ConnectionArgs.First,
 		query:         args.Query,
 		path:          args.Path,
+		after:         args.After,
 		repo:          r.repo,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2522,6 +2522,8 @@ type GitCommit implements Node {
         query: String
         # Return commits that affect the path.
         path: String
+        # Return commits more recent than the specified date.
+        after: String
     ): GitCommitConnection!
     # Returns the number of commits that this commit is behind and ahead of revspec.
     behindAhead(revspec: String!): BehindAheadCounts!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2529,6 +2529,8 @@ type GitCommit implements Node {
         query: String
         # Return commits that affect the path.
         path: String
+        # Return commits more recent than the specified date.
+        after: String
     ): GitCommitConnection!
     # Returns the number of commits that this commit is behind and ahead of revspec.
     behindAhead(revspec: String!): BehindAheadCounts!

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -87,6 +87,8 @@ interface ConnectionDisplayProps {
     /** The component displayed when the list of nodes is empty. */
     emptyElement?: JSX.Element
 
+    /** The component displayed when all nodes have been fetched. */
+    totalCountSummaryComponent?: React.ComponentType<{ totalCount: number }>
     /**
      * Set to true when the GraphQL response is expected to emit an `PageInfo.endCursor` value when
      * there is a subsequent page of results. This will request the next page of results and append
@@ -162,6 +164,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
         const ListComponent: any = this.props.listComponent || 'ul' // TODO: remove cast when https://github.com/Microsoft/TypeScript/issues/28768 is fixed
         const HeadComponent = this.props.headComponent
         const FootComponent = this.props.footComponent
+        const TotalCountSummaryComponent = this.props.totalCountSummaryComponent
 
         const hasNextPage = this.props.connection
             ? this.props.connection.pageInfo
@@ -196,7 +199,9 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
             (!this.props.noSummaryIfAllNodesVisible || this.props.connection.nodes.length === 0 || hasNextPage)
         ) {
             if (totalCount !== null && totalCount > 0) {
-                summary = (
+                summary = TotalCountSummaryComponent ? (
+                    <TotalCountSummaryComponent totalCount={totalCount}></TotalCountSummaryComponent>
+                ) : (
                     <p className="filtered-connection__summary">
                         <small>
                             <span>
@@ -786,6 +791,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         onShowMore={this.onClickShowMore}
                         location={this.props.location}
                         emptyElement={this.props.emptyElement}
+                        totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                     />
                 )}
                 {this.state.loading && (

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -42,6 +42,7 @@ import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 import { ThemeProps } from '../../../shared/src/theme'
 import { ErrorAlert } from '../components/alerts'
 import { subYears, formatISO } from 'date-fns'
+import { pluralize } from '../../../shared/src/util/strings'
 
 const TreeEntry: React.FunctionComponent<{
     isDir: boolean
@@ -245,7 +246,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                     <>{totalCount} total commits in this tree.</>
                 ) : (
                     <>
-                        {totalCount} commit{totalCount > 1 ? 's' : ''} in this tree in the past year.
+                        {totalCount} {pluralize('commit', totalCount)} in this tree in the past year.
                         <br />
                         <button type="button" className="btn btn-secondary btn-sm mt-1" onClick={this.showOlderCommits}>
                             Show all commits

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -41,6 +41,7 @@ import { GitCommitNode, GitCommitNodeProps } from './commits/GitCommitNode'
 import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 import { ThemeProps } from '../../../shared/src/theme'
 import { ErrorAlert } from '../components/alerts'
+import { subYears, formatISO } from 'date-fns'
 
 const TreeEntry: React.FunctionComponent<{
     isDir: boolean
@@ -91,14 +92,15 @@ const fetchTreeCommits = memoizeObservable(
         revspec: string
         first?: number
         filePath?: string
+        after?: string
     }): Observable<GQL.IGitCommitConnection> =>
         queryGraphQL(
             gql`
-                query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String) {
+                query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
                     node(id: $repo) {
                         ... on Repository {
                             commit(rev: $revspec) {
-                                ancestors(first: $first, path: $filePath) {
+                                ancestors(first: $first, path: $filePath, after: $after) {
                                     nodes {
                                         ...GitCommitFields
                                     }
@@ -125,7 +127,7 @@ const fetchTreeCommits = memoizeObservable(
                 return repo.commit.ancestors
             })
         ),
-    args => `${args.repo}:${args.revspec}:${args.first}:${args.filePath}`
+    args => `${args.repo}:${args.revspec}:${args.first}:${args.filePath}:${args.after}`
 )
 
 interface Props
@@ -156,6 +158,8 @@ interface State {
      * The value of the search query input field.
      */
     queryState: QueryState
+
+    showOlderCommits?: true
 }
 
 export class TreePage extends React.PureComponent<Props, State> {
@@ -203,7 +207,6 @@ export class TreePage extends React.PureComponent<Props, State> {
                     err => console.error(err)
                 )
         )
-
         this.componentUpdates.next(this.props)
     }
 
@@ -224,6 +227,33 @@ export class TreePage extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        const emptyElement = this.state.showOlderCommits ? (
+            <>No commits in this tree.</>
+        ) : (
+            <>
+                No commits in this tree in the past year.
+                <br />
+                <button type="button" className="btn btn-secondary btn-sm" onClick={this.showOlderCommits}>
+                    Show all commits
+                </button>
+            </>
+        )
+
+        const TotalCountSummary: React.FunctionComponent<{ totalCount: number }> = ({ totalCount }) => (
+            <div className="mt-2">
+                {this.state.showOlderCommits ? (
+                    <>{totalCount} total commits in this tree.</>
+                ) : (
+                    <>
+                        {totalCount} commit{totalCount > 1 ? 's' : ''} in this tree in the past year.
+                        <br />
+                        <button type="button" className="btn btn-secondary btn-sm mt-1" onClick={this.showOlderCommits}>
+                            Show all commits
+                        </button>
+                    </>
+                )}
+            </div>
+        )
         return (
             <div className="tree-page">
                 <PageTitle title={this.getPageTitle()} />
@@ -354,10 +384,13 @@ export class TreePage extends React.PureComponent<Props, State> {
                                         className: 'list-group-item',
                                         compact: true,
                                     }}
-                                    updateOnChange={`${this.props.repoName}:${this.props.rev}:${this.props.filePath}`}
+                                    updateOnChange={`${this.props.repoName}:${this.props.rev}:${this.props.filePath}:${this.state.showOlderCommits}`}
                                     defaultFirst={7}
                                     useURLQuery={false}
                                     hideSearch={true}
+                                    emptyElement={emptyElement}
+                                    // eslint-disable-next-line react/jsx-no-bind
+                                    totalCountSummaryComponent={TotalCountSummary}
                                 />
                             </div>
                         </>
@@ -388,11 +421,19 @@ export class TreePage extends React.PureComponent<Props, State> {
         return `${repoStr}`
     }
 
-    private queryCommits = (args: { first?: number }): Observable<GQL.IGitCommitConnection> =>
-        fetchTreeCommits({
+    private queryCommits = (args: { first?: number }): Observable<GQL.IGitCommitConnection> => {
+        const after: string | undefined = this.state.showOlderCommits ? undefined : formatISO(subYears(Date.now(), 1))
+        return fetchTreeCommits({
             ...args,
             repo: this.props.repoID,
             revspec: this.props.rev || '',
             filePath: this.props.filePath,
+            after,
         })
+    }
+
+    private showOlderCommits = (e: React.MouseEvent): void => {
+        e.preventDefault()
+        this.setState({ showOlderCommits: true })
+    }
 }


### PR DESCRIPTION
Rel. https://github.com/sourcegraph/customer/issues/23

The "Changes" view searches linearly through git log for the last N commits affecting the given subdirectory. When the git history is very long, and the subdirectory has no recent changes, this can be very slow.

With this change, the Changes section only displays commits from the past year by default, passing down an `after` argument to `git log`. The user can opt to display all commits.

![image](https://user-images.githubusercontent.com/1741180/74934403-6e84c580-53e6-11ea-82ad-152e6f0711b2.png)

cc @beyang 