### PR TITLE
search: search indexed if @commit is at HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Archived repositories are excluded from search by default. Adding `archived:yes` includes archived repositories.
 - Forked repositories are excluded from search by default. Adding `fork:yes` includes forked repositories.
 - CSRF and session cookies now set `SameSite=None` when Sourcegraph is running behind HTTPS and `SameSite=Lax` when Sourcegraph is running behind HTTP in order to comply with a [recent IETF proposal](https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure). As a side effect, the Sourcegraph browser extension and GitLab/Bitbucket native integrations can only connect to private instances that have HTTPS configured. If your private instance is only running behind HTTP, please configure your instance to use HTTPS in order to continue using these.
+- If a single, unambiguous commit SHA is used in a search query (e.g., `repo@c98f56`) and a search index exists at this commit (i.e., it is the `HEAD` commit), then the query is searched using the index. Prior to this change, unindexed search was performed for any query containing an `@commit` specifier.
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -449,10 +449,61 @@ func queryToZoektFileOnlyQueries(query *search.TextPatternInfo, listOfFilePaths 
 	return zoektQueries, nil
 }
 
+func zoektSingleIndexedRepo(ctx context.Context, z *searchbackend.Zoekt, rev *search.RepositoryRevisions, filter func(*zoekt.Repository) bool) (indexed, unindexed []*search.RepositoryRevisions, err error) {
+	indexed = []*search.RepositoryRevisions{}
+	unindexed = []*search.RepositoryRevisions{}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	if len(rev.RevSpecs()) >= 2 || len(rev.RevSpecs()) != len(rev.Revs) {
+		// Zoekt only indexes 1 rev per repository, so it will not have the full results for the
+		// query on repositories for which multiple revs are searched.
+		return indexed, append(unindexed, rev), nil
+	}
+
+	set, err := z.ListAll(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
+	if !ok || (filter != nil && !filter(repo)) {
+		return indexed, append(unindexed, rev), nil
+	}
+
+	for _, branch := range repo.Branches {
+		if branch.Name == "HEAD" {
+			rev.SetIndexedHEADCommit(api.CommitID(branch.Version))
+			break
+		}
+	}
+
+	if len(rev.Revs) == 1 {
+		revSpecToSearch := rev.Revs[0].RevSpec
+		if len(revSpecToSearch) > 0 && len(revSpecToSearch) < 4 {
+			// revSpecToSearch is nonempty but shorter than the
+			// minimum 4 chars expected for a short SHA. It can't
+			// match a commit, maybe it refers to a one-character
+			// branch name.
+			return indexed, append(unindexed, rev), nil
+		}
+		if revSpecToSearch == "" || revSpecToSearch == "HEAD" || strings.HasPrefix(string(rev.IndexedHEADCommit()), revSpecToSearch) {
+			return append(indexed, rev), unindexed, nil
+		}
+	}
+
+	return indexed, append(unindexed, rev), nil
+}
+
 // zoektIndexedRepos splits the input repo list into two parts: (1) the
 // repositories `indexed` by Zoekt and (2) the repositories that are
 // `unindexed`.
 func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*search.RepositoryRevisions, filter func(*zoekt.Repository) bool) (indexed, unindexed []*search.RepositoryRevisions, err error) {
+	if len(revs) == 1 {
+		// Classify indexed versus unindexed for the common case of a single revision
+		return zoektSingleIndexedRepo(ctx, z, revs[0], filter)
+	}
+
 	count := 0
 	for _, r := range revs {
 		if len(r.Revs) > 0 && r.Revs[0].RevSpec == "" {


### PR DESCRIPTION
Addresses #9022. I'm putting this up early so that there's enough time to check it carefully for 3.14 branch cut. Notes on the change:

- Since we can specify `repo@HEAD` is valid, it makes sense to also use the index if the revision is `HEAD`.

- If the commit is short and ambiguous, search will fail early with the standard alert:

> Some repositories could not be searched
> The repository github.com/sourcegraph/sourcegraph matched by your repo: filter could not be searched because it does not contain the revision "c98f4".

This behavior is not part of the code that is tested or changed in this PR (i.e., the alert message would be the same message if we did unindexed search at an ambiguous commit). If we want to say something more informative like "Make sure the commit is unambiguous" that is something to do separately.

Implementation notes:
- I wanted to integrate this change into the `zoektIndexedRepos` function, but had real trouble disentangling things. I tried, kept breaking tests, and kept finding myself thinking I'm breaking some existing assumption. So this PR duplicate some cod but with this change I can at least be very confident it:
- (a) addresses the issue, without
- (b) breaking some existing assumption (except what we want to change), and 
- (c) can be tested in isolation. 

We can refactor later, or maybe review uncovers a better approach. 


