### PR TITLE
Revert "Respect smartSearchField feature flag on TreePage (#8888)"

### DIFF
--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -15,7 +15,7 @@ import { ErrorLike, isErrorLike, asError } from '../../../shared/src/util/errors
 import { makeRepoURI } from '../../../shared/src/util/url'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
-import { searchQueryForRepoRev, PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '../search'
+import { searchQueryForRepoRev, PatternTypeProps, CaseSensitivityProps } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
 import { EventLoggerProps } from '../tracking/eventLogger'
 import { RouteDescriptor } from '../util/contributions'
@@ -42,8 +42,7 @@ export interface RepoContainerContext
         EventLoggerProps,
         ActivationProps,
         PatternTypeProps,
-        CaseSensitivityProps,
-        SmartSearchFieldProps {
+        CaseSensitivityProps {
     repo: GQL.IRepository
     authenticatedUser: GQL.IUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
@@ -72,8 +71,7 @@ interface RepoContainerProps
         ActivationProps,
         ThemeProps,
         PatternTypeProps,
-        CaseSensitivityProps,
-        SmartSearchFieldProps {
+        CaseSensitivityProps {
     repoContainerRoutes: readonly RepoContainerRoute[]
     repoRevContainerRoutes: readonly RepoRevContainerRoute[]
     repoHeaderActionButtons: readonly RepoHeaderActionButton[]
@@ -255,7 +253,6 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
             setCaseSensitivity: this.props.setCaseSensitivity,
             repoSettingsAreaRoutes: this.props.repoSettingsAreaRoutes,
             repoSettingsSidebarItems: this.props.repoSettingsSidebarItems,
-            smartSearchField: this.props.smartSearchField,
         }
 
         return (

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -28,7 +28,7 @@ import { RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { EmptyRepositoryPage, RepositoryCloningInProgressPage } from './RepositoryGitDataContainer'
 import { RevisionsPopover } from './RevisionsPopover'
-import { PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '../search'
+import { PatternTypeProps, CaseSensitivityProps } from '../search'
 import { RepoSettingsAreaRoute } from './settings/RepoSettingsArea'
 import { RepoSettingsSideBarItem } from './settings/RepoSettingsSidebar'
 
@@ -46,8 +46,7 @@ export interface RepoRevContainerContext
             Exclude<keyof RepoContainerContext, 'onDidUpdateRepository' | 'onDidUpdateExternalLinks'>
         >,
         PatternTypeProps,
-        CaseSensitivityProps,
-        SmartSearchFieldProps {
+        CaseSensitivityProps {
     repo: GQL.IRepository
     rev: string
     resolvedRev: ResolvedRev
@@ -69,8 +68,7 @@ interface RepoRevContainerProps
         ThemeProps,
         ActivationProps,
         PatternTypeProps,
-        CaseSensitivityProps,
-        SmartSearchFieldProps {
+        CaseSensitivityProps {
     routes: readonly RepoRevContainerRoute[]
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarItems: readonly RepoSettingsSideBarItem[]
@@ -229,7 +227,6 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
             setCaseSensitivity: this.props.setCaseSensitivity,
             repoSettingsAreaRoutes: this.props.repoSettingsAreaRoutes,
             repoSettingsSidebarItems: this.props.repoSettingsSidebarItems,
-            smartSearchField: this.props.smartSearchField,
         }
 
         return (

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -30,7 +30,7 @@ import { Form } from '../components/Form'
 import { PageTitle } from '../components/PageTitle'
 import { isDiscussionsEnabled } from '../discussions'
 import { DiscussionsList } from '../discussions/DiscussionsList'
-import { searchQueryForRepoRev, PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps } from '../search'
+import { searchQueryForRepoRev, PatternTypeProps, CaseSensitivityProps } from '../search'
 import { submitSearch, QueryState } from '../search/helpers'
 import { QueryInput } from '../search/input/QueryInput'
 import { SearchButton } from '../search/input/SearchButton'
@@ -43,7 +43,6 @@ import { ThemeProps } from '../../../shared/src/theme'
 import { ErrorAlert } from '../components/alerts'
 import { subYears, formatISO } from 'date-fns'
 import { pluralize } from '../../../shared/src/util/strings'
-import { LazyMonacoQueryInput } from '../search/input/LazyMonacoQueryInput'
 
 const TreeEntry: React.FunctionComponent<{
     isDir: boolean
@@ -140,8 +139,7 @@ interface Props
         EventLoggerProps,
         ActivationProps,
         PatternTypeProps,
-        CaseSensitivityProps,
-        SmartSearchFieldProps {
+        CaseSensitivityProps {
     repoName: string
     repoID: GQL.ID
     repoDescription: string
@@ -326,27 +324,15 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 <h3 className="tree-page__section-header">
                                     Search in this {this.props.filePath ? 'tree' : 'repository'}
                                 </h3>
-                                <Form className="tree-page__section-search" onSubmit={this.onFormSubmit}>
-                                    {this.props.smartSearchField ? (
-                                        <LazyMonacoQueryInput
-                                            {...this.props}
-                                            queryState={this.state.queryState}
-                                            onSubmit={this.onSubmit}
-                                            onChange={this.onQueryChange}
-                                            autoFocus={true}
-                                            prependQueryForSuggestions={this.getQueryPrefix()}
-                                        />
-                                    ) : (
-                                        <QueryInput
-                                            {...this.props}
-                                            value={this.state.queryState}
-                                            onChange={this.onQueryChange}
-                                            prependQueryForSuggestions={this.getQueryPrefix()}
-                                            autoFocus={true}
-                                            placeholder=""
-                                        />
-                                    )}
-
+                                <Form className="tree-page__section-search" onSubmit={this.onSubmit}>
+                                    <QueryInput
+                                        {...this.props}
+                                        value={this.state.queryState}
+                                        onChange={this.onQueryChange}
+                                        prependQueryForSuggestions={this.getQueryPrefix()}
+                                        autoFocus={true}
+                                        placeholder=""
+                                    />
                                     <SearchButton />
                                 </Form>
                             </section>
@@ -422,12 +408,8 @@ export class TreePage extends React.PureComponent<Props, State> {
 
     private onQueryChange = (queryState: QueryState): void => this.setState({ queryState })
 
-    private onFormSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        this.onSubmit()
-    }
-
-    private onSubmit = (): void => {
         submitSearch(
             this.props.history,
             this.getQueryPrefix() + this.state.queryState.query,

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -12,7 +12,7 @@ import { Omit } from 'utility-types'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { CaseSensitivityProps, PatternTypeProps } from '..'
 import { Toggles, TogglesProps } from './toggles/Toggles'
-import { SearchPatternType, SearchSuggestion } from '../../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 
 export interface MonacoQueryInputProps
     extends Omit<TogglesProps, 'navbarSearchQuery'>,
@@ -25,12 +25,6 @@ export interface MonacoQueryInputProps
     onChange: (newState: QueryState) => void
     onSubmit: () => void
     autoFocus?: boolean
-
-    /**
-     * A string that is appended to the query input's query before
-     * fetching suggestions.
-     */
-    prependQueryForSuggestions?: string
 }
 
 const SOURCEGRAPH_SEARCH: 'sourcegraphSearch' = 'sourcegraphSearch'
@@ -53,8 +47,7 @@ function addSouregraphSearchCodeIntelligence(
     monaco: typeof Monaco,
     searchQueries: Observable<string>,
     patternTypes: Observable<SearchPatternType>,
-    themeChanges: Observable<Theme>,
-    fetchSuggestions: (query: string) => Observable<SearchSuggestion>
+    themeChanges: Observable<Theme>
 ): Subscription {
     const subscriptions = new Subscription()
 
@@ -243,19 +236,10 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
         this.props.onSubmit()
     }
 
-    private fetchSuggestions = (query: string): Observable<SearchSuggestion> =>
-        fetchSuggestions(`${this.props.prependQueryForSuggestions ?? ''} ${query}`)
-
     private editorWillMount = (monaco: typeof Monaco): void => {
         // Register themes and code intelligence providers.
         this.subscriptions.add(
-            addSouregraphSearchCodeIntelligence(
-                monaco,
-                this.searchQueries,
-                this.patternTypes,
-                this.themeChanges,
-                this.fetchSuggestions
-            )
+            addSouregraphSearchCodeIntelligence(monaco, this.searchQueries, this.patternTypes, this.themeChanges)
         )
     }
 


### PR DESCRIPTION
This reverts commit cf5c5f67e5a8568397f8e10f776b9c3bb2a4084b.

Fixes #8922

The way providers are registered (https://sourcegraph.com/github.com/sourcegraph/sourcegraph@5e592f2a70992a3226662df63fc573f7ffc60c24/-/blob/web/src/search/input/MonacoQueryInput.tsx#L47-134) needs to be changed if we have more than one search field on the page, otherwise duplicate providers are registered, leading to undefined behaviours (exceptions when getting completions, incorrect tokens returned. duh).

Reverting the problematic commit while working on the right fix.