### PR TITLE
search: add content: filter button to interactive mode

### DIFF
--- a/web/src/search/input/interactive/AddFilterRow.tsx
+++ b/web/src/search/input/interactive/AddFilterRow.tsx
@@ -15,7 +15,7 @@ interface RowProps {
 }
 
 // Filters that are shown as buttons, and not in the dropdown menu.
-export const defaultFilterTypes = [FilterType.repo, FilterType.file]
+export const defaultFilterTypes = [FilterType.repo, FilterType.file, FilterType.content]
 
 /**
  * The row containing the buttons to add new filters in interactive mode.


### PR DESCRIPTION
Adds a content filter. See this PR more as a proposal (though I think it makes sense to merge). What do we think @attfarhan, @christinaforney? We know users have used the content option from the dropdown, and I feel this should be more discoverable.

<img width="971" alt="Screen Shot 2020-03-13 at 12 38 09 PM" src="https://user-images.githubusercontent.com/888624/76654174-9f5ca400-6527-11ea-8a3e-45f8cee91554.png">

As a follow up (and maybe I'm getting a little ahead of myself): the top search bar is basically redundant once all parts of the query can be specified with buttons/filters. One thing that could make sense down the line is to completely remove the view of the search bar and make the query only editable with the dedicated buttons/fields _but_ then to include a toggle that converts this query to the raw mode when it's clicked (and back to the field/button editing mode when toggled again). I realize that the right hand side toggle _already does this_ to some extent, which is great. And that's why I'd be in favor of removing the raw input search bar completely when in interactive mode. It would also be much more convenient for it to just be a toggle, rather than a dropdown (the advanced search doesn't offer much additionally, and worse, it doesn't preserve my query, I feel this option on the dropdown can go away).
