### PR TITLE
search: simplify determineResultTypes function

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -161,7 +161,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, err
 	}
 
-	resultTypes, _ := r.determineResultTypes(args, "")
+	resultTypes := r.determineResultTypes(args, "")
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 
 	if len(resultTypes) != 1 || resultTypes[0] != "file" {


### PR DESCRIPTION
`determineResultTypes` returns a map that is always empty and only used later. I looked at the history of this function to see whether it should be doing something with the map, but this 'noop' behavior has been like this for the past 5 months, so I feel good about removing this.