### PR TITLE
Add baseUri to DocumentFilter

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -394,10 +394,15 @@ declare module 'sourcegraph' {
     export interface DocumentFilter {
         /** A language id, such as `typescript` or `*`. */
         language?: string
+
         /** A URI scheme, such as `file` or `untitled`. */
         scheme?: string
+
         /** A glob pattern, such as `*.{ts,js}`. */
         pattern?: string
+
+        /** A base URI (e.g. root URI of a workspace folder) that the document must be within. */
+        baseUri?: URL | string
     }
 
     /**

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -59,7 +59,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                         editorId: 'editor#0',
                         type: 'CodeEditor' as const,
                         selections: [new Selection(1, 2, 3, 4).toPlain()],
-                        resource: 'u',
+                        resource: 'file:///g',
                         model: { languageId: 'l' },
                     })
                 ).toBe('a', {
@@ -81,7 +81,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                         editorId: 'editor#0',
                         type: 'CodeEditor' as const,
                         selections: [new Selection(1, 2, 3, 4).toPlain()],
-                        resource: 'u',
+                        resource: 'file:///g',
                         model: { languageId: 'l' },
                     })
                 ).toBe('a', {

--- a/shared/src/api/client/types/textDocument.test.ts
+++ b/shared/src/api/client/types/textDocument.test.ts
@@ -27,29 +27,35 @@ describe('match', () => {
 
 describe('score', () => {
     test('matches', () => {
-        expect(score(['l'], 'file:///f', 'l')).toBe(10)
-        expect(score(['*'], 'file:///f', 'l')).toBe(5)
-        expect(score(['x'], 'file:///f', 'l')).toBe(0)
-        expect(score([{ scheme: 'file' }], 'file:///f', 'l')).toBe(10)
-        expect(score([{ scheme: '*' }], 'file:///f', 'l')).toBe(5)
-        expect(score([{ scheme: 'x' }], 'file:///f', 'l')).toBe(0)
-        expect(score([{ pattern: 'file:///*.txt' }], 'file:///f.txt', 'l')).toBe(10)
-        expect(score([{ pattern: '**/*.txt' }], 'file:///f.txt', 'l')).toBe(10)
-        expect(score([{ pattern: '*.txt' }], 'file:///f.txt', 'l')).toBe(5)
+        expect(score(['l'], new URL('file:///f'), 'l')).toBe(10)
+        expect(score(['*'], new URL('file:///f'), 'l')).toBe(5)
+        expect(score(['x'], new URL('file:///f'), 'l')).toBe(0)
+        expect(score([{ scheme: 'file' }], new URL('file:///f'), 'l')).toBe(10)
+        expect(score([{ scheme: '*' }], new URL('file:///f'), 'l')).toBe(5)
+        expect(score([{ scheme: 'x' }], new URL('file:///f'), 'l')).toBe(0)
+        expect(score([{ pattern: '**/*.txt' }], new URL('file:///f.txt'), 'l')).toBe(10)
+        expect(score([{ pattern: '*.txt' }], new URL('file:///f.txt'), 'l')).toBe(10)
+        expect(score([{ baseUri: 'git://repo?rev', pattern: '*.txt' }], new URL('git://repo?rev#f.txt'), 'l')).toBe(10)
+        expect(score([{ baseUri: 'file:///a/b', pattern: '*.txt' }], new URL('file:///a/b/c.txt'), 'l')).toBe(5)
+        expect(score([{ baseUri: 'git://repo?rev', pattern: '**/*.txt' }], new URL('git://repo?rev#f.txt'), 'l')).toBe(
+            10
+        )
+        expect(score([{ baseUri: 'git://repo', pattern: '**/*.txt' }], new URL('git://repo?rev#f.txt'), 'l')).toBe(10)
+        expect(score([{ baseUri: 'git://repo?rev' }], new URL('git://repo?rev#f.txt'), 'l')).toBe(5)
         expect(
             score(
                 [{ pattern: '*.go' }],
-                'git://127.0.0.1-3434/repos/.git?51c44e6be08627c613f787032a2759162bf6f7c2#web/api.go',
+                new URL('git://127.0.0.1-3434/repos/.git?51c44e6be08627c613f787032a2759162bf6f7c2#web/api.go'),
                 'l'
             )
         ).toBe(5)
-        expect(score([{ pattern: 'f.txt' }], 'file:///f.txt', 'l')).toBe(10)
-        expect(score([{ pattern: 'x' }], 'file:///f.txt', 'l')).toBe(0)
-        expect(score([{ pattern: 'f.txt', language: 'x' }], 'file:///f.txt', 'l')).toBe(0)
-        expect(score([{ language: 'x' }], 'file:///f.txt', 'l')).toBe(0)
-        expect(score([{ language: 'l' }], 'file:///f.txt', 'l')).toBe(10)
-        expect(score([{ language: '*' }], 'file:///f.txt', 'l')).toBe(5)
-        expect(score([{}], 'file:///f.txt', 'l')).toBe(5)
+        expect(score([{ pattern: 'f.txt' }], new URL('file:///f.txt'), 'l')).toBe(10)
+        expect(score([{ pattern: 'x' }], new URL('file:///f.txt'), 'l')).toBe(0)
+        expect(score([{ pattern: 'f.txt', language: 'x' }], new URL('file:///f.txt'), 'l')).toBe(0)
+        expect(score([{ language: 'x' }], new URL('file:///f.txt'), 'l')).toBe(0)
+        expect(score([{ language: 'l' }], new URL('file:///f.txt'), 'l')).toBe(10)
+        expect(score([{ language: '*' }], new URL('file:///f.txt'), 'l')).toBe(5)
+        expect(score([{}], new URL('file:///f.txt'), 'l')).toBe(5)
     })
 })
 

