### PR TITLE
refactor: fix unnecessary verbosity in GitLab OAuth authz provider naming

### DIFF
--- a/enterprise/cmd/frontend/authz_test.go
+++ b/enterprise/cmd/frontend/authz_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type gitlabAuthzProviderParams struct {
-	OAuthOp gitlab.OAuthAuthzProviderOp
+	OAuthOp gitlab.OAuthProviderOp
 	SudoOp  gitlab.SudoProviderOp
 }
 
@@ -45,7 +45,7 @@ func (m gitlabAuthzProviderParams) ServiceType() string {
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
 
 func Test_authzProvidersFromConfig(t *testing.T) {
-	gitlab.NewOAuthProvider = func(op gitlab.OAuthAuthzProviderOp) authz.Provider {
+	gitlab.NewOAuthProvider = func(op gitlab.OAuthProviderOp) authz.Provider {
 		op.MockCache = nil // ignore cache value
 		return gitlabAuthzProviderParams{OAuthOp: op}
 	}
@@ -101,7 +101,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 			expAuthzAllowAccessByDefault: true,
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
-					OAuthOp: gitlab.OAuthAuthzProviderOp{
+					OAuthOp: gitlab.OAuthProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
 						Token:             "asdf",
 						CacheTTL:          48 * time.Hour,
@@ -205,7 +205,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 			expAuthzAllowAccessByDefault: true,
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
-					OAuthOp: gitlab.OAuthAuthzProviderOp{
+					OAuthOp: gitlab.OAuthProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
 						Token:             "asdf",
 						CacheTTL:          3 * time.Hour,
@@ -214,7 +214,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 					},
 				},
 				gitlabAuthzProviderParams{
-					OAuthOp: gitlab.OAuthAuthzProviderOp{
+					OAuthOp: gitlab.OAuthProviderOp{
 						BaseURL:           mustURLParse(t, "https://gitlab.com"),
 						Token:             "asdf",
 						CacheTTL:          3 * time.Hour,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
@@ -15,7 +15,7 @@ type cache interface {
 }
 
 // userProjCacheKey returns the key for caching the value describing if the given GitLab user has
-// access to the given GitLab project. This key must be unique among *all* OAuthAuthzProvider
+// access to the given GitLab project. This key must be unique among *all* OAuthProvider
 // cache keys, including those for repo visibility (see projVisibilityCacheKey).
 func userProjCacheKey(gitlabAccountID string, gitlabProjID int) string {
 	return fmt.Sprintf("userRepo:%s:%d", gitlabAccountID, gitlabProjID) // GitLab account IDs cannot have ':'
@@ -57,7 +57,7 @@ func cacheSetUserRepo(c cache, gitlabAccountID string, gitlabProjID int, v userR
 
 // projVisibilityCacheKey returns the key for caching the value describing the visibility of the
 // GitLab project (public, internal, private). This key must be unique among *all*
-// OAuthAuthzProvider cache keys, including those for user-project access (see
+// OAuthProvider cache keys, including those for user-project access (see
 // userProjCacheKey).
 func projVisibilityCacheKey(gitlabProjID int) string {
 	return fmt.Sprintf("visibility:%d", gitlabProjID)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -86,7 +86,7 @@ func newAuthzProvider(a *schema.GitLabAuthorization, instanceURL, token string, 
 		if idp.Oauth.MaxBatchRequests > 0 {
 			maxBatchRequests = idp.Oauth.MaxBatchRequests
 		}
-		return NewOAuthProvider(OAuthAuthzProviderOp{
+		return NewOAuthProvider(OAuthProviderOp{
 			BaseURL:           glURL,
 			Token:             token,
 			CacheTTL:          ttl,
@@ -127,8 +127,8 @@ func newAuthzProvider(a *schema.GitLabAuthorization, instanceURL, token string, 
 	}
 }
 
-// NewOAuthProvider is a mockable constructor for new OAuthAuthzProvider instances.
-var NewOAuthProvider = func(op OAuthAuthzProviderOp) authz.Provider {
+// NewOAuthProvider is a mockable constructor for new OAuthProvider instances.
+var NewOAuthProvider = func(op OAuthProviderOp) authz.Provider {
 	return newOAuthProvider(op)
 }
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -20,9 +20,9 @@ import (
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
-var _ authz.Provider = (*OAuthAuthzProvider)(nil)
+var _ authz.Provider = (*OAuthProvider)(nil)
 
-type OAuthAuthzProvider struct {
+type OAuthProvider struct {
 	// The token is the access token used for syncing repositories from the code host,
 	// but it may or may not be a sudo-scoped.
 	token string
@@ -36,7 +36,7 @@ type OAuthAuthzProvider struct {
 	maxBatchRequests  int
 }
 
-type OAuthAuthzProviderOp struct {
+type OAuthProviderOp struct {
 	// BaseURL is the URL of the GitLab instance.
 	BaseURL *url.URL
 
@@ -64,8 +64,8 @@ type OAuthAuthzProviderOp struct {
 	MaxBatchRequests int
 }
 
-func newOAuthProvider(op OAuthAuthzProviderOp) *OAuthAuthzProvider {
-	p := &OAuthAuthzProvider{
+func newOAuthProvider(op OAuthProviderOp) *OAuthProvider {
+	p := &OAuthProvider{
 		token: op.Token,
 
 		clientProvider:    gitlab.NewClientProvider(op.BaseURL, nil),
@@ -82,23 +82,23 @@ func newOAuthProvider(op OAuthAuthzProviderOp) *OAuthAuthzProvider {
 	return p
 }
 
-func (p *OAuthAuthzProvider) Validate() (problems []string) {
+func (p *OAuthProvider) Validate() (problems []string) {
 	return nil
 }
 
-func (p *OAuthAuthzProvider) ServiceID() string {
+func (p *OAuthProvider) ServiceID() string {
 	return p.codeHost.ServiceID
 }
 
-func (p *OAuthAuthzProvider) ServiceType() string {
+func (p *OAuthProvider) ServiceType() string {
 	return p.codeHost.ServiceType
 }
 
-func (p *OAuthAuthzProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
 	return nil, nil
 }
 
-func (p *OAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos []*types.Repo) (
+func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos []*types.Repo) (
 	[]authz.RepoPerms, error,
 ) {
 	accountID := "" // empty means public / unauthenticated to the code host
@@ -232,7 +232,7 @@ func (p *OAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.Exte
 // - whether the repository contents are accessible to usr, and
 // - any error encountered in fetching (not including an error due to the repository not being visible);
 //   if the error is non-nil, all other return values should be disregraded
-func (p *OAuthAuthzProvider) fetchProjVis(ctx context.Context, oauthToken string, projID int) (
+func (p *OAuthProvider) fetchProjVis(ctx context.Context, oauthToken string, projID int) (
 	isAccessible bool, vis gitlab.Visibility, isContentAccessible bool, err error,
 ) {
 	proj, err := p.clientProvider.GetOAuthClient(oauthToken).GetProject(ctx, gitlab.GetProjectOp{
@@ -290,7 +290,7 @@ const batchProjVisSize = 100
 
 // fetchProjVisBatch returns the list of repositories best-effort sorted into groups. The visiblity
 // results are valid even if err is non-nil.
-func (p *OAuthAuthzProvider) fetchProjVisBatch(ctx context.Context, oauthToken string, reposByProjID map[int]*types.Repo, op fetchProjectVisibilityBatchOp) (
+func (p *OAuthProvider) fetchProjVisBatch(ctx context.Context, oauthToken string, reposByProjID map[int]*types.Repo, op fetchProjectVisibilityBatchOp) (
 	projIDVisibility map[int]visibilityLevel, err error,
 ) {
 	projIDVisibility = make(map[int]visibilityLevel, len(reposByProjID))

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -28,7 +28,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 		// Configures the provider. Do NOT set the MaxBatchRequests and MinBatchThreshold fields in
 		// the test struct declarations, as these are set to a range of values in the test logic,
 		// itself.
-		op OAuthAuthzProviderOp
+		op OAuthProviderOp
 
 		calls []call
 	}
@@ -92,7 +92,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 	tests := []test{
 		{
 			description: "standard config",
-			op: OAuthAuthzProviderOp{
+			op: OAuthProviderOp{
 				BaseURL: mustURL(t, "https://gitlab.mine"),
 			},
 			calls: []call{
@@ -240,7 +240,7 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 	gitlab.MockListTree = gitlabMock.ListTree
 
 	ctx := context.Background()
-	authzProvider := newOAuthProvider(OAuthAuthzProviderOp{
+	authzProvider := newOAuthProvider(OAuthProviderOp{
 		BaseURL:   mustURL(t, "https://gitlab.mine"),
 		MockCache: make(mockCache),
 		CacheTTL:  3 * time.Hour,
@@ -384,7 +384,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 		gitlab.MockListTree = gitlabMock.ListTree
 
 		ctx := context.Background()
-		authzProvider := newOAuthProvider(OAuthAuthzProviderOp{
+		authzProvider := newOAuthProvider(OAuthProviderOp{
 			BaseURL:           mustURL(t, "https://gitlab.mine"),
 			MockCache:         make(mockCache),
 			CacheTTL:          3 * time.Hour,
@@ -435,7 +435,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 		gitlab.MockListTree = gitlabMock.ListTree
 
 		ctx := context.Background()
-		authzProvider := newOAuthProvider(OAuthAuthzProviderOp{
+		authzProvider := newOAuthProvider(OAuthProviderOp{
 			BaseURL:           mustURL(t, "https://gitlab.mine"),
 			MockCache:         make(mockCache),
 			CacheTTL:          3 * time.Hour,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -18,7 +18,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -43,7 +43,7 @@ func (p *OAuthAuthzProvider) FetchUserPerms(ctx context.Context, account *extsvc
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-func (p *OAuthAuthzProvider) FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]extsvc.ExternalAccountID, error) {
+func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *api.ExternalRepoSpec) ([]extsvc.ExternalAccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, repo) {


### PR DESCRIPTION
This PRs fix the inconsistent naming for GitLab OAuthz authz provider, i.e. removed "authz" portion as it's already under authz namespace, and be consistent to have `SudoProvider` and `OAuthProvider`~`OAuthAuthzProvider`~.
