### PR TITLE
Fix unmarshaling and displaying of gitserver CreateCommitFromPatchError

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -71,8 +71,8 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		if resp.Error != nil {
 			resp.Error.Command = redactor.redact(resp.Error.Command)
 			resp.Error.CombinedOutput = redactor.redact(resp.Error.CombinedOutput)
-			if resp.Error.Err != nil {
-				resp.Error.Err = errors.New(redactor.redact(resp.Error.Err.Error()))
+			if resp.Error.InternalError != "" {
+				resp.Error.InternalError = redactor.redact(resp.Error.InternalError)
 			}
 		}
 	}()

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -336,7 +336,7 @@ func RunChangesetJob(
 
 	if err != nil {
 		if diffErr, ok := err.(*protocol.CreateCommitFromPatchError); ok {
-			return errors.Errorf("creating commit from patch for repo %q: %v (command: %q)", diffErr.RepositoryName, diffErr.Err, diffErr.Command)
+			return errors.Errorf("creating commit from patch for repo %q: %q (command: %q)", diffErr.RepositoryName, diffErr.InternalError, diffErr.Command)
 		}
 		return err
 	}

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -181,7 +181,7 @@ func (e *CreateCommitFromPatchResponse) SetError(repo, command, out string, err 
 	e.Error.RepositoryName = repo
 	e.Error.Command = command
 	e.Error.CombinedOutput = out
-	e.Error.Err = err
+	e.Error.InternalError = err.Error()
 }
 
 // CreateCommitFromPatchError is populated on errors running
@@ -189,8 +189,10 @@ func (e *CreateCommitFromPatchResponse) SetError(repo, command, out string, err 
 type CreateCommitFromPatchError struct {
 	// RepositoryName is the name of the repository
 	RepositoryName string
-	// Error is the internal error
-	Err error
+
+	// InternalError is the internal error
+	InternalError string
+
 	// Command is the last git command that was attempted
 	Command string
 	// CombinedOutput is the combined stderr and stdout from running the command
@@ -199,13 +201,5 @@ type CreateCommitFromPatchError struct {
 
 // Error returns a detailed error conforming to the error interface
 func (e *CreateCommitFromPatchError) Error() string {
-	if e.Err == nil {
-		return ""
-	}
-	return e.Err.Error()
-}
-
-// Unwrap return the original error and satisfies the errors.Unwrap interface
-func (e *CreateCommitFromPatchError) Unwrap() error {
-	return e.Err
+	return e.InternalError
 }


### PR DESCRIPTION
Before this change I ran into this error message:

    frontend | WARN decoding gitserver create-commit-from-patch response, err: json: cannot unmarshal object into Go struct field CreateCommitFromPatchError.Error.Err of type error

This commit changes the field from an `error` to a `string`, which can
be marshaled/unmarshaled by the json package.

I don't see where we need to satisfy the `Unwrap()` interface and
preserve the original error, so in order to make this work, I got rid of
it.

