### PR TITLE
gitserver: Don't redact username if password also supplied

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -918,11 +918,19 @@ func newURLRedactor(rawurl string) *urlRedactor {
 	var sensitive []string
 	parsedURL, _ := url.Parse(rawurl)
 	if parsedURL != nil {
-		if pw, _ := parsedURL.User.Password(); pw != "" {
+		pw, _ := parsedURL.User.Password()
+		u := parsedURL.User.Username()
+		if pw != "" && u != "" {
+			// Only block password if we have both as we can
+			// assume that the username isn't sensitive in this case
 			sensitive = append(sensitive, pw)
-		}
-		if u := parsedURL.User.Username(); u != "" {
-			sensitive = append(sensitive, u)
+		} else {
+			if pw != "" {
+				sensitive = append(sensitive, pw)
+			}
+			if u != "" {
+				sensitive = append(sensitive, u)
+			}
 		}
 	}
 	sensitive = append(sensitive, rawurl)

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -292,7 +292,12 @@ func TestUrlRedactor(t *testing.T) {
 		{
 			url:      "http://user:password@github.com/foo/bar/",
 			message:  "fatal: repository 'http://user:password@github.com/foo/bar/' not found",
-			redacted: "fatal: repository 'http://<redacted>:<redacted>@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://user:<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://git:password@github.com/foo/bar/",
+			message:  "fatal: repository 'http://git:password@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://git:<redacted>@github.com/foo/bar/' not found",
 		},
 		{
 			url:      "http://token@github.com///repo//nick/",
@@ -311,9 +316,11 @@ func TestUrlRedactor(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		if actual := newURLRedactor(testCase.url).redact(testCase.message); actual != testCase.redacted {
-			t.Errorf("newUrlRedactor(%q).redact(%q) got %q; want %q", testCase.url, testCase.message, actual, testCase.redacted)
-		}
+		t.Run("", func(t *testing.T) {
+			if actual := newURLRedactor(testCase.url).redact(testCase.message); actual != testCase.redacted {
+				t.Fatalf("newUrlRedactor(%q).redact(%q) got %q; want %q", testCase.url, testCase.message, actual, testCase.redacted)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
It is quite common for the username to be "git" in which case we see
things like: `<redacted>hub.com`

Closes: https://github.com/sourcegraph/sourcegraph/issues/8586
