### PR TITLE
Ensure that Sourcegraph instances don't overwrite BBS webhook

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -30,6 +30,7 @@ import (
 	codeIntelResolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
@@ -65,11 +66,23 @@ func main() {
 		log.Println("enterprise edition")
 	}
 
+	globalState, err := globalstatedb.Get(ctx)
+	if err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+
 	campaignsStore := campaigns.NewStoreWithClock(dbconn.Global, clock)
 	repositories := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 
 	githubWebhook := campaigns.NewGitHubWebhook(campaignsStore, repositories, clock)
-	bitbucketServerWebhook := campaigns.NewBitbucketServerWebhook(campaignsStore, repositories, clock)
+
+	bitbucketWebhookName := "sourcegraph-" + globalState.SiteID
+	bitbucketServerWebhook := campaigns.NewBitbucketServerWebhook(
+		campaignsStore,
+		repositories,
+		clock,
+		bitbucketWebhookName,
+	)
 
 	go bitbucketServerWebhook.Upsert(30 * time.Second)
 


### PR DESCRIPTION
If you have multiple Sourcegraph instances running and configured to use
the `"plugin.webhooks"` attribute, they would overwrite each others
webhooks because they used the same name.

This change here attaches the unique SiteID to each webhook. It doesn't
change across restarts and persists between changes of external URLs, so
it's perfect for our usecase.
