### PR TITLE
conf: add docker-compose and pure-docker deploy types

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -29,22 +29,31 @@ var pubSubPingsTopicID = env.Get("PUBSUB_TOPIC_ID", "", "Pub/sub pings topic ID 
 
 var (
 	// latestReleaseDockerServerImageBuild is only used by sourcegraph.com to tell existing
-	// non-cluster installations what the latest version is. The version here _must_ be
-	// available at https://hub.docker.com/r/sourcegraph/server/tags/ before
-	// landing in master.
+	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
+	//version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
+	// before landing in master.
 	latestReleaseDockerServerImageBuild = newBuild("3.13.1")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
 	latestReleaseKubernetesBuild = newBuild("3.13.1")
+
+	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
+	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
+	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
+	latestReleaseDockerComposeOrPureDocker = newBuild("3.12.5-1")
 )
 
 func getLatestRelease(deployType string) build {
-	if conf.IsDeployTypeCluster(deployType) {
+	switch {
+	case conf.IsDeployTypeCluster(deployType):
 		return latestReleaseKubernetesBuild
+	case conf.IsDeployTypeDockerCompose(deployType), conf.IsDeployTypePureDocker(deployType):
+		return latestReleaseDockerComposeOrPureDocker
+	default:
+		return latestReleaseDockerServerImageBuild
 	}
-	return latestReleaseDockerServerImageBuild
 }
 
 // Handler is an HTTP handler that responds with information about software updates

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -47,7 +47,7 @@ var (
 
 func getLatestRelease(deployType string) build {
 	switch {
-	case conf.IsDeployTypeCluster(deployType):
+	case conf.IsDeployTypeKubernetes(deployType):
 		return latestReleaseKubernetesBuild
 	case conf.IsDeployTypeDockerCompose(deployType), conf.IsDeployTypePureDocker(deployType):
 		return latestReleaseDockerComposeOrPureDocker

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler_test.go
@@ -46,6 +46,22 @@ func TestLatestKubernetesVersionPushed(t *testing.T) {
 	}
 }
 
+func TestLatestDockerComposeOrPureDockerVersionPushed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping due to network request")
+	}
+
+	url := fmt.Sprintf("https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v%v", latestReleaseDockerComposeOrPureDocker.Version)
+	resp, err := http.Head(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Could not find Docker Compose or Pure Docker release %s on GitHub. Response code %s from %s, err: %v", latestReleaseDockerComposeOrPureDocker.Version, resp.Status, url, err)
+	}
+}
+
 func TestCanUpdate(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	deployType := DeployType()
 	if !IsValidDeployType(deployType) {
-		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q. Got: %q", DeployCluster, DeployDocker, DeployDev, deployType)
+		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q. Got: %q", DeployCluster, DeployDockerCompose, DeployPureDocker, DeploySingleDocker, DeployDev, deployType)
 	}
 
 	confdefaults.Default = defaultConfigForDeployment()
@@ -27,9 +27,9 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 	switch {
 	case IsDev(deployType):
 		return confdefaults.DevAndTesting
-	case IsDeployTypeDockerContainer(deployType):
+	case IsDeployTypeSingleDockerContainer(deployType):
 		return confdefaults.DockerContainer
-	case IsDeployTypeCluster(deployType):
+	case IsDeployTypeCluster(deployType), IsDeployTypeDockerCompose(deployType), IsDeployTypePureDocker(deployType):
 		return confdefaults.Cluster
 	default:
 		panic("deploy type did not register default configuration")
@@ -136,9 +136,11 @@ func CanReadEmail() bool {
 // Deploy type constants. Any changes here should be reflected in the DeployType type declared in web/src/globals.d.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
 const (
-	DeployCluster = "cluster"
-	DeployDocker  = "docker-container"
-	DeployDev     = "dev"
+	DeployCluster       = "cluster"
+	DeploySingleDocker  = "docker-container"
+	DeployDockerCompose = "docker-compose"
+	DeployPureDocker    = "pure-docker"
+	DeployDev           = "dev"
 )
 
 // DeployType tells the deployment type.
@@ -152,7 +154,7 @@ func DeployType() string {
 }
 
 // IsDeployTypeCluster tells if the given deployment type is a cluster (and
-// non-dev, non-single Docker image).
+// non-dev, not docker-compose, not pure-docker, and non-single Docker image).
 func IsDeployTypeCluster(deployType string) bool {
 	if deployType == "k8s" {
 		// backwards compatibility for older deployments
@@ -161,10 +163,22 @@ func IsDeployTypeCluster(deployType string) bool {
 	return deployType == DeployCluster
 }
 
-// IsDeployTypeDockerContainer tells if the given deployment type is Docker sourcegraph/server
-// single-container (non-Kubernetes, non-cluster, non-dev).
-func IsDeployTypeDockerContainer(deployType string) bool {
-	return deployType == DeployDocker
+// IsDeployTypeDockerCompose tells if the given deployment type is the Docker Compose
+// deployment (and non-dev, not pure-docker, non-cluster, and non-single Docker image).
+func IsDeployTypeDockerCompose(deployType string) bool {
+	return deployType == DeployDockerCompose
+}
+
+// IsDeployTypePureDocker tells if the given deployment type is the pure Docker
+// deployment (and non-dev, not docker-compose, non-cluster, and non-single Docker image).
+func IsDeployTypePureDocker(deployType string) bool {
+	return deployType == DeployPureDocker
+}
+
+// IsDeployTypeSingleDockerContainer tells if the given deployment type is Docker sourcegraph/server
+// single-container (non-Kubernetes, not docker-compose, not pure-docker, non-cluster, non-dev).
+func IsDeployTypeSingleDockerContainer(deployType string) bool {
+	return deployType == DeploySingleDocker
 }
 
 // IsDev tells if the given deployment type is "dev".
@@ -172,10 +186,14 @@ func IsDev(deployType string) bool {
 	return deployType == DeployDev
 }
 
-// IsValidDeployType returns true iff the given deployType is a Kubernetes deployment, Docker deployment, or a
-// local development environmnent.
+// IsValidDeployType returns true iff the given deployType is a Kubernetes deployment, a Docker Compose
+// deployment, a pure Docker deployment, a Docker deployment, or a local development environment.
 func IsValidDeployType(deployType string) bool {
-	return IsDeployTypeCluster(deployType) || IsDeployTypeDockerContainer(deployType) || IsDev(deployType)
+	return IsDeployTypeCluster(deployType) ||
+		IsDeployTypeDockerCompose(deployType) ||
+		IsDeployTypePureDocker(deployType) ||
+		IsDeployTypeSingleDockerContainer(deployType) ||
+		IsDev(deployType)
 }
 
 // UpdateChannel tells the update channel. Default is "release".
@@ -200,7 +218,7 @@ func SearchIndexEnabled() bool {
 		enabled, _ := strconv.ParseBool(v)
 		return enabled
 	}
-	return DeployType() != DeployDocker
+	return DeployType() != DeploySingleDocker
 }
 
 func SymbolIndexEnabled() bool {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	deployType := DeployType()
 	if !IsValidDeployType(deployType) {
-		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q. Got: %q", DeployCluster, DeployDockerCompose, DeployPureDocker, DeploySingleDocker, DeployDev, deployType)
+		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q. Got: %q", DeployKubernetes, DeployDockerCompose, DeployPureDocker, DeploySingleDocker, DeployDev, deployType)
 	}
 
 	confdefaults.Default = defaultConfigForDeployment()
@@ -29,8 +29,8 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 		return confdefaults.DevAndTesting
 	case IsDeployTypeSingleDockerContainer(deployType):
 		return confdefaults.DockerContainer
-	case IsDeployTypeCluster(deployType), IsDeployTypeDockerCompose(deployType), IsDeployTypePureDocker(deployType):
-		return confdefaults.Cluster
+	case IsDeployTypeKubernetes(deployType), IsDeployTypeDockerCompose(deployType), IsDeployTypePureDocker(deployType):
+		return confdefaults.Kubernetes
 	default:
 		panic("deploy type did not register default configuration")
 	}
@@ -136,7 +136,7 @@ func CanReadEmail() bool {
 // Deploy type constants. Any changes here should be reflected in the DeployType type declared in web/src/globals.d.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
 const (
-	DeployCluster       = "cluster"
+	DeployKubernetes    = "cluster"
 	DeploySingleDocker  = "docker-container"
 	DeployDockerCompose = "docker-compose"
 	DeployPureDocker    = "pure-docker"
@@ -148,19 +148,19 @@ func DeployType() string {
 	if e := os.Getenv("DEPLOY_TYPE"); e != "" {
 		return e
 	}
-	// Default to Cluster so that every Cluster deployment doesn't need to be
-	// configured with DEPLOY_TYPE.
-	return DeployCluster
+	// Default to Kubernetes cluster so that every Kubernetes c
+	// cluster deployment doesn't need to be configured with DEPLOY_TYPE.
+	return DeployKubernetes
 }
 
-// IsDeployTypeCluster tells if the given deployment type is a cluster (and
-// non-dev, not docker-compose, not pure-docker, and non-single Docker image).
-func IsDeployTypeCluster(deployType string) bool {
-	if deployType == "k8s" {
+// IsDeployTypeKubernetes tells if the given deployment type is a Kubernetes
+// cluster (and non-dev, not docker-compose, not pure-docker, and non-single Docker image).
+func IsDeployTypeKubernetes(deployType string) bool {
+	if deployType == "cluster" {
 		// backwards compatibility for older deployments
 		return true
 	}
-	return deployType == DeployCluster
+	return deployType == DeployKubernetes
 }
 
 // IsDeployTypeDockerCompose tells if the given deployment type is the Docker Compose
@@ -189,7 +189,7 @@ func IsDev(deployType string) bool {
 // IsValidDeployType returns true iff the given deployType is a Kubernetes deployment, a Docker Compose
 // deployment, a pure Docker deployment, a Docker deployment, or a local development environment.
 func IsValidDeployType(deployType string) bool {
-	return IsDeployTypeCluster(deployType) ||
+	return IsDeployTypeKubernetes(deployType) ||
 		IsDeployTypeDockerCompose(deployType) ||
 		IsDeployTypePureDocker(deployType) ||
 		IsDeployTypeSingleDockerContainer(deployType) ||

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -30,7 +30,7 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 	case IsDeployTypeSingleDockerContainer(deployType):
 		return confdefaults.DockerContainer
 	case IsDeployTypeKubernetes(deployType), IsDeployTypeDockerCompose(deployType), IsDeployTypePureDocker(deployType):
-		return confdefaults.Kubernetes
+		return confdefaults.KubernetesOrDockerComposeOrPureDocker
 	default:
 		panic("deploy type did not register default configuration")
 	}
@@ -136,7 +136,7 @@ func CanReadEmail() bool {
 // Deploy type constants. Any changes here should be reflected in the DeployType type declared in web/src/globals.d.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
 const (
-	DeployKubernetes    = "cluster"
+	DeployKubernetes    = "kubernetes"
 	DeploySingleDocker  = "docker-container"
 	DeployDockerCompose = "docker-compose"
 	DeployPureDocker    = "pure-docker"
@@ -156,11 +156,13 @@ func DeployType() string {
 // IsDeployTypeKubernetes tells if the given deployment type is a Kubernetes
 // cluster (and non-dev, not docker-compose, not pure-docker, and non-single Docker image).
 func IsDeployTypeKubernetes(deployType string) bool {
-	if deployType == "cluster" {
-		// backwards compatibility for older deployments
+	switch deployType {
+	// includes older Kubernetes aliases for backwards compatibility
+	case "k8s", "cluster", DeployKubernetes:
 		return true
 	}
-	return deployType == DeployKubernetes
+
+	return false
 }
 
 // IsDeployTypeDockerCompose tells if the given deployment type is the Docker Compose

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -64,7 +64,7 @@ func TestSearchIndexEnabled(t *testing.T) {
 	}
 
 	defaults := map[string]conftypes.RawUnified{
-		"Cluster":         confdefaults.Cluster,
+		"Kubernetes":      confdefaults.Kubernetes,
 		"Default":         confdefaults.Default,
 		"DevAndTesting":   confdefaults.DevAndTesting,
 		"DockerContainer": confdefaults.DockerContainer,

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -64,7 +64,7 @@ func TestSearchIndexEnabled(t *testing.T) {
 	}
 
 	defaults := map[string]conftypes.RawUnified{
-		"Kubernetes":      confdefaults.Kubernetes,
+		"Kubernetes":      confdefaults.KubernetesOrDockerComposeOrPureDocker,
 		"Default":         confdefaults.Default,
 		"DevAndTesting":   confdefaults.DevAndTesting,
 		"DockerContainer": confdefaults.DockerContainer,

--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -52,9 +52,9 @@ var DockerContainer = conftypes.RawUnified{
 }`,
 }
 
-// Kubernetes is the default configuration applied to Kubernetes cluster
-// instances of Sourcegraph.
-var Kubernetes = conftypes.RawUnified{
+// KubernetesOrDockerComposeOrPureDocker is the default configuration
+// applied to Kubernetes, Docker Compose, and pure Docker instances of Sourcegraph.
+var KubernetesOrDockerComposeOrPureDocker = conftypes.RawUnified{
 	Critical: `{}`,
 	Site: `{
 	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)

--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -52,11 +52,11 @@ var DockerContainer = conftypes.RawUnified{
 }`,
 }
 
-// Cluster is the default configuration applied to Cluster instances of
-// Sourcegraph.
-var Cluster = conftypes.RawUnified{
+// Kubernetes is the default configuration applied to Kubernetes cluster
+// instances of Sourcegraph.
+var Kubernetes = conftypes.RawUnified{
 	Critical: `{}`,
-	Site: `{	
+	Site: `{
 	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
 	// This is required to be configured for Sourcegraph to work correctly.
 	// "externalURL": "https://sourcegraph.example.com",

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -273,7 +273,7 @@ func (f jsonLoaderFactory) New(source string) gojsonschema.JSONLoader {
 func MustValidateDefaults() {
 	mustValidate("DevAndTesting", confdefaults.DevAndTesting)
 	mustValidate("DockerContainer", confdefaults.DockerContainer)
-	mustValidate("Kubernetes", confdefaults.Kubernetes)
+	mustValidate("KubernetesOrDockerComposeOrPureDocker", confdefaults.KubernetesOrDockerComposeOrPureDocker)
 }
 
 // mustValidate panics if the configuration does not pass validation.

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -273,7 +273,7 @@ func (f jsonLoaderFactory) New(source string) gojsonschema.JSONLoader {
 func MustValidateDefaults() {
 	mustValidate("DevAndTesting", confdefaults.DevAndTesting)
 	mustValidate("DockerContainer", confdefaults.DockerContainer)
-	mustValidate("Cluster", confdefaults.Cluster)
+	mustValidate("Kubernetes", confdefaults.Kubernetes)
 }
 
 // mustValidate panics if the configuration does not pass validation.

--- a/internal/sysreq/unix.go
+++ b/internal/sysreq/unix.go
@@ -23,7 +23,7 @@ func rlimitCheck(ctx context.Context) (problem, fix string, err error) {
 	if limit.Cur < minLimit {
 		fix := fmt.Sprintf(`Please increase the open file limit by running "ulimit -n %d".`, minLimit)
 
-		if conf.IsDeployTypeDockerContainer(conf.DeployType()) {
+		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
 			fix = fmt.Sprintf("Add --ulimit nofile=%d:%d to the docker run command", minLimit, minLimit)
 		}
 

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -21,7 +21,7 @@ interface ImmutableUser {
     readonly UID: number
 }
 
-type DeployType = 'cluster' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev'
+type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev'
 
 /**
  * Defined in cmd/frontend/internal/app/jscontext/jscontext.go JSContext struct

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -21,7 +21,7 @@ interface ImmutableUser {
     readonly UID: number
 }
 
-type DeployType = 'cluster' | 'docker-container' | 'dev'
+type DeployType = 'cluster' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev'
 
 /**
  * Defined in cmd/frontend/internal/app/jscontext/jscontext.go JSContext struct

--- a/web/src/repo/DirectImportRepoAlert.tsx
+++ b/web/src/repo/DirectImportRepoAlert.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 
 export const DirectImportRepoAlert: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
     <>
-        {window.context.deployType !== 'cluster' && (
+        {['dev', 'docker-container'].includes(window.context.deployType) && (
             <div className={`alert alert-info ${className}`}>
                 <InformationOutlineIcon className="icon-inline" /> Very large repository? See{' '}
                 <Link to="/help/admin/repo/add_from_local_disk#add-repositories-already-cloned-to-disk">

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -441,11 +441,12 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                 results.timedout.length === results.repositoriesCount &&
                                                 /* All repositories timed out. */
                                                 this.renderRecommendations(
-                                                    window.context.deployType !== 'cluster'
+                                                    ['dev', 'docker-container'].includes(window.context.deployType)
                                                         ? [
                                                               <>
                                                                   Upgrade to Sourcegraph Enterprise for a highly
-                                                                  scalable Kubernetes cluster deployment option.
+                                                                  scalable Docker Compose or Kubernetes cluster
+                                                                  deployment option.
                                                               </>,
                                                               window.context.likelyDockerOnMac
                                                                   ? 'Use Docker Machine instead of Docker for Mac for better performance on macOS.'


### PR DESCRIPTION
@dadlerj  I reverted https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f75a88c0a1708a3c5e26ea24b16ed191b2f1f424 because I didn't realize that new values of the `DEPLOY_TYPE` environment variable needed to be explicitly added to our internal configuration package. Before this revert, the frontend container would crash with the following error message:

```
2020/02/28 19:57:53 The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: "cluster", "docker-container", "dev". Got: "docker-compose"
```
---

This PR adds support for `DEPLOY_TYPE=docker-compose` and `DEPLOY_TYPE=pure-docker` so that instances are properly classified for analytics and support purposes. 

A new release (3.13.2) will need to be cut for this.