### PR TITLE
extsvc: Reuse rate limiters between clients for the same host

### DIFF
--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -3,7 +3,6 @@ package campaigns
 import (
 	"container/heap"
 	"context"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -20,7 +19,7 @@ type ChangesetSyncer struct {
 	Store       SyncStore
 	ReposStore  repos.Store
 	HTTPFactory *httpcli.Factory
-	sourceCache sourceCache
+
 	// ComputeScheduleInterval determines how often a new schedule will be computed.
 	// Note that it involves a DB query but no communication with codehosts
 	ComputeScheduleInterval time.Duration
@@ -356,7 +355,7 @@ func (s *ChangesetSyncer) GroupChangesetsBySource(ctx context.Context, cs ...*ca
 
 	bySource := make(map[int64]*SourceChangesets, len(es))
 	for _, e := range es {
-		src, err := s.sourceCache.Get(e, s.HTTPFactory)
+		src, err := repos.NewSource(e, s.HTTPFactory)
 		if err != nil {
 			return nil, err
 		}
@@ -532,33 +531,4 @@ const (
 type SourceChangesets struct {
 	repos.ChangesetSource
 	Changesets []*repos.Changeset
-}
-
-// sourceCache allows us to reuse sources and their associated
-// rate limiters rather than recreating them on every sync.
-type sourceCache struct {
-	mu    sync.Mutex
-	cache map[int64]repos.Source
-}
-
-func (sc sourceCache) Get(es *repos.ExternalService, cf *httpcli.Factory) (repos.Source, error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-
-	if sc.cache == nil {
-		sc.cache = make(map[int64]repos.Source)
-	}
-
-	s, ok := sc.cache[es.ID]
-	if ok {
-		return s, nil
-	}
-
-	s, err := repos.NewSource(es, cf)
-	if err != nil {
-		return nil, err
-	}
-
-	sc.cache[es.ID] = s
-	return s, nil
 }


### PR DESCRIPTION
This avoids creating a new source on every sync and more importantly makes
sure that we reuse the same rate limiter across syncs.

Part of https://github.com/sourcegraph/sourcegraph/issues/8546
