### PR TITLE
WIP: Update @types/express.

### DIFF
--- a/lsif/package.json
+++ b/lsif/package.json
@@ -52,7 +52,7 @@
     "@sourcegraph/tsconfig": "^4.0.0",
     "@types/bloomfilter": "0.0.0",
     "@types/body-parser": "1.19.0",
-    "@types/express": "4.17.2",
+    "@types/express": "^4.17.3",
     "@types/express-winston": "3.0.4",
     "@types/got": "9.6.9",
     "@types/ioredis": "4.14.8",

--- a/lsif/yarn.lock
+++ b/lsif/yarn.lock
@@ -473,10 +473,19 @@
     "@types/logform" "*"
     winston "^3.0.0"
 
-"@types/express@*", "@types/express@4.17.2":
+"@types/express@*":
   version "4.17.2"
   resolved "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
   integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.3":
+  version "4.17.3"
+  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz#38e4458ce2067873b09a73908df488870c303bd9"
+  integrity sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"


### PR DESCRIPTION
yarn --cwd lsif add @types/express
yarn --cwd lsif add @types/body-parser
yarn --cwd lsif add @types/express-serve-static-core
yarn --cwd lsif add @types/serve-static

After doing this, yarn --cwd lsif run build works without error.

An attempt at fixing #8775 CI break.