### PR TITLE
campaigns: Ignore check state for suites with zero runs

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -446,7 +446,7 @@ func TestCampaigns(t *testing.T) {
 					ServiceType: "github",
 				},
 				ReviewState: "APPROVED",
-				CheckState:  "PENDING",
+				CheckState:  "PASSED",
 				Events: ChangesetEventConnection{
 					TotalCount: 57,
 				},

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -789,6 +789,12 @@ func computeGitHubCheckState(lastSynced time.Time, pr *github.PullRequest, event
 			statusPerContext[c.Context] = parseGithubCheckState(c.State)
 		}
 		for _, c := range commit.Commit.CheckSuites.Nodes {
+			if len(c.CheckRuns.Nodes) == 0 {
+				// Ignore suites with no runs.
+				// It is common for suites to be created and then stay in the QUEUED state
+				// forever with zero runs.
+				continue
+			}
 			statusPerCheckSuite[c.ID] = parseGithubCheckSuiteState(c.Status, c.Conclusion)
 			for _, r := range c.CheckRuns.Nodes {
 				statusPerCheckRun[r.ID] = parseGithubCheckSuiteState(r.Status, r.Conclusion)
@@ -814,6 +820,11 @@ func computeGitHubCheckState(lastSynced time.Time, pr *github.PullRequest, event
 				}
 			}
 		case *github.CheckSuite:
+			if len(m.CheckRuns.Nodes) == 0 {
+				// Ignore suites with no runs.
+				// See previous comment.
+				continue
+			}
 			if m.ReceivedAt.After(lastSynced) {
 				statusPerCheckSuite[m.ID] = parseGithubCheckSuiteState(m.Status, m.Conclusion)
 			}

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -482,17 +482,38 @@ func TestChangesetEventsReviewState(t *testing.T) {
 
 func TestComputeGithubCheckState(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	testEvent := func(minutesSinceSync int, context, state string) *ChangesetEvent {
+	commitEvent := func(minutesSinceSync int, context, state string) *ChangesetEvent {
 		commit := &github.CommitStatus{
 			Context:    context,
 			State:      state,
 			ReceivedAt: now.Add(time.Duration(minutesSinceSync) * time.Minute),
 		}
-		ce := &ChangesetEvent{
+		event := &ChangesetEvent{
 			Kind:     ChangesetEventKindCommitStatus,
 			Metadata: commit,
 		}
-		return ce
+		return event
+	}
+	checkRun := func(id, status, conclusion string) github.CheckRun {
+		return github.CheckRun{
+			ID:         id,
+			Status:     status,
+			Conclusion: conclusion,
+		}
+	}
+	checkSuiteEvent := func(minutesSinceSync int, id, status, conclusion string, runs ...github.CheckRun) *ChangesetEvent {
+		suite := &github.CheckSuite{
+			ID:         id,
+			Status:     status,
+			Conclusion: conclusion,
+			ReceivedAt: now.Add(time.Duration(minutesSinceSync) * time.Minute),
+		}
+		suite.CheckRuns.Nodes = runs
+		event := &ChangesetEvent{
+			Kind:     ChangesetEventKindCheckSuite,
+			Metadata: suite,
+		}
+		return event
 	}
 
 	lastSynced := now.Add(-1 * time.Minute)
@@ -511,61 +532,77 @@ func TestComputeGithubCheckState(t *testing.T) {
 		{
 			name: "single success",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "SUCCESS"),
+				commitEvent(1, "ctx1", "SUCCESS"),
+			},
+			want: ChangesetCheckStatePassed,
+		},
+		{
+			name: "success status and suite",
+			events: []*ChangesetEvent{
+				commitEvent(1, "ctx1", "SUCCESS"),
+				checkSuiteEvent(1, "cs1", "COMPLETED", "SUCCESS", checkRun("cr1", "COMPLETED", "SUCCESS")),
 			},
 			want: ChangesetCheckStatePassed,
 		},
 		{
 			name: "single pending",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "PENDING"),
+				commitEvent(1, "ctx1", "PENDING"),
 			},
 			want: ChangesetCheckStatePending,
 		},
 		{
 			name: "single error",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "ERROR"),
+				commitEvent(1, "ctx1", "ERROR"),
 			},
 			want: ChangesetCheckStateFailed,
 		},
 		{
 			name: "pending + error",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "PENDING"),
-				testEvent(1, "ctx2", "ERROR"),
+				commitEvent(1, "ctx1", "PENDING"),
+				commitEvent(1, "ctx2", "ERROR"),
 			},
 			want: ChangesetCheckStatePending,
 		},
 		{
 			name: "pending + success",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "PENDING"),
-				testEvent(1, "ctx2", "SUCCESS"),
+				commitEvent(1, "ctx1", "PENDING"),
+				commitEvent(1, "ctx2", "SUCCESS"),
 			},
 			want: ChangesetCheckStatePending,
 		},
 		{
 			name: "success + error",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "SUCCESS"),
-				testEvent(1, "ctx2", "ERROR"),
+				commitEvent(1, "ctx1", "SUCCESS"),
+				commitEvent(1, "ctx2", "ERROR"),
 			},
 			want: ChangesetCheckStateFailed,
 		},
 		{
 			name: "success x2",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "SUCCESS"),
-				testEvent(1, "ctx2", "SUCCESS"),
+				commitEvent(1, "ctx1", "SUCCESS"),
+				commitEvent(1, "ctx2", "SUCCESS"),
 			},
 			want: ChangesetCheckStatePassed,
 		},
 		{
 			name: "later events have precedence",
 			events: []*ChangesetEvent{
-				testEvent(1, "ctx1", "PENDING"),
-				testEvent(1, "ctx1", "SUCCESS"),
+				commitEvent(1, "ctx1", "PENDING"),
+				commitEvent(1, "ctx1", "SUCCESS"),
+			},
+			want: ChangesetCheckStatePassed,
+		},
+		{
+			name: "suites with zero runs should be ignored",
+			events: []*ChangesetEvent{
+				commitEvent(1, "ctx1", "SUCCESS"),
+				checkSuiteEvent(1, "cs1", "QUEUED", ""),
 			},
 			want: ChangesetCheckStatePassed,
 		},


### PR DESCRIPTION
CheckSuites that have zero CheckRuns will be ignored.

This appears to be very common in the wild, most often as
CheckSuites that are always QUEUED, having zero runs. This meant that we
would show status and PENDING forever.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
