### PR TITLE
search: match literal expressions when including forks

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	regexpsyntax "regexp/syntax"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,8 +16,6 @@ import (
 
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
-
-	regexpsyntax "regexp/syntax"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -258,6 +257,7 @@ func resolveRepoGroups(ctx context.Context) (map[string][]*types.Repo, error) {
 	return groups, nil
 }
 
+// Cf. golang/go/src/regexp/syntax/parse.go.
 const regexpFlags regexpsyntax.Flags = regexpsyntax.ClassNL | regexpsyntax.PerlX | regexpsyntax.UnicodeGroups
 
 // exactlyOneRepo returns whether exactly one repo: literal field is specified and

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -354,6 +354,11 @@ func Test_exactlyOneRepo(t *testing.T) {
 			want:        true,
 		},
 		{
+			repoFilters: []string{`^.*$`},
+			want:        false,
+		},
+
+		{
 			repoFilters: []string{`^github\.com/sourcegraph/zoekt`},
 			want:        false,
 		},


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/8993#discussion_r392212136. When including search results for a fork based on a pattern like `repo:^blah_blah$`, the `blah_blah` part should be a literal (i.e., not contain any regex operators).