### PR TITLE
campaigns: Changeset syncing will only happen in repo-updater

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -95,7 +95,7 @@ type CampaignsResolver interface {
 	PublishCampaign(ctx context.Context, args *PublishCampaignArgs) (CampaignResolver, error)
 	PublishChangeset(ctx context.Context, args *PublishChangesetArgs) (*EmptyResponse, error)
 
-	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error)
+	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]graphql.ID, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error)
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ExternalChangesetsConnectionResolver, error)
 
@@ -147,7 +147,7 @@ func (defaultCampaignsResolver) PublishChangeset(ctx context.Context, args *Publ
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error) {
+func (defaultCampaignsResolver) CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]graphql.ID, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -32,7 +32,7 @@ scalar JSONCString
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
-    # exists, it's id returned instead of a new entry being added to the database.
+    # exists, its id is returned instead of a new entry being added to the database.
     createChangesets(input: [CreateChangesetInput!]!): [ID!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -32,8 +32,8 @@ scalar JSONCString
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
-    # exists, it's returned instead of a new entry being added to the database.
-    createChangesets(input: [CreateChangesetInput!]!): [ExternalChangeset!]!
+    # exists, it's id returned instead of a new entry being added to the database.
+    createChangesets(input: [CreateChangesetInput!]!): [ID!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -34,8 +34,8 @@ scalar JSONCString
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
-    # exists, it's returned instead of a new entry being added to the database.
-    createChangesets(input: [CreateChangesetInput!]!): [ExternalChangeset!]!
+    # exists, it's id returned instead of a new entry being added to the database.
+    createChangesets(input: [CreateChangesetInput!]!): [ID!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -34,7 +34,7 @@ scalar JSONCString
 type Mutation {
     # Creates a list of Changesets of a given repository in a code host (e.g.
     # pull request on GitHub). If a changeset with the given input already
-    # exists, it's id returned instead of a new entry being added to the database.
+    # exists, its id is returned instead of a new entry being added to the database.
     createChangesets(input: [CreateChangesetInput!]!): [ID!]!
     # Adds a list of Changesets to a Campaign.
     # The campaign must not have a campaign plan.

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -33,7 +33,7 @@ const port = "3182"
 
 // EnterpriseInit is a function that allows enterprise code to be triggered when dependencies
 // created in Main are ready for use.
-type EnterpriseInit func(db *sql.DB, store repos.Store, cf *httpcli.Factory)
+type EnterpriseInit func(db *sql.DB, store repos.Store, cf *httpcli.Factory, server *repoupdater.Server)
 
 func Main(enterpriseInit EnterpriseInit) {
 	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
@@ -97,11 +97,6 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	cf := httpcli.NewExternalHTTPClientFactory()
 
-	// All dependencies ready
-	if enterpriseInit != nil {
-		enterpriseInit(db, store, cf)
-	}
-
 	var src repos.Sourcer
 	{
 		m := repos.NewSourceMetrics()
@@ -111,10 +106,15 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	scheduler := repos.NewUpdateScheduler()
-	server := repoupdater.Server{
+	server := &repoupdater.Server{
 		Store:           store,
 		Scheduler:       scheduler,
 		GitserverClient: gitserver.DefaultClient,
+	}
+
+	// All dependencies ready
+	if enterpriseInit != nil {
+		enterpriseInit(db, store, cf, server)
 	}
 
 	var handler http.Handler

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -376,7 +376,7 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 	}, nil
 }
 
-func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.CreateChangesetsArgs) (_ []graphqlbackend.ExternalChangesetResolver, err error) {
+func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.CreateChangesetsArgs) (_ []graphql.ID, err error) {
 	// 🚨 SECURITY: Only site admins may create changesets for now
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -462,17 +462,12 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 		}
 	}
 
-	store = repos.NewDBStore(tx.DB(), sql.TxOptions{})
-	csr := make([]graphqlbackend.ExternalChangesetResolver, len(cs))
+	gids := make([]graphql.ID, len(cs))
 	for i := range cs {
-		csr[i] = &changesetResolver{
-			store:         r.store,
-			Changeset:     cs[i],
-			preloadedRepo: repoSet[cs[i].RepoID],
-		}
+		gids[i] = marshalChangesetID(cs[i].ID)
 	}
 
-	return csr, nil
+	return gids, nil
 }
 
 func (r *Resolver) Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (graphqlbackend.ExternalChangesetsConnectionResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -380,6 +381,19 @@ func TestCampaigns(t *testing.T) {
 		graphqlGithubRepoID, "999",
 		graphqlBBSRepoID, "2",
 	)
+
+	repoupdater.MockEnqueueChangesetSync = func(ctx context.Context, ids []int64) error {
+		// Call directly so we don't need to set up a repo updater instance in tests
+		syncer := ee.ChangesetSyncer{
+			Store:       sr.store,
+			ReposStore:  store,
+			HTTPFactory: cf,
+		}
+		return syncer.EnqueueChangesetSyncs(ctx, ids)
+	}
+	defer func() {
+		repoupdater.MockEnqueueChangesetSync = nil
+	}()
 
 	mustExec(ctx, t, s, nil, &result, fmt.Sprintf(`
 		fragment gitRef on GitRef {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -767,7 +767,6 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 				if !j.StartedAt.IsZero() {
 					t.Fatalf("ChangesetJob StartedAt is set. have=%v", j.StartedAt)
 				}
-
 				if !j.FinishedAt.IsZero() {
 					t.Fatalf("ChangesetJob FinishedAt is set. have=%v", j.FinishedAt)
 				}
@@ -782,12 +781,12 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 			for _, j := range append(wantUnmodifiedChangesetJobs, wantModifiedChangesetJobs...) {
 				wantAttachedChangesetIDs = append(wantAttachedChangesetIDs, j.ChangesetID)
 			}
-			changesets, _, err := store.ListChangesets(ctx, ListChangesetsOpts{IDs: wantAttachedChangesetIDs})
+			changesets, _, err := store.ListChangesets(ctx, ListChangesetsOpts{IDs: wantAttachedChangesetIDs, IncludeUnsynced: true})
 			if err != nil {
 				t.Fatal(err)
 			}
 			if have, want := len(changesets), len(wantAttachedChangesetIDs); have != want {
-				t.Fatalf("wrong number of changesets. want=%d, have=%d", have, want)
+				t.Fatalf("wrong number of changesets. want=%d, have=%d", want, have)
 			}
 			for _, c := range changesets {
 				if len(c.CampaignIDs) != 1 || c.CampaignIDs[0] != campaign.ID {
@@ -829,7 +828,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 			sort.Slice(wantIDs, func(i, j int) bool { return wantIDs[i] < wantIDs[j] })
 			sort.Slice(haveIDs, func(i, j int) bool { return haveIDs[i] < haveIDs[j] })
 
-			if diff := cmp.Diff(haveIDs, wantIDs); diff != "" {
+			if diff := cmp.Diff(wantIDs, haveIDs); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -177,6 +177,39 @@ func (c *Client) EnqueueRepoUpdate(ctx context.Context, repo gitserver.Repo) (*p
 	return &res, nil
 }
 
+// MockEnqueueRepoUpdate mocks (*Client).EnqueueRepoUpdate for tests.
+var MockEnqueueChangesetSync func(ctx context.Context, ids []int64) error
+
+func (c *Client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
+	if MockEnqueueChangesetSync != nil {
+		return MockEnqueueChangesetSync(ctx, ids)
+	}
+
+	req := protocol.ChangesetSyncRequest{IDs: ids}
+	resp, err := c.httpPost(ctx, "enqueue-changeset-sync", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
+
+	var res protocol.ChangesetSyncResponse
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return errors.New(string(bs))
+	} else if err = json.Unmarshal(bs, &res); err != nil {
+		return err
+	}
+
+	if res.Error == "" {
+		return nil
+	}
+	return errors.New(res.Error)
+}
+
 // SyncExternalService requests the given external service to be synced.
 func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
 	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -160,6 +160,16 @@ type RepoUpdateResponse struct {
 	URL string `json:"url"`
 }
 
+// ChangesetSyncRequest is a request to sync a number of changesets
+type ChangesetSyncRequest struct {
+	IDs []int64
+}
+
+// ChangesetSyncResponse is a response to sync a number of changesets
+type ChangesetSyncResponse struct {
+	Error string
+}
+
 // ExternalServiceSyncRequest is a request to sync a specific external service eagerly.
 //
 // The FrontendAPI is one of the issuers of this request. It does so when creating or

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -33,7 +33,7 @@ async function addChangeset({
         throw new RepoNotFoundError(repoName)
     }
 
-    const changeset = dataOrThrowErrors(
+    const changesetID = dataOrThrowErrors(
         await mutateGraphQL(
             gql`
                 mutation CreateChangeSet($repositoryID: ID!, $externalID: String!) {
@@ -55,7 +55,7 @@ async function addChangeset({
                     }
                 }
             `,
-            { campaignID, changesets: [changeset.id] }
+            { campaignID, changesets: [changesetID] }
         ).toPromise()
     )
 }


### PR DESCRIPTION
We now only have one instance of campaigns.ChangesetSyncer which is
instantiated during startup of enterprise/repo-updater.

Instead of creating a syncer from the frontend we now make an HTTP RPC
call to repo-updater to enqueue the sync. The actual enqueing process has
not been implemented yet and will be done in another PR, this change just
refactors the code to make it possible.

The CreateChangesets mutation only returns ids now

This a breaking change since it changes the API. It is needed since
syncing changesets happens asynchronously and we don't want the mutation
to block. Also, the old approach would allow the possibility of
returning a rate limit error to the user when trying to create changesets.