### PR TITLE
Remove ProcessPendingCampaignJob

### DIFF
--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -23,5 +23,5 @@ func TestIntegration(t *testing.T) {
 
 	// The following tests need to be separate because testStore above wraps everything in a global transaction
 	t.Run("StoreLocking", testStoreLocking(db))
-	t.Run("ProcessCampaignJob", testProcessCampaignJob(db))
+	t.Run("ProcessChangesetJob", testProcessChangesetJob(db))
 }

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -1051,14 +1051,25 @@ var testUser = db.NewUser{
 	EmailVerificationCode: "foobar",
 }
 
-func createTestUser(ctx context.Context, t *testing.T) *types.User {
-	t.Helper()
-	user, err := db.Users.Create(ctx, testUser)
-	if err != nil {
-		t.Fatal(err)
+var createTestUser = func() func(context.Context, *testing.T) *types.User {
+	count := 0
+
+	return func(ctx context.Context, t *testing.T) *types.User {
+		t.Helper()
+
+		u := testUser
+		u.Username = fmt.Sprintf("%s-%d", u.Username, count)
+
+		user, err := db.Users.Create(ctx, u)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		count += 1
+
+		return user
 	}
-	return user
-}
+}()
 
 func testCampaignJob(plan int64, repo api.RepoID, t time.Time) *campaigns.CampaignJob {
 	return &campaigns.CampaignJob{

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -116,59 +116,6 @@ RETURNING j.id,
   j.updated_at
 `
 
-// ProcessPendingCampaignJob attempts to fetch one pending campaign job. If found, 'process'
-// is called. We guarantee that if process is called it will have exclusive global access to the job.
-// All operations on the job should be done using the supplied store as they will run in a transaction.
-// Returning an error will roll back the transaction.
-// NOTE: It should not be called from within an existing transaction
-func (s *Store) ProcessPendingCampaignJob(ctx context.Context, process func(ctx context.Context, s *Store, job campaigns.CampaignJob) error) (didRun bool, err error) {
-	tx, err := s.Transact(ctx)
-	if err != nil {
-		return false, errors.Wrap(err, "starting transaction")
-	}
-	defer tx.Done(&err)
-	q := sqlf.Sprintf(getPendingCampaignJobQuery)
-	var job campaigns.CampaignJob
-	_, count, err := tx.query(ctx, q, func(sc scanner) (last, count int64, err error) {
-		err = scanCampaignJob(&job, sc)
-		if err != nil {
-			return 0, 0, errors.Wrap(err, "scanning campaign job row")
-		}
-		return job.ID, 1, nil
-	})
-	if err != nil {
-		return false, errors.Wrap(err, "querying for pending campaign job")
-	}
-	if count == 0 {
-		return false, nil
-	}
-	err = process(ctx, tx, job)
-	return true, err
-}
-
-const getPendingCampaignJobQuery = `
-UPDATE campaign_jobs c SET started_at = now() WHERE id = (
-	SELECT c.id FROM campaign_jobs c
-	JOIN campaign_plans p ON p.id = c.campaign_plan_id
-	WHERE c.started_at IS NULL
-	AND p.canceled_at IS NULL
-	ORDER BY c.id ASC
-	FOR UPDATE SKIP LOCKED LIMIT 1
-)
-RETURNING c.id,
-  c.campaign_plan_id,
-  c.repo_id,
-  c.rev,
-  c.base_ref,
-  c.diff,
-  c.description,
-  c.error,
-  c.started_at,
-  c.finished_at,
-  c.created_at,
-  c.updated_at
-`
-
 // Done terminates the underlying Tx in a Store either by committing or rolling
 // back based on the value pointed to by the first given error pointer.
 // It's a no-op if the `Store` is not operating within a transaction,


### PR DESCRIPTION
We don't need it anymore.

And, as it turns out, we didn't have tests for `ProcessPendingChangesetJobs`, so I converted the tests for `ProcessPendingCampaignJob` to test that.