### PR TITLE
tracking-issue: Use TRACKING_ISSUE_SYNCER_TOKEN

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           args: -milestone 3.14 -labels team/core-services -update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRACKING_ISSUE_SYNCER_TOKEN }}


### PR DESCRIPTION
This allows the tool to access issues in other repos. The secret has been added here: https://github.com/sourcegraph/sourcegraph/settings/secrets and stored in 1Password (sourcegraph-bot).
