### PR TITLE
repo-updater: exclude archived setting for GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Site-Admin/Instrumentation is now available in the Kubernetes cluster deployment [8805](https://github.com/sourcegraph/sourcegraph/pull/8805).
 - Extensions can now specify a `baseUri` in the `DocumentFilter` when registering providers.
-- Admins can now exclude GitHub forks from the set of repositories being mirrored in Sourcegraph with the `"exclude": [{"forks": true}]` GitHub external service configuration. [#8974](https://github.com/sourcegraph/sourcegraph/pull/8974)
+- Admins can now exclude GitHub forks and/or archived repositories from the set of repositories being mirrored in Sourcegraph with the `"exclude": [{"forks": true}]` or `"exclude": [{"archived": true}]` GitHub external service configuration. [#8974](https://github.com/sourcegraph/sourcegraph/pull/8974)
 - Campaign changesets can be filtered by State, Review State and Check State [8848](https://github.com/sourcegraph/sourcegraph/pull/8848)
 
 ### Changed

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -82,9 +82,14 @@
           { "required": ["name"] },
           { "required": ["id"] },
           { "required": ["pattern"] },
-          { "required": ["forks"] }
+          { "required": ["forks"] },
+          { "required": ["archived"] }
         ],
         "properties": {
+          "archived": {
+            "description": "If set to true, archived repositories will be excluded.",
+            "type": "boolean"
+          },
           "forks": {
             "description": "If set to true, forks will be excluded.",
             "type": "boolean"

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -87,9 +87,14 @@ const GitHubSchemaJSON = `{
           { "required": ["name"] },
           { "required": ["id"] },
           { "required": ["pattern"] },
-          { "required": ["forks"] }
+          { "required": ["forks"] },
+          { "required": ["archived"] }
         ],
         "properties": {
+          "archived": {
+            "description": "If set to true, archived repositories will be excluded.",
+            "type": "boolean"
+          },
           "forks": {
             "description": "If set to true, forks will be excluded.",
             "type": "boolean"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -341,6 +341,8 @@ type ExcludedBitbucketServerRepo struct {
 	Pattern string `json:"pattern,omitempty"`
 }
 type ExcludedGitHubRepo struct {
+	// Archived description: If set to true, archived repositories will be excluded.
+	Archived bool `json:"archived,omitempty"`
 	// Forks description: If set to true, forks will be excluded.
 	Forks bool `json:"forks,omitempty"`
 	// Id description: The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: "curl https://api.github.com/repos/vuejs/vue | jq .node_id"


### PR DESCRIPTION
This follows on from our exclude fork work to allow excluding archived. This was
very recently requested by a customer, so would be nice to get out in 3.14.

I didn't add any end to end tests. It feels a bit overkill. Rather I think I
will look into making our exclude code more generic / unit testable in a future
commit.