### PR TITLE
search: remove parse tree reference in query type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -84,7 +84,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 		proposedQueries: []*searchQueryDescription{
 			{
 				description: "query with longer timeout",
-				query:       fmt.Sprintf("timeout:%v %s", suggestTime, omitQueryField(r.query.ParseTree, query.FieldTimeout)),
+				query:       fmt.Sprintf("timeout:%v %s", suggestTime, omitQueryField(r.parseTree, query.FieldTimeout)),
 				patternType: r.patternType,
 			},
 		},
@@ -143,7 +143,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 
 	// TODO(sqs): handle -repo:foo fields.
 
-	withoutRepoFields := omitQueryField(r.query.ParseTree, query.FieldRepo)
+	withoutRepoFields := omitQueryField(r.parseTree, query.FieldRepo)
 
 	var a searchAlert
 	switch {
@@ -163,7 +163,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		if len(repos1) > 0 {
 			a.proposedQueries = append(a.proposedQueries, &searchQueryDescription{
 				description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-				query:       omitQueryField(r.query.ParseTree, query.FieldRepoGroup),
+				query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
 				patternType: r.patternType,
 			})
 		}
@@ -201,7 +201,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		if len(repos1) > 0 {
 			a.proposedQueries = append(a.proposedQueries, &searchQueryDescription{
 				description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-				query:       omitQueryField(r.query.ParseTree, query.FieldRepoGroup),
+				query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
 				patternType: r.patternType,
 			})
 		}
@@ -346,7 +346,7 @@ outer:
 		// add it to the user's query, but be smart. For example, if the user's
 		// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
 		// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
-		newExpr := addRegexpField(r.query.ParseTree, query.FieldRepo, repoParentPattern)
+		newExpr := addRegexpField(r.parseTree, query.FieldRepo, repoParentPattern)
 		alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 			description: "in repositories under " + repoParent + more,
 			query:       newExpr,
@@ -365,7 +365,7 @@ outer:
 			if i >= maxReposToPropose {
 				break
 			}
-			newExpr := addRegexpField(r.query.ParseTree, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
+			newExpr := addRegexpField(r.parseTree, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
 			alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 				description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
 				query:       newExpr,

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -134,11 +134,11 @@ func TestAddQueryRegexpField(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s, add %s:%s", test.query, test.addField, test.addPattern), func(t *testing.T) {
-			query, err := query.ParseAndCheck(test.query)
+			parseTree, err := query.Parse(test.query)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := addRegexpField(query.ParseTree, test.addField, test.addPattern)
+			got := addRegexpField(parseTree, test.addField, test.addPattern)
 			if got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
 			}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1288,7 +1288,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == query.SearchTypeLiteral {
-		alert = alertForQuotesInQueryInLiteralMode(r.query.ParseTree)
+		alert = alertForQuotesInQueryInLiteralMode(r.parseTree)
 	}
 
 	// If we have some results, only log the error instead of returning it,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -46,7 +46,7 @@ var (
 func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
 	args.applyDefaultsAndConstraints()
 
-	if len(r.query.ParseTree) == 0 {
+	if len(r.parseTree) == 0 {
 		return nil, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -347,9 +347,9 @@ func Test_detectSearchType(t *testing.T) {
 func Test_QuoteSuggestions(t *testing.T) {
 	t.Run("regex error", func(t *testing.T) {
 		raw := "*"
-		_, err := query.Process(raw, query.SearchTypeRegex)
+		_, _, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
-			t.Fatalf("error returned from syntax.Parse(%q) is nil", raw)
+			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
 		alert := alertForQuery(raw, err)
 		if !strings.Contains(strings.ToLower(alert.title), "regexp") {
@@ -362,17 +362,17 @@ func Test_QuoteSuggestions(t *testing.T) {
 
 	t.Run("type error that is not a regex error should show a suggestion", func(t *testing.T) {
 		raw := "-foobar"
-		_, alert := query.Process(raw, query.SearchTypeRegex)
+		_, _, alert := query.Process(raw, query.SearchTypeRegex)
 		if alert == nil {
-			t.Fatalf("alert returned from syntax.Parse(%q) is nil", raw)
+			t.Fatalf("alert returned from query.Process(%q) is nil", raw)
 		}
 	})
 
 	t.Run("query parse error", func(t *testing.T) {
 		raw := ":"
-		_, err := query.Process(raw, query.SearchTypeRegex)
+		_, _, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
-			t.Fatalf("error returned from syntax.Parse(%q) is nil", raw)
+			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
 		alert := alertForQuery(raw, err)
 		if strings.Contains(strings.ToLower(alert.title), "regexp") {
@@ -385,7 +385,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 
 	t.Run("negated file field with an invalid regex", func(t *testing.T) {
 		raw := "-f:(a"
-		_, err := query.Process(raw, query.SearchTypeRegex)
+		_, _, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
 			t.Fatal("query.Process failed to detect the invalid regex in the f: field")
 		}

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -167,25 +167,25 @@ func Validate(q *Query, searchType SearchType) error {
 	return nil
 }
 
-// Process is the top level function for processing raw strings into parsed,
-// typechecked, and validated queries.
-func Process(queryString string, searchType SearchType) (*Query, error) {
+// Process is a top level convenience function for processing a raw string into
+// a validated and type checked query, and the parse tree of the raw string.
+func Process(queryString string, searchType SearchType) (*Query, syntax.ParseTree, error) {
 	parseTree, err := Parse(queryString)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	query, err := Check(parseTree)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = Validate(query, searchType)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return query, nil
+	return query, parseTree, nil
 }
 
 // parseAndCheck is preserved for testing custom Configs only.

--- a/internal/search/query/types/check.go
+++ b/internal/search/query/types/check.go
@@ -42,8 +42,7 @@ type FieldType struct {
 // Check typechecks the input query for field and type validity.
 func (c *Config) Check(parseTree syntax.ParseTree) (*Query, error) {
 	checkedQuery := Query{
-		ParseTree: parseTree,
-		Fields:    map[string][]*Value{},
+		Fields: map[string][]*Value{},
 	}
 	for _, expr := range parseTree {
 		field, fieldType, value, err := c.checkExpr(expr)

--- a/internal/search/query/types/query.go
+++ b/internal/search/query/types/query.go
@@ -12,8 +12,7 @@ import (
 
 // A Query is the typechecked representation of a search query.
 type Query struct {
-	ParseTree syntax.ParseTree    // the query parse tree
-	Fields    map[string][]*Value // map of field name -> values
+	Fields map[string][]*Value // map of field name -> values
 }
 
 func (q *Query) String() string {


### PR DESCRIPTION
The main change is that the `ParseTree` reference is removed from our current `Query` type:

```patch
type Query struct {
-	ParseTree syntax.ParseTree    // the query parse tree
	Fields map[string][]*Value // map of field name -> values
}
```

The motivation is that we should keep this `Query` type, which represents a parsed and validated query, _pure_. References to the parse tree should be bundled in other types, or kept around by the process that needs it, instead of dragging it along everywhere query is referenced.

For our search functionality, we still need a reference to the parse tree for other reasons. For now, I'm returning the parse tree from `query.Process(...)` and keeping the reference in the resolver. In time, it may make sense to have a dedicated type. The most important thing right now is just that we don't reference the parse tree _inside_ this query type, but rather with or alongside it, as needed.


