### PR TITLE
Fix: URLs with case:yes in the query fail

### DIFF
--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -42,8 +42,21 @@ export function dedupeWhitespace(value: string): string {
 
 /**
  * Checkes whether a given string is quoted.
+ *
  * @param value string to check against
  */
 export function isQuoted(value: string): boolean {
     return value.startsWith('"') && value.endsWith('"') && value !== '"'
+}
+
+/**
+ * Replaces a substring within a string.
+ *
+ * @param s Origianl string
+ * @param start starting index of the substring to be replace
+ * @param end starting index of the substring to be replace
+ * @param replacement replacement string, if any
+ */
+export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement?: string): string {
+    return s.slice(0, start) + replacement ?? '' + s.slice(end)
 }

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -54,7 +54,7 @@ export function isQuoted(value: string): boolean {
  *
  * @param s Original string
  * @param start starting index of the substring to be replaced
- * @param end starting index of the substring to be replace
+ * @param end starting index of the substring to be replaced
  * @param replacement replacement string, if any
  */
 export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement = ''): string {

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -55,7 +55,7 @@ export function isQuoted(value: string): boolean {
  * @param s Original string
  * @param start starting index of the substring to be replaced
  * @param end starting index of the substring to be replaced
- * @param replacement replacement string, if any
+ * @param an optional replacement string
  */
 export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement = ''): string {
     return s.slice(0, start) + replacement + s.slice(end)

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -57,6 +57,6 @@ export function isQuoted(value: string): boolean {
  * @param end starting index of the substring to be replace
  * @param replacement replacement string, if any
  */
-export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement?: string): string {
-    return s.slice(0, start) + replacement ?? '' + s.slice(end)
+export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement = ''): string {
+    return s.slice(0, start) + replacement + s.slice(end)
 }

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -53,7 +53,7 @@ export function isQuoted(value: string): boolean {
  * Replaces a substring within a string.
  *
  * @param s Original string
- * @param start starting index of the substring to be replace
+ * @param start starting index of the substring to be replaced
  * @param end starting index of the substring to be replace
  * @param replacement replacement string, if any
  */

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -52,7 +52,7 @@ export function isQuoted(value: string): boolean {
 /**
  * Replaces a substring within a string.
  *
- * @param s Origianl string
+ * @param s Original string
  * @param start starting index of the substring to be replace
  * @param end starting index of the substring to be replace
  * @param replacement replacement string, if any

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -541,10 +541,7 @@ export function buildSearchURLQuery(
 
     const patternTypeInQuery = parsePatternTypeFromQuery(fullQuery)
     if (patternTypeInQuery) {
-        fullQuery = replaceRange(fullQuery, {
-            start: patternTypeInQuery.range.start,
-            end: patternTypeInQuery.range.end,
-        })
+        fullQuery = replaceRange(fullQuery, patternTypeInQuery.range)
         searchParams.set('q', fullQuery)
         searchParams.set('patternType', patternTypeInQuery.value)
     } else {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -540,13 +540,9 @@ export function buildSearchURLQuery(
 
     const patternTypeInQuery = parsePatternTypeFromQuery(fullQuery)
     if (patternTypeInQuery) {
-        const newQuery = fullQuery.replace(
-            query.substring(patternTypeInQuery.range.start, patternTypeInQuery.range.end),
-            ''
-        )
-        searchParams.set('q', newQuery)
+        fullQuery = fullQuery.slice(0, patternTypeInQuery.range.start) + fullQuery.slice(patternTypeInQuery.range.end)
+        searchParams.set('q', fullQuery)
         searchParams.set('patternType', patternTypeInQuery.value)
-        fullQuery = newQuery
     } else {
         searchParams.set('q', fullQuery)
         searchParams.set('patternType', patternType)
@@ -554,13 +550,12 @@ export function buildSearchURLQuery(
 
     const caseInQuery = parseCaseSensitivityFromQuery(fullQuery)
     if (caseInQuery) {
-        const newQuery = fullQuery.replace(query.substring(caseInQuery.range.start, caseInQuery.range.end), '')
-        searchParams.set('q', newQuery)
+        fullQuery = fullQuery.slice(0, caseInQuery.range.start) + fullQuery.slice(caseInQuery.range.end)
+        searchParams.set('q', fullQuery)
 
         if (caseInQuery.value === 'yes') {
-            const newQuery = fullQuery.replace(query.substring(caseInQuery.range.start, caseInQuery.range.end), '')
+            fullQuery = fullQuery.slice(0, caseInQuery.range.start) + fullQuery.slice(caseInQuery.range.end)
             searchParams.set('case', caseInQuery.value)
-            fullQuery = newQuery
         } else {
             // For now, remove case when case:no, since it's the default behavior. Avoids
             // queries breaking when only `repo:` filters are specified.
@@ -568,8 +563,6 @@ export function buildSearchURLQuery(
             // TODO: just set case=no when https://github.com/sourcegraph/sourcegraph/issues/7671 is fixed.
             searchParams.delete('case')
         }
-
-        fullQuery = newQuery
     } else {
         searchParams.set('q', fullQuery)
         if (caseSensitive) {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -4,6 +4,7 @@ import { SearchPatternType } from '../graphql/schema'
 import { FiltersToTypeAndValue } from '../search/interactive/util'
 import { isEmpty } from 'lodash'
 import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
+import { replaceRange } from './strings'
 
 export interface RepoSpec {
     /**
@@ -540,7 +541,10 @@ export function buildSearchURLQuery(
 
     const patternTypeInQuery = parsePatternTypeFromQuery(fullQuery)
     if (patternTypeInQuery) {
-        fullQuery = fullQuery.slice(0, patternTypeInQuery.range.start) + fullQuery.slice(patternTypeInQuery.range.end)
+        fullQuery = replaceRange(fullQuery, {
+            start: patternTypeInQuery.range.start,
+            end: patternTypeInQuery.range.end,
+        })
         searchParams.set('q', fullQuery)
         searchParams.set('patternType', patternTypeInQuery.value)
     } else {
@@ -550,11 +554,11 @@ export function buildSearchURLQuery(
 
     const caseInQuery = parseCaseSensitivityFromQuery(fullQuery)
     if (caseInQuery) {
-        fullQuery = fullQuery.slice(0, caseInQuery.range.start) + fullQuery.slice(caseInQuery.range.end)
+        fullQuery = replaceRange(fullQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
         searchParams.set('q', fullQuery)
 
         if (caseInQuery.value === 'yes') {
-            fullQuery = fullQuery.slice(0, caseInQuery.range.start) + fullQuery.slice(caseInQuery.range.end)
+            fullQuery = replaceRange(fullQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
             searchParams.set('case', caseInQuery.value)
         } else {
             // For now, remove case when case:no, since it's the default behavior. Avoids

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -551,7 +551,7 @@ export function buildSearchURLQuery(
 
     const caseInQuery = parseCaseSensitivityFromQuery(fullQuery)
     if (caseInQuery) {
-        fullQuery = replaceRange(fullQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
+        fullQuery = replaceRange(fullQuery, caseInQuery.range.start)
         searchParams.set('q', fullQuery)
 
         if (caseInQuery.value === 'yes') {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -551,7 +551,7 @@ export function buildSearchURLQuery(
 
     const caseInQuery = parseCaseSensitivityFromQuery(fullQuery)
     if (caseInQuery) {
-        fullQuery = replaceRange(fullQuery, caseInQuery.range.start)
+        fullQuery = replaceRange(fullQuery, caseInQuery.range)
         searchParams.set('q', fullQuery)
 
         if (caseInQuery.value === 'yes') {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -558,7 +558,9 @@ export function buildSearchURLQuery(
         searchParams.set('q', newQuery)
 
         if (caseInQuery.value === 'yes') {
+            const newQuery = fullQuery.replace(query.substring(caseInQuery.range.start, caseInQuery.range.end), '')
             searchParams.set('case', caseInQuery.value)
+            fullQuery = newQuery
         } else {
             // For now, remove case when case:no, since it's the default behavior. Avoids
             // queries breaking when only `repo:` filters are specified.
@@ -600,7 +602,7 @@ export function generateFiltersQuery(filtersInQuery: FiltersToTypeAndValue): str
         .join(' ')
 }
 
-function parsePatternTypeFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
+export function parsePatternTypeFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
     const parsedQuery = parseSearchQuery(query)
     if (parsedQuery.type === 'success') {
         for (const member of parsedQuery.token.members) {
@@ -621,7 +623,7 @@ function parsePatternTypeFromQuery(query: string): { range: CharacterRange; valu
     return undefined
 }
 
-function parseCaseSensitivityFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
+export function parseCaseSensitivityFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
     const parsedQuery = parseSearchQuery(query)
     if (parsedQuery.type === 'success') {
         for (const member of parsedQuery.token.members) {

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -555,7 +555,7 @@ export function buildSearchURLQuery(
         searchParams.set('q', fullQuery)
 
         if (caseInQuery.value === 'yes') {
-            fullQuery = replaceRange(fullQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
+            fullQuery = replaceRange(fullQuery, caseInQuery.range)
             searchParams.set('case', caseInQuery.value)
         } else {
             // For now, remove case when case:no, since it's the default behavior. Avoids

--- a/web/src/search/index.test.tsx
+++ b/web/src/search/index.test.tsx
@@ -1,0 +1,46 @@
+import { parseSearchURL } from '.'
+import { SearchPatternType } from '../../../shared/src/graphql/schema'
+
+describe('search/index', () => {
+    test('parseSearchURL', () => {
+        expect(
+            parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=literal&case=yes')
+        ).toStrictEqual({
+            query: 'TEST repo:sourcegraph/sourcegraph ',
+            patternType: SearchPatternType.literal,
+            caseSensitive: true,
+        })
+
+        expect(
+            parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:no&patternType=literal&case=yes')
+        ).toStrictEqual({
+            query: 'TEST repo:sourcegraph/sourcegraph ',
+            patternType: SearchPatternType.literal,
+            caseSensitive: false,
+        })
+
+        expect(
+            parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+patternType:regexp&patternType=literal&case=yes')
+        ).toStrictEqual({
+            query: 'TEST repo:sourcegraph/sourcegraph ',
+            patternType: SearchPatternType.regexp,
+            caseSensitive: true,
+        })
+
+        expect(parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=literal')).toStrictEqual({
+            query: 'TEST repo:sourcegraph/sourcegraph ',
+            patternType: SearchPatternType.literal,
+            caseSensitive: true,
+        })
+
+        expect(
+            parseSearchURL(
+                'q=TEST+repo:sourcegraph/sourcegraph+case:no+patternType:regexp&patternType=literal&case=yes'
+            )
+        ).toStrictEqual({
+            query: 'TEST repo:sourcegraph/sourcegraph  ',
+            patternType: SearchPatternType.regexp,
+            caseSensitive: false,
+        })
+    })
+})

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -67,10 +67,7 @@ export function parseSearchURL(
     const patternTypeInQuery = parsePatternTypeFromQuery(finalQuery)
     if (patternTypeInQuery) {
         // Any `patterntype:` filter in the query should override the patternType= URL query parameter if it exists.
-        finalQuery = replaceRange(finalQuery, {
-            start: patternTypeInQuery.range.start,
-            end: patternTypeInQuery.range.end,
-        })
+        finalQuery = replaceRange(finalQuery, patternTypeInQuery.range)
         patternType = patternTypeInQuery.value as SearchPatternType
     }
 

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -66,25 +66,21 @@ export function parseSearchURL(
     const patternTypeInQuery = parsePatternTypeFromQuery(finalQuery)
     if (patternTypeInQuery) {
         // Any `patterntype:` filter in the query should override the patternType= URL query parameter if it exists.
-        const newQuery = finalQuery.replace(
-            finalQuery.substring(patternTypeInQuery.range.start, patternTypeInQuery.range.end),
-            ''
-        )
-        finalQuery = newQuery
+        finalQuery =
+            finalQuery.slice(0, patternTypeInQuery.range.start) + finalQuery.slice(patternTypeInQuery.range.end)
         patternType = patternTypeInQuery.value as SearchPatternType
     }
 
     const caseInQuery = parseCaseSensitivityFromQuery(finalQuery)
     if (caseInQuery) {
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
-        const newQuery = finalQuery.replace(finalQuery.substring(caseInQuery.range.start, caseInQuery.range.end), '')
+        finalQuery = finalQuery.slice(0, caseInQuery.range.start) + finalQuery.slice(caseInQuery.range.end)
 
         if (caseInQuery.value === 'yes') {
             caseSensitive = true
         } else if (caseInQuery.value === 'no') {
             caseSensitive = false
         }
-        finalQuery = newQuery
     }
 
     return { query: finalQuery, patternType, caseSensitive }

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -37,7 +37,7 @@ export function parseSearchURLPatternType(query: string): SearchPatternType | un
 }
 
 export function searchURLIsCaseSensitive(query: string): boolean {
-    const queryCaseSensitivty = parseCaseSensitivityFromQuery(query)
+    const queryCaseSensitivity = parseCaseSensitivityFromQuery(query)
     if (queryCaseSensitivty) {
         // if `case:` filter exists in the query, override the existing case: query param
         return queryCaseSensitivty.value === 'yes'

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -74,7 +74,7 @@ export function parseSearchURL(
     const caseInQuery = parseCaseSensitivityFromQuery(finalQuery)
     if (caseInQuery) {
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
-        finalQuery = replaceRange(finalQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
+        finalQuery = replaceRange(finalQuery, caseInQuery.range)
 
         if (caseInQuery.value === 'yes') {
             caseSensitive = true

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -38,9 +38,9 @@ export function parseSearchURLPatternType(query: string): SearchPatternType | un
 
 export function searchURLIsCaseSensitive(query: string): boolean {
     const queryCaseSensitivity = parseCaseSensitivityFromQuery(query)
-    if (queryCaseSensitivty) {
+    if (queryCaseSensitivity) {
         // if `case:` filter exists in the query, override the existing case: query param
-        return queryCaseSensitivty.value === 'yes'
+        return queryCaseSensitivity.value === 'yes'
     }
     const searchParams = new URLSearchParams(query)
     const caseSensitive = searchParams.get('case')

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -2,6 +2,7 @@ import { escapeRegExp } from 'lodash'
 import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import { FiltersToTypeAndValue } from '../../../shared/src/search/interactive/util'
 import { parseCaseSensitivityFromQuery, parsePatternTypeFromQuery } from '../../../shared/src/util/url'
+import { replaceRange } from '../../../shared/src/util/strings'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -66,15 +67,17 @@ export function parseSearchURL(
     const patternTypeInQuery = parsePatternTypeFromQuery(finalQuery)
     if (patternTypeInQuery) {
         // Any `patterntype:` filter in the query should override the patternType= URL query parameter if it exists.
-        finalQuery =
-            finalQuery.slice(0, patternTypeInQuery.range.start) + finalQuery.slice(patternTypeInQuery.range.end)
+        finalQuery = replaceRange(finalQuery, {
+            start: patternTypeInQuery.range.start,
+            end: patternTypeInQuery.range.end,
+        })
         patternType = patternTypeInQuery.value as SearchPatternType
     }
 
     const caseInQuery = parseCaseSensitivityFromQuery(finalQuery)
     if (caseInQuery) {
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
-        finalQuery = finalQuery.slice(0, caseInQuery.range.start) + finalQuery.slice(caseInQuery.range.end)
+        finalQuery = replaceRange(finalQuery, { start: caseInQuery.range.start, end: caseInQuery.range.end })
 
         if (caseInQuery.value === 'yes') {
             caseSensitive = true

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -9,7 +9,7 @@ import {
     PatternTypeProps,
     InteractiveSearchProps,
     CaseSensitivityProps,
-    searchURLIsCaseSensitive,
+    parseSearchURL,
 } from '..'
 import { Contributions, Evaluated } from '../../../../shared/src/api/protocol'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
@@ -112,11 +112,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
             this.componentUpdates
                 .pipe(
                     startWith(this.props),
-                    map(props => ({
-                        query: parseSearchURLQuery(props.location.search),
-                        patternType: parseSearchURLPatternType(props.location.search),
-                        caseSensitive: searchURLIsCaseSensitive(props.location.search),
-                    })),
+                    map(props => parseSearchURL(props.location.search)),
                     // Search when a new search query was specified in the URL
                     distinctUntilChanged((a, b) => isEqual(a, b)),
                     filter(


### PR DESCRIPTION
When  directly landing on URLs with `case:yes` in the query, the query failed, because we didn't parse the query to check for `case:` filters and appended a `case:yes` to the query.

Also related, if a `patternType:` filter was in the query, the patternType toggle
would show the incorrect state, since we didn't parse the query to look for `patternType` filters to check if there was an effective value. 

Now, when the `SearchResults` component is mounted, we use the new `parseSearchURL` function to get the effective query, case, and patternType values, by parsing the `q` query param for `case:` and `patternType:` filters first.

Fixes https://github.com/sourcegraph/sourcegraph/issues/8723.