### PR TITLE
fix: don't show users an error if they submit surveys on instances no…

### DIFF
--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/hubspot/hubspotutil"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 type surveyResponseResolver struct {
@@ -111,7 +112,8 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 		IsAuthenticated: actor.IsAuthenticated(),
 		SiteID:          siteid.Get(),
 	}); err != nil {
-		return nil, err
+		// Log an error, but don't return one if the only failure was in submitting survey results to HubSpot.
+		log15.Error("Unable to submit survey results to Sourcegraph remote", "error", err)
 	}
 
 	return &EmptyResponse{}, nil


### PR DESCRIPTION
…t connected to the internet

Addresses https://github.com/sourcegraph/sourcegraph/issues/8598

From an ugly red error message hitting users in the face, to:

```
00:08:26            frontend | ERROR Unable to submit survey results to Sourcegraph remote, error: hubspot.SubmitForm: Post https://forms.hubspot.com/uploads/form/v2/2762526/a86bbac5-576d-4ca0-86c1-0c60837c3eab: dial tcp: lookup forms.hubspot.com: no such host
```
