### PR TITLE
authz: enforce one authz provider per code host type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The "automation" feature was renamed to "campaigns".
   - `campaigns.readAccess.enabled` replaces the deprecated site configuration property `automation.readAccess.enabled`.
   - The experimental feature flag was not renamed (because it will go away soon) and remains `{"experimentalFeatures": {"automation": "enabled"}}`.
+- Enforce only one authorization configuration per code host type is supported.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The "automation" feature was renamed to "campaigns".
   - `campaigns.readAccess.enabled` replaces the deprecated site configuration property `automation.readAccess.enabled`.
   - The experimental feature flag was not renamed (because it will go away soon) and remains `{"experimentalFeatures": {"automation": "enabled"}}`.
-- Enforce only one authorization configuration per code host type is supported.
+- A new validation enforces that only one authorization configuration is set per code host type.
 
 ### Fixed
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -4,7 +4,7 @@ Sourcegraph can be configured to enforce repository permissions from code hosts.
 
 Currently, GitHub, GitHub Enterprise, GitLab and Bitbucket Server permissions are supported. Check our [product direction](https://about.sourcegraph.com/direction) for plans to support other code hosts. If your desired code host is not yet on the roadmap, please [open a feature request](https://github.com/sourcegraph/sourcegraph/issues/new?template=feature_request.md).
 
-Please be noted that we only support enforcing repository permissions for one code host per type. For example, you are able to configure authorization for one GitHub and one GitLab instances, but not for two GitLab instances. Although it is still possible to configure as many instances as you need for adding repositories to your Sourcegraph instance.
+Please note that we only support enforcing repository permissions for one code host per type. You can, for example, configure authorization for one GitHub and one GitLab instance but not for two GitLab instances. That doesn't affect how many code hosts are can be configured to sync repositories.
 
 > NOTE: Site admin users bypass all permission checks and have access to every repository on Sourcegraph.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -4,6 +4,8 @@ Sourcegraph can be configured to enforce repository permissions from code hosts.
 
 Currently, GitHub, GitHub Enterprise, GitLab and Bitbucket Server permissions are supported. Check our [product direction](https://about.sourcegraph.com/direction) for plans to support other code hosts. If your desired code host is not yet on the roadmap, please [open a feature request](https://github.com/sourcegraph/sourcegraph/issues/new?template=feature_request.md).
 
+Please be noted that we only support enforcing repository permissions for one code host per type. For example, you are able to configure authorization for one GitHub and one GitLab instances, but not for two GitLab instances. Although it is still possible to configure as many instances as you need for adding repositories to your Sourcegraph instance.
+
 > NOTE: Site admin users bypass all permission checks and have access to every repository on Sourcegraph.
 
 ## GitHub

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -169,7 +169,7 @@ func authzProvidersFromConfig(
 	} else {
 		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(ghConns)
 		if len(ghProviders) > 1 {
-			ghProblems = append(ghProblems, "Only one GitHub authorization configuration is supported.")
+			ghWarnings = append(ghWarnings, "Only one GitHub authorization configuration is supported.")
 		}
 		providers = append(providers, ghProviders...)
 		seriousProblems = append(seriousProblems, ghProblems...)
@@ -181,7 +181,7 @@ func authzProvidersFromConfig(
 	} else {
 		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg, glConns)
 		if len(glProviders) > 1 {
-			glProblems = append(glProblems, "Only one GitLab authorization configuration is supported.")
+			glWarnings = append(glWarnings, "Only one GitLab authorization configuration is supported.")
 		}
 		providers = append(providers, glProviders...)
 		seriousProblems = append(seriousProblems, glProblems...)
@@ -193,7 +193,7 @@ func authzProvidersFromConfig(
 	} else {
 		bbsProviders, bbsProblems, bbsWarnings := bitbucketserver.NewAuthzProviders(bbsConns, db)
 		if len(bbsProviders) > 1 {
-			bbsProblems = append(bbsProblems, "Only one Bitbucket Server authorization configuration is supported.")
+			bbsWarnings = append(bbsWarnings, "Only one Bitbucket Server authorization configuration is supported.")
 		}
 		providers = append(providers, bbsProviders...)
 		seriousProblems = append(seriousProblems, bbsProblems...)

--- a/enterprise/cmd/frontend/authz.go
+++ b/enterprise/cmd/frontend/authz.go
@@ -168,6 +168,9 @@ func authzProvidersFromConfig(
 		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load GitHub external service configs: %s", err))
 	} else {
 		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(ghConns)
+		if len(ghProviders) > 1 {
+			ghProblems = append(ghProblems, "Only one GitHub authorization configuration is supported.")
+		}
 		providers = append(providers, ghProviders...)
 		seriousProblems = append(seriousProblems, ghProblems...)
 		warnings = append(warnings, ghWarnings...)
@@ -177,6 +180,9 @@ func authzProvidersFromConfig(
 		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load GitLab external service configs: %s", err))
 	} else {
 		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg, glConns)
+		if len(glProviders) > 1 {
+			glProblems = append(glProblems, "Only one GitLab authorization configuration is supported.")
+		}
 		providers = append(providers, glProviders...)
 		seriousProblems = append(seriousProblems, glProblems...)
 		warnings = append(warnings, glWarnings...)
@@ -186,6 +192,9 @@ func authzProvidersFromConfig(
 		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load Bitbucket Server external service configs: %s", err))
 	} else {
 		bbsProviders, bbsProblems, bbsWarnings := bitbucketserver.NewAuthzProviders(bbsConns, db)
+		if len(bbsProviders) > 1 {
+			bbsProblems = append(bbsProblems, "Only one Bitbucket Server authorization configuration is supported.")
+		}
 		providers = append(providers, bbsProviders...)
 		seriousProblems = append(seriousProblems, bbsProblems...)
 		warnings = append(warnings, bbsWarnings...)

--- a/enterprise/cmd/frontend/authz_test.go
+++ b/enterprise/cmd/frontend/authz_test.go
@@ -205,7 +205,25 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 				},
 			},
 			expAuthzAllowAccessByDefault: true,
-			expWarnings:                  []string{"Only one GitLab authorization configuration is supported."},
+			expAuthzProviders: providersEqual(
+				gitlabAuthzProviderParams{
+					OAuthOp: gitlab.OAuthAuthzProviderOp{
+						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
+						CacheTTL:          3 * time.Hour,
+						MinBatchThreshold: 200,
+						MaxBatchRequests:  300,
+					},
+				},
+				gitlabAuthzProviderParams{
+					OAuthOp: gitlab.OAuthAuthzProviderOp{
+						BaseURL:           mustURLParse(t, "https://gitlab.com"),
+						CacheTTL:          3 * time.Hour,
+						MinBatchThreshold: 200,
+						MaxBatchRequests:  300,
+					},
+				},
+			),
+			expWarnings: []string{"Only one GitLab authorization configuration is supported."},
 		},
 		{
 			description: "1 GitLab connection with authz disabled",


### PR DESCRIPTION
This PR enforces one authz provider per code host type in the code level, also updated relevant docs.

![image](https://user-images.githubusercontent.com/2946214/75538239-3f5bfd00-5a53-11ea-9bb0-a5ce1d7b454b.png)


Fixes #8597.