### PR TITLE
search: tidy structural search alerts

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -1,10 +1,12 @@
 package graphqlbackend
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
@@ -142,5 +144,50 @@ func TestAddQueryRegexpField(t *testing.T) {
 				t.Errorf("got %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func Test_ErrorToAlertStructuralSearch(t *testing.T) {
+	cases := []struct {
+		name           string
+		errors         []error
+		wantErrors     []error
+		wantAlertTitle string
+	}{
+		{
+			name:           "multierr_is_unaffected",
+			errors:         []error{errors.New("some error")},
+			wantErrors:     []error{errors.New("some error")},
+			wantAlertTitle: "",
+		},
+		{
+			name: "surface_friendly_alert_on_oom_err_message",
+			errors: []error{
+				errors.New("some error"),
+				errors.New("Worker_oomed"),
+				errors.New("some other error"),
+			},
+			wantErrors: []error{
+				errors.New("some error"),
+				errors.New("some other error"),
+			},
+			wantAlertTitle: "Structural search needs more memory",
+		},
+	}
+	for _, test := range cases {
+		multiErr := &multierror.Error{
+			Errors:      test.errors,
+			ErrorFormat: multierror.ListFormatFunc,
+		}
+		haveMultiErr, haveAlert := alertForStructuralSearch(multiErr)
+
+		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
+			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
+		}
+
+		if haveAlert != nil && haveAlert.title != test.wantAlertTitle {
+			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
+		}
+
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/zoekt"
 	zoektrpc "github.com/google/zoekt/rpc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -1256,64 +1255,6 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 			}
 			t.Fatalf("test %s, have result type: %q, want result type: %q", test.name, haveResultType, wantResultType)
 		}
-	}
-}
-
-func Test_ErrorToAlertConversion(t *testing.T) {
-	cases := []struct {
-		name           string
-		errors         []error
-		wantErrors     []error
-		wantAlertTitle string
-	}{
-		{
-			name:           "multierr_is_unaffected",
-			errors:         []error{errors.New("some error")},
-			wantErrors:     []error{errors.New("some error")},
-			wantAlertTitle: "",
-		},
-		{
-			name: "multierr_converts_zip_error",
-			errors: []error{
-				errors.New("some error"),
-				errors.New("Assert_failure zip"),
-				errors.New("some other error"),
-			},
-			wantErrors: []error{
-				errors.New("some error"),
-				errors.New("some other error"),
-			},
-			wantAlertTitle: "Repository too large for structural search",
-		},
-		{
-			name: "surface_friendly_alert_on_oom_err_message",
-			errors: []error{
-				errors.New("some error"),
-				errors.New("Worker_oomed"),
-				errors.New("some other error"),
-			},
-			wantErrors: []error{
-				errors.New("some error"),
-				errors.New("some other error"),
-			},
-			wantAlertTitle: "Structural search needs more memory",
-		},
-	}
-	for _, test := range cases {
-		multiErr := &multierror.Error{
-			Errors:      test.errors,
-			ErrorFormat: multierror.ListFormatFunc,
-		}
-		haveMultiErr, haveAlert := alertOnError(multiErr)
-
-		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
-			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
-		}
-
-		if haveAlert != nil && haveAlert.title != test.wantAlertTitle {
-			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
-		}
-
 	}
 }
 


### PR DESCRIPTION
- Moves alert construction for structural search out of `search_results.go`
- Removes an alert for a resolved issue.
