### PR TITLE
authz: various fixes to `PermsSyncer`

### DIFF
--- a/cmd/frontend/authz/register.go
+++ b/cmd/frontend/authz/register.go
@@ -11,7 +11,7 @@ var (
 	// not matched by any authz provider. The default value is true. It is only set to false in
 	// error modes (when the configuration is in a state where interpreting it literally could lead
 	// to leakage of private repositories).
-	allowAccessByDefault bool = true
+	allowAccessByDefault = true
 
 	// authzProvidersReady and authzProvidersReadyOnce together indicate when
 	// GetProviders should no longer block. It should block until SetProviders


### PR DESCRIPTION
This PR:
1. Fixes SQL error with raw time string.
2. Adds logging upon completing repo and user perms sync.
3. Change schedule to 1 minute to be more responsive to users and repos with no permissions.

NOTE: Tests for `PermsSyncer` are on the way but not included in this PR.
