### PR TITLE
docs: Add globally visible breadcrumbs without flaky auto-correct

### DIFF
--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -26,7 +26,6 @@ window.sgdocs = (() => {
       mobileNavInit()
       navInit()
       scrollNavToSelected()
-      breadcrumbsInit()
       docsVersionLinks()
       startSourcegraphCommandInit()
       setTimeout(schemaLinkCheck, 0) // Browser scrolls straight to element without this
@@ -108,18 +107,6 @@ window.sgdocs = (() => {
 
   function scrollNavToSelected() {
     setTimeout(() => scrollToElement(CONTENT_NAV, CONTENT_NAV.querySelector('.selected')), 50)
-  }
-
-  function breadcrumbsInit() {
-    const capitalized = ['AWS', 'URL', 'CI', 'LSIF', 'GRAPHQL', 'API', 'UI', 'SSL', 'NGINX', 'TLS', 'SSH', 'SSO', 'FAQ', 'SQL']
-    document.querySelectorAll('.breadcrumb-links a').forEach((el, index) => {
-      if (index > 0) {
-        let text = el.text.replace(/_/g, ' ')
-        text = text.charAt(0).toUpperCase() + text.slice(1)
-        capitalized.forEach(word => text = text.replace(new RegExp(word, 'gi'), word))
-        el.text = text
-      }
-    })
   }
 
   /**

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -558,7 +558,7 @@ code {
     padding-bottom: 2rem;
     padding-top: 0;
     max-height: calc(100vh - 70px);
-    top: 70px;
+    top: 110px;
     padding-top: 4px;
     overflow-scrolling: touch;
 }
@@ -786,6 +786,7 @@ li.content-nav-no-hover:hover {
 /* Docs Content layout */
 
 .docs-content {
+    margin-top: 114px;
     position: relative;
     width: 100%;
     min-height: 100vh;
@@ -798,9 +799,7 @@ li.content-nav-no-hover:hover {
 /* Docs breadcrumbs */
 
 .breadcrumbs {
-    margin-top: 84px;
-    font-size: 12px;
-    margin-bottom: 0.75rem;
+  border-top: 1px solid #eaeaea;
 }
 
 .breadcrumbs>.active {
@@ -816,6 +815,11 @@ li.content-nav-no-hover:hover {
     .content-nav-wrapper {
         border: none;
     }
+
+    .docs-content {
+      margin-top: 0px;
+    }
+
     /* Give space at bottom of div for breadcrumbs */
     .docs-content-section .markdown-body {
         padding: 1rem 0;

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -29,9 +29,15 @@
                 <span class="content-nav-mobile-button"></span>
                 <span class="breadcrumb-links">
                     {{with .Content}}
-                        {{if eq (len .Breadcrumbs ) 0}}<a href="#">Home</a>{{end}}
+                        {{if eq (len .Breadcrumbs ) 0}}<a href="#">docs</a>{{end}}
                             {{range .Breadcrumbs}}
-                                <a href="{{.URL}}" {{if .IsActive}} class="active" {{end}}>{{.Label}}</a>
+                                <a href="{{.URL}}" {{if .IsActive}} class="active" {{end}}>
+                                  {{if eq .Label "Documentation"}}
+                                  docs
+                                  {{else}}
+                                  {{.Label}}
+                                  {{end}}
+                                </a>
                                 {{if not .IsActive}}/{{end}}
                                 {{end}}
                                 &nbsp;
@@ -52,9 +58,6 @@
                     <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
                     <button class="btn btn-primary nav-search-button ml-2" type="submit">Search</button>
                 </form>
-                <ul class="content-nav-section expandable">
-                    <li><a class="content-nav-section-header" href="/">Home</a></li>
-                </ul>
                 <ul class="content-nav-section expandable" data-nav-section="user">
                     <button class="content-nav-button"></button>
                     <div class="close--icon">
@@ -329,21 +332,6 @@
         {{end}}
         <section class="column large-7 large-push-3 medium-6 medium-push-4 small-12 docs-content-section">
             {{/* Create breadcrumb nav*/}} {{with .Content}}
-
-            <nav id="breadcrumbs" class="breadcrumbs small-hidden">
-                <input type="button" class="content-nav-mobile-state large-hidden medium-hidden" />
-                <span class="content-nav-mobile-button"></span> {{if gt (len .Breadcrumbs ) 0}}
-                <span class="breadcrumb-links">
-                    {{if eq (len .Breadcrumbs ) 0}}
-                        <a href="/" class=" large-hidden medium-hidden active">Documentation</a> &nbsp;
-                    {{end}}
-                    {{range .Breadcrumbs}}
-                        <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">{{.Label}}</a>
-                        {{if not .IsActive}}/{{end}}
-                    {{end}} &nbsp;
-                    </span>
-                    {{end}}
-            </nav>
             <div class="markdown-body">{{markdown .}}</div>
             {{else}}
             <nav id="breadcrumbs" class="breadcrumbs small-hidden">

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -36,6 +36,25 @@
                     </form>
                 </div>
             </div>
+              {{ with .Content }}
+                  <div class="nav-container flex-container mb-2 pt-2 breadcrumbs small-hidden">
+                      <span class="breadcrumb-links">
+                        {{if eq (len .Breadcrumbs ) 0}}
+                            <a href="/" class="active">docs</a> &nbsp;
+                        {{end}}
+                        {{range .Breadcrumbs}}
+                            <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">
+                              {{if eq .Label "Documentation"}}
+                              docs
+                              {{else}}
+                              {{.Label}}
+                              {{end}}
+                            </a>
+                            {{if not .IsActive}}/{{end}}
+                        {{end}} &nbsp;
+                      </span>
+                  </div>
+              {{end}}
         </div>
     </div>
     {{block "content" .}}{{end}}


### PR DESCRIPTION
This might be controversial, but I really think we need a global navbar, so I'm proposing it here. If we don't want it, we can close this PR :)

This PR

* adds a globally visible "breadcrumbs" to our docs to make navigation and knowing where you are easier.
* gets rid of the "auto-correct" that we had on breadcrumb items and _embraces_ the file path structure we have. My thinking behind this is: the solution we had tried to make titles out of file paths, which doesn't work that well without meta-data (example:  it often failed in its capitalization efforts because it didn't take word-boundaries into account, so "ui" would be capitalized inside every word). So instead we embrace the file paths, which are still pretty readable and don't get us into this uncanny valley where the breadcrumbs kinda, sorta match the headings of the doc files, but not really. Now it's clear that it's file paths, which is okay, because our intended audience are admins and developers.
*  gets rid of the redundant "home" button. The logo in the top left already linked to this and now we have a "docs" link in the breadcrumbs.

@sourcegraph/web I'm not that sure about the CSS, so maybe someone can take a look.

### Demo GIF

![add_global_navbar](https://user-images.githubusercontent.com/1185253/76226001-8ac59680-621d-11ea-8123-51df695b31a6.gif)

