### PR TITLE
authz: create constants for Sourcegraph service type and ID

### DIFF
--- a/cmd/frontend/authz/consts.go
+++ b/cmd/frontend/authz/consts.go
@@ -1,0 +1,8 @@
+package authz
+
+// The service type and service ID for explicit repository permissions APIs
+// (aka Sourcegraph authz provider).
+const (
+	SourcegraphServiceType = "sourcegraph"
+	SourcegraphServiceID   = "https://sourcegraph.com/"
+)

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 )
@@ -65,8 +66,8 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	// This call is purely for the purpose of cleanup.
 	if err := db.Authz.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
 		UserID:         user.ID,
-		ServiceType:    "sourcegraph",
-		ServiceID:      "https://sourcegraph.com/",
+		ServiceType:    authz.SourcegraphServiceType,
+		ServiceID:      authz.SourcegraphServiceID,
 		Username:       user.Username,
 		VerifiedEmails: emailStrs,
 	}); err != nil {

--- a/enterprise/cmd/frontend/db/authz.go
+++ b/enterprise/cmd/frontend/db/authz.go
@@ -75,8 +75,8 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.Grant
 
 	for _, bindID := range bindIDs {
 		err = txs.GrantPendingPermissions(ctx, args.UserID, &authz.UserPendingPermissions{
-			ServiceType: "sourcegraph",
-			ServiceID:   "https://sourcegraph.com/",
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
 			BindID:      bindID,
 			Perm:        args.Perm,
 			Type:        args.Type,

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -75,24 +75,24 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice@example.com"},
 					},
 					repoID: 1,
 				},
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice2@example.com"},
 					},
 					repoID: 2,
 				},
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice3@example.com"},
 					},
 					repoID: 3,
@@ -113,16 +113,16 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
 					},
 					repoID: 1,
 				},
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob"},
 					},
 					repoID: 2,
@@ -285,8 +285,8 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	}
 
 	accounts := &extsvc.ExternalAccounts{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  []string{"alice", "alice@example.com"},
 	}
 	if err := s.store.SetRepoPendingPermissions(ctx, accounts, &authz.RepoPermissions{
@@ -299,8 +299,8 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	// Revoke all of them
 	if err := s.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
 		UserID:         1,
-		ServiceType:    "sourcegraph",
-		ServiceID:      "https://sourcegraph.com/",
+		ServiceType:    authz.SourcegraphServiceType,
+		ServiceID:      authz.SourcegraphServiceID,
 		Username:       "alice",
 		VerifiedEmails: []string{"alice@example.com"},
 	}); err != nil {

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -548,8 +548,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			defer cleanupPermsTables(t, s)
 
 			accounts := &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
 			}
 			rp := &authz.RepoPermissions{
@@ -561,8 +561,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			}
 
 			alice := &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "alice",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,
@@ -579,8 +579,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			defer cleanupPermsTables(t, s)
 
 			accounts := &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
 			}
 			rp := &authz.RepoPermissions{
@@ -610,8 +610,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			defer cleanupPermsTables(t, s)
 
 			accounts := &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
 			}
 			rp := &authz.RepoPermissions{
@@ -623,8 +623,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			}
 
 			alice := &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "alice",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,
@@ -641,8 +641,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			defer cleanupPermsTables(t, s)
 
 			accounts := &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice", "bob"},
 			}
 			rp := &authz.RepoPermissions{
@@ -663,8 +663,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			}
 
 			alice := &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "alice",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,
@@ -675,8 +675,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			equal(t, "IDs", 0, len(bitmapToArray(alice.IDs)))
 
 			bob := &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "bob",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,
@@ -688,8 +688,8 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 			equal(t, "UpdatedAt", now, bob.UpdatedAt.UnixNano())
 
 			cindy := &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "cindy",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,
