### PR TITLE
frontend: Speed up NewRepositoryComparison

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
-
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
+
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -49,6 +51,12 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 			return nil, nil
 		}
 
+		// Optimistically fetch using revspec
+		commit, err := git.GetCommit(ctx, repo, nil, api.CommitID(revspec))
+		if err == nil {
+			return toGitCommitResolver(r, commit), nil
+		}
+
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
 		// exist).
 		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, nil)
@@ -56,7 +64,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 			return nil, err
 		}
 
-		commit, err := git.GetCommit(ctx, repo, nil, commitID)
+		commit, err = git.GetCommit(ctx, repo, nil, commitID)
 		if err != nil {
 			return nil, err
 		}
@@ -67,13 +75,28 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 	if err != nil {
 		return nil, err
 	}
-	base, err := getCommit(ctx, *grepo, baseRevspec)
-	if err != nil {
-		return nil, err
+
+	var (
+		wg               sync.WaitGroup
+		base, head       *GitCommitResolver
+		baseErr, headErr error
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		base, baseErr = getCommit(ctx, *grepo, baseRevspec)
+	}()
+	go func() {
+		defer wg.Done()
+		head, headErr = getCommit(ctx, *grepo, headRevspec)
+	}()
+	wg.Wait()
+	if baseErr != nil {
+		return nil, baseErr
 	}
-	head, err := getCommit(ctx, *grepo, headRevspec)
-	if err != nil {
-		return nil, err
+	if headErr != nil {
+		return nil, headErr
 	}
 
 	return &RepositoryComparisonResolver{

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -15,7 +15,7 @@ zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
 zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
 zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
 keycloak: ./dev/auth-provider/keycloak.sh
-jaeger: docker run --name=jaeger --rm -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
+# jaeger: docker run --name=jaeger --rm -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
 docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
 lsif-server: yarn --cwd lsif run run:server
 lsif-worker: yarn --cwd lsif run run:worker

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -15,7 +15,7 @@ zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
 zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
 zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
 keycloak: ./dev/auth-provider/keycloak.sh
-# jaeger: docker run --name=jaeger --rm -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
+jaeger: docker run --name=jaeger --rm -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
 docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
 lsif-server: yarn --cwd lsif run run:server
 lsif-worker: yarn --cwd lsif run run:worker

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -130,7 +130,7 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 }
 
 func isBadObjectErr(output, obj string) bool {
-	return string(output) == "fatal: bad object "+obj
+	return output == "fatal: bad object "+obj
 }
 
 func isInvalidRevisionRangeError(output, obj string) bool {
@@ -148,7 +148,7 @@ func commitLog(ctx context.Context, repo gitserver.Repo, opt CommitsOptions) (co
 
 	cmd := gitserver.DefaultClient.Command("git", args...)
 	cmd.Repo = repo
-	cmd.EnsureRevision = string(opt.Range)
+	cmd.EnsureRevision = opt.Range
 	retryer := &commandRetryer{
 		cmd:           cmd,
 		remoteURLFunc: opt.RemoteURLFunc,


### PR DESCRIPTION
Fetch commits in parallel.
Optimistically fetch based on revspec, fall back to resolving commit
only on error.

Specifically, this helps speed up our changeset list view as it needs fetch many commits to calculate diffs.

Locally the page load drop from around 400ms to 250ms

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
