### PR TITLE
campaigns: Changeset resolver now uses derived fields 

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -235,9 +235,9 @@ type ExternalChangesetResolver interface {
 	UpdatedAt() DateTime
 	Title() (string, error)
 	Body() (string, error)
-	State() (campaigns.ChangesetState, error)
+	State() campaigns.ChangesetState
 	ExternalURL() (*externallink.Resolver, error)
-	ReviewState(context.Context) (campaigns.ChangesetReviewState, error)
+	ReviewState(context.Context) campaigns.ChangesetReviewState
 	CheckState(context.Context) (*campaigns.ChangesetCheckState, error)
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 	Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error)

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -488,7 +488,7 @@ func (c *Changeset) Events() (events []*ChangesetEvent) {
 			events = append(events, &ChangesetEvent{
 				ChangesetID: c.ID,
 				Key:         a.Key(),
-				Kind:        ChangesetEventKindFor(&a),
+				Kind:        ChangesetEventKindFor(a),
 				Metadata:    a,
 			})
 		}

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -193,7 +193,7 @@ func TestChangesetEvents(t *testing.T) {
 		user := bitbucketserver.User{Name: "john-doe"}
 		reviewer := bitbucketserver.User{Name: "jane-doe"}
 
-		activities := []bitbucketserver.Activity{{
+		activities := []*bitbucketserver.Activity{{
 			ID:     1,
 			User:   user,
 			Action: bitbucketserver.OpenedActivityAction,

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -552,9 +552,9 @@ func (c *Client) LoadPullRequestActivities(ctx context.Context, pr *PullRequest)
 
 	t := &PageToken{Limit: 1000}
 
-	var activities []Activity
+	var activities []*Activity
 	for t.HasMore() {
-		var page []Activity
+		var page []*Activity
 		if t, err = c.page(ctx, path, nil, t, &page); err != nil {
 			return err
 		}
@@ -583,9 +583,9 @@ func (c *Client) LoadPullRequestCommits(ctx context.Context, pr *PullRequest) (e
 
 	t := &PageToken{Limit: 1000}
 
-	var commits []Commit
+	var commits []*Commit
 	for t.HasMore() {
-		var page []Commit
+		var page []*Commit
 		if t, err = c.page(ctx, path, nil, t, &page); err != nil {
 			return err
 		}
@@ -604,7 +604,7 @@ func (c *Client) LoadPullRequestBuildStatuses(ctx context.Context, pr *PullReque
 	var latestCommit Commit
 	for _, c := range pr.Commits {
 		if latestCommit.CommitterTimestamp < c.CommitterTimestamp {
-			latestCommit = c
+			latestCommit = *c
 		}
 	}
 
@@ -612,9 +612,9 @@ func (c *Client) LoadPullRequestBuildStatuses(ctx context.Context, pr *PullReque
 
 	t := &PageToken{Limit: 1000}
 
-	var statuses []BuildStatus
+	var statuses []*BuildStatus
 	for t.HasMore() {
-		var page []BuildStatus
+		var page []*BuildStatus
 		if t, err = c.page(ctx, path, nil, t, &page); err != nil {
 			return err
 		}
@@ -1056,9 +1056,9 @@ type PullRequest struct {
 		} `json:"self"`
 	} `json:"links"`
 
-	Activities    []Activity    `json:"activities,omitempty"`
-	Commits       []Commit      `json:"commits,omitempty"`
-	BuildStatuses []BuildStatus `json:"buildstatuses,omitempty"`
+	Activities    []*Activity    `json:"activities,omitempty"`
+	Commits       []*Commit      `json:"commits,omitempty"`
+	BuildStatuses []*BuildStatus `json:"buildstatuses,omitempty"`
 }
 
 // Activity is a union type of all supported pull request activity items.


### PR DESCRIPTION
Also, see first commit for interesting bug.