### PR TITLE
Remove redundant ReadDir() calls in isSingleChild

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -58,12 +58,14 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 		entries = entries[:int(*args.First)]
 	}
 
+	hasSingleChild := len(entries) == 1
 	var l []*GitTreeEntryResolver
 	for _, entry := range entries {
 		if filter == nil || filter(entry) {
 			l = append(l, &GitTreeEntryResolver{
-				commit: r.commit,
-				stat:   entry,
+				commit:        r.commit,
+				stat:          entry,
+				isSingleChild: &hasSingleChild,
 			})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -41,7 +41,8 @@ type GitTreeEntryResolver struct {
 	// the root, not the basename.
 	stat os.FileInfo
 
-	isRecursive bool // whether entries is populated recursively (otherwise just current level of hierarchy)
+	isRecursive   bool // whether entries is populated recursively (otherwise just current level of hierarchy)
+	isSingleChild *bool
 }
 
 func NewGitTreeEntryResolver(commit *GitCommitResolver, stat os.FileInfo) *GitTreeEntryResolver {
@@ -208,6 +209,9 @@ func CreateFileInfo(path string, isDir bool) os.FileInfo {
 }
 
 func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeEntryConnectionArgs) (bool, error) {
+	if r.isSingleChild != nil {
+		return r.IsDirectory() && *r.isSingleChild, nil
+	}
 	if !r.IsDirectory() {
 		return false, nil
 	}

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -41,8 +41,8 @@ type GitTreeEntryResolver struct {
 	// the root, not the basename.
 	stat os.FileInfo
 
-	isRecursive   bool // whether entries is populated recursively (otherwise just current level of hierarchy)
-	isSingleChild *bool
+	isRecursive   bool  // whether entries is populated recursively (otherwise just current level of hierarchy)
+	isSingleChild *bool // whether this is the single entry in its parent. Only set by the (&GitTreeEntryResolver) entries.
 }
 
 func NewGitTreeEntryResolver(commit *GitCommitResolver, stat os.FileInfo) *GitTreeEntryResolver {
@@ -209,11 +209,11 @@ func CreateFileInfo(path string, isDir bool) os.FileInfo {
 }
 
 func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeEntryConnectionArgs) (bool, error) {
-	if r.isSingleChild != nil {
-		return r.IsDirectory() && *r.isSingleChild, nil
-	}
 	if !r.IsDirectory() {
 		return false, nil
+	}
+	if r.isSingleChild != nil {
+		return *r.isSingleChild, nil
 	}
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.commit.repo.repo)
 	if err != nil {

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -36,7 +36,7 @@ import { QueryInput } from '../search/input/QueryInput'
 import { SearchButton } from '../search/input/SearchButton'
 import { eventLogger, EventLoggerProps } from '../tracking/eventLogger'
 import { basename } from '../util/path'
-import { fetchTree } from './backend'
+import { fetchTreeEntries } from './backend'
 import { GitCommitNode, GitCommitNodeProps } from './commits/GitCommitNode'
 import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 import { ThemeProps } from '../../../shared/src/theme'
@@ -190,7 +190,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                     ),
                     tap(props => this.logViewEvent(props)),
                     switchMap(props =>
-                        fetchTree({
+                        fetchTreeEntries({
                             repoName: props.repoName,
                             commitID: props.commitID,
                             rev: props.rev,

--- a/web/src/repo/backend.ts
+++ b/web/src/repo/backend.ts
@@ -237,47 +237,22 @@ export const fetchFileExternalLinks = memoizeObservable(
     makeRepoURI
 )
 
-export const fetchTree = memoizeObservable(
+export const fetchTreeEntries = memoizeObservable(
     (args: AbsoluteRepoFile & { first?: number }): Observable<GQL.IGitTree> =>
         queryGraphQL(
             gql`
-                query Tree($repoName: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
+                query TreeEntries(
+                    $repoName: String!
+                    $rev: String!
+                    $commitID: String!
+                    $filePath: String!
+                    $first: Int
+                ) {
                     repository(name: $repoName) {
                         commit(rev: $commitID, inputRevspec: $rev) {
                             tree(path: $filePath) {
                                 isRoot
                                 url
-                                entries(first: $first) {
-                                    name
-                                    path
-                                    isDirectory
-                                    url
-                                }
-                            }
-                        }
-                    }
-                }
-            `,
-            args
-        ).pipe(
-            map(({ data, errors }) => {
-                if (errors || !data?.repository?.commit?.tree) {
-                    throw createAggregateError(errors)
-                }
-                return data.repository.commit.tree
-            })
-        ),
-    makeRepoURI
-)
-
-export const fetchTreeEntries = memoizeObservable(
-    (args: AbsoluteRepoFile & { first?: number }): Observable<GQL.IGitTree> =>
-        queryGraphQL(
-            gql`
-                query Tree($repoName: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
-                    repository(name: $repoName) {
-                        commit(rev: $commitID, inputRevspec: $rev) {
-                            tree(path: $filePath) {
                                 entries(first: $first, recursiveSingleChild: true) {
                                     name
                                     path
@@ -303,5 +278,5 @@ export const fetchTreeEntries = memoizeObservable(
                 return data.repository.commit.tree
             })
         ),
-    makeRepoURI
+    ({ first, ...args }) => `${makeRepoURI(args)}:first-${first}`
 )


### PR DESCRIPTION
Rel https://github.com/sourcegraph/customer/issues/23

A [customer](https://app.hubspot.com/contacts/2762526/company/554275594) reported that the files sidebar was slow to load, even though the "Files and directories" section of the main tree view, which displays basically the same information, was not.

The graphQL query for the sidebar (in `fetchTreeEntries()`) requested the following additional fields for each tree entry:

```
submodule {
    url
    commit
}
isSingleChild
```

In my tests, `submodule` did not affect performance, but `isSingleChild` did, causing up to a 50% perf hit for the same repository/commit/path even for small repositories.

Looking at the resolvers, I realised that the `IsSingleChild()` resolver performed a `git.ReadDir()` of the parent directory for each entry. This meant that the query was resulting in N+1 `git.ReadDir()` calls for the same directory, where N is the number of entries in that directory.