### PR TITLE
docs: (docker-compose) recommend that users create their own fork

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -119,7 +119,7 @@
                                             <li><a href="/admin/install/docker/google_cloud">Install Sourcegraph with Docker on Google Cloud</a></li>
                                         </ul>
                                     </li>
-                                    <li><a href="/admin/install/docker">Install Sourcegraph with Docker Compose</a></li>
+                                    <li><a href="/admin/install/docker-compose">Install Sourcegraph with Docker Compose</a></li>
                                     <li class="content-nav-no-hover" data-sub-section-item="Install Sourcegraph with Docker Compose" )>
                                         <ul>
                                             <li><a href="/admin/install/docker-compose/aws">Install Sourcegraph with Docker Compose on AWS</a></li>

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -6,6 +6,12 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
 ---
 
+## (optional, recommended) Create a fork for customizations
+
+We **strongly** recommend that you create your own fork of [sourcegraph/deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/) to track customizations to the [Sourcegraph Docker Compose yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml). This will make will make upgrades far easier.
+
+See ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork) for full instructions.
+
 ## Deploy to EC2
 
 * Click **Launch Instance** from your [EC2 dashboard](https://console.aws.amazon.com/ec2/v2/home).
@@ -13,6 +19,9 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 * Select an appropriate instance size (we recommend `t2.2xlarge` or larger, depending on team size and number of repositories/languages enabled), then **Next: Configure Instance Details**
 * Ensure the **Auto-assign Public IP** option is "Enable". This ensures your instance is accessible to the Internet.
 * Add the following user data (as text) in the **Advanced Details** section:
+  * (optional) If you [created a fork as recommended above](#optional-recommended-create-a-fork-for-customizations), update the following environment variables in the script below:
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: Your fork's git clone URL
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The git revision containing your fork's customizations to the base Sourcegraph Docker Compose yaml. Most likely, `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='release'` if you followed our branching recommendations in ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork).
 
 ```bash
 #!/usr/bin/env bash
@@ -23,17 +32,20 @@ EBS_VOLUME_DEVICE_NAME='/dev/sdb'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
 DOCKER_COMPOSE_VERSION='1.25.3'
-SOURCEGRAPH_VERSION='v3.12.5'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
+
+# 🚨 Update these variables with the correct values from your fork!
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.12.5'
 
 # Install git
 yum update -y
 yum install git -y
 
 # Clone Docker Compose definition
-git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
 cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout "${SOURCEGRAPH_VERSION}"
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
 
 # Format (if necessary) and mount EBS volume
 device_fs=$(lsblk "${EBS_VOLUME_DEVICE_NAME}" --noheadings --output fsType)

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -6,6 +6,12 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
 ---
 
+## (optional, recommended) Create a fork for customizations
+
+We **strongly** recommend that you create your own fork of [sourcegraph/deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/) to track customizations to the [Sourcegraph Docker Compose yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml). This will make will make upgrades far easier.
+
+See ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork) for full instructions.
+
 ## Run Sourcegraph on a Digital Ocean Droplet
 
 * [Create a new Digital Ocean Droplet](https://cloud.digitalocean.com/droplets/new).
@@ -17,6 +23,9 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
 * In the "Select additional options" section of the Droplet creation page, select the "User Data" and "Monitoring" boxes,
    and paste the following script in the "`Enter user data here...`" text box:
+  * (optional) If you [created a fork as recommended above](#optional-recommended-create-a-fork-for-customizations), update the following environment variables in the script below:
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: Your fork's git clone URL
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The git revision containing your fork's customizations to the base Sourcegraph Docker Compose yaml. Most likely, `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='release'` if you followed our branching recommendations in ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork).
 
 ```bash
 #!/usr/bin/env bash
@@ -27,17 +36,20 @@ PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
 DOCKER_COMPOSE_VERSION='1.25.3'
-SOURCEGRAPH_VERSION='v3.12.5'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+
+# 🚨 Update these variables with the correct values from your fork!
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.12.5'
 
 # Install git
 sudo apt-get update -y
 sudo apt-get install -y git
 
 # Clone Docker Compose definition
-git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
 cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout ${SOURCEGRAPH_VERSION}
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
 
 # Format (if necessary) and mount DO persistent disk
 device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -49,9 +49,9 @@ sudo apt-get update -y
 sudo apt-get install -y git
 
 # Clone Docker Compose definition
-git clone "https://github.com/sourcegraph/deploy-sourcegraph-docker.git" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
 cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout ${SOURCEGRAPH_VERSION}
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
 
 # Format (if necessary) and mount GCP persistent disk
 device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -6,6 +6,12 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 
 ---
 
+## (optional, recommended) Create a fork for customizations
+
+We **strongly** recommend that you create your own fork of [sourcegraph/deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/) to track customizations to the [Sourcegraph Docker Compose yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml). This will make will make upgrades far easier.
+
+See ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork) for full instructions.
+
 ## Deploy to Google Cloud VM
 
 * [Open your Google Cloud console](https://console.cloud.google.com/compute/instances) to create a new VM instance and click **Create Instance**
@@ -19,6 +25,9 @@ This tutorial shows you how to deploy Sourcegraph via [Docker Compose](https://d
 * Check the boxes for **Allow HTTP traffic** and **Allow HTTPS traffic** in the **Firewall** section
 * Open the **Management, disks, networking, and SSH keys** dropdown section
 * Under the **Management** section, add the following in the **Startup script** field:
+  * (optional) If you [created a fork as recommended above](#optional-recommended-create-a-fork-for-customizations), update the following environment variables in the script below:
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: Your fork's git clone URL
+    * `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The git revision containing your fork's customizations to the base Sourcegraph Docker Compose yaml. Most likely, `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='release'` if you followed our branching recommendations in ["Store customizations in a fork"](./index.md#optional-recommended-store-customizations-in-a-fork).
 
 ```bash
 #!/usr/bin/env bash
@@ -29,8 +38,11 @@ PERSISTENT_DISK_DEVICE_NAME='/dev/sdb'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
 DOCKER_COMPOSE_VERSION='1.25.3'
-SOURCEGRAPH_VERSION='v3.12.5'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+
+# 🚨 Update these variables with the correct values from your fork!
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v3.12.5'
 
 # Install git
 sudo apt-get update -y

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -1,7 +1,7 @@
 # Install Sourcegraph with Docker Compose
 
 | Deployment Type                                          | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
-|----------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
+| -------------------------------------------------------- | --------------------------------------------------- | ---------- | -------------- | ------------- | ----------- |
 | [Single-container server](../../install/docker/index.md) | Local testing                                       | 60 seconds | Impossible     | No            | No          |
 | [Docker Compose](../../install/docker-compose/index.md)  | Small & medium production deployments               | 5 minutes  | Possible       | No            | Yes         |
 | [Kubernetes](../../install/cluster.md)                   | Medium & large highly-available cluster deployments | 30 minutes | Easily         | Yes           | Yes         |
@@ -25,6 +25,22 @@ Once the server is ready (the `sourcegraph-frontend-0` service is healthy when r
 For next steps and further configuration options, visit the [site administration documentation](../../index.md).
 
 > NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
+
+## (optional, recommended) Store customizations in a fork
+
+We **strongly** recommend that you create your own fork of [sourcegraph/deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/) to track customizations to the [Sourcegraph Docker Compose yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml). This will make will make upgrades far easier.
+
+* Fork [sourcegraph/deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/)
+  * The fork can be public **unless** you plan to store secrets (SSL certificates, external Postgres credentials, etc.) in the repository itself.
+
+* Create a `release` branch (to track all of your customizations to Sourcegraph. When you upgrade Sourcegraph's Docker Compose definition, you will merge upstream into this branch.
+
+```bash
+SOURCEGRAPH_VERSION="v3.12.5-1"
+git checkout $SOURCEGRAPH_VERSION -b release
+```
+
+* Commit customizations to the [Sourcegraph Docker Compose yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) to your `release` branch
 
 ## Storage
 


### PR DESCRIPTION
This PR changes our docs to recommend that users create a fork to store their customizations to https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml. Users will need to customize the yaml to change resource requirements, replica counts, customize environment variables, etc. 

Our recommended merging strategy is the same one that we recommend in deploy-sourcegraph: https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/configure.md#fork-this-repository 