### PR TITLE
authz: remove all call sites to dbconn.Global in `PermsSyncer`

### DIFF
--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 // NewAuthzStore returns an OSS db.AuthzStore set with enterprise implementation.
@@ -129,7 +130,7 @@ func (s *authzStore) RevokeUserPermissions(ctx context.Context, args *db.RevokeU
 		return err
 	}
 
-	accounts := &ExternalAccounts{
+	accounts := &extsvc.ExternalAccounts{
 		ServiceType: args.ServiceType,
 		ServiceID:   args.ServiceID,
 		AccountIDs:  append([]string{args.Username}, args.VerifiedEmails...),

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -51,7 +52,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	s := NewAuthzStore(dbconn.Global, clock).(*authzStore)
 
 	type update struct {
-		accounts *ExternalAccounts
+		accounts *extsvc.ExternalAccounts
 		repoID   int32
 	}
 	tests := []struct {
@@ -73,7 +74,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			},
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice@example.com"},
@@ -81,7 +82,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 					repoID: 1,
 				},
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice2@example.com"},
@@ -89,7 +90,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 					repoID: 2,
 				},
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice3@example.com"},
@@ -111,7 +112,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			},
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice"},
@@ -119,7 +120,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 					repoID: 1,
 				},
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"bob"},
@@ -283,7 +284,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	accounts := &ExternalAccounts{
+	accounts := &extsvc.ExternalAccounts{
 		ServiceType: "sourcegraph",
 		ServiceID:   "https://sourcegraph.com/",
 		AccountIDs:  []string{"alice", "alice@example.com"},

--- a/enterprise/cmd/frontend/db/integration_test.go
+++ b/enterprise/cmd/frontend/db/integration_test.go
@@ -36,6 +36,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"PermsStore/DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 
 		{"PermsStore/ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
+		{"PermsStore/GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
 	} {
 		t.Run(tc.name, tc.test)
 	}

--- a/enterprise/cmd/frontend/db/integration_test.go
+++ b/enterprise/cmd/frontend/db/integration_test.go
@@ -34,6 +34,8 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"PermsStore/DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
 		{"PermsStore/DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"PermsStore/DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
+
+		{"PermsStore/ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
 	} {
 		t.Run(tc.name, tc.test)
 	}

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1226,9 +1226,13 @@ func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (ac
 
 	q := sqlf.Sprintf(`
 -- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.ListExternalAccounts
-SELECT id, user_id, service_type, service_id, client_id, account_id, auth_data, account_data, created_at, updated_at
+SELECT id, user_id,
+       service_type, service_id, client_id, account_id,
+       auth_data, account_data,
+       created_at, updated_at
 FROM user_external_accounts
 WHERE user_id = %d
+ORDER BY id ASC
 `, userID)
 	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1091,6 +1091,7 @@ func (s *PermsStore) DeleteAllUserPendingPermissions(ctx context.Context, accoun
 		items[i] = sqlf.Sprintf("%s", accounts.AccountIDs[i])
 	}
 	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.DeleteAllUserPendingPermissions
 DELETE FROM user_pending_permissions
 WHERE service_type = %s
 AND service_id = %s
@@ -1216,6 +1217,80 @@ func (s *PermsStore) batchLoadIDs(ctx context.Context, q *sqlf.Query) (map[int32
 	}
 
 	return loaded, nil
+}
+
+// ListExternalAccounts returns all external accounts that are associated with given user.
+func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (results []*extsvc.ExternalAccount, err error) {
+	ctx, save := s.observe(ctx, "ListExternalAccounts", "")
+	defer func() { save(&err, otlog.Int32("userID", userID)) }()
+
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.ListExternalAccounts
+SELECT id, user_id, service_type, service_id, client_id, account_id, auth_data, account_data, created_at, updated_at
+FROM user_external_accounts
+WHERE user_id = %d
+`, userID)
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ea extsvc.ExternalAccount
+		if err := rows.Scan(&ea.ID, &ea.UserID, &ea.ServiceType, &ea.ServiceID, &ea.ClientID, &ea.AccountID, &ea.AuthData, &ea.AccountData, &ea.CreatedAt, &ea.UpdatedAt); err != nil {
+			return nil, err
+		}
+		results = append(results, &ea)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetUserIDsByExternalAccounts returns all user IDs matched by given external account specs.
+// The returned set has mapping relation as "account ID -> user ID". The number of results
+// could be less than the candidate list due to some users are not associated with any external
+// account.
+func (s *PermsStore) GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.ExternalAccounts) (_ map[string]int32, err error) {
+	ctx, save := s.observe(ctx, "ListUsersByExternalAccounts", "")
+	defer func() { save(&err, accounts.TracingFields()...) }()
+
+	items := make([]*sqlf.Query, len(accounts.AccountIDs))
+	for i := range accounts.AccountIDs {
+		items[i] = sqlf.Sprintf("%s", accounts.AccountIDs[i])
+	}
+
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.GetUserIDsByExternalAccounts
+SELECT user_id, account_id
+FROM user_external_accounts
+WHERE service_type = %s
+AND service_id = %s
+AND account_id IN (%s)
+`, accounts.ServiceType, accounts.ServiceID, sqlf.Join(items, ","))
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	userIDs := make(map[string]int32)
+	for rows.Next() {
+		var userID int32
+		var accountID string
+		if err := rows.Scan(&userID, &accountID); err != nil {
+			return nil, err
+		}
+		userIDs[accountID] = userID
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return userIDs, nil
 }
 
 // tx begins a new transaction.

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1220,7 +1220,7 @@ func (s *PermsStore) batchLoadIDs(ctx context.Context, q *sqlf.Query) (map[int32
 }
 
 // ListExternalAccounts returns all external accounts that are associated with given user.
-func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (results []*extsvc.ExternalAccount, err error) {
+func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (accounts []*extsvc.ExternalAccount, err error) {
 	ctx, save := s.observe(ctx, "ListExternalAccounts", "")
 	defer func() { save(&err, otlog.Int32("userID", userID)) }()
 
@@ -1237,17 +1237,22 @@ WHERE user_id = %d
 	defer rows.Close()
 
 	for rows.Next() {
-		var ea extsvc.ExternalAccount
-		if err := rows.Scan(&ea.ID, &ea.UserID, &ea.ServiceType, &ea.ServiceID, &ea.ClientID, &ea.AccountID, &ea.AuthData, &ea.AccountData, &ea.CreatedAt, &ea.UpdatedAt); err != nil {
+		var acct extsvc.ExternalAccount
+		if err := rows.Scan(
+			&acct.ID, &acct.UserID,
+			&acct.ServiceType, &acct.ServiceID, &acct.ClientID, &acct.AccountID,
+			&acct.AuthData, &acct.AccountData,
+			&acct.CreatedAt, &acct.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
-		results = append(results, &ea)
+		accounts = append(accounts, &acct)
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
 
-	return results, nil
+	return accounts, nil
 }
 
 // GetUserIDsByExternalAccounts returns all user IDs matched by given external account specs.

--- a/enterprise/cmd/frontend/db/perms_store_mock.go
+++ b/enterprise/cmd/frontend/db/perms_store_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 type MockPerms struct {
@@ -12,6 +13,6 @@ type MockPerms struct {
 	LoadUserPermissions        func(ctx context.Context, p *authz.UserPermissions) error
 	LoadUserPendingPermissions func(ctx context.Context, p *authz.UserPendingPermissions) error
 	SetRepoPermissions         func(ctx context.Context, p *authz.RepoPermissions) error
-	SetRepoPendingPermissions  func(ctx context.Context, accounts *ExternalAccounts, p *authz.RepoPermissions) error
+	SetRepoPendingPermissions  func(ctx context.Context, accounts *extsvc.ExternalAccounts, p *authz.RepoPermissions) error
 	ListPendingUsers           func(ctx context.Context) ([]string, error)
 }

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gitchander/permutation"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -543,7 +544,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			s := NewPermsStore(db, clock)
 			defer cleanupPermsTables(t, s)
 
-			accounts := &ExternalAccounts{
+			accounts := &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"bob"},
@@ -574,7 +575,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			s := NewPermsStore(db, clock)
 			defer cleanupPermsTables(t, s)
 
-			accounts := &ExternalAccounts{
+			accounts := &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"alice"},
@@ -605,7 +606,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			s := NewPermsStore(db, clock)
 			defer cleanupPermsTables(t, s)
 
-			accounts := &ExternalAccounts{
+			accounts := &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"alice", "bob"},
@@ -769,7 +770,7 @@ func checkRepoPendingPermsTable(ctx context.Context, s *PermsStore, bindIDs map[
 
 func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 	type update struct {
-		accounts *ExternalAccounts
+		accounts *extsvc.ExternalAccounts
 		perm     *authz.RepoPermissions
 	}
 	tests := []struct {
@@ -782,7 +783,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "empty",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  nil,
@@ -798,7 +799,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice"},
@@ -808,7 +809,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice", "bob"},
@@ -818,7 +819,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"cindy", "david"},
@@ -845,7 +846,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add and update",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice", "bob"},
@@ -855,7 +856,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"bob", "cindy"},
@@ -865,7 +866,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice", "bob"},
@@ -875,7 +876,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"cindy", "david"},
@@ -901,7 +902,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add and clear",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice", "bob", "cindy"},
@@ -911,7 +912,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{},
@@ -980,7 +981,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 
 func testPermsStore_ListPendingUsers(db *sql.DB) func(t *testing.T) {
 	type update struct {
-		accounts *ExternalAccounts
+		accounts *extsvc.ExternalAccounts
 		perm     *authz.RepoPermissions
 	}
 	tests := []struct {
@@ -996,7 +997,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(t *testing.T) {
 			name: "has user with pending permissions",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"alice"},
@@ -1013,7 +1014,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(t *testing.T) {
 			name: "has user but with empty object_ids",
 			updates: []update{
 				{
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  []string{"bob@example.com"},
@@ -1023,7 +1024,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(t *testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &ExternalAccounts{
+					accounts: &extsvc.ExternalAccounts{
 						ServiceType: "sourcegraph",
 						ServiceID:   "https://sourcegraph.com/",
 						AccountIDs:  nil,
@@ -1071,7 +1072,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(t *testing.T) {
 
 func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 	type pending struct {
-		accounts *ExternalAccounts
+		accounts *extsvc.ExternalAccounts
 		perm     *authz.RepoPermissions
 	}
 	type update struct {
@@ -1123,7 +1124,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"alice"},
@@ -1133,7 +1134,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"bob"},
@@ -1192,7 +1193,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"alice"},
@@ -1202,7 +1203,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"bob"},
@@ -1261,7 +1262,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"alice@example.com"},
@@ -1271,7 +1272,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(t *testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &ExternalAccounts{
+							accounts: &extsvc.ExternalAccounts{
 								ServiceType: "sourcegraph",
 								ServiceID:   "https://sourcegraph.com/",
 								AccountIDs:  []string{"alice2@example.com"},
@@ -1434,7 +1435,7 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(t *testing.
 
 		ctx := context.Background()
 
-		accounts := &ExternalAccounts{
+		accounts := &extsvc.ExternalAccounts{
 			ServiceType: "sourcegraph",
 			ServiceID:   "https://sourcegraph.com/",
 			AccountIDs:  []string{"alice", "bob"},
@@ -1508,7 +1509,7 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(t *testing.T) {
 			}
 		}
 		setRepoPendingPermissions := func(ctx context.Context, t *testing.T) {
-			accounts := &ExternalAccounts{
+			accounts := &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"alice"},

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -17,6 +17,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 type Resolver struct {
@@ -103,7 +104,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	}
 	defer txs.Done(&err)
 
-	accounts := &edb.ExternalAccounts{
+	accounts := &extsvc.ExternalAccounts{
 		ServiceType: "sourcegraph",
 		ServiceID:   "https://sourcegraph.com/",
 		AccountIDs:  pendingBindIDs,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -21,6 +21,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -67,7 +68,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 		mockUsers          []*types.User
 		gqlTests           []*gqltesting.Test
 		expUserIDs         []uint32
-		expAccounts        *edb.ExternalAccounts
+		expAccounts        *extsvc.ExternalAccounts
 	}{
 		{
 			name: "set permissions via email",
@@ -102,7 +103,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				},
 			},
 			expUserIDs: []uint32{1},
-			expAccounts: &edb.ExternalAccounts{
+			expAccounts: &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"bob"},
@@ -141,7 +142,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				},
 			},
 			expUserIDs: []uint32{1},
-			expAccounts: &edb.ExternalAccounts{
+			expAccounts: &extsvc.ExternalAccounts{
 				ServiceType: "sourcegraph",
 				ServiceID:   "https://sourcegraph.com/",
 				AccountIDs:  []string{"bob"},
@@ -174,7 +175,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				}
 				return nil
 			}
-			edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *edb.ExternalAccounts, _ *authz.RepoPermissions) error {
+			edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *extsvc.ExternalAccounts, _ *authz.RepoPermissions) error {
 				if diff := cmp.Diff(test.expAccounts, accounts); diff != "" {
 					return fmt.Errorf("accounts: %v", diff)
 				}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -278,9 +278,9 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 		}
 
 		// Set up the set of all account IDs that need to be bound to permissions
-		pendingAccountIDsSet = make(map[string]struct{}, len(extAccountIDs))
-		for i := range extAccountIDs {
-			pendingAccountIDsSet[string(extAccountIDs[i])] = struct{}{}
+		pendingAccountIDsSet = make(map[string]struct{}, len(accountIDs))
+		for i := range accountIDs {
+			pendingAccountIDsSet[accountIDs[i]] = struct{}{}
 		}
 	}
 
@@ -300,8 +300,8 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 	}
 
 	pendingAccountIDs := make([]string, 0, len(pendingAccountIDsSet))
-	for id := range pendingAccountIDsSet {
-		pendingAccountIDs = append(pendingAccountIDs, id)
+	for aid := range pendingAccountIDsSet {
+		pendingAccountIDs = append(pendingAccountIDs, aid)
 	}
 
 	txs, err := s.permsStore.Transact(ctx)

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -9,8 +9,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -174,10 +172,7 @@ func (s *PermsSyncer) fetchers() map[string]PermsFetcher {
 
 // syncUserPerms processes permissions syncing request in user-centric way.
 func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32) error {
-	// TODO(jchen): Remove the use of dbconn.Global().
-	accts, err := db.ExternalAccounts.List(ctx, db.ExternalAccountsListOptions{
-		UserID: userID,
-	})
+	accts, err := s.permsStore.ListExternalAccounts(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, "list external accounts")
 	}
@@ -259,35 +254,33 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 		return nil
 	}
 
-	// NOTE: The following logic is based on the assumption that we have accurate
-	// one-to-one username mapping between the internal database and the code host.
-	// See last paragraph of https://docs.sourcegraph.com/admin/auth#username-normalization
-	// for details.
-
-	accountIDs, err := fetcher.FetchRepoPerms(ctx, &repo.ExternalRepo)
+	extAccountIDs, err := fetcher.FetchRepoPerms(ctx, &repo.ExternalRepo)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository permissions")
 	}
 
-	bindUsernamesSet := make(map[string]struct{})
-	var users []*types.User
-	if len(accountIDs) > 0 {
-		usernames := make([]string, len(accountIDs))
-		for i := range accountIDs {
-			usernames[i] = string(accountIDs[i])
+	pendingAccountIDsSet := make(map[string]struct{})
+	var userIDs map[string]int32 // Account ID -> User ID
+	if len(extAccountIDs) > 0 {
+		accountIDs := make([]string, len(extAccountIDs))
+		for i := range extAccountIDs {
+			accountIDs[i] = string(extAccountIDs[i])
 		}
 
 		// Get corresponding internal database IDs
-		// TODO(jchen): Remove the use of dbconn.Global().
-		users, err = db.Users.GetByUsernames(ctx, usernames...)
+		userIDs, err = s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.ExternalAccounts{
+			ServiceType: fetcher.ServiceType(),
+			ServiceID:   fetcher.ServiceID(),
+			AccountIDs:  accountIDs,
+		})
 		if err != nil {
-			return errors.Wrap(err, "get users by usernames")
+			return errors.Wrap(err, "get user IDs by external accounts")
 		}
 
-		// Set up set of all usernames that need to be bound to permissions
-		bindUsernamesSet = make(map[string]struct{}, len(usernames))
-		for i := range usernames {
-			bindUsernamesSet[usernames[i]] = struct{}{}
+		// Set up the set of all account IDs that need to be bound to permissions
+		pendingAccountIDsSet = make(map[string]struct{}, len(extAccountIDs))
+		for i := range extAccountIDs {
+			pendingAccountIDsSet[string(extAccountIDs[i])] = struct{}{}
 		}
 	}
 
@@ -298,17 +291,17 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 		UserIDs: roaring.NewBitmap(),
 	}
 
-	for i := range users {
+	for aid, uid := range userIDs {
 		// Add existing user to permissions
-		p.UserIDs.Add(uint32(users[i].ID))
+		p.UserIDs.Add(uint32(uid))
 
-		// Remove existing user from set of pending users
-		delete(bindUsernamesSet, users[i].Username)
+		// Remove existing user from the set of pending users
+		delete(pendingAccountIDsSet, aid)
 	}
 
-	pendingBindUsernames := make([]string, 0, len(bindUsernamesSet))
-	for id := range bindUsernamesSet {
-		pendingBindUsernames = append(pendingBindUsernames, id)
+	pendingAccountIDs := make([]string, 0, len(pendingAccountIDsSet))
+	for id := range pendingAccountIDsSet {
+		pendingAccountIDs = append(pendingAccountIDs, id)
 	}
 
 	txs, err := s.permsStore.Transact(ctx)
@@ -318,9 +311,9 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 	defer txs.Done(&err)
 
 	accounts := &extsvc.ExternalAccounts{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
-		AccountIDs:  pendingBindUsernames,
+		ServiceType: fetcher.ServiceType(),
+		ServiceID:   fetcher.ServiceID(),
+		AccountIDs:  pendingAccountIDs,
 	}
 
 	if err = txs.SetRepoPermissions(ctx, p); err != nil {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -317,7 +317,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID) erro
 	}
 	defer txs.Done(&err)
 
-	accounts := &edb.ExternalAccounts{
+	accounts := &extsvc.ExternalAccounts{
 		ServiceType: "sourcegraph",
 		ServiceID:   "https://sourcegraph.com/",
 		AccountIDs:  pendingBindUsernames,

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -3,10 +3,12 @@ package extsvc
 import (
 	"encoding/json"
 	"time"
+
+	otlog "github.com/opentracing/opentracing-go/log"
 )
 
 // ExternalAccount represents a row in the `user_external_accounts` table. See the GraphQL API's
-// corresponding fields for documentation.
+// corresponding fields in "ExternalAccount" for documentation.
 type ExternalAccount struct {
 	ID                  int32
 	UserID              int32
@@ -18,7 +20,7 @@ type ExternalAccount struct {
 
 // ExternalAccountSpec specifies a user external account by its external identifier (i.e., by
 // the identifier provided by the account's owner service), instead of by our database's serial
-// ID. See the GraphQL API's corresponding fields for documentation.
+// ID. See the GraphQL API's corresponding fields in "ExternalAccount" for documentation.
 type ExternalAccountSpec struct {
 	ServiceType string
 	ServiceID   string
@@ -31,6 +33,24 @@ type ExternalAccountSpec struct {
 type ExternalAccountData struct {
 	AuthData    *json.RawMessage
 	AccountData *json.RawMessage
+}
+
+// ExternalAccounts contains a list of accounts that belong to the same external service.
+// All fields have a same meaning to ExternalAccountSpec. See GraphQL API's corresponding
+// fields in "ExternalAccount" for documentation.
+type ExternalAccounts struct {
+	ServiceType string
+	ServiceID   string
+	AccountIDs  []string
+}
+
+// TracingFields returns tracing fields for the opentracing log.
+func (s *ExternalAccounts) TracingFields() []otlog.Field {
+	return []otlog.Field{
+		otlog.String("ExternalAccounts.ServiceType", s.ServiceType),
+		otlog.String("ExternalAccounts.Perm", s.ServiceID),
+		otlog.Int("ExternalAccounts.AccountIDs.Count", len(s.AccountIDs)),
+	}
 }
 
 // ExternalAccountID is a descriptive type for the external identifier of an external account


### PR DESCRIPTION
This PRs removes two call sites that relies on `dbconn.Global` from `PermsSyncer`, replaced with two new methods in the `PermsStore`.

TODO: Tests will be added after review.

