### PR TITLE
repo-updater: introduce excluder

### DIFF
--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -179,7 +179,7 @@ func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results c
 }
 
 func (s *AWSCodeCommitSource) excludes(r *awscodecommit.Repository) bool {
-	return s.exclude.Name(r.Name) || s.exclude.Name(r.ID)
+	return s.exclude.Match(r.Name) || s.exclude.Match(r.ID)
 }
 
 // The code below is copied from

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -30,7 +30,7 @@ type AWSCodeCommitSource struct {
 	awsRegion    endpoints.Region
 	client       *awscodecommit.Client
 
-	exclude map[string]bool
+	exclude excluder
 }
 
 // NewAWSCodeCommitSource returns a new AWSCodeCommitSource from the given external service.
@@ -72,15 +72,13 @@ func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnect
 	}
 	awsConfig.HTTPClient = cli
 
-	exclude := make(map[string]bool, len(c.Exclude))
+	var exclude excluder
 	for _, r := range c.Exclude {
-		if r.Name != "" {
-			exclude[r.Name] = true
-		}
-
-		if r.Id != "" {
-			exclude[r.Id] = true
-		}
+		exclude.Exact(r.Name)
+		exclude.Exact(r.Id)
+	}
+	if err := exclude.Err(); err != nil {
+		return nil, err
 	}
 
 	s := &AWSCodeCommitSource{
@@ -181,7 +179,7 @@ func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results c
 }
 
 func (s *AWSCodeCommitSource) excludes(r *awscodecommit.Repository) bool {
-	return s.exclude[r.Name] || s.exclude[r.ID]
+	return s.exclude.Name(r.Name) || s.exclude.Name(r.ID)
 }
 
 // The code below is copied from

--- a/cmd/repo-updater/repos/awscodecommit_test.go
+++ b/cmd/repo-updater/repos/awscodecommit_test.go
@@ -38,7 +38,6 @@ func TestAWSCodeCommitSource_Exclude(t *testing.T) {
 		{"id does not match", &awscodecommit.Repository{ID: "id99"}, false},
 		{"name and id match", &awscodecommit.Repository{ID: "id2", Name: "other-repository"}, true},
 		{"name or id match", &awscodecommit.Repository{ID: "id1", Name: "made-up-name"}, true},
-		{"name does not match case", &awscodecommit.Repository{Name: "MY-REPOSITORY"}, false},
 	} {
 
 		tc := tc

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -22,11 +20,10 @@ import (
 // A BitbucketCloudSource yields repositories from a single BitbucketCloud connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketCloudSource struct {
-	svc             *ExternalService
-	config          *schema.BitbucketCloudConnection
-	exclude         map[string]bool
-	excludePatterns []*regexp.Regexp
-	client          *bitbucketcloud.Client
+	svc     *ExternalService
+	config  *schema.BitbucketCloudConnection
+	exclude excluder
+	client  *bitbucketcloud.Client
 }
 
 // NewBitbucketCloudSource returns a new BitbucketCloudSource from the given external service.
@@ -57,24 +54,14 @@ func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConne
 		return nil, err
 	}
 
-	exclude := make(map[string]bool, len(c.Exclude))
-	var excludePatterns []*regexp.Regexp
+	var exclude excluder
 	for _, r := range c.Exclude {
-		if r.Name != "" {
-			exclude[strings.ToLower(r.Name)] = true
-		}
-
-		if r.Uuid != "" {
-			exclude[strings.ToLower(r.Uuid)] = true
-		}
-
-		if r.Pattern != "" {
-			re, err := regexp.Compile(r.Pattern)
-			if err != nil {
-				return nil, err
-			}
-			excludePatterns = append(excludePatterns, re)
-		}
+		exclude.Exact(r.Name)
+		exclude.Exact(r.Uuid)
+		exclude.Pattern(r.Pattern)
+	}
+	if err := exclude.Err(); err != nil {
+		return nil, err
 	}
 
 	client := bitbucketcloud.NewClient(apiURL, cli)
@@ -82,11 +69,10 @@ func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConne
 	client.AppPassword = c.AppPassword
 
 	return &BitbucketCloudSource{
-		svc:             svc,
-		config:          c,
-		exclude:         exclude,
-		excludePatterns: excludePatterns,
-		client:          client,
+		svc:     svc,
+		config:  c,
+		exclude: exclude,
+		client:  client,
 	}, nil
 }
 
