### PR TITLE
search: and/or expression parser

### DIFF
--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+/*
+Parser implements a parser for the following grammar:
+
+OrTerm     → AndTerm { OR AndTerm }
+AndTerm    → Term { AND Term }
+Term       → (OrTerm) | Parameters
+Parameters → Parameter { " " Parameter }
+*/
+
 type Node interface {
 	String() string
 	node()
@@ -57,9 +66,9 @@ type keyword string
 // Reserved keyword syntax.
 const (
 	AND    keyword = "and"
-	OR             = "or"
-	LPAREN         = "("
-	RPAREN         = ")"
+	OR     keyword = "or"
+	LPAREN keyword = "("
+	RPAREN keyword = ")"
 )
 
 func isSpace(c byte) bool {

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -1,0 +1,264 @@
+package search
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Node interface {
+	String() string
+}
+
+type Parameter struct {
+	Value string
+}
+
+type Op struct {
+	Kind     string
+	Children []Node
+}
+
+func (node Parameter) String() string {
+	return node.Value
+}
+
+func (node Op) String() string {
+	var result []string
+	for _, child := range node.Children {
+		result = append(result, child.String())
+	}
+	return fmt.Sprintf("(%s %s)", strings.ToLower(node.Kind), strings.Join(result, " "))
+}
+
+func isSpace(c byte) bool {
+	return (c == ' ') || (c == '\n') || (c == '\r') || (c == '\t')
+}
+
+func skipSpace(buf []byte) int {
+	for i, c := range buf {
+		if !isSpace(c) {
+			return i
+		}
+	}
+	return len(buf)
+}
+
+type state struct {
+	buf      []byte
+	pos      int
+	balanced int
+}
+
+func (s *state) done() bool {
+	return s.pos >= len(s.buf)
+}
+
+func (s *state) advance(n int) {
+	s.pos += n
+}
+
+func (s *state) peek(n int) (string, error) {
+	if s.pos+n > len(s.buf) {
+		return "", io.ErrShortBuffer
+	}
+	return string(s.buf[s.pos : s.pos+n]), nil
+}
+
+func (s *state) skipSpaces() error {
+	if s.pos > len(s.buf) {
+		return io.ErrShortBuffer
+	}
+
+	s.pos += skipSpace(s.buf[s.pos:])
+	if s.pos > len(s.buf) {
+		return io.ErrShortBuffer
+	}
+	return nil
+}
+
+// reserved returns a reserved string (token) and it's value at the current
+// position. If no such reserved string exists, it returns the empty string.
+// This lets the parser observe syntactic cues and decide to, e.g., keep lexing
+// or return control to parsing a different term.
+func (s *state) reserved() string {
+	if v, err := s.peek(3); err == nil && (v == "AND" || v == "and") {
+		return "and"
+	}
+	if v, err := s.peek(2); err == nil && (v == "OR" || v == "or") {
+		return "or"
+	}
+	if v, err := s.peek(1); err == nil && (v == "(" || v == ")") {
+		return v
+	}
+	return ""
+}
+
+func (s *state) scanParameter() (string, error) {
+	start := s.pos
+	for {
+		if v := s.reserved(); v != "" {
+			break
+		}
+		if s.done() {
+			break
+		}
+		if isSpace(s.buf[s.pos]) {
+			break
+		}
+		s.pos++
+	}
+	return string(s.buf[start:s.pos]), nil
+}
+
+func (s *state) parseParameterList() ([]Node, error) {
+	var nodes []Node
+	for {
+		if err := s.skipSpaces(); err != nil {
+			return nil, err
+		}
+		if s.done() {
+			break
+		}
+		switch s.reserved() {
+		case "(":
+			s.balanced++
+			s.advance(1)
+			result, err := s.parseOr()
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, result...)
+		case ")":
+			s.balanced--
+			s.advance(1)
+			return nodes, nil
+		case "and", "or":
+			// caller advances
+			return nodes, nil
+		default:
+			value, err := s.scanParameter()
+			if err != nil {
+				return nil, err
+			}
+			if value != "" {
+				nodes = append(nodes, Parameter{Value: value})
+			}
+		}
+	}
+	return nodes, nil
+}
+
+func reduce(left, right []Node, kind string) ([]Node, bool) {
+	switch right[0].(type) {
+	case Op:
+		if kind == right[0].(Op).Kind {
+			// Reduce right node
+			left = append(left, right[0].(Op).Children...)
+			if len(right) > 1 {
+				left = append(left, right[1:]...)
+			}
+			return left, true
+		}
+	case Parameter:
+		switch left[0].(type) {
+		case Op:
+			if kind == left[0].(Op).Kind {
+				// Reduce left node
+				return append(left[0].(Op).Children, right...), true
+			}
+		}
+	}
+	if len(right) > 1 {
+		// Reduce right list
+		reduced, changed := reduce(append(left, right[0]), right[1:], kind)
+		if changed {
+			return reduced, true
+		}
+	}
+	return append(left, right...), false
+}
+
+func newOp(nodes []Node, kind string) []Node {
+	if len(nodes) == 0 {
+		return nil
+	} else if len(nodes) == 1 {
+		return nodes
+	}
+
+	reduced, changed := reduce([]Node{nodes[0]}, nodes[1:], kind)
+	if changed {
+		return newOp(reduced, kind)
+	}
+
+	return []Node{Op{Kind: kind, Children: reduced}}
+}
+
+func newAnd(nodes []Node) []Node {
+	return newOp(nodes, "and")
+}
+
+func newOr(nodes []Node) []Node {
+	return newOp(nodes, "or")
+}
+
+func (s *state) continueParsing(left []Node, operator string) ([]Node, error) {
+	if left == nil {
+		return nil, fmt.Errorf("expected operand at %d", s.pos)
+	}
+
+	var parse func() ([]Node, error)
+	var newOp func(nodes []Node) []Node
+	if operator == "and" {
+		parse = s.parseAnd
+		newOp = newAnd
+	} else {
+		parse = s.parseOr
+		newOp = newOr
+	}
+
+	if s.done() {
+		return newOp(left), nil
+	}
+	if s.reserved() == operator {
+		s.advance(len(operator))
+		right, err := parse()
+		if err != nil {
+			return nil, err
+		}
+		return newOp(append(left, right...)), nil
+	}
+	return newOp(left), nil
+}
+
+func (s *state) parseAnd() ([]Node, error) {
+	left, err := s.parseParameterList()
+	if err != nil {
+		return nil, err
+	}
+	return s.continueParsing(left, "and")
+}
+
+func (s *state) parseOr() ([]Node, error) {
+	left, err := s.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	return s.continueParsing(left, "or")
+}
+
+func Parse(in string) ([]Node, error) {
+	if in == "" {
+		return nil, nil
+	}
+	state := &state{buf: []byte(in)}
+	nodes, err := state.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if state.balanced != 0 {
+		return nil, errors.New("unbalanced expression")
+	}
+	return nodes, nil
+}

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -210,14 +210,6 @@ func newOperator(nodes []Node, kind string) []Node {
 	return []Node{Operator{Kind: kind, Operands: reduced}}
 }
 
-func newAnd(nodes []Node) []Node {
-	return newOperator(nodes, "and")
-}
-
-func newOr(nodes []Node) []Node {
-	return newOperator(nodes, "or")
-}
-
 func (p *parser) parseAnd() ([]Node, error) {
 	left, err := p.parseParameterList()
 	if err != nil {
@@ -227,13 +219,13 @@ func (p *parser) parseAnd() ([]Node, error) {
 		return nil, fmt.Errorf("expected operand at %d", p.pos)
 	}
 	if !p.expect("and") {
-		return newAnd(left), nil
+		return left, nil
 	}
 	right, err := p.parseAnd()
 	if err != nil {
 		return nil, err
 	}
-	return newAnd(append(left, right...)), nil
+	return newOperator(append(left, right...), "and"), nil
 }
 
 func (p *parser) parseOr() ([]Node, error) {
@@ -245,13 +237,13 @@ func (p *parser) parseOr() ([]Node, error) {
 		return nil, fmt.Errorf("expected operand at %d", p.pos)
 	}
 	if !p.expect("or") {
-		return newAnd(left), nil
+		return left, nil
 	}
 	right, err := p.parseOr()
 	if err != nil {
 		return nil, err
 	}
-	return newOr(append(left, right...)), nil
+	return newOperator(append(left, right...), "or"), nil
 }
 
 func Parse(in string) ([]Node, error) {
@@ -266,5 +258,5 @@ func Parse(in string) ([]Node, error) {
 	if parser.balanced != 0 {
 		return nil, errors.New("unbalanced expression")
 	}
-	return nodes, nil
+	return newOperator(nodes, "and"), nil
 }

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -19,6 +19,16 @@ func Test_Parse(t *testing.T) {
 			Want:  "",
 		},
 		{
+			Name:  "Single",
+			Input: "a",
+			Want:  "a",
+		},
+		{
+			Name:  "Whitespace basic",
+			Input: "a b",
+			Want:  "(and a b)",
+		},
+		{
 			Name:  "Basic",
 			Input: "a and b and c",
 			Want:  "(and a b c)",
@@ -58,6 +68,7 @@ func Test_Parse(t *testing.T) {
 			Input: "(((a b c))) and d",
 			Want:  "(and a b c d)",
 		},
+		// Errors.
 		{
 			Name:  "Unbalanced",
 			Input: "(foo) (bar",
@@ -88,6 +99,7 @@ func Test_Parse(t *testing.T) {
 			Input: "or or or",
 			Want:  "expected operand at 0",
 		},
+		// Reduction.
 		{
 			Name:  "paren reduction with ands",
 			Input: "(a and b) and (c and d)",
@@ -132,6 +144,37 @@ func Test_Parse(t *testing.T) {
 			Name:  "mixed interpolated grouped paren reduction",
 			Input: "(a and b and (z or q)) and (c and d) and (e and f)",
 			Want:  "(and a b (or z q) c d e f)",
+		},
+		// Parentheses.
+		{
+			Name:  "empty paren",
+			Input: "()",
+			Want:  "",
+		},
+		{
+			Name:  "nested empty paren",
+			Input: "(x())",
+			Want:  "x",
+		},
+		{
+			Name:  "interpolated nested empty paren",
+			Input: "(()x(  )(())())",
+			Want:  "x",
+		},
+		{
+			Name:  "empty paren on or",
+			Input: "() or ()",
+			Want:  "",
+		},
+		{
+			Name:  "empty left paren on or",
+			Input: "() or (x)",
+			Want:  "x",
+		},
+		{
+			Name:  "complex interpolated nested empty paren",
+			Input: "(()x(  )(y or () or (f))())",
+			Want:  "(and x (or y f))",
 		},
 	}
 	for _, tt := range cases {

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -1,0 +1,156 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_Parse(t *testing.T) {
+	cases := []struct {
+		Name  string
+		Input string
+		Want  string
+	}{
+		{
+			Name:  "Empty string",
+			Input: "",
+			Want:  "",
+		},
+		{
+			Name:  "Basic",
+			Input: "a and b and c",
+			Want:  "(and a b c)",
+		},
+		{
+			Name:  "Reduced complex query mixed caps",
+			Input: "a and b AND c or d and (e OR f) g h i or j",
+			Want:  "(or (and a b c) (and d (or e f) g h i) j)",
+		},
+		{
+			Name:  "Basic reduced complex query",
+			Input: "a and b or c and d or e",
+			Want:  "(or (and a b) (and c d) e)",
+		},
+		{
+			Name:  "Reduced complex query, reduction over parens",
+			Input: "(a and b or c and d) or e",
+			Want:  "(or (and a b) (and c d) e)",
+		},
+		{
+			Name:  "Reduced complex query, nested 'or' trickles up",
+			Input: "(a and b or c) or d",
+			Want:  "(or (and a b) c d)",
+		},
+		{
+			Name:  "Reduced complex query, nested nested 'or' trickles up",
+			Input: "(a and b or (c and d or f)) or e",
+			Want:  "(or (and a b) (and c d) f e)",
+		},
+		{
+			Name:  "No reduction on precedence defined by parens",
+			Input: "(a and (b or c) and d) or e",
+			Want:  "(or (and a (or b c) d) e)",
+		},
+		{
+			Name:  "Paren reduction over operators",
+			Input: "(((a b c))) and d",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "Unbalanced",
+			Input: "(foo) (bar",
+			Want:  "unbalanced expression",
+		},
+		{
+			Name:  "Incomplete expression",
+			Input: "a or",
+			Want:  "expected operand at 4",
+		},
+		{
+			Name:  "Illegal expression on the right",
+			Input: "a or or b",
+			Want:  "expected operand at 5",
+		},
+		{
+			Name:  "Illegal expression on the right, mixed operators",
+			Input: "a and OR",
+			Want:  "expected operand at 6",
+		},
+		{
+			Name:  "Illegal expression on the left",
+			Input: "or",
+			Want:  "expected operand at 0",
+		},
+		{
+			Name:  "Illegal expression on the left, multiple operators",
+			Input: "or or or",
+			Want:  "expected operand at 0",
+		},
+		{
+			Name:  "paren reduction with ands",
+			Input: "(a and b) and (c and d)",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "paren reduction with ors",
+			Input: "(a or b) or (c or d)",
+			Want:  "(or a b c d)",
+		},
+		{
+			Name:  "nested paren reduction with whitespace",
+			Input: "(((a b c))) d",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "left paren reduction with whitespace",
+			Input: "(a b) c d",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "right paren reduction with whitespace",
+			Input: "a b (c d)",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "grouped paren reduction with whitespace",
+			Input: "(a b) (c d)",
+			Want:  "(and a b c d)",
+		},
+		{
+			Name:  "multiple grouped paren reduction with whitespace",
+			Input: "(a b) (c d) (e f)",
+			Want:  "(and a b c d e f)",
+		},
+		{
+			Name:  "interpolated grouped paren reduction",
+			Input: "(a b) c d (e f)",
+			Want:  "(and a b c d e f)",
+		},
+		{
+			Name:  "mixed interpolated grouped paren reduction",
+			Input: "(a and b and (z or q)) and (c and d) and (e and f)",
+			Want:  "(and a b (or z q) c d e f)",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			result, err := Parse(tt.Input)
+			if err != nil {
+				if diff := cmp.Diff(tt.Want, err.Error()); diff != "" {
+					t.Fatal(diff)
+				}
+				return
+			}
+			var resultStr []string
+			for _, node := range result {
+				resultStr = append(resultStr, node.String())
+			}
+			got := strings.Join(resultStr, " ")
+			if diff := cmp.Diff(tt.Want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is just the parser for the basic tree structure we want to target with tests. Leaves are only strings. This code is not called by any of our code yet. I will incrementally build on this code until it converges with our current query parsing and types, and migrate existing tests. Right now it's time to start checking in code :-). See the test inputs to get an idea of what's supported.

---

**Background** for posterity and those interested

I wanted to avoid a couple of things to make our implementation simple and straightforward. I looked at existing parser generators and implementations (including Zoekt's) and there was usually something that I put me off :P (confusing or bloated code). I used some existing implementations as inspiration but eventually settled on this PR. Implementation highlights:

- No lex/parse distinction. Unnecessary level of indirection, particularly for something simpler like our language.
- No token types: parse directly to the tree data structure. The traditional idea of having tokens might be helpful in some cases but it doesn't really gain much (in our context) and adds another layer of definitions that we don't need.
- No state tracking for operator precedence parsing, it's implicit in the recursion order.
- Parser control flow depends on lookahead on reserved syntax/keywords like `(`, `and`, `or`.
- No extra steps or processing for tree reduction: expressions reduce as the tree is constructed during parsing. This removes the need for implementing another post processing pass. The key functions that do this are `newOp` and `reduce` and not very long. For comparison, the Zoekt implementation is ~130 lines just for this [simplification](https://sourcegraph.com/github.com/sourcegraph/zoekt/-/blob/query/query.go#L300-453), and it's not obvious what's going on, and does an additional traversal of the query after parsing (not that perf matters, but it's just preferable to avoid the complexity). This is also one of the reasons I avoided generators, which usually return the raw tree. In our language we know what reductions we can do at parsing time thanks to the shape of the grammar.

Next steps, to happen in subsequent PRs:

- Support the lexical parts of our current queries (parameters, pattern sequences, `not`)
- Add unicode support
- Migrate tests