### PR TITLE
Update LSIF uploads UI

### DIFF
--- a/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
@@ -209,6 +209,12 @@ export const RepoSettingsCodeIntelligencePage: FunctionComponent<Props> = ({ rep
                 <a href="https://docs.sourcegraph.com/user/code_intelligence/lsif">uploading LSIF data</a>.
             </p>
 
+            <p>
+                Current uploads provide code intelligence for the latest commit on the default branch and are used in
+                cross-repository <em>Find References</em> requests. Non-current uploads may still provide code
+                intelligence for historic and branch commits.
+            </p>
+
             <FilteredConnection<GQL.ILSIFUpload, { onDelete: () => void }>
                 className="list-group list-group-flush mt-3"
                 noun="upload"

--- a/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
@@ -4,7 +4,7 @@ import CheckIcon from 'mdi-react/CheckIcon'
 import ClockOutlineIcon from 'mdi-react/ClockOutlineIcon'
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
 import { asError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
-import { catchError } from 'rxjs/operators'
+import { catchError, flatMap, takeWhile } from 'rxjs/operators'
 import { ErrorAlert } from '../../../components/alerts'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { fetchLsifUpload, deleteLsifUpload } from './backend'
@@ -15,9 +15,21 @@ import { RouteComponentProps, Redirect } from 'react-router'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { useObservable } from '../../../util/useObservable'
 import DeleteIcon from 'mdi-react/DeleteIcon'
+import { SchedulerLike, timer, combineLatest, of } from 'rxjs'
+
+const REFRESH_INTERVAL_MS = 5000
 
 interface Props extends RouteComponentProps<{ id: string }> {
     repo: GQL.IRepository
+
+    /** Scheduler for the refresh timer */
+    scheduler?: SchedulerLike
+}
+
+const terminalStates = [GQL.LSIFUploadState.COMPLETED, GQL.LSIFUploadState.ERRORED]
+
+function shouldReload(v: GQL.ILSIFUpload | ErrorLike | null | undefined): boolean {
+    return !isErrorLike(v) && !(v && terminalStates.includes(v.state))
 }
 
 /**
@@ -25,6 +37,7 @@ interface Props extends RouteComponentProps<{ id: string }> {
  */
 export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
     repo,
+    scheduler,
     match: {
         params: { id },
     },
@@ -34,7 +47,16 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
     const [deletionOrError, setDeletionOrError] = useState<'loading' | 'deleted' | ErrorLike>()
 
     const uploadOrError = useObservable(
-        useMemo(() => fetchLsifUpload({ id }).pipe(catchError((error): [ErrorLike] => [asError(error)])), [id])
+        useMemo(
+            () =>
+                combineLatest([timer(0, REFRESH_INTERVAL_MS, scheduler), of(id)]).pipe(
+                    flatMap(([, id]) =>
+                        fetchLsifUpload({ id }).pipe(catchError((error): [ErrorLike] => [asError(error)]))
+                    ),
+                    takeWhile(shouldReload, true)
+                ),
+            [id, scheduler]
+        )
     )
 
     const deleteUpload = async (): Promise<void> => {


### PR DESCRIPTION
Combine the two filtered connections for LSIF uploads into one with an additional toggle for state. Refresh the page on a timer when viewing a single LSIF upload that is not yet in a terminal state.