--- a/shared/src/api/client/types/textDocument.ts
+++ b/shared/src/api/client/types/textDocument.ts
@@ -58,7 +58,7 @@ function isDocumentFilter(value: any): value is DocumentFilter {
 }
 
 function match1(selector: DocumentSelector, document: Pick<TextDocument, 'uri' | 'languageId'>): boolean {
-    return score(selector, document.uri, document.languageId) !== 0
+    return score(selector, new URL(document.uri), document.languageId) !== 0
 }
 
 /**
@@ -72,7 +72,7 @@ function match1(selector: DocumentSelector, document: Pick<TextDocument, 'uri' |
  * Taken from
  * https://github.com/Microsoft/vscode/blob/3d35801127f0a62d58d752bc613506e836c5d120/src/vs/editor/common/modes/languageSelector.ts#L24.
  */
-export function score(selector: DocumentSelector, candidateUri: string, candidateLanguage: string): number {
+export function score(selector: DocumentSelector, candidateUri: URL, candidateLanguage: string): number {
     // array -> take max individual value
     let ret = 0
     for (const filter of selector) {
@@ -87,7 +87,7 @@ export function score(selector: DocumentSelector, candidateUri: string, candidat
     return ret
 }
 
-function score1(selector: DocumentSelector[0], candidateUri: string, candidateLanguage: string): number {
+function score1(selector: DocumentSelector[0], candidateUri: URL, candidateLanguage: string): number {
     if (typeof selector === 'string') {
         // Shorthand notation: "mylang" -> {language: "mylang"}, "*" -> {language: "*""}.
         if (selector === '*') {
@@ -99,16 +99,24 @@ function score1(selector: DocumentSelector[0], candidateUri: string, candidateLa
         return 0
     }
 
-    const { language, scheme, pattern } = selector
+    const { language, scheme, pattern, baseUri } = selector
     if (!language && !scheme && !pattern) {
         // `{}` was passed as a document filter, treat it like a wildcard
         return 5
     }
     let ret = 0
     if (scheme) {
-        if (candidateUri.startsWith(scheme + ':')) {
+        if (candidateUri.protocol === scheme + ':') {
             ret = 10
         } else if (scheme === '*') {
+            ret = 5
+        } else {
+            return 0
+        }
+    }
+    if (baseUri) {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        if (candidateUri.href.startsWith(baseUri.toString())) {
             ret = 5
         } else {
             return 0
@@ -124,9 +132,12 @@ function score1(selector: DocumentSelector[0], candidateUri: string, candidateLa
         }
     }
     if (pattern) {
-        if (pattern === candidateUri || candidateUri.endsWith(pattern) || minimatch(candidateUri, pattern)) {
+        const filePath = decodeURIComponent(
+            candidateUri.protocol === 'git:' ? candidateUri.hash.slice(1) : candidateUri.pathname.replace(/^\//, '')
+        )
+        if (filePath.endsWith(pattern) || minimatch(filePath, pattern)) {
             ret = 10
-        } else if (minimatch(candidateUri, '**/' + pattern, { dot: true })) {
+        } else if (filePath && minimatch(filePath, pattern, { dot: true, matchBase: true })) {
             ret = 5
         } else {
             return 0


### PR DESCRIPTION
This is a proper fix for both #8602 and broken codeintel for root files ([Slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1583444612193300?thread_ts=1583444599.193000&cid=CHXHX7XAS)).
Codeintel extensions need to be able to scope providers to workspace roots. Doing so in `pattern` does not work, because `minimatch` is not built for working with URIs (in particular it broke for files in the root).

Considering all options, I decided to go with this solution. Alternatives considered: 
- Making `pattern` work for URIs
  - This is ambiguous with percent-encoding
- Adding explicit filters for repository and revision
  - This is more cumbersome for lsp-client, which wants to scope to the root URI
  - Not clearly defined in editors with `file:///` URIs
- A `uriPattern` property
  - More complex, no direct use case

