### PR TITLE
refactor: search alert construction for no resolved repos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -145,7 +145,6 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 
 	withoutRepoFields := omitQueryField(r.parseTree, query.FieldRepo)
 
-	var a searchAlert
 	switch {
 	case len(repoGroupFilters) > 1:
 		// This is a rare case, so don't bother proposing queries.
@@ -307,8 +306,11 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			proposedQueries: proposedQueries,
 		}, nil
 	}
-
-	return &a, nil
+	// Should be unreachable. Return a generic alert if reached.
+	return &searchAlert{
+		title:       "No repository results.",
+		description: "There are no repositories to search.",
+	}, nil
 }
 
 func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert, error) {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -174,7 +174,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		}
 		if reposExist(ctx, tryRemoveRepoGroup) {
 			proposedQueries = []*searchQueryDescription{
-				&searchQueryDescription{
+				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
 					query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
 					patternType: r.patternType,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -114,13 +114,11 @@ func alertForQuotesInQueryInLiteralMode(p syntax.ParseTree) *searchAlert {
 
 // reposExist returns true if one or more repos resolve. If the attempt
 // returns 0 repos or fails, it returns false. It is a helper function for
-// raising NoResolvedrepos alerts with suggestions when we know the original
+// raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func reposExist(ctx context.Context, options resolveRepoOp) bool {
-	if repos, _, _, err := resolveRepositories(ctx, options); err == nil && len(repos) > 0 {
-		return true
-	}
-	return false
+	repos, _, _, err := resolveRepositories(ctx, options)
+	return err == nil && len(repos) > 0
 }
 
 func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAlert {
@@ -161,7 +159,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		// This is a rare case, so don't bother proposing queries.
 		return &searchAlert{
 			title:       "Expand your repository filters to see results",
-			description: fmt.Sprintf("No repository exists in all specified groups and satisfies all of your repo: filters."),
+			description: "No repository exists in all specified groups and satisfies all of your repo: filters.",
 		}
 
 	case len(repoGroupFilters) == 1 && len(repoFilters) > 1:

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -221,7 +221,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		}
 		if reposExist(ctx, tryRemoveRepoGroup) {
 			proposedQueries = []*searchQueryDescription{
-				&searchQueryDescription{
+				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
 					query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
 					patternType: r.patternType,
@@ -252,7 +252,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		}
 		if reposExist(ctx, tryAnyRepo) {
 			proposedQueries = []*searchQueryDescription{
-				&searchQueryDescription{
+				{
 					description: fmt.Sprintf("include repositories satisfying any (not all) of your repo: filters"),
 					query:       withoutRepoFields + fmt.Sprintf(" repo:%s", unionRepoFilter),
 					patternType: r.patternType,
@@ -292,7 +292,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		proposedQueries := []*searchQueryDescription{}
 		if strings.TrimSpace(withoutRepoFields) != "" {
 			proposedQueries = []*searchQueryDescription{
-				&searchQueryDescription{
+				{
 					description: "remove repo: filter",
 					query:       withoutRepoFields,
 					patternType: r.patternType,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -123,7 +123,7 @@ func reposExist(ctx context.Context, options resolveRepoOp) bool {
 	return false
 }
 
-func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAlert, error) {
+func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAlert {
 	repoFilters, minusRepoFilters := r.query.RegexpPatterns(query.FieldRepo)
 	repoGroupFilters, _ := r.query.StringValues(query.FieldRepoGroup)
 	fork, _ := r.query.StringValue(query.FieldFork)
@@ -135,21 +135,21 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			prometheusType: "no_resolved_repos__no_repositories",
 			title:          "Add repositories or connect repository hosts",
 			description:    "There are no repositories to search. Add an external service connection to your code host.",
-		}, nil
+		}
 	}
 	if len(repoFilters) == 0 && len(repoGroupFilters) == 1 {
 		return &searchAlert{
 			prometheusType: "no_resolved_repos__repogroup_empty",
 			title:          fmt.Sprintf("Add repositories to repogroup:%s to see results", repoGroupFilters[0]),
 			description:    fmt.Sprintf("The repository group %q is empty. See the documentation for configuration and troubleshooting.", repoGroupFilters[0]),
-		}, nil
+		}
 	}
 	if len(repoFilters) == 0 && len(repoGroupFilters) > 1 {
 		return &searchAlert{
 			prometheusType: "no_resolved_repos__repogroup_none_in_common",
 			title:          "Repository groups have no repositories in common",
 			description:    "No repository exists in all of the specified repository groups.",
-		}, nil
+		}
 	}
 
 	// TODO(sqs): handle -repo:foo fields.
@@ -162,7 +162,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		return &searchAlert{
 			title:       "Expand your repository filters to see results",
 			description: fmt.Sprintf("No repository exists in all specified groups and satisfies all of your repo: filters."),
-		}, nil
+		}
 
 	case len(repoGroupFilters) == 1 && len(repoFilters) > 1:
 		proposedQueries := []*searchQueryDescription{}
@@ -209,7 +209,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			title:           "Expand your repository filters to see results",
 			description:     fmt.Sprintf("No repositories in repogroup:%s satisfied all of your repo: filters.", repoGroupFilters[0]),
 			proposedQueries: proposedQueries,
-		}, nil
+		}
 
 	case len(repoGroupFilters) == 1 && len(repoFilters) == 1:
 		proposedQueries := []*searchQueryDescription{}
@@ -238,7 +238,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			title:           "Expand your repository filters to see results",
 			description:     fmt.Sprintf("No repositories in repogroup:%s satisfied all of your repo: filters.", repoGroupFilters[0]),
 			proposedQueries: proposedQueries,
-		}, nil
+		}
 
 	case len(repoGroupFilters) == 0 && len(repoFilters) > 1:
 		proposedQueries := []*searchQueryDescription{}
@@ -268,7 +268,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			title:           "Expand your repo: filters to see results",
 			description:     fmt.Sprintf("No repositories satisfied all of your repo: filters."),
 			proposedQueries: proposedQueries,
-		}, nil
+		}
 
 	case len(repoGroupFilters) == 0 && len(repoFilters) == 1:
 		isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
@@ -278,13 +278,13 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 					return &searchAlert{
 						title:       "No repositories or code hosts configured",
 						description: "To start searching code, first go to site admin to configure repositories and code hosts.",
-					}, nil
+					}
 
 				} else {
 					return &searchAlert{
 						title:       "No repositories or code hosts configured",
 						description: "To start searching code, ask the site admin to configure and enable repositories.",
-					}, nil
+					}
 				}
 			}
 		}
