### PR TITLE
Faster dev startup

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     access_log off;
     upstream backend {
-        server localhost:3082;
+        server localhost:3082 max_fails=0;
     }
 
     client_body_temp_path dev/nginx/body;

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -81,10 +81,15 @@ export NODE_OPTIONS="--max_old_space_size=4096"
 
 # Make sure chokidar-cli is installed in the background
 printf >&2 "Concurrently installing Yarn and Go dependencies...\n\n"
-yarn_pid=''
+yarn_root_pid=''
+yarn_lsif_pid=''
 [ -n "${OFFLINE-}" ] || {
     yarn --no-progress &
-    yarn_pid="$!"
+    yarn_root_pid="$!"
+    pushd ./lsif 1> /dev/null
+    yarn --no-progress &
+    yarn_lsif_pid="$!"
+    popd 1> /dev/null
 }
 
 if ! ./dev/go-install.sh; then
@@ -95,9 +100,12 @@ if ! ./dev/go-install.sh; then
 	exit 1
 fi
 
-# Wait for yarn if it is still running
-if [[ -n "$yarn_pid" ]]; then
-    wait "$yarn_pid"
+# Wait for yarns if they are still running
+if [[ -n "$yarn_root_pid" ]]; then
+    wait "$yarn_root_pid"
+fi
+if [[ -n "$yarn_lsif_pid" ]]; then
+    wait "$yarn_lsif_pid"
 fi
 
 # Increase ulimit (not needed on Windows/WSL)
@@ -105,11 +113,6 @@ type ulimit > /dev/null && ulimit -n 10000 || true
 
 # Put .bin:node_modules/.bin onto the $PATH
 export PATH="$PWD/.bin:$PWD/node_modules/.bin:$PATH"
-
-# LSIF server
-[ -n "${OFFLINE-}" ] || {
-    pushd ./lsif && yarn --no-progress && popd
-}
 
 # Build once to make sure editor codeintel works
 # This is fast if no changes were made.

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -114,10 +114,12 @@ type ulimit > /dev/null && ulimit -n 10000 || true
 # Put .bin:node_modules/.bin onto the $PATH
 export PATH="$PWD/.bin:$PWD/node_modules/.bin:$PATH"
 
-# Build once to make sure editor codeintel works
+# Build once in the background to make sure editor codeintel works
 # This is fast if no changes were made.
 # Don't fail if it errors as this is only for codeintel, not for the build.
-yarn run build-ts || true
+trap 'kill $build_ts_pid; exit' INT
+(yarn run build-ts || true) &
+build_ts_pid="$!"
 
 printf >&2 "\nStarting all binaries...\n\n"
 export GOREMAN="goreman --set-ports=false --exit-on-error -f dev/Procfile"

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -21,9 +21,6 @@ if [ -f "$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json" ]; then
     exit 1
 fi
 
-echo "Installing enterprise web dependencies..."
-[ -n "${OFFLINE-}" ] || yarn --check-files
-
 source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 
 export SITE_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json


### PR DESCRIPTION
Please review commit by commit.

This should reduce time taken by `./dev/start`. 

- Removed apparently unnecessary second `yarn` run
- Fixed a nginx config error that caused 502s to be delivered longer than needed
	I realized that when I was working on the go frontend service, it was already up but the GQL explorer still received 502s. This is immediate now
- Parallelized root and LSIF yarn cc @efritz or was this intentional? 🤔 
- Made `tsc -b` a background process as it's not needed for startup of the dev stack, just for code intelligence while developing. This shaves off another at least 10s, if a lot changed possibly even 20-30.