### PR TITLE
search: check results are non-nil before logging latency

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -560,8 +560,9 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	}
 
 	rr, err := r.resultsWithTimeoutSuggestion(ctx)
-
-	r.logSearchLatency(ctx, rr.ElapsedMilliseconds())
+	if rr != nil {
+		r.logSearchLatency(ctx, rr.ElapsedMilliseconds())
+	}
 
 	// Record what type of response we sent back via Prometheus.
 	var status, alertType string


### PR DESCRIPTION
It's possible `rr` results is nil here, and will cause a panic if we try to log. I reproduced a panic locally with a malformed query. Since writing a test for this is hard and the change is important but not invasive, let's merge this now and I'll add an e2e test after.