### PR TITLE
fix: build essential Go tools before updating GOBIN

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -1,38 +1,39 @@
 #!/usr/bin/env bash
 #
-# Build commands, optionally with or without race detector.  a list of every command we know about,
-# to use by default
+# Build commands, optionally with or without race detector.  a list of every
+# command we know about, to use by default
 #
 # This will install binaries into the `.bin` directory under the repository root.
+#
 
 all_oss_commands=" gitserver query-runner github-proxy searcher replacer frontend repo-updater symbols "
 
 # handle options
 verbose=false
 while getopts 'v' o; do
-	case $o in
-	v)	verbose=true;;
-	\?)	echo >&2 "usage: go-install.sh [-v] [commands]"
-		exit 1
-		;;
-	esac
+    case $o in
+        v)      verbose=true;;
+        \?)     echo >&2 "usage: go-install.sh [-v] [commands]"
+                exit 1
+                ;;
+    esac
 done
 shift $(expr $OPTIND - 1)
 
 # check provided commands
 ok=true
 case $# in
-0)	commands=$all_oss_commands;;
-*)	commands=" $* "
-	for cmd in $commands; do
-		case $all_oss_commands in
-		*" $cmd "*)	;;
-		*)	echo >&2 "unknown command: $cmd"
-			ok=false
-			;;
-		esac
-	done
-	;;
+    0)      commands=$all_oss_commands;;
+    *)      commands=" $* "
+            for cmd in $commands; do
+                case $all_oss_commands in
+                    *" $cmd "*)     ;;
+                    *)      echo >&2 "unknown command: $cmd"
+                            ok=false
+                            ;;
+                esac
+            done
+            ;;
 esac
 
 $ok || exit 1
@@ -52,15 +53,15 @@ if [ ! -n "${OFFLINE-}" ]; then
 fi
 
 if ! go install $INSTALL_GO_PKGS; then
-	echo >&2 "failed to install prerequisites, aborting."
-	exit 1
+    echo >&2 "failed to install prerequisites, aborting."
+    exit 1
 fi
 
 TAGS='dev'
 if [ -n "$DELVE" ]; then
-	echo >&2 'Building with optimizations disabled (for debugging). Make sure you have at least go1.10 installed.'
-	GCFLAGS='all=-N -l'
-	TAGS="$TAGS delve"
+    echo >&2 'Building with optimizations disabled (for debugging). Make sure you have at least go1.10 installed.'
+    GCFLAGS='all=-N -l'
+    TAGS="$TAGS delve"
 fi
 
 # build a list of "cmd,true" and "cmd,false" pairs to indicate whether each command
@@ -69,42 +70,42 @@ fi
 raced=""
 unraced=""
 case $GORACED in
-"all")	for cmd in $commands; do
-		raced="$raced $cmd"
-	done
-	;;
-*)	for cmd in $commands; do
-		case " $GORACED " in
-		*" $cmd "*)
-			raced="$raced $cmd"
-			;;
-		*)
-			unraced="$unraced $cmd"
-			;;
-		esac
-	done
-	;;
+    "all")  for cmd in $commands; do
+                raced="$raced $cmd"
+            done
+            ;;
+    *)      for cmd in $commands; do
+                case " $GORACED " in
+                    *" $cmd "*)
+                        raced="$raced $cmd"
+                        ;;
+                    *)
+                        unraced="$unraced $cmd"
+                        ;;
+                esac
+            done
+            ;;
 esac
 
 # Shared logic for the go install part
 do_install() {
-	race=$1
-	shift
-	cmdlist="$*"
-	cmds=""
-	for cmd in $cmdlist; do
-		replaced=false
-    		for enterpriseCmd in $ENTERPRISE_COMMANDS; do
-			if [ "$cmd" == "$enterpriseCmd" ]; then
-				cmds="$cmds github.com/sourcegraph/sourcegraph/enterprise/cmd/$enterpriseCmd"
-				replaced=true
-			fi
-		done
-		if [ $replaced == false ]; then
-			cmds="$cmds github.com/sourcegraph/sourcegraph/cmd/$cmd"
-		fi
-	done
-	if ( go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race=$race $cmds ); then
+    race=$1
+    shift
+    cmdlist="$*"
+    cmds=""
+    for cmd in $cmdlist; do
+        replaced=false
+        for enterpriseCmd in $ENTERPRISE_COMMANDS; do
+            if [ "$cmd" == "$enterpriseCmd" ]; then
+                cmds="$cmds github.com/sourcegraph/sourcegraph/enterprise/cmd/$enterpriseCmd"
+                replaced=true
+            fi
+        done
+        if [ $replaced == false ]; then
+            cmds="$cmds github.com/sourcegraph/sourcegraph/cmd/$cmd"
+        fi
+    done
+    if ( go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race=$race $cmds ); then
         for cmd in $cmdlist; do
             # Check whether the binary of each command has changed
             diff "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}" >/dev/null
@@ -119,23 +120,23 @@ do_install() {
                 fi
             fi
         done
-	else
-		failed="$failed $cmdlist"
-	fi
+    else
+        failed="$failed $cmdlist"
+    fi
 }
 
 if [ -n "$raced" ]; then
-	echo >&2 "Go race detector enabled for: $GORACED."
-	do_install true $raced
+    echo >&2 "Go race detector enabled for: $GORACED."
+    do_install true $raced
 else
-	echo >&2 "Go race detector disabled. You can enable it for specific commands by setting GORACED (e.g. GORACED=frontend,searcher or GORACED=all for all commands)"
+    echo >&2 "Go race detector disabled. You can enable it for specific commands by setting GORACED (e.g. GORACED=frontend,searcher or GORACED=all for all commands)"
 fi
 
 if [ -n "$unraced" ]; then
-	do_install false $unraced
+    do_install false $unraced
 fi
 
 if [ -n "$failed" ]; then
-	echo >&2 "failed to build:$failed"
-	exit 1
+    echo >&2 "failed to build:$failed"
+    exit 1
 fi

--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -61,7 +61,7 @@ fi
 
 # For the target commands, build into a temp directory for comparison, so that
 # we can update only those packages that change. Clean up the temp at exit.
-tmpdir="$(mktemp -d -t src-binaries)"
+tmpdir="$(mktemp -d -t src-binaries.XXXXXXXX)"
 trap 'rm "$tmpdir"/*; rmdir "$tmpdir"' EXIT
 export GOBIN="$tmpdir"
 


### PR DESCRIPTION
PR #8912 pointed GOBIN to a temp directory, so that the target binaries can be compared to the installed set to avoid unnecessary restarts.  However, that change applies to ALL the Go tools built by this script, including dlv and the Zoekt indexer binaries that are not updated in this way.
    
That means in a clean checkout (or in any other case where .bin has been purged), the .bin directory never receives the zoekt binaries at all, and the service cannot start up.
    
The key change here is to move the update of GOBIN until after those core tools are built and installed. Then the target commands are built with GOBIN pointed to a temp directory, as before.
    
Along the way, I also cleaned up some of the formatting in the file (tabs to spaces, fixed indentation). There is more that could be done.
