### PR TITLE
docs: two small doc fixes

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -65,7 +65,7 @@ export GRAFANA_SERVER_URL=http://localhost:3370
 
 # webpack-dev-server is a proxy running on port 3080 that (1) serves assets, waiting to respond
 # until they are (re)built and (2) otherwise proxies to nginx running on port 3081 (which proxies to
-# Sourcegraph running on port 3082). That is why Sourcegraph listens on 3081 despite the externalURL
+# Sourcegraph running on port 3082). That is why Sourcegraph listens on 3082 despite the externalURL
 # having port 3080.
 export SRC_HTTP_ADDR=":3082"
 export WEBPACK_DEV_SERVER=1

--- a/web/src/regression/README.md
+++ b/web/src/regression/README.md
@@ -64,7 +64,7 @@ export NO_CLEANUP=true
 
 - Start the Docker image `IMAGE=sourcegraph/server:VERSION ./dev/run-server-image.sh`
 
-- Then run `yarn jest src/regression/search.test.ts`
+- Then run `yarn mocha src/regression/search.test.ts`
 
 Tips:
 


### PR DESCRIPTION
- we switched from jest to mocha as test driver in regression tests
- we run two proxies in dev, and sourcegraph-frontend is behind the second one at 3082