### PR TITLE
Upgrade to TypeScript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "thread-loader": "^2.1.3",
     "ts-node": "^8.6.2",
     "tslint": "^5.20.1",
-    "typescript": "^3.7.2",
+    "typescript": "^3.8.3",
     "utc-version": "^2.0.1",
     "web-ext": "^4.1.0",
     "webpack": "^4.42.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19784,10 +19784,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
This got somewhat lost in renovates PR, because it always uses the latest nightly release of TS. There have been quite a few fixes in 3.7.3-3.7.5 and even a ~~major~~ minor version of TS