### PR TITLE
authz: switch on/off permissions background sync no longer requires restart

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -538,6 +539,10 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 		case <-ticker.C:
 		case <-ctx.Done():
 			return
+		}
+
+		if !globals.PermissionsBackgroundSync().Enabled {
+			continue
 		}
 
 		schedule, err := s.schedule(ctx)

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -10,6 +10,7 @@ import (
 
 	ossAuthz "github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	ossDB "github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
@@ -80,15 +81,7 @@ func enterpriseInit(
 
 // startBackgroundPermsSync sets up background permissions syncing.
 func startBackgroundPermsSync(ctx context.Context, syncer *authz.PermsSyncer, db dbutil.DB) {
-	// Block until config is available, otherwise will always get default value (i.e. false).
-	enabled := conf.Cached(func() interface{} {
-		return conf.PermissionsBackgroundSyncEnabled()
-	})().(bool)
-	if !enabled {
-		log15.Debug("startBackgroundPermsSync.notEnabled")
-		return
-	}
-
+	globals.WatchPermissionsBackgroundSync()
 	go func() {
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {


### PR DESCRIPTION
This PR makes our `PermsSyncer`'s schedule part to be reactive on config changes and no longer requires a restart to switch on/off the sync.