### PR TITLE
Revise BBS documentation to mention webhooks and give clearer instructions

### DIFF
--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -24,7 +24,7 @@ There are four fields for configuring which repositories are mirrored:
 
 The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server instance to send webhooks to Sourcegraph.
 
-Using webhooks is highly recommend when using [Campaigns](../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
+Using webhooks is highly recommended when using [Campaigns](../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
 
 To setup webhooks:
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -24,7 +24,7 @@ There are four fields for configuring which repositories are mirrored:
 
 The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server instance to send webhooks to Sourcegraph.
 
-Using webhooks is highly recommended when using [Campaigns](../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
+Using webhooks is highly recommended when using [Campaigns](../../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
 
 To set up webhooks:
 
@@ -36,7 +36,7 @@ To set up webhooks:
 1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr`.
 1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
-Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../user/campaigns.md), fast and more efficiently.
+Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../../user/campaigns.md), fast and more efficiently.
 
 ## Repository permissions
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -26,7 +26,7 @@ The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#
 
 Using webhooks is highly recommended when using [Campaigns](../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
 
-To setup webhooks:
+To set up webhooks:
 
 1. Connect Bitbucket Server to Sourcegraph (_see instructions above_)
 1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server instance

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -9,6 +9,8 @@ To connect Bitbucket Server to Sourcegraph:
 1. Configure the connection to Bitbucket Server using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
 1. Press **Add repositories**.
 
+Also consider installing the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) which enables native code intelligence for every Bitbucket user when browsing code and reviewing pull requests, allows for faster permission syncing between Sourcegraph and Bitbucket Server and adds support for webhooks to Bitbucket Server.
+
 ## Repository syncing
 
 There are four fields for configuring which repositories are mirrored:
@@ -40,7 +42,3 @@ Sourcegraph will mark repositories as archived if they have the `archived` label
 Bitbucket Server connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage repositories" area.
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/bitbucket_server.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/bitbucket_server) to see rendered content.</div>
-
-## Sourcegraph native code intelligence plugin
-
-Learn more about the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-native-code-intelligence-plugin) for enabling native code intelligence for every Bitbucket user when browsing code and reviewing pull requests.

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -36,7 +36,7 @@ To set up webhooks:
     "plugin.webhooks": [ {"secret": "verylongrandomsecret"} ]
     ```
 1. Click **Update repositories**
-1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr`.
+1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr` scope.
 1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../user/campaigns.md), fast and more efficiently.

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -28,16 +28,13 @@ Using webhooks is highly recommended when using [Campaigns](../user/campaigns.md
 
 To set up webhooks:
 
-1. Connect Bitbucket Server to Sourcegraph (_see instructions above_)
-1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server instance
-1. In Sourcegraph, go to **Site admin > Manage repositories** and edit the Bitbucket Server configuration
-1. Add the `"plugin.webhooks"` property (you can generate a secret with `openssl rand -hex 32`):
-    ```json
-    "plugin.webhooks": [ {"secret": "verylongrandomsecret"} ]
-    ```
-1. Click **Update repositories**
-1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr` scope.
-1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column
+1. Connect Bitbucket Server to Sourcegraph (_see instructions above_).
+1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server instance.
+1. In Sourcegraph, go to **Site admin > Manage repositories** and edit the Bitbucket Server configuration.
+1. Add the `"plugin.webhooks"` property (you can generate a secret with `openssl rand -hex 32`):<br /> `"plugin.webhooks": [ {"secret": "verylongrandomsecret"} ]`
+1. Click **Update repositories**.
+1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr`.
+1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../user/campaigns.md), fast and more efficiently.
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -20,6 +20,27 @@ There are four fields for configuring which repositories are mirrored:
 - [`exclude`](bitbucket_server.md#configuration)<br>A list of repositories to exclude which takes precedence over the `repos`, and `repositoryQuery` fields.
 - ['excludePersonalRepositories'](bitbucket_server.md#configuration)<br>With this enabled, Sourcegraph will exclude any personal repositories from being imported, even if it has access to them.
 
+## Webhooks
+
+The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server instance to send webhooks to Sourcegraph.
+
+Using webhooks is highly recommend when using [Campaigns](../user/campaigns.md), since they speed up the syncing of pull request data between Bitbucket Server and Sourcegraph and make it more efficient.
+
+To setup webhooks:
+
+1. Connect Bitbucket Server to Sourcegraph (_see instructions above_)
+1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server instance
+1. In Sourcegraph, go to **Site admin > Manage repositories** and edit the Bitbucket Server configuration
+1. Add the `"plugin.webhooks"` property (you can generate a secret with `openssl rand -hex 32`):
+    ```json
+    "plugin.webhooks": [ {"secret": "verylongrandomsecret"} ]
+    ```
+1. Click **Update repositories**
+1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-campaigns` and the `pr`.
+1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column
+
+Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../user/campaigns.md), fast and more efficiently.
+
 ## Repository permissions
 
 By default, all Sourcegraph users can view all repositories. To configure Sourcegraph to use

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -6,7 +6,7 @@ Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_server.md) | ✅
 [Repository permissions](../admin/external_service/bitbucket_server.md#repository-permissions) | ✅
-[Sourcegraph native code intelligence plugin](#sourcegraph-native-code-intelligence-plugin) | ✅
+[Sourcegraph Bitbucket Server plugin](#sourcegraph-bitbucket-server-plugin) | ✅
 [Browser extension](#browser-extension) | ✅
 
 ## Repository syncing
@@ -17,21 +17,24 @@ Site admins can [add Bitbucket Server repositories to Sourcegraph](../admin/exte
 
 Site admins can [configure Sourcegraph to respect Bitbucket Server's repository access permissions](../admin/external_service/bitbucket_server.md#repository-permissions).
 
-## Sourcegraph native code intelligence plugin
+## Sourcegraph Bitbucket Server Plugin
+
+We recommend installing the [Sourcegraph Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/tree/master) so user doesn't need to install and configure the browser extension to get code intelligence when browsing code or reviewing pull requests on Bitbucket Server.
+
+The plugin also enables **faster ACL permission syncing between Sourcegraph and Bitbucket Server** and adds **webhooks to Bitbucket Server**, which are used by and highly recommended for [Campaigns](../user/campaigns.md).
 
 ![Bitbucket Server code intelligence](https://storage.googleapis.com/sourcegraph-assets/bitbucket-code-intel-pr-short.gif)
 
-We recommend installing the [Sourcegraph Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/tree/master) so each user doesn't need to install and configure the browser extension.
+### Installation and requirements
 
-This involves adding a new add-on to your Bitbucket Server instance and see the [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin) repository for installation instructions and configuration settings.
+See the [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin) repository for instructions on how to install the plugin on your Bitbucket Server instance.
 
-> NOTE: For the Bitbucket Server plugin to communicate with the Sourcegraph instance, the Sourcegraph site configuration must be updated to add the Bitbucket Server URL to the [`corsOrigin` property](../admin/config/site_config.md)
+For the Bitbucket Server plugin to then communicate with the Sourcegraph instance, the Sourcegraph site configuration must be updated to include the [`corsOrigin` property](../admin/config/site_config.md) with the Bitbucket Server URL
 
 ```json
 {
   // ...
-  "corsOrigin":
-    "https://my-bitbucket.example.com"
+  "corsOrigin":"https://my-bitbucket.example.com"
   // ...
 }
 ```

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -20,7 +20,7 @@ Site admins can [configure Sourcegraph to respect Bitbucket Server's repository 
 
 ## Sourcegraph Bitbucket Server Plugin
 
-We recommend installing the [Sourcegraph Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/tree/master) so user doesn't need to install and configure the browser extension to get code intelligence when browsing code or reviewing pull requests on Bitbucket Server.
+We recommend installing the [Sourcegraph Bitbucket Server plugin](https://github.com/sourcegraph/bitbucket-server-plugin/tree/master) so users don't need to install and configure the browser extension to get code intelligence when browsing code or reviewing pull requests on Bitbucket Server.
 
 The plugin also enables **faster ACL permission syncing between Sourcegraph and Bitbucket Server** and adds **webhooks to Bitbucket Server**, which are used by and highly recommended for [Campaigns](../user/campaigns.md).
 
@@ -35,7 +35,7 @@ For the Bitbucket Server plugin to then communicate with the Sourcegraph instanc
 ```json
 {
   // ...
-  "corsOrigin":"https://my-bitbucket.example.com"
+  "corsOrigin": "https://my-bitbucket.example.com"
   // ...
 }
 ```

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -5,6 +5,7 @@ You can use Sourcegraph with Git repositories hosted on [Bitbucket Server](https
 Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_server.md) | ✅
+[Webhooks](../admin/external_service/bitbucket_server.md#webhooks) | ✅
 [Repository permissions](../admin/external_service/bitbucket_server.md#repository-permissions) | ✅
 [Sourcegraph Bitbucket Server plugin](#sourcegraph-bitbucket-server-plugin) | ✅
 [Browser extension](#browser-extension) | ✅
@@ -39,7 +40,13 @@ For the Bitbucket Server plugin to then communicate with the Sourcegraph instanc
 }
 ```
 
-### Experimental Faster ACL permissions fetching
+### Webhooks
+
+Once the plugin is installed, go to **Administration > Add-ons > Sourcegraph** to see a list of all configured webhooks and to create a new one.
+
+Sourcegraph automatically creates a webhook for usage with [Campaigns](../user/campaigns.md) once the [`"plugin.webhooks"` property in the Bitbucket Server configuration](../admin/external_service/bitbucket_server.md) is configured in Sourcegraph.
+
+### Experimental: faster ACL permissions fetching
 
 The plugin also supports an experimental method of faster ACL permissions fetching that aims to improve search speed. You can enable this in the experimental section of the [site configuration](../admin/config/site_config.md):
 


### PR DESCRIPTION
This is just the first step. I plan on adding more docs about the webhook integration after today's sync with @eseliger.

But what this does is:

- Consistently name it `Sourcegraph Bitbucket Server plugin` instead of mixing that and `Sourcegraph native code intelligence plugin`
- Mention the features of the plugin
- Give clearer and easy to find instructions on how to install and set it up

All of this can be improved and I will probably push to this PR.
