### PR TITLE
Always defined ExtWindows.activeWindow

### DIFF
--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -1,6 +1,6 @@
 import { ProxyResult, ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
 import { sortBy } from 'lodash'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, Observable, of } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { asError } from '../../../util/errors'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
@@ -140,15 +140,17 @@ export interface ExtWindowsAPI extends ProxyValue {
 export class ExtWindows implements ExtWindowsAPI, ProxyValue {
     public readonly [proxyValueSymbol] = true
 
-    public activeWindow: ExtWindow | undefined
+    public activeWindow: ExtWindow
+    public readonly activeWindowChanges: Observable<sourcegraph.Window>
 
     /** @internal */
     constructor(
         private proxy: ProxyResult<{ windows: ClientWindowsAPI; codeEditor: ClientCodeEditorAPI }>,
         private documents: ExtDocuments
-    ) {}
-
-    public readonly activeWindowChanges = new BehaviorSubject<sourcegraph.Window | undefined>(undefined)
+    ) {
+        this.activeWindow = new ExtWindow(this.proxy, this.documents, [])
+        this.activeWindowChanges = of(this.activeWindow)
+    }
 
     /**
      * Returns all known windows.
@@ -156,23 +158,11 @@ export class ExtWindows implements ExtWindowsAPI, ProxyValue {
      * @internal
      */
     public getAll(): sourcegraph.Window[] {
-        return this.activeWindow ? [this.activeWindow] : []
+        return [this.activeWindow]
     }
 
     /** @internal */
     public $acceptWindowData(editorUpdates: EditorUpdate[]): void {
-        if (!this.activeWindow) {
-            const window = new ExtWindow(this.proxy, this.documents, editorUpdates)
-            if (window.visibleViewComponents.length) {
-                this.activeWindow = window
-                this.activeWindowChanges.next(this.activeWindow)
-            }
-        } else {
-            this.activeWindow.update(editorUpdates)
-            if (this.activeWindow.visibleViewComponents.length === 0) {
-                this.activeWindow = undefined
-                this.activeWindowChanges.next(undefined)
-            }
-        }
+        this.activeWindow.update(editorUpdates)
     }
 }

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -24,7 +24,8 @@ describe('Windows (integration)', () => {
     })
 
     describe('app.activeWindowChanges', () => {
-        test('reflects changes to the active window', async () => {
+        // Skipped, as sourcegraph.app.activeWindow is always defined.
+        test.skip('reflects changes to the active window', async () => {
             const {
                 services: { editor: editorService, model: modelService },
                 extensionAPI,
@@ -171,7 +172,8 @@ describe('Windows (integration)', () => {
         })
 
         describe('Window#activeViewComponentChanges', () => {
-            test('reflects changes to the active window', async () => {
+            // Skipped, as sourcegraph.app.activeWindow is always defined.
+            test.skip('reflects changes to the active window', async () => {
                 const {
                     services: { editor: editorService, model: modelService },
                     extensionAPI,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8519

This changes ExtWindows to initialize `activeWindow` in the constructor, and keep the same active window for its entire lifetime, rather than starting out with an undefined `activeWindow` and adding/removing it as editors are added/removed.

This makes it possible for extension to call methods on `sourcegraph.activeWindow`  (such as `showNotification()` and `showInputBox()`) on all pages where the extension host is active, rather than solely on code view pages.