### PR TITLE
Only accept suggestions on tab

### DIFF
--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -280,16 +280,16 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
             )
         )
 
-        // Submit on enter when not showing suggestions.
+        // Submit on enter, hiding the suggestions widget if it's visible.
         this.subscriptions.add(
             toUnsubscribable(
                 editor.addAction({
                     id: 'submitOnEnter',
                     label: 'submitOnEnter',
                     keybindings: [Monaco.KeyCode.Enter],
-                    precondition: '!suggestWidgetVisible',
                     run: () => {
                         this.onSubmit()
+                        editor.trigger('submitOnEnter', 'hideSuggestWidget', [])
                     },
                 })
             )


### PR DESCRIPTION
Fixes #8904

With this change, <kbd>enter</kbd> will always submit the search query, and suggestions will only be accepted with <kbd>tab</kbd>.
