### PR TITLE
LSIF: Ensure document URIs are always relative to dump root.

### DIFF
--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -204,7 +204,14 @@ export async function convertTestData(
 
     const tmp = path.join(storageRoot, constants.TEMP_DIR, uuid.v4())
     const pathExistenceChecker = new PathExistenceChecker({ repositoryId, commit, root })
-    const { packages, references } = await convertLsif(fullFilename, '', tmp, pathExistenceChecker)
+
+    const { packages, references } = await convertLsif({
+        path: fullFilename,
+        root: '',
+        database: tmp,
+        pathExistenceChecker,
+    })
+
     const dump = await insertDump(connection, dumpManager, repositoryId, commit, root, indexer)
     await dependencyManager.addPackagesAndReferences(dump.id, packages, references)
     await fs.rename(tmp, dbFilename(storageRoot, dump.id))

--- a/lsif/src/tests/integration/integration-test-util.ts
+++ b/lsif/src/tests/integration/integration-test-util.ts
@@ -204,7 +204,7 @@ export async function convertTestData(
 
     const tmp = path.join(storageRoot, constants.TEMP_DIR, uuid.v4())
     const pathExistenceChecker = new PathExistenceChecker({ repositoryId, commit, root })
-    const { packages, references } = await convertLsif(fullFilename, tmp, pathExistenceChecker)
+    const { packages, references } = await convertLsif(fullFilename, '', tmp, pathExistenceChecker)
     const dump = await insertDump(connection, dumpManager, repositoryId, commit, root, indexer)
     await dependencyManager.addPackagesAndReferences(dump.id, packages, references)
     await fs.rename(tmp, dbFilename(storageRoot, dump.id))

--- a/lsif/src/worker/conversion/conversion.ts
+++ b/lsif/src/worker/conversion/conversion.ts
@@ -45,7 +45,13 @@ export async function convertDatabase(
         })
 
         // Create database in a temp path
-        const { packages, references } = await convertLsif(upload.filename, tempFile, pathExistenceChecker, ctx)
+        const { packages, references } = await convertLsif(
+            upload.filename,
+            upload.root,
+            tempFile,
+            pathExistenceChecker,
+            ctx
+        )
 
         // Insert dump and add packages and references to Postgres
         await dependencyManager.addPackagesAndReferences(upload.id, packages, references, ctx, entityManager)

--- a/lsif/src/worker/conversion/conversion.ts
+++ b/lsif/src/worker/conversion/conversion.ts
@@ -45,13 +45,13 @@ export async function convertDatabase(
         })
 
         // Create database in a temp path
-        const { packages, references } = await convertLsif(
-            upload.filename,
-            upload.root,
-            tempFile,
+        const { packages, references } = await convertLsif({
+            path: upload.filename,
+            root: upload.root,
+            database: tempFile,
             pathExistenceChecker,
-            ctx
-        )
+            ctx,
+        })
 
         // Insert dump and add packages and references to Postgres
         await dependencyManager.addPackagesAndReferences(upload.id, packages, references, ctx, entityManager)

--- a/lsif/src/worker/conversion/correlator.ts
+++ b/lsif/src/worker/conversion/correlator.ts
@@ -100,7 +100,13 @@ export class Correlator {
      */
     public exportedMonikers = new Set<sqliteModels.MonikerId>()
 
-    constructor(private logger: Logger = createSilentLogger()) {}
+    /**
+     * Creates a new Correlator.
+     *
+     * @param dumpRoot The repository-relative root of all files that are in the dump.
+     * @param logger The logger instance.
+     */
+    constructor(private dumpRoot: string = '', private logger: Logger = createSilentLogger()) {}
 
     /**
      * Process a single vertex or edge.
@@ -250,6 +256,19 @@ export class Correlator {
     private handleMetaData(vertex: lsif.MetaData): void {
         this.lsifVersion = vertex.version
         this.projectRoot = new URL(vertex.projectRoot)
+
+        // We assume that the project root in the LSIF dump is either:
+        //
+        //   (1) the root of the LSIF dump, or
+        //   (2) the root of the repository
+        //
+        // These are the common cases and we don't explicitly support
+        // anything else. Here we normalize to (1) by appending the dump
+        // root if it's not already suffixed by it.
+
+        if (this.dumpRoot !== '' && !this.projectRoot.href.endsWith(this.dumpRoot)) {
+            this.projectRoot = new URL(this.dumpRoot, `${this.projectRoot.href}/`)
+        }
     }
 
     //

--- a/lsif/src/worker/conversion/importer.ts
+++ b/lsif/src/worker/conversion/importer.ts
@@ -49,19 +49,26 @@ const MAX_NUM_RESULT_CHUNKS = readEnvInt('MAX_NUM_RESULT_CHUNKS', 1000)
  * Populate a SQLite database with the given input stream. Returns the
  * data required to populate the dependency tables in Postgres.
  *
- * @param path The filepath containing a gzipped compressed stream of JSON lines composing the LSIF dump.
- * @param root The root of all files that are in the dump.
- * @param database The filepath of the database to populate.
- * @param pathExistenceChecker An object that tracks whether a path is visible within the LSIF dump.
- * @param ctx The tracing context.
+ * @param args Parameter bag.
  */
-export async function convertLsif(
-    path: string,
-    root: string,
-    database: string,
-    pathExistenceChecker: PathExistenceChecker,
-    { logger = createSilentLogger(), span }: TracingContext = {}
-): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
+export async function convertLsif({
+    path,
+    root,
+    database,
+    pathExistenceChecker,
+    ctx: { logger = createSilentLogger(), span } = {},
+}: {
+    /** The filepath containing a gzipped compressed stream of JSON lines composing the LSIF dump. */
+    path: string
+    /** The root of all files that are in the dump. */
+    root: string
+    /** The filepath of the database to populate. */
+    database: string
+    /** An object that tracks whether a path is visible within the LSIF dump. */
+    pathExistenceChecker: PathExistenceChecker
+    /** The tracing context. */
+    ctx?: TracingContext
+}): Promise<{ packages: Package[]; references: SymbolReferences[] }> {
     const connection = await createSqliteConnection(database, sqliteModels.entities, logger)
 
     try {


### PR DESCRIPTION
This PR makes an assumption explicit (one that we had before): an LSIF upload's projectRoot value will be either the repository root (which is now true in lsif-go and our fork of lsif-node via https://github.com/sourcegraph/lsif-go/pull/46 and https://github.com/sourcegraph/lsif-node/pull/10), or will be the path to the subproject being indexed.

No other projectRoot really makes sense, so I feel it's appropriate to enforce this on the indexer's side.