### PR TITLE
Fix display of activation dropdown confetti

### DIFF
--- a/shared/src/components/activation/ActivationDropdown.scss
+++ b/shared/src/components/activation/ActivationDropdown.scss
@@ -30,6 +30,10 @@
     &__loader {
         padding-left: 0.8375rem;
     }
+
+    &__confetti {
+        z-index: 1000;
+    }
 }
 
 .activation-dropdown-header {

--- a/shared/src/components/activation/ActivationDropdown.tsx
+++ b/shared/src/components/activation/ActivationDropdown.tsx
@@ -77,8 +77,6 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
             dragFriction: 0.09,
             duration: animationDurationMillis,
             delay: 20,
-            width: 10,
-            height: 10,
             colors: ['#a864fd', '#29cdff', '#78ff44', '#ff718d', '#fdff6a'],
         }
         return (
@@ -94,21 +92,25 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
                     } activation-dropdown-button__animated-button bg-transparent d-flex align-items-center e2e-activation-nav-item-toggle`}
                     nav={true}
                 >
-                    <Confetti
-                        active={this.state.animate}
-                        config={{
-                            angle: 210,
-                            ...confettiConfig,
-                        }}
-                    />
+                    <div className="activation-dropdown-button__confetti">
+                        <Confetti
+                            active={this.state.animate}
+                            config={{
+                                angle: 210,
+                                ...confettiConfig,
+                            }}
+                        />
+                    </div>
                     Get started
-                    <Confetti
-                        active={this.state.animate}
-                        config={{
-                            angle: 330,
-                            ...confettiConfig,
-                        }}
-                    />
+                    <div className="activation-dropdown-button__confetti">
+                        <Confetti
+                            active={this.state.animate}
+                            config={{
+                                angle: 330,
+                                ...confettiConfig,
+                            }}
+                        />
+                    </div>
                     <span className="activation-dropdown-button__progress-bar-container">
                         <CircularProgressbar
                             className="activation-dropdown-button__circular-progress-bar"

--- a/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
@@ -13,20 +13,28 @@ exports[`ActivationDropdown render 0/2 completed 1`] = `
     onClick={[Function]}
   >
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     Get started
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     <span
       className="activation-dropdown-button__progress-bar-container"
     >
@@ -163,20 +171,28 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
     onClick={[Function]}
   >
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     Get started
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     <span
       className="activation-dropdown-button__progress-bar-container"
     >
@@ -313,20 +329,28 @@ exports[`ActivationDropdown render loading 1`] = `
     onClick={[Function]}
   >
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     Get started
     <div
-      style={
-        Object {
-          "position": "relative",
+      className="activation-dropdown-button__confetti"
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
         }
-      }
-    />
+      />
+    </div>
     <span
       className="activation-dropdown-button__progress-bar-container"
     >


### PR DESCRIPTION
Fixes #8527

Two issues here:
- Confetti actually didn't display at all following this change: https://github.com/sourcegraph/sourcegraph/pull/6953/files. Typings in version 0.1.3 of `react-dom-confetti` are wrong, and passing in numbers for with and height breaks the display of confetti altogether, as the individual divs generated for each confetti have 0px*0px dimensions (https://github.com/daniel-lundin/react-dom-confetti/pull/26/files). The default width/height of confetti looks very similar to `'10px'` width/height, so I suggest we just rely on the defaults here.

![image](https://user-images.githubusercontent.com/1741180/76877004-10c38c00-6873-11ea-8c94-e23b8673ed8c.png)

- Z-index of confetti conflicted with other UI elements.
