### PR TITLE
campaigns: Dedupe priority items

### DIFF
--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -57,6 +57,7 @@ func (s *ChangesetSyncer) Run() {
 			err := s.SyncChangesetByID(ctx, id)
 			if err != nil {
 				log15.Error("Syncing changeset", "err", err)
+				continue
 			}
 			s.queue.mtx.Lock()
 			s.queue.prioritySynced[id] = time.Now()

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -361,18 +361,8 @@ func (q *changesetQueue) reschedule(schedule []syncSchedule) {
 	ctx, q.cancel = context.WithCancel(ctx)
 	go func() {
 		for _, s := range schedule {
-			var ok bool
-			q.mtx.Lock()
-			_, ok = q.priority[s.changesetID]
-			q.mtx.Unlock()
-			if ok {
-				continue
-			}
 			// Get most urgent changeset and sleep until it should be synced
-			now := time.Now()
-			nextSync := s.nextSync
-			d := nextSync.Sub(now)
-			sleep(ctx, d)
+			sleep(ctx, time.Until(s.nextSync))
 
 			select {
 			case <-ctx.Done():

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -113,7 +113,7 @@ func nextSync(h campaigns.ChangesetSyncHeuristics) time.Time {
 }
 
 func absDuration(d time.Duration) time.Duration {
-	if d > 0 {
+	if d >= 0 {
 		return d
 	}
 	return -1 * d

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -362,14 +362,7 @@ func (q *changesetQueue) reschedule(schedule []syncSchedule) {
 			now := time.Now()
 			nextSync := schedule[i].nextSync
 			d := nextSync.Sub(now)
-			timer := time.NewTimer(d)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-				// Timer ready, try and send sync instruction
-			}
+			sleep(ctx, d)
 
 			select {
 			case <-ctx.Done():
@@ -378,6 +371,16 @@ func (q *changesetQueue) reschedule(schedule []syncSchedule) {
 			}
 		}
 	}()
+}
+
+// sleep is a context aware time.Sleep
+func sleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+	case <-t.C:
+	}
 }
 
 func (q *changesetQueue) enqueuePriority(ids []int64) {

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -92,9 +92,9 @@ var (
 func nextSync(h campaigns.ChangesetSyncHeuristics) time.Time {
 	lastSync := h.UpdatedAt
 	var lastChange time.Time
-	// When we perform a sync, event timestamps are all updated.
+	// When we perform a sync, event timestamps are all updated, even if nothing has changed.
 	// We should fall back to h.ExternalUpdated if the diff is small
-	if diff := h.LatestEvent.Sub(lastSync); !h.LatestEvent.IsZero() && diff < minSyncDelay {
+	if diff := h.LatestEvent.Sub(lastSync); !h.LatestEvent.IsZero() && absDuration(diff) < minSyncDelay {
 		lastChange = h.ExternalUpdatedAt
 	} else {
 		lastChange = maxTime(h.ExternalUpdatedAt, h.LatestEvent)
@@ -109,6 +109,13 @@ func nextSync(h campaigns.ChangesetSyncHeuristics) time.Time {
 		diff = minSyncDelay
 	}
 	return lastSync.Add(diff)
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return -1 * d
 }
 
 func maxTime(a, b time.Time) time.Time {


### PR DESCRIPTION
This PR follows the original design but fixes the possibility of the same changeset getting queued up more than once in the priority channel.

It also makes sure that priority items are always run before non priority. Previously the select statement would pick randomly between scheduled and high priority items.

I also tried a different design using a heap which can be seen here:
https://github.com/sourcegraph/sourcegraph/pull/8769

Overall I think this version that follows the original design is easier to understand. The heap implementation had too many mutex's for my liking and it was difficult to deal with handling priority requests cleanly because a request could come in for the currently pending item. As it had already been "popped" from the heap it's priority would not be modified so extra logic was needed in the main select loop to handle this.