### PR TITLE
Add missing repo checks for incoming webhooks

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1011,6 +1011,7 @@ type Project struct {
 type Ref struct {
 	ID         string `json:"id"`
 	Repository struct {
+		ID      int64  `json:"id"`
 		Slug    string `json:"slug"`
 		Project struct {
 			Key string `json:"key"`


### PR DESCRIPTION
The first commit contains the pieces that I think are required in order to fix this bug. 

The second commit is my initial attempt to implement the actual fix, I was stuck though when I realized that in the `repo` table the externalservice is not referenced by it's id :( I wanted to use the tuple `[externalRepoID, externalServiceID, webhookKind]` in order to fetch the correct repository to use when attaching the event.
Imo the best fix for this would be to have unique URLs for the webhooks that are directly associated to an external service and hence the repo fetching is simple. But my attempt is trying to work around that by making an assumption that a secret is always used just _once_ across all external services 🤔 feel free to revert commit 2 if that is confusing to you