### PR TITLE
Bump Comby CI to 0.14.1

### DIFF
--- a/dev/comby-install-or-upgrade.sh
+++ b/dev/comby-install-or-upgrade.sh
@@ -3,7 +3,7 @@
 # This function installs the comby dependency for cmd/searcher and
 # cmd/replacer. The CI pipeline calls this script to install or upgrade comby
 # for tests or development environments.
-REQUIRE_VERSION="0.11.3"
+REQUIRE_VERSION="0.14.1"
 
 RELEASE_VERSION=$REQUIRE_VERSION
 RELEASE_TAG=$REQUIRE_VERSION


### PR DESCRIPTION
The `comby` version in CI hasn't been bumped for a while. This is infrequent (and still not strictly necessary), so I'm fine with updating this manually for now.