### PR TITLE
campaigns: Sort changeset labels by name

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
@@ -243,6 +244,9 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 	// have come in via webhooks
 	events := campaigns.ChangesetEvents(es)
 	labels := events.UpdateLabelsSince(r.Changeset)
+	sort.Slice(labels, func(i, j int) bool {
+		return labels[i].Name < labels[j].Name
+	})
 	resolvers := make([]graphqlbackend.ChangesetLabelResolver, 0, len(labels))
 	for _, l := range labels {
 		resolvers = append(resolvers, &changesetLabelResolver{label: l})


### PR DESCRIPTION
I have no idea if this is the "right" way to do it but I felt it made more sense to do it in the presentation layer than in the backend.

Closes: https://github.com/sourcegraph/sourcegraph/issues/8987