@@ -168,17 +154,7 @@ func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo)
 }
 
 func (s *BitbucketCloudSource) excludes(r *bitbucketcloud.Repo) bool {
-	if s.exclude[strings.ToLower(r.FullName)] ||
-		s.exclude[strings.ToLower(r.UUID)] {
-		return true
-	}
-
-	for _, re := range s.excludePatterns {
-		if re.MatchString(r.FullName) {
-			return true
-		}
-	}
-	return false
+	return s.exclude.Name(r.FullName) || s.exclude.Name(r.UUID)
 }
 
 func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan SourceResult) {

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -154,7 +154,7 @@ func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo)
 }
 
 func (s *BitbucketCloudSource) excludes(r *bitbucketcloud.Repo) bool {
-	return s.exclude.Name(r.FullName) || s.exclude.Name(r.UUID)
+	return s.exclude.Match(r.FullName) || s.exclude.Match(r.UUID)
 }
 
 func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan SourceResult) {

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,11 +24,10 @@ import (
 // A BitbucketServerSource yields repositories from a single BitbucketServer connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketServerSource struct {
-	svc             *ExternalService
-	config          *schema.BitbucketServerConnection
-	exclude         map[string]bool
-	excludePatterns []*regexp.Regexp
-	client          *bitbucketserver.Client
+	svc     *ExternalService
+	config  *schema.BitbucketServerConnection
+	exclude excluder
+	client  *bitbucketserver.Client
 }
 
 // NewBitbucketServerSource returns a new BitbucketServerSource from the given external service.
@@ -62,24 +60,14 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 		return nil, err
 	}
 
-	exclude := make(map[string]bool, len(c.Exclude))
-	var excludePatterns []*regexp.Regexp
+	var exclude excluder
 	for _, r := range c.Exclude {
-		if r.Name != "" {
-			exclude[strings.ToLower(r.Name)] = true
-		}
-
-		if r.Id != 0 {
-			exclude[strconv.Itoa(r.Id)] = true
-		}
-
-		if r.Pattern != "" {
-			re, err := regexp.Compile(r.Pattern)
-			if err != nil {
-				return nil, err
-			}
-			excludePatterns = append(excludePatterns, re)
-		}
+		exclude.Exact(r.Name)
+		exclude.Exact(strconv.Itoa(r.Id))
+		exclude.Pattern(r.Pattern)
+	}
+	if err := exclude.Err(); err != nil {
+		return nil, err
 	}
 
 	client := bitbucketserver.NewClient(baseURL, cli)
@@ -88,11 +76,10 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 	client.Password = c.Password
 
 	return &BitbucketServerSource{
-		svc:             svc,
-		config:          c,
-		exclude:         exclude,
-		excludePatterns: excludePatterns,
-		client:          client,
+		svc:     svc,
+		config:  c,
+		exclude: exclude,
+		client:  client,
 	}, nil
 }
 
@@ -339,17 +326,12 @@ func (s *BitbucketServerSource) excludes(r *bitbucketserver.Repo) bool {
 		name = r.Project.Key + "/" + name
 	}
 	if r.State != "AVAILABLE" ||
-		s.exclude[strings.ToLower(name)] ||
-		s.exclude[strconv.Itoa(r.ID)] ||
+		s.exclude.Name(name) ||
+		s.exclude.Name(strconv.Itoa(r.ID)) ||
 		(s.config.ExcludePersonalRepositories && r.IsPersonalRepository()) {
 		return true
 	}
 
-	for _, re := range s.excludePatterns {
-		if re.MatchString(name) {
-			return true
-		}
-	}
 	return false
 }
 

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -326,8 +326,8 @@ func (s *BitbucketServerSource) excludes(r *bitbucketserver.Repo) bool {
 		name = r.Project.Key + "/" + name
 	}
 	if r.State != "AVAILABLE" ||
-		s.exclude.Name(name) ||
-		s.exclude.Name(strconv.Itoa(r.ID)) ||
+		s.exclude.Match(name) ||
+		s.exclude.Match(strconv.Itoa(r.ID)) ||
 		(s.config.ExcludePersonalRepositories && r.IsPersonalRepository()) {
 		return true
 	}

--- a/cmd/repo-updater/repos/exclude.go
+++ b/cmd/repo-updater/repos/exclude.go
@@ -39,7 +39,7 @@ func (e *excluder) Err() error {
 	return e.err
 }
 
