### PR TITLE
Add cursor pointer to search reference sheet

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -191,6 +191,10 @@ body,
     flex: 1;
 }
 
+.cursor-pointer {
+    cursor: pointer;
+}
+
 // Our simple popovers only need these styles. We don't want the caret or special font sizes from
 // Bootstrap's popover CSS.
 .popover-inner {

--- a/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -16,7 +16,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
             <DropdownToggle
                 tag="span"
                 caret={false}
-                className="px-2 btn btn-link d-flex align-items-center"
+                className="px-2 btn btn-link d-flex align-items-center cursor-pointer"
                 aria-label="Quick help for search"
             >
                 <HelpCircleOutlineIcon className="icon-inline small" aria-hidden="true" />


### PR DESCRIPTION
Before it didn't look like it can be clicked, because the cursor was still the 'arrow' 