### PR TITLE
fix formatting issue in admin/config/site_config

### DIFF
--- a/doc/admin/config/site_config.md
+++ b/doc/admin/config/site_config.md
@@ -53,16 +53,13 @@ docker exec -it $CONTAINER sh -c 'vi ~/site-config.json'
 ```
 
 > **Note:** Not running Sourcegraph v3.12.1+? Use the following:
->
-> ```sh
-> docker exec -it $CONTAINER sh -c 'apk add --no-cache nano && nano /site-config.json'
-> ```
->
+```sh
+docker exec -it $CONTAINER sh -c 'apk add --no-cache nano && nano /site-config.json'
+```
 > Or if you prefer using a Vim editor:
->
-> ```sh
-> docker exec -it $CONTAINER sh -c 'vi /site-config.json'
-> ```
+```sh
+docker exec -it $CONTAINER sh -c 'vi /site-config.json'
+```
 
 #### Kubernetes cluster instances
 
@@ -77,16 +74,14 @@ kubectl exec -it $FRONTEND_POD -- sh -c 'vi ~/site-config.json'
 ```
 
 > **Note:** Not running Sourcegraph v3.12.1+? Use the following:
->
-> ```sh
-> kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano /site-config.json'
-> ```
->
+```
+kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano /site-config.json'
+```
+
 > Or if you prefer using a Vim editor:
->
-> ```sh
-> kubectl exec -it $FRONTEND_POD -- sh -c 'vi /site-config.json'
-> ```
+```sh
+kubectl exec -it $FRONTEND_POD -- sh -c 'vi /site-config.json'
+```
 
 Then simply save your changes (type <kbd>ctrl+x</kbd> and <kbd>y</kbd> to exit `nano` and save your changes). Your changes will be applied immediately in the same was as if you had made them through the web UI.
 

--- a/doc/admin/faq.md
+++ b/doc/admin/faq.md
@@ -72,6 +72,16 @@ Alternatively, you can use [`git-svn`](https://git-scm.com/docs/git-svn) or
 Git repositories. Unlike `src-expose`, this will preserve commit history, but is generally much
 slower.
 
+## How do I access Sourcegraph if my authentication provider experiences an outage?
+
+If you are using an external authentication provider and the provider experiences an outage, users
+will be unable to sign into Sourcegraph. A site administrator can configure an alternate sign-in
+method by modifying the `auth.providers` field in site configuration. However, the site
+administrator may themselves be unable to sign in. If this is the case, then a site administrator
+can update the configuration if they have direct `docker exec` or `kubectl exec` access to the
+Sourcegraph instance. Follow the [instructions to update the site config if the web UI is
+inaccessible](config/site_config.md#editing-your-site-configuration-if-you-cannot-access-the-web-ui).
+
 ## Troubleshooting
 
 Content moved to a [dedicated troubleshooting page](troubleshooting.md).


### PR DESCRIPTION
This addresses a recent question from a customer interested in ensuring business continuity (i.e., Sourcegraph can still be made accessible) if their auth provider experiences an outage:

* fix formatting issue in admin/config/site_config
* add section in FAQ to address question of accessing Sourcegraph if authentication provider experiences an outage

