### PR TITLE
db/repos: remove explicit authz bypass logic

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -100,8 +100,6 @@ func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.R
 
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
-// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin because this method returns all available data from the database.
 func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
 	if Mocks.Repos.GetByIDs != nil {
 		return Mocks.Repos.GetByIDs(ctx, ids...)
@@ -116,7 +114,7 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 		items[i] = sqlf.Sprintf("%d", ids[i])
 	}
 	q := sqlf.Sprintf("id IN (%s)", sqlf.Join(items, ","))
-	return s.getReposBySQL(ctx, false, true, q)
+	return s.getReposBySQL(ctx, true, q)
 }
 
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
@@ -157,12 +155,10 @@ var getBySQLColumns = []string{
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
-	return s.getReposBySQL(ctx, true, false, querySuffix)
+	return s.getReposBySQL(ctx, false, querySuffix)
 }
 
-// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin who is authorized to see the repositories returned even when authorize=false.
-func (s *repos) getReposBySQL(ctx context.Context, authorize, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+func (s *repos) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {
 		columns = columns[:6]
@@ -196,9 +192,6 @@ func (s *repos) getReposBySQL(ctx context.Context, authorize, minimal bool, quer
 		return nil, err
 	}
 
-	if !authorize {
-		return repos, nil
-	}
 	// 🚨 SECURITY: This enforces repository permissions
 	return authzFilter(ctx, repos, authz.Read)
 }
@@ -334,7 +327,7 @@ func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*type
 	// fetch matching repos
 	fetchSQL := sqlf.Sprintf("%s %s %s", sqlf.Join(conds, "AND"), opt.OrderBy.SQL(), opt.LimitOffset.SQL())
 	tr.LazyPrintf("SQL query: %s, SQL args: %v", fetchSQL.Query(sqlf.PostgresBindVar), fetchSQL.Args())
-	return s.getReposBySQL(ctx, true, opt.OnlyRepoIDs, fetchSQL)
+	return s.getReposBySQL(ctx, opt.OnlyRepoIDs, fetchSQL)
 }
 
 // ListEnabledNames returns a list of all enabled repo names. This is commonly


### PR DESCRIPTION
As a result of recent learning, if the `ctx` has an actor that is an admin, `authzFilter` bypass checks automatically. Therefore, there is no need to explicit bypass authorization again.

This PR then fixes the only exception method that did not go through `authzFilter` (i.e. `db.Repos.GetByIDs`).

We're back to the unified authz checking process!