### PR TITLE
docs: fix template error in search

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -22,23 +22,19 @@
 {{end}}
 
 {{define "breadcrumb"}}
-    {{ with .Content }}
+    {{with .Content}}
         <div class="nav-container flex-container mb-2 pt-2 breadcrumbs small-hidden">
-          <span class="breadcrumb-links">
-            {{if eq (len .Breadcrumbs ) 0}}
-                <a href="/" class="active">docs</a> &nbsp;
-            {{end}}
-              {{range .Breadcrumbs}}
-                  <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">
-                  {{if eq .Label "Documentation"}}
-                      docs
-                  {{else}}
-                      {{.Label}}
-                  {{end}}
-                </a>
-                  {{if not .IsActive}}/{{end}}
-              {{end}} &nbsp;
-          </span>
+            <span class="breadcrumb-links">
+                {{if eq (len .Breadcrumbs) 0}}
+                    <a href="/" class="active">docs</a> &nbsp;
+                {{end}}
+                {{range .Breadcrumbs}}
+                    <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">
+                        {{if eq .Label "Documentation"}}docs{{else}}{{.Label}}{{end}}
+                    </a>
+                    {{if not .IsActive}}/{{end}}
+                {{end}}
+            </span>
         </div>
     {{end}}
 {{end}}

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -21,6 +21,28 @@
     </div>
 {{end}}
 
+{{define "breadcrumb"}}
+    {{ with .Content }}
+        <div class="nav-container flex-container mb-2 pt-2 breadcrumbs small-hidden">
+          <span class="breadcrumb-links">
+            {{if eq (len .Breadcrumbs ) 0}}
+                <a href="/" class="active">docs</a> &nbsp;
+            {{end}}
+              {{range .Breadcrumbs}}
+                  <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">
+                  {{if eq .Label "Documentation"}}
+                      docs
+                  {{else}}
+                      {{.Label}}
+                  {{end}}
+                </a>
+                  {{if not .IsActive}}/{{end}}
+              {{end}} &nbsp;
+          </span>
+        </div>
+    {{end}}
+{{end}}
+
 {{define "content"}}
     <div class="docs-content">
         <div class="nav-sticky-wrapper content-nav-wrapper column large-3 medium-4 mobile-show">

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -36,25 +36,7 @@
                     </form>
                 </div>
             </div>
-              {{ with .Content }}
-                  <div class="nav-container flex-container mb-2 pt-2 breadcrumbs small-hidden">
-                      <span class="breadcrumb-links">
-                        {{if eq (len .Breadcrumbs ) 0}}
-                            <a href="/" class="active">docs</a> &nbsp;
-                        {{end}}
-                        {{range .Breadcrumbs}}
-                            <a href="{{.URL}}" class="{{if .IsActive}}active{{end}}">
-                              {{if eq .Label "Documentation"}}
-                              docs
-                              {{else}}
-                              {{.Label}}
-                              {{end}}
-                            </a>
-                            {{if not .IsActive}}/{{end}}
-                        {{end}} &nbsp;
-                      </span>
-                  </div>
-              {{end}}
+            {{block "breadcrumb" .}}{{end}}
         </div>
     </div>
     {{block "content" .}}{{end}}


### PR DESCRIPTION
This PRs fixes template error occurs in search results page due to undefined field name.

Fixes #8905.