### PR TITLE
src-expose: remove subcommand flagsets

### DIFF
--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -46,6 +46,7 @@ var indexHTML = template.Must(template.New("").Parse(`<html>
 </html>`))
 
 func serve(logger *log.Logger, ln net.Listener, reposRoot string) (*http.Server, error) {
+	logger.Printf("serving git repositories from %s", reposRoot)
 	configureRepos(logger, reposRoot)
 
 	// Start the HTTP server.


### PR DESCRIPTION
They are unused. Except in one case where there was both a globalAddr and a
serveAddr. It was confusing which one took priority, so instead we remove
both.