### PR TITLE
go: upgrade to 1.14

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.13.8
+golang 1.14
 yarn 1.19.2

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -124,4 +124,6 @@ func (r *GitRefResolver) Target() interface {
 }
 func (r *GitRefResolver) Repository() *RepositoryResolver { return r.repo }
 
-func (r *GitRefResolver) URL() string { return r.repo.URL() + "@" + escapeRevspecForURL(r.AbbrevName()) }
+func (r *GitRefResolver) URL() string {
+	return r.repo.URL() + "@" + escapeRevspecForURL(r.AbbrevName())
+}

--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -33,6 +33,7 @@ echo ""
 
 # Recreate the test DB and run TestMigrations once to ensure that the schema version is the latest.
 set -ex
+asdf install # in case the go version has changed in between these two commits
 go test -count=1 -v ./cmd/frontend/db/  -run=TestMigrations
 HEAD="$HEAD" OLD="${COMMIT_BEFORE_LAST_MIGRATION}" ./dev/ci/db-backcompat.sh
 set +ex

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -26,7 +26,7 @@ Sourcegraph server is a collection of smaller binaries. The development server, 
 Sourcegraph has the following dependencies:
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (v2.18 or higher)
-- [Go](https://golang.org/doc/install) (v1.13 or higher)
+- [Go](https://golang.org/doc/install) (v1.14 or higher)
 - [Node JS](https://nodejs.org/en/download/) (see current recommended version in [.nvmrc](https://github.com/sourcegraph/sourcegraph/blob/master/.nvmrc))
 - [make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/engine/installation/) (v18 or higher)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go/datastore v1.1.0 // indirect

--- a/internal/extsvc/phabricator/client_test.go
+++ b/internal/extsvc/phabricator/client_test.go
@@ -62,7 +62,7 @@ func TestClient_ListRepos(t *testing.T) {
 		{
 			name: "timeout",
 			ctx:  timeout,
-			err:  "Post https://secure.phabricator.com/api/diffusion.repository.search: context deadline exceeded",
+			err:  `Post "https://secure.phabricator.com/api/diffusion.repository.search": context deadline exceeded`,
 		},
 	} {
 		tc := tc
@@ -136,7 +136,7 @@ func TestClient_GetRawDiff(t *testing.T) {
 	}, {
 		name: "timeout",
 		ctx:  timeout,
-		err:  "Post https://secure.phabricator.com/api/differential.getrawdiff: context deadline exceeded",
+		err:  `Post "https://secure.phabricator.com/api/differential.getrawdiff": context deadline exceeded`,
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestClient_GetDiffInfo(t *testing.T) {
 	}, {
 		name: "timeout",
 		ctx:  timeout,
-		err:  "Post https://secure.phabricator.com/api/differential.querydiffs: context deadline exceeded",
+		err:  `Post "https://secure.phabricator.com/api/differential.querydiffs": context deadline exceeded`,
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/version/minversion/minversion.go
+++ b/internal/version/minversion/minversion.go
@@ -20,7 +20,7 @@ func main() {
 	//
 	// Note: This is just for development, our images are built in CI with the
 	// version specified in .tool-versions in the root of our repository.
-	minimumVersion := "1.13"
+	minimumVersion := "1.14"
 	rawVersion := runtime.Version()
 	versionNumber := strings.TrimPrefix(rawVersion, "go")
 	minimumVersionMet := version.Compare(minimumVersion, versionNumber, "<=")


### PR DESCRIPTION
https://blog.golang.org/go1.14

---

Can someone from @sourcegraph/core-services own fixing this PR? It seems like the test failures are just `go fmt` related changes, but I'm not certain. I don't see any relevant changes to `go fmt` in the release notes. 