### PR TITLE
Use correct changeset state for diff property

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -270,14 +270,9 @@ func (r *changesetResolver) Events(ctx context.Context, args *struct {
 }
 
 func (r *changesetResolver) Diff(ctx context.Context) (*graphqlbackend.RepositoryComparisonResolver, error) {
-	s, err := r.Changeset.State()
-	if err != nil {
-		return nil, err
-	}
-
 	// Only return diffs for open changesets, otherwise we can't guarantee that
 	// we have the refs on gitserver
-	if s != campaigns.ChangesetStateOpen {
+	if r.ExternalState != campaigns.ChangesetStateOpen {
 		return nil, nil
 	}
 

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -626,12 +626,7 @@ func (s *Service) DeleteCampaign(ctx context.Context, id int64, closeChangesets 
 // CloseOpenChangesets closes the given Changesets on their respective codehosts and syncs them.
 func (s *Service) CloseOpenChangesets(ctx context.Context, cs []*campaigns.Changeset) (err error) {
 	cs = selectChangesets(cs, func(c *campaigns.Changeset) bool {
-		s, err := c.State()
-		if err != nil {
-			log15.Warn("could not determine changeset state", "err", err)
-			return false
-		}
-		return s == campaigns.ChangesetStateOpen
+		return c.ExternalState == campaigns.ChangesetStateOpen
 	})
 
 	if len(cs) == 0 {
@@ -1031,12 +1026,7 @@ func computeCampaignUpdateDiff(
 			// .. but if we already have a Changeset and that is merged, we
 			// don't want to update it...
 			if group.changeset != nil {
-				// TODO: This needs to change based on the outcome of this:
-				// https://github.com/sourcegraph/sourcegraph/pull/8848#discussion_r389000197
-				s, err := group.changeset.State()
-				if err != nil {
-					return nil, errors.Wrap(err, "determining a changeset's state")
-				}
+				s := group.changeset.ExternalState
 				if s == campaigns.ChangesetStateMerged || s == campaigns.ChangesetStateClosed {
 					// Note: in the future we want to create a new ChangesetJob here.
 					continue

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -1096,6 +1096,7 @@ func testChangeset(repoID api.RepoID, campaign int64, changesetJob int64, state 
 		ExternalServiceType: "github",
 		ExternalID:          fmt.Sprintf("ext-id-%d", changesetJob),
 		Metadata:            pr,
+		ExternalState:       state,
 	}
 }
 

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -415,7 +415,8 @@ func (c *Changeset) IsDeleted() bool {
 	return !c.ExternalDeletedAt.IsZero()
 }
 
-// State of a Changeset.
+// State of a Changeset based on the metadata.
+// It does NOT reflect the final calculated state, use `ExternalState` therefore.
 func (c *Changeset) State() (s ChangesetState, err error) {
 	if !c.ExternalDeletedAt.IsZero() {
 		return ChangesetStateDeleted, nil

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -415,9 +415,9 @@ func (c *Changeset) IsDeleted() bool {
 	return !c.ExternalDeletedAt.IsZero()
 }
 
-// State of a Changeset based on the metadata.
-// It does NOT reflect the final calculated state, use `ExternalState` therefore.
-func (c *Changeset) State() (s ChangesetState, err error) {
+// state of a Changeset based on the metadata.
+// It does NOT reflect the final calculated state, use `ExternalState` instead.
+func (c *Changeset) state() (s ChangesetState, err error) {
 	if !c.ExternalDeletedAt.IsZero() {
 		return ChangesetStateDeleted, nil
 	}
@@ -718,11 +718,11 @@ func ComputeCheckState(c *Changeset, events ChangesetEvents) ChangesetCheckState
 // associated events. The events should be presorted.
 func ComputeChangesetState(c *Changeset, events ChangesetEvents) (ChangesetState, error) {
 	if len(events) == 0 {
-		return c.State()
+		return c.state()
 	}
 	newestEvent := events[len(events)-1]
 	if c.UpdatedAt.After(newestEvent.Timestamp()) {
-		return c.State()
+		return c.state()
 	}
 	return events.State(), nil
 }

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -62,7 +62,7 @@ func TestChangesetMetadata(t *testing.T) {
 		t.Errorf("changeset body wrong. want=%q, have=%q", want, have)
 	}
 
-	state, err := changeset.State()
+	state, err := changeset.state()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
After reopening a PR, it had no diff anymore (here)[https://k8s.sgdev.org/campaigns/Q2FtcGFpZ246MTY=]
![image](https://user-images.githubusercontent.com/19534377/76692583-d8486600-6658-11ea-8a23-8e3e5b29beb9.png)

A changesets `diff` is meant to be `null` in the API, whenever a changeset is _NOT_ open. We previously checked only the metadata of the changeset, not the events also, which lead to inconsistent `null` behavior, when a webhook changed the state. I also added a docstring so such bugs are less likely to happen again.