### PR TITLE
Fix n+1 query in extension registry list endpoint.

### DIFF
--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -23,24 +22,55 @@ func validateExtensionManifest(text string) error {
 	return jsonc.Unmarshal(text, &o)
 }
 
-// getExtensionManifestWithBundleURL returns the extension manifest as JSON. If there are no
+// getLatestRelease returns the release with the extension manifest as JSON. If there are no
 // releases, it returns a nil manifest. If the manifest has no "url" field itself, a "url" field
 // pointing to the extension's bundle is inserted. It also returns the date that the release was
 // published.
-func getExtensionManifestWithBundleURL(ctx context.Context, extensionID string, registryExtensionID int32, releaseTag string) (manifest *string, publishedAt time.Time, err error) {
+func getLatestRelease(ctx context.Context, extensionID string, registryExtensionID int32, releaseTag string) (*dbRelease, error) {
 	release, err := dbReleases{}.GetLatest(ctx, registryExtensionID, releaseTag, false)
 	if err != nil && !errcode.IsNotFound(err) {
-		return nil, time.Time{}, err
+		return nil, err
 	}
 	if release == nil {
-		return nil, time.Time{}, nil
+		return nil, nil
 	}
 
 	if err := prepReleaseManifest(extensionID, release); err != nil {
-		return nil, time.Time{}, fmt.Errorf("parsing extension manifest for extension with ID %d (release tag %q): %s", registryExtensionID, releaseTag, err)
+		return nil, fmt.Errorf("parsing extension manifest for extension with ID %d (release tag %q): %s", registryExtensionID, releaseTag, err)
 	}
 
-	return &release.Manifest, release.CreatedAt, nil
+	return release, nil
+}
+
+// getLatestForBatch returns a map from extension identifiers to the latest DB release
+// with the extension manifest as JSON for that extension. If there are no releases, it
+// returns a nil manifest. If the manifest has no "url" field itself, a "url" field
+// pointing to the extension's bundle is inserted. It also returns the date that the
+// release was published.
+func getLatestForBatch(ctx context.Context, vs []*dbExtension) (map[int32]*dbRelease, error) {
+	var extensionIDs []int32
+	extensionIDMap := map[int32]string{}
+	for _, v := range vs {
+		extensionIDs = append(extensionIDs, v.ID)
+		extensionIDMap[v.ID] = v.NonCanonicalExtensionID
+	}
+	releases, err := dbReleases{}.GetLatestBatch(ctx, extensionIDs, "release", false)
+	if err != nil {
+		return nil, err
+	}
+
+	releasesByExtensionID := map[int32]*dbRelease{}
+	for _, r := range releases {
+		releasesByExtensionID[r.RegistryExtensionID] = r
+	}
+
+	for _, r := range releases {
+		if err := prepReleaseManifest(extensionIDMap[r.RegistryExtensionID], r); err != nil {
+			return nil, fmt.Errorf("parsing extension manifest for extension with ID %d (release tag %q): %s", r.RegistryExtensionID, "release", err)
+		}
+	}
+
+	return releasesByExtensionID, nil
 }
 
 // prepReleaseManifest will set the Manifest field of the release. If the manifest has no "url"

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -78,12 +78,9 @@ func getLatestForBatch(ctx context.Context, vs []*dbExtension) (map[int32]*dbRel
 // the date that the release was published.
 func prepReleaseManifest(extensionID string, release *dbRelease) error {
 	// Add URL to bundle if necessary.
-	var o map[string]interface{}
+	o := make(map[string]interface{})
 	if err := json.Unmarshal([]byte(release.Manifest), &o); err != nil {
 		return err
-	}
-	if o == nil {
-		o = map[string]interface{}{}
 	}
 	urlStr, _ := o["url"].(string)
 	if urlStr == "" {

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
@@ -11,13 +11,6 @@ import (
 func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 	resetMocks()
 	ctx := context.Background()
-
-	nilOrEmpty := func(s *string) string {
-		if s == nil {
-			return ""
-		}
-		return *s
-	}
 	t0 := time.Unix(1234, 0)
 
 	t.Run(`manifest with "url"`, func(t *testing.T) {
@@ -28,15 +21,15 @@ func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 			}, nil
 		}
 		defer func() { mocks.releases.GetLatest = nil }()
-		manifest, publishedAt, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
+		release, err := getLatestRelease(ctx, "x", 1, "t")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want := `{"name":"x","url":"u"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
-			t.Errorf("got %q, want %q", nilOrEmpty(manifest), want)
+		if want := `{"name":"x","url":"u"}`; !jsonDeepEqual(release.Manifest, want) {
+			t.Errorf("got %q, want %q", release.Manifest, want)
 		}
-		if publishedAt != t0 {
-			t.Errorf("got %v, want %v", publishedAt, t0)
+		if release.CreatedAt != t0 {
+			t.Errorf("got %v, want %v", release.CreatedAt, t0)
 		}
 	})
 
@@ -48,15 +41,15 @@ func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 			}, nil
 		}
 		defer func() { mocks.releases.GetLatest = nil }()
-		manifest, publishedAt, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
+		release, err := getLatestRelease(ctx, "x", 1, "t")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want := `{"name":"x","url":"/-/static/extension/0-x.js?fqw3qlts--x"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
-			t.Errorf("got %q, want %q", nilOrEmpty(manifest), want)
+		if want := `{"name":"x","url":"/-/static/extension/0-x.js?fqw3qlts--x"}`; !jsonDeepEqual(release.Manifest, want) {
+			t.Errorf("got %q, want %q", release.Manifest, want)
 		}
-		if publishedAt != t0 {
-			t.Errorf("got %v, want %v", publishedAt, t0)
+		if release.CreatedAt != t0 {
+			t.Errorf("got %v, want %v", release.CreatedAt, t0)
 		}
 	})
 }

--- a/enterprise/cmd/frontend/internal/registry/releases_db.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db.go
@@ -67,9 +67,8 @@ RETURNING id
 	return id, nil
 }
 
-// GetLatest gets the latest release for the extension with the given release tag (e.g.,
-// "release"). If includeArtifacts is true, it populates the
-// (*dbRelease).{Bundle,SourceMap} fields, which may be large.
+// GetLatest gets the latest release for the extension with the given release tag (e.g., "release").
+// If includeArtifacts is true, it populates the (*dbRelease).{Bundle,SourceMap} fields, which may be large.
 func (dbReleases) GetLatest(ctx context.Context, registryExtensionID int32, releaseTag string, includeArtifacts bool) (*dbRelease, error) {
 	if mocks.releases.GetLatest != nil {
 		return mocks.releases.GetLatest(registryExtensionID, releaseTag, includeArtifacts)
@@ -90,6 +89,56 @@ LIMIT 1`, includeArtifacts, includeArtifacts, registryExtensionID, releaseTag)
 		return nil, err
 	}
 	return &r, nil
+}
+
+// GetLatestBatch gest the latest releases for the estensions with the given release tag
+// (e.g., "release"). If includeArtifacts is true, it populates the (*dbRelease).{Bundle,SourceMap}
+// fields, which may be large.
+func (dbReleases) GetLatestBatch(ctx context.Context, registryExtensionIDs []int32, releaseTag string, includeArtifacts bool) ([]*dbRelease, error) {
+	if mocks.releases.GetLatestBatch != nil {
+		return mocks.releases.GetLatestBatch(registryExtensionIDs, releaseTag, includeArtifacts)
+	}
+
+	var ids []*sqlf.Query
+	for _, id := range registryExtensionIDs {
+		ids = append(ids, sqlf.Sprintf("%s", id))
+	}
+
+	q := sqlf.Sprintf(`
+SELECT rer.id, rer.registry_extension_id, rer.creator_user_id, rer.release_version, rer.release_tag, rer.manifest, CASE WHEN %v::boolean THEN rer.bundle ELSE null END AS bundle, CASE WHEN %v::boolean THEN rer.source_map ELSE null END AS source_map, rer.created_at
+FROM registry_extension_releases rer
+WHERE rer.registry_extension_id IN (%s) AND rer.release_tag=%s AND rer.deleted_at IS NULL
+-- Select only the latest
+AND NOT EXISTS (SELECT 1 FROM registry_extension_releases rer2
+	WHERE rer.registry_extension_id=rer2.registry_extension_id
+					AND rer2.release_tag=%s
+					AND rer2.deleted_at IS NULL
+					AND rer2.created_at > rer.created_at
+  )
+
+`, includeArtifacts, includeArtifacts, sqlf.Join(ids, ","), releaseTag, releaseTag)
+
+	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var releases []*dbRelease
+	for rows.Next() {
+		var r dbRelease
+		err := rows.Scan(&r.ID, &r.RegistryExtensionID, &r.CreatorUserID, &r.ReleaseVersion, &r.ReleaseTag, &r.Manifest, &r.Bundle, &r.SourceMap, &r.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+		releases = append(releases, &r)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return releases, nil
 }
 
 // GetArtifacts gets the bundled JavaScript source file contents and the source map for a release
@@ -113,6 +162,7 @@ WHERE id=%d AND deleted_at IS NULL`, id)
 
 // mockReleases mocks the registry extension releases store.
 type mockReleases struct {
-	Create    func(release *dbRelease) (int64, error)
-	GetLatest func(registryExtensionID int32, releaseTag string, includeArtifacts bool) (*dbRelease, error)
+	Create         func(release *dbRelease) (int64, error)
+	GetLatest      func(registryExtensionID int32, releaseTag string, includeArtifacts bool) (*dbRelease, error)
+	GetLatestBatch func(registryExtensionIDs []int32, releaseTag string, includeArtifacts bool) ([]*dbRelease, error)
 }

--- a/enterprise/cmd/frontend/internal/registry/releases_db.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db.go
@@ -134,7 +134,7 @@ AND NOT EXISTS (SELECT 1 FROM registry_extension_releases rer2
 		releases = append(releases, &r)
 	}
 
-	if err = rows.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/registry/releases_db.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db.go
@@ -104,6 +104,10 @@ func (dbReleases) GetLatestBatch(ctx context.Context, registryExtensionIDs []int
 		ids = append(ids, sqlf.Sprintf("%s", id))
 	}
 
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	q := sqlf.Sprintf(`
 SELECT rer.id, rer.registry_extension_id, rer.creator_user_id, rer.release_version, rer.release_tag, rer.manifest, CASE WHEN %v::boolean THEN rer.bundle ELSE null END AS bundle, CASE WHEN %v::boolean THEN rer.source_map ELSE null END AS source_map, rer.created_at
 FROM registry_extension_releases rer

--- a/enterprise/cmd/frontend/internal/registry/releases_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db_test.go
@@ -22,7 +22,11 @@ func TestRegistryExtensionReleases(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	extensionID, err := (dbExtensions{}).Create(ctx, user.ID, 0, "x")
+	xExtensionID, err := (dbExtensions{}).Create(ctx, user.ID, 0, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	yExtensionID, err := (dbExtensions{}).Create(ctx, user.ID, 0, "y")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +36,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 	}
 
 	t.Run("GetLatest with no releases", func(t *testing.T) {
-		_, err := dbReleases{}.GetLatest(ctx, extensionID, "release", false)
+		_, err := dbReleases{}.GetLatest(ctx, xExtensionID, "release", false)
 		if !errcode.IsNotFound(err) {
 			t.Errorf("got err %v, want errcode.IsNotFound", err)
 		}
@@ -54,7 +58,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		input := dbRelease{
-			RegistryExtensionID: extensionID,
+			RegistryExtensionID: xExtensionID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{"m": true}`,
@@ -81,7 +85,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 		})
 
 		t.Run("GetLatest for 1st release", func(t *testing.T) {
-			r1, err := dbReleases{}.GetLatest(ctx, extensionID, "release", true)
+			r1, err := dbReleases{}.GetLatest(ctx, xExtensionID, "release", true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -92,16 +96,17 @@ func TestRegistryExtensionReleases(t *testing.T) {
 		})
 
 		t.Run("GetLatest with wrong release tag", func(t *testing.T) {
-			_, err := dbReleases{}.GetLatest(ctx, extensionID, "other", true)
+			_, err := dbReleases{}.GetLatest(ctx, xExtensionID, "other", true)
 			if !errcode.IsNotFound(err) {
 				t.Errorf("got err %v, want errcode.IsNotFound", err)
 			}
 		})
 	})
 
+	var input2 dbRelease
 	t.Run("Create 2nd release and GetLatest", func(t *testing.T) {
-		input2 := dbRelease{
-			RegistryExtensionID: extensionID,
+		input2 = dbRelease{
+			RegistryExtensionID: xExtensionID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{"m2": true}`,
@@ -114,7 +119,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 		}
 		input2.ID = id2
 
-		r2, err := dbReleases{}.GetLatest(ctx, extensionID, "release", true)
+		r2, err := dbReleases{}.GetLatest(ctx, xExtensionID, "release", true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -124,9 +129,36 @@ func TestRegistryExtensionReleases(t *testing.T) {
 		}
 	})
 
+	t.Run("GetLatestBatch", func(t *testing.T) {
+		input3 := dbRelease{
+			RegistryExtensionID: yExtensionID,
+			CreatorUserID:       user.ID,
+			ReleaseTag:          "release",
+			Manifest:            `{"m2": true}`,
+			Bundle:              strptr("b2"),
+			SourceMap:           strptr("sm2"),
+		}
+		id3, err := dbReleases{}.Create(ctx, &input3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		input3.ID = id3
+
+		r3, err := dbReleases{}.GetLatestBatch(ctx, []int32{xExtensionID, yExtensionID}, "release", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		norm(r3[0])
+		norm(r3[1])
+		expected := []*dbRelease{&input2, &input3}
+		if !reflect.DeepEqual(r3, expected) {
+			t.Errorf("got %+v, want %+v", r3, expected)
+		}
+	})
+
 	t.Run("Create fails on invalid JSON", func(t *testing.T) {
 		_, err := dbReleases{}.Create(ctx, &dbRelease{
-			RegistryExtensionID: extensionID,
+			RegistryExtensionID: xExtensionID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{title/`, // weird bad JSON (any invalid JSON suffices for this test)
@@ -140,7 +172,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 
 	t.Run("Release without bundle", func(t *testing.T) {
 		input := dbRelease{
-			RegistryExtensionID: extensionID,
+			RegistryExtensionID: xExtensionID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{"m3": true}`,

--- a/enterprise/cmd/frontend/internal/registry/releases_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db_test.go
@@ -22,11 +22,11 @@ func TestRegistryExtensionReleases(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	xExtensionID, err := (dbExtensions{}).Create(ctx, user.ID, 0, "x")
+	xExtensionID, err := dbExtensions{}.Create(ctx, user.ID, 0, "x")
 	if err != nil {
 		t.Fatal(err)
 	}
-	yExtensionID, err := (dbExtensions{}).Create(ctx, user.ID, 0, "y")
+	yExtensionID, err := dbExtensions{}.Create(ctx, user.ID, 0, "y")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This alert keeps flapping: https://sourcegraph.app.opsgenie.com/alert/detail/78d8cf4f-2394-4df0-98f7-de97a44ed1f2-1582579884047/details.

It may be because the extension registry list endpoint will perform a SELECT of all ~230 extensions and perform an additional multi-join SQL query for each one in sequence before constructing a response. This will select the extensions, then do a single SQL query to get the latest release (making the endpoint only make 2 SQL queries rather than >230).