### PR TITLE
repo-updater: Add support for excluding forks from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Site-Admin/Instrumentation is now available in the Kubernetes cluster deployment [8805](https://github.com/sourcegraph/sourcegraph/pull/8805).
 - Extensions can now specify a `baseUri` in the `DocumentFilter` when registering providers.
+- Admins can now exclude GitHub forks from the set of repositories being mirrored in Sourcegraph with the `"exclude": [{"forks": true}]` GitHub external service configuration. [#8974](https://github.com/sourcegraph/sourcegraph/pull/8974)
 
 ### Changed
 

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -82,8 +82,8 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 	}
 
 	var (
-		exclude = make(map[string]bool, len(c.Exclude))
-		excludeForks bool
+		exclude         = make(map[string]bool, len(c.Exclude))
+		excludeForks    bool
 		excludePatterns []*regexp.Regexp
 	)
 

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -29,6 +29,7 @@ type GithubSource struct {
 	svc             *ExternalService
 	config          *schema.GitHubConnection
 	exclude         map[string]bool
+	excludeForks    bool
 	excludePatterns []*regexp.Regexp
 	githubDotCom    bool
 	baseURL         *url.URL
@@ -80,8 +81,12 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		return nil, err
 	}
 
-	exclude := make(map[string]bool, len(c.Exclude))
-	var excludePatterns []*regexp.Regexp
+	var (
+		exclude = make(map[string]bool, len(c.Exclude))
+		excludeForks bool
+		excludePatterns []*regexp.Regexp
+	)
+
 	for _, r := range c.Exclude {
 		if r.Name != "" {
 			exclude[strings.ToLower(r.Name)] = true
@@ -98,12 +103,17 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 			}
 			excludePatterns = append(excludePatterns, re)
 		}
+
+		if r.Forks {
+			excludeForks = true
+		}
 	}
 
 	return &GithubSource{
 		svc:              svc,
 		config:           c,
 		exclude:          exclude,
+		excludeForks:     excludeForks,
 		excludePatterns:  excludePatterns,
 		baseURL:          baseURL,
 		githubDotCom:     githubDotCom,
@@ -316,11 +326,16 @@ func (s *GithubSource) excludes(r *github.Repository) bool {
 		return true
 	}
 
+	if s.excludeForks && r.IsFork {
+		return true
+	}
+
 	for _, re := range s.excludePatterns {
 		if re.MatchString(r.NameWithOwner) {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -125,11 +125,13 @@ func TestSources_ListRepos(t *testing.T) {
 						"sourcegraph/Sourcegraph",
 						"keegancsmith/sqlf",
 						"tsenart/VEGETA",
+						"tsenart/go-tsz", // fork
 					},
 					Exclude: []*schema.ExcludedGitHubRepo{
 						{Name: "tsenart/Vegeta"},
 						{Id: "MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU="}, // tsenart/patrol ID
 						{Pattern: "^keegancsmith/.*"},
+						{Forks: true},
 					},
 				}),
 			},
