### PR TITLE
Prevent loading changesets twice on page init

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -116,7 +116,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
             return
         }
         // on the very first fetch, a reload of the changesets is not required
-        let isFirstFetch = true
+        let isFirstCampaignFetch = true
         // Fetch campaign if ID was given
         const subscription = merge(of(undefined), campaignUpdates)
             .pipe(
@@ -153,10 +153,10 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         setName(fetchedCampaign.name)
                         setDescription(fetchedCampaign.description)
                     }
-                    if (!isFirstFetch) {
+                    if (!isFirstCampaignFetch) {
                         changesetUpdates.next()
                     }
-                    isFirstFetch = false
+                    isFirstCampaignFetch = false
                 },
                 error: triggerError,
             })

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -115,6 +115,8 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         if (!campaignID) {
             return
         }
+        // on the very first fetch, a reload of the changesets is not required
+        let isFirstFetch = true
         // Fetch campaign if ID was given
         const subscription = merge(of(undefined), campaignUpdates)
             .pipe(
@@ -151,7 +153,10 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                         setName(fetchedCampaign.name)
                         setDescription(fetchedCampaign.description)
                     }
-                    changesetUpdates.next()
+                    if (!isFirstFetch) {
+                        changesetUpdates.next()
+                    }
+                    isFirstFetch = false
                 },
                 error: triggerError,
             })


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
