### PR TITLE
Document increased WriteTimeout as fix in 3.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+## 3.13.1
+
+### Fixed
+
+- To reduce the chance of users running into "502 Bad Gateway" errors an internal timeout has been increased from 60 seconds to 10 minutes so that long running requests are cut short by the proxy in front of `sourcegraph-frontend` and correctly reported as "504 Gateway Timeout". [#8606](https://github.com/sourcegraph/sourcegraph/pull/8606)
+
 ## 3.13.0
 
 ### Added


### PR DESCRIPTION
I want to ship https://github.com/sourcegraph/sourcegraph/pull/8606 (https://github.com/sourcegraph/sourcegraph/commit/4b038a28a25e7827baa2a31d7abb5871adfa0e4a) in a
patch release in 3.13.1.

This documents the change by adding a changelog entry.

I have **not** yet cherry-picked https://github.com/sourcegraph/sourcegraph/commit/4b038a28a25e7827baa2a31d7abb5871adfa0e4a into `3.13`.