### PR TITLE
Don't use keycloak by default in dev env

### DIFF
--- a/dev/auth-provider/README.md
+++ b/dev/auth-provider/README.md
@@ -4,11 +4,11 @@
 
 ## Using Keycloak in local dev
 
-Keycloak is started when you run `dev/start.sh`.
+Keycloak is **not** started by default when you run `dev/start.sh`.
+
+To enable it, use `USE_KEYCLOAK=1 dev/start.sh`.
 
 To use it, visit your local dev server's sign-in page and authenticate using an auth provider whose name contains "Keycloak".
-
-To disable it, use `NO_KEYCLOAK=1 dev/start.sh`.
 
 ## Advanced
 

--- a/dev/auth-provider/keycloak.sh
+++ b/dev/auth-provider/keycloak.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ -n "$NO_KEYCLOAK" ]; then
+if [ -z "$USE_KEYCLOAK" ]; then
     echo Not using Keycloak. Keycloak authentication providers will not work.
     exit 0
 fi


### PR DESCRIPTION
It adds very high CPU load the first 2 minutes after startup.
Since most developers seem not to need it in their daily lifecycle,
and I've seen quite a few disable it by default, I think it's helpful to
remove keycloak from the standard processes.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

Docker stats output:

```
9136b0297e09        keycloak              353.38%             537.9MiB / 1.942GiB   25.67%               928B / 150B         219MB / 623kB         105
```
