### PR TITLE
doc: fix invalid code blocks

### DIFF
--- a/doc/admin/monitoring_and_tracing.md
+++ b/doc/admin/monitoring_and_tracing.md
@@ -27,7 +27,7 @@ This URL will show the home dashboard and from there you can add, modify and del
 If you're using the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph),  
 you can access Grafana directly using Kubernetes port forwarding to your local machine:
 
-```bash script
+```bash
 kubectl port-forward svc/grafana 3370:30070
 ``` 
 
@@ -39,7 +39,7 @@ Therefore, if accessing Grafana locally, the URL will be http://localhost:3370/-
 such as [sshuttle](https://github.com/sshuttle/sshuttle) is required to establish a secure connection to Grafana.
 To access the remote server using `sshuttle` from your local machine:
 
-```bash script
+```bash
 sshuttle -r user@host 0/0
 ```
 


### PR DESCRIPTION
"bash script" after three backticks is not valid in Markdown (or, at least, some markdown parsers). GitHub is lenient here, but our docsite isn't so this produced a broken rendering at https://docs.sourcegraph.com/admin/monitoring_and_tracing#kubernetes. This change fixes that.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
