### PR TITLE
doc/admin/updates: add file for docker-compose manual migrations

### DIFF
--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -16,6 +16,10 @@ You can always find the version number of the latest release at [docs.sourcegrap
 
 See "[Updating Sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/update.md)" in the Kubernetes cluster administrator guide.
 
+## For Docker Compose deployments
+
+Please see: [updating a Docker Compose Sourcegraph instance](updates/docker_compose.md)
+
 ## For pure-Docker cluster deployments
 
 Please see: [updating a pure-Docker Sourcegraph cluster](updates/pure_docker.md)

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -1,0 +1,27 @@
+# Updating a Docker Compose Sourcegraph instance
+
+This document describes the exact changes needed to update a Docker Compose Sourcegraph instance.
+
+Each section comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
+
+## v3.12 -> v3.13
+
+### Manual migration step: adjust file permissions
+
+Please adjust the redis-store and redis-cache volume permissions by running the following on the host machine:
+
+```
+docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'chown -R 999:1000 /docker/volumes/docker-compose_redis-store /docker/volumes/docker-compose_redis-cache'
+```
+
+### Upgrade
+
+In your checkout of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository:
+
+```sh
+cd docker-compose/
+git pull
+docker-compose down
+git checkout v3.13.2
+docker-compose up -d
+```

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -16,12 +16,20 @@ docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'chown -R 999
 
 ### Upgrade
 
-In your checkout of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository:
+In your fork of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository:
 
 ```sh
 cd docker-compose/
-git pull
+git fetch upstream
+git merge upstream v3.13.2
+# Address any merge conflicts you may have.
+```
+
+Then on your server:
+
+```sh
+cd deploy-sourcegraph-docker/docker-compose/
 docker-compose down
-git checkout v3.13.2
+git pull
 docker-compose up -d
 ```


### PR DESCRIPTION
This file will document any manual steps needed for docker-compose migrations.

In the near future, I also plan to move https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/migrate.md into a file on our docsite here as well.