@@ -303,13 +303,13 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 			title:           "No repositories satisfied your repo: filter",
 			description:     "Change your repo: filter to see results",
 			proposedQueries: proposedQueries,
-		}, nil
+		}
 	}
 	// Should be unreachable. Return a generic alert if reached.
 	return &searchAlert{
 		title:       "No repository results.",
 		description: "There are no repositories to search.",
-	}, nil
+	}
 }
 
 func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert, error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -904,10 +904,7 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 
 	tr.LazyPrintf("searching %d repos, %d missing", len(repos), len(missingRepoRevs))
 	if len(repos) == 0 {
-		alert, err := r.alertForNoResolvedRepos(ctx)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+		alert := r.alertForNoResolvedRepos(ctx)
 		return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 	}
 	if overLimit {


### PR DESCRIPTION
This refactor concentrates logic that creates search alerts and suggestions when repos are not resolved for a search. I was working on this part of the code before, but now it is more immediately important prep-work for #8739. The gist is to create search alerts in-place for each of the cases we currently handle, instead of tracking assignments to search alert `title`, `description`, etc across some hundred lines and not being able to clearly see when the final value for the alert field is set by the control flow.

Reviewer: please go by commit or this will be tough to read through. The change is semantics-preserving _except_ that previously the alert construction could fail (and return an `err`) when it attempts to subsequently resolve reports for query suggestions. I have made it so that it cannot fail, and instead emits the alert, but without the suggestion in case of errors. In principle I don't think alert construction should ever fail--the user shouldn't miss seeing an alert because something errored when trying to make the alert more informative. 

In practice and specific to this change: `resolveRepositories` is the function that may fail during alert construction, but that same function is called before alert construction, so any error that raises the second time during alert construction is very likely less critical (or can be reasonably suppressed) because any critical related errors would be caught the first time around. 