### PR TITLE
Do not show "Restart server" button if server cannot be restarted

### DIFF
--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -332,9 +332,11 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                     className="alert alert-warning site-admin-configuration-page__alert site-admin-configuration-page__alert-flex"
                 >
                     Server restart is required for the configuration to take effect.
-                    <button type="button" className="btn btn-primary btn-sm" onClick={this.reloadSite}>
-                        Restart server
-                    </button>
+                    {(this.state.site === undefined || this.state.site?.canReloadSite) && (
+                        <button type="button" className="btn btn-primary btn-sm" onClick={this.reloadSite}>
+                            Restart server
+                        </button>
+                    )}
                 </div>
             )
         }

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -293,6 +293,7 @@ export function fetchSite(): Observable<GQL.ISite> {
         query Site {
             site {
                 id
+                canReloadSite
                 configuration {
                     id
                     effectiveContents


### PR DESCRIPTION
I ran into this when setting up a k8s test cluster yesterday and got
really frustrated by the error message "Server cannot be restarted"
after I hit the "restart server" button.
