### PR TITLE
refactor: flatten nested query type to fields

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1229,11 +1229,7 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
 			Repos: repoRevs,
-			Query: &query.Query{
-				Query: &searchquerytypes.Query{
-					Fields: test.fields,
-				},
-			},
+			Query: &query.Query{Fields: test.fields},
 		})
 
 		haveAlertDescription := ""

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -91,11 +91,11 @@ var (
 	}
 )
 
-// A Query is the parsed representation of a search query.
+// A Query is the typechecked representation of a search query.
 type Query struct {
 	conf *types.Config // the typechecker config used to produce this query
 
-	*types.Query // the underlying query
+	types.Fields // the query fields
 }
 
 func Parse(input string) (syntax.ParseTree, error) {
@@ -112,11 +112,11 @@ func Parse(input string) (syntax.ParseTree, error) {
 }
 
 func Check(parseTree syntax.ParseTree) (*Query, error) {
-	checkedQuery, err := conf.Check(parseTree)
+	checkedFields, err := conf.Check(parseTree)
 	if err != nil {
 		return nil, err
 	}
-	return &Query{conf: &conf, Query: checkedQuery}, nil
+	return &Query{conf: &conf, Fields: *checkedFields}, nil
 }
 
 // ParseAndCheck parses and typechecks a search query using the default
@@ -204,7 +204,7 @@ func parseAndCheck(conf *types.Config, input string) (*Query, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Query{conf: conf, Query: checkedQuery}, nil
+	return &Query{conf: conf, Fields: *checkedQuery}, nil
 }
 
 // BoolValue returns the last boolean value (yes/no) for the field. For example, if the query is

--- a/internal/search/query/searchquery_test.go
+++ b/internal/search/query/searchquery_test.go
@@ -187,7 +187,7 @@ func TestQuery_CaseInsensitiveFields(t *testing.T) {
 		t.Errorf("unexpected values: want {\"foo\"}, got %v", values)
 	}
 
-	if got, want := query.Query.String(), `repohasfile~"foo"`; got != want {
+	if got, want := query.Fields.String(), `repohasfile~"foo"`; got != want {
 		t.Errorf("unexpected parsed query:\ngot:  %s\nwant: %s", got, want)
 	}
 }

--- a/internal/search/query/types/check.go
+++ b/internal/search/query/types/check.go
@@ -40,19 +40,17 @@ type FieldType struct {
 }
 
 // Check typechecks the input query for field and type validity.
-func (c *Config) Check(parseTree syntax.ParseTree) (*Query, error) {
-	checkedQuery := Query{
-		Fields: map[string][]*Value{},
-	}
+func (c *Config) Check(parseTree syntax.ParseTree) (*Fields, error) {
+	checkedQuery := Fields{}
 	for _, expr := range parseTree {
 		field, fieldType, value, err := c.checkExpr(expr)
 		if err != nil {
 			return nil, err
 		}
-		if fieldType.Singular && len(checkedQuery.Fields[field]) >= 1 {
+		if fieldType.Singular && len(checkedQuery[field]) >= 1 {
 			return nil, &TypeError{Pos: expr.Pos, Err: fmt.Errorf("field %q may not be used more than once", field)}
 		}
-		checkedQuery.Fields[field] = append(checkedQuery.Fields[field], value)
+		checkedQuery[field] = append(checkedQuery[field], value)
 	}
 	return &checkedQuery, nil
 }

--- a/internal/search/query/types/check_test.go
+++ b/internal/search/query/types/check_test.go
@@ -119,7 +119,7 @@ func TestCheck(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if got := toTestValueMap(query.Fields); !reflect.DeepEqual(got, test.want) {
+			if got := toTestValueMap(*query); !reflect.DeepEqual(got, test.want) {
 				t.Errorf("fields\ngot  %+v\nwant %+v", got, test.want)
 			}
 		})

--- a/internal/search/query/types/query.go
+++ b/internal/search/query/types/query.go
@@ -10,14 +10,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
 
-// A Query is the typechecked representation of a search query.
-type Query struct {
-	Fields map[string][]*Value // map of field name -> values
-}
+// Map of field name -> values
+type Fields map[string][]*Value
 
-func (q *Query) String() string {
+func (f *Fields) String() string {
 	fields := []string{}
-	for key, values := range q.Fields {
+	for key, values := range *f {
 		for _, v := range values {
 			switch s := v.Value().(type) {
 			case string:


### PR DESCRIPTION
Before this change, we had two type definitions for `Query`, the one's members inlined inside the other. With the removal of the parse tree reference in #8559 , it is now easier to remove this inlining and use a `type Fields` instead. Instead of:

```go
type Query struct {
	conf *types.Config // the typechecker config used to produce this query
	*types.Query // the underlying query
}

type Query struct {
	Fields map[string][]*Value // map of field name -> values
}
```

We now have:


```go
type Query struct {
	conf *types.Config // the typechecker config used to produce this query
	types.Fields // the query fields
}

// map of field name -> values
type Fields map[string][]*Value
```

This is not the final end state. It is one crucial step to destructure the type definitions to simplify them and their references overall, so that the `Query` type can change to accommodate AND/OR expressions.