### PR TITLE
Test updating unchanged ChangsetEvent doesn't modify database row

### DIFF
--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -991,6 +991,7 @@ changed AS (
   SET
     metadata   = excluded.metadata,
     updated_at = excluded.updated_at
+  WHERE changeset_events.metadata != excluded.metadata
   RETURNING changeset_events.*
 )
 ` + batchChangesetEventsQuerySuffix
@@ -1003,6 +1004,7 @@ func (s *Store) upsertChangesetEventsQuery(es []*campaigns.ChangesetEvent) (*sql
 		}
 
 		if !e.UpdatedAt.After(e.CreatedAt) {
+			fmt.Printf("Setting updatedAt\n")
 			e.UpdatedAt = now
 		}
 	}
@@ -2681,6 +2683,7 @@ func scanChangesetEvent(e *campaigns.ChangesetEvent, s scanner) error {
 		&e.UpdatedAt,
 		&metadata,
 	)
+	fmt.Printf("scanChangesetEvent. e.UpdatedAt=%v\n", e.UpdatedAt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We talked about this in the watercooler chat. Currently we always update the `changeset_events.updated_at` column, even if nothing changed.

I started to hack on this for a bit, but as it turns out: when the new `WHERE` clause in the the `ON CONFLICT [...]` doesn't evaluate to true, then the `RETURNING changeset_events.*` is not executed, I think.

As I understand it @ryanslade already solved this in code, not in SQL, and I only picked it up for a bit of fun hacking. If one of you wants to take over this branch: let me know.
