### PR TITLE
ci: disable unused Go lint

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -18,4 +18,4 @@ go install -tags=dev -buildmode=archive ${pkgs}
 
 echo "--- lint"
 
-golangci-lint run ${pkgs}
+golangci-lint run -e unused ${pkgs}


### PR DESCRIPTION
This lint may be useful, and there may be a better way to do this. It's caused a number of FPs [example](https://buildkite.com/sourcegraph/sourcegraph/builds/56558#9b01e718-1943-442f-ac27-8537477c52b0/1072-1075) and I just want to stop red builds. 

I suspect it is a combination of our CI and the linter that causes this to crop up unpredictably. I don't know how to reliably reproduce it. I confirmed adding `-e unused` stops this lint report with a manual example.