### PR TITLE
Add CampaignPlanPatch.BaseRef and make BaseRevision a commit ID

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -8,6 +8,7 @@ import (
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
@@ -46,7 +47,8 @@ type CreateCampaignPlanFromPatchesArgs struct {
 
 type CampaignPlanPatch struct {
 	Repository   graphql.ID
-	BaseRevision string
+	BaseRevision api.CommitID
+	BaseRef      string
 	Patch        string
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -411,8 +411,13 @@ input CampaignPlanPatch {
     # The repository that this patch is applied to.
     repository: ID!
 
-    # The base revision in the repository that this patch is applied to.
+    # The base revision in the repository that this patch is based on.
+    # Example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
     baseRevision: String!
+
+    # The reference to the base revision at the time the patch was created.
+    # Example: "refs/heads/master"
+    baseRef: String!
 
     # The patch (in unified diff format) to apply.
     #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -418,8 +418,13 @@ input CampaignPlanPatch {
     # The repository that this patch is applied to.
     repository: ID!
 
-    # The base revision in the repository that this patch is applied to.
+    # The base revision in the repository that this patch is based on.
+    # Example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
     baseRevision: String!
+
+    # The reference to the base revision at the time the patch was created.
+    # Example: "refs/heads/master"
+    baseRef: String!
 
     # The patch (in unified diff format) to apply.
     #

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -537,6 +537,7 @@ func (r *Resolver) CreateCampaignPlanFromPatches(ctx context.Context, args graph
 		patches[i] = campaigns.CampaignPlanPatch{
 			Repo:         repo,
 			BaseRevision: patch.BaseRevision,
+			BaseRef:      patch.BaseRef,
 			Patch:        patch.Patch,
 		}
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -256,7 +256,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	err = svc.CreateCampaign(ctx, campaign, draft)
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 		updateArgs.Plan = &campaignPlanID
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	campaign, detachedChangesets, err := svc.UpdateCampaign(ctx, updateArgs)
 	if err != nil {
 		return nil, err
@@ -331,7 +331,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	err = svc.DeleteCampaign(ctx, campaignID, args.CloseChangesets)
 	return &graphqlbackend.EmptyResponse{}, err
 }
@@ -542,7 +542,7 @@ func (r *Resolver) CreateCampaignPlanFromPatches(ctx context.Context, args graph
 		}
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches, user.ID)
 	if err != nil {
 		return nil, err
@@ -568,7 +568,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 
 	campaign, err := svc.CloseCampaign(ctx, campaignID, args.CloseChangesets)
 	if err != nil {
@@ -595,7 +595,7 @@ func (r *Resolver) PublishCampaign(ctx context.Context, args *graphqlbackend.Pub
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	campaign, err := svc.PublishCampaign(ctx, campaignID)
 	if err != nil {
 		return nil, errors.Wrap(err, "publishing campaign")
@@ -621,7 +621,7 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, nil, r.httpFactory)
+	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
 	err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJobID)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -974,7 +974,8 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 			Patches: []graphqlbackend.CampaignPlanPatch{
 				{
 					Repository:   graphqlbackend.MarshalRepositoryID(1),
-					BaseRevision: "master",
+					BaseRevision: "f00b4r",
+					BaseRef:      "master",
 					Patch:        "!!! this is not a valid unified diff !!!\n--- x\n+++ y\n@@ 1,1 2,2\na",
 				},
 			},
@@ -1045,7 +1046,7 @@ func TestCreateCampaignPlanFromPatchesResolver(t *testing.T) {
 
 		mustExec(ctx, t, s, nil, &response, fmt.Sprintf(`
       mutation {
-        createCampaignPlanFromPatches(patches: [{repository: %q, baseRevision: "master", patch: %q}]) {
+		createCampaignPlanFromPatches(patches: [{repository: %q, baseRevision: "f00b4r", baseRef: "master", patch: %q}]) {
           ... on CampaignPlan {
             id
             status {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -120,16 +120,11 @@ func (s *Service) CreateCampaignPlanFromPatches(ctx context.Context, patches []c
 			continue
 		}
 
-		commit, err := s.repoResolveRevision(ctx, repo, patch.BaseRevision)
-		if err != nil {
-			return nil, errors.Wrapf(err, "repository %q", repo.Name)
-		}
-
 		job := &campaigns.CampaignJob{
 			CampaignPlanID: plan.ID,
 			RepoID:         patch.Repo,
-			BaseRef:        patch.BaseRevision,
-			Rev:            commit,
+			BaseRef:        patch.BaseRef,
+			Rev:            patch.BaseRevision,
 			Diff:           patch.Patch,
 			StartedAt:      s.clock(),
 			FinishedAt:     s.clock(),

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -23,23 +22,14 @@ import (
 )
 
 // NewService returns a Service.
-func NewService(store *Store, git GitserverClient, repoResolveRevision repoResolveRevision, cf *httpcli.Factory) *Service {
-	return NewServiceWithClock(store, git, repoResolveRevision, cf, store.Clock())
+func NewService(store *Store, git GitserverClient, cf *httpcli.Factory) *Service {
+	return NewServiceWithClock(store, git, cf, store.Clock())
 }
 
 // NewServiceWithClock returns a Service the given clock used
 // to generate timestamps.
-func NewServiceWithClock(store *Store, git GitserverClient, repoResolveRevision repoResolveRevision, cf *httpcli.Factory, clock func() time.Time) *Service {
-	svc := &Service{
-		store:               store,
-		git:                 git,
-		repoResolveRevision: repoResolveRevision,
-		cf:                  cf,
-		clock:               clock,
-	}
-	if svc.repoResolveRevision == nil {
-		svc.repoResolveRevision = defaultRepoResolveRevision
-	}
+func NewServiceWithClock(store *Store, git GitserverClient, cf *httpcli.Factory, clock func() time.Time) *Service {
+	svc := &Service{store: store, git: git, cf: cf, clock: clock}
 
 	return svc
 }
@@ -49,32 +39,17 @@ type GitserverClient interface {
 }
 
 type Service struct {
-	store               *Store
-	git                 GitserverClient
-	repoResolveRevision repoResolveRevision
-	cf                  *httpcli.Factory
+	store *Store
+	git   GitserverClient
+	cf    *httpcli.Factory
 
 	clock func() time.Time
-}
-
-// repoResolveRevision resolves a Git revspec in a repository and returns the resolved commit ID.
-type repoResolveRevision func(context.Context, *repos.Repo, string) (api.CommitID, error)
-
-// defaultRepoResolveRevision is an implementation of repoResolveRevision that talks to gitserver to
-// resolve a Git revspec.
-var defaultRepoResolveRevision = func(ctx context.Context, repo *repos.Repo, revspec string) (api.CommitID, error) {
-	return backend.Repos.ResolveRev(ctx,
-		&types.Repo{Name: api.RepoName(repo.Name), ExternalRepo: repo.ExternalRepo},
-		revspec,
-	)
 }
 
 // CreateCampaignPlanFromPatches creates a CampaignPlan and its associated CampaignJobs from patches
 // computed by the caller. There is no diff execution or computation performed during creation of
 // the CampaignJobs in this case (unlike when using Runner to create a CampaignPlan from a
 // specification).
-//
-// If resolveRevision is nil, a default implementation is used.
 func (s *Service) CreateCampaignPlanFromPatches(ctx context.Context, patches []campaigns.CampaignPlanPatch, userID int32) (*campaigns.CampaignPlan, error) {
 	if userID == 0 {
 		return nil, backend.ErrNotAuthenticated

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -58,12 +58,7 @@ func TestService(t *testing.T) {
 	}
 
 	t.Run("CreateCampaignPlanFromPatches", func(t *testing.T) {
-		const commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		repoResolveRevision := func(context.Context, *repos.Repo, string) (api.CommitID, error) {
-			return commit, nil
-		}
-
-		svc := NewServiceWithClock(store, nil, repoResolveRevision, nil, clock)
+		svc := NewServiceWithClock(store, nil, nil, clock)
 
 		const patch = `diff f f
 --- f
@@ -120,7 +115,7 @@ func TestService(t *testing.T) {
 		}
 
 		campaign := testCampaign(user.ID, plan.ID)
-		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+		svc := NewServiceWithClock(store, gitClient, cf, clock)
 
 		// Without CampaignJobs it should fail
 		err = svc.CreateCampaign(ctx, campaign, false)
@@ -178,7 +173,7 @@ func TestService(t *testing.T) {
 
 		campaign := testCampaign(user.ID, plan.ID)
 
-		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+		svc := NewServiceWithClock(store, gitClient, cf, clock)
 		err = svc.CreateCampaign(ctx, campaign, true)
 		if err != nil {
 			t.Fatal(err)
@@ -220,7 +215,7 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+		svc := NewServiceWithClock(store, gitClient, cf, clock)
 		err = svc.CreateChangesetJobForCampaignJob(ctx, campaignJob.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -308,7 +303,7 @@ func TestService(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+				svc := NewServiceWithClock(store, gitClient, cf, clock)
 				campaign := testCampaign(user.ID, plan.ID)
 
 				err = svc.CreateCampaign(ctx, campaign, tc.draft)
@@ -547,7 +542,7 @@ func TestService_UpdateCampaignWithNewCampaignPlanID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewStoreWithClock(dbconn.Global, clock)
-			svc := NewServiceWithClock(store, gitClient, nil, cf, clock)
+			svc := NewServiceWithClock(store, gitClient, cf, clock)
 
 			var (
 				campaign         *campaigns.Campaign

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -73,8 +73,8 @@ func TestService(t *testing.T) {
  y
 `
 		patches := []campaigns.CampaignPlanPatch{
-			{Repo: api.RepoID(rs[0].ID), BaseRevision: "b0", Patch: patch},
-			{Repo: api.RepoID(rs[1].ID), BaseRevision: "b1", Patch: patch},
+			{Repo: api.RepoID(rs[0].ID), BaseRevision: "deadbeef", BaseRef: "refs/heads/master", Patch: patch},
+			{Repo: api.RepoID(rs[1].ID), BaseRevision: "f00b4r", BaseRef: "refs/heads/master", Patch: patch},
 		}
 
 		plan, err := svc.CreateCampaignPlanFromPatches(ctx, patches, user.ID)
@@ -98,8 +98,8 @@ func TestService(t *testing.T) {
 			wantJobs[i] = &campaigns.CampaignJob{
 				CampaignPlanID: plan.ID,
 				RepoID:         patch.Repo,
-				BaseRef:        patch.BaseRevision,
-				Rev:            commit,
+				Rev:            patch.BaseRevision,
+				BaseRef:        patch.BaseRef,
 				Diff:           patch.Patch,
 				StartedAt:      now,
 				FinishedAt:     now,

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -34,9 +34,12 @@ func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
 
 // CampaignPlanPatch is a patch applied to a repository (to create a new branch).
 type CampaignPlanPatch struct {
-	Repo         api.RepoID
-	BaseRevision string
-	Patch        string
+	Repo api.RepoID
+	// The commit SHA this patch is based on (e.g.: "4095572721c6234cd72013fd49dff4fb48f0f8a4").
+	BaseRevision api.CommitID
+	// The ref name that pointed to the BaseRevision at the time of patch creation (e.g.: "refs/heads/master").
+	BaseRef string
+	Patch   string
 }
 
 // A CampaignPlan represents the application of a CampaignType to the Arguments

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1532,7 +1532,8 @@ describe('e2e test suite', () => {
             const { previewURL } = await driver.createCampaignPlanFromPatches([
                 {
                     repository: repo.id,
-                    baseRevision: 'master',
+                    baseRevision: '339d09ae1ce5907e0678ae5f1f91d9ad38db6107',
+                    baseRef: 'refs/heads/master',
                     patch: `diff --unified file1.txt file1.txt
 --- file1.txt 2020-01-01 01:02:03 -0700
 +++ file1.txt 2020-01-01 03:04:05 -0700


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/8846 and extends the API with a `BaseRef` field that should now contain what previously was in `BaseRevision`.

`BaseRevision` will be interpreted as a commit ID. The updated `src` CLI client does that: https://github.com/sourcegraph/src-cli/pull/158

After releasing `src CLI 3.10.12` I'm going to change the `MinimumVersion` here to require that.