### PR TITLE
search: don't match and/or substrings as keywords inside parameters

### DIFF
--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -133,11 +133,6 @@ func (p *parser) expect(keyword keyword) bool {
 	return true
 }
 
-// isKeyword returns whether current parser position matches a reserved keyword.
-func (p *parser) isKeyword() bool {
-	return p.match(AND) || p.match(OR) || p.match(LPAREN) || p.match(RPAREN)
-}
-
 // skipSpaces advances the input and places the parser position at the next
 // non-space value.
 func (p *parser) skipSpaces() error {
@@ -193,7 +188,7 @@ func (p *parser) ParseParameter() Parameter {
 		if p.expect(`\ `) || p.expect(`\(`) || p.expect(`\)`) {
 			continue
 		}
-		if p.isKeyword() {
+		if p.match(LPAREN) || p.match(RPAREN) {
 			break
 		}
 		if p.done() {

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -100,6 +100,14 @@ func Test_Parse(t *testing.T) {
 			Want:  "(and a b c)",
 		},
 		{
+			Input: "aorb",
+			Want:  "aorb",
+		},
+		{
+			Input: "aANDb",
+			Want:  "aANDb",
+		},
+		{
 			Name:  "Reduced complex query mixed caps",
 			Input: "a and b AND c or d and (e OR f) g h i or j",
 			Want:  "(or (and a b c) (and d (or e f) g h i) j)",


### PR DESCRIPTION
Don't bail out of scanning a parameter when we see `and` or `or` keywords as a substring. Otherwise a string like `aorb` is parsed as `(or a b)`.

![smashing](https://user-images.githubusercontent.com/888624/67184525-d83d8600-f398-11e9-84aa-4cd30d4ab5ed.gif)