### PR TITLE
Upper-case GitHub webhook event's state before conversion

### DIFF
--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -881,7 +881,7 @@ func (e *ChangesetEvent) ReviewState() (ChangesetReviewState, error) {
 			return "", errors.New("ChangesetEvent metadata event not PullRequestReview")
 		}
 
-		s := ChangesetReviewState(review.State)
+		s := ChangesetReviewState(strings.ToUpper(review.State))
 		if !s.Valid() {
 			// Ignore invalid states
 			log15.Warn("invalid review state", "state", review.State)


### PR DESCRIPTION
The webhook events' state is lower-case as opposed to GitHub's GraphQL
events.

Webhook docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
GraphQL docs: https://developer.github.com/v4/enum/pullrequestreviewstate/
