### PR TITLE
Fix Firefox horizontal scrolling

### DIFF
--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -1,14 +1,9 @@
 .file-match-children {
-    // stylelint-disable-next-line declaration-property-unit-whitelist
-    margin-top: -1px;
-
     &__item {
         text-decoration: none; // don't use cascading link style
         display: flex;
         align-items: center;
         padding: 0.25rem 0.5rem;
-        overflow-x: auto;
-        overflow-y: hidden;
 
         &-clickable {
             cursor: pointer;
@@ -18,13 +13,12 @@
             text-decoration: none;
         }
 
-        &:not(:first-child) {
-            border-top: 1px solid var(--border-color);
-        }
-
         &-code-wrapper {
             position: relative;
-            border-bottom: solid 1px var(--border-color);
+            overflow-x: auto;
+            &:not(:first-child) {
+                border-top: 1px solid var(--border-color);
+            }
         }
 
         &-badge-row {

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -1,11 +1,10 @@
 .result-container {
     position: relative;
 
-    border-width: 0 0 1px 0;
-    border-style: solid;
-    border-color: var(--border-color);
-    &:first-child {
-        border-top-width: 1px;
+    border: 0 solid var(--border-color);
+    border-top-width: 1px;
+    &:last-child {
+        border-bottom-width: 1px;
     }
 
     &__header {


### PR DESCRIPTION
Fixes #8757. We need to make sure to not apply `overflow: auto` to interactive elements (anchors, buttons).

Fixes #8760 