### PR TITLE
Add ExcludeForks to GitHub external service configuration and client.

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -133,7 +133,7 @@ func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult) 
 			results <- SourceResult{Source: s, Err: res.err}
 			continue
 		}
-		if !seen[res.repo.DatabaseID] && !s.excludes(res.repo) {
+		if !seen[res.repo.DatabaseID] && !s.excludes(res.repo) && !s.filtered(res.repo) {
 			results <- SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
 			seen[res.repo.DatabaseID] = true
 		}
@@ -322,6 +322,12 @@ func (s *GithubSource) excludes(r *github.Repository) bool {
 		}
 	}
 	return false
+}
+
+// filtered returns whether or not the repo should be filtered. Currently this is only based on whether
+// the repo is a fork.
+func (s *GithubSource) filtered(r *github.Repository) bool {
+	return s.config.ExcludeForks && r.IsFork
 }
 
 // repositoryPager is a function that returns repositories on a given `page`.

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -132,6 +132,11 @@
           "default": "3h"
         }
       }
+    },
+    "excludeForks": {
+      "description": "Flag that can be used to filter out forks from being synced and indexed.",
+      "type": "boolean",
+      "default": "false"
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -483,6 +483,8 @@ type GitHubConnection struct {
 	Url string `json:"url"`
 	// Webhooks description: An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.
 	Webhooks []*GitHubWebhook `json:"webhooks,omitempty"`
+	// ExcludeForks description: Will filter out repositories that are forks from being cloned and indexed.
+	ExcludeForks bool
 }
 type GitHubWebhook struct {
 	// Org description: The name of the GitHub organization to which the webhook belongs


### PR DESCRIPTION
This allows you to exclude forks from being cloned and indexed.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
