### PR TITLE
graphql: expose whether a repo is forked

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -147,6 +147,14 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *RepositoryC
 	return resolver, nil
 }
 
+func (r *RepositoryResolver) IsFork(ctx context.Context) (bool, error) {
+	err := r.hydrate(ctx)
+	if err != nil {
+		return false, err
+	}
+	return r.repo.Fork, nil
+}
+
 func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1813,6 +1813,8 @@ type Repository implements Node & GenericSearchResultInterface {
     url: String!
     # The URLs to this repository on external services associated with it.
     externalURLs: [ExternalLink!]!
+    # Whether the repository is a fork.
+    isFork: Boolean!
     # The repository's default Git branch (HEAD symbolic ref). If the repository is currently being cloned or is
     # empty, this field will be null.
     defaultBranch: GitRef

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1820,6 +1820,8 @@ type Repository implements Node & GenericSearchResultInterface {
     url: String!
     # The URLs to this repository on external services associated with it.
     externalURLs: [ExternalLink!]!
+    # Whether the repository is a fork.
+    isFork: Boolean!
     # The repository's default Git branch (HEAD symbolic ref). If the repository is currently being cloned or is
     # empty, this field will be null.
     defaultBranch: GitRef


### PR DESCRIPTION
TODO: changelog.
TODO: expose archived (seems to be an attr not exposed in the repository type currently)

Experimenting with this on the webapp side before taking it out of draft.