### PR TITLE
LSIF: Replicate worker within container

### DIFF
--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -1,4 +1,4 @@
-# Keep this in sync with docker-images/prometheus/Dockerfile
+# keep this in sync with docker-images/prometheus/Dockerfile
 FROM prom/prometheus:v2.15.2@sha256:35c52c0c2b76433bbfc44a5a7abc294c2f032ed80250be02b441db5dd91b203a AS prometheus
 
 FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a AS lsif-builder
@@ -41,7 +41,7 @@ COPY ./lsif-server /usr/local/bin/lsif-server
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
-# HTTP server, (first) worker metrics server, prometheus
+# http server, (first) worker metrics server, prometheus
 EXPOSE 3186 3187 9090
 ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/lsif-server"]

--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -39,7 +39,7 @@ USER sourcegraph
 COPY --from=lsif-builder /lsif /lsif
 COPY ./lsif-server /usr/local/bin/lsif-server
 COPY --from=prometheus /bin/prometheus /bin/prometheus
-COPY ./prometheus/prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
+COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
 # HTTP server, (first) worker metrics server, prometheus
 EXPOSE 3186 3187 9090

--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -1,16 +1,18 @@
+# Keep this in sync with docker-images/prometheus/Dockerfile
+FROM prom/prometheus:v2.15.2@sha256:35c52c0c2b76433bbfc44a5a7abc294c2f032ed80250be02b441db5dd91b203a AS prometheus
+
 FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a AS lsif-builder
 
 RUN apk add --no-cache nodejs-current=12.4.0-r0 nodejs-npm=10.19.0-r0
 RUN npm install -g yarn@1.17.3
 
-COPY lsif/package.json lsif/tsconfig.json lsif/yarn.lock /lsif/
+COPY lsif/package.json lsif/yarn.lock lsif/tsconfig.json /lsif/
 COPY lsif/src /lsif/src
 
 RUN yarn --cwd /lsif
 RUN yarn --cwd /lsif run build
 
-# TODO: Make this image use our sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
+FROM sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -21,17 +23,25 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# set default environment variables
-ENV PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg
+# environment variables used by startup
+ENV PROMETHEUS_STORAGE_DIR=/prometheus
+ENV PROMETHEUS_CONFIGURATION_DIR=/prometheus_config
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     tini nodejs-current=12.4.0-r0
 
+USER root
+RUN mkdir -p $PROMETHEUS_STORAGE_DIR && chown -R sourcegraph:sourcegraph $PROMETHEUS_STORAGE_DIR
+RUN mkdir -p $PROMETHEUS_CONFIGURATION_DIR && chown -R sourcegraph:sourcegraph $PROMETHEUS_CONFIGURATION_DIR
+USER sourcegraph
+
 COPY --from=lsif-builder /lsif /lsif
+COPY ./lsif-server /usr/local/bin/lsif-server
+COPY --from=prometheus /bin/prometheus /bin/prometheus
+COPY ./prometheus/prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
-COPY . /
-
-EXPOSE 3186 3187
-ENV GO111MODULES=on LANG=en_US.utf8
+# HTTP server, (first) worker metrics server, prometheus
+EXPOSE 3186 3187 9090
+ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/lsif-server"]

--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -7,9 +7,9 @@ RUN apk add --no-cache nodejs-current=12.4.0-r0 nodejs-npm=10.19.0-r0
 RUN npm install -g yarn@1.17.3
 
 COPY lsif/package.json lsif/yarn.lock lsif/tsconfig.json /lsif/
-COPY lsif/src /lsif/src
-
 RUN yarn --cwd /lsif
+
+COPY lsif/src /lsif/src
 RUN yarn --cwd /lsif run build
 
 FROM sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c

