### PR TITLE
Fix parsing filter values that end with a colon

### DIFF
--- a/shared/src/search/parser/diagnostics.test.ts
+++ b/shared/src/search/parser/diagnostics.test.ts
@@ -44,10 +44,10 @@ describe('getDiagnostics()', () => {
             )
         ).toStrictEqual([
             {
-                endColumn: 28,
+                endColumn: 14,
                 endLineNumber: 1,
-                message: 'Quoting the query may help if you want a literal match.',
-                severity: 4,
+                message: 'Invalid filter type.',
+                severity: 8,
                 startColumn: 1,
                 startLineNumber: 1,
             },
@@ -60,7 +60,16 @@ describe('getDiagnostics()', () => {
                 (parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token,
                 SearchPatternType.literal
             )
-        ).toStrictEqual([])
+        ).toStrictEqual([
+            {
+                endColumn: 14,
+                endLineNumber: 1,
+                message: 'Invalid filter type.',
+                severity: 8,
+                startColumn: 1,
+                startLineNumber: 1,
+            },
+        ])
     })
 
     test('search query containing quoted token, regexp pattern type', () => {

--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -198,7 +198,7 @@ describe('parseSearchQuery()', () => {
     })
 
     test('filter with a value ending with a colon', () => {
-        expect(parseSearchQuery('f:a:')).toMatchInlineSnapshot({
+        expect(parseSearchQuery('f:a:')).toStrictEqual({
             range: {
                 end: 4,
                 start: 0,
@@ -244,7 +244,7 @@ describe('parseSearchQuery()', () => {
     })
 
     test('filter where the value is a colon', () => {
-        expect(parseSearchQuery('f::')).toMatchInlineSnapshot({
+        expect(parseSearchQuery('f::')).toStrictEqual({
             range: {
                 end: 3,
                 start: 0,

--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -197,6 +197,98 @@ describe('parseSearchQuery()', () => {
         })
     })
 
+    test('filter with a value ending with a colon', () => {
+        expect(parseSearchQuery('f:a:')).toMatchInlineSnapshot({
+            range: {
+                end: 4,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 4,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 1,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'f',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 4,
+                                    start: 2,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'a:',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
+    test('filter where the value is a colon', () => {
+        expect(parseSearchQuery('f::')).toMatchInlineSnapshot({
+            range: {
+                end: 3,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 3,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 1,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'f',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 3,
+                                    start: 2,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: ':',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
     test('quoted', () =>
         expect(parseSearchQuery('"a:b"')).toMatchObject({
             range: {

--- a/shared/src/search/parser/parser.ts
+++ b/shared/src/search/parser/parser.ts
@@ -237,7 +237,7 @@ const filterKeyword = pattern(/-?[a-zA-Z]+(?=:)/)
 
 const filterDelimiter = character(':')
 
-const filterValue = oneOf<Quoted | Literal>(quoted, pattern(/[^:\s'"]+/))
+const filterValue = oneOf<Quoted | Literal>(quoted, literal)
 
 /**
  * A {@link Parser} that will attempt to parse {@link Filter} tokens


### PR DESCRIPTION
The backend search parser does accept filter values that contain colon, eg. searching for `repo::` results in `" No repositories satisfied your repo: filter"`. While this is debatable behaviour, we should match it.

![image](https://user-images.githubusercontent.com/1741180/75348271-c6b63e80-58a2-11ea-9838-020254a4577d.png)