### PR TITLE
Add postgres_host_auth_method=trust to schema doc generation

### DIFF
--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -58,7 +58,7 @@ func generate(log *log.Logger) (string, error) {
 			log.Println("docker pull complete")
 		}
 		runIgnoreError("docker", "rm", "--force", dbname)
-		server := exec.Command("docker", "run", "--rm", "--name", dbname, "-p", "5433:5432", "postgres:9.6")
+		server := exec.Command("docker", "run", "--rm", "--name", dbname, "-e", "POSTGRES_HOST_AUTH_METHOD=trust", "-p", "5433:5432", "postgres:9.6")
 		if err := server.Start(); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The schema doc generation no longer works without a postgres password supplied to the docker container. This envvar disables that requirement.