### PR TITLE
search: try more exhaustive structural search for no initial results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1215,6 +1215,22 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					multiErr = multierror.Append(multiErr, errors.Wrap(err, "text search failed"))
 					multiErrMu.Unlock()
 				}
+				if args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == defaultMaxSearchResults && len(fileResults) == 0 {
+					// No results for structural search? Automatically search again and force Zoekt to resolve
+					// more potential file matches by setting a higher FileMatchLimit.
+					args.PatternInfo.FileMatchLimit = 1000
+					fileResults, fileCommon, err = searchFilesInRepos(ctx, &args)
+					if err != nil && !isContextError(ctx, err) {
+						multiErrMu.Lock()
+						multiErr = multierror.Append(multiErr, errors.Wrap(err, "text search failed"))
+						multiErrMu.Unlock()
+					}
+					if len(fileResults) == 0 && fileCommon.limitHit {
+						// Still no results? Give up.
+						log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
+						fileCommon.limitHit = false // Ensure we don't display "Show more".
+					}
+				}
 				for _, r := range fileResults {
 					key := r.uri
 					fileMatchesMu.Lock()


### PR DESCRIPTION
Addresses #9079. See https://github.com/sourcegraph/sourcegraph/pull/8372 for why this happens. The gist is: It's possible that Zoekt  only gives partial file results (`limitHit = true`) that we pipe to `comby`. If `comby` finds zero results using Zoekt's partial file results, we can either:

1. Raise an alert of some sort that appends `count:XXX` to make Zoekt do more work and try again, or
2. Automatically try again with a `count:1000` value, and then give up and definitively say "No results" if there are still no results.

This PR implements (2) and stops "show more" from showing up when there are zero results. In rare cases it's possible that `count:1000` is not high enough and would miss results. I added a log statement for this case, and if it happens often in practice, I'll add an alert in the flavor of (1).

---

Implementation aside: I want this logic to live in a structural search-specific code path, but unfortunately I haven't restructured the search code to make that possible yet. It's on my radar.

There isn't a good way to test this. The main objective is to avoid unpleasant UX with a reasonable heuristic that stops the webapp from displaying "show more" along with "No results".