--- a/cmd/lsif-server/README.md
+++ b/cmd/lsif-server/README.md
@@ -9,8 +9,8 @@ These processes are run in a [goreman](https://github.com/mattn/goreman) supervi
 
 ## Prometheus metrics
 
-The lsif-server process exposes an HTTP API on port 3186. This API contains a `/metrics` endpoint to be scraped by prometheus. The lsif-worker process exposes a metrics server (but nothing else interesting) on port 3187.
+The lsif-server process exposes an HTTP API on port 3186. This API contains a `/metrics` endpoint to be scraped by prometheus. The lsif-worker process exposes a metrics server (but nothing else interesting) on port 3187. It's possible to run multiple worker processes, but impossible for them all to serve metrics from the same port. Therefore, this container also contains a minimally-configured Prometheus process that will scrape metrics from the server and worker processes.
 
-It's possible to run multiple worker processes, but impossible for them all to serve metrics from the same port.
+For non-standard configurations with multiple workers, use [federation](https://prometheus.io/docs/prometheus/latest/federation/) to scrape all of the process metrics at once.
 
-Therefore, this container also contains a minimally-configured Prometheus process that will scrape metrics from the server and worker processes. For the default configuration (one server and one worker), metrics can be scraped directly from ports 3186 and 3187. For non-standard configurations with multiple workers, use [federation](https://prometheus.io/docs/prometheus/latest/federation/) to scrape all of the process metrics at once.
+For the default configuration (one server and/or one worker), metrics can be scraped directly from ports 3186 and/or 3187. In this case, the prometheus process can be disabled completely by setting the environment variable `DISABLE_PROMETHEUS` to true.

--- a/cmd/lsif-server/README.md
+++ b/cmd/lsif-server/README.md
@@ -1,3 +1,16 @@
 # lsif-server
 
-Runs the [lsif-server](../../lsif/src/server/server.ts) and [lsif-worker](../../lsif/src/worker/worker.ts) processes in a [goreman](https://github.com/mattn/goreman) supervisor.
+A small wrapper around the TypeScript/node processes that serve precise LSIF code intelligence data.
+
+- [lsif-server](../../lsif/src/server/server.ts)
+- [lsif-worker](../../lsif/src/worker/worker.ts)
+
+These processes are run in a [goreman](https://github.com/mattn/goreman) supervisor. By default, there will be one server process and one worker process. The number of replicas per process can be tuned with the environment variables `LSIF_NUM_SERVERS` (zero or one) and `LSIF_NUM_WORKERS` (zero or more).
+
+## Prometheus metrics
+
+The lsif-server process exposes an HTTP API on port 3186. This API contains a `/metrics` endpoint to be scraped by prometheus. The lsif-worker process exposes a metrics server (but nothing else interesting) on port 3187.
+
+It's possible to run multiple worker processes, but impossible for them all to serve metrics from the same port.
+
+Therefore, this container also contains a minimally-configured Prometheus process that will scrape metrics from the server and worker processes. For the default configuration (one server and one worker), metrics can be scraped directly from ports 3186 and 3187. For non-standard configurations with multiple workers, use [federation](https://prometheus.io/docs/prometheus/latest/federation/) to scrape all of the process metrics at once.

--- a/cmd/lsif-server/README.md
+++ b/cmd/lsif-server/README.md
@@ -9,8 +9,4 @@ These processes are run in a [goreman](https://github.com/mattn/goreman) supervi
 
 ## Prometheus metrics
 
-The lsif-server process exposes an HTTP API on port 3186. This API contains a `/metrics` endpoint to be scraped by prometheus. The lsif-worker process exposes a metrics server (but nothing else interesting) on port 3187. It's possible to run multiple worker processes, but impossible for them all to serve metrics from the same port. Therefore, this container also contains a minimally-configured Prometheus process that will scrape metrics from the server and worker processes.
-
-For non-standard configurations with multiple workers, use [federation](https://prometheus.io/docs/prometheus/latest/federation/) to scrape all of the process metrics at once.
-
-For the default configuration (one server and/or one worker), metrics can be scraped directly from ports 3186 and/or 3187. In this case, the prometheus process can be disabled completely by setting the environment variable `DISABLE_PROMETHEUS` to true.
+The lsif-server process exposes an HTTP API on port 3186. This API contains a `/metrics` endpoint to be scraped by prometheus. The lsif-worker process exposes a metrics server (but nothing else interesting) on port 3187. It's possible to run multiple worker processes, but impossible for them all to serve metrics from the same port. Therefore, this container also contains a minimally-configured Prometheus process that will scrape metrics from the server and worker processes. It is suggested that you use [federation](https://prometheus.io/docs/prometheus/latest/federation/) to scrape all of the process metrics at once instead of scraping the server and worker(s) ports directly. Doing so will ensure that scaling up or down the number of workers will not change the the required Prometheus configuration.

--- a/cmd/lsif-server/build.sh
+++ b/cmd/lsif-server/build.sh
@@ -17,14 +17,13 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 cp -a ./lsif "$OUTPUT"
-export bindir="$OUTPUT/usr/local/bin"
-mkdir -p "$bindir"
+cp -a ./cmd/lsif-server/prometheus.yml "$OUTPUT"
 
 echo "--- go build"
 go build \
     -trimpath \
     -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION"  \
-    -o "$bindir/lsif-server" github.com/sourcegraph/sourcegraph/cmd/lsif-server
+    -o "$OUTPUT/lsif-server" github.com/sourcegraph/sourcegraph/cmd/lsif-server
 
 echo "--- docker build"
 docker build -f cmd/lsif-server/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	servers              = env.Get("LSIF_NUM_SERVERS", "1", "the number of server instances to run (defaults to one)")
 	workers              = env.Get("LSIF_NUM_WORKERS", "1", "the number of worker instances to run (defaults to one)")
-	disablePrometheus, _ = strconv.ParseBool(env.Get("DISABLE_PROMETHEUS", "", "do not run a prometheus process"))
+	disablePrometheus, _ = strconv.ParseBool(env.Get("DISABLE_PROMETHEUS", "false", "do not run a prometheus process"))
 
 	// Set in docker image
 	prometheusStorageDir       = os.Getenv("PROMETHEUS_STORAGE_DIR")

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -43,7 +43,7 @@ func main() {
 		[]byte(makePrometheusTargets(numServers, numWorkers)),
 		0644,
 	); err != nil {
-		log.Fatal(err.Error())
+		log.Fatalf("Writing prometheus config: %v", err)
 	}
 
 	// This mirrors the behavior from cmd/start

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -14,9 +14,8 @@ import (
 )
 
 var (
-	servers              = env.Get("LSIF_NUM_SERVERS", "1", "the number of server instances to run (defaults to one)")
-	workers              = env.Get("LSIF_NUM_WORKERS", "1", "the number of worker instances to run (defaults to one)")
-	disablePrometheus, _ = strconv.ParseBool(env.Get("DISABLE_PROMETHEUS", "false", "do not run a prometheus process"))
+	servers = env.Get("LSIF_NUM_SERVERS", "1", "the number of server instances to run (defaults to one)")
+	workers = env.Get("LSIF_NUM_WORKERS", "1", "the number of worker instances to run (defaults to one)")
 
 	// Set in docker image
 	prometheusStorageDir       = os.Getenv("PROMETHEUS_STORAGE_DIR")
@@ -73,12 +72,10 @@ func makeProcfile(numServers, numWorkers int64) string {
 		)
 	}
 
-	if !disablePrometheus {
-		addProcess("prometheus", fmt.Sprintf("prometheus --storage.tsdb.path=%s --config.file=%s/prometheus.yml",
-			prometheusStorageDir,
-			prometheusConfigurationDir,
-		))
-	}
+	addProcess("prometheus", fmt.Sprintf("prometheus --storage.tsdb.path=%s --config.file=%s/prometheus.yml",
+		prometheusStorageDir,
+		prometheusConfigurationDir,
+	))
 
 	return strings.Join(procfile, "\n") + "\n"
 }

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -1,45 +1,55 @@
 package main
 
 import (
+	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goreman"
 )
 
+var (
+	servers = env.Get("LSIF_NUM_SERVERS", "1", "the number of server instances to run (defaults to one)")
+	workers = env.Get("LSIF_NUM_WORKERS", "1", "the number of worker instances to run (defaults to one)")
+)
+
 func main() {
-	targets, ok := os.LookupEnv("LSIF_RUN_TARGET")
-	if !ok {
-		targets = "server,worker"
+	procfile, err := makeProcfile()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	// This mirrors the behavior from cmd/start
+	if err := goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
+		RPCAddr:        "127.0.0.1:5005",
+		ProcDiedAction: goreman.Shutdown,
+	}); err != nil {
+		log.Fatalf(err.Error())
+	}
+}
+
+func makeProcfile() ([]string, error) {
+	numServers, err := strconv.ParseInt(servers, 10, 64)
+	if err != nil || numServers < 0 || numServers > 1 {
+		return nil, fmt.Errorf("invalid int %q for LSIF_NUM_SERVERS: %s", servers, err)
+	}
+
+	numWorkers, err := strconv.ParseInt(workers, 10, 64)
+	if err != nil || numWorkers < 0 {
+		return nil, fmt.Errorf("invalid int %q for LSIF_NUM_WORKERS: %s", workers, err)
 	}
 
 	procfile := []string{}
-	for _, target := range strings.Split(targets, ",") {
-		switch target {
-		case "server":
-			procfile = append(procfile, `lsif-server: node /lsif/out/server/server.js`)
-		case "worker":
-			procfile = append(procfile, `lsif-worker: node /lsif/out/worker/worker.js`)
-		default:
-			log.Fatalf("Unknown value '%s' for LSIF_RUN_TARGET (expected 'server' or 'worker')", target)
-		}
+
+	for i := int64(0); i < numServers; i++ {
+		procfile = append(procfile, fmt.Sprintf(`lsif-server-%d: node /lsif/out/server/server.js`, i))
 	}
 
-	// Shutdown if any process dies
-	procDiedAction := goreman.Shutdown
-	if ignore, _ := strconv.ParseBool(os.Getenv("IGNORE_PROCESS_DEATH")); ignore {
-		// IGNORE_PROCESS_DEATH is an escape hatch that matches the same behavior
-		// as in sourcegraph/server.
-		procDiedAction = goreman.Ignore
+	for i := int64(0); i < numWorkers; i++ {
+		procfile = append(procfile, fmt.Sprintf(`lsif-worker-%d: env WORKER_METRICS_PORT=%d node /lsif/out/worker/worker.js`, i, 3187+i))
 	}
 
-	err := goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
-		RPCAddr:        "127.0.0.1:5005",
-		ProcDiedAction: procDiedAction,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
+	return procfile, nil
 }

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	numWorkers, err := strconv.ParseInt(workers, 10, 64)
 	if err != nil || numWorkers < 0 {
-		log.Fatalf("invalid int %q for LSIF_NUM_WORKERS: %s", workers, err)
+		log.Fatalf("Invalid int %q for LSIF_NUM_WORKERS: %s", workers, err)
 	}
 
 	if err := ioutil.WriteFile(

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -72,7 +72,7 @@ func makeProcfile(numServers, numWorkers int64) string {
 		)
 	}
 
-	addProcess("prometheus", fmt.Sprintf("prometheus --storage.tsdb.path=%s --config.file=%s/prometheus.yml",
+	addProcess("prometheus", fmt.Sprintf("prometheus '--storage.tsdb.path=%s' '--config.file=%s/prometheus.yml'",
 		prometheusStorageDir,
 		prometheusConfigurationDir,
 	))

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -96,7 +96,7 @@ func makePrometheusTargets(numServers, numWorkers int64) string {
 	}
 
 	for i := 0; i < int(numWorkers); i++ {
-		addTarget(fmt.Sprintf("lsif-worker-%d", i), workerPort+i)
+		addTarget("lsif-worker", workerPort+i)
 	}
 
 	return strings.Join(content, "\n") + "\n"

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -30,7 +30,7 @@ const (
 func main() {
 	numServers, err := strconv.ParseInt(servers, 10, 64)
 	if err != nil || numServers < 0 || numServers > 1 {
-		log.Fatalf("invalid int %q for LSIF_NUM_SERVERS: %s", servers, err)
+		log.Fatalf("Invalid int %q for LSIF_NUM_SERVERS: %s", servers, err)
 	}
 
 	numWorkers, err := strconv.ParseInt(workers, 10, 64)

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	if err := ioutil.WriteFile(
-		path.Join(prometheusConfigurationDir, "targets.yml"),
+		filepath.Join(prometheusConfigurationDir, "targets.yml"),
 		[]byte(makePrometheusTargets(numServers, numWorkers)),
 		0644,
 	); err != nil {

--- a/cmd/lsif-server/main.go
+++ b/cmd/lsif-server/main.go
@@ -51,7 +51,7 @@ func main() {
 		RPCAddr:        "127.0.0.1:5005",
 		ProcDiedAction: goreman.Shutdown,
 	}); err != nil {
-		log.Fatal(err.Error())
+		log.Fatalf("Starting goreman: %v", err)
 	}
 }
 

--- a/cmd/lsif-server/prometheus.yml
+++ b/cmd/lsif-server/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: lsif
+    file_sd_configs:
+      - files:
+          - targets.yml

--- a/cmd/lsif-server/prometheus.yml
+++ b/cmd/lsif-server/prometheus.yml
@@ -1,6 +1,7 @@
 global:
-  scrape_interval: 30s
-  evaluation_interval: 30s
+  scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
+  evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.
+  # scrape_timeout is set to the global default (10s).
 
 scrape_configs:
   - job_name: lsif

--- a/lsif/src/server/routes/meta.ts
+++ b/lsif/src/server/routes/meta.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import promClient from 'prom-client'
 
-/** Create a router containing health endpoint. */
+/** Create a router containing health and metrics endpoint. */
 export function createMetaRouter(): express.Router {
     const router = express.Router()
     router.get('/ping', (_, res) => res.send('ok'))

--- a/lsif/src/server/startup-migrations/redis.ts
+++ b/lsif/src/server/startup-migrations/redis.ts
@@ -28,7 +28,7 @@ export function clearOldRedisData(ctx: TracingContext): Promise<void> {
             const evalAsync: (script: string, numArgs: number) => Promise<void> = promisify(client.eval).bind(client)
             await evalAsync(script, 0)
         } catch (err) {
-            logger.warning('Failed to clean old LSIF data from redis-store', { error: err })
+            logger.warn('Failed to clean old LSIF data from redis-store', { error: err })
         }
     })
 }

--- a/lsif/src/shared/database/postgres.ts
+++ b/lsif/src/shared/database/postgres.ts
@@ -32,11 +32,12 @@ const MAX_CONNECTION_RETRIES = readEnvInt('MAX_CONNECTION_RETRIES', 60)
 const CONNECTION_RETRY_INTERVAL = readEnvInt('CONNECTION_RETRY_INTERVAL', 5)
 
 /**
- * Create a Postgres connection. This creates a typorm connection pool with the
- * name `lsif`. The connection configuration is constructed by the method
- * `createPostgresConnectionOptions`. This method blocks (failing after a configured
- * time) until the connection is established, then blocks indefinitely while the
- * database migration state is behind the expected minimum, or dirty.
+ * Create a Postgres connection. This creates a typorm connection pool with
+ * the name `lsif`. The connection configuration is constructed by the method
+ * `createPostgresConnectionOptions`. This method blocks until the connection
+ * is established, then blocks indefinitely while the database migration state
+ * is behind the expected minimum, or dirty. If a connection is not made within
+ * a configurable timeout, an exception is thrown.
  *
  * @param configuration The current configuration.
  * @param logger The logger instance.

--- a/lsif/src/worker/server.ts
+++ b/lsif/src/worker/server.ts
@@ -2,6 +2,7 @@ import * as settings from './settings'
 import express from 'express'
 import promClient from 'prom-client'
 import { Logger } from 'winston'
+import { logger as loggingMiddleware } from 'express-winston'
 
 /**
  * Create an express server that only has /healthz and /metric endpoints.
@@ -10,13 +11,31 @@ import { Logger } from 'winston'
  */
 export function startMetricsServer(logger: Logger): void {
     const app = express()
-    app.get('/healthz', (_, res) => res.send('ok'))
-    app.get('/metrics', (_, res) => {
-        res.writeHead(200, { 'Content-Type': 'text/plain' })
-        res.end(promClient.register.metrics())
-    })
+    app.use(
+        loggingMiddleware({
+            winstonInstance: logger,
+            level: 'debug',
+            ignoredRoutes: ['/ping', '/healthz', '/metrics'],
+            requestWhitelist: ['method', 'url'],
+            msg: 'Handled request',
+        })
+    )
+    app.use(createMetaRouter)
 
     app.listen(settings.WORKER_METRICS_PORT, () =>
         logger.debug('Worker metrics server listening', { port: settings.WORKER_METRICS_PORT })
     )
+}
+
+/** Create a router containing health and metrics endpoint. */
+export function createMetaRouter(): express.Router {
+    const router = express.Router()
+    router.get('/ping', (_, res) => res.send('ok'))
+    router.get('/healthz', (_, res) => res.send('ok'))
+    router.get('/metrics', (_, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end(promClient.register.metrics())
+    })
+
+    return router
 }

--- a/lsif/src/worker/server.ts
+++ b/lsif/src/worker/server.ts
@@ -2,40 +2,18 @@ import * as settings from './settings'
 import express from 'express'
 import promClient from 'prom-client'
 import { Logger } from 'winston'
-import { logger as loggingMiddleware } from 'express-winston'
 
-/**
- * Create an express server that only has /healthz and /metric endpoints.
- *
- * @param logger The logger instance.
- */
+/** Create an express server containing health and metrics endpoint. */
 export function startMetricsServer(logger: Logger): void {
     const app = express()
-    app.use(
-        loggingMiddleware({
-            winstonInstance: logger,
-            level: 'debug',
-            ignoredRoutes: ['/ping', '/healthz', '/metrics'],
-            requestWhitelist: ['method', 'url'],
-            msg: 'Handled request',
-        })
-    )
-    app.use(createMetaRouter)
-
-    app.listen(settings.WORKER_METRICS_PORT, () =>
-        logger.debug('Worker metrics server listening', { port: settings.WORKER_METRICS_PORT })
-    )
-}
-
-/** Create a router containing health and metrics endpoint. */
-export function createMetaRouter(): express.Router {
-    const router = express.Router()
-    router.get('/ping', (_, res) => res.send('ok'))
-    router.get('/healthz', (_, res) => res.send('ok'))
-    router.get('/metrics', (_, res) => {
+    app.get('/ping', (_, res) => res.send('ok'))
+    app.get('/healthz', (_, res) => res.send('ok'))
+    app.get('/metrics', (_, res) => {
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.end(promClient.register.metrics())
     })
 
-    return router
+    app.listen(settings.WORKER_METRICS_PORT, () =>
+        logger.debug('Worker metrics server listening', { port: settings.WORKER_METRICS_PORT })
+    )
 }


### PR DESCRIPTION
From a [conversation](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1583866063311600) with @creachadair and @slimsag, we decided to scale lsif-workers on two fronts:

- horizontally via replica counts in k8s deployments (easy and the correct way)
- horizontally via a combination of multiple compose services and intra-container parallelization in docker/docker-compose deployments (harder for us, but easier for companies using that environment - it's a big pain point to have to scale to double-digits manually)

Syntect server does something similar to the second approach (`ENV WORKERS=4`) in the dockerfile to ensure that one slow process does not block the remaining resources of the container. This could also be beneficial on bursty workloads with small repositories, as the containers may otherwise be idle or under-provisioned and a handful of processes per container may make use of the excess headroom.

Unfortunately, running multiple (unaltered) workers immediately runs into an issue of port-clashing. Each worker tries to serve its own metrics on port 3187, and more than one worker cannot bind to the same port. Giving these unique and sequentially increasing ports (3187, 3188, 3189, etc) solves the problem, but makes it so our current prometheus configuration will only be able to scrape the first of _n_ workers' metrics. We could scrape all ports, but then the worker count is not a dynamic property of the deployment (and every port must be exposed via compose or 

A chat with @uwedeportivo revealed that we could get seamless scaling using [Prometheus federation](https://prometheus.io/docs/prometheus/latest/federation/). This will basically let one Prometheus instance pre-aggregate the metrics that can then be scraped by a _higher-level_ Prometheus instance.

This PR changes the lsif-server image to accept the number of workers as an environment variable, and will start up 0-1 servers, 0-_n_ workers, and a Prometheus instance that scrapes the (dynamic number of) running processes. The Prometheus instance exposes itself so that it can itself be scraped by our "main" Prometheus instance within a compose or k8s cluster.