### PR TITLE
Bump src CLI MinimumVersion to 3.10.12

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.10.7"
+const MinimumVersion = "3.10.12"


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/8846 and bumps the src CLI MinimumVersion so that https://github.com/sourcegraph/src-cli/pull/158 is required.
