### PR TITLE
Do not log conf client error if frontend is (re!)started

### DIFF
--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -216,6 +216,10 @@ func (c *client) continuouslyUpdate(optOnlySetByTests *continuousUpdateOptions) 
 			if time.Since(start) > opt.delayBeforeUnreachableLog || !isFrontendUnreachableError(err) {
 				opt.log("received error during background config update, err: %s", err)
 			}
+		} else {
+			// We successfully fetched the config, we reset the timer to give
+			// frontend time if it needs to restart
+			start = time.Now()
 		}
 
 		opt.sleep()


### PR DESCRIPTION
The code previously only suppressed the error message for the first 15s
that frontend is _started_.

Now it also suppresses the error messages for 15s after frontend is
_restarted_.

#### Before

<img width="1275" alt="Screen Shot 2020-03-10 at 15 10 17" src="https://user-images.githubusercontent.com/1185253/76320949-a4c8ad00-62e1-11ea-911a-f531ef9c3ce7.png">

#### After

<img width="954" alt="Screen Shot 2020-03-10 at 15 10 00" src="https://user-images.githubusercontent.com/1185253/76320919-9ed2cc00-62e1-11ea-8d34-5c0c3e7c652d.png">

