### PR TITLE
docs: Improve navigation of docs by making headers more consistent

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -107,24 +107,23 @@
                     <li class="content-nav-no-hover">
                         <a class="content-nav-section-header" href="/admin">Administration</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/admin/privileges">Site admin privileges</a></li>
                             <li><a href="/admin/install">Installing Sourcegraph</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
                                     <li><a href="/admin/install/docker">Install Sourcegraph with Docker</a></li>
                                     <li class="content-nav-no-hover" data-sub-section-item="Install Sourcegraph with Docker" )>
-                                        <ul>
-                                            <li><a href="/admin/install/docker/aws">Install Sourcegraph with Docker on AWS</a></li>
-                                            <li><a href="/admin/install/docker/digitalocean">Install Sourcegraph with Docker on DigitalOcean</a></li>
-                                            <li><a href="/admin/install/docker/google_cloud">Install Sourcegraph with Docker on Google Cloud</a></li>
+                                        <ul class="content-nav-section-subsection">
+                                            <li><a href="/admin/install/docker/aws">AWS</a></li>
+                                            <li><a href="/admin/install/docker/digitalocean">DigitalOcean</a></li>
+                                            <li><a href="/admin/install/docker/google_cloud">Google Cloud</a></li>
                                         </ul>
                                     </li>
                                     <li><a href="/admin/install/docker-compose">Install Sourcegraph with Docker Compose</a></li>
-                                    <li class="content-nav-no-hover" data-sub-section-item="Install Sourcegraph with Docker Compose" )>
-                                        <ul>
-                                            <li><a href="/admin/install/docker-compose/aws">Install Sourcegraph with Docker Compose on AWS</a></li>
-                                            <li><a href="/admin/install/docker-compose/digitalocean">Install Sourcegraph with Docker Compose on DigitalOcean</a></li>
-                                            <li><a href="/admin/install/docker-compose/google_cloud">Install Sourcegraph with Docker Compose on Google Cloud</a></li>
+                                    <li class="content-nav-no-hover" data-sub-section-item="Install Sourcegraph with Docker Compose">
+                                        <ul class="content-nav-section-subsection">
+                                            <li><a href="/admin/install/docker-compose/aws">AWS</a></li>
+                                            <li><a href="/admin/install/docker-compose/digitalocean">DigitalOcean</a></li>
+                                            <li><a href="/admin/install/docker-compose/google_cloud">Google Cloud</a></li>
                                         </ul>
                                     </li>
                                     <li><a href="/admin/install/cluster">Installing Sourcegraph on a cluster</a></li>
@@ -190,6 +189,7 @@
                             <li><a href="/admin/user_data_deletion">User data deletion</a></li>
                             <li><a href="/admin/external_database">Using external databases with Sourcegraph</a></li>
                             <li><a href="/admin/extensions">Sourcegraph extensions and the extension registry</a></li>
+                            <li><a href="/admin/privileges">Site admin privileges</a></li>
                             <li><a href="/admin/faq">Administration FAQ</a></li>
                             <li><a href="/admin/lfaq">Administration LFAQ</a></li>
                             <li><a href="/admin/troubleshooting">Administration troubleshooting</a></li>
@@ -232,8 +232,9 @@
                     <li class="content-nav-no-hover">
                         <a class="content-nav-section-header" href="/extensions">Extensions</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/extensions/principles">Principles of extensibility for Sourcegraph</a></li>
+                            <li><a href="/extensions/usage">Using Sourcegraph extensions</a></li>
                             <li><a href="/extensions/security">Security and privacy of Sourcegraph extensions</a></li>
+                            <li><a href="/extensions/principles">Principles of extensibility for Sourcegraph</a></li>
                             <li><a href="/extensions/authoring">Sourcegraph extension authoring</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
@@ -243,8 +244,8 @@
                                     <li><a href="/extensions/authoring/debugging">Debugging a Sourcegraph extension</a></li>
                                     <li><a href="/extensions/authoring/ux_style_guide">Extension UX style guide</a></li>
                                     <li><a href="/extensions/authoring/tutorials">Extension authoring tutorials</a></li>
-                                    <li class="content-nav-no-hover" data-sub-section-item="Extension authoring tutorials" )>
-                                        <ul>
+                                    <li class="content-nav-no-hover" data-sub-section-item="Extension authoring tutorials">
+                                        <ul class="content-nav-section-subsection">
                                             <li><a href="/extensions/authoring/tutorials/hello_world">Building a "Hello, world!" Sourcegraph extension</a></li>
                                             <li><a href="/extensions/authoring/tutorials/lang_specific_extension_tutorial">Building a language-specific extension tutorial</a></li>
                                             <li><a href="/extensions/authoring/tutorials/button_custom_commands">Sourcegraph extension buttons and custom commands</a></li>
@@ -259,7 +260,6 @@
                                     <li><a href="/extensions/authoring/manifest">Sourcegraph extension manifest - package.json</a></li>
                                 </ul>
                             </li>
-                            <li><a href="/extensions/usage">Using Sourcegraph extensions</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -63,9 +63,10 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/user">User documentation</a>
+                        <a class="content-nav-section-header" href="/user">Usage</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/user/code_intelligence">Code intelligence overview</a></li>
+                            <li><a href="/user/tour">Tour</a></li>
+                            <li><a href="/user/code_intelligence">Code Intelligence</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
                                     <li><a href="/user/code_intelligence/basic_code_intelligence">Basic code intelligence</a></li>
@@ -76,7 +77,7 @@
                                     <li><a href="/user/code_intelligence/language_servers">Language servers</a></li>
                                 </ul>
                             </li>
-                            <li><a href="/user/search">Code search overview</a></li>
+                            <li><a href="/user/search">Code Search</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
                                     <li><a href="/user/search/queries">Search query syntax</a></li>
