### PR TITLE
Fix negated filter suggestions

### DIFF
--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -31,6 +31,7 @@ const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] 
                 {
                     ...completionItem,
                     label: `-${label}`,
+                    filterText: `-${label}`,
                     detail: FILTERS[filterType].description(true),
                 },
             ]


### PR DESCRIPTION
Adds an appropriate `filterText` to negated filters completion items so that they are correctly displayed (otherwise typing `-` yielded no suggestions).

![image](https://user-images.githubusercontent.com/1741180/75347594-5e1a9200-58a1-11ea-98ee-8ed6dd5612bf.png)

