### PR TITLE
refactor: remove ExprString for parse tree

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -90,7 +90,7 @@ func alertForQuotesInQueryInLiteralMode(q *query.Query) *searchAlert {
 		description:    "Your search is interpreted literally and contains quotes. Did you mean to search for quotes?",
 		proposedQueries: []*searchQueryDescription{{
 			description: "Remove quotes",
-			query:       syntax.ExprString(omitQuotes(q)),
+			query:       omitQuotes(q).String(),
 			patternType: query.SearchTypeLiteral,
 		}},
 	}
@@ -333,7 +333,7 @@ outer:
 		newExpr := addQueryRegexpField(r.query, query.FieldRepo, repoParentPattern)
 		alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 			description: "in repositories under " + repoParent + more,
-			query:       syntax.ExprString(newExpr),
+			query:       newExpr.String(),
 			patternType: r.patternType,
 		})
 	}
@@ -352,7 +352,7 @@ outer:
 			newExpr := addQueryRegexpField(r.query, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
 			alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 				description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
-				query:       syntax.ExprString(newExpr),
+				query:       newExpr.String(),
 				patternType: r.patternType,
 			})
 		}
@@ -384,7 +384,7 @@ func alertForMissingRepoRevs(patternType query.SearchType, missingRepoRevs []*se
 }
 
 func omitQueryFields(r *searchResolver, field string) string {
-	return syntax.ExprString(omitQueryExprWithField(r.query, field))
+	return omitQueryExprWithField(r.query, field).String()
 }
 
 func omitQueryExprWithField(query *query.Query, field string) syntax.ParseTree {

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
 
 func TestSearchPatternForSuggestion(t *testing.T) {
@@ -138,7 +137,7 @@ func TestAddQueryRegexpField(t *testing.T) {
 				t.Fatal(err)
 			}
 			got := addQueryRegexpField(query, test.addField, test.addPattern)
-			if got := syntax.ExprString(got); got != test.want {
+			if got := got.String(); got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
 			}
 		})

--- a/internal/search/query/syntax/parse_tree.go
+++ b/internal/search/query/syntax/parse_tree.go
@@ -10,10 +10,6 @@ import (
 // The parse tree for search input. It is a list of expressions.
 type ParseTree []*Expr
 
-func (p ParseTree) String() string {
-	return ExprString(p)
-}
-
 // Values returns the raw string values associated with a field.
 func (p ParseTree) Values(field string) []string {
 	var v []string
@@ -33,6 +29,16 @@ func (p ParseTree) WithErrorsQuoted() ParseTree {
 		p2 = append(p2, &e2)
 	}
 	return p2
+}
+
+// String returns a string that parses to the parse tree, where expressions are
+// separated by a single space.
+func (p ParseTree) String() string {
+	s := make([]string, len(p))
+	for i, e := range p {
+		s[i] = e.String()
+	}
+	return strings.Join(s, " ")
 }
 
 // An Expr describes an expression in the parse tree.
@@ -84,13 +90,4 @@ func (e Expr) WithErrorsQuoted() Expr {
 		e2.ValueType = TokenQuoted
 	}
 	return e2
-}
-
-// ExprString returns the string that parses to expr.
-func ExprString(expr []*Expr) string {
-	s := make([]string, len(expr))
-	for i, e := range expr {
-		s[i] = e.String()
-	}
-	return strings.Join(s, " ")
 }

--- a/internal/search/query/syntax/parser_test.go
+++ b/internal/search/query/syntax/parser_test.go
@@ -105,7 +105,7 @@ func TestParser(t *testing.T) {
 			if test.wantString == "" && len(query) > 0 {
 				test.wantString = input
 			}
-			if exprString := ExprString(query); exprString != test.wantString {
+			if exprString := query.String(); exprString != test.wantString {
 				t.Errorf("expr string: %s\ngot  %s\nwant %s", input, exprString, test.wantString)
 			}
 		})


### PR DESCRIPTION
Seems weird that `ExprString` exists and `ParseTree.String()` just passes through to it, unless there is a good reason that I'm missing?