### PR TITLE
authz: implement `PermsFetcher` interface for GitLab authz providers

### DIFF
--- a/enterprise/cmd/frontend/authz_test.go
+++ b/enterprise/cmd/frontend/authz_test.go
@@ -103,6 +103,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
+						Token:             "asdf",
 						CacheTTL:          48 * time.Hour,
 						MinBatchThreshold: 200,
 						MaxBatchRequests:  300,
@@ -206,6 +207,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
+						Token:             "asdf",
 						CacheTTL:          3 * time.Hour,
 						MinBatchThreshold: 200,
 						MaxBatchRequests:  300,
@@ -214,6 +216,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthAuthzProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.com"),
+						Token:             "asdf",
 						CacheTTL:          3 * time.Hour,
 						MinBatchThreshold: 200,
 						MaxBatchRequests:  300,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -88,6 +88,7 @@ func newAuthzProvider(a *schema.GitLabAuthorization, instanceURL, token string, 
 		}
 		return NewOAuthProvider(OAuthAuthzProviderOp{
 			BaseURL:           glURL,
+			Token:             token,
 			CacheTTL:          ttl,
 			MinBatchThreshold: minBatchThreshold,
 			MaxBatchRequests:  maxBatchRequests,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -23,6 +23,10 @@ import (
 var _ authz.Provider = (*OAuthAuthzProvider)(nil)
 
 type OAuthAuthzProvider struct {
+	// The token is the access token used for syncing repositories from the code host,
+	// but it may or may not be a sudo-scoped.
+	token string
+
 	clientProvider    *gitlab.ClientProvider
 	clientURL         *url.URL
 	codeHost          *extsvc.CodeHost
@@ -35,6 +39,11 @@ type OAuthAuthzProvider struct {
 type OAuthAuthzProviderOp struct {
 	// BaseURL is the URL of the GitLab instance.
 	BaseURL *url.URL
+
+	// Token is an access token with api scope, it may or may not have sudo scope.
+	//
+	// 🚨 SECURITY: This value contains secret information that must not be shown to non-site-admins.
+	Token string
 
 	// CacheTTL is the TTL of cached permissions lists from the GitLab API.
 	CacheTTL time.Duration
@@ -57,6 +66,8 @@ type OAuthAuthzProviderOp struct {
 
 func newOAuthProvider(op OAuthAuthzProviderOp) *OAuthAuthzProvider {
 	p := &OAuthAuthzProvider{
+		token: op.Token,
+
 		clientProvider:    gitlab.NewClientProvider(op.BaseURL, nil),
 		clientURL:         op.BaseURL,
 		codeHost:          extsvc.NewCodeHost(op.BaseURL, gitlab.ServiceType),

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -44,7 +44,7 @@ type SudoProvider struct {
 	cacheTTL          time.Duration
 }
 
-var _ authz.Provider = ((*SudoProvider)(nil))
+var _ authz.Provider = (*SudoProvider)(nil)
 
 type SudoProviderOp struct {
 	// BaseURL is the URL of the GitLab instance.

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -1,0 +1,73 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+)
+
+// FetchUserPerms returns a list of project IDs (on code host) that the given account
+// has read access on the code host. The project ID has the same value as it would be
+// used as api.ExternalRepoSpec.ID. The returned list only includes private project IDs.
+//
+// This method may return partial but valid results in case of error, and it is up to
+// callers to decide whether to discard.
+//
+// API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error) {
+	if account == nil {
+		return nil, errors.New("no account provided")
+	} else if account.ServiceType != p.codeHost.ServiceType || account.ServiceID != p.codeHost.ServiceID {
+		return nil, fmt.Errorf("service mismatch: want %q - %q but the account has %q - %q",
+			p.codeHost.ServiceType, p.codeHost.ServiceID, account.ServiceType, account.ServiceID)
+	}
+
+	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	if err != nil {
+		return nil, errors.Wrap(err, "get external account data")
+	}
+	token := tok.AccessToken
+
+	q := make(url.Values)
+	q.Add("visibility", "private")  // This method is meant to return only private projects
+	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
+	q.Add("per_page", "100")        // 100 is the maximum page size
+
+	// The next URL to request for projects, and it is reused in the succeeding for loop.
+	nextURL := "projects?" + q.Encode()
+
+	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
+	// when appending the first 100 results to the slice.
+	projectIDs := make([]string, 0, 100)
+
+	client := p.clientProvider.GetOAuthClient(token)
+	for {
+		projects, next, err := client.ListProjects(ctx, nextURL)
+		if err != nil {
+			return projectIDs, err
+		}
+
+		for i := range projects {
+			projectIDs = append(projectIDs, strconv.Itoa(projects[i].ID))
+		}
+
+		if next == nil {
+			break
+		}
+		nextURL = *next
+	}
+
+	return projectIDs, nil
+}
+
+// FetchRepoPerms is a stub implementation for OAuth authz provider because the API
+// endpoint we use requires admin in order to get complete results.
+func (p *OAuthAuthzProvider) FetchRepoPerms(context.Context, *api.ExternalRepoSpec) ([]string, error) {
+	return []string{}, nil
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 
-// FetchUserPerms returns a list of project IDs (on code host) that the given account
-// has read access on the code host. The project ID has the same value as it would be
+// FetchUserPerms returns a list of private project IDs (on code host) that the given account
+// has read access to. The project ID has the same value as it would be
 // used as api.ExternalRepoSpec.ID. The returned list only includes private project IDs.
 //
 // This method may return partial but valid results in case of error, and it is up to

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -3,8 +3,6 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -32,38 +30,9 @@ func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}
-	token := tok.AccessToken
 
-	q := make(url.Values)
-	q.Add("visibility", "private")  // This method is meant to return only private projects
-	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
-	q.Add("per_page", "100")        // 100 is the maximum page size
-
-	// The next URL to request for projects, and it is reused in the succeeding for loop.
-	nextURL := "projects?" + q.Encode()
-
-	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
-	// when appending the first 100 results to the slice.
-	projectIDs := make([]string, 0, 100)
-
-	client := p.clientProvider.GetOAuthClient(token)
-	for {
-		projects, next, err := client.ListProjects(ctx, nextURL)
-		if err != nil {
-			return projectIDs, err
-		}
-
-		for i := range projects {
-			projectIDs = append(projectIDs, strconv.Itoa(projects[i].ID))
-		}
-
-		if next == nil {
-			break
-		}
-		nextURL = *next
-	}
-
-	return projectIDs, nil
+	client := p.clientProvider.GetOAuthClient(tok.AccessToken)
+	return listProjects(ctx, client)
 }
 
 // FetchRepoPerms is a stub implementation for OAuth authz provider because the API

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -34,8 +34,22 @@ func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc
 	return listProjects(ctx, client)
 }
 
-// FetchRepoPerms is a stub implementation for OAuth authz provider because the API
-// endpoint we use requires admin in order to get complete results.
-func (p *OAuthAuthzProvider) FetchRepoPerms(context.Context, *api.ExternalRepoSpec) ([]string, error) {
-	return []string{}, nil
+// FetchRepoPerms returns a list of user IDs (on code host) who have read ccess to
+// the given project on the code host. The user ID has the same value as it would
+// be used as extsvc.ExternalAccount.AccountID. The returned list includes both
+// direct access and inherited from the group membership.
+//
+// This method may return partial but valid results in case of error, and it is up to
+// callers to decide whether to discard.
+//
+// API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+func (p *OAuthAuthzProvider) FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]extsvc.ExternalAccountID, error) {
+	if repo == nil {
+		return nil, errors.New("no repository provided")
+	} else if !extsvc.IsHostOfRepo(p.codeHost, repo) {
+		return nil, fmt.Errorf("not a code host of the repository: want %+v but have %+v", repo, p.codeHost)
+	}
+
+	client := p.clientProvider.GetPATClient(p.token, "")
+	return listMembers(ctx, client, repo.ID)
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -21,9 +21,8 @@ import (
 func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
-	} else if account.ServiceType != p.codeHost.ServiceType || account.ServiceID != p.codeHost.ServiceID {
-		return nil, fmt.Errorf("service mismatch: want %q - %q but the account has %q - %q",
-			p.codeHost.ServiceType, p.codeHost.ServiceID, account.ServiceType, account.ServiceID)
+	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
+		return nil, fmt.Errorf("not a code host of the account: want %+v but have %+v", account, p.codeHost)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -18,7 +18,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error) {
+func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -1,0 +1,111 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+)
+
+// FetchUserPerms returns a list of project IDs (on code host) that the given account
+// has read access on the code host. The project ID has the same value as it would be
+// used as api.ExternalRepoSpec.ID. The returned list only includes private project IDs.
+//
+// This method may return partial but valid results in case of error, and it is up to
+// callers to decide whether to discard.
+//
+// API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error) {
+	if account == nil {
+		return nil, errors.New("no account provided")
+	} else if account.ServiceType != p.codeHost.ServiceType || account.ServiceID != p.codeHost.ServiceID {
+		return nil, fmt.Errorf("service mismatch: want %q - %q but the account has %q - %q",
+			p.codeHost.ServiceType, p.codeHost.ServiceID, account.ServiceType, account.ServiceID)
+	}
+
+	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	if err != nil {
+		return nil, errors.Wrap(err, "get external account data")
+	}
+	sudo := strconv.Itoa(int(user.ID))
+
+	q := make(url.Values)
+	q.Add("visibility", "private")  // This method is meant to return only private projects
+	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
+	q.Add("per_page", "100")        // 100 is the maximum page size
+
+	// The next URL to request for projects, and it is reused in the succeeding for loop.
+	nextURL := "projects?" + q.Encode()
+
+	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
+	// when appending the first 100 results to the slice.
+	projectIDs := make([]string, 0, 100)
+
+	client := p.clientProvider.GetPATClient(p.sudoToken, sudo)
+	for {
+		projects, next, err := client.ListProjects(ctx, nextURL)
+		if err != nil {
+			return projectIDs, err
+		}
+
+		for i := range projects {
+			projectIDs = append(projectIDs, strconv.Itoa(projects[i].ID))
+		}
+
+		if next == nil {
+			break
+		}
+		nextURL = *next
+	}
+
+	return projectIDs, nil
+}
+
+// FetchRepoPerms returns a list of user IDs (on code host) who have read ccess to
+// the given project on the code host. The user ID has the same value as it would
+// be used as extsvc.ExternalAccount.AccountID. The returned list includes both
+// direct access and inherited from the group membership.
+//
+// API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]string, error) {
+	if repo == nil {
+		return nil, errors.New("no repository provided")
+	} else if repo.ServiceType != p.codeHost.ServiceType || repo.ServiceID != p.codeHost.ServiceID {
+		return nil, fmt.Errorf("service mismatch: want %q - %q but the repository has %q - %q",
+			p.codeHost.ServiceType, p.codeHost.ServiceID, repo.ServiceType, repo.ServiceID)
+	}
+
+	q := make(url.Values)
+	q.Add("per_page", "100") // 100 is the maximum page size
+
+	// The next URL to request for members, and it is reused in the succeeding for loop.
+	nextURL := fmt.Sprintf("projects/%s/members/all?%s", repo.ID, q.Encode())
+
+	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
+	// when appending the first 100 results to the slice.
+	userIDs := make([]string, 0, 100)
+
+	client := p.clientProvider.GetPATClient(p.sudoToken, "")
+	for {
+		members, next, err := client.ListMembers(ctx, nextURL)
+		if err != nil {
+			return userIDs, err
+		}
+
+		for i := range members {
+			userIDs = append(userIDs, strconv.Itoa(int(members[i].ID)))
+		}
+
+		if next == nil {
+			break
+		}
+		nextURL = *next
+	}
+
+	return userIDs, nil
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -38,7 +38,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Exter
 }
 
 // listProjects is a helper function to request for all private projects that are accessible
-// (20 => Reporter access) by the authenticated or impersonated user in the client. It may
+// (access level: 20 => Reporter access) by the authenticated or impersonated user in the client. It may
 // return partial but valid results in case of error, and it is up to callers to decide
 // whether to discard.
 func listProjects(ctx context.Context, client *gitlab.Client) ([]string, error) {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -149,6 +149,9 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32) error {
 			})
 		}
 	}
+	if len(repoSpecs) == 0 {
+		return nil
+	}
 
 	// Get corresponding internal database IDs
 	rs, err := s.reposStore.ListRepos(ctx, repos.StoreListReposArgs{
@@ -212,6 +215,9 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 	usernames, err := fetcher.FetchRepoPerms(ctx, &repo.ExternalRepo)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository permissions")
+	}
+	if len(usernames) == 0 {
+		return nil
 	}
 
 	// Get corresponding internal database IDs

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -49,7 +49,7 @@ type PermsFetcher interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error)
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read ccess to
 	// the given repository/project on the code host. The user ID should be the same value
 	// as it would be used as extsvc.ExternalAccount.AccountID. The returned list should
@@ -58,7 +58,7 @@ type PermsFetcher interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]string, error)
+	FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]extsvc.ExternalAccountID, error)
 }
 
 // NewPermsSyncer returns a new permissions syncing request manager.

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -41,15 +41,23 @@ type PermsSyncer struct {
 // user-centric and repository-centric ways.
 type PermsFetcher interface {
 	authz.Provider
-	// FetchUserPerms returns a list of repository IDs (on code host) that the given
-	// account has read access on the code host. The repository ID should be the same
-	// value as it would be used as api.ExternalRepoSpec.ID. The returned list should
-	// only include private repositories.
+	// FetchUserPerms returns a list of repository/project IDs (on code host) that the
+	// given account has read access on the code host. The repository ID should be the
+	// same value as it would be used as api.ExternalRepoSpec.ID. The returned list
+	// should only include private repositories/project IDs.
+	//
+	// Because permissions fetching APIs are often expensive, the implementation should
+	// try to return partial but valid results in case of error, and it is up to callers
+	// to decide whether to discard.
 	FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]string, error)
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read ccess to
-	// the given repository on the code host. The user ID should be the same value as it
-	// would be used as extsvc.ExternalAccount.AccountID. The returned list should include
-	// both direct access and inherited from the group/organization/team membership.
+	// the given repository/project on the code host. The user ID should be the same value
+	// as it would be used as extsvc.ExternalAccount.AccountID. The returned list should
+	// include both direct access and inherited from the group/organization/team membership.
+	//
+	// Because permissions fetching APIs are often expensive, the implementation should
+	// try to return partial but valid results in case of error, and it is up to callers
+	// to decide whether to discard.
 	FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]string, error)
 }
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -143,7 +143,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32) error {
 
 		for i := range extIDs {
 			repoSpecs = append(repoSpecs, api.ExternalRepoSpec{
-				ID:          extIDs[i],
+				ID:          string(extIDs[i]),
 				ServiceType: fetcher.ServiceType(),
 				ServiceID:   fetcher.ServiceID(),
 			})
@@ -212,12 +212,17 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 	// TODO(jchen): Ship the initial design to unblock working on authz providers,
 	// but should revisit the feasibility of using ExternalAccount before final delivery.
 
-	usernames, err := fetcher.FetchRepoPerms(ctx, &repo.ExternalRepo)
+	accountIDs, err := fetcher.FetchRepoPerms(ctx, &repo.ExternalRepo)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository permissions")
 	}
-	if len(usernames) == 0 {
+	if len(accountIDs) == 0 {
 		return nil
+	}
+
+	usernames := make([]string, len(accountIDs))
+	for i := range accountIDs {
+		usernames[i] = string(accountIDs[i])
 	}
 
 	// Get corresponding internal database IDs

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -35,8 +35,14 @@ func NewCodeHost(baseURL *url.URL, serviceType string) *CodeHost {
 	}
 }
 
-func IsHostOf(c *CodeHost, repo *api.ExternalRepoSpec) bool {
+// IsHostOfRepo returns true if the repository belongs to given code host.
+func IsHostOfRepo(c *CodeHost, repo *api.ExternalRepoSpec) bool {
 	return c.ServiceID == repo.ServiceID && c.ServiceType == repo.ServiceType
+}
+
+// IsHostOfAccount returns true if the account belongs to given code host.
+func IsHostOfAccount(c *CodeHost, account *ExternalAccount) bool {
+	return c.ServiceID == account.ServiceID && c.ServiceType == account.ServiceType
 }
 
 // NormalizeBaseURL modifies the input and returns a normalized form of the a base URL with insignificant

--- a/internal/extsvc/gitlab/members.go
+++ b/internal/extsvc/gitlab/members.go
@@ -1,0 +1,44 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/peterhellberg/link"
+)
+
+// Member contains fields for a group or project membership.
+type Member struct {
+	ID                int32  `json:"id"`
+	Username          string `json:"username"`
+	Name              string `json:"name"`
+	State             string `json:"state"`
+	AvatarURL         string `json:"avatar_url"`
+	WebURL            string `json:"web_url"`
+	ExpiresAt         string `json:"expires_at"`
+	AccessLevel       int    `json:"access_level"`
+	GroupSAMLIdentity *struct {
+		Provider       string `json:"provider"`
+		ExternUID      string `json:"extern_uid"`
+		SAMLProviderID int    `json:"saml_provider_id"`
+	} `json:"group_saml_identity"`
+}
+
+// ListMembers returns a list of members parsed from reponse of given URL.
+func (c *Client) ListMembers(ctx context.Context, urlStr string) (members []*Member, nextPageURL *string, err error) {
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	respHeader, err := c.do(ctx, req, &members)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get URL to next page. See https://docs.gitlab.com/ee/api/README.html#pagination-link-header.
+	if l := link.Parse(respHeader.Get("Link"))["next"]; l != nil {
+		nextPageURL = &l.URI
+	}
+
+	return members, nextPageURL, nil
+}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -32,3 +32,13 @@ type ExternalAccountData struct {
 	AuthData    *json.RawMessage
 	AccountData *json.RawMessage
 }
+
+// ExternalAccountID is a descriptive type for the external identifier of an external account
+// on the code host. It can be the string representation of an integer (e.g. GitLab) or a
+// GraphQL ID (e.g. GitHub) depends on the code host type.
+type ExternalAccountID string
+
+// ExternalRepoID is a descriptive type for the external identifier of an external repository
+// on the code host. It can be the string representation of an integer (e.g. GitLab) or a
+// GraphQL ID (e.g. GitHub) depends on the code host type.
+type ExternalRepoID string


### PR DESCRIPTION
This PR implements `PermsFetcher` interface for GitLab authz providers, both `SudoProvider` and `OAuthProvider`.

### Notes
- Tests will be added in followup PRs once I run through the new permissions syncing process end-to-end.
- This PR does not change any functionality currently in use, safe to merge upon approvals.
- This PR explicitly mentions in `PermsFetcher` definition that implementations should return "partial but valid results in case of error". The rationales are:
	- API calls to code host are expensive.
	- When a new user or repo just being added, there is literally no permissions, something (valid) is better than nothing. LMK any objections, if anyone thinks this will make debugging harder.

Implements #8492.