@@ -262,9 +264,14 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 
 					for _, r := range rs {
+						if r.Fork {
+							t.Errorf("excluded fork was yielded: %s", r.Name)
+						}
+
 						if set[r.Name] || set[r.ExternalRepo.ID] {
 							t.Errorf("excluded repo{name=%s, id=%s} was yielded", r.Name, r.ExternalRepo.ID)
 						}
+						
 						for _, re := range patterns {
 							if re.MatchString(r.Name) {
 								t.Errorf("excluded repo{name=%s} matching %q was yielded", r.Name, re.String())

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -271,7 +271,7 @@ func TestSources_ListRepos(t *testing.T) {
 						if set[r.Name] || set[r.ExternalRepo.ID] {
 							t.Errorf("excluded repo{name=%s, id=%s} was yielded", r.Name, r.ExternalRepo.ID)
 						}
-						
+
 						for _, re := range patterns {
 							if re.MatchString(r.Name) {
 								t.Errorf("excluded repo{name=%s} matching %q was yielded", r.Name, re.String())

--- a/cmd/repo-updater/repos/testdata/sources/GITHUB/excluded-repos-are-never-yielded.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GITHUB/excluded-repos-are-never-yielded.yaml
@@ -2,11 +2,306 @@
 version: 1
 interactions:
 - request:
+    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tviewerPermission\n}\n\tquery
+      {\nrepo0: repository(owner: \"sourcegraph\", name: \"Sourcegraph\") { ... on
+      Repository { ...RepositoryFields } }\nrepo1: repository(owner: \"keegancsmith\",
+      name: \"sqlf\") { ... on Repository { ...RepositoryFields } }\nrepo2: repository(owner:
+      \"tsenart\", name: \"VEGETA\") { ... on Repository { ...RepositoryFields } }\nrepo3:
+      repository(owner: \"tsenart\", name: \"go-tsz\") { ... on Repository { ...RepositoryFields
+      } }\n}","variables":{}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"message":"This endpoint requires you to be authenticated.","documentation_url":"https://developer.github.com/v3/#authentication"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Content-Length:
+      - "131"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2020 11:35:26 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 401 Unauthorized
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.antiope-preview; format=json
+      X-Github-Request-Id:
+      - 559E:42752:256C878:2BF8F8E:5E6A1E7E
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 401 Unauthorized
+    code: 401
+    duration: ""
+- request:
     body: ""
     form: {}
     headers:
       Accept:
-      - application/vnd.github.jean-grey-preview+json
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/tsenart/go-tsz
+    method: GET
+  response:
+    body: '{"id":141798075,"node_id":"MDEwOlJlcG9zaXRvcnkxNDE3OTgwNzU=","name":"go-tsz","full_name":"tsenart/go-tsz","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/go-tsz","description":"Time
+      series compression algorithm from Facebook''s Gorilla paper","fork":true,"url":"https://api.github.com/repos/tsenart/go-tsz","forks_url":"https://api.github.com/repos/tsenart/go-tsz/forks","keys_url":"https://api.github.com/repos/tsenart/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/go-tsz/teams","hooks_url":"https://api.github.com/repos/tsenart/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/tsenart/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/go-tsz/events","assignees_url":"https://api.github.com/repos/tsenart/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/go-tsz/tags","blobs_url":"https://api.github.com/repos/tsenart/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/go-tsz/languages","stargazers_url":"https://api.github.com/repos/tsenart/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/tsenart/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/tsenart/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/tsenart/go-tsz/subscription","commits_url":"https://api.github.com/repos/tsenart/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/go-tsz/merges","archive_url":"https://api.github.com/repos/tsenart/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/go-tsz/downloads","issues_url":"https://api.github.com/repos/tsenart/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/go-tsz/deployments","created_at":"2018-07-21T09:17:19Z","updated_at":"2018-08-14T23:56:35Z","pushed_at":"2018-08-14T23:56:33Z","git_url":"git://github.com/tsenart/go-tsz.git","ssh_url":"git@github.com:tsenart/go-tsz.git","clone_url":"https://github.com/tsenart/go-tsz.git","svn_url":"https://github.com/tsenart/go-tsz","homepage":"","size":326,"stargazers_count":0,"watchers_count":0,"language":"Go","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"topics":[],"forks":2,"open_issues":0,"watchers":0,"default_branch":"master","temp_clone_token":null,"parent":{"id":41533478,"node_id":"MDEwOlJlcG9zaXRvcnk0MTUzMzQ3OA==","name":"go-tsz","full_name":"dgryski/go-tsz","private":false,"owner":{"login":"dgryski","id":970862,"node_id":"MDQ6VXNlcjk3MDg2Mg==","avatar_url":"https://avatars2.githubusercontent.com/u/970862?v=4","gravatar_id":"","url":"https://api.github.com/users/dgryski","html_url":"https://github.com/dgryski","followers_url":"https://api.github.com/users/dgryski/followers","following_url":"https://api.github.com/users/dgryski/following{/other_user}","gists_url":"https://api.github.com/users/dgryski/gists{/gist_id}","starred_url":"https://api.github.com/users/dgryski/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/dgryski/subscriptions","organizations_url":"https://api.github.com/users/dgryski/orgs","repos_url":"https://api.github.com/users/dgryski/repos","events_url":"https://api.github.com/users/dgryski/events{/privacy}","received_events_url":"https://api.github.com/users/dgryski/received_events","type":"User","site_admin":false},"html_url":"https://github.com/dgryski/go-tsz","description":"Time
+      series compression algorithm from Facebook''s Gorilla paper","fork":false,"url":"https://api.github.com/repos/dgryski/go-tsz","forks_url":"https://api.github.com/repos/dgryski/go-tsz/forks","keys_url":"https://api.github.com/repos/dgryski/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/dgryski/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/dgryski/go-tsz/teams","hooks_url":"https://api.github.com/repos/dgryski/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/dgryski/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/dgryski/go-tsz/events","assignees_url":"https://api.github.com/repos/dgryski/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/dgryski/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/dgryski/go-tsz/tags","blobs_url":"https://api.github.com/repos/dgryski/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/dgryski/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/dgryski/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/dgryski/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/dgryski/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/dgryski/go-tsz/languages","stargazers_url":"https://api.github.com/repos/dgryski/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/dgryski/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/dgryski/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/dgryski/go-tsz/subscription","commits_url":"https://api.github.com/repos/dgryski/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/dgryski/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/dgryski/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/dgryski/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/dgryski/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/dgryski/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/dgryski/go-tsz/merges","archive_url":"https://api.github.com/repos/dgryski/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/dgryski/go-tsz/downloads","issues_url":"https://api.github.com/repos/dgryski/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/dgryski/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/dgryski/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/dgryski/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/dgryski/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/dgryski/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/dgryski/go-tsz/deployments","created_at":"2015-08-28T07:28:39Z","updated_at":"2020-03-09T21:21:51Z","pushed_at":"2018-07-21T09:44:43Z","git_url":"git://github.com/dgryski/go-tsz.git","ssh_url":"git@github.com:dgryski/go-tsz.git","clone_url":"https://github.com/dgryski/go-tsz.git","svn_url":"https://github.com/dgryski/go-tsz","homepage":"","size":295,"stargazers_count":373,"watchers_count":373,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":42,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":2,"license":{"key":"bsd-2-clause","name":"BSD
+      2-Clause \"Simplified\" License","spdx_id":"BSD-2-Clause","url":"https://api.github.com/licenses/bsd-2-clause","node_id":"MDc6TGljZW5zZTQ="},"forks":42,"open_issues":2,"watchers":373,"default_branch":"master"},"source":{"id":41533478,"node_id":"MDEwOlJlcG9zaXRvcnk0MTUzMzQ3OA==","name":"go-tsz","full_name":"dgryski/go-tsz","private":false,"owner":{"login":"dgryski","id":970862,"node_id":"MDQ6VXNlcjk3MDg2Mg==","avatar_url":"https://avatars2.githubusercontent.com/u/970862?v=4","gravatar_id":"","url":"https://api.github.com/users/dgryski","html_url":"https://github.com/dgryski","followers_url":"https://api.github.com/users/dgryski/followers","following_url":"https://api.github.com/users/dgryski/following{/other_user}","gists_url":"https://api.github.com/users/dgryski/gists{/gist_id}","starred_url":"https://api.github.com/users/dgryski/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/dgryski/subscriptions","organizations_url":"https://api.github.com/users/dgryski/orgs","repos_url":"https://api.github.com/users/dgryski/repos","events_url":"https://api.github.com/users/dgryski/events{/privacy}","received_events_url":"https://api.github.com/users/dgryski/received_events","type":"User","site_admin":false},"html_url":"https://github.com/dgryski/go-tsz","description":"Time
+      series compression algorithm from Facebook''s Gorilla paper","fork":false,"url":"https://api.github.com/repos/dgryski/go-tsz","forks_url":"https://api.github.com/repos/dgryski/go-tsz/forks","keys_url":"https://api.github.com/repos/dgryski/go-tsz/keys{/key_id}","collaborators_url":"https://api.github.com/repos/dgryski/go-tsz/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/dgryski/go-tsz/teams","hooks_url":"https://api.github.com/repos/dgryski/go-tsz/hooks","issue_events_url":"https://api.github.com/repos/dgryski/go-tsz/issues/events{/number}","events_url":"https://api.github.com/repos/dgryski/go-tsz/events","assignees_url":"https://api.github.com/repos/dgryski/go-tsz/assignees{/user}","branches_url":"https://api.github.com/repos/dgryski/go-tsz/branches{/branch}","tags_url":"https://api.github.com/repos/dgryski/go-tsz/tags","blobs_url":"https://api.github.com/repos/dgryski/go-tsz/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/dgryski/go-tsz/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/dgryski/go-tsz/git/refs{/sha}","trees_url":"https://api.github.com/repos/dgryski/go-tsz/git/trees{/sha}","statuses_url":"https://api.github.com/repos/dgryski/go-tsz/statuses/{sha}","languages_url":"https://api.github.com/repos/dgryski/go-tsz/languages","stargazers_url":"https://api.github.com/repos/dgryski/go-tsz/stargazers","contributors_url":"https://api.github.com/repos/dgryski/go-tsz/contributors","subscribers_url":"https://api.github.com/repos/dgryski/go-tsz/subscribers","subscription_url":"https://api.github.com/repos/dgryski/go-tsz/subscription","commits_url":"https://api.github.com/repos/dgryski/go-tsz/commits{/sha}","git_commits_url":"https://api.github.com/repos/dgryski/go-tsz/git/commits{/sha}","comments_url":"https://api.github.com/repos/dgryski/go-tsz/comments{/number}","issue_comment_url":"https://api.github.com/repos/dgryski/go-tsz/issues/comments{/number}","contents_url":"https://api.github.com/repos/dgryski/go-tsz/contents/{+path}","compare_url":"https://api.github.com/repos/dgryski/go-tsz/compare/{base}...{head}","merges_url":"https://api.github.com/repos/dgryski/go-tsz/merges","archive_url":"https://api.github.com/repos/dgryski/go-tsz/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/dgryski/go-tsz/downloads","issues_url":"https://api.github.com/repos/dgryski/go-tsz/issues{/number}","pulls_url":"https://api.github.com/repos/dgryski/go-tsz/pulls{/number}","milestones_url":"https://api.github.com/repos/dgryski/go-tsz/milestones{/number}","notifications_url":"https://api.github.com/repos/dgryski/go-tsz/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/dgryski/go-tsz/labels{/name}","releases_url":"https://api.github.com/repos/dgryski/go-tsz/releases{/id}","deployments_url":"https://api.github.com/repos/dgryski/go-tsz/deployments","created_at":"2015-08-28T07:28:39Z","updated_at":"2020-03-09T21:21:51Z","pushed_at":"2018-07-21T09:44:43Z","git_url":"git://github.com/dgryski/go-tsz.git","ssh_url":"git@github.com:dgryski/go-tsz.git","clone_url":"https://github.com/dgryski/go-tsz.git","svn_url":"https://github.com/dgryski/go-tsz","homepage":"","size":295,"stargazers_count":373,"watchers_count":373,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":42,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":2,"license":{"key":"bsd-2-clause","name":"BSD
+      2-Clause \"Simplified\" License","spdx_id":"BSD-2-Clause","url":"https://api.github.com/licenses/bsd-2-clause","node_id":"MDc6TGljZW5zZTQ="},"topics":[],"forks":42,"open_issues":2,"watchers":373,"default_branch":"master"},"network_count":42,"subscribers_count":1}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2020 11:35:27 GMT
+      Etag:
+      - W/"6d32db5f2197c2d57b35b86eb44902f8"
+      Last-Modified:
+      - Tue, 14 Aug 2018 23:56:35 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
+        github.machine-man-preview; format=json
+      X-Github-Request-Id:
+      - 559E:42752:256C8D6:2BF8FE6:5E6A1E7E
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/tsenart/VEGETA
+    method: GET
+  response:
+    body: '{"id":12080551,"node_id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","name":"vegeta","full_name":"tsenart/vegeta","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/vegeta","description":"HTTP
+      load testing tool and library. It''s over 9000!","fork":false,"url":"https://api.github.com/repos/tsenart/vegeta","forks_url":"https://api.github.com/repos/tsenart/vegeta/forks","keys_url":"https://api.github.com/repos/tsenart/vegeta/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/vegeta/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/vegeta/teams","hooks_url":"https://api.github.com/repos/tsenart/vegeta/hooks","issue_events_url":"https://api.github.com/repos/tsenart/vegeta/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/vegeta/events","assignees_url":"https://api.github.com/repos/tsenart/vegeta/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/vegeta/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/vegeta/tags","blobs_url":"https://api.github.com/repos/tsenart/vegeta/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/vegeta/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/vegeta/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/vegeta/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/vegeta/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/vegeta/languages","stargazers_url":"https://api.github.com/repos/tsenart/vegeta/stargazers","contributors_url":"https://api.github.com/repos/tsenart/vegeta/contributors","subscribers_url":"https://api.github.com/repos/tsenart/vegeta/subscribers","subscription_url":"https://api.github.com/repos/tsenart/vegeta/subscription","commits_url":"https://api.github.com/repos/tsenart/vegeta/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/vegeta/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/vegeta/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/vegeta/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/vegeta/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/vegeta/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/vegeta/merges","archive_url":"https://api.github.com/repos/tsenart/vegeta/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/vegeta/downloads","issues_url":"https://api.github.com/repos/tsenart/vegeta/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/vegeta/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/vegeta/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/vegeta/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/vegeta/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/vegeta/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/vegeta/deployments","created_at":"2013-08-13T11:45:21Z","updated_at":"2020-03-12T10:26:23Z","pushed_at":"2020-03-09T14:50:16Z","git_url":"git://github.com/tsenart/vegeta.git","ssh_url":"git@github.com:tsenart/vegeta.git","clone_url":"https://github.com/tsenart/vegeta.git","svn_url":"https://github.com/tsenart/vegeta","homepage":"http://godoc.org/github.com/tsenart/vegeta/lib","size":1703,"stargazers_count":14055,"watchers_count":14055,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":905,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":35,"license":{"key":"mit","name":"MIT
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":["benchmarking","go","http","load-testing"],"forks":905,"open_issues":35,"watchers":14055,"default_branch":"master","temp_clone_token":null,"network_count":905,"subscribers_count":293}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2020 11:35:27 GMT
+      Etag:
+      - W/"e35268ce80294fa31a4c7d01e4c64f23"
+      Last-Modified:
+      - Thu, 12 Mar 2020 10:26:23 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
+        github.machine-man-preview; format=json
+      X-Github-Request-Id:
+      - 559E:42752:256C956:2BF908C:5E6A1E7F
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/keegancsmith/sqlf
+    method: GET
+  response:
+    body: '{"id":58958942,"node_id":"MDEwOlJlcG9zaXRvcnk1ODk1ODk0Mg==","name":"sqlf","full_name":"keegancsmith/sqlf","private":false,"owner":{"login":"keegancsmith","id":187831,"node_id":"MDQ6VXNlcjE4NzgzMQ==","avatar_url":"https://avatars1.githubusercontent.com/u/187831?v=4","gravatar_id":"","url":"https://api.github.com/users/keegancsmith","html_url":"https://github.com/keegancsmith","followers_url":"https://api.github.com/users/keegancsmith/followers","following_url":"https://api.github.com/users/keegancsmith/following{/other_user}","gists_url":"https://api.github.com/users/keegancsmith/gists{/gist_id}","starred_url":"https://api.github.com/users/keegancsmith/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/keegancsmith/subscriptions","organizations_url":"https://api.github.com/users/keegancsmith/orgs","repos_url":"https://api.github.com/users/keegancsmith/repos","events_url":"https://api.github.com/users/keegancsmith/events{/privacy}","received_events_url":"https://api.github.com/users/keegancsmith/received_events","type":"User","site_admin":false},"html_url":"https://github.com/keegancsmith/sqlf","description":"sqlf
+      generates parameterized SQL statements in Go, sprintf style","fork":false,"url":"https://api.github.com/repos/keegancsmith/sqlf","forks_url":"https://api.github.com/repos/keegancsmith/sqlf/forks","keys_url":"https://api.github.com/repos/keegancsmith/sqlf/keys{/key_id}","collaborators_url":"https://api.github.com/repos/keegancsmith/sqlf/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/keegancsmith/sqlf/teams","hooks_url":"https://api.github.com/repos/keegancsmith/sqlf/hooks","issue_events_url":"https://api.github.com/repos/keegancsmith/sqlf/issues/events{/number}","events_url":"https://api.github.com/repos/keegancsmith/sqlf/events","assignees_url":"https://api.github.com/repos/keegancsmith/sqlf/assignees{/user}","branches_url":"https://api.github.com/repos/keegancsmith/sqlf/branches{/branch}","tags_url":"https://api.github.com/repos/keegancsmith/sqlf/tags","blobs_url":"https://api.github.com/repos/keegancsmith/sqlf/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/keegancsmith/sqlf/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/keegancsmith/sqlf/git/refs{/sha}","trees_url":"https://api.github.com/repos/keegancsmith/sqlf/git/trees{/sha}","statuses_url":"https://api.github.com/repos/keegancsmith/sqlf/statuses/{sha}","languages_url":"https://api.github.com/repos/keegancsmith/sqlf/languages","stargazers_url":"https://api.github.com/repos/keegancsmith/sqlf/stargazers","contributors_url":"https://api.github.com/repos/keegancsmith/sqlf/contributors","subscribers_url":"https://api.github.com/repos/keegancsmith/sqlf/subscribers","subscription_url":"https://api.github.com/repos/keegancsmith/sqlf/subscription","commits_url":"https://api.github.com/repos/keegancsmith/sqlf/commits{/sha}","git_commits_url":"https://api.github.com/repos/keegancsmith/sqlf/git/commits{/sha}","comments_url":"https://api.github.com/repos/keegancsmith/sqlf/comments{/number}","issue_comment_url":"https://api.github.com/repos/keegancsmith/sqlf/issues/comments{/number}","contents_url":"https://api.github.com/repos/keegancsmith/sqlf/contents/{+path}","compare_url":"https://api.github.com/repos/keegancsmith/sqlf/compare/{base}...{head}","merges_url":"https://api.github.com/repos/keegancsmith/sqlf/merges","archive_url":"https://api.github.com/repos/keegancsmith/sqlf/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/keegancsmith/sqlf/downloads","issues_url":"https://api.github.com/repos/keegancsmith/sqlf/issues{/number}","pulls_url":"https://api.github.com/repos/keegancsmith/sqlf/pulls{/number}","milestones_url":"https://api.github.com/repos/keegancsmith/sqlf/milestones{/number}","notifications_url":"https://api.github.com/repos/keegancsmith/sqlf/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/keegancsmith/sqlf/labels{/name}","releases_url":"https://api.github.com/repos/keegancsmith/sqlf/releases{/id}","deployments_url":"https://api.github.com/repos/keegancsmith/sqlf/deployments","created_at":"2016-05-16T19:01:04Z","updated_at":"2019-12-05T07:32:47Z","pushed_at":"2018-09-13T13:40:54Z","git_url":"git://github.com/keegancsmith/sqlf.git","ssh_url":"git@github.com:keegancsmith/sqlf.git","clone_url":"https://github.com/keegancsmith/sqlf.git","svn_url":"https://github.com/keegancsmith/sqlf","homepage":"","size":14,"stargazers_count":49,"watchers_count":49,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"mit","name":"MIT
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":["go","golang","sprintf-style","sql"],"forks":3,"open_issues":0,"watchers":49,"default_branch":"master","temp_clone_token":null,"network_count":3,"subscribers_count":2}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2020 11:35:27 GMT
+      Etag:
+      - W/"3f72859dc224ea8e125bd52e2987ed52"
+      Last-Modified:
+      - Thu, 05 Dec 2019 07:32:47 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
+        github.machine-man-preview; format=json
+      X-Github-Request-Id:
+      - 559E:42752:256C9BD:2BF9102:5E6A1E7F
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/Sourcegraph
+    method: GET
+  response:
+    body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Universal
+      code search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2020-03-12T11:26:20Z","pushed_at":"2020-03-12T11:17:02Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":356829,"stargazers_count":3336,"watchers_count":3336,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":321,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1152,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"topics":["code-intelligence","code-search","lsif-enabled","open-source","repo-type-main","sourcegraph"],"forks":321,"open_issues":1152,"watchers":3336,"default_branch":"master","temp_clone_token":null,"organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":321,"subscribers_count":82}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2020 11:35:27 GMT
+      Etag:
+      - W/"b4b96df4f51ad712c1cc6ddcecbb13bb"
+      Last-Modified:
+      - Thu, 12 Mar 2020 11:26:20 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
+        github.machine-man-preview; format=json
+      X-Github-Request-Id:
+      - 559E:42752:256CA28:2BF9180:5E6A1E7F
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
       Content-Type:
       - application/json; charset=utf-8
     url: https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol
