### PR TITLE
search: fallback to literal search if structural search pattern is empty

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1040,6 +1040,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 	p, err := r.getPatternInfo(options)
 
+	// Fallback to literal search for searching repos and files if
+	// the structural search pattern is empty.
+	if r.patternType == query.SearchTypeStructural && p.Pattern == "" {
+		r.patternType = query.SearchTypeLiteral
+		p.IsStructuralPat = false
+		forceOnlyResultType = ""
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -391,6 +391,15 @@ describe('Search regression test suite', () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
             await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
         })
+        test('Structural search, return repo results if pattern is empty', async () => {
+            const urlQuery = buildSearchURLQuery(
+                'repo:^github\\.com/facebook/react$',
+                GQL.SearchPatternType.structural,
+                false
+            )
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 0)
+        })
         test('Commit search, nonzero result', async () => {
             const urlQuery = buildSearchURLQuery(
                 'repo:^github\\.com/facebook/react$ type:commit hello world',


### PR DESCRIPTION
In #8312 I fixed some poor usability with structural search to only operate on file contents. This change meant that when the query has an empty pattern, like `repo:foo` or `file:bar`, it would always return `No results`, since those are different result types. This means you have to change to regex or literal mode to do repo or file search when in structural search. No bueno.

This change makes it so that if the pattern is empty in structural search, it falls back to "literal" search (i.e., just do file/repo search as usual).

All this kind of ad-hoc processing on the query with get pulled into the `query` package (this processing is part of query validation and transformation) and will become more consistent soon.

I've added an e2e regression test for this behavior, since it's hard to test `doResults` until I've moved things to the query processing.
