### PR TITLE
search: default timeout increased from 10s to 20s

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -837,7 +837,7 @@ func langIncludeExcludePatterns(values, negatedValues []string) (includePatterns
 
 var (
 	// The default timeout to use for queries.
-	defaultTimeout = 10 * time.Second
+	defaultTimeout = 20 * time.Second
 	// The max timeout to use for queries.
 	maxTimeout = time.Minute
 )

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -567,7 +567,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 				repos:           singleRepositoryRevisions,
 				useFullDeadline: false,
 				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
-				since:           func(time.Time) time.Duration { return 15 * time.Second },
+				since:           func(time.Time) time.Duration { return time.Minute },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -47,7 +47,7 @@ func zoektResultCountFactor(numRepos int, query *search.TextPatternInfo) int {
 
 func zoektSearchOpts(k int, query *search.TextPatternInfo) zoekt.SearchOptions {
 	searchOpts := zoekt.SearchOptions{
-		MaxWallTime:            10 * time.Second,
+		MaxWallTime:            defaultTimeout,
 		ShardMaxMatchCount:     100 * k,
 		TotalMaxMatchCount:     100 * k,
 		ShardMaxImportantMatch: 15 * k,


### PR DESCRIPTION
If a user has to wait 10s for results, they might as well wait 20s and get
more results.

Motivated by a customer with an under povisioned zoekt cluster getting no
results within 10s (but do within 11s).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
