### PR TITLE
search: introduce concat operator

### DIFF
--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -247,7 +247,6 @@ func containsPattern(node Node) bool {
 // descendents contain one or more search patterns.
 func partitionParameters(nodes []Node) []Node {
 	var patterns, unorderedParams []Node
-	unorderedParams := []Node{}
 	for _, n := range nodes {
 		switch v := n.(type) {
 		case Parameter:

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -39,6 +39,7 @@ type operatorKind int
 const (
 	Or operatorKind = iota
 	And
+	Concat
 )
 
 // Operator is a nonterminal node of kind Kind with child nodes Operands.
@@ -63,11 +64,15 @@ func (node Operator) String() string {
 		result = append(result, child.String())
 	}
 	var kind string
-	if node.Kind == Or {
+	switch node.Kind {
+	case Or:
 		kind = "or"
-	} else {
+	case And:
 		kind = "and"
+	case Concat:
+		kind = "concat"
 	}
+
 	return fmt.Sprintf("(%s %s)", kind, strings.Join(result, " "))
 }
 
@@ -202,6 +207,70 @@ func (p *parser) ParseParameter() Parameter {
 	return ScanParameter(p.buf[start:p.pos])
 }
 
+func visit(node Node, f func(node Node)) {
+	switch v := node.(type) {
+	case Parameter:
+		f(v)
+	case Operator:
+		f(v)
+		for _, n := range v.Operands {
+			visit(n, f)
+		}
+	}
+}
+
+// containsPattern returns true if any descendent of node is a search pattern
+// (i.e., a parameter where the field is the empty string).
+func containsPattern(node Node) bool {
+	var result bool
+	f := func(node Node) {
+		switch v := node.(type) {
+		case Parameter:
+			if v.Field == "" {
+				result = true
+			}
+		}
+	}
+	visit(node, f)
+	return result
+}
+
+// partitionParameters constructs a parse tree to distinguish terms where
+// ordering is insignificant (e.g., "repo:foo file:bar") versus terms where
+// ordering may be significant (e.g., search patterns like "foo bar"). Search
+// patterns are parameters whose field is the empty string.
+//
+// The resulting tree defines an ordering relation on nodes in the following cases:
+// (1) When more than one search patterns exist at the same operator level, they
+// are concatenated in order.
+// (2) Any nonterminal node is concatenated (ordered in the tree) if its
+// descendents contain one or more search patterns.
+func partitionParameters(nodes []Node) []Node {
+	patterns := []Node{}
+	unorderedParams := []Node{}
+	for _, n := range nodes {
+		switch v := n.(type) {
+		case Parameter:
+			if v.Field == "" {
+				patterns = append(patterns, n)
+			} else {
+				unorderedParams = append(unorderedParams, n)
+			}
+		case Operator:
+			if containsPattern(n) {
+				patterns = append(patterns, n)
+			} else {
+				unorderedParams = append(unorderedParams, n)
+			}
+		}
+	}
+	if len(patterns) > 1 {
+		orderedPatterns := newOperator(patterns, Concat)
+		return newOperator(append(unorderedParams, orderedPatterns...), And)
+	}
+	return newOperator(append(unorderedParams, patterns...), And)
+}
+
 // scanParameterList scans for consecutive leaf nodes.
 func (p *parser) parseParameterList() ([]Node, error) {
 	var nodes []Node
@@ -210,7 +279,7 @@ func (p *parser) parseParameterList() ([]Node, error) {
 			return nil, err
 		}
 		if p.done() {
-			break
+			goto done
 		}
 		switch {
 		case p.expect(LPAREN):
@@ -224,18 +293,19 @@ func (p *parser) parseParameterList() ([]Node, error) {
 			p.balanced--
 			if len(nodes) == 0 {
 				// Return a non-nil node if we parsed "()".
-				return []Node{Parameter{Value: ""}}, nil
+				nodes = []Node{Parameter{Value: ""}}
 			}
-			return nodes, nil
+			goto done
 		case p.match(AND), p.match(OR):
 			// Caller advances.
-			return nodes, nil
+			goto done
 		default:
 			parameter := p.ParseParameter()
 			nodes = append(nodes, parameter)
 		}
 	}
-	return nodes, nil
+done:
+	return partitionParameters(nodes), nil
 }
 
 // reduce takes lists of left and right nodes and reduces them if possible. For example,

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -274,12 +274,13 @@ func partitionParameters(nodes []Node) []Node {
 // scanParameterList scans for consecutive leaf nodes.
 func (p *parser) parseParameterList() ([]Node, error) {
 	var nodes []Node
+loop:
 	for {
 		if err := p.skipSpaces(); err != nil {
 			return nil, err
 		}
 		if p.done() {
-			goto done
+			break loop
 		}
 		switch {
 		case p.expect(LPAREN):
@@ -295,16 +296,15 @@ func (p *parser) parseParameterList() ([]Node, error) {
 				// Return a non-nil node if we parsed "()".
 				nodes = []Node{Parameter{Value: ""}}
 			}
-			goto done
+			break loop
 		case p.match(AND), p.match(OR):
 			// Caller advances.
-			goto done
+			break loop
 		default:
 			parameter := p.ParseParameter()
 			nodes = append(nodes, parameter)
 		}
 	}
-done:
 	return partitionParameters(nodes), nil
 }
 

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -246,7 +246,7 @@ func containsPattern(node Node) bool {
 // (2) Any nonterminal node is concatenated (ordered in the tree) if its
 // descendents contain one or more search patterns.
 func partitionParameters(nodes []Node) []Node {
-	patterns := []Node{}
+	var patterns, unorderedParams []Node
 	unorderedParams := []Node{}
 	for _, n := range nodes {
 		switch v := n.(type) {


### PR DESCRIPTION
This PR introduces a `concat` operator in the parse tree.  It is not an operator that a user can specify--rather, it delineates which part of the query contains search patterns (or trees containing search patterns) versus other parameters (typically filters, like `repo:foo`). The main semantic distinction is that we want to treat order significantly for search patterns, but parameters can otherwise be unordered. It's important to delineate ordered (or concatenated) search patterns, because we have established use cases for interpreting a query like `foo bar baz` as any of 

`foo(.*)?bar(.*)?baz` or `foo bar baz`, or `foo\s+bar\s+baz`, and in future, perhaps `foo and bar and baz`

depending on search mode/user preference.

We currently treat search patterns ordered by default (unlike other code search engines, which will typically interpret all whitespace as `and`, unless quotes imply an ordering, as in `"search pattern"`). We would like to preserve this ordering without quotation (it's more natural), but that means we must disambiguate whitespace-separated terms into those that imply an ordering, and those that do not. Parameters that do not imply an ordering instead imply `and` in the usual sense, as we currently do for queries like `repo:foo file:bar`. This PR takes care of the conversion and simplification of concated terms versus other terms. See the `partitionParameters` docstring for more. 

Resulting queries are not necessarily valid or supported (in fact, the concat operator makes it easier to validate and alert on unexpected or nonsensical queries). Refer to [RFC 94](https://docs.google.com/document/d/1nYv_p1138eHsN7WOw0s3x69Y0HK2L8x7VP-nFKQGal8/edit?ts=5e2845ae#) to better understand what will be supported initially.
