### PR TITLE
tracking-issue: smaller docker image

### DIFF
--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,9 +1,15 @@
-FROM golang:1.13
+FROM golang:1.13-alpine
 
 WORKDIR /go/src/tracking-issue
 COPY main.go .
 
-RUN go get -d -v ./...
-RUN go install -v ./...
+RUN go mod init tracking-issue
+RUN CGO_ENABLED=0 go install .
+
+FROM alpine:3.11
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=0 /go/bin/* /usr/local/bin/
 
 ENTRYPOINT ["tracking-issue"]

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY main.go .
@@ -8,8 +8,9 @@ RUN CGO_ENABLED=0 go install .
 
 FROM alpine:3.11
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates
 
-COPY --from=0 /go/bin/* /usr/local/bin/
+COPY --from=builder /go/bin/* /usr/local/bin/
 
 ENTRYPOINT ["tracking-issue"]


### PR DESCRIPTION
Our docker image size goes from 833mb to 13mb by not including the layer for
building and the fetched dependency source code.