### PR TITLE
repo-updater: init authz.Providers

### DIFF
--- a/enterprise/cmd/frontend/authz/authz_test.go
+++ b/enterprise/cmd/frontend/authz/authz_test.go
@@ -1,4 +1,4 @@
-package main
+package authz
 
 import (
 	"context"
@@ -521,7 +521,7 @@ func Test_authzProvidersFromConfig(t *testing.T) {
 		}
 
 		allowAccessByDefault, authzProviders, seriousProblems, _ :=
-			authzProvidersFromConfig(context.Background(), &test.cfg, &store, nil)
+			ProvidersFromConfig(context.Background(), &test.cfg, &store, nil)
 		if allowAccessByDefault != test.expAuthzAllowAccessByDefault {
 			t.Errorf("allowAccessByDefault: (actual) %v != (expected) %v", asJSON(t, allowAccessByDefault), asJSON(t, test.expAuthzAllowAccessByDefault))
 		}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/authz.go
@@ -1,7 +1,6 @@
 package bitbucketserver
 
 import (
-	"database/sql"
 	"fmt"
 	"net/url"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -20,7 +20,7 @@ import (
 // to false. "Warnings" are all other validation problems.
 func NewAuthzProviders(
 	conns []*schema.BitbucketServerConnection,
-	db *sql.DB,
+	db dbutil.DB,
 ) (ps []authz.Provider, problems []string, warnings []string) {
 	// Authorization (i.e., permissions) providers
 	for _, c := range conns {
@@ -43,7 +43,7 @@ func NewAuthzProviders(
 }
 
 func newAuthzProvider(
-	db *sql.DB,
+	db dbutil.DB,
 	a *schema.BitbucketServerAuthorization,
 	instanceURL, username string,
 	pluginPerm bool,

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -3,7 +3,6 @@ package bitbucketserver
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -39,7 +39,7 @@ var clock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond
 // the given bitbucketserver.Client to talk to a Bitbucket Server API that is
 // the source of truth for permissions. It assumes usernames of Sourcegraph accounts
 // match 1-1 with usernames of Bitbucket Server API users.
-func NewProvider(cli *bitbucketserver.Client, db *sql.DB, ttl, hardTTL time.Duration, pluginPerm bool) *Provider {
+func NewProvider(cli *bitbucketserver.Client, db dbutil.DB, ttl, hardTTL time.Duration, pluginPerm bool) *Provider {
 	return &Provider{
 		client:     cli,
 		codeHost:   extsvc.NewCodeHost(cli.URL, bitbucketserver.ServiceType),

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
+	eauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz"
 	authzResolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz/resolvers"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
@@ -47,14 +48,14 @@ func main() {
 	clock := func() time.Time {
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
-	initAuthz(dbconn.Global, clock)
+	eauthz.Init(dbconn.Global, clock)
 
 	ctx := context.Background()
 	go func() {
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _ :=
-				authzProvidersFromConfig(ctx, conf.Get(), db.ExternalServices, dbconn.Global)
+				eauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices, dbconn.Global)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -9,13 +9,17 @@ import (
 	"sync"
 	"time"
 
+	ossAuthz "github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	ossDB "github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
-	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
+	frontendAuthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz"
+	frontendDB "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -74,10 +78,22 @@ func startBackgroundPermsSync(ctx context.Context, repoStore repos.Store, db dbu
 		return
 	}
 
+	go func() {
+		// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.
+		dbconn.Global = db.(*sql.DB)
+
+		t := time.NewTicker(5 * time.Second)
+		for range t.C {
+			allowAccessByDefault, authzProviders, _, _ :=
+				frontendAuthz.ProvidersFromConfig(ctx, conf.Get(), ossDB.ExternalServices, db)
+			ossAuthz.SetProviders(allowAccessByDefault, authzProviders)
+		}
+	}()
+
 	clock := func() time.Time {
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
-	permsStore := edb.NewPermsStore(db, clock)
+	permsStore := frontendDB.NewPermsStore(db, clock)
 	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, db, clock)
 	go permsSyncer.Run(ctx)
 }


### PR DESCRIPTION
This PR inits authz.Providers in the repo-updater by moving authz related functions to its own package.

It contains an unfortunate compromise/hack but my brain do not have bandwidth to tackle it right now. Will fix in a followup PR. 