### PR TITLE
Fix triple quotes breaking frontend query parser

### DIFF
--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -61,6 +61,31 @@ describe('parseSearchQuery()', () => {
             type: 'success',
         }))
 
+    test('triple quotes', () => {
+        expect(parseSearchQuery('"""')).toMatchObject({
+            range: {
+                end: 3,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 3,
+                            start: 0,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: '"""',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
     test('filter', () =>
         expect(parseSearchQuery('a:b')).toMatchObject({
             range: {


### PR DESCRIPTION
Fixes #8801

The parser failed on queries containing tripe quotes, as it was parsing a quoted string, then expecting whitespace, instead of parsing all three quotes as a single literal. With this fix, if parsing a quoted string followed by whitespace or EOF fails, the parser will fall back to parsing a literal followed by whitespace or EOF.
