### PR TITLE
refactor: use Map to add query fields for alert

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -331,10 +331,10 @@ outer:
 		// add it to the user's query, but be smart. For example, if the user's
 		// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
 		// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
-		newExpr := addQueryRegexpField(r.query, query.FieldRepo, repoParentPattern)
+		newExpr := addRegexpField(r.query.ParseTree, query.FieldRepo, repoParentPattern)
 		alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 			description: "in repositories under " + repoParent + more,
-			query:       newExpr.String(),
+			query:       newExpr,
 			patternType: r.patternType,
 		})
 	}
@@ -350,10 +350,10 @@ outer:
 			if i >= maxReposToPropose {
 				break
 			}
-			newExpr := addQueryRegexpField(r.query, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
+			newExpr := addRegexpField(r.query.ParseTree, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
 			alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 				description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
-				query:       newExpr.String(),
+				query:       newExpr,
 				patternType: r.patternType,
 			})
 		}
@@ -460,38 +460,33 @@ func pathParentsByFrequency(paths []string) []string {
 	return parents
 }
 
-// addQueryRegexpField adds a new expr to the query with the given field
+// addRegexpField adds a new expr to the query with the given field
 // and pattern value. The field is assumed to be a regexp.
 //
-// It tries to simplify (avoid redundancy in) the result. For example, given
+// It tries to remove redundancy in the result. For example, given
 // a query like "x:foo", if given a field "x" with pattern "foobar" to add,
 // it will return a query "x:foobar" instead of "x:foo x:foobar". It is not
 // guaranteed to always return the simplest query.
-func addQueryRegexpField(query *query.Query, field, pattern string) syntax.ParseTree {
-	// Copy query expressions.
-	expr := make(syntax.ParseTree, len(query.ParseTree))
-	for i, e := range query.ParseTree {
-		tmp := *e
-		expr[i] = &tmp
-	}
-
+func addRegexpField(p syntax.ParseTree, field, pattern string) string {
 	var added bool
-	for i, e := range expr {
+	addRegexpField := func(e syntax.Expr) *syntax.Expr {
 		if e.Field == field && strings.Contains(pattern, e.Value) {
-			expr[i].Value = pattern
+			e.Value = pattern
 			added = true
-			break
+			return &e
 		}
+		return &e
 	}
-
+	modified := syntax.Map(p, addRegexpField)
 	if !added {
-		expr = append(expr, &syntax.Expr{
+		p = append(p, &syntax.Expr{
 			Field:     field,
 			Value:     pattern,
 			ValueType: syntax.TokenLiteral,
 		})
+		return p.String()
 	}
-	return expr
+	return modified.String()
 }
 
 func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -138,8 +138,8 @@ func TestAddQueryRegexpField(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := addQueryRegexpField(query, test.addField, test.addPattern)
-			if got := got.String(); got != test.want {
+			got := addRegexpField(query.ParseTree, test.addField, test.addPattern)
+			if got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
 			}
 		})

--- a/internal/search/query/syntax/parse_tree.go
+++ b/internal/search/query/syntax/parse_tree.go
@@ -40,7 +40,7 @@ func Map(p ParseTree, f func(e Expr) *Expr) ParseTree {
 		cpy := *e
 		e = &cpy
 		if result := f(*e); result != nil {
-			p2 = append(p, result)
+			p2 = append(p2, result)
 		}
 	}
 	return p2


### PR DESCRIPTION
- Use the `syntax.Map` function for `addQueryRegexpField` and touch up the function comment and name.
- Corrects a mistake in the `syntax.Map` function.