### PR TITLE
bitbucketserver: Increase client rate limit to 8 req/s

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -36,16 +36,8 @@ var requestCounter = metrics.NewRequestMeter("bitbucket", "Total number of reque
 //
 // See https://godoc.org/golang.org/x/time/rate#Limiter for an explanation of these fields.
 //
-// The limits chosen here are based on the following logic: Bitbucket Cloud restricts
-// "List all repositories" requests (which are a good portion of our requests) to 1,000/hr,
-// and they restrict "List a user or team's repositories" requests (which are roughly equal
-// to our repository lookup requests) to 1,000/hr. We perform a list repositories request
-// for every 1000 repositories on Bitbucket every 1m by default, so for someone with 20,000
-// Bitbucket repositories we need 20,000/1000 requests per minute (1200/hr) + overhead for
-// repository lookup requests by users. So we use a generous 7,200/hr here until we hear
-// from someone that these values do not work well for them.
 const (
-	rateLimitRequestsPerSecond = 2 // 120/min or 7200/hr
+	rateLimitRequestsPerSecond = 8
 	RateLimitMaxBurstRequests  = 500
 )
 


### PR DESCRIPTION
This commit increases each `bitbucketserver.Client` rate limit from 2 to
8 requests per second. The previous number didn't account for all the
extra things we're now doing with the Bitbucket Server API, namely
changesets and permissions syncing.

In the context of testing the Bitbucket Server Plugin, a large customer
has reported that their Bitbucket Server instance receives ~100 req/s.

With those numbers in mind, I think it's OK for us to max out at 8
req/s by default. This is so that the permissions and changeset syncing
takes a little less time, now that we're planning to ship background
permissions syncing in 3.14.

@ryanslade is going to work on overhauling our rate limit story,
including allowing admins to define themselves what rate limit they
want, but for now I think we need this to make background permissions
syncing usable.