### PR TITLE
Fix branch input hidden on update

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -181,7 +181,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         return () => unblockHistoryRef.current()
     }, [campaignID, history, planID])
 
-    const updateMode = campaignID && planID
+    const updateMode = !!campaignID && !!planID
     const previewCampaignPlans = useMemo(() => new Subject<GQL.ID>(), [])
     const campaignPlan = useObservable(
         useMemo(
@@ -453,33 +453,33 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         </div>
                     </>
                 )}
+                {(mode === 'editing' || mode === 'saving') && specifyingBranchAllowed && (
+                    <div className="form-group mt-3">
+                        <label>
+                            Branch name{' '}
+                            <small>
+                                <InformationOutlineIcon
+                                    className="icon-inline"
+                                    data-tooltip={
+                                        'If a branch with the given name already exists, a fallback name will be created by appending a count. Example: "my-branch-name" becomes "my-branch-name-1".'
+                                    }
+                                />
+                            </small>
+                        </label>
+                        <input
+                            type="text"
+                            className="form-control"
+                            onChange={onBranchChange}
+                            placeholder="my-awesome-campaign"
+                            value={branch}
+                            required={true}
+                            disabled={mode === 'saving'}
+                        />
+                    </div>
+                )}
                 {!updateMode ? (
                     (!campaign || campaignPlan) && (
                         <>
-                            {specifyingBranchAllowed && (
-                                <div className="form-group mt-3">
-                                    <label>
-                                        Branch name{' '}
-                                        <small>
-                                            <InformationOutlineIcon
-                                                className="icon-inline"
-                                                data-tooltip={
-                                                    'If a branch with the given name already exists, a fallback name will be created by appending a count. Example: "my-branch-name" becomes "my-branch-name-1".'
-                                                }
-                                            />
-                                        </small>
-                                    </label>
-                                    <input
-                                        type="text"
-                                        className="form-control"
-                                        onChange={onBranchChange}
-                                        placeholder="my-awesome-campaign"
-                                        value={branch}
-                                        required={true}
-                                        disabled={mode === 'saving'}
-                                    />
-                                </div>
-                            )}
                             <div className="mt-3">
                                 {campaignPlan && (
                                     <button


### PR DESCRIPTION
Updating the branch was not possible when updating a campaign. In addition, updating just the description failed because an empty branch has been passed.