### PR TITLE
Stringify URLs in DocumentSelectors for Firefox

### DIFF
--- a/shared/src/api/extension/api/languageFeatures.ts
+++ b/shared/src/api/extension/api/languageFeatures.ts
@@ -16,7 +16,7 @@ import { ReferenceParams, TextDocumentPositionParams } from '../../protocol'
 import { syncSubscription } from '../../util'
 import { toProxyableSubscribable } from './common'
 import { ExtDocuments } from './documents'
-import { fromHover, fromLocation, toPosition } from './types'
+import { fromHover, fromLocation, toPosition, fromDocumentSelector } from './types'
 
 /** @internal */
 export class ExtLanguageFeatures {
@@ -31,7 +31,7 @@ export class ExtLanguageFeatures {
                 hover => (hover ? fromHover(hover) : hover)
             )
         )
-        return syncSubscription(this.proxy.$registerHoverProvider(selector, providerFunction))
+        return syncSubscription(this.proxy.$registerHoverProvider(fromDocumentSelector(selector), providerFunction))
     }
 
     public registerDefinitionProvider(selector: DocumentSelector, provider: DefinitionProvider): Unsubscribable {
@@ -43,7 +43,9 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(this.proxy.$registerDefinitionProvider(selector, providerFunction))
+        return syncSubscription(
+            this.proxy.$registerDefinitionProvider(fromDocumentSelector(selector), providerFunction)
+        )
     }
 
     public registerReferenceProvider(selector: DocumentSelector, provider: ReferenceProvider): Unsubscribable {
@@ -59,7 +61,7 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(this.proxy.$registerReferenceProvider(selector, providerFunction))
+        return syncSubscription(this.proxy.$registerReferenceProvider(fromDocumentSelector(selector), providerFunction))
     }
 
     public registerLocationProvider(
@@ -75,7 +77,9 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(this.proxy.$registerLocationProvider(idStr, selector, proxyValue(providerFunction)))
+        return syncSubscription(
+            this.proxy.$registerLocationProvider(idStr, fromDocumentSelector(selector), proxyValue(providerFunction))
+        )
     }
 
     public registerCompletionItemProvider(
@@ -90,7 +94,9 @@ export class ExtLanguageFeatures {
                 items => items
             )
         )
-        return syncSubscription(this.proxy.$registerCompletionItemProvider(selector, providerFunction))
+        return syncSubscription(
+            this.proxy.$registerCompletionItemProvider(fromDocumentSelector(selector), providerFunction)
+        )
     }
 }
 

--- a/shared/src/api/extension/api/types.ts
+++ b/shared/src/api/extension/api/types.ts
@@ -3,6 +3,17 @@ import * as clientType from '@sourcegraph/extension-api-types'
 import * as sourcegraph from 'sourcegraph'
 
 /**
+ * Firefox does not like URLs being transmitted, so convert them to strings.
+ *
+ * https://github.com/sourcegraph/sourcegraph/issues/8928
+ */
+export function fromDocumentSelector(selector: sourcegraph.DocumentSelector): sourcegraph.DocumentSelector {
+    return selector.map(filter =>
+        typeof filter === 'string' ? filter : { ...filter, baseUri: filter.baseUri?.toString() }
+    )
+}
+
+/**
  * Converts from a plain object {@link clientType.Position} to an instance of {@link Position}.
  *
  * @internal


### PR DESCRIPTION
This is a quick fix to solve the symptoms of https://github.com/sourcegraph/sourcegraph/issues/8928, but not the root cause.
