### PR TITLE
repo-updater/repos: add unit tests for `updateQueue.Less`

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -502,7 +502,7 @@ func (q *updateQueue) acquireNext() *configuredRepo2 {
 
 // The following methods implement heap.Interface based on the priority queue example:
 // https://golang.org/pkg/container/heap/#example__priorityQueue
-// These methods are not concurrent safe by themselves. Therefore, it is caller's
+// These methods are not safe for concurrent use. Therefore, it is the caller's
 // responsibility to ensure they're being guarded by a mutex during any heap operation,
 // i.e. heap.Fix, heap.Remove, heap.Push, heap.Pop.
 
@@ -669,7 +669,7 @@ func (s *schedule) reset() {
 
 // The following methods implement heap.Interface based on the priority queue example:
 // https://golang.org/pkg/container/heap/#example__priorityQueue
-// These methods are not concurrent safe by themselves. Therefore, it is caller's
+// These methods are not safe for concurrent use. Therefore, it is the caller's
 // responsibility to ensure they're being guarded by a mutex during any heap operation,
 // i.e. heap.Fix, heap.Remove, heap.Push, heap.Pop.
 

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -502,6 +502,9 @@ func (q *updateQueue) acquireNext() *configuredRepo2 {
 
 // The following methods implement heap.Interface based on the priority queue example:
 // https://golang.org/pkg/container/heap/#example__priorityQueue
+// These methods are not concurrent safe by themselves. Therefore, it is caller's
+// responsibility to ensure they're being guarded by a mutex during any heap operation,
+// i.e. heap.Fix, heap.Remove, heap.Push, heap.Pop.
 
 func (q *updateQueue) Len() int { return len(q.heap) }
 func (q *updateQueue) Less(i, j int) bool {
@@ -666,6 +669,9 @@ func (s *schedule) reset() {
 
 // The following methods implement heap.Interface based on the priority queue example:
 // https://golang.org/pkg/container/heap/#example__priorityQueue
+// These methods are not concurrent safe by themselves. Therefore, it is caller's
+// responsibility to ensure they're being guarded by a mutex during any heap operation,
+// i.e. heap.Fix, heap.Remove, heap.Push, heap.Pop.
 
 func (s *schedule) Len() int { return len(s.heap) }
 func (s *schedule) Less(i, j int) bool {

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -1313,3 +1313,46 @@ func verifyRecording(t *testing.T, s *updateScheduler, timeAfterFuncDelays []tim
 func timePtr(t time.Time) *time.Time {
 	return &t
 }
+
+func Test_updateQueue_Less(t *testing.T) {
+	q := &updateQueue{}
+	tests := []struct {
+		name   string
+		heap   []*repoUpdate
+		expVal bool
+	}{
+		{
+			name: "updating",
+			heap: []*repoUpdate{
+				{Updating: false},
+				{Updating: true},
+			},
+			expVal: true,
+		},
+		{
+			name: "priority",
+			heap: []*repoUpdate{
+				{Priority: priorityHigh},
+				{Priority: priorityLow},
+			},
+			expVal: true,
+		},
+		{
+			name: "seq",
+			heap: []*repoUpdate{
+				{Seq: 1},
+				{Seq: 2},
+			},
+			expVal: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q.heap = test.heap
+			got := q.Less(0, 1)
+			if test.expVal != got {
+				t.Fatalf("want %v but got: %v", test.expVal, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PRs adds unit tests for `updateQueue.Less` method.

The motivation was I got confused by how `Less` is supposed to work, adding tests to ensure its behavior is desired.