### PR TITLE
campaigns: Use heap for changeset syncing

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -42,7 +42,7 @@ func enterpriseInit(db *sql.DB, repoStore repos.Store, cf *httpcli.Factory, serv
 		}
 
 		// Set up syncer
-		go syncer.Run()
+		go syncer.Run(ctx)
 
 		// Set up expired campaign deletion
 		go func() {

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -547,13 +547,13 @@ func getChangesetQuery(opts *GetChangesetOpts) *sqlf.Query {
 	return sqlf.Sprintf(getChangesetsQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
-// ListChangesetSyncHeuristics returns sync timing data on all non-externally-deleted changesets.
-func (s *Store) ListChangesetSyncHeuristics(ctx context.Context) ([]campaigns.ChangesetSyncHeuristics, error) {
-	q := listChangesetSyncHeuristicsQuery()
-	results := make([]campaigns.ChangesetSyncHeuristics, 0)
+// ListChangesetSyncData returns sync timing data on all non-externally-deleted changesets.
+func (s *Store) ListChangesetSyncData(ctx context.Context) ([]campaigns.ChangesetSyncData, error) {
+	q := listChangesetSyncData()
+	results := make([]campaigns.ChangesetSyncData, 0)
 	_, _, err := s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
-		var h campaigns.ChangesetSyncHeuristics
-		if err = scanChangesetHeuristics(&h, sc); err != nil {
+		var h campaigns.ChangesetSyncData
+		if err = scanChangesetSyncData(&h, sc); err != nil {
 			return 0, 0, err
 		}
 		results = append(results, h)
@@ -565,7 +565,7 @@ func (s *Store) ListChangesetSyncHeuristics(ctx context.Context) ([]campaigns.Ch
 	return results, nil
 }
 
-func scanChangesetHeuristics(h *campaigns.ChangesetSyncHeuristics, s scanner) error {
+func scanChangesetSyncData(h *campaigns.ChangesetSyncData, s scanner) error {
 	return s.Scan(
 		&h.ChangesetID,
 		&h.UpdatedAt,
@@ -574,7 +574,7 @@ func scanChangesetHeuristics(h *campaigns.ChangesetSyncHeuristics, s scanner) er
 	)
 }
 
-func listChangesetSyncHeuristicsQuery() *sqlf.Query {
+func listChangesetSyncData() *sqlf.Query {
 	return sqlf.Sprintf(`
 SELECT changesets.id,
        changesets.updated_at,

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -983,14 +983,14 @@ func testStore(db *sql.DB) func(*testing.T) {
 			})
 		})
 
-		t.Run("ListChangesetHeuristics", func(t *testing.T) {
+		t.Run("ListChangesetSyncData", func(t *testing.T) {
 			// Differs from clock() due to updates higher up
 			externalUpdatedAt := clock().Add(-2 * time.Second)
-			hs, err := s.ListChangesetSyncHeuristics(ctx)
+			hs, err := s.ListChangesetSyncData(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []cmpgn.ChangesetSyncHeuristics{
+			want := []cmpgn.ChangesetSyncData{
 				{
 					ChangesetID:       2,
 					UpdatedAt:         clock(),

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -433,11 +433,9 @@ func (pq *changesetPriorityQueue) Push(x interface{}) {
 
 // Pop is not to be used directly, use heap.Pop(pq)
 func (pq *changesetPriorityQueue) Pop() interface{} {
-	old := pq.items
-	n := len(old)
-	item := old[n-1]
+	item := pq.items[len(pq.items)-1]
 	delete(pq.index, item.changesetID)
-	pq.items = old[0 : n-1]
+	pq.items = pq.items[:len(pq.items)-1]
 	return item
 }
 

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -139,7 +139,7 @@ func nextSync(h campaigns.ChangesetSyncData) time.Time {
 	var lastChange time.Time
 	// When we perform a sync, event timestamps are all updated even if nothing has changed.
 	// We should fall back to h.ExternalUpdated if the diff is small
-	// TODO: This is a workaround for related to this: https://github.com/sourcegraph/sourcegraph/pull/8771
+	// TODO: This is a workaround while we try to implement syncing without always updating events. See: https://github.com/sourcegraph/sourcegraph/pull/8771
 	// Once the above issue is fixed we can simply use maxTime(h.ExternalUpdatedAt, h.LatestEvent)
 	if diff := h.LatestEvent.Sub(lastSync); !h.LatestEvent.IsZero() && absDuration(diff) < minSyncDelay {
 		lastChange = h.ExternalUpdatedAt

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -109,7 +109,7 @@ var (
 )
 
 // nextSync computes the time we want the next sync to happen.
-func nextSync(h campaigns.ChangesetSyncHeuristics) time.Time {
+func nextSync(h campaigns.ChangesetSyncData) time.Time {
 	lastSync := h.UpdatedAt
 	var lastChange time.Time
 	// When we perform a sync, event timestamps are all updated even if nothing has changed.
@@ -147,9 +147,9 @@ func absDuration(d time.Duration) time.Duration {
 }
 
 func (s *ChangesetSyncer) computeSchedule(ctx context.Context) ([]syncSchedule, error) {
-	hs, err := s.Store.ListChangesetSyncHeuristics(ctx)
+	hs, err := s.Store.ListChangesetSyncData(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing changeset heuristics")
+		return nil, errors.Wrap(err, "listing changeset sync data")
 	}
 
 	ss := make([]syncSchedule, len(hs))

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -184,6 +184,8 @@ func (s *ChangesetSyncer) EnqueueChangesetSyncs(ctx context.Context, ids []int64
 		s.queue.Upsert(item)
 	}
 
+	// Non blocking send here in order not to hold the mutex and
+	// also because this is likely to have been triggered by a user action
 	select {
 	case s.priorityNotify <- struct{}{}:
 	default:

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -483,7 +483,7 @@ type priority int
 
 const (
 	priorityNormal priority = iota
-	priorityHigh   priority = iota
+	priorityHigh
 )
 
 // A SourceChangesets groups *repos.Changesets together with the

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -39,7 +39,7 @@ func (s *ChangesetSyncer) Run() {
 	if scheduleInterval == 0 {
 		scheduleInterval = 2 * time.Minute
 	}
-	s.priorityNotify = make(chan struct{})
+	s.priorityNotify = make(chan struct{}, 1)
 	s.queue = newChangesetPriorityQueue()
 	// How often to refresh the schedule
 	scheduleTicker := time.NewTicker(scheduleInterval)

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -64,12 +64,11 @@ func (s *ChangesetSyncer) Run() {
 			if next.priority == priorityHigh {
 				// Fire ASAP
 				timer = time.NewTimer(0)
-				timerChan = timer.C
 			} else {
 				// Use scheduled time
 				timer = time.NewTimer(time.Until(next.nextSync))
-				timerChan = timer.C
 			}
+			timerChan = timer.C
 		}
 
 		select {

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -443,7 +443,7 @@ func (pq *changesetPriorityQueue) Peek() (syncSchedule, bool) {
 
 // Upsert modifies at item if it exists or adds a new item
 // NOTE: If an existing item is high priority, it will not be changed back
-// to normal. This allows high priority items to stay that way reschedules
+// to normal. This allows high priority items to stay that way through reschedules
 func (pq *changesetPriorityQueue) Upsert(s syncSchedule) {
 	i, ok := pq.index[s.changesetID]
 	if !ok {

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -13,8 +13,8 @@ import (
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
-// A ChangesetSyncer periodically sync the metadata of the changesets
-// saved in the database
+// A ChangesetSyncer periodically syncs metadata of changesets
+// saved in the database.
 type ChangesetSyncer struct {
 	Store       SyncStore
 	ReposStore  repos.Store
@@ -192,7 +192,7 @@ func (s *ChangesetSyncer) computeSchedule(ctx context.Context) ([]scheduledSync,
 }
 
 // EnqueueChangesetSyncs will enqueue the changesets with the supplied ids for high priority syncing.
-// An error indicates that no changesets have been synced
+// An error indicates that no changesets have been enqueued.
 func (s *ChangesetSyncer) EnqueueChangesetSyncs(ctx context.Context, ids []int64) error {
 	if s.queue == nil {
 		return errors.New("background syncing not initialised")
@@ -207,7 +207,7 @@ func (s *ChangesetSyncer) EnqueueChangesetSyncs(ctx context.Context, ids []int64
 	return nil
 }
 
-// SyncChangesetByID will sync a single changeset given its id
+// SyncChangesetByID will sync a single changeset given its id.
 func (s *ChangesetSyncer) SyncChangesetByID(ctx context.Context, id int64) error {
 	log15.Debug("SyncChangesetByID", "id", id)
 	cs, err := s.Store.GetChangeset(ctx, GetChangesetOpts{
@@ -220,7 +220,7 @@ func (s *ChangesetSyncer) SyncChangesetByID(ctx context.Context, id int64) error
 }
 
 // SyncChangesets refreshes the metadata of the given changesets and
-// updates them in the database
+// updates them in the database.
 func (s *ChangesetSyncer) SyncChangesets(ctx context.Context, cs ...*campaigns.Changeset) (err error) {
 	if len(cs) == 0 {
 		return nil
@@ -389,16 +389,14 @@ type scheduledSync struct {
 }
 
 // changesetPriorityQueue is a min heap that sorts syncs by priority
-// and time of next sync
-// It is not safe for concurrent use so callers should protect it with
-// a mutex
+// and time of next sync. It is not safe for concurrent use.
 type changesetPriorityQueue struct {
 	items []scheduledSync
 	index map[int64]int // changesetID -> index
 }
 
 // newChangesetPriorityQueue creates a new queue for holding changeset sync instructions in chronological order.
-// items with a high priority will always appear at the front of the queue
+// items with a high priority will always appear at the front of the queue.
 func newChangesetPriorityQueue() *changesetPriorityQueue {
 	q := &changesetPriorityQueue{
 		items: make([]scheduledSync, 0),
@@ -453,7 +451,7 @@ func (pq *changesetPriorityQueue) Pop() interface{} {
 
 // End of heap methods
 
-// Peek fetches the highest priority item without removing it
+// Peek fetches the highest priority item without removing it.
 func (pq *changesetPriorityQueue) Peek() (scheduledSync, bool) {
 	if len(pq.items) == 0 {
 		return scheduledSync{}, false
@@ -461,9 +459,9 @@ func (pq *changesetPriorityQueue) Peek() (scheduledSync, bool) {
 	return pq.items[0], true
 }
 
-// Upsert modifies at item if it exists or adds a new item
+// Upsert modifies at item if it exists or adds a new item if not.
 // NOTE: If an existing item is high priority, it will not be changed back
-// to normal. This allows high priority items to stay that way through reschedules
+// to normal. This allows high priority items to stay that way through reschedules.
 func (pq *changesetPriorityQueue) Upsert(ss ...scheduledSync) {
 	for _, s := range ss {
 		i, ok := pq.index[s.changesetID]
@@ -480,7 +478,7 @@ func (pq *changesetPriorityQueue) Upsert(ss ...scheduledSync) {
 	}
 }
 
-// Get fetches the item with the supplied id without removing it
+// Get fetches the item with the supplied id without removing it.
 func (pq *changesetPriorityQueue) Get(id int64) (scheduledSync, bool) {
 	i, ok := pq.index[id]
 	if !ok {

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -178,7 +178,13 @@ func (s *ChangesetSyncer) EnqueueChangesetSyncs(ctx context.Context, ids []int64
 	for _, id := range ids {
 		item, ok := s.queue.Get(id)
 		if !ok {
-			continue
+			// Item has been recently synced and removed or we have an invalid id
+			// We have no way of telling the difference without making a DB call so
+			// add a new item anyway which will just lead to a harmless error later
+			item = syncSchedule{
+				changesetID: id,
+				nextSync:    time.Time{},
+			}
 		}
 		item.priority = priorityHigh
 		s.queue.Upsert(item)

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -92,10 +92,7 @@ func (s *ChangesetSyncer) Run() {
 			// Remove item, we need to get it again as it could have moved
 			// due to a high priority item arriving
 			s.mu.Lock()
-			i, ok := s.queue.index[next.changesetID]
-			if ok {
-				heap.Remove(s.queue, i)
-			}
+			s.queue.Remove(next.changesetID)
 			s.mu.Unlock()
 		case <-s.priorityNotify:
 			timer.Stop()
@@ -476,6 +473,13 @@ func (pq *changesetPriorityQueue) Get(id int64) (scheduledSync, bool) {
 func (pq *changesetPriorityQueue) Reschedule(ss []scheduledSync) {
 	for i := range ss {
 		pq.Upsert(ss[i])
+	}
+}
+
+func (pq *changesetPriorityQueue) Remove(id int64) {
+	i, ok := pq.index[id]
+	if ok {
+		heap.Remove(pq, i)
 	}
 }
 

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -29,9 +29,8 @@ type ChangesetSyncer struct {
 
 // Run will start the process of changeset syncing. It is long running
 // and is expected to be launched once at startup.
-func (s *ChangesetSyncer) Run() {
+func (s *ChangesetSyncer) Run(ctx context.Context) {
 	// TODO: Setup instrumentation here
-	ctx := context.Background()
 	scheduleInterval := s.ComputeScheduleInterval
 	if scheduleInterval == 0 {
 		scheduleInterval = 2 * time.Minute
@@ -72,6 +71,8 @@ func (s *ChangesetSyncer) Run() {
 		}
 
 		select {
+		case <-ctx.Done():
+			return
 		case <-scheduleTicker.C:
 			if timer != nil {
 				timer.Stop()

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -167,9 +167,9 @@ func TestSyncerRun(t *testing.T) {
 				return []campaigns.ChangesetSyncData{
 					{
 						ChangesetID:       1,
-						UpdatedAt:         now.Add(-24 * time.Hour),
-						LatestEvent:       now.Add(-24 * time.Hour),
-						ExternalUpdatedAt: now.Add(-24 * time.Hour),
+						UpdatedAt:         now.Add(-2 * maxSyncDelay),
+						LatestEvent:       now.Add(-2 * maxSyncDelay),
+						ExternalUpdatedAt: now.Add(-2 * maxSyncDelay),
 					},
 				}, nil
 			},

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -155,5 +155,4 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	if q.Len() != 0 {
 		t.Fatalf("Expected %d, got %d", q.Len(), 0)
 	}
-
 }

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -86,7 +86,7 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	now := time.Now()
 	q := newChangesetPriorityQueue()
 
-	items := []*syncSchedule{
+	items := []syncSchedule{
 		{
 			changesetID: 1,
 			nextSync:    now,
@@ -119,14 +119,14 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	}
 
 	// Set item to high priority
-	q.Upsert(&syncSchedule{
+	q.Upsert(syncSchedule{
 		changesetID: 4,
 		nextSync:    now.Add(-2 * time.Hour),
 		priority:    priorityHigh,
 	})
 
 	// Can't reduce priority of existing item
-	q.Upsert(&syncSchedule{
+	q.Upsert(syncSchedule{
 		changesetID: 4,
 		nextSync:    now.Add(-2 * time.Hour),
 		priority:    priorityNormal,
@@ -138,7 +138,14 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	expectedOrder := []int64{4, 2, 3, 1, 5}
 
 	for i := 0; i < len(items); i++ {
-		item := heap.Pop(q).(*syncSchedule)
+		peeked, ok := q.Peek()
+		if !ok {
+			t.Fatalf("Queue should not be empty")
+		}
+		item := heap.Pop(q).(syncSchedule)
+		if peeked.changesetID != item.changesetID {
+			t.Fatalf("Peeked and Popped item should have the same id")
+		}
 		if item.changesetID != expectedOrder[i] {
 			t.Fatalf("Expected item at index %d to be %d, got %d", i, expectedOrder[i], item.changesetID)
 		}

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -18,12 +18,12 @@ func TestNextSync(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		h    campaigns.ChangesetSyncHeuristics
+		h    campaigns.ChangesetSyncData
 		want time.Time
 	}{
 		{
 			name: "No time passed",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock(),
 			},
@@ -31,7 +31,7 @@ func TestNextSync(t *testing.T) {
 		},
 		{
 			name: "Linear backoff",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock().Add(-1 * time.Hour),
 			},
@@ -39,7 +39,7 @@ func TestNextSync(t *testing.T) {
 		},
 		{
 			name: "Use max of ExternalUpdateAt and LatestEvent",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock().Add(-2 * time.Hour),
 				LatestEvent:       clock().Add(-1 * time.Hour),
@@ -49,7 +49,7 @@ func TestNextSync(t *testing.T) {
 		{
 			// Could happen due to clock skew
 			name: "Future change",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock().Add(1 * time.Hour),
 			},
@@ -57,7 +57,7 @@ func TestNextSync(t *testing.T) {
 		},
 		{
 			name: "Diff max is capped",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock().Add(-2 * maxSyncDelay),
 			},
@@ -65,7 +65,7 @@ func TestNextSync(t *testing.T) {
 		},
 		{
 			name: "Diff min is capped",
-			h: campaigns.ChangesetSyncHeuristics{
+			h: campaigns.ChangesetSyncData{
 				UpdatedAt:         clock(),
 				ExternalUpdatedAt: clock().Add(-1 * minSyncDelay / 2),
 			},

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -86,7 +86,7 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	now := time.Now()
 	q := newChangesetPriorityQueue()
 
-	items := []syncSchedule{
+	items := []scheduledSync{
 		{
 			changesetID: 1,
 			nextSync:    now,
@@ -119,14 +119,14 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	}
 
 	// Set item to high priority
-	q.Upsert(syncSchedule{
+	q.Upsert(scheduledSync{
 		changesetID: 4,
 		nextSync:    now.Add(-2 * time.Hour),
 		priority:    priorityHigh,
 	})
 
 	// Can't reduce priority of existing item
-	q.Upsert(syncSchedule{
+	q.Upsert(scheduledSync{
 		changesetID: 4,
 		nextSync:    now.Add(-2 * time.Hour),
 		priority:    priorityNormal,
@@ -142,7 +142,7 @@ func TestChangesetPriorityQueue(t *testing.T) {
 		if !ok {
 			t.Fatalf("Queue should not be empty")
 		}
-		item := heap.Pop(q).(syncSchedule)
+		item := heap.Pop(q).(scheduledSync)
 		if peeked.changesetID != item.changesetID {
 			t.Fatalf("Peeked and Popped item should have the same id")
 		}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1454,8 +1454,8 @@ const (
 	ChangesetEventKindBitbucketServerMerged     ChangesetEventKind = "bitbucketserver:merged"
 )
 
-// ChangesetSyncHeuristics represents data about the sync status of a changeset
-type ChangesetSyncHeuristics struct {
+// ChangesetSyncData represents data about the sync status of a changeset
+type ChangesetSyncData struct {
 	ChangesetID int64
 	// UpdatedAt is the time we last updated / synced the changeset in our DB
 	UpdatedAt time.Time


### PR DESCRIPTION
This PR rewrites the changeset syncer to use a heap.

The downside is that we have long lived state, but we avoid the possibility of items getting queued more than once in the high priority channel.

Follow on from https://github.com/sourcegraph/sourcegraph/pull/8653