### PR TITLE
highlight: only return `<table>` section for the result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Zoekt's watchdog ensures the service is down upto 3 times before exiting. The watchdog would misfire on startup on resource constrained systems, with the retries this should make a false positive far less likely. [#7867](https://github.com/sourcegraph/sourcegraph/issues/7867)
 - A regression in repo-updater was fixed that lead to every repository's git clone being updated every time the list of repositories was synced from the code host. [#8501](https://github.com/sourcegraph/sourcegraph/issues/8501)
 - Sourcegraph instances that are not connected to the internet will no longer display errors when users submit NPS survey responses (the responses will continue to be stored locally). Rather, an error will be printed to the frontend logs. [#8598](https://github.com/sourcegraph/sourcegraph/issues/8598)
+- Showing `head>` in the search results if the first line of the file is shown [#8619](https://github.com/sourcegraph/sourcegraph/issues/8619)
 
 ### Removed
 

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -442,7 +442,9 @@ func unhighlightLongLines(h string, n int) (string, error) {
 	}
 
 	buf.Reset()
-	if err := html.Render(&buf, doc); err != nil {
+	// NOTE: The result of html.Parse has parent nodes like "<html><head><body><table>..."
+	// to be a valid HTML, but what we want to return is just the <table> section.
+	if err := html.Render(&buf, table); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -107,9 +107,9 @@ func TestUnhighlightLongLines_Simple(t *testing.T) {
 </span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div><span>this line is over 40 bytes</span><span> so spans are not kept
 </span></div></td></tr></table>`
 
-	want := `<html><head></head><body><table><tbody><tr><td class="line" data-line="1"></td><td class="code"><div><span>under 40 bytes</span><span> spans are kept
+	want := `<table><tbody><tr><td class="line" data-line="1"></td><td class="code"><div><span>under 40 bytes</span><span> spans are kept
 </span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div><span>this line is over 40 bytes so spans are not kept
-</span></div></td></tr></tbody></table></body></html>`
+</span></div></td></tr></tbody></table>`
 	got, err := unhighlightLongLines(input, 40)
 	if err != nil {
 		t.Fatal(err)
@@ -130,7 +130,7 @@ func TestUnhighlightLongLines_Complex(t *testing.T) {
 </span></div></td></tr><tr><td class="line" data-line="8"></td><td class="code"><div><span style="color:#323232;">
 </span></div></td></tr><tr><td class="line" data-line="9"></td><td class="code"><div></div></td></tr></table>`
 
-	want := `<html><head></head><body><table><tbody><tr><td class="line" data-line="1"></td><td class="code"><div><span style="font-weight:bold;color:#a71d5d;">package</span><span style="color:#323232;"> spans on short lines like this are kept
+	want := `<table><tbody><tr><td class="line" data-line="1"></td><td class="code"><div><span style="font-weight:bold;color:#a71d5d;">package</span><span style="color:#323232;"> spans on short lines like this are kept
 </span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div><span style="color:#323232;">
 </span></div></td></tr><tr><td class="line" data-line="3"></td><td class="code"><div><span>spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber long lines like this are dropped spans on uber
 </span></div></td></tr><tr><td class="line" data-line="4"></td><td class="code"><div><span style="color:#323232;">	</span><span style="color:#183691;">&#34;net/http&#34;
@@ -138,7 +138,7 @@ func TestUnhighlightLongLines_Complex(t *testing.T) {
 </span></div></td></tr><tr><td class="line" data-line="6"></td><td class="code"><div><span style="color:#323232;">)
 </span></div></td></tr><tr><td class="line" data-line="7"></td><td class="code"><div><span style="color:#323232;">
 </span></div></td></tr><tr><td class="line" data-line="8"></td><td class="code"><div><span style="color:#323232;">
-</span></div></td></tr><tr><td class="line" data-line="9"></td><td class="code"><div></div></td></tr></tbody></table></body></html>`
+</span></div></td></tr><tr><td class="line" data-line="9"></td><td class="code"><div></div></td></tr></tbody></table>`
 	got, err := unhighlightLongLines(input, 1000)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Please see the code comment.

Fixes #8619.