### PR TITLE
refactor: move timeout alert to alert file

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -76,6 +76,21 @@ func alertForQuery(queryString string, err error) *searchAlert {
 	}
 }
 
+func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searchResolver) *searchAlert {
+	return &searchAlert{
+		prometheusType: "timed_out",
+		title:          "Timed out while searching",
+		description:    fmt.Sprintf("We weren't able to find any results in %s.", roundStr(usedTime.String())),
+		proposedQueries: []*searchQueryDescription{
+			{
+				description: "query with longer timeout",
+				query:       fmt.Sprintf("timeout:%v %s", suggestTime, omitQueryField(r.query.ParseTree, query.FieldTimeout)),
+				patternType: r.patternType,
+			},
+		},
+	}
+}
+
 func alertForStalePermissions() *searchAlert {
 	return &searchAlert{
 		prometheusType: "no_resolved_repos__stale_permissions",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -520,23 +520,9 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 		shouldShowAlert = true
 	}
 	if shouldShowAlert {
-		dt := time.Since(start)
-		dt2 := longer(2, dt)
-		rr = &SearchResultsResolver{
-			alert: &searchAlert{
-				prometheusType: "timed_out",
-				title:          "Timed out while searching",
-				description:    fmt.Sprintf("We weren't able to find any results in %s.", roundStr(dt.String())),
-				proposedQueries: []*searchQueryDescription{
-					{
-						description: "query with longer timeout",
-						query:       fmt.Sprintf("timeout:%v %s", dt2, omitQueryField(r.query.ParseTree, query.FieldTimeout)),
-						patternType: r.patternType,
-					},
-				},
-			},
-		}
-		return rr, nil
+		usedTime := time.Since(start)
+		suggestTime := longer(2, usedTime)
+		return &SearchResultsResolver{alert: alertForTimeout(usedTime, suggestTime, r)}, nil
 	}
 	return rr, err
 }


### PR DESCRIPTION
Moves a big alert construction in `search_results` to `search_alerts`

Stacked on #8562
