### PR TITLE
CODEOWNERS: overhaul rules previously owned by code-search team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,17 +182,17 @@ tslint.config.js @sourcegraph/web
 /enterprise/cmd/frontend/internal/symbols @sourcegraph/code-intel
 
 # Search and code mod
-/cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
 */search/**/* @sourcegraph/code-search
-/cmd/searcher/ @sourcegraph/code-search
 /cmd/frontend/db/*search* @sourcegraph/code-search
 /cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
+/cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
 /cmd/frontend/internal/pkg/search @sourcegraph/code-search
-/cmd/symbols @sourcegraph/code-search
 /cmd/query-runner @sourcegraph/code-search
 /cmd/replacer @rvantonder
-/internal/symbols/ @sourcegraph/code-search
+/cmd/searcher/ @sourcegraph/code-search
+/cmd/symbols @sourcegraph/code-search
 /internal/search @sourcegraph/code-search
+/internal/symbols/ @sourcegraph/code-search
 
 # Saved searches
 /web/src/SavedQuery.tsx @attfarhan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,11 +187,11 @@ tslint.config.js @sourcegraph/web
 /cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
 /cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
 /cmd/frontend/internal/pkg/search @sourcegraph/code-search
-/cmd/query-runner @sourcegraph/code-search
-/cmd/replacer @rvantonder
+/cmd/query-runner/ @sourcegraph/code-search
+/cmd/replacer/ @rvantonder
 /cmd/searcher/ @sourcegraph/code-search
-/cmd/symbols @sourcegraph/code-search
-/internal/search @sourcegraph/code-search
+/cmd/symbols/ @sourcegraph/code-search
+/internal/search/ @sourcegraph/code-search
 /internal/symbols/ @sourcegraph/code-search
 
 # Saved searches

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -169,7 +169,7 @@ tslint.config.js @sourcegraph/web
 /internal/api/ @sourcegraph/core-services
 /internal/extsvc/ @sourcegraph/core-services
 /internal/gitserver/ @sourcegraph/core-services
-/internal/jsonc/ @tsenart @slimsag
+/internal/jsonc/ @sourcegraph/core-services @tsenart @slimsag
 /internal/repoupdater/ @sourcegraph/core-services
 /internal/trace/ @sourcegraph/core-services
 /internal/tracer/ @sourcegraph/core-services
@@ -185,7 +185,7 @@ tslint.config.js @sourcegraph/web
 */search/**/* @sourcegraph/core-services
 /cmd/frontend/internal/pkg/search @sourcegraph/core-services
 /cmd/query-runner/ @sourcegraph/core-services
-/cmd/replacer/ @rvantonder
+/cmd/replacer/ @sourcegraph/core-services @rvantonder
 /cmd/searcher/ @sourcegraph/core-services
 /cmd/symbols/ @sourcegraph/core-services
 /internal/search/ @sourcegraph/core-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -183,9 +183,6 @@ tslint.config.js @sourcegraph/web
 
 # Search and code mod
 */search/**/* @sourcegraph/code-search
-/cmd/frontend/db/*search* @sourcegraph/code-search
-/cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
-/cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search
 /cmd/frontend/internal/pkg/search @sourcegraph/code-search
 /cmd/query-runner/ @sourcegraph/code-search
 /cmd/replacer/ @rvantonder

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -256,7 +256,6 @@ Dockerfile @sourcegraph/distribution
 /cmd/frontend/graphqlbackend/codeintel.go @sourcegraph/code-intel
 
 # Development
-/dev/fakehub @sourcegraph/core-services
 /dev/repogen @sourcegraph/core-services
 /.vscode @felixfbecker
 /.graphqlconfig @felixfbecker

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,10 +177,6 @@ tslint.config.js @sourcegraph/web
 /migrations/ @sourcegraph/core-services
 /schema/ @sourcegraph/core-services
 
-# Symbols
-/cmd/frontend/graphqlbackend/*symbols* @sourcegraph/code-intel
-/enterprise/cmd/frontend/internal/symbols @sourcegraph/code-intel
-
 # Search and code mod
 */search/**/* @sourcegraph/core-services
 /cmd/frontend/internal/pkg/search @sourcegraph/core-services
@@ -190,6 +186,10 @@ tslint.config.js @sourcegraph/web
 /cmd/symbols/ @sourcegraph/core-services
 /internal/search/ @sourcegraph/core-services
 /internal/symbols/ @sourcegraph/core-services
+
+# Symbols
+/cmd/frontend/graphqlbackend/*symbols* @sourcegraph/code-intel
+/enterprise/cmd/frontend/internal/symbols @sourcegraph/code-intel
 
 # Saved searches
 /web/src/SavedQuery.tsx @attfarhan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,14 +182,14 @@ tslint.config.js @sourcegraph/web
 /enterprise/cmd/frontend/internal/symbols @sourcegraph/code-intel
 
 # Search and code mod
-*/search/**/* @sourcegraph/code-search
-/cmd/frontend/internal/pkg/search @sourcegraph/code-search
-/cmd/query-runner/ @sourcegraph/code-search
+*/search/**/* @sourcegraph/core-services
+/cmd/frontend/internal/pkg/search @sourcegraph/core-services
+/cmd/query-runner/ @sourcegraph/core-services
 /cmd/replacer/ @rvantonder
-/cmd/searcher/ @sourcegraph/code-search
-/cmd/symbols/ @sourcegraph/code-search
-/internal/search/ @sourcegraph/code-search
-/internal/symbols/ @sourcegraph/code-search
+/cmd/searcher/ @sourcegraph/core-services
+/cmd/symbols/ @sourcegraph/core-services
+/internal/search/ @sourcegraph/core-services
+/internal/symbols/ @sourcegraph/core-services
 
 # Saved searches
 /web/src/SavedQuery.tsx @attfarhan


### PR DESCRIPTION
This PRs overhauls the CODEOWNERS file to fix rules for code-search team, which no longer exists.

Ref: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

Easier to review commit by commit, please see "Commits" tab for details.