### PR TITLE
zoekt: prometheus metrics and debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ All notable changes to Sourcegraph are documented in this file.
 - Site-Admin/Instrumentation is now available in the Kubernetes cluster deployment [8805](https://github.com/sourcegraph/sourcegraph/pull/8805).
 - Extensions can now specify a `baseUri` in the `DocumentFilter` when registering providers.
 - Admins can now exclude GitHub forks and/or archived repositories from the set of repositories being mirrored in Sourcegraph with the `"exclude": [{"forks": true}]` or `"exclude": [{"archived": true}]` GitHub external service configuration. [#8974](https://github.com/sourcegraph/sourcegraph/pull/8974)
-- Campaign changesets can be filtered by State, Review State and Check State [8848](https://github.com/sourcegraph/sourcegraph/pull/8848)
+- Campaign changesets can be filtered by State, Review State and Check State. [#8848](https://github.com/sourcegraph/sourcegraph/pull/8848)
 - Counts of users of and searches conducted with interactive and plain text search modes will be sent back in pings, aggregated daily, weekly, and monthly.
 - Aggregated counts of daily, weekly, and monthly active users of search will be sent back in pings.
 - Counts of number of searches conducted using each filter will be sent back in pings, aggregated daily, weekly, and monthly.
 - Counts of number of users conducting searches containing each filter will be sent back in pings, aggregated daily, weekly, and monthly.
 - Added more entries (Bash, Erlang, Julia, OCaml, Scala) to the list of suggested languages for the `lang:` filter.
 - Permissions background sync is now supported for GitLab and Bitbucket Server via site configuration `"permissions.backgroundSync": {"enabled": true}`.
+- Indexed search exports more prometheus metrics and debug logs to aid debugging performance issues. [#9111](https://github.com/sourcegraph/sourcegraph/issues/9111)
 
 ### Changed
 

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -28,6 +28,6 @@ func maybeZoektProcFile() []string {
 
 	return []string{
 		fmt.Sprintf("zoekt-indexserver: env GOGC=50 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
-		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s | grep -v 'listening on'", defaultHost, indexDir),
+		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
 	}
 }

--- a/doc/admin/observability/troubleshooting.md
+++ b/doc/admin/observability/troubleshooting.md
@@ -130,10 +130,12 @@ If Sourcegraph feels sluggish overall, the likely culprit is resource allocation
 
 If your users are experiencing search timeouts or search performance issues, please perform the following steps:
 
+1. Try appending variations of `index:only`, `timeout:60s` and `count:999999` to the search query to see if it is still slow.
 1. [Access Grafana directly](metrics.md#accessing-grafana-directly).
 1. Select the **+** icon on the left-hand side, then choose **Import**.
 1. Paste [this JSON](https://gist.githubusercontent.com/slimsag/3fcc134f5ce09728188b94b463131527/raw/f8b545f4ce14b0c30a93f05cd1ee469594957a2c/sourcegraph-debug-search-timeouts.json) into the input and click **Load**.
 1. Once the dashboard appears, include screenshots of **the entire** dashboard in the issue report.
+1. Include the logs of `zoekt-webserver` container in the `indexed-search` pods. If you are using single Docker container enable [debug logs](index.md#Logs) first.
 
 
 ## Actions

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200316094253-d68b6426de67
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200318141102-0b140b7dc6c9
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -853,8 +853,8 @@ github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bC
 github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/sourcegraph/zoekt v0.0.0-20200316094253-d68b6426de67 h1:Y2aDkuSJJwYCyVyL7k8N/EOS7o0r061D/rIMuWqj8DM=
-github.com/sourcegraph/zoekt v0.0.0-20200316094253-d68b6426de67/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
+github.com/sourcegraph/zoekt v0.0.0-20200318141102-0b140b7dc6c9 h1:vUz68uAPzIPdz9ibYgEOvRh33fErNN4LFYnGSCObP28=
+github.com/sourcegraph/zoekt v0.0.0-20200318141102-0b140b7dc6c9/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This includes changes to zoekt which adds request logs and prometheus
metrics. This is to aid debugging of performance issues.

We add some points to the "slow search" troubleshooting scenario.

Zoekt now respects `SRC_LOG_LEVEL` and won't output "listening on" unless debug
logs are enabled. As such we can remove the "grep -v" we have in the server
procfile entry.

Fixes https://github.com/sourcegraph/sourcegraph/issues/9111