-func (e *excluder) Name(name string) bool {
+func (e *excluder) Match(name string) bool {
 	if _, ok := e.exact[strings.ToLower(name)]; ok {
 		return true
 	}

--- a/cmd/repo-updater/repos/exclude.go
+++ b/cmd/repo-updater/repos/exclude.go
@@ -1,0 +1,54 @@
+package repos
+
+import (
+	"regexp"
+	"strings"
+)
+
+type excluder struct {
+	exact    map[string]struct{}
+	patterns []*regexp.Regexp
+
+	err error
+}
+
+func (e *excluder) Exact(name string) {
+	if e.exact == nil {
+		e.exact = map[string]struct{}{}
+	}
+	if name == "" {
+		return
+	}
+	e.exact[strings.ToLower(name)] = struct{}{}
+}
+
+func (e *excluder) Pattern(pattern string) {
+	if pattern == "" {
+		return
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		e.err = err
+		return
+	}
+	e.patterns = append(e.patterns, re)
+}
+
+func (e *excluder) Err() error {
+	return e.err
+}
+
+func (e *excluder) Name(name string) bool {
+	if _, ok := e.exact[strings.ToLower(name)]; ok {
+		return true
+	}
+
+	for _, re := range e.patterns {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -317,7 +317,7 @@ func (s *GithubSource) authenticatedRemoteURL(repo *github.Repository) string {
 }
 
 func (s *GithubSource) excludes(r *github.Repository) bool {
-	if s.exclude.Name(r.NameWithOwner) || s.exclude.Name(r.ID) {
+	if s.exclude.Match(r.NameWithOwner) || s.exclude.Match(r.ID) {
 		return true
 	}
 

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -28,10 +27,9 @@ import (
 type GithubSource struct {
 	svc             *ExternalService
 	config          *schema.GitHubConnection
-	exclude         *excluder
+	exclude         excluder
 	excludeArchived bool
 	excludeForks    bool
-	excludePatterns []*regexp.Regexp
 	githubDotCom    bool
 	baseURL         *url.URL
 	client          *github.Client
@@ -109,7 +107,7 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 	return &GithubSource{
 		svc:              svc,
 		config:           c,
-		exclude:          &exclude,
+		exclude:          exclude,
 		excludeArchived:  excludeArchived,
 		excludeForks:     excludeForks,
 		baseURL:          baseURL,

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -160,7 +160,7 @@ func (s *GitLabSource) authenticatedRemoteURL(proj *gitlab.Project) string {
 }
 
 func (s *GitLabSource) excludes(p *gitlab.Project) bool {
-	return s.exclude.Name(p.PathWithNamespace) || s.exclude.Name(strconv.Itoa(p.ID))
+	return s.exclude.Match(p.PathWithNamespace) || s.exclude.Match(strconv.Itoa(p.ID))
 }
 
 func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceResult) {

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -24,7 +24,7 @@ import (
 type GitLabSource struct {
 	svc                 *ExternalService
 	config              *schema.GitLabConnection
-	exclude             map[string]bool
+	exclude             excluder
 	baseURL             *url.URL // URL with path /api/v4 (no trailing slash)
 	nameTransformations reposource.NameTransformations
 	client              *gitlab.Client
@@ -60,15 +60,13 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 		return nil, err
 	}
 
-	exclude := make(map[string]bool, len(c.Exclude))
+	var exclude excluder
 	for _, r := range c.Exclude {
-		if r.Name != "" {
-			exclude[r.Name] = true
-		}
-
-		if r.Id != 0 {
-			exclude[strconv.Itoa(r.Id)] = true
-		}
+		exclude.Exact(r.Name)
+		exclude.Exact(strconv.Itoa(r.Id))
+	}
+	if err := exclude.Err(); err != nil {
+		return nil, err
 	}
 
 	// Validate and cache user-defined name transformations.
@@ -162,7 +160,7 @@ func (s *GitLabSource) authenticatedRemoteURL(proj *gitlab.Project) string {
 }
 
 func (s *GitLabSource) excludes(p *gitlab.Project) bool {
-	return s.exclude[p.PathWithNamespace] || s.exclude[strconv.Itoa(p.ID)]
+	return s.exclude.Name(p.PathWithNamespace) || s.exclude.Name(strconv.Itoa(p.ID))
 }
 
 func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceResult) {

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -94,7 +94,7 @@ func (s GitoliteSource) ExternalServices() ExternalServices {
 }
 
 func (s GitoliteSource) excludes(gr *gitolite.Repo, r *Repo) bool {
-	return s.exclude.Name(gr.Name) ||
+	return s.exclude.Match(gr.Name) ||
 		strings.ContainsAny(r.Name, "\\^$|()[]*?{},") ||
 		(s.blacklist != nil && s.blacklist.MatchString(r.Name))
 }

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -27,7 +27,7 @@ type GitoliteSource struct {
 	// required for authentication.
 	cli       *gitserver.Client
 	blacklist *regexp.Regexp
-	exclude   map[string]bool
+	exclude   excluder
 }
 
 // NewGitoliteSource returns a new GitoliteSource from the given external service.
@@ -54,11 +54,12 @@ func NewGitoliteSource(svc *ExternalService, cf *httpcli.Factory) (*GitoliteSour
 		}
 	}
 
-	exclude := make(map[string]bool, len(c.Exclude))
+	var exclude excluder
 	for _, r := range c.Exclude {
-		if r.Name != "" {
-			exclude[r.Name] = true
-		}
+		exclude.Exact(r.Name)
+	}
+	if err := exclude.Err(); err != nil {
+		return nil, err
 	}
 
 	return &GitoliteSource{
@@ -93,7 +94,7 @@ func (s GitoliteSource) ExternalServices() ExternalServices {
 }
 
 func (s GitoliteSource) excludes(gr *gitolite.Repo, r *Repo) bool {
-	return s.exclude[gr.Name] ||
+	return s.exclude.Name(gr.Name) ||
 		strings.ContainsAny(r.Name, "\\^$|()[]*?{},") ||
 		(s.blacklist != nil && s.blacklist.MatchString(r.Name))
 }


### PR DESCRIPTION
This is a first and minimal attempt at factoring out the common logic in our
exclude clause. It is just targetting names and IDs, since that is the only
thing common across all code hosts.

In future this can be evolved into taking a common schema object, etc. This
commit only applies it to GitHub, rest of the sources will also use it in
follow-up commits.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
