### PR TITLE
Ensure (n>1)-th page of references does not re-request first page from lsif-server

### DIFF
--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -94,7 +94,7 @@ func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend
 		}
 		if nextURL, ok := nextURLs[upload.ID]; ok {
 			opts.Cursor = &nextURL
-		} else if len(nextURLs) > 0 {
+		} else if len(nextURLs) != 0 {
 			// Result set is exhausted or newer than the first page
 			// of results. Skip anything from this upload as it will
 			// have duplicate results, or it will be out of order.

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -94,6 +94,11 @@ func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend
 		}
 		if nextURL, ok := nextURLs[upload.ID]; ok {
 			opts.Cursor = &nextURL
+		} else if len(nextURLs) > 0 {
+			// Result set is exhausted or newer than the first page
+			// of results. Skip anything from this upload as it will
+			// have duplicate results, or it will be out of order.
+			continue
 		}
 
 		locations, nextURL, err := client.DefaultClient.References(ctx, opts)


### PR DESCRIPTION
We request the first page of results (a POST without a cursor value) whenever we don't have a _next_ URL from a previous request.

We ensure that we either have an empty cursor map (first requests for all uploads), or a non-empty cursor map (making only requests for which we have a previous cursor). This stops us from requesting without a cursor for an upload we've already queried.