### PR TITLE
all: enable staticcheck unused

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -475,8 +474,4 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 		next = page
 	}
 	return ids, nil
-}
-
-func unixMilliToTime(ms int64) time.Time {
-	return time.Unix(0, ms*int64(time.Millisecond))
 }

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -18,4 +18,4 @@ go install -tags=dev -buildmode=archive ${pkgs}
 
 echo "--- lint"
 
-golangci-lint run -e unused ${pkgs}
+golangci-lint run ${pkgs}

--- a/enterprise/cmd/repo-updater/authz/request_queue.go
+++ b/enterprise/cmd/repo-updater/authz/request_queue.go
@@ -24,8 +24,7 @@ type requestType int
 // requestTypeUser had the highest because it is often triggered by a user
 // action (e.g. sign up, log in).
 const (
-	requestTypeUnknown requestType = iota
-	requestTypeRepo
+	requestTypeRepo requestType = iota + 1
 	requestTypeUser
 )
 

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -388,23 +388,6 @@ func (s *ChangesetSyncer) GroupChangesetsBySource(ctx context.Context, cs ...*ca
 	return res, nil
 }
 
-func (s *ChangesetSyncer) listAllNonDeletedChangesets(ctx context.Context) (all []*campaigns.Changeset, err error) {
-	for cursor := int64(-1); cursor != 0; {
-		opts := ListChangesetsOpts{
-			Cursor:         cursor,
-			Limit:          1000,
-			WithoutDeleted: true,
-		}
-		cs, next, err := s.Store.ListChangesets(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		all, cursor = append(all, cs...), next
-	}
-
-	return all, err
-}
-
 type scheduledSync struct {
 	changesetID int64
 	nextSync    time.Time


### PR DESCRIPTION
I cleaned this up a while ago, but then forgot to enable it so we ended up regressing in a few places. See individual commits, I'll cc the relevant author in to confirm.