### PR TITLE
repo-updater: ignore bitbucket servers which do not support labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,9 @@ All notable changes to Sourcegraph are documented in this file.
 - Zoekt's watchdog ensures the service is down upto 3 times before exiting. The watchdog would misfire on startup on resource constrained systems, with the retries this should make a false positive far less likely. [#7867](https://github.com/sourcegraph/sourcegraph/issues/7867)
 - A regression in repo-updater was fixed that lead to every repository's git clone being updated every time the list of repositories was synced from the code host. [#8501](https://github.com/sourcegraph/sourcegraph/issues/8501)
 - The default timeout of indexed search has been increased. Previously indexed search would always return within 3s. This lead to broken behaviour on new instances which had yet to tune resource allocations. [#8720](https://github.com/sourcegraph/sourcegraph/pull/8720)
+- Bitbucket Server older than 5.13 failed to sync since Sourcegraph 3.12. This was due to us querying for the `archived` label, but Bitbucket Server 5.13 does not support labels. [#8883](https://github.com/sourcegraph/sourcegraph/issues/8883)
 
 ### Removed
-
-## 3.13.2 (Unreleased)
-
-### Fixed
-
-- Bitbucket Server older than 5.13 failed to sync since Sourcegraph 3.12. This was due to us querying for the `archived` label, but Bitbucket Server 5.13 does not support labels. [#8883](https://github.com/sourcegraph/sourcegraph/issues/8883)
 
 ## 3.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+## 3.13.2 (Unreleased)
+
+### Fixed
+
+- Bitbucket Server older than 5.13 failed to sync since Sourcegraph 3.12. This was due to us querying for the `archived` label, but Bitbucket Server 5.13 does not support labels. [#8883](https://github.com/sourcegraph/sourcegraph/issues/8883)
+
 ## 3.13.1
 
 ### Fixed

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -450,7 +450,10 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 	for next.HasMore() {
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
 		if err != nil {
-			if bitbucketserver.IsNoSuchLabel(err) {
+			// If the instance doesn't have the label then no repos are
+			// labeled. Older versions of bitbucket do not support labels, so
+			// they too have no labelled repos.
+			if bitbucketserver.IsNoSuchLabel(err) || bitbucketserver.IsNotFound(err) {
 				// treat as empty
 				return ids, nil
 			}


### PR DESCRIPTION
Bitbucket Server labels were only released in version 5.13. However, we always
query for the "archived" label when syncing. This leads us to failing to sync
on versions before 5.13. We now handle the 404. Example error message:

```
  External service updated, but we encountered a problem while validating the
  external service: failed to list repos with archived label: Bitbucket API
  HTTP error: code=404
  url="https://example-bitbucket.com/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000"
  body="404null for uri:
  https://example-bitbucket.com/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000"
```

Fixes https://github.com/sourcegraph/sourcegraph/issues/8883