### PR TITLE
Register a comlink transfer handler for URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Site-Admin/Instrumentation is now available in the Kubernetes cluster deployment [8805](https://github.com/sourcegraph/sourcegraph/pull/8805).
+- Extensions can now specify a `baseUri` in the `DocumentFilter` when registering providers.
 
 ### Changed
 

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -26,6 +26,7 @@ import {
 } from './services/notifications'
 import { TextModelUpdate } from './services/modelService'
 import { EditorUpdate } from './services/editorService'
+import { registerComlinkTransferHandlers } from '../util'
 
 export interface ExtensionHostClientConnection {
     /**
@@ -50,7 +51,7 @@ export interface ActivatedExtension {
 }
 
 /**
- * @param endpoint The Worker object to communicate with
+ * @param endpoints The Worker object to communicate with
  */
 export async function createExtensionHostClientConnection(
     endpoints: EndpointPair,
@@ -60,6 +61,8 @@ export async function createExtensionHostClientConnection(
     const subscription = new Subscription()
 
     // MAIN THREAD
+
+    registerComlinkTransferHandlers()
 
     /** Proxy to the exposed extension host API */
     const initializeExtensionHost = comlink.proxy<ExtensionHostAPIFactory>(endpoints.proxy)

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -18,6 +18,7 @@ import { ExtRoots } from './api/roots'
 import { ExtSearch } from './api/search'
 import { ExtViews } from './api/views'
 import { ExtWindows } from './api/windows'
+import { registerComlinkTransferHandlers } from '../util'
 
 /**
  * Required information when initializing an extension host.
@@ -38,7 +39,7 @@ export interface InitData {
  * It expects to receive a message containing {@link InitData} from the client application as the
  * first message.
  *
- * @param transports The message reader and writer to use for communication with the client.
+ * @param endpoints The endpoints to the client.
  * @returns An unsubscribable to terminate the extension host.
  */
 export function startExtensionHost(
@@ -76,7 +77,7 @@ export function startExtensionHost(
  * The extension API is made globally available to all requires/imports of the "sourcegraph" module
  * by other scripts running in the same JavaScript context.
  *
- * @param connection The connection used to communicate with the client.
+ * @param endpoints The endpoints to the client.
  * @param initData The information to initialize this extension host.
  * @returns An unsubscribable to terminate the extension host.
  */
@@ -116,6 +117,8 @@ function createExtensionAPI(
     const subscription = new Subscription()
 
     // EXTENSION HOST WORKER
+
+    registerComlinkTransferHandlers()
 
     /** Proxy to main thread */
     const proxy = comlink.proxy<ClientAPI>(endpoints.proxy)

--- a/shared/src/api/util.ts
+++ b/shared/src/api/util.ts
@@ -1,6 +1,29 @@
-import { ProxiedObject, ProxyValue } from '@sourcegraph/comlink'
+import { ProxiedObject, ProxyValue, transferHandlers } from '@sourcegraph/comlink'
 import { Subscription } from 'rxjs'
 import { Subscribable, Unsubscribable } from 'sourcegraph'
+
+/**
+ * Tests whether a value is a WHATWG URL object.
+ */
+export const isURL = (value: any): value is URL =>
+    typeof value !== 'undefined' &&
+    value !== null &&
+    typeof value.toString === 'function' &&
+    value.href === value.toString()
+
+/**
+ * Registers global comlink transfer handlers.
+ * This needs to be called before using comlink.
+ * Idempotent.
+ */
+export function registerComlinkTransferHandlers(): void {
+    transferHandlers.set('URL', {
+        canHandle: isURL,
+        // TODO the comlink types could be better here to avoid the any
+        serialize: (url: any) => url.href,
+        deserialize: (urlString: any) => new URL(urlString),
+    })
+}
 
 /**
  * Creates a synchronous Subscription that will unsubscribe the given proxied Subscription asynchronously.


### PR DESCRIPTION
This is why https://github.com/sourcegraph/code-intel-extensions/pull/303 was not working.
This will also be helpful to replace more `uri` properties in the extension API with `URL` types in the future.

I verified that codeintel now works (together with https://github.com/sourcegraph/code-intel-extensions/pull/303):

![image](https://user-images.githubusercontent.com/10532611/76140933-be5ac200-605f-11ea-92d9-0e5ab1dc4a01.png)

Related https://github.com/sourcegraph/sourcegraph/issues/8602