### PR TITLE
Only return static suggestions when the token matches a known filter

### DIFF
--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -4,13 +4,67 @@ import { NEVER, of } from 'rxjs'
 import { SearchSuggestion } from '../../graphql/schema'
 
 describe('getCompletionItems()', () => {
-    test('returns static filter type completions along with dynamically fetched completions', async () => {
+    test('returns only static filter type completions when the token matches a known filter', async () => {
         expect(
             (
                 await getCompletionItems(
                     're',
                     (parseSearchQuery('re') as ParseSuccess<Sequence>).token,
                     { column: 3 },
+                    () =>
+                        of([
+                            {
+                                __typename: 'Repository',
+                                name: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                            {
+                                __typename: 'Symbol',
+                                name: 'RepoRoutes',
+                                kind: 'VARIABLE',
+                                location: {
+                                    resource: {
+                                        repository: {
+                                            name: 'github.com/sourcegraph/jsonrpc2',
+                                        },
+                                    },
+                                },
+                            },
+                        ] as SearchSuggestion[])
+                )
+            )?.suggestions.map(({ label }) => label)
+        ).toStrictEqual([
+            'after',
+            'archived',
+            'author',
+            'before',
+            'case',
+            'content',
+            'count',
+            'file',
+            '-file',
+            'fork',
+            'lang',
+            '-lang',
+            'message',
+            'patterntype',
+            'repo',
+            '-repo',
+            'repogroup',
+            'repohascommitafter',
+            'repohasfile',
+            '-repohasfile',
+            'timeout',
+            'type',
+        ])
+    })
+
+    test("returns static filter type completions along with dynamically fetched completions when the token doesn't match a filter", async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    'reposi',
+                    (parseSearchQuery('reposi') as ParseSuccess<Sequence>).token,
+                    { column: 7 },
                     () =>
                         of([
                             {

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -184,6 +184,16 @@ export async function getCompletionItems(
                 command: TRIGGER_SUGGESTIONS,
             })
         )
+        // If the token being typed matches a known filter,
+        // only return static filter type suggestions.
+        // This avoids blocking on dynamic suggestions to display
+        // the suggestions widget.
+        if (
+            token.type === 'literal' &&
+            staticSuggestions.some(({ label }) => label.startsWith(token.value.toLowerCase()))
+        ) {
+            return { suggestions: staticSuggestions }
+        }
         const dynamicSuggestions = (await fetchSuggestions(rawQuery).toPromise())
             .map(suggestionToCompletionItem)
             .filter(isDefined)


### PR DESCRIPTION
Suggestions are slow to display when dynamic suggestions are slow to fetch because:
- Monaco `CompletionItemProvider` does not support observables, so it's impossible to return a stream of suggestions that gets displayed incrementally.
- Even if we register several completion item providers, for instance one for static suggestions and one for dynamic suggestions, Monaco will block on the slowest provider to display the suggestions widget.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/75347283-bb621380-58a0-11ea-93e3-e8c01edd37e6.gif">
</details>

There would be some hacky ways to solve this (eg. force a refresh of suggestions when dynamic suggestions have been fetched), but a straightforward solution that makes suggestions as reactive as possible is to only display static filter type suggestions if the token being typed matches a known filter.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/75347317-c9b02f80-58a0-11ea-9a1f-346685bf23f5.gif">
</details>