@@ -817,18 +817,18 @@ func checkRepoPendingPermsTable(
 
 func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 	alice := extsvc.ExternalAccountSpec{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
 	bob := extsvc.ExternalAccountSpec{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
 	}
 	cindy := extsvc.ExternalAccountSpec{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "cindy",
 	}
 	cindyGitHub := extsvc.ExternalAccountSpec{
@@ -852,8 +852,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  nil,
 					},
 					perm: &authz.RepoPermissions{
@@ -868,8 +868,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
 					},
 					perm: &authz.RepoPermissions{
@@ -878,8 +878,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				}, {
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob"},
 					},
 					perm: &authz.RepoPermissions{
@@ -914,8 +914,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob"},
 					},
 					perm: &authz.RepoPermissions{
@@ -924,8 +924,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				}, {
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob", "cindy"},
 					},
 					perm: &authz.RepoPermissions{
@@ -960,8 +960,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob", "cindy"},
 					},
 					perm: &authz.RepoPermissions{
@@ -970,8 +970,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				}, {
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{},
 					},
 					perm: &authz.RepoPermissions{
@@ -1057,8 +1057,8 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
 					},
 					perm: &authz.RepoPermissions{
@@ -1074,8 +1074,8 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 			updates: []update{
 				{
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob@example.com"},
 					},
 					perm: &authz.RepoPermissions{
@@ -1084,8 +1084,8 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 					},
 				}, {
 					accounts: &extsvc.ExternalAccounts{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  nil,
 					},
 					perm: &authz.RepoPermissions{
@@ -1136,7 +1136,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 					}
 				}
 
-				bindIDs, err := s.ListPendingUsers(ctx, "sourcegraph", "https://sourcegraph.com/")
+				bindIDs, err := s.ListPendingUsers(ctx, authz.SourcegraphServiceType, authz.SourcegraphServiceID)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1148,13 +1148,13 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 
 func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 	alice := extsvc.ExternalAccountSpec{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
 	bob := extsvc.ExternalAccountSpec{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
 	}
 
@@ -1185,8 +1185,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				{
 					userID: 1,
 					perm: &authz.UserPendingPermissions{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						BindID:      "alice",
 						Perm:        authz.Read,
 						Type:        authz.PermRepos,
@@ -1212,8 +1212,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					pendings: []pending{
 						{
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1222,8 +1222,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 							},
 						}, {
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"bob"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1238,8 +1238,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				{
 					userID: 1,
 					perm: &authz.UserPendingPermissions{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						BindID:      "cindy",
 						Perm:        authz.Read,
 						Type:        authz.PermRepos,
@@ -1281,8 +1281,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					pendings: []pending{
 						{
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1302,8 +1302,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 							},
 						}, {
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"bob"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1318,8 +1318,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				{
 					userID: 3,
 					perm: &authz.UserPendingPermissions{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						BindID:      "alice",
 						Perm:        authz.Read,
 						Type:        authz.PermRepos,
@@ -1371,8 +1371,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					pendings: []pending{
 						{
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice@example.com"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1381,8 +1381,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 							},
 						}, {
 							accounts: &extsvc.ExternalAccounts{
-								ServiceType: "sourcegraph",
-								ServiceID:   "https://sourcegraph.com/",
+								ServiceType: authz.SourcegraphServiceType,
+								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice2@example.com"},
 							},
 							perm: &authz.RepoPermissions{
@@ -1397,8 +1397,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				{
 					userID: 3,
 					perm: &authz.UserPendingPermissions{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						BindID:      "alice@example.com",
 						Perm:        authz.Read,
 						Type:        authz.PermRepos,
@@ -1406,8 +1406,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				}, {
 					userID: 3,
 					perm: &authz.UserPendingPermissions{
-						ServiceType: "sourcegraph",
-						ServiceID:   "https://sourcegraph.com/",
+						ServiceType: authz.SourcegraphServiceType,
+						ServiceID:   authz.SourcegraphServiceID,
 						BindID:      "alice2@example.com",
 						Perm:        authz.Read,
 						Type:        authz.PermRepos,
@@ -1544,8 +1544,8 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T)
 		ctx := context.Background()
 
 		accounts := &extsvc.ExternalAccounts{
-			ServiceType: "sourcegraph",
-			ServiceID:   "https://sourcegraph.com/",
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
 			AccountIDs:  []string{"alice", "bob"},
 		}
 
@@ -1565,8 +1565,8 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T)
 
 		// Check alice should not have any pending permissions now
 		err := s.LoadUserPendingPermissions(ctx, &authz.UserPendingPermissions{
-			ServiceType: "sourcegraph",
-			ServiceID:   "https://sourcegraph.com/",
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
 			BindID:      "alice",
 			Perm:        authz.Read,
 			Type:        authz.PermRepos,
@@ -1577,8 +1577,8 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T)
 
 		// Check bob shoud not be affected
 		p := &authz.UserPendingPermissions{
-			ServiceType: "sourcegraph",
-			ServiceID:   "https://sourcegraph.com/",
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
 			BindID:      "bob",
 			Perm:        authz.Read,
 			Type:        authz.PermRepos,
@@ -1618,8 +1618,8 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(*testing.T) {
 		}
 		setRepoPendingPermissions := func(ctx context.Context, t *testing.T) {
 			accounts := &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
 			}
 			if err := s.SetRepoPendingPermissions(ctx, accounts, &authz.RepoPermissions{
@@ -1631,8 +1631,8 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(*testing.T) {
 		}
 		grantPendingPermissions := func(ctx context.Context, t *testing.T) {
 			if err := s.GrantPendingPermissions(ctx, 1, &authz.UserPendingPermissions{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      "alice",
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -105,8 +105,8 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	defer txs.Done(&err)
 
 	accounts := &extsvc.ExternalAccounts{
-		ServiceType: "sourcegraph",
-		ServiceID:   "https://sourcegraph.com/",
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  pendingBindIDs,
 	}
 
@@ -155,8 +155,8 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 		ids = p.IDs
 	} else {
 		p := &authz.UserPendingPermissions{
-			ServiceType: "sourcegraph",
-			ServiceID:   "https://sourcegraph.com/",
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
 			BindID:      bindID,
 			Perm:        authz.Read, // Note: We currently only support read for repository permissions.
 			Type:        authz.PermRepos,
@@ -185,7 +185,7 @@ func (r *Resolver) UsersWithPendingPermissions(ctx context.Context) ([]string, e
 		return nil, err
 	}
 
-	return r.store.ListPendingUsers(ctx, "sourcegraph", "https://sourcegraph.com/")
+	return r.store.ListPendingUsers(ctx, authz.SourcegraphServiceType, authz.SourcegraphServiceID)
 }
 
 func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.RepoAuthorizedUserArgs) (graphqlbackend.UserConnectionResolver, error) {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -104,8 +104,8 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 			},
 			expUserIDs: []uint32{1},
 			expAccounts: &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
 			},
 		},
@@ -143,8 +143,8 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 			},
 			expUserIDs: []uint32{1},
 			expAccounts: &extsvc.ExternalAccounts{
-				ServiceType: "sourcegraph",
-				ServiceID:   "https://sourcegraph.com/",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
 			},
 		},


### PR DESCRIPTION
This PR creates two constants for Sourcegraph authz provider (explicit permissions APIs) and replace all occurrences with these constants.