### PR TITLE
Don't detach merged/closed changesets on update

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -1011,6 +1011,14 @@ func computeCampaignUpdateDiff(
 		// Either we _don't_ have a matching _new_ Patch, then we delete
 		// the ChangesetJob and detach & close Changeset.
 		if group.newPatch == nil {
+			// But if we have already created a changeset for this repo and its
+			// merged or closed, we keep it.
+			if group.changeset != nil {
+				s := group.changeset.ExternalState
+				if s == campaigns.ChangesetStateMerged || s == campaigns.ChangesetStateClosed {
+					continue
+				}
+			}
 			diff.Delete = append(diff.Delete, group.changesetJob)
 			continue
 		}

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -682,6 +682,28 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 			},
 			wantErr: ErrClosedCampaignUpdatePatchIllegal,
 		},
+		{
+			name:            "1 unmodified merged, 1 new changeset",
+			updatePatchSet:  true,
+			oldPatches:      repoNames{"repo-0"},
+			changesetStates: map[string]campaigns.ChangesetState{"repo-0": campaigns.ChangesetStateMerged},
+			newPatches: []newPatchSpec{
+				{repo: "repo-1"},
+			},
+			wantUnmodified: repoNames{"repo-0"},
+			wantCreated:    repoNames{"repo-1"},
+		},
+		{
+			name:            "1 unmodified closed, 1 new changeset",
+			updatePatchSet:  true,
+			oldPatches:      repoNames{"repo-0"},
+			changesetStates: map[string]campaigns.ChangesetState{"repo-0": campaigns.ChangesetStateClosed},
+			newPatches: []newPatchSpec{
+				{repo: "repo-1"},
+			},
+			wantUnmodified: repoNames{"repo-0"},
+			wantCreated:    repoNames{"repo-1"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -869,7 +891,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 				if len(tt.individuallyPublished) != 0 {
 					wantChangesetJobLen = len(tt.individuallyPublished)
 				} else {
-					wantChangesetJobLen = len(newPatches)
+					wantChangesetJobLen = len(tt.wantCreated) + len(tt.wantUnmodified) + len(tt.wantModified)
 				}
 			} else {
 				wantChangesetJobLen = len(oldPatches)

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1600,8 +1600,9 @@ NOT EXISTS (
   FROM
     changeset_jobs
   JOIN patches ON patches.id = changeset_jobs.patch_id
+  JOIN changesets ON changesets.id = changeset_jobs.changeset_id
   WHERE
-    changeset_jobs.changeset_id IS NOT NULL
+    (SELECT COUNT(*) FROM jsonb_object_keys(changesets.campaign_ids)) > 0
 );
 `
 

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1590,10 +1590,19 @@ AND
 NOT EXISTS (
   SELECT 1
   FROM
-  campaigns
+    campaigns
   WHERE
-  campaigns.patch_set_id = patch_sets.id
-)
+    campaigns.patch_set_id = patch_sets.id
+  )
+AND
+NOT EXISTS (
+  SELECT 1
+  FROM
+    changeset_jobs
+  JOIN patches ON patches.id = changeset_jobs.patch_id
+  WHERE
+    changeset_jobs.changeset_id IS NOT NULL
+);
 `
 
 // CountPatchSets returns the number of code mods in the database.

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1831,12 +1831,15 @@ func testStore(db *sql.DB) func(*testing.T) {
 					wantDeleted: false,
 				},
 				{
-					hasCampaign:                    false,
+					hasCampaign: false,
+					createdAt:   now.Add(-500 * time.Minute),
+
 					patchesAttachedToOtherCampaign: true,
 					patches: []*cmpgn.Patch{
 						{Diff: "foobar", Rev: "f00b4r", BaseRef: "refs/heads/master"},
 						{Diff: "barfoo", Rev: "b4rf00", BaseRef: "refs/heads/master"},
 					},
+
 					wantDeleted: false,
 				},
 			}
@@ -1847,6 +1850,14 @@ func testStore(db *sql.DB) func(*testing.T) {
 				err := s.CreatePatchSet(ctx, patchSet)
 				if err != nil {
 					t.Fatal(err)
+				}
+
+				for _, p := range tc.patches {
+					p.PatchSetID = patchSet.ID
+					err := s.CreatePatch(ctx, p)
+					if err != nil {
+						t.Fatal(err)
+					}
 				}
 
 				if tc.hasCampaign {

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1803,9 +1803,12 @@ func testStore(db *sql.DB) func(*testing.T) {
 
 		t.Run("PatchSet DeleteExpired", func(t *testing.T) {
 			tests := []struct {
-				hasCampaign bool
-				createdAt   time.Time
-				wantDeleted bool
+				createdAt                      time.Time
+				hasCampaign                    bool
+				patchesAttachedToOtherCampaign bool
+				patches                        []*cmpgn.Patch
+				wantDeleted                    bool
+				want                           *cmpgn.BackgroundProcessStatus
 			}{
 				{
 					hasCampaign: false,
@@ -1827,6 +1830,15 @@ func testStore(db *sql.DB) func(*testing.T) {
 					createdAt:   now.Add(-500 * time.Minute),
 					wantDeleted: false,
 				},
+				{
+					hasCampaign:                    false,
+					patchesAttachedToOtherCampaign: true,
+					patches: []*cmpgn.Patch{
+						{Diff: "foobar", Rev: "f00b4r", BaseRef: "refs/heads/master"},
+						{Diff: "barfoo", Rev: "b4rf00", BaseRef: "refs/heads/master"},
+					},
+					wantDeleted: false,
+				},
 			}
 
 			for _, tc := range tests {
@@ -1838,17 +1850,69 @@ func testStore(db *sql.DB) func(*testing.T) {
 				}
 
 				if tc.hasCampaign {
-					c := &cmpgn.Campaign{
-						Name:            "test",
-						Description:     "testing",
+					err = s.CreateCampaign(ctx, &cmpgn.Campaign{
 						PatchSetID:      patchSet.ID,
+						Name:            "Test",
 						AuthorID:        4567,
+						NamespaceUserID: 4567,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				if tc.patchesAttachedToOtherCampaign {
+					otherPatchSet := &cmpgn.PatchSet{}
+					err = s.CreatePatchSet(ctx, otherPatchSet)
+					if err != nil {
+						t.Fatal(err)
+					}
+					otherCampaign := &cmpgn.Campaign{
+						PatchSetID:      otherPatchSet.ID,
+						AuthorID:        4567,
+						Name:            "Other campaign",
 						NamespaceUserID: 4567,
 					}
 
-					err := s.CreateCampaign(ctx, c)
+					err = s.CreateCampaign(ctx, otherCampaign)
 					if err != nil {
 						t.Fatal(err)
+					}
+
+					for i, p := range tc.patches {
+						changeset := &cmpgn.Changeset{
+							RepoID:              api.RepoID(99 + i),
+							CreatedAt:           now,
+							UpdatedAt:           now,
+							Metadata:            &github.PullRequest{},
+							CampaignIDs:         []int64{otherCampaign.ID},
+							ExternalID:          fmt.Sprintf("foobar-%d", i),
+							ExternalServiceType: "github",
+							ExternalBranch:      "campaigns/test",
+							ExternalUpdatedAt:   now,
+							ExternalState:       cmpgn.ChangesetStateOpen,
+							ExternalReviewState: cmpgn.ChangesetReviewStateApproved,
+							ExternalCheckState:  cmpgn.ChangesetCheckStatePassed,
+						}
+						err = s.CreateChangesets(ctx, changeset)
+						if err != nil {
+							t.Fatal(err)
+						}
+						job := &cmpgn.ChangesetJob{
+							CampaignID:  otherCampaign.ID,
+							PatchID:     p.ID,
+							ChangesetID: changeset.ID,
+						}
+						err = s.CreateChangesetJob(ctx, job)
+						if err != nil {
+							t.Fatal(err)
+						}
+						defer func() {
+							err = s.DeleteChangesetJob(ctx, job.ID)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}()
 					}
 				}
 


### PR DESCRIPTION
This closes #8981 by doing two things:

When we previously updated a Campaign that had a patch set with patches for repositories A, B, C to use a patch set with patches for repositories A, B and D, we would remove the patch for repository C and if a changeset was already created on the code host, we would close it and detach it from the campaign.

Now we check whether the changeset we're about to close & detach has already been merged or closed (signifying a success!) and if so, we don't detach it, but keep it around.

That means you can keep re-running an `src action exec` command with the same action definition while the changesets in the campaign are being merged or closed. If a repository doesn't produce a patch anymore (because the requested changes have been accepted!) you can still update your campaign with the new patch set without the merged changeset being lost.

The other thing this PR does is to change our "clean up of old patch sets"-behavior. Previously we deleted old PatchSets that weren't attached to a Campaign. Now we  delete PatchSets that are either (a) not attached to a campaign and (b) don't have patches that are associated with ChangesetJobs/Changests that are associated with another campaign.

We had to add the second condition, (b), because if we keep closed/merged changesets around a Campaign can now contain changesets that originate from different PatchSets.