### PR TITLE
LSIF: Ensure projectRoot has trailing slash in correlator

### DIFF
--- a/lsif/src/worker/conversion/correlator.test.ts
+++ b/lsif/src/worker/conversion/correlator.test.ts
@@ -15,7 +15,7 @@ describe('Correlator', () => {
 
         const projectRoot = c.projectRoot
         expect(c.lsifVersion).toEqual('0.4.3')
-        expect(projectRoot?.href).toEqual('file:///lsif-test')
+        expect(projectRoot?.href).toEqual('file:///lsif-test/')
     })
 
     it('should require metadata vertex before document vertices', () => {

--- a/lsif/src/worker/conversion/correlator.ts
+++ b/lsif/src/worker/conversion/correlator.ts
@@ -230,9 +230,9 @@ export class Correlator {
      *
      * @param vertex The metadata vertex.
      */
-    private handleMetaData(vertex: lsif.MetaData): void {
-        this.lsifVersion = vertex.version
-        this.projectRoot = new URL(vertex.projectRoot)
+    private handleMetaData({ version, projectRoot }: lsif.MetaData): void {
+        this.lsifVersion = version
+        this.projectRoot = new URL(projectRoot.endsWith('/') ? projectRoot : projectRoot + '/')
 
         // We assume that the project root in the LSIF dump is either:
         //


### PR DESCRIPTION
@uwedeportivo found this issue for me

lsif-jsonnet currently has a projectRoot without a trailing slash. This messes up the endsWith check immediately below and appended the dump root onto the end of the project root even though it already was suffixed with the dump root.