### PR TITLE
Properly return nil for unresolvable node

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -279,6 +279,9 @@ func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }
 	if err != nil {
 		return nil, err
 	}
+	if n == nil {
+		return nil, nil
+	}
 	return &NodeResolver{n}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -62,6 +62,9 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 
 	changeset, err := r.store.GetChangeset(ctx, ee.GetChangesetOpts{ID: changesetID})
 	if err != nil {
+		if err == ee.ErrNoResults {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -81,6 +84,9 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 
 	campaign, err := r.store.GetCampaign(ctx, ee.GetCampaignOpts{ID: campaignID})
 	if err != nil {
+		if err == ee.ErrNoResults {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -100,6 +106,9 @@ func (r *Resolver) ChangesetPlanByID(ctx context.Context, id graphql.ID) (graphq
 
 	job, err := r.store.GetCampaignJob(ctx, ee.GetCampaignJobOpts{ID: campaignJobID})
 	if err != nil {
+		if err == ee.ErrNoResults {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -119,6 +128,9 @@ func (r *Resolver) CampaignPlanByID(ctx context.Context, id graphql.ID) (graphql
 
 	plan, err := r.store.GetCampaignPlan(ctx, ee.GetCampaignPlanOpts{ID: planID})
 	if err != nil {
+		if err == ee.ErrNoResults {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently, an error is thrown on the query, but the schema also allows Node to return null
This enables a pretty "campaign not found" error message instead of an ugly error

Before:
![image](https://user-images.githubusercontent.com/19534377/75544896-32281980-5a25-11ea-8e60-5933cc2f2323.png)

After:
![image](https://user-images.githubusercontent.com/19534377/75544876-289eb180-5a25-11ea-8bbe-8d4355de24cf.png)
