### PR TITLE
graphql: remove duplicate builtin signup code

### DIFF
--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -147,15 +147,6 @@ func Providers() []Provider {
 	return providers
 }
 
-func BuiltinAuthEnabled() bool {
-	for _, p := range Providers() {
-		if p.Config().Builtin != nil {
-			return true
-		}
-	}
-	return false
-}
-
 type sortProviders []Provider
 
 func (p sortProviders) Len() int {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -7,7 +7,6 @@ import (
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -117,7 +116,7 @@ func (r *UserResolver) DisplayName() *string {
 }
 
 func (r *UserResolver) BuiltinAuth() bool {
-	return r.user.BuiltinAuth && providers.BuiltinAuthEnabled()
+	return r.user.BuiltinAuth && conf.IsBuiltinSignupAllowed()
 }
 
 func (r *UserResolver) AvatarURL() *string {


### PR DESCRIPTION
This PR removes some extraneous code for detecting builtin auth that was introduced in #7889.