### PR TITLE
authz: add `SetUserPermissions` method to `PermsStore`

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -120,8 +120,6 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 // GetByExternalIDs returns a list repositories by given (code host) IDs, external service
 // type and service ID. The number of results in the returned list could be less than the
 // candidate list due to no repository being associated with some IDs.
-// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
-// is the site admin because this method returns all available data from the database.
 func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {
 	if len(extIDs) == 0 {
 		return []*types.Repo{}, nil
@@ -136,7 +134,7 @@ func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID str
 AND external_service_id = %s
 AND external_id IN (%s)`,
 		serviceType, serviceID, sqlf.Join(items, ","))
-	return s.getReposBySQL(ctx, false, true, q)
+	return s.getReposBySQL(ctx, true, true, q)
 }
 
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -117,9 +117,9 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 	return s.getReposBySQL(ctx, true, q)
 }
 
-// GetByExternalIDs a list repositories by given (code host) IDs with external service type
-// and service ID. The number of results in the returned list could be less than the candidate
-// list due to no repository is associated with some IDs.
+// GetByExternalIDs returns a list repositories by given (code host) IDs, external service
+// type and service ID. The number of results in the returned list could be less than the
+// candidate list due to no repository is associated with some IDs.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
 // is the site admin because this method returns all available data from the database.
 func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -117,6 +117,28 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 	return s.getReposBySQL(ctx, true, q)
 }
 
+// GetByExternalIDs a list repositories by given (code host) IDs with external service type
+// and service ID. The number of results in the returned list could be less than the candidate
+// list due to no repository is associated with some IDs.
+// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
+// is the site admin because this method returns all available data from the database.
+func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {
+	if len(extIDs) == 0 {
+		return []*types.Repo{}, nil
+	}
+
+	items := make([]*sqlf.Query, len(extIDs))
+	for i := range extIDs {
+		items[i] = sqlf.Sprintf("%s", extIDs[i])
+	}
+	q := sqlf.Sprintf(`
+    external_service_type = %s
+AND external_service_id = %s
+AND external_id IN (%s)`,
+		serviceType, serviceID, sqlf.Join(items, ","))
+	return s.getReposBySQL(ctx, false, true, q)
+}
+
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -121,7 +121,11 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 // type and service ID. The number of results in the returned list could be less than the
 // candidate list due to no repository being associated with some IDs.
 func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {
-	if len(extIDs) == 0 {
+	if serviceType == "" {
+		return nil, errors.New("empty serviceType")
+	} else if serviceID == "" {
+		return nil, errors.New("empty serviceID")
+	} else if len(extIDs) == 0 {
 		return []*types.Repo{}, nil
 	}
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -117,30 +117,6 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 	return s.getReposBySQL(ctx, true, q)
 }
 
-// GetByExternalIDs returns a list repositories by given (code host) IDs, external service
-// type and service ID. The number of results in the returned list could be less than the
-// candidate list due to no repository being associated with some IDs.
-func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {
-	if serviceType == "" {
-		return nil, errors.New("empty serviceType")
-	} else if serviceID == "" {
-		return nil, errors.New("empty serviceID")
-	} else if len(extIDs) == 0 {
-		return []*types.Repo{}, nil
-	}
-
-	items := make([]*sqlf.Query, len(extIDs))
-	for i := range extIDs {
-		items[i] = sqlf.Sprintf("%s", extIDs[i])
-	}
-	q := sqlf.Sprintf(`
-    external_service_type = %s
-AND external_service_id = %s
-AND external_id IN (%s)`,
-		serviceType, serviceID, sqlf.Join(items, ","))
-	return s.getReposBySQL(ctx, true, true, q)
-}
-
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -119,7 +119,7 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 
 // GetByExternalIDs returns a list repositories by given (code host) IDs, external service
 // type and service ID. The number of results in the returned list could be less than the
-// candidate list due to no repository is associated with some IDs.
+// candidate list due to no repository being associated with some IDs.
 // 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
 // is the site admin because this method returns all available data from the database.
 func (s *repos) GetByExternalIDs(ctx context.Context, serviceType, serviceID string, extIDs ...string) ([]*types.Repo, error) {

--- a/enterprise/cmd/frontend/db/integration_test.go
+++ b/enterprise/cmd/frontend/db/integration_test.go
@@ -25,6 +25,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 	}{
 		{"PermsStore/LoadUserPermissions", testPermsStore_LoadUserPermissions(db)},
 		{"PermsStore/LoadRepoPermissions", testPermsStore_LoadRepoPermissions(db)},
+		{"PermsStore/SetUserPermissions", testPermsStore_SetUserPermissions(db)},
 		{"PermsStore/SetRepoPermissions", testPermsStore_SetRepoPermissions(db)},
 		{"PermsStore/LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
 		{"PermsStore/SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -131,7 +131,7 @@ AND provider = %s
 //
 //  "repo_permissions":
 //   repo_id | permission | user_ids  |   provider  | updated_at
-//  ---------+------------+--------------+-------------+------------
+//  ---------+------------+-----------+-------------+------------
 //         1 |       read | bitmap{1} | sourcegraph | <DateTime>
 //         2 |       read | bitmap{1} | sourcegraph | <DateTime>
 func (s *PermsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermissions) (err error) {
@@ -149,7 +149,7 @@ func (s *PermsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermis
 	var oldIDs *roaring.Bitmap
 	vals, err := txs.load(ctx, loadUserPermissionsQuery(p, "FOR UPDATE"))
 	if err != nil {
-		if err == ErrPermsNotFound {
+		if err == authz.ErrPermsNotFound {
 			oldIDs = roaring.NewBitmap()
 		} else {
 			return errors.Wrap(err, "load user permissions")

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
+	"github.com/gitchander/permutation"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"golang.org/x/sync/errgroup"
@@ -264,6 +265,164 @@ func checkRegularPermsTable(s *PermsStore, sql string, expects map[int32][]uint3
 	}
 
 	return nil
+}
+
+func testPermsStore_SetUserPermissions(db *sql.DB) func(*testing.T) {
+	tests := []struct {
+		name            string
+		updates         []*authz.UserPermissions
+		expectUserPerms map[int32][]uint32 // user_id -> object_ids
+		expectRepoPerms map[int32][]uint32 // repo_id -> user_ids
+	}{
+		{
+			name: "empty",
+			updates: []*authz.UserPermissions{
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					Provider: authz.ProviderSourcegraph,
+				},
+			},
+		},
+		{
+			name: "add",
+			updates: []*authz.UserPermissions{
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   2,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1, 2),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   3,
+					Perm:     authz.Read,
+					IDs:      toBitmap(3, 4),
+					Provider: authz.ProviderSourcegraph,
+				},
+			},
+			expectUserPerms: map[int32][]uint32{
+				1: {1},
+				2: {1, 2},
+				3: {3, 4},
+			},
+			expectRepoPerms: map[int32][]uint32{
+				1: {1, 2},
+				2: {2},
+				3: {3},
+				4: {3},
+			},
+		},
+		{
+			name: "add and update",
+			updates: []*authz.UserPermissions{
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					IDs:      toBitmap(2, 3),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   2,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1, 2),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   2,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1, 3),
+					Provider: authz.ProviderSourcegraph,
+				},
+			},
+			expectUserPerms: map[int32][]uint32{
+				1: {2, 3},
+				2: {1, 3},
+			},
+			expectRepoPerms: map[int32][]uint32{
+				1: {2},
+				2: {1},
+				3: {1, 2},
+			},
+		},
+		{
+			name: "add and clear",
+			updates: []*authz.UserPermissions{
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					IDs:      toBitmap(1, 2, 3),
+					Provider: authz.ProviderSourcegraph,
+				},
+				{
+					UserID:   1,
+					Perm:     authz.Read,
+					IDs:      toBitmap(),
+					Provider: authz.ProviderSourcegraph,
+				},
+			},
+			expectUserPerms: map[int32][]uint32{
+				1: {},
+			},
+			expectRepoPerms: map[int32][]uint32{
+				1: {},
+				2: {},
+				3: {},
+			},
+		},
+	}
+
+	return func(t *testing.T) {
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				s := NewPermsStore(db, clock)
+				defer cleanupPermsTables(t, s)
+
+				for _, p := range test.updates {
+					const numOps = 30
+					g, ctx := errgroup.WithContext(context.Background())
+					for i := 0; i < numOps; i++ {
+						g.Go(func() error {
+							tmp := &authz.UserPermissions{
+								UserID:    p.UserID,
+								Perm:      p.Perm,
+								Provider:  p.Provider,
+								UpdatedAt: p.UpdatedAt,
+							}
+							if p.IDs != nil {
+								tmp.IDs = p.IDs.Clone()
+							}
+							return s.SetUserPermissions(ctx, tmp)
+						})
+					}
+					if err := g.Wait(); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				err := checkRegularPermsTable(s, `SELECT user_id, object_ids FROM user_permissions`, test.expectUserPerms)
+				if err != nil {
+					t.Fatal("user_permissions:", err)
+				}
+
+				err = checkRegularPermsTable(s, `SELECT repo_id, user_ids FROM repo_permissions`, test.expectRepoPerms)
+				if err != nil {
+					t.Fatal("repo_permissions:", err)
+				}
+			})
+		}
+	}
 }
 
 func testPermsStore_SetRepoPermissions(db *sql.DB) func(*testing.T) {
@@ -1306,6 +1465,16 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 
 		ctx := context.Background()
 
+		setUserPermissions := func(ctx context.Context, t *testing.T) {
+			if err := s.SetUserPermissions(ctx, &authz.UserPermissions{
+				UserID:   1,
+				Perm:     authz.Read,
+				IDs:      toBitmap(1),
+				Provider: authz.ProviderSourcegraph,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
 		setRepoPermissions := func(ctx context.Context, t *testing.T) {
 			if err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
 				RepoID:   1,
@@ -1335,17 +1504,13 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 			}
 		}
 
-		// Ensure we've run all permutations of ordering of the 3 calls to avoid nondeterminism in
+		// Ensure we've run all permutations of ordering of the 4 calls to avoid nondeterminism in
 		// test coverage stats.
-		funcPerms := [][3]func(context.Context, *testing.T){
-			{setRepoPendingPermissions, grantPendingPermissions, setRepoPermissions},
-			{setRepoPendingPermissions, setRepoPermissions, grantPendingPermissions},
-			{setRepoPermissions, setRepoPendingPermissions, grantPendingPermissions},
-			{setRepoPermissions, grantPendingPermissions, setRepoPendingPermissions},
-			{grantPendingPermissions, setRepoPendingPermissions, setRepoPermissions},
-			{grantPendingPermissions, setRepoPermissions, setRepoPendingPermissions},
+		funcs := []func(context.Context, *testing.T){
+			setRepoPendingPermissions, grantPendingPermissions, setRepoPermissions, setUserPermissions,
 		}
-		for _, funcs := range funcPerms {
+		permutated := permutation.New(permutation.MustAnySlice(funcs))
+		for permutated.Next() {
 			for _, f := range funcs {
 				f(ctx, t)
 			}
@@ -1353,7 +1518,13 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 
 		const numOps = 50
 		var wg sync.WaitGroup
-		wg.Add(3)
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < numOps; i++ {
+				setUserPermissions(ctx, t)
+			}
+		}()
 		go func() {
 			defer wg.Done()
 			for i := 0; i < numOps; i++ {


### PR DESCRIPTION
This PR implements the stub method `SetUserPermissions` introduced in https://github.com/sourcegraph/sourcegraph/pull/8571.

Unit tests are added.