### PR TITLE
Add total search unique users count per period to pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Site-Admin/Instrumentation is now available in the Kubernetes cluster deployment [8805](https://github.com/sourcegraph/sourcegraph/pull/8805).
 - Extensions can now specify a `baseUri` in the `DocumentFilter` when registering providers.
 - Aggregated daily, weekly, monthly usage of interactive and plain text search modes will be sent back in pings.
+- Aggregated counts of daily, weekly, and monthly active users of search will be sent back in pings.
 
 ### Changed
 

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -222,6 +222,7 @@ type SearchUsageStatistics struct {
 // BigQuery, which requires the input match its schema exactly.
 type SearchUsagePeriod struct {
 	StartTime   time.Time
+	TotalUsers  *SearchEventStatistics
 	Literal     *SearchEventStatistics
 	Regexp      *SearchEventStatistics
 	Structural  *SearchEventStatistics


### PR DESCRIPTION
Adds counts of total search users to our pings, aggregated daily, weekly, and monthly.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
