### PR TITLE
gitlab: add tests for `PermsFetcher` methods

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -129,12 +129,12 @@ func newAuthzProvider(a *schema.GitLabAuthorization, instanceURL, token string, 
 
 // NewOAuthProvider is a mockable constructor for new OAuthProvider instances.
 var NewOAuthProvider = func(op OAuthProviderOp) authz.Provider {
-	return newOAuthProvider(op)
+	return newOAuthProvider(op, nil)
 }
 
 // NewSudoProvider is a mockable constructor for new SudoProvider instances.
 var NewSudoProvider = func(op SudoProviderOp) authz.Provider {
-	return newSudoProvider(op)
+	return newSudoProvider(op, nil)
 }
 
 // ValidateAuthz validates the authorization fields of the given GitLab external

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -64,11 +65,11 @@ type OAuthProviderOp struct {
 	MaxBatchRequests int
 }
 
-func newOAuthProvider(op OAuthProviderOp) *OAuthProvider {
+func newOAuthProvider(op OAuthProviderOp, cli httpcli.Doer) *OAuthProvider {
 	p := &OAuthProvider{
 		token: op.Token,
 
-		clientProvider:    gitlab.NewClientProvider(op.BaseURL, nil),
+		clientProvider:    gitlab.NewClientProvider(op.BaseURL, cli),
 		clientURL:         op.BaseURL,
 		codeHost:          extsvc.NewCodeHost(op.BaseURL, gitlab.ServiceType),
 		cache:             op.MockCache,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -190,7 +190,7 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 					op := test.op
 					op.MinBatchThreshold, op.MaxBatchRequests = batchingThreshold[0], batchingThreshold[1]
 					op.MockCache = make(mockCache)
-					authzProvider := newOAuthProvider(op)
+					authzProvider := newOAuthProvider(op, nil)
 					for i := 0; i < 2; i++ {
 						t.Logf("iter %d", i)
 						perms, err := authzProvider.RepoPerms(ctx, c.account, c.repos)
@@ -244,7 +244,7 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 		BaseURL:   mustURL(t, "https://gitlab.mine"),
 		MockCache: make(mockCache),
 		CacheTTL:  3 * time.Hour,
-	})
+	}, nil)
 
 	// Initial request for private repo
 	if _, err := authzProvider.RepoPerms(ctx,
@@ -390,7 +390,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 			CacheTTL:          3 * time.Hour,
 			MinBatchThreshold: 1,
 			MaxBatchRequests:  300,
-		})
+		}, nil)
 		expPerms := []authz.RepoPerms{
 			{Repo: repos["u1/repo1"], Perms: authz.Read},
 			{Repo: repos["internal/repo1"], Perms: authz.Read},
@@ -441,7 +441,7 @@ func Test_GitLab_RepoPerms_batchVisibility(t *testing.T) {
 			CacheTTL:          3 * time.Hour,
 			MinBatchThreshold: 200,
 			MaxBatchRequests:  300,
-		})
+		}, nil)
 		expPerms := []authz.RepoPerms{
 			{Repo: repos["u1/repo1"], Perms: authz.Read},
 			{Repo: repos["internal/repo1"], Perms: authz.Read},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -76,11 +77,11 @@ type SudoProviderOp struct {
 	MockCache pcache
 }
 
-func newSudoProvider(op SudoProviderOp) *SudoProvider {
+func newSudoProvider(op SudoProviderOp, cli httpcli.Doer) *SudoProvider {
 	p := &SudoProvider{
 		sudoToken: op.SudoToken,
 
-		clientProvider:    gitlab.NewClientProvider(op.BaseURL, nil),
+		clientProvider:    gitlab.NewClientProvider(op.BaseURL, cli),
 		clientURL:         op.BaseURL,
 		codeHost:          extsvc.NewCodeHost(op.BaseURL, gitlab.ServiceType),
 		cache:             op.MockCache,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
@@ -192,7 +192,7 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 			defer func() { providers.MockProviders = nil }()
 
 			ctx := context.Background()
-			authzProvider := newSudoProvider(test.op)
+			authzProvider := newSudoProvider(test.op, nil)
 			for _, c := range test.calls {
 				t.Run(c.description, func(t *testing.T) {
 					acct, err := authzProvider.FetchAccount(ctx, c.user, c.current)
@@ -375,7 +375,7 @@ func Test_SudoProvider_RepoPerms(t *testing.T) {
 				ctx := context.Background()
 				op := test.op
 				op.MockCache = make(mockCache)
-				authzProvider := newSudoProvider(op)
+				authzProvider := newSudoProvider(op, nil)
 
 				for i := 0; i < 2; i++ {
 					t.Logf("iter %d", i)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -22,12 +22,14 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Exte
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, fmt.Errorf("not a code host of the account: want %+v but have %+v", account, p.codeHost)
+		return nil, fmt.Errorf("not a code host of the account: want %+v but have %+v", account.ExternalAccountSpec, p.codeHost)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
+	} else if tok == nil {
+		return nil, errors.New("no token found in the external account data")
 	}
 
 	client := p.clientProvider.GetOAuthClient(tok.AccessToken)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -1,0 +1,198 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+)
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func TestOAuthProvider_FetchUserPerms(t *testing.T) {
+	t.Run("nil account", func(t *testing.T) {
+		p := newOAuthProvider(OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchUserPerms(context.Background(), nil)
+		want := "no account provided"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("not the code host of the account", func(t *testing.T) {
+		p := newOAuthProvider(OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchUserPerms(context.Background(),
+			&extsvc.ExternalAccount{
+				ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					ServiceType: "github",
+					ServiceID:   "https://github.com/",
+				},
+			},
+		)
+		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	// The OAuthProvider uses the gitlab.Client under the hood,
+	// which uses rcache, a caching layer that uses Redis.
+	// We need to clear the cache before we run the tests
+	rcache.SetupForTest(t)
+
+	p := newOAuthProvider(
+		OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			Token:   "admin_token",
+		},
+		&mockDoer{
+			do: func(r *http.Request) (*http.Response, error) {
+				want := "https://api.gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				if r.URL.String() != want {
+					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+				}
+
+				want = "Bearer my_access_token"
+				got := r.Header.Get("Authorization")
+				if got != want {
+					return nil, fmt.Errorf("HTTP Authorization: want %q but got %q", want, got)
+				}
+
+				body := `[{"id": 1}, {"id": 2}, {"id": 3}]`
+				return &http.Response{
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+				}, nil
+			},
+		},
+	)
+
+	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
+	repoIDs, err := p.FetchUserPerms(context.Background(),
+		&extsvc.ExternalAccount{
+			UserID: 0,
+			ExternalAccountSpec: extsvc.ExternalAccountSpec{
+				ServiceType: "gitlab",
+				ServiceID:   "https://api.gitlab.com/",
+			},
+			ExternalAccountData: extsvc.ExternalAccountData{
+				AuthData: &authData,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expRepoIDs := []extsvc.ExternalRepoID{"1", "2", "3"}
+	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
+	t.Run("nil repository", func(t *testing.T) {
+		p := newOAuthProvider(OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchRepoPerms(context.Background(), nil)
+		want := "no repository provided"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("not the code host of the repository", func(t *testing.T) {
+		p := newOAuthProvider(OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchRepoPerms(context.Background(),
+			&api.ExternalRepoSpec{
+				ServiceType: "github",
+				ServiceID:   "https://github.com/",
+			},
+		)
+		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	// The OAuthProvider uses the gitlab.Client under the hood,
+	// which uses rcache, a caching layer that uses Redis.
+	// We need to clear the cache before we run the tests
+	rcache.SetupForTest(t)
+
+	p := newOAuthProvider(
+		OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			Token:   "admin_token",
+		},
+		&mockDoer{
+			do: func(r *http.Request) (*http.Response, error) {
+				want := "https://api.gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+				if r.URL.String() != want {
+					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+				}
+
+				want = "admin_token"
+				got := r.Header.Get("Private-Token")
+				if got != want {
+					return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+				}
+
+				body := `
+[
+	{"id": 1, "access_level": 10},
+	{"id": 2, "access_level": 20},
+	{"id": 3, "access_level": 30}
+]`
+				return &http.Response{
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+				}, nil
+			},
+		},
+	)
+
+	accountIDs, err := p.FetchRepoPerms(context.Background(),
+		&api.ExternalRepoSpec{
+			ServiceType: "gitlab",
+			ServiceID:   "https://api.gitlab.com/",
+			ID:          "gitlab_project_id",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 should not be included because of "access_level" < 20
+	expAccountIDs := []extsvc.ExternalAccountID{"2", "3"}
+	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -26,7 +26,7 @@ func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
 func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	t.Run("nil account", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
@@ -38,7 +38,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.ExternalAccount{
@@ -48,7 +48,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				},
 			},
 		)
-		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://gitlab.com/ ServiceType:gitlab BaseURL:https://gitlab.com/}"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
 			t.Fatalf("err: want %q but got %q", want, got)
@@ -62,12 +62,12 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 
 	p := newOAuthProvider(
 		OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 			Token:   "admin_token",
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://api.gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
 				if r.URL.String() != want {
 					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -93,7 +93,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		&extsvc.ExternalAccount{
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
-				ServiceID:   "https://api.gitlab.com/",
+				ServiceID:   "https://gitlab.com/",
 			},
 			ExternalAccountData: extsvc.ExternalAccountData{
 				AuthData: &authData,
@@ -113,7 +113,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("nil repository", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(), nil)
 		want := "no repository provided"
@@ -125,7 +125,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 
 	t.Run("not the code host of the repository", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(),
 			&api.ExternalRepoSpec{
@@ -133,7 +133,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 				ServiceID:   "https://github.com/",
 			},
 		)
-		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://gitlab.com/ ServiceType:gitlab BaseURL:https://gitlab.com/}"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
 			t.Fatalf("err: want %q but got %q", want, got)
@@ -147,12 +147,12 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 
 	p := newOAuthProvider(
 		OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 			Token:   "admin_token",
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://api.gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+				want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
 				if r.URL.String() != want {
 					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -181,7 +181,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	accountIDs, err := p.FetchRepoPerms(context.Background(),
 		&api.ExternalRepoSpec{
 			ServiceType: "gitlab",
-			ServiceID:   "https://api.gitlab.com/",
+			ServiceID:   "https://gitlab.com/",
 			ID:          "gitlab_project_id",
 		},
 	)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -91,7 +91,6 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.ExternalAccount{
-			UserID: 0,
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://api.gitlab.com/",

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -114,6 +114,7 @@ func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]e
 		}
 
 		for i := range members {
+			// Members with access level 20 (i.e. Reporter) has access to project code.
 			if members[i].AccessLevel < 20 {
 				continue
 			}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -24,7 +24,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Exter
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, fmt.Errorf("not a code host of the account: want %+v but have %+v", account, p.codeHost)
+		return nil, fmt.Errorf("not a code host of the account: want %+v but have %+v", account.ExternalAccountSpec, p.codeHost)
 	}
 
 	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
@@ -114,6 +114,10 @@ func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]e
 		}
 
 		for i := range members {
+			if members[i].AccessLevel < 20 {
+				continue
+			}
+
 			userIDs = append(userIDs, extsvc.ExternalAccountID(strconv.Itoa(int(members[i].ID))))
 		}
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -1,0 +1,190 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+)
+
+func TestSudoProvider_FetchUserPerms(t *testing.T) {
+	t.Run("nil account", func(t *testing.T) {
+		p := newSudoProvider(SudoProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchUserPerms(context.Background(), nil)
+		want := "no account provided"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("not the code host of the account", func(t *testing.T) {
+		p := newSudoProvider(SudoProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchUserPerms(context.Background(),
+			&extsvc.ExternalAccount{
+				ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					ServiceType: "github",
+					ServiceID:   "https://github.com/",
+				},
+			},
+		)
+		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	// The OAuthProvider uses the gitlab.Client under the hood,
+	// which uses rcache, a caching layer that uses Redis.
+	// We need to clear the cache before we run the tests
+	rcache.SetupForTest(t)
+
+	p := newSudoProvider(
+		SudoProviderOp{
+			BaseURL:   mustURL(t, "https://api.gitlab.com"),
+			SudoToken: "admin_token",
+		},
+		&mockDoer{
+			do: func(r *http.Request) (*http.Response, error) {
+				want := "https://api.gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				if r.URL.String() != want {
+					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+				}
+
+				want = "admin_token"
+				got := r.Header.Get("Private-Token")
+				if got != want {
+					return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+				}
+
+				body := `[{"id": 1}, {"id": 2}, {"id": 3}]`
+				return &http.Response{
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+				}, nil
+			},
+		},
+	)
+
+	accountData := json.RawMessage(`{"id": 999}`)
+	repoIDs, err := p.FetchUserPerms(context.Background(),
+		&extsvc.ExternalAccount{
+			UserID: 0,
+			ExternalAccountSpec: extsvc.ExternalAccountSpec{
+				ServiceType: "gitlab",
+				ServiceID:   "https://api.gitlab.com/",
+			},
+			ExternalAccountData: extsvc.ExternalAccountData{
+				AccountData: &accountData,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expRepoIDs := []extsvc.ExternalRepoID{"1", "2", "3"}
+	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSudoProvider_FetchRepoPerms(t *testing.T) {
+	t.Run("nil repository", func(t *testing.T) {
+		p := newSudoProvider(SudoProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchRepoPerms(context.Background(), nil)
+		want := "no repository provided"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("not the code host of the repository", func(t *testing.T) {
+		p := newSudoProvider(SudoProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+		}, nil)
+		_, err := p.FetchRepoPerms(context.Background(),
+			&api.ExternalRepoSpec{
+				ServiceType: "github",
+				ServiceID:   "https://github.com/",
+			},
+		)
+		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	// The OAuthProvider uses the gitlab.Client under the hood,
+	// which uses rcache, a caching layer that uses Redis.
+	// We need to clear the cache before we run the tests
+	rcache.SetupForTest(t)
+
+	p := newOAuthProvider(
+		OAuthProviderOp{
+			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			Token:   "admin_token",
+		},
+		&mockDoer{
+			do: func(r *http.Request) (*http.Response, error) {
+				want := "https://api.gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+				if r.URL.String() != want {
+					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+				}
+
+				want = "admin_token"
+				got := r.Header.Get("Private-Token")
+				if got != want {
+					return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+				}
+
+				body := `
+[
+	{"id": 1, "access_level": 10},
+	{"id": 2, "access_level": 20},
+	{"id": 3, "access_level": 30}
+]`
+				return &http.Response{
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+				}, nil
+			},
+		},
+	)
+
+	accountIDs, err := p.FetchRepoPerms(context.Background(),
+		&api.ExternalRepoSpec{
+			ServiceType: "gitlab",
+			ServiceID:   "https://api.gitlab.com/",
+			ID:          "gitlab_project_id",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 should not be included because of "access_level" < 20
+	expAccountIDs := []extsvc.ExternalAccountID{"2", "3"}
+	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -70,6 +70,12 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 					return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
 				}
 
+				want = "999"
+				got = r.Header.Get("Sudo")
+				if got != want {
+					return nil, fmt.Errorf("HTTP Sudo: want %q but got %q", want, got)
+				}
+
 				body := `[{"id": 1}, {"id": 2}, {"id": 3}]`
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
@@ -83,7 +89,6 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	accountData := json.RawMessage(`{"id": 999}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.ExternalAccount{
-			UserID: 0,
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://api.gitlab.com/",

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -18,7 +18,7 @@ import (
 func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	t.Run("nil account", func(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
@@ -30,7 +30,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.ExternalAccount{
@@ -40,7 +40,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				},
 			},
 		)
-		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		want := "not a code host of the account: want {ServiceType:github ServiceID:https://github.com/ ClientID: AccountID:} but have &{ServiceID:https://gitlab.com/ ServiceType:gitlab BaseURL:https://gitlab.com/}"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
 			t.Fatalf("err: want %q but got %q", want, got)
@@ -54,12 +54,12 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 
 	p := newSudoProvider(
 		SudoProviderOp{
-			BaseURL:   mustURL(t, "https://api.gitlab.com"),
+			BaseURL:   mustURL(t, "https://gitlab.com"),
 			SudoToken: "admin_token",
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://api.gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
 				if r.URL.String() != want {
 					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -91,7 +91,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		&extsvc.ExternalAccount{
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
-				ServiceID:   "https://api.gitlab.com/",
+				ServiceID:   "https://gitlab.com/",
 			},
 			ExternalAccountData: extsvc.ExternalAccountData{
 				AccountData: &accountData,
@@ -111,7 +111,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("nil repository", func(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(), nil)
 		want := "no repository provided"
@@ -123,7 +123,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 
 	t.Run("not the code host of the repository", func(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(),
 			&api.ExternalRepoSpec{
@@ -131,7 +131,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 				ServiceID:   "https://github.com/",
 			},
 		)
-		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://api.gitlab.com/ ServiceType:gitlab BaseURL:https://api.gitlab.com/}"
+		want := "not a code host of the repository: want ExternalRepoSpec{https://github.com/ github } but have &{ServiceID:https://gitlab.com/ ServiceType:gitlab BaseURL:https://gitlab.com/}"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
 			t.Fatalf("err: want %q but got %q", want, got)
@@ -145,12 +145,12 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 
 	p := newOAuthProvider(
 		OAuthProviderOp{
-			BaseURL: mustURL(t, "https://api.gitlab.com"),
+			BaseURL: mustURL(t, "https://gitlab.com"),
 			Token:   "admin_token",
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://api.gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+				want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
 				if r.URL.String() != want {
 					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -179,7 +179,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 	accountIDs, err := p.FetchRepoPerms(context.Background(),
 		&api.ExternalRepoSpec{
 			ServiceType: "gitlab",
-			ServiceID:   "https://api.gitlab.com/",
+			ServiceID:   "https://gitlab.com/",
 			ID:          "gitlab_project_id",
 		},
 	)

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -50,9 +50,9 @@ func getJSONOrError(field *json.RawMessage, v interface{}) error {
 		return errors.New("field was nil")
 	}
 
-	if err := json.Unmarshal([]byte(*field), v); err != nil {
+	if err := json.Unmarshal(*field, v); err != nil {
 		var jsonErr jsonError
-		if err := json.Unmarshal([]byte(*field), &jsonErr); err != nil {
+		if err := json.Unmarshal(*field, &jsonErr); err != nil {
 			return fmt.Errorf("could not parse field as JSON: %s", err)
 		}
 		return errors.New(jsonErr.Error)


### PR DESCRIPTION
This PR adds unit tests for `PermsFetcher` methods (i.e. `FetchUserPerms` and `FetchRepoPerms`) of two GitLab authz providers.
