### PR TITLE
Remove history resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,8 +322,5 @@
     "uuid": "^8.2.0",
     "webext-domain-permission-toggle": "^1.0.1",
     "webextension-polyfill": "^0.6.0"
-  },
-  "resolutions": {
-    "history": "4.5.1"
   }
 }

--- a/shared/src/components/Link.tsx
+++ b/shared/src/components/Link.tsx
@@ -1,4 +1,4 @@
-import H from 'history'
+import * as H from 'history'
 import React from 'react'
 
 export type LinkProps = { to: string | H.LocationDescriptor<any> } & Pick<

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import React, { Suspense } from 'react'
-import { Redirect, Route, RouteComponentProps, Switch, matchPath } from 'react-router'
+import { Redirect, Route, RouteComponentProps, Switch, matchPath, StaticContext } from 'react-router'
 import { Observable } from 'rxjs'
 import { ActivationProps } from '../../shared/src/components/activation/Activation'
 import { FetchFileCtx } from '../../shared/src/components/CodeExcerpt'
@@ -52,7 +52,7 @@ import { SurveyToast } from './marketing/SurveyToast'
 import { ThemeProps } from '../../shared/src/theme'
 import { ThemePreferenceProps } from './theme'
 import { KeyboardShortcutsProps, KEYBOARD_SHORTCUT_SHOW_HELP } from './keyboardShortcuts/keyboardShortcuts'
-import { QueryState } from './search/helpers'
+import { QueryState, SearchQueryLocationState } from './search/helpers'
 import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import { VersionContextProps } from '../../shared/src/search/util'
 import { VersionContext } from './schema/site.schema'
@@ -62,7 +62,7 @@ import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../shared/src/api/contract'
 
 export interface LayoutProps
-    extends RouteComponentProps<{}>,
+    extends RouteComponentProps<{}, StaticContext, SearchQueryLocationState>,
         SettingsCascadeProps<Settings>,
         PlatformContextProps,
         ExtensionsControllerProps,

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -22,7 +22,7 @@ import { NavLinks } from './NavLinks'
 import { ThemeProps } from '../../../shared/src/theme'
 import { ThemePreferenceProps } from '../theme'
 import { KeyboardShortcutsProps } from '../keyboardShortcuts/keyboardShortcuts'
-import { QueryState } from '../search/helpers'
+import { QueryState, SearchQueryLocationState } from '../search/helpers'
 import { InteractiveModeInput } from '../search/input/interactive/InteractiveModeInput'
 import { FiltersToTypeAndValue } from '../../../shared/src/search/interactive/util'
 import { SearchModeToggle } from '../search/input/interactive/SearchModeToggle'
