### PR TITLE
campaigns: Ignore merged/closed campaigns when updating a campaign

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -1042,9 +1042,7 @@ func computeCampaignUpdateDiff(
 			// if we do want to update it, we _reset_ the ChangesetJob, so it
 			// gets run again when RunChangesetJobs is called after
 			// UpdateCampaign.
-			group.changesetJob.Error = ""
-			group.changesetJob.StartedAt = time.Time{}
-			group.changesetJob.FinishedAt = time.Time{}
+			group.changesetJob.Reset()
 		}
 
 		diff.Update = append(diff.Update, group.changesetJob)

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -926,11 +926,13 @@ type campaignUpdateDiff struct {
 	Create []*campaigns.ChangesetJob
 }
 
-// repoJobs is a triplet of jobs that are associated with the same repository.
-type repoJobs struct {
+// repoGroup is a group of entities involved in a Campaign that are associated
+// with the same repository.
+type repoGroup struct {
 	changesetJob   *campaigns.ChangesetJob
 	campaignJob    *campaigns.CampaignJob
 	newCampaignJob *campaigns.CampaignJob
+	changeset      *campaigns.Changeset
 }
 
 func computeCampaignUpdateDiff(
@@ -948,6 +950,14 @@ func computeCampaignUpdateDiff(
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "listing changesets jobs")
+	}
+
+	changesets, _, err := tx.ListChangesets(ctx, ListChangesetsOpts{
+		CampaignID: campaign.ID,
+		Limit:      -1,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing changesets")
 	}
 
 	// We need OnlyFinished and OnlyWithDiff because we don't create
@@ -981,14 +991,14 @@ func computeCampaignUpdateDiff(
 	// We can find out which ones we want to keep by looking at the RepoID of
 	// their CampaignJobs.
 
-	jobsByRepoID, err := mergeByRepoID(changesetJobs, campaignJobs)
+	byRepoID, err := mergeByRepoID(changesetJobs, campaignJobs, changesets)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, j := range newCampaignJobs {
-		if jobs, ok := jobsByRepoID[j.RepoID]; ok {
-			jobs.newCampaignJob = j
+		if group, ok := byRepoID[j.RepoID]; ok {
+			group.newCampaignJob = j
 		} else {
 			// If we have new CampaignJobs that don't match an existing
 			// ChangesetJob we need to create new ChangesetJobs.
@@ -999,29 +1009,45 @@ func computeCampaignUpdateDiff(
 		}
 	}
 
-	for _, jobs := range jobsByRepoID {
+	for _, group := range byRepoID {
 		// Either we _don't_ have a matching _new_ CampaignJob, then we delete
 		// the ChangesetJob and detach & close Changeset.
-		if jobs.newCampaignJob == nil {
-			diff.Delete = append(diff.Delete, jobs.changesetJob)
+		if group.newCampaignJob == nil {
+			diff.Delete = append(diff.Delete, group.changesetJob)
 			continue
 		}
 
 		// Or we have a matching _new_ CampaignJob, then we keep the
 		// ChangesetJob around, but need to rewire it.
-		jobs.changesetJob.CampaignJobID = jobs.newCampaignJob.ID
+		group.changesetJob.CampaignJobID = group.newCampaignJob.ID
 
 		//  And, if the {Diff,Rev,BaseRef,Description} are different, we  need to
 		// update the Changeset on the codehost...
-		if updateAttributes || campaignJobsDiffer(jobs.newCampaignJob, jobs.campaignJob) {
-			// ... to do that, we _reset_ the ChangesetJob, so it gets run again
-			// when RunChangesetJobs is called after UpdateCampaign.
-			jobs.changesetJob.Error = ""
-			jobs.changesetJob.StartedAt = time.Time{}
-			jobs.changesetJob.FinishedAt = time.Time{}
+		if updateAttributes || campaignJobsDiffer(group.newCampaignJob, group.campaignJob) {
+			// .. but if we already have a Changeset and that is merged, we
+			// don't want to update it...
+			if group.changeset != nil {
+				// TODO: This needs to change based on the outcome of this:
+				// https://github.com/sourcegraph/sourcegraph/pull/8848#discussion_r389000197
+				s, err := group.changeset.State()
+				if err != nil {
+					return nil, errors.Wrap(err, "determining a changeset's state")
+				}
+				if s == campaigns.ChangesetStateMerged || s == campaigns.ChangesetStateClosed {
+					// Note: in the future we want to create a new ChangesetJob here.
+					continue
+				}
+			}
+
+			// if we do want to update it, we _reset_ the ChangesetJob, so it
+			// gets run again when RunChangesetJobs is called after
+			// UpdateCampaign.
+			group.changesetJob.Error = ""
+			group.changesetJob.StartedAt = time.Time{}
+			group.changesetJob.FinishedAt = time.Time{}
 		}
 
-		diff.Update = append(diff.Update, jobs.changesetJob)
+		diff.Update = append(diff.Update, group.changesetJob)
 	}
 
 	return diff, nil
@@ -1079,8 +1105,12 @@ func isOutdated(c *repos.Changeset) (bool, error) {
 	return false, nil
 }
 
-func mergeByRepoID(chs []*campaigns.ChangesetJob, cas []*campaigns.CampaignJob) (map[api.RepoID]*repoJobs, error) {
-	jobs := make(map[api.RepoID]*repoJobs, len(chs))
+func mergeByRepoID(
+	chs []*campaigns.ChangesetJob,
+	cas []*campaigns.CampaignJob,
+	cs []*campaigns.Changeset,
+) (map[api.RepoID]*repoGroup, error) {
+	jobs := make(map[api.RepoID]*repoGroup, len(chs))
 
 	byID := make(map[int64]*campaigns.CampaignJob, len(cas))
 	for _, j := range cas {
@@ -1092,7 +1122,13 @@ func mergeByRepoID(chs []*campaigns.ChangesetJob, cas []*campaigns.CampaignJob) 
 		if !ok {
 			return nil, fmt.Errorf("CampaignJob with ID %d cannot be found for ChangesetJob %d", j.CampaignJobID, j.ID)
 		}
-		jobs[caj.RepoID] = &repoJobs{changesetJob: j, campaignJob: caj}
+		jobs[caj.RepoID] = &repoGroup{changesetJob: j, campaignJob: caj}
+	}
+
+	for _, c := range cs {
+		if j, ok := jobs[c.RepoID]; ok {
+			j.changeset = c
+		}
 	}
 
 	return jobs, nil

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -264,6 +264,14 @@ func (c *ChangesetJob) SuccessfullyCompleted() bool {
 	return c.Error == "" && !c.FinishedAt.IsZero() && c.ChangesetID != 0
 }
 
+// Reset sets the Error, StartedAt and FinishedAt fields to their respective
+// zero values, so that the ChangesetJob can be executed again.
+func (c *ChangesetJob) Reset() {
+	c.Error = ""
+	c.StartedAt = time.Time{}
+	c.FinishedAt = time.Time{}
+}
+
 // A Changeset is a changeset on a code host belonging to a Repository and many
 // Campaigns.
 type Changeset struct {


### PR DESCRIPTION
This addresses the first task in https://github.com/sourcegraph/sourcegraph/issues/8846
