### PR TITLE
Badge style fix

### DIFF
--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -576,7 +576,7 @@ code {
     list-style: none;
 }
 
-.content-nav-section li.selected .badge {
+.content-nav-section li.selected > a >.badge {
     background: var(--body-bg);
     color: var(--primary);
 }

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -4,7 +4,7 @@
     <title>{{block "title" .}}Home{{end}} - Sourcegraph docs</title>
     <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
     <link rel="stylesheet" href="{{asset "bootstrap.min.css"}}?4.3.1" />
-    <link rel="stylesheet" href="{{asset "layout.css"}}?14" />
+    <link rel="stylesheet" href="{{asset "layout.css"}}?15" />
     <link rel="stylesheet" href="{{asset "search.css"}}?14" />
     <link rel="stylesheet" href="{{asset "content.css"}}?14" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />


### PR DESCRIPTION
Keep badge primary style unless the actual link that contains the badge is selected.

<img width="420" alt="Screen Shot 2020-03-03 at 11 20 23 AM" src="https://user-images.githubusercontent.com/133014/75733448-184a4780-5d41-11ea-9ac5-215d33a25104.png">
