### PR TITLE
Enable smartSearchField in dev mode

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,6 +1,6 @@
 {
   // This is set from an environment variable
   "experimentalFeatures": {
-    "splitSearchModes": true
+    "smartSearchField": true
   }
 }


### PR DESCRIPTION
Enable the `smartSearchField` feature flag by default in dev mode. Also removed `splitSearchModes` from `global-settings.json`, since it now defaults to on.