### PR TITLE
search: use Map for parse tree changes

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -530,7 +530,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 				proposedQueries: []*searchQueryDescription{
 					{
 						description: "query with longer timeout",
-						query:       fmt.Sprintf("timeout:%v %s", dt2, omitQueryFields(r, query.FieldTimeout)),
+						query:       fmt.Sprintf("timeout:%v %s", dt2, omitQueryField(r.query.ParseTree, query.FieldTimeout)),
 						patternType: r.patternType,
 					},
 				},
@@ -1302,7 +1302,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == query.SearchTypeLiteral {
-		alert = alertForQuotesInQueryInLiteralMode(r.query)
+		alert = alertForQuotesInQueryInLiteralMode(r.query.ParseTree)
 	}
 
 	// If we have some results, only log the error instead of returning it,

--- a/internal/search/query/syntax/parse_tree.go
+++ b/internal/search/query/syntax/parse_tree.go
@@ -31,6 +31,21 @@ func (p ParseTree) WithErrorsQuoted() ParseTree {
 	return p2
 }
 
+// Map builds a new parse tree by running a function f on each expression in an
+// existing parse tree and substituting the resulting expression. If f returns
+// nil, the expression is removed in the new parse tree.
+func Map(p ParseTree, f func(e Expr) *Expr) ParseTree {
+	p2 := make(ParseTree, 0, len(p))
+	for _, e := range p {
+		cpy := *e
+		e = &cpy
+		if result := f(*e); result != nil {
+			p2 = append(p, result)
+		}
+	}
+	return p2
+}
+
 // String returns a string that parses to the parse tree, where expressions are
 // separated by a single space.
 func (p ParseTree) String() string {


### PR DESCRIPTION
- Introduces `Map` for code that wants to change ParseTrees
- Refactor alerts to use `Map`

Side note: these changes are towards separating code dependencies on `Query` that really just want access to `ParseTree` and transformations on it.

Side note: `Map` is loosely based on query transformer functions in Zoekt, but I would say it's a common higher-order function for transforming trees. Such functions will be useful with AND/OR queries.