@@ -48,7 +48,7 @@ interface Props
         CopyQueryButtonProps,
         VersionContextProps {
     history: H.History
-    location: H.Location<{ query: string }>
+    location: H.Location<SearchQueryLocationState>
     authenticatedUser: GQL.IUser | null
     navbarSearchQueryState: QueryState
     onNavbarQueryChange: (queryState: QueryState) => void
@@ -96,7 +96,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 props.onNavbarQueryChange({ query, cursorPosition: query.length })
             } else {
                 // If we have no component state, then we may have gotten unmounted during a route change.
-                const query = props.location.state ? props.location.state.query : ''
+                const query = props.location?.state?.query ?? ''
                 props.onNavbarQueryChange({
                     query,
                     cursorPosition: query.length,

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -105,10 +105,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                 objectType: 'blob' | 'tree' | undefined
                 filePath: string | undefined
             }>) => {
-            // The decoding depends on the pinned `history` version.
-            // See https://github.com/sourcegraph/sourcegraph/issues/4408
-            // and https://github.com/ReactTraining/history/issues/505
-            const filePath = decodeURIComponent(match.params.filePath || '') // empty string is root
+            const filePath = match.params.filePath || '' // empty string is root
 
             // Redirect tree and blob routes pointing to the root to the repo page
             if (match.params.objectType && filePath.replace(/\/+$/g, '') === '') {

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Redirect, RouteComponentProps } from 'react-router'
+import { Redirect, RouteComponentProps, StaticContext } from 'react-router'
 import { LayoutProps } from './Layout'
 import { parseSearchURLQuery } from './search'
 import { lazyComponent } from './util/lazyComponent'
@@ -10,6 +10,7 @@ import { kubernetes } from './repogroups/Kubernetes'
 import { golang } from './repogroups/Golang'
 import { reactHooks } from './repogroups/ReactHooks'
 import { android } from './repogroups/Android'
+import { SearchQueryLocationState } from './search/helpers'
 
 const SearchPage = lazyComponent(() => import('./search/input/SearchPage'), 'SearchPage')
 const SearchResults = lazyComponent(() => import('./search/results/SearchResults'), 'SearchResults')
@@ -17,7 +18,7 @@ const SiteAdminArea = lazyComponent(() => import('./site-admin/SiteAdminArea'), 
 const ExtensionsArea = lazyComponent(() => import('./extensions/ExtensionsArea'), 'ExtensionsArea')
 
 interface LayoutRouteComponentProps<Params extends { [K in keyof Params]?: string }>
-    extends RouteComponentProps<Params>,
+    extends RouteComponentProps<Params, StaticContext, SearchQueryLocationState>,
         Omit<LayoutProps, 'match'> {}
 
 export interface LayoutRouteProps<Params extends { [K in keyof Params]?: string }> {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -12,13 +12,15 @@ import { isolatedFuzzySearchFiltersFilterType } from './input/interactive/filter
 import { InteractiveSearchProps, CaseSensitivityProps, PatternTypeProps } from '.'
 import { VersionContextProps } from '../../../shared/src/search/util'
 
+export type SearchQueryLocationState = null | undefined | { query?: string }
+
 export interface SubmitSearchParams
     extends Partial<Pick<ActivationProps, 'activation'>>,
         Partial<Pick<InteractiveSearchProps, 'filtersInQuery'>>,
         Pick<PatternTypeProps, 'patternType'>,
         Pick<CaseSensitivityProps, 'caseSensitive'>,
         VersionContextProps {
-    history: H.History
+    history: H.History<SearchQueryLocationState>
     query: string
     source: 'home' | 'nav' | 'repo' | 'tree' | 'filter' | 'type' | 'scopePage' | 'repogroupPage'
     searchParameters?: { key: string; value: string }[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,7 +2302,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -11480,16 +11481,17 @@ highlightjs-graphql@^1.0.1:
   resolved "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz#e6e3a69585348a14492386260bb2c0c54c6a2e7b"
   integrity sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA==
 
-history@4.5.1, history@^4.9.0:
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"
-  integrity sha1-RJNaUQIeO45n66wmejVnVzKrpWk=
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.npmjs.org/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
   dependencies:
-    invariant "^2.2.1"
+    "@babel/runtime" "^7.1.2"
     loose-envify "^1.2.0"
-    resolve-pathname "^2.0.0"
-    value-equal "^0.2.0"
-    warning "^3.0.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -12071,7 +12073,7 @@ interpret@^2.0.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz#b783ffac0b8371503e9ab39561df223286aa5433"
   integrity sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==
 
-invariant@2.2.4, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -19253,10 +19255,10 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-pathname@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
-  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -20272,7 +20274,8 @@ sourcegraph@^24.0.0:
   integrity sha512-PlGvkdBy5r5iHdKAVNY/jsPgWb3oY+2iAdIQ3qR83UHhvBFVgoctDAnyfJ1eMstENY3etBWtAJ8Kleoar3ecaA==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.7.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -22351,10 +22354,10 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-value-equal@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/value-equal/-/value-equal-0.2.1.tgz#c220a304361fce6994dbbedaa3c7e1a1b895871d"
-  integrity sha1-wiCjBDYfzmmU277ao8fhobiVhx0=
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 value-or-function@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,9 +3392,9 @@
   integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
 "@types/history@*":
-  version "4.7.2"
-  resolved "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
-  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+  version "4.7.5"
+  resolved "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
+  integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
 
 "@types/http-cache-semantics@*":
   version "4.0.0"


### PR DESCRIPTION
https://github.com/ReactTraining/history/commit/845d690c5576c7f55ecbe14babe0092e8e5bc2bb is released in the latest version, which fixes https://github.com/sourcegraph/sourcegraph/issues/4408 for us.

Also saves 2 lines of logspam on yarn install!



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
