### PR TITLE
Fix: quotes appearing in content filter input

### DIFF
--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -54,8 +54,7 @@ describe('FilterInput', () => {
         }
         filterHandler(newFiltersInQuery, `${inputValue}`)
     }
-
-    it('filter input for content filters get auto-quoted', () => {
+    it('filter input for content filters get auto-quoted when not editable', () => {
         container = render(
             <FilterInput
                 {...defaultProps}
@@ -86,8 +85,40 @@ describe('FilterInput', () => {
         ).container
         expect(getByText(container, 'content:"test query"')).toBeTruthy()
     })
+    it('filter input for content filters get stripped of quotes when editable', () => {
+        container = render(
+            <FilterInput
+                {...defaultProps}
+                mapKey="content"
+                filterType={FilterType.content}
+                onFilterEdited={onFilterEditedHandler}
+                editable={true}
+            />
+        ).container
 
-    test('filter input for message filters get auto-quoted', () => {
+        const inputEl = container.querySelector('.filter-input__input-field')
+        expect(inputEl).toBeTruthy()
+        fireEvent.click(inputEl!)
+        fireEvent.change(inputEl!, { target: { value: 'test query' } })
+        const confirmBtn = container.querySelector('.check-button__btn')
+        expect(confirmBtn).toBeTruthy()
+        fireEvent.click(confirmBtn!)
+        container = render(
+            <FilterInput
+                {...defaultProps}
+                mapKey="content"
+                filtersInQuery={nextFiltersInQuery}
+                filterType={FilterType.content}
+                value={nextValue}
+                onFilterEdited={onFilterEditedHandler}
+                editable={false}
+            />
+        ).container
+        fireEvent.click(container.querySelector('.filter-input__button-text')!)
+        expect(getByText(container, 'content:test query')).toBeTruthy()
+    })
+
+    test('filter input for message filters do not get auto-quoted when editable', () => {
         container = render(
             <FilterInput
                 {...defaultProps}
@@ -139,5 +170,26 @@ describe('FilterInput', () => {
         expect(confirmBtn).toBeTruthy()
         fireEvent.click(confirmBtn!)
         expect(defaultProps.onFilterEdited.calledOnce).toBe(true)
+    })
+
+    it('filter input for content filters called filter edited handler with quoted value', () => {
+        container = render(
+            <FilterInput
+                {...defaultProps}
+                mapKey="content"
+                filterType={FilterType.content}
+                onFilterEdited={defaultProps.onFilterEdited}
+                editable={true}
+            />
+        ).container
+
+        const inputEl = container.querySelector('.filter-input__input-field')
+        expect(inputEl).toBeTruthy()
+        fireEvent.click(inputEl!)
+        fireEvent.change(inputEl!, { target: { value: 'test query' } })
+        const confirmBtn = container.querySelector('.check-button__btn')
+        expect(confirmBtn).toBeTruthy()
+        fireEvent.click(confirmBtn!)
+        expect(defaultProps.onFilterEdited.calledWith(['content', '"test query"'])).toBe(true)
     })
 })

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -118,7 +118,7 @@ describe('FilterInput', () => {
         expect(getByText(container, 'content:test query')).toBeTruthy()
     })
 
-    test('filter input for message filters do not get auto-quoted when editable', () => {
+    test('filter input for message filters does not get auto-quoted when editable', () => {
         container = render(
             <FilterInput
                 {...defaultProps}

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -54,7 +54,7 @@ describe('FilterInput', () => {
         }
         filterHandler(newFiltersInQuery, `${inputValue}`)
     }
-    it('filter input for content filters get auto-quoted when not editable', () => {
+    it('filter input for content filters gets auto-quoted when not editable', () => {
         container = render(
             <FilterInput
                 {...defaultProps}

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -172,7 +172,7 @@ describe('FilterInput', () => {
         expect(defaultProps.onFilterEdited.calledOnce).toBe(true)
     })
 
-    it('filter input for content filters called filter edited handler with quoted value', () => {
+    it('filter input for content filters calls onFilterEdited with quoted value', () => {
         container = render(
             <FilterInput
                 {...defaultProps}

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -190,6 +190,6 @@ describe('FilterInput', () => {
         const confirmBtn = container.querySelector('.check-button__btn')
         expect(confirmBtn).toBeTruthy()
         fireEvent.click(confirmBtn!)
-        expect(defaultProps.onFilterEdited.calledWith(['content', '"test query"'])).toBe(true)
+        expect(defaultProps.onFilterEdited.calledWith('content', '"test query"')).toBe(true)
     })
 })

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -85,7 +85,7 @@ describe('FilterInput', () => {
         ).container
         expect(getByText(container, 'content:"test query"')).toBeTruthy()
     })
-    it('filter input for content filters get stripped of quotes when editable', () => {
+    it('filter input for content filters gets stripped of quotes when editable', () => {
         container = render(
             <FilterInput
                 {...defaultProps}

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -37,7 +37,6 @@ describe('FilterInput', () => {
         nextFiltersInQuery = {}
         nextValue = ''
     })
-
     const filterHandler = (newFiltersInQuery: FiltersToTypeAndValue, value: string) => {
         nextFiltersInQuery = newFiltersInQuery
         nextValue = value
@@ -54,101 +53,6 @@ describe('FilterInput', () => {
         }
         filterHandler(newFiltersInQuery, `${inputValue}`)
     }
-    it('filter input for content filters gets auto-quoted when not editable', () => {
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="content"
-                filterType={FilterType.content}
-                onFilterEdited={onFilterEditedHandler}
-                editable={true}
-            />
-        ).container
-
-        const inputEl = container.querySelector('.filter-input__input-field')
-        expect(inputEl).toBeTruthy()
-        fireEvent.click(inputEl!)
-        fireEvent.change(inputEl!, { target: { value: 'test query' } })
-        const confirmBtn = container.querySelector('.check-button__btn')
-        expect(confirmBtn).toBeTruthy()
-        fireEvent.click(confirmBtn!)
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="content"
-                filtersInQuery={nextFiltersInQuery}
-                filterType={FilterType.content}
-                value={nextValue}
-                onFilterEdited={onFilterEditedHandler}
-                editable={false}
-            />
-        ).container
-        expect(getByText(container, 'content:"test query"')).toBeTruthy()
-    })
-    it('filter input for content filters gets stripped of quotes when editable', () => {
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="content"
-                filterType={FilterType.content}
-                onFilterEdited={onFilterEditedHandler}
-                editable={true}
-            />
-        ).container
-
-        const inputEl = container.querySelector('.filter-input__input-field')
-        expect(inputEl).toBeTruthy()
-        fireEvent.click(inputEl!)
-        fireEvent.change(inputEl!, { target: { value: 'test query' } })
-        const confirmBtn = container.querySelector('.check-button__btn')
-        expect(confirmBtn).toBeTruthy()
-        fireEvent.click(confirmBtn!)
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="content"
-                filtersInQuery={nextFiltersInQuery}
-                filterType={FilterType.content}
-                value={nextValue}
-                onFilterEdited={onFilterEditedHandler}
-                editable={false}
-            />
-        ).container
-        fireEvent.click(container.querySelector('.filter-input__button-text')!)
-        expect(getByText(container, 'content:test query')).toBeTruthy()
-    })
-
-    test('filter input for message filters does not get auto-quoted when editable', () => {
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="message"
-                filterType={FilterType.message}
-                onFilterEdited={onFilterEditedHandler}
-                editable={true}
-            />
-        ).container
-
-        const inputEl = container.querySelector('.filter-input__input-field')
-        expect(inputEl).toBeTruthy()
-        fireEvent.click(inputEl!)
-        fireEvent.change(inputEl!, { target: { value: 'test query' } })
-        const confirmBtn = container.querySelector('.check-button__btn')
-        expect(confirmBtn).toBeTruthy()
-        fireEvent.click(confirmBtn!)
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="message"
-                filtersInQuery={nextFiltersInQuery}
-                filterType={FilterType.message}
-                value={nextValue}
-                onFilterEdited={onFilterEditedHandler}
-                editable={false}
-            />
-        ).container
-        expect(getByText(container, 'message:"test query"')).toBeTruthy()
-    })
 
     test('Updating filters with an empty value does not work', () => {
         container = render(<FilterInput {...defaultProps} />).container
@@ -160,36 +64,137 @@ describe('FilterInput', () => {
         expect(defaultProps.onFilterEdited.notCalled).toBe(true)
     })
 
-    test('Updating type filter with an empty value does work', () => {
-        container = render(<FilterInput {...defaultProps} value="diff" filterType={FilterType.type} mapKey="type" />)
-            .container
-        const codeRadioButton = container.querySelector('.e2e-filter-input-radio-button-')
-        expect(codeRadioButton).toBeTruthy()
-        fireEvent.click(codeRadioButton!)
-        const confirmBtn = container.querySelector('.e2e-confirm-filter-button')
-        expect(confirmBtn).toBeTruthy()
-        fireEvent.click(confirmBtn!)
-        expect(defaultProps.onFilterEdited.calledOnce).toBe(true)
+    describe('For type filters', () => {
+        it('successfully updates when submitting with an empty value', () => {
+            container = render(
+                <FilterInput {...defaultProps} value="diff" filterType={FilterType.type} mapKey="type" />
+            ).container
+            const codeRadioButton = container.querySelector('.e2e-filter-input-radio-button-')
+            expect(codeRadioButton).toBeTruthy()
+            fireEvent.click(codeRadioButton!)
+            const confirmBtn = container.querySelector('.e2e-confirm-filter-button')
+            expect(confirmBtn).toBeTruthy()
+            fireEvent.click(confirmBtn!)
+            expect(defaultProps.onFilterEdited.calledOnce).toBe(true)
+        })
     })
 
-    it('filter input for content filters calls onFilterEdited with quoted value', () => {
-        container = render(
-            <FilterInput
-                {...defaultProps}
-                mapKey="content"
-                filterType={FilterType.content}
-                onFilterEdited={defaultProps.onFilterEdited}
-                editable={true}
-            />
-        ).container
+    describe('For content and message filters', () => {
+        it('gets auto-quoted when not editable', () => {
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="content"
+                    filterType={FilterType.content}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={true}
+                />
+            ).container
 
-        const inputEl = container.querySelector('.filter-input__input-field')
-        expect(inputEl).toBeTruthy()
-        fireEvent.click(inputEl!)
-        fireEvent.change(inputEl!, { target: { value: 'test query' } })
-        const confirmBtn = container.querySelector('.check-button__btn')
-        expect(confirmBtn).toBeTruthy()
-        fireEvent.click(confirmBtn!)
-        expect(defaultProps.onFilterEdited.calledWith('content', '"test query"')).toBe(true)
+            const inputEl = container.querySelector('.filter-input__input-field')
+            expect(inputEl).toBeTruthy()
+            fireEvent.click(inputEl!)
+            fireEvent.change(inputEl!, { target: { value: 'test query' } })
+            const confirmBtn = container.querySelector('.check-button__btn')
+            expect(confirmBtn).toBeTruthy()
+            fireEvent.click(confirmBtn!)
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="content"
+                    filtersInQuery={nextFiltersInQuery}
+                    filterType={FilterType.content}
+                    value={nextValue}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={false}
+                />
+            ).container
+            expect(getByText(container, 'content:"test query"')).toBeTruthy()
+        })
+        it('gets stripped of quotes when editable', () => {
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="content"
+                    filterType={FilterType.content}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={true}
+                />
+            ).container
+
+            const inputEl = container.querySelector('.filter-input__input-field')
+            expect(inputEl).toBeTruthy()
+            fireEvent.click(inputEl!)
+            fireEvent.change(inputEl!, { target: { value: 'test query' } })
+            const confirmBtn = container.querySelector('.check-button__btn')
+            expect(confirmBtn).toBeTruthy()
+            fireEvent.click(confirmBtn!)
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="content"
+                    filtersInQuery={nextFiltersInQuery}
+                    filterType={FilterType.content}
+                    value={nextValue}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={false}
+                />
+            ).container
+            fireEvent.click(container.querySelector('.filter-input__button-text')!)
+            expect(getByText(container, 'content:test query')).toBeTruthy()
+        })
+
+        test('filter input for message filters does not get auto-quoted when editable', () => {
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="message"
+                    filterType={FilterType.message}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={true}
+                />
+            ).container
+
+            const inputEl = container.querySelector('.filter-input__input-field')
+            expect(inputEl).toBeTruthy()
+            fireEvent.click(inputEl!)
+            fireEvent.change(inputEl!, { target: { value: 'test query' } })
+            const confirmBtn = container.querySelector('.check-button__btn')
+            expect(confirmBtn).toBeTruthy()
+            fireEvent.click(confirmBtn!)
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="message"
+                    filtersInQuery={nextFiltersInQuery}
+                    filterType={FilterType.message}
+                    value={nextValue}
+                    onFilterEdited={onFilterEditedHandler}
+                    editable={false}
+                />
+            ).container
+            expect(getByText(container, 'message:"test query"')).toBeTruthy()
+        })
+
+        it('filter input for content filters calls onFilterEdited with quoted value', () => {
+            container = render(
+                <FilterInput
+                    {...defaultProps}
+                    mapKey="content"
+                    filterType={FilterType.content}
+                    onFilterEdited={defaultProps.onFilterEdited}
+                    editable={true}
+                />
+            ).container
+
+            const inputEl = container.querySelector('.filter-input__input-field')
+            expect(inputEl).toBeTruthy()
+            fireEvent.click(inputEl!)
+            fireEvent.change(inputEl!, { target: { value: 'test query' } })
+            const confirmBtn = container.querySelector('.check-button__btn')
+            expect(confirmBtn).toBeTruthy()
+            fireEvent.click(confirmBtn!)
+            expect(defaultProps.onFilterEdited.calledWith('content', '"test query"')).toBe(true)
+        })
     })
 })

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -308,7 +308,8 @@ export class FilterInput extends React.Component<Props, State> {
         }
         if (this.props.filterType === FilterType.content || this.props.filterType === FilterType.message) {
             // The content and message filters should always be quoted and escaped, but we don't display
-            // the quoted and escaped value to the user. This makes it easier to edit and avoids double quoting.
+            // the quoted and escaped value to the user. This makes it easier to edit and makes sure URLs are always
+            // properly escaped.
             const inputValue = this.state.inputValue
             this.inputValues.next(isQuoted(inputValue) ? JSON.parse(inputValue) : inputValue)
         }

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -310,7 +310,7 @@ export class FilterInput extends React.Component<Props, State> {
             // The content and message filters should always be quoted and escaped, but we don't display
             // the quoted and escaped value to the user. This makes it easier to edit and makes sure URLs are always
             // properly escaped.
-            const inputValue = this.state.inputValue
+            const { inputValue } = this.state
             this.inputValues.next(isQuoted(inputValue) ? JSON.parse(inputValue) : inputValue)
         }
         this.props.toggleFilterEditable(this.props.mapKey)

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -306,6 +306,12 @@ export class FilterInput extends React.Component<Props, State> {
         if (this.inputEl.current) {
             this.inputEl.current.focus()
         }
+        if (this.props.filterType === FilterType.content || this.props.filterType === FilterType.message) {
+            // The content and message filters should always be quoted and escaped, but we don't display
+            // the quoted and escaped value to the user. This makes it easier to edit and avoids double quoting.
+            const inputValue = this.state.inputValue
+            this.inputValues.next(isQuoted(inputValue) ? JSON.parse(inputValue) : inputValue)
+        }
         this.props.toggleFilterEditable(this.props.mapKey)
     }
 


### PR DESCRIPTION
Fixes the issue in https://sourcegraph.slack.com/archives/C0W2E592M/p1583559994068500. 

Now, in interactive mode, the content filter will always be quoted when the query is sent to the backend, but when we display the editable value to the user, it eliminates the quotes and escape sequences. This ensures URLs are always properly escaped.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
