### PR TITLE
Wait for Docker image build in patch-notest branches

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -47,10 +47,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]
-		pipelineOperations = append(pipelineOperations,
+		pipelineOperations = []func(*bk.Pipeline){
 			addCanidateDockerImage(c, app),
+			wait,
 			addFinalDockerImage(c, app, false),
-		)
+		}
 
 	case c.isBextReleaseBranch:
 		// If this is a browser extension release branch, run the browser-extension tests and


### PR DESCRIPTION
This fixes the problem I described here in the documentation for this feature: https://github.com/sourcegraph/about/pull/613

The two steps are run in parallel which leads to the second step failing because the Docker image has not been pushed, see: https://buildkite.com/sourcegraph/sourcegraph/builds/56655