### PR TITLE
Reduce 502 errors by increasing WriteTimeout to 10min

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -259,7 +259,7 @@ func Main(githubWebhook, bitbucketServerWebhook http.Handler) error {
 	srv.GoServe(l, &http.Server{
 		Handler:      externalHandler,
 		ReadTimeout:  75 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		WriteTimeout: 10 * time.Minute,
 	})
 
 	if httpAddrInternal != "" {


### PR DESCRIPTION
This adresses customer reports of 502 errors showing up in the UI.

I could easily reproduce the error message by putting a
`time.Sleep(65*time.Second)` in the `NewSearchImplementer` code in the
GraphQL backend.

That lead to the request running into the write timeout, which closes
the connection after 60s without writing a byte on it. That in turn
leads to nginx in front of `frontend` to respond with a 502 Bad Gateway.

I discussed this fix here with @keegancsmith and while we do think that
we should fix the underlying problem (search is slow for customers)
increasing this timeout also makes sense since customers might make
non-search requests that take longer than 60s (downloading a zip file,
for example?)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