@@ -89,7 +90,6 @@
                             <li><a href="/user/themes">Color themes</a></li>
                             <li><a href="/user/organizations">Organizations</a></li>
                             <li><a href="/user/repository">Repositories</a></li>
-                            <li><a href="/user/tour">Sourcegraph tour</a></li>
                             <li><a href="/user/markdown">Sourcegraph-flavored Markdown</a></li>
                             <li><a href="/user/campaigns">Campaigns <span class="badge badge-primary">private beta</span></a></li>
                             <li><a href="/user/usage_statistics">Usage statistics</a></li>
@@ -105,7 +105,7 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/admin">Site admin documentation</a>
+                        <a class="content-nav-section-header" href="/admin">Administration</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/admin/privileges">Site admin privileges</a></li>
                             <li><a href="/admin/install">Installing Sourcegraph</a></li>
@@ -230,7 +230,7 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/extensions">Sourcegraph extensions</a>
+                        <a class="content-nav-section-header" href="/extensions">Extensions</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/extensions/principles">Principles of extensibility for Sourcegraph</a></li>
                             <li><a href="/extensions/security">Security and privacy of Sourcegraph extensions</a></li>
@@ -271,7 +271,7 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/api">Sourcegraph APIs</a>
+                        <a class="content-nav-section-header" href="/api">API Documentation</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/api/graphql">GraphQL API</a></li>
                             <li class="content-nav-no-hover">
@@ -304,7 +304,7 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/dev">Open source development documentation</a>
+                        <a class="content-nav-section-header" href="/dev">Developing Sourcegraph</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/dev/campaigns_development">Developing campaigns</a></li>
                             <li><a href="/dev/graphql_api">Developing the Sourcegraph GraphQL API</a></li>

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -94,6 +94,7 @@
                             <li><a href="/user/campaigns">Campaigns <span class="badge badge-primary">private beta</span></a></li>
                             <li><a href="/user/usage_statistics">Usage statistics</a></li>
                             <li><a href="/user/user_surveys">User surveys</a></li>
+                            <li><a href="/user/quick_links">Quick links</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -1,4 +1,4 @@
-# Site administration documentation
+# Administration
 
 Site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users. They have [special privileges](privileges.md) on the Sourcegraph instance.
 

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1,6 +1,6 @@
-# Sourcegraph APIs
+# API Documentation
 
 Sourcegraph exposes the following APIs:
 
 - [Sourcegraph GraphQL API](graphql/index.md), for accessing data stored or computed by Sourcegraph
-- [Sourcegraph extension API](../extensions/index.md), for extending the functionality of Sourcegraph and other tools (including code hosts)
+- [Sourcegraph Extension API](../extensions/index.md), for extending the functionality of Sourcegraph and other tools (including code hosts)

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -1,39 +1,6 @@
-# User documentation
+# Using Sourcegraph
 
-Welcome to Sourcegraph! As a developer, you can use Sourcegraph to get help while writing and reviewing code.
-
-- [Tour](tour.md): A walkthrough of Sourcegraph's features, with real-world example use cases.
-- Integrations:
-  - [Browser extension](../integration/browser_extension.md) (adds go-to-definition, hover tooltips, etc., to your code host and review tool)
-  - [Browser search engine](../integration/browser_search_engine.md)
-  - [Editor extension](../integration/editor.md)
-- [Code search](search/index.md)
-  - [Query syntax](search/queries.md): Supported query operators.
-  - [Search examples](search/examples.md)
-  - Types of searches:
-    - Cross-repository search
-    - Full-text search (with regular expression support)
-    - Repository name search
-    - Filename search
-    - Diff search
-    - Commit message search
-    - Multi-branch search
-- [Code intelligence](code_intelligence/index.md)
-  - Hover tooltips (type signatures, docs, etc.)
-  - Jump-to-definition
-  - Find-references
-  - Cross-repository jump-to-definition and find-references
-  - Supports [Go](https://sourcegraph.com/extensions/sourcegraph/go), [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript), [Python](https://sourcegraph.com/extensions/sourcegraph/python) - check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
-- [GraphQL API](../api/graphql/index.md)
-- [Repository badges](repository/badges.md)
-
-All features:
-
-- [Usage statistics](usage_statistics.md)
-- [User surveys](user_surveys.md)
-- [Color themes](themes.md)
-- [Campaigns](campaigns.md)
-- [Quick links](quick_links.md)
+Welcome to Sourcegraph!
 
 ## What is Sourcegraph?
 

--- a/doc/user/search/index.md
+++ b/doc/user/search/index.md
@@ -1,4 +1,4 @@
-# Code search overview
+# Code search
 
 > Reference the [**search query syntax**](queries.md) and see [search examples](examples.md) for inspiration.
 


### PR DESCRIPTION
This does multiple things:

* Rename some headers to result in a more uniform naming of headers
* Fix styling of sub-headers
* Reorder headers to match the navigational-structure that's shown on index pages
* Get rid of duplicate content

I have a few more improvements for the docs, but I think shipping small PRs makes more sense, since this is hard to review.

---

### Screenshots

#### Collapsed navigation before and after

<img width="884" alt="Screen Shot 2020-03-09 at 14 32 32" src="https://user-images.githubusercontent.com/1185253/76217930-9ca23c00-6213-11ea-8a62-9e2f76739c3b.png">

#### Expanded navigation before and after

<img width="290" alt="Before" src="https://user-images.githubusercontent.com/1185253/76217958-a5930d80-6213-11ea-8d56-12acfe70af33.png" align=left>

<img width="260" alt="After" src="https://user-images.githubusercontent.com/1185253/76218000-b6dc1a00-6213-11ea-8a08-b0022261b35c.png" align=right>




