### PR TITLE
Rename C# language ID from cs -> csharp.

### DIFF
--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -62,7 +62,7 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'sh':
         case 'bash':
         case 'zsh':
-            return 'bash'
+            return 'shell'
 
         // Clojure
         case 'clj':

--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -91,7 +91,7 @@ function getModeFromExtension(ext: string): string | undefined {
         // C#
         case 'cs':
         case 'csx':
-            return 'cs'
+            return 'csharp'
 
         // C++
         case 'c':


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1582759442042200