### PR TITLE
authz: move DB methods from `PermsSyncer` to `PermsStore`

### DIFF
--- a/enterprise/cmd/frontend/db/integration_test.go
+++ b/enterprise/cmd/frontend/db/integration_test.go
@@ -37,6 +37,11 @@ func TestIntegration_PermsStore(t *testing.T) {
 
 		{"PermsStore/ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
 		{"PermsStore/GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
+
+		{"PermsStore/UserIDsWithNoPerms", testPermsStore_UserIDsWithNoPerms(db)},
+		{"PermsStore/RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
+		{"PermsStore/UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
+		{"PermsStore/ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
 	} {
 		t.Run(tc.name, tc.test)
 	}

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -11,6 +11,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -1314,6 +1315,109 @@ AND account_id IN (%s)
 	}
 
 	return userIDs, nil
+}
+
+// UserIDsWithNoPerms returns a list of user IDs with no permissions found in
+// the database.
+func (s *PermsStore) UserIDsWithNoPerms(ctx context.Context) ([]int32, error) {
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.UserIDsWithNoPerms
+SELECT users.id, '1970-01-01 00:00:00+00'::timestamptz FROM users
+WHERE users.site_admin = FALSE
+AND users.id NOT IN
+	(SELECT perms.user_id FROM user_permissions AS perms)
+`)
+	results, err := s.loadIDsWithTime(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int32, 0, len(results))
+	for id := range results {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// UserIDsWithNoPerms returns a list of private repository IDs with no permissions
+// found in the database.
+func (s *PermsStore) RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, error) {
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.RepoIDsWithNoPerms
+SELECT repo.id, '1970-01-01 00:00:00+00'::timestamptz FROM repo
+WHERE repo.private = TRUE AND repo.id NOT IN
+	(SELECT perms.repo_id FROM repo_permissions AS perms)
+`)
+
+	results, err := s.loadIDsWithTime(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]api.RepoID, 0, len(results))
+	for id := range results {
+		ids = append(ids, api.RepoID(id))
+	}
+	return ids, nil
+}
+
+// UserIDsWithOldestPerms returns a list of user ID and last updated pairs for users
+// who have oldest permissions in database and capped results by the limit.
+func (s *PermsStore) UserIDsWithOldestPerms(ctx context.Context, limit int) (map[int32]time.Time, error) {
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.UserIDsWithOldestPerms
+SELECT user_id, updated_at FROM user_permissions
+ORDER BY updated_at ASC
+LIMIT %s
+`, limit)
+	return s.loadIDsWithTime(ctx, q)
+}
+
+// ReposIDsWithOldestPerms returns a list of repository ID and last updated pairs for
+// repositories that have oldest permissions in database and capped results by the limit.
+func (s *PermsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int) (map[api.RepoID]time.Time, error) {
+	q := sqlf.Sprintf(`
+-- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.ReposIDsWithOldestPerms
+SELECT repo_id, updated_at FROM repo_permissions
+ORDER BY updated_at ASC
+LIMIT %s
+`, limit)
+
+	pairs, err := s.loadIDsWithTime(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[api.RepoID]time.Time, len(pairs))
+	for id, t := range pairs {
+		results[api.RepoID(id)] = t
+	}
+	return results, nil
+}
+
+// loadIDsWithTime runs the query and returns a list of ID and time pairs.
+func (s *PermsStore) loadIDsWithTime(ctx context.Context, q *sqlf.Query) (map[int32]time.Time, error) {
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make(map[int32]time.Time)
+	for rows.Next() {
+		var id int32
+		var t time.Time
+		if err = rows.Scan(&id, &t); err != nil {
+			return nil, err
+		}
+
+		results[id] = t
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 // tx begins a new transaction.

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -60,7 +60,9 @@ func testPermsStore_LoadUserPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("no matching", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			rp := &authz.RepoPermissions{
 				RepoID:  1,
@@ -85,7 +87,9 @@ func testPermsStore_LoadUserPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("found matching", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			rp := &authz.RepoPermissions{
 				RepoID:  1,
@@ -110,7 +114,9 @@ func testPermsStore_LoadUserPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("add and change", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			rp := &authz.RepoPermissions{
 				RepoID:  1,
@@ -169,7 +175,9 @@ func testPermsStore_LoadRepoPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("no matching", func(t *testing.T) {
 			s := NewPermsStore(db, time.Now)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			rp := &authz.RepoPermissions{
 				RepoID:  1,
@@ -193,7 +201,9 @@ func testPermsStore_LoadRepoPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("found matching", func(t *testing.T) {
 			s := NewPermsStore(db, time.Now)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			rp := &authz.RepoPermissions{
 				RepoID:  1,
@@ -363,7 +373,9 @@ func testPermsStore_SetUserPermissions(db *sql.DB) func(*testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				s := NewPermsStore(db, clock)
-				defer cleanupPermsTables(t, s)
+				t.Cleanup(func() {
+					cleanupPermsTables(t, s)
+				})
 
 				for _, p := range test.updates {
 					const numOps = 30
@@ -505,7 +517,9 @@ func testPermsStore_SetRepoPermissions(db *sql.DB) func(*testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				s := NewPermsStore(db, clock)
-				defer cleanupPermsTables(t, s)
+				t.Cleanup(func() {
+					cleanupPermsTables(t, s)
+				})
 
 				for _, p := range test.updates {
 					const numOps = 30
@@ -546,7 +560,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("no matching with different account ID", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			accounts := &extsvc.ExternalAccounts{
 				ServiceType: authz.SourcegraphServiceType,
@@ -577,7 +593,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("no matching with different service ID", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			accounts := &extsvc.ExternalAccounts{
 				ServiceType: authz.SourcegraphServiceType,
@@ -608,7 +626,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("found matching", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			accounts := &extsvc.ExternalAccounts{
 				ServiceType: authz.SourcegraphServiceType,
@@ -639,7 +659,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 
 		t.Run("add and change", func(t *testing.T) {
 			s := NewPermsStore(db, clock)
-			defer cleanupPermsTables(t, s)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+			})
 
 			accounts := &extsvc.ExternalAccounts{
 				ServiceType: authz.SourcegraphServiceType,
@@ -996,7 +1018,9 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				s := NewPermsStore(db, clock)
-				defer cleanupPermsTables(t, s)
+				t.Cleanup(func() {
+					cleanupPermsTables(t, s)
+				})
 
 				ctx := context.Background()
 
@@ -1119,7 +1143,9 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				s := NewPermsStore(db, clock)
-				defer cleanupPermsTables(t, s)
+				t.Cleanup(func() {
+					cleanupPermsTables(t, s)
+				})
 
 				ctx := context.Background()
 
@@ -1435,7 +1461,9 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				s := NewPermsStore(db, clock)
-				defer cleanupPermsTables(t, s)
+				t.Cleanup(func() {
+					cleanupPermsTables(t, s)
+				})
 
 				ctx := context.Background()
 
@@ -1488,7 +1516,9 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)
-		defer cleanupPermsTables(t, s)
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -1540,7 +1570,9 @@ func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(*testing.T) {
 func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)
-		defer cleanupPermsTables(t, s)
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -1595,7 +1627,9 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T)
 func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)
-		defer cleanupPermsTables(t, s)
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -1700,7 +1734,9 @@ func cleanupUsersTable(t *testing.T, s *PermsStore) {
 func testPermsStore_ListExternalAccounts(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)
-		defer cleanupUsersTable(t, s)
+		t.Cleanup(func() {
+			cleanupUsersTable(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -1792,7 +1828,9 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 func testPermsStore_GetUserIDsByExternalAccounts(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)
-		defer cleanupUsersTable(t, s)
+		t.Cleanup(func() {
+			cleanupUsersTable(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -1842,10 +1880,10 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 func testPermsStore_UserIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)
-		defer func() {
+		t.Cleanup(func() {
 			cleanupUsersTable(t, s)
 			cleanupPermsTables(t, s)
-		}()
+		})
 
 		ctx := context.Background()
 
@@ -1909,10 +1947,10 @@ func cleanupReposTable(t *testing.T, s *PermsStore) {
 func testPermsStore_RepoIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, time.Now)
-		defer func() {
+		t.Cleanup(func() {
 			cleanupReposTable(t, s)
 			cleanupPermsTables(t, s)
-		}()
+		})
 
 		ctx := context.Background()
 
@@ -1964,7 +2002,9 @@ func testPermsStore_RepoIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 func testPermsStore_UserIDsWithOldestPerms(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)
-		defer cleanupPermsTables(t, s)
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
 
 		ctx := context.Background()
 
@@ -2017,7 +2057,9 @@ WHERE user_id = 2`, clock().AddDate(1, 0, 0))
 func testPermsStore_ReposIDsWithOldestPerms(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)
-		defer cleanupPermsTables(t, s)
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
 
 		ctx := context.Background()
 

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -93,6 +93,6 @@ func startBackgroundPermsSync(ctx context.Context, repoStore repos.Store, db dbu
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
 	permsStore := frontendDB.NewPermsStore(db, clock)
-	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, db, clock)
+	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, clock)
 	go permsSyncer.Run(ctx)
 }


### PR DESCRIPTION
This PR moves DB methods previously defined in `PermsSyncer` to DB layer (i.e. `PermsStore`).

