### PR TITLE
Remove CampaignPlan.status from GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Multiple backwards-incompatible changes in the parts of the GraphQL API related to Campaigns:
+  - `CampaignPlan.status` has been removed, since we don't need it anymore after moving execution of campaigns to src CLI in [#8008](https://github.com/sourcegraph/sourcegraph/pull/8008).
+
 ### Fixed
 
 ### Removed

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -295,11 +295,6 @@ type ChangesetCountsResolver interface {
 	OpenPending() int32
 }
 
-type CampaignPlanArgResolver interface {
-	Name() string
-	Value() string
-}
-
 type BackgroundProcessStatus interface {
 	CompletedCount() int32
 	PendingCount() int32
@@ -311,8 +306,6 @@ type BackgroundProcessStatus interface {
 
 type CampaignPlanResolver interface {
 	ID() graphql.ID
-
-	Status(ctx context.Context) (BackgroundProcessStatus, error)
 
 	// DEPRECATED: Remove in 3.15 in favor of ChangesetPlans.
 	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) ChangesetPlansConnectionResolver

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -487,9 +487,6 @@ type CampaignPlan implements Node {
     # The unique ID of this campaign plan.
     id: ID!
 
-    # The progress status of generating changesets.
-    status: BackgroundProcessStatus!
-
     # DEPRECATED
     # The proposed patches ("plans") for the changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -494,9 +494,6 @@ type CampaignPlan implements Node {
     # The unique ID of this campaign plan.
     id: ID!
 
-    # The progress status of generating changesets.
-    status: BackgroundProcessStatus!
-
     # DEPRECATED
     # The proposed patches ("plans") for the changesets that will be created by the campaign.
     changesets(first: Int): ChangesetPlanConnection!

--- a/enterprise/internal/campaigns/resolvers/campaign_plans.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_plans.go
@@ -54,10 +54,6 @@ func (r *campaignPlanResolver) ID() graphql.ID {
 	return marshalCampaignPlanID(r.campaignPlan.ID)
 }
 
-func (r *campaignPlanResolver) Status(ctx context.Context) (graphqlbackend.BackgroundProcessStatus, error) {
-	return r.store.GetCampaignPlanStatus(ctx, r.campaignPlan.ID)
-}
-
 // DEPRECATED: Remove in 3.15 in favor of ChangesetPlans.
 func (r *campaignPlanResolver) Changesets(
 	ctx context.Context,

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1642,28 +1642,6 @@ func getCampaignPlanQuery(opts *GetCampaignPlanOpts) *sqlf.Query {
 	return sqlf.Sprintf(getCampaignPlansQueryFmtstr, sqlf.Join(preds, "\n AND "))
 }
 
-// DEPRECATED: GetCampaignPlanStatus gets the campaigns.BackgroundProcessStatus for a CampaignPlan.
-// It's deprecated because we don't execute jobs anymore.
-func (s *Store) GetCampaignPlanStatus(ctx context.Context, id int64) (*campaigns.BackgroundProcessStatus, error) {
-	return s.queryBackgroundProcessStatus(ctx, sqlf.Sprintf(
-		getCampaignPlanStatusQueryFmtstr,
-		sqlf.Sprintf("campaign_plan_id = %s", id),
-	))
-}
-
-var getCampaignPlanStatusQueryFmtstr = `
--- source: enterprise/internal/campaigns/store.go:GetCampaignPlanStatus
-SELECT
-  false AS canceled,
-  COUNT(*) AS total,
-  0 AS pending,
-  COUNT(*) AS completed,
-  NULL AS errors
-FROM campaign_jobs
-WHERE %s
-LIMIT 1;
-`
-
 // GetCampaignStatus gets the campaigns.BackgroundProcessStatus for a Campaign
 func (s *Store) GetCampaignStatus(ctx context.Context, id int64) (*campaigns.BackgroundProcessStatus, error) {
 	return s.queryBackgroundProcessStatus(ctx, sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1695,59 +1695,6 @@ func testStore(db *sql.DB) func(*testing.T) {
 			})
 		})
 
-		t.Run("CampaignPlan BackgroundProcessStatus", func(t *testing.T) {
-			tests := []struct {
-				jobs []*cmpgn.CampaignJob
-				want *cmpgn.BackgroundProcessStatus
-			}{
-				{
-					jobs: []*cmpgn.CampaignJob{}, // no jobs
-					want: &cmpgn.BackgroundProcessStatus{
-						ProcessState: cmpgn.BackgroundProcessStateCompleted,
-					},
-				},
-				{
-					jobs: []*cmpgn.CampaignJob{ // two jobs
-						{},
-						{},
-					},
-					want: &cmpgn.BackgroundProcessStatus{
-						ProcessState: cmpgn.BackgroundProcessStateCompleted,
-						Total:        2,
-						Completed:    2,
-					},
-				},
-			}
-			for _, tc := range tests {
-				plan := &cmpgn.CampaignPlan{}
-				err := s.CreateCampaignPlan(ctx, plan)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				for i, j := range tc.jobs {
-					j.CampaignPlanID = plan.ID
-					j.RepoID = api.RepoID(i)
-					j.Rev = api.CommitID(fmt.Sprintf("deadbeef-%d", i))
-					j.BaseRef = "master"
-
-					err := s.CreateCampaignJob(ctx, j)
-					if err != nil {
-						t.Fatal(err)
-					}
-				}
-
-				status, err := s.GetCampaignPlanStatus(ctx, plan.ID)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if diff := cmp.Diff(status, tc.want); diff != "" {
-					t.Fatalf("wrong diff: %s", diff)
-				}
-			}
-		})
-
 		t.Run("CampaignPlan DeleteExpired", func(t *testing.T) {
 			tests := []struct {
 				hasCampaign bool

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2326,6 +2326,20 @@ func testStore(db *sql.DB) func(*testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				// Cleanup existing ChangesetJobs so we don't have interference
+				// between the previous tests and this one.
+				chjs, _, err := s.ListChangesetJobs(ctx, ListChangesetJobsOpts{Limit: -1})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, j := range chjs {
+					err := s.DeleteChangesetJob(ctx, j.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+
 				campaignJob := &cmpgn.CampaignJob{
 					CampaignPlanID: plan.ID,
 					BaseRef:        "x",

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -66,7 +66,6 @@ interface Campaign
 
 interface CampaignPlan extends Pick<GQL.ICampaignPlan, '__typename' | 'id'> {
     changesetPlans: Pick<GQL.ICampaignPlan['changesetPlans'], 'nodes' | 'totalCount'>
-    status: Pick<GQL.ICampaignPlan['status'], 'completedCount' | 'pendingCount' | 'errors' | 'state'>
 }
 
 interface Props extends ThemeProps {


### PR DESCRIPTION
This depends on https://github.com/sourcegraph/src-cli/pull/160

It's a breaking change, but it removes this unused field that doesn't make any sense anymore.

I propose we only merge this in 3.15.
