### PR TITLE
search: add basic parameter scanning to query parser

### DIFF
--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -27,7 +28,9 @@ func (Operator) node()  {}
 
 // Parameter is a leaf node of expressions.
 type Parameter struct {
-	Value string
+	Field   string `json:"field"`
+	Value   string `json:"value"`
+	Negated bool   `json:"negated"`
 }
 
 type operatorKind int
@@ -44,7 +47,11 @@ type Operator struct {
 }
 
 func (node Parameter) String() string {
-	return node.Value
+	if node.Field == "" {
+		return node.Value
+	} else {
+		return fmt.Sprintf("%s:%s", node.Field, node.Value)
+	}
 }
 
 func (node Operator) String() string {
@@ -142,10 +149,46 @@ func (p *parser) skipSpaces() error {
 	return nil
 }
 
-// scanParameter scans for leaf node values.
-func (p *parser) scanParameter() (string, error) {
+// ScanParameter returns a leaf node value usable by _any_ kind of search (e.g.,
+// literal or regexp, or...) and always succeeds.
+//
+// A parameter is a contiguous sequence characters, where the following two forms are distinguished:
+// (1) a string of syntax field:<string> where : matches the first encountered colon, and field must match ^-?[a-zA-Z0-9]+
+// (2) <string>
+//
+// When a parameter is of form (1), the string corresponds to Field:Value in type Parameter, and negated if Field starts with '-'.
+// When form (1) does not match, Value corresponds to <string> and Field is the empty string.
+//
+// The value parameter in the parse tree is only distinguished with respect to
+// the two forms above. There is no restriction on values that <string> may take
+// on. Notably, there is no interpretation of quoting or escaping, which may vary
+// depending on the search being performed. All validation with respect to such
+// properties, and how these should be interpretted, is thus context dependent
+// and handled appropriately within those contexts.
+func ScanParameter(parameter []byte) Parameter {
+	fieldValuePattern := regexp.MustCompile("(^-?[a-zA-Z0-9]+):(.*)")
+	result := fieldValuePattern.FindSubmatch(parameter)
+	if result != nil {
+		if result[1][0] == '-' {
+			return Parameter{
+				Field:   string(result[1][1:]),
+				Value:   string(result[2]),
+				Negated: true,
+			}
+		}
+		return Parameter{Field: string(result[1]), Value: string(result[2])}
+	}
+	return Parameter{Field: "", Value: string(parameter)}
+}
+
+// ParseParameter returns valid leaf node values for AND/OR queries, taking into
+// account escape sequencies for special syntax: whitespace and parentheses.
+func (p *parser) ParseParameter() Parameter {
 	start := p.pos
 	for {
+		if p.expect(`\ `) || p.expect(`\(`) || p.expect(`\)`) {
+			continue
+		}
 		if p.isKeyword() {
 			break
 		}
@@ -157,7 +200,7 @@ func (p *parser) scanParameter() (string, error) {
 		}
 		p.pos++
 	}
-	return string(p.buf[start:p.pos]), nil
+	return ScanParameter(p.buf[start:p.pos])
 }
 
 // scanParameterList scans for consecutive leaf nodes.
@@ -184,18 +227,16 @@ func (p *parser) parseParameterList() ([]Node, error) {
 				// Return a non-nil node if we parsed "()".
 				return []Node{Parameter{Value: ""}}, nil
 			}
-			return nodes, nil
+			goto Done
 		case p.match(AND), p.match(OR):
 			// Caller advances.
-			return nodes, nil
+			goto Done
 		default:
-			value, err := p.scanParameter()
-			if err != nil {
-				return nil, err
-			}
-			nodes = append(nodes, Parameter{Value: value})
+			parameter := p.ParseParameter()
+			nodes = append(nodes, parameter)
 		}
 	}
+Done:
 	return nodes, nil
 }
 

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -16,48 +16,44 @@ func Test_ScanParameter(t *testing.T) {
 	}{
 		{
 			Name:  "Normal field:value",
-			Input: `field:value`,
-			Want:  `{"field":"field","value":"value","negated":false}`,
+			Input: `file:README.md`,
+			Want:  `{"field":"file","value":"README.md","negated":false}`,
 		},
+
 		{
 			Name:  "First char is colon",
-			Input: `:value`,
-			Want:  `{"field":"","value":":value","negated":false}`,
+			Input: `:foo`,
+			Want:  `{"field":"","value":":foo","negated":false}`,
 		},
 		{
 			Name:  "Last char is colon",
-			Input: `field:`,
-			Want:  `{"field":"field","value":"","negated":false}`,
+			Input: `foo:`,
+			Want:  `{"field":"foo","value":"","negated":false}`,
 		},
 		{
 			Name:  "Match first colon",
-			Input: `field:value:value`,
-			Want:  `{"field":"field","value":"value:value","negated":false}`,
+			Input: `foo:bar:baz`,
+			Want:  `{"field":"foo","value":"bar:baz","negated":false}`,
 		},
 		{
 			Name:  "No field, start with minus",
-			Input: `-:value`,
-			Want:  `{"field":"","value":"-:value","negated":false}`,
+			Input: `-:foo`,
+			Want:  `{"field":"","value":"-:foo","negated":false}`,
 		},
 		{
 			Name:  "Minus prefix on field",
-			Input: `-field:value`,
-			Want:  `{"field":"field","value":"value","negated":true}`,
+			Input: `-file:README.md`,
+			Want:  `{"field":"file","value":"README.md","negated":true}`,
 		},
 		{
 			Name:  "Double minus prefix on field",
-			Input: `--field:value`,
-			Want:  `{"field":"","value":"--field:value","negated":false}`,
+			Input: `--foo:bar`,
+			Want:  `{"field":"","value":"--foo:bar","negated":false}`,
 		},
 		{
 			Name:  "Minus in the middle is not a valid field",
-			Input: `fie-ld:value`,
-			Want:  `{"field":"","value":"fie-ld:value","negated":false}`,
-		},
-		{
-			Name:  "No effect on whitespace",
-			Input: `  a pattern  `,
-			Want:  `{"field":"","value":"","negated":false}`,
+			Input: `fie-ld:bar`,
+			Want:  `{"field":"","value":"fie-ld:bar","negated":false}`,
 		},
 		{
 			Name:  "No effect on escaped whitespace",


### PR DESCRIPTION
This PR changes the previous

```
type Parameter {
	Value string
}
```
to
```
type Parameter struct {
	Field   string
	Value   string
	Negated bool
}
```

I thought deeply about where to draw the line of parsing a "parameter" at this low level parsing stage. Please see comment for `ScanParameter` for what it entails. I chose this way because I'd like our literal parser (or _any_ parser, ever, really) to have a low level representation of a 'parameter' that can then decide what it considers to be valid or not. The logic is, in essence, a minimal unvalidated interpretation that doesn't lose or throw away (e.g. by, unquoting, etc.) any syntactic information that could potentially be useful in a search, and cannot fail. For example, if literal search wanted to search for `"`, it should be able to get that value in a leaf node by using `ScanParameter`. And, indeed, the current approach allows this.

I fully plan to migrate our literal search parser to use `ScanParameter`. Note that `ParseParameter` is the caller that is specific to AND/OR query parsing (it is less general than `ScanParameter`) which is why these two functions are kept separate.

---

A note on `NOT`: don't think about it in the context of this PR right now. When introduced, it will serve as syntactic sugar, specific to AND/OR queries, that influences the `Negated` field of a parameter. In the future, `NOT` may apply to whole expressions, which will then be promoted to it's own `Operator`, rather than syntactic sugar on `Parameter`s