@@ -14,15 +309,15 @@ interactions:
   response:
     body: '{"total_count":1,"incomplete_results":false,"items":[{"id":153657245,"node_id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","name":"patrol","full_name":"tsenart/patrol","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/patrol","description":"Patrol
       is an operator friendly distributed rate limiting HTTP API with strong eventually
-      consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-05-06T21:09:03Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":21,"watchers_count":21,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":3,"open_issues":1,"watchers":21,"default_branch":"master","permissions":{"admin":false,"push":false,"pull":true},"score":46.521248}]}'
+      consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-10-29T09:53:49Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":26,"watchers_count":26,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"topics":[],"forks":3,"open_issues":1,"watchers":26,"default_branch":"master","score":1.0}]}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
         X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
+        X-GitHub-Media-Type, Deprecation, Sunset
       Cache-Control:
       - no-cache
       Content-Security-Policy:
@@ -30,7 +325,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 22 Jun 2019 05:36:03 GMT
+      - Thu, 12 Mar 2020 11:35:27 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -40,78 +335,16 @@ interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Vary:
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - ""
+      - Accept-Encoding, Accept, X-Requested-With
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - deny
       X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
+        github.machine-man-preview; format=json
       X-Github-Request-Id:
-      - DF9E:11328:46A41C1:58E185D:5D0DBE42
-      X-Oauth-Scopes:
-      - repo
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"query":"\nfragment RepositoryFields on Repository {\n\tid\n\tdatabaseId\n\tnameWithOwner\n\tdescription\n\turl\n\tisPrivate\n\tisFork\n\tisArchived\n\tviewerPermission\n}\n\tquery
-      {\nrepo0: repository(owner: \"sourcegraph\", name: \"Sourcegraph\") { ... on
-      Repository { ...RepositoryFields } }\nrepo1: repository(owner: \"keegancsmith\",
-      name: \"sqlf\") { ... on Repository { ...RepositoryFields } }\nrepo2: repository(owner:
-      \"tsenart\", name: \"VEGETA\") { ... on Repository { ...RepositoryFields } }\n}","variables":{}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/graphql
-    method: POST
-  response:
-    body: '{"data":{"repo0":{"id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","databaseId":41288708,"nameWithOwner":"sourcegraph/sourcegraph","description":"Code
-      search and navigation tool (self-hosted)","url":"https://github.com/sourcegraph/sourcegraph","isPrivate":false,"isFork":false,"isArchived":false,"viewerPermission":"ADMIN"},"repo1":{"id":"MDEwOlJlcG9zaXRvcnk1ODk1ODk0Mg==","databaseId":58958942,"nameWithOwner":"keegancsmith/sqlf","description":"sqlf
-      generates parameterized SQL statements in Go, sprintf style","url":"https://github.com/keegancsmith/sqlf","isPrivate":false,"isFork":false,"isArchived":false,"viewerPermission":"ADMIN"},"repo2":{"id":"MDEwOlJlcG9zaXRvcnkxMjA4MDU1MQ==","databaseId":12080551,"nameWithOwner":"tsenart/vegeta","description":"HTTP
-      load testing tool and library. It''s over 9000!","url":"https://github.com/tsenart/vegeta","isPrivate":false,"isFork":false,"isArchived":false,"viewerPermission":"READ"}}}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - no-cache
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sat, 22 Jun 2019 05:36:03 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v4; format=json
-      X-Github-Request-Id:
-      - DF9E:11328:46A4216:58E18CD:5D0DBE43
-      X-Oauth-Scopes:
-      - repo
+      - 559E:42752:256CA9A:2BF9204:5E6A1E7F
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -78,8 +78,17 @@
         "type": "object",
         "title": "ExcludedGitHubRepo",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
+        "anyOf": [
+          { "required": ["name"] },
+          { "required": ["id"] },
+          { "required": ["pattern"] },
+          { "required": ["forks"] }
+        ],
         "properties": {
+          "forks": {
+            "description": "If set to true, forks will be excluded.",
+            "type": "boolean"
+          },
           "name": {
             "description": "The name of a GitHub repository (\"owner/name\") to exclude from mirroring.",
             "type": "string",
@@ -98,6 +107,7 @@
         }
       },
       "examples": [
+        [{ "forks": true }],
         [{ "name": "owner/name" }, { "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==" }],
         [{ "name": "vuejs/vue" }, { "name": "php/php-src" }, { "pattern": "^topsecretorg/.*" }]
       ]

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -83,8 +83,17 @@ const GitHubSchemaJSON = `{
         "type": "object",
         "title": "ExcludedGitHubRepo",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
+        "anyOf": [
+          { "required": ["name"] },
+          { "required": ["id"] },
+          { "required": ["pattern"] },
+          { "required": ["forks"] }
+        ],
         "properties": {
+          "forks": {
+            "description": "If set to true, forks will be excluded.",
+            "type": "boolean"
+          },
           "name": {
             "description": "The name of a GitHub repository (\"owner/name\") to exclude from mirroring.",
             "type": "string",
@@ -103,6 +112,7 @@ const GitHubSchemaJSON = `{
         }
       },
       "examples": [
+        [{ "forks": true }],
         [{ "name": "owner/name" }, { "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==" }],
         [{ "name": "vuejs/vue" }, { "name": "php/php-src" }, { "pattern": "^topsecretorg/.*" }]
       ]

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -341,6 +341,8 @@ type ExcludedBitbucketServerRepo struct {
 	Pattern string `json:"pattern,omitempty"`
 }
 type ExcludedGitHubRepo struct {
+	// Forks description: If set to true, forks will be excluded.
+	Forks bool `json:"forks,omitempty"`
 	// Id description: The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: "curl https://api.github.com/repos/vuejs/vue | jq .node_id"
 	Id string `json:"id,omitempty"`
 	// Name description: The name of a GitHub repository ("owner/name") to exclude from mirroring.


### PR DESCRIPTION
This commit is an alternative implementation of #8861 that re-uses our
existing `exclude` setting.