### PR TITLE
Pass a className to <Toggles>

### DIFF
--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -47,8 +47,8 @@
         }
     }
 
-    &__regexp-toggle {
-        padding-right: 0.25rem;
+    &__toggle-container {
+        padding-right: 0.35rem;
     }
 }
 

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -211,7 +211,11 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
                         border={false}
                     ></MonacoEditor>
                 </div>
-                <Toggles {...this.props} navbarSearchQuery={this.props.queryState.query} />
+                <Toggles
+                    {...this.props}
+                    navbarSearchQuery={this.props.queryState.query}
+                    className="monaco-query-input-container__toggle-container"
+                />
             </div>
         )
     }

--- a/web/src/search/input/QueryInput.scss
+++ b/web/src/search/input/QueryInput.scss
@@ -1,4 +1,5 @@
 @import './Suggestion';
+@import './toggles/Toggles.scss';
 
 .query-input2 {
     flex: 1 1 auto;
@@ -71,33 +72,8 @@
 
     &__toggle-container {
         position: absolute;
-        display: flex;
         right: 0.375rem;
         top: 0.375rem;
-    }
-
-    &__toggle {
-        display: block;
-        cursor: pointer;
-        &:not(:last-child) {
-            margin-right: 0.25rem;
-        }
-    }
-
-    &__toggle-icon {
-        border: 1px solid transparent;
-
-        &--active {
-            border: 1px solid $color-border-active;
-            padding-bottom: 0.25rem;
-            border-radius: 2px;
-            .theme-dark & {
-                background: $color-bg-5;
-            }
-            .theme-light & {
-                background: $color-light-bg-3;
-            }
-        }
     }
 }
 

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -446,6 +446,7 @@ export class QueryInput extends React.Component<Props, State> {
                                     {...this.props}
                                     navbarSearchQuery={this.props.value.query}
                                     filtersInQuery={this.props.filterQuery}
+                                    className="query-input2__toggle-container"
                                 />
                             </div>
                         </div>

--- a/web/src/search/input/toggles/QueryInputToggle.tsx
+++ b/web/src/search/input/toggles/QueryInputToggle.tsx
@@ -69,7 +69,7 @@ export class QueryInputToggle extends React.Component<ToggleProps> {
                 ref={this.toggleCheckbox}
                 onClick={this.props.onToggle}
                 className={classNames(
-                    'btn btn-icon icon-inline query-input2__toggle e2e-regexp-toggle',
+                    'btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle',
                     this.props.className,
                     { disabled: this.props.disabledCondition }
                 )}
@@ -82,8 +82,8 @@ export class QueryInputToggle extends React.Component<ToggleProps> {
             >
                 <span
                     className={classNames(
-                        'query-input2__toggle-icon',
-                        { 'query-input2__toggle-icon--active': this.props.isActive },
+                        'toggle-container__toggle-icon',
+                        { 'toggle-container__toggle-icon--active': this.props.isActive },
                         this.props.activeClassName
                     )}
                 >

--- a/web/src/search/input/toggles/Toggles.scss
+++ b/web/src/search/input/toggles/Toggles.scss
@@ -1,0 +1,27 @@
+.toggle-container {
+    display: flex;
+
+    &__toggle {
+        display: block;
+        cursor: pointer;
+        &:not(:last-child) {
+            margin-right: 0.25rem;
+        }
+    }
+
+    &__toggle-icon {
+        border: 1px solid transparent;
+
+        &--active {
+            border: 1px solid $color-border-active;
+            padding-bottom: 0.25rem;
+            border-radius: 2px;
+            .theme-dark & {
+                background: $color-bg-5;
+            }
+            .theme-light & {
+                background: $color-light-bg-3;
+            }
+        }
+    }
+}

--- a/web/src/search/input/toggles/Toggles.tsx
+++ b/web/src/search/input/toggles/Toggles.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as H from 'history'
 import RegexIcon from 'mdi-react/RegexIcon'
+import classNames from 'classnames'
 import FormatLetterCaseIcon from 'mdi-react/FormatLetterCaseIcon'
 import { PatternTypeProps, CaseSensitivityProps } from '../..'
 import { FiltersToTypeAndValue } from '../../../../../shared/src/search/interactive/util'
@@ -19,6 +20,7 @@ export interface TogglesProps extends PatternTypeProps, CaseSensitivityProps, Se
     location: H.Location
     filtersInQuery?: FiltersToTypeAndValue
     hasGlobalQueryBehavior?: boolean
+    className?: string
 }
 
 interface SubmitSearchArgs {
@@ -126,7 +128,7 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
     }
 
     return (
-        <div className="query-input2__toggle-container">
+        <div className={classNames('toggle-container', props.className)}>
             <QueryInputToggle
                 {...props}
                 title="Case sensitivity"


### PR DESCRIPTION
`<Toggles/>` had the `query-input2__toggle-container ` class by default, styled with `position: absolute`. This was problematic as it's also used in the Monaco query input, where it should _not_ be absolutely positioned.

This changes `<Toggles>` to take a className as props, so that it can be styled differently depending on the query input where it's embedded. Child components of `<Toggles>` now have `.toggle-container__` classes applied, rather than `.query-input2__`.