### PR TITLE
Compute Bitbucket Server changeset review state based on events

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -213,10 +213,6 @@ func (r *changesetResolver) ExternalURL() (*externallink.Resolver, error) {
 }
 
 func (r *changesetResolver) ReviewState(ctx context.Context) (campaigns.ChangesetReviewState, error) {
-	if _, ok := r.Changeset.Metadata.(*github.PullRequest); !ok {
-		return r.Changeset.ReviewState()
-	}
-
 	es, err := r.computeEvents(ctx)
 	if err != nil {
 		return campaigns.ChangesetReviewStatePending, err

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -482,7 +482,7 @@ func TestCampaigns(t *testing.T) {
 					URL:         "https://bitbucket.sgdev.org/projects/SOUR/repos/vegeta/pull-requests/2",
 					ServiceType: "bitbucketServer",
 				},
-				ReviewState: "PENDING",
+				ReviewState: "APPROVED",
 				CheckState:  "PENDING",
 				Events: ChangesetEventConnection{
 					TotalCount: 9,

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -386,34 +386,6 @@ func (c *Changeset) URL() (s string, err error) {
 	}
 }
 
-// ReviewState of a Changeset.
-func (c *Changeset) ReviewState() (s ChangesetReviewState, err error) {
-	states := map[ChangesetReviewState]bool{}
-
-	switch m := c.Metadata.(type) {
-	case *github.PullRequest:
-		// For GitHub we need to use `ChangesetEvents.ReviewState`
-		log15.Warn("Changeset.ReviewState() called, but GitHub review state is calculated through ChangesetEvents.ReviewState", "changeset", c)
-		return ChangesetReviewStatePending, nil
-
-	case *bitbucketserver.PullRequest:
-		for _, r := range m.Reviewers {
-			switch r.Status {
-			case "UNAPPROVED":
-				states[ChangesetReviewStatePending] = true
-			case "NEEDS_WORK":
-				states[ChangesetReviewStateChangesRequested] = true
-			case "APPROVED":
-				states[ChangesetReviewStateApproved] = true
-			}
-		}
-	default:
-		return "", errors.New("unknown changeset type")
-	}
-
-	return SelectReviewState(states), nil
-}
-
 // Events returns the list of ChangesetEvents from the Changeset's metadata.
 func (c *Changeset) Events() (events []*ChangesetEvent) {
 	switch m := c.Metadata.(type) {


### PR DESCRIPTION
Now that we pull the event activity on every sync and we receive webhook
events we can do the same thing we do for GitHub and look at the events
in order to compute the ReviewState.