### PR TITLE
List sub-headers under "On this page" in docs

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -368,7 +368,7 @@
     {{if gt (len .Doc.Tree) 0}}
         {{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
             <h3 class="page-nav-title">On this page:</h3>
-            <ul>{{template "doc_nav" .}}</ul>
+            <ul>{{template "doc_nav_nested" .}}</ul>
         {{end}}
     {{end}}
     <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>


### PR DESCRIPTION
I don't know why this wasn't used, but I think it should be.

#### Before

<img width="378" alt="Screen Shot 2020-03-06 at 15 24 41" src="https://user-images.githubusercontent.com/1185253/76092086-168db780-5fbf-11ea-9449-c8be8adb3ee0.png">

#### After

<img width="428" alt="Screen Shot 2020-03-06 at 15 24 30" src="https://user-images.githubusercontent.com/1185253/76092076-142b5d80-5fbf-11ea-90a4-f618f92ec573.png">

