### PR TITLE
docs: update macOS install instructions for nvm

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -55,16 +55,42 @@ The following are two recommendations for installing these dependencies:
 3.  Install Go, Node Version Manager, PostgreSQL, Redis, Git, NGINX, golang-migrate, Comby, and SQLite tools with the following command:
 
     ```bash
-    brew install go nvm yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
+    brew install go yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
     ```
 
-4. Install the current recommended version of Node JS using:
+4.  Install the Node Version Manager (`nvm`) using:
+
+    ```bash
+    NVM_VERSION="$(curl https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name)"
+    curl -L https://raw.githubusercontent.com/nvm-sh/nvm/"$NVM_VERSION"/install.sh -o install-nvm.sh
+    sh install-nvm.sh
+    ```
+
+    After the install script is finished, re-source your shell profile (e.g.,
+    `source ~/.zshrc`) or restart your terminal session to pick up the `nvm`
+    definitions. Re-running the install script will update the installation.
+
+    Note: `nvm` is implemented as a shell function, so it may not show up in
+    the output of `which nvm`. Use `type nvm` to verify whether it is set up.
+    There is also a Homebrew package for `nvm`, but it is unsupported by the
+    `nvm` maintainers.
+
+5.  Install the current recommended version of Node JS by running the following
+    from the working directory of a sourcegraph repository clone:
 
     ```bash
     nvm install
+    nvm use --delete-prefix
     ```
 
-5.  Configure PostgreSQL and Redis to start automatically
+    After doing this, `node -v` should show the same version mentioned in
+    `.nvmrc` at the root of the sourcegraph repository.
+
+    Note: Although there is a Homebrew package for Node, we advise using `nvm`
+    instead, to ensure you get a Node version compatible with the current state
+    of the sourcegraph repository.
+
+6.  Configure PostgreSQL and Redis to start automatically
 
     ```bash
     brew services start postgresql
@@ -73,7 +99,7 @@ The following are two recommendations for installing these dependencies:
 
     (You can stop them later by calling `stop` instead of `start` above.)
 
-6.  Ensure `psql`, the PostgreSQL command line client, is on your `$PATH`.
+7.  Ensure `psql`, the PostgreSQL command line client, is on your `$PATH`.
     Homebrew does not put it there by default. Homebrew gives you the command to run to insert `psql` in your path in the "Caveats" section of `brew info postgresql`. Alternatively, you can use the command below. It might need to be adjusted depending on your Homebrew prefix (`/usr/local` below) and shell (bash below).
 
     ```bash
@@ -81,7 +107,7 @@ The following are two recommendations for installing these dependencies:
     source ~/.bash_profile
     ```
 
-7.  Open a new Terminal window to ensure `psql` is now on your `$PATH`.
+8.  Open a new Terminal window to ensure `psql` is now on your `$PATH`.
 
 ### Ubuntu
 


### PR DESCRIPTION
Context: [Slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1583689200233500)

Our local development setup recommends installing `nvm` via Homebrew, and installing NodeJS using `nvm install`. However, the Homebrew formula for `nvm` is not supported by the NVM maintainers, and must be configured manually, and the `node` version installed by `brew install node` may not be compatible with the current state of the sourcegraph repository.

Update the local setup instructions to more clearly document the necessary steps, so that the setup instructions are more likely to "just work" without additional context.

This includes:

- Use the recommended `nvm` installation script from GitHub (rather than Homebrew).
- Expand the instructions for `nvm install` to include `nvm use` (to ensure PATH is updated).
- Clarify why this is preferred to installing the `nvm` and `node` packages directly from Homebrew.
