### PR TITLE
search: remove patterntype field from alert construction

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -436,7 +436,6 @@ func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 		prometheusType:  a.prometheusType,
 		title:           a.title,
 		description:     a.description,
-		patternType:     a.patternType,
 		proposedQueries: a.proposedQueries,
 	}
 	return &SearchResultsResolver{alert: alert}, nil


### PR DESCRIPTION
Merged #8514 without rebasing after merging #8511 broke the build.