### PR TITLE
Fix storing of events after creating a campaign

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -433,7 +433,10 @@ func RunChangesetJob(
 			return err
 		}
 	}
-
+	// the events don't have the changesetID yet, because it's not known at the point of cloning
+	for _, e := range events {
+		e.ChangesetID = clone.ID
+	}
 	if err := store.UpsertChangesetEvents(ctx, events...); err != nil {
 		log15.Error("UpsertChangesetEvents", "err", err)
 		return err


### PR DESCRIPTION
Currently, this failed, creating new PRs until githubs limit of 100 open prs per head-sha errors the creation

```
errors:
13:37:17           gitserver | INFO command ran successfully, prefix: 10 github.com/sourcegraph/automation-testing , command: git update-ref -- refs/heads/test-gh-reuse-9 db905d0c2de0bddd46b8c8d2c8eef5c711720b15, duration: 7.486024ms, output: 
13:37:19            frontend | ERROR UpsertChangesetEvents, err: pq: insert or update on table "changeset_events" violates foreign key constraint "changeset_events_changeset_id_fkey"
13:37:19            frontend | ERROR RunChangesetJob, jobID: 140, err: <nil>
```

![image](https://user-images.githubusercontent.com/19534377/76684529-f0929380-660c-11ea-9592-73b255e37372.png)