### PR TITLE
search: remove 'ref' result type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -877,7 +877,7 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceO
 	} else {
 		resultTypes, _ = r.query.StringValues(query.FieldType)
 		if len(resultTypes) == 0 {
-			resultTypes = []string{"file", "path", "repo", "ref"}
+			resultTypes = []string{"file", "path", "repo"}
 		}
 	}
 	for _, resultType := range resultTypes {


### PR DESCRIPTION
We add a "ref" result type to this slice but there is no `"ref"` case when we process the slice, so it is a noop. You can see where the result types are cased out on starting [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a23a8fbec94864ab0cd0a2b251b77430b33303a4/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1055-1062), and there is no `case "ref"` or any other reference to it in this function. Perhaps this was historically used, but it is now dead.

Stacked on #8870