### PR TITLE
Remove activeExtensions event

### DIFF
--- a/shared/src/api/client/api/extensions.ts
+++ b/shared/src/api/client/api/extensions.ts
@@ -1,9 +1,8 @@
-import { ExecutableExtension, ExtensionsService } from '../services/extensionsService'
 import { ProxyResult } from '@sourcegraph/comlink'
 import { from, Subscription } from 'rxjs'
 import { bufferCount, startWith } from 'rxjs/operators'
 import { ExtExtensionsAPI } from '../../extension/api/extensions'
-import { TelemetryService } from '../../../telemetry/telemetryService'
+import { ExecutableExtension, ExtensionsService } from '../services/extensionsService'
 
 /** @internal */
 export class ClientExtensions {
@@ -16,22 +15,7 @@ export class ClientExtensions {
      * @param extensions An observable that emits the set of extensions that should be activated
      * upon subscription and whenever it changes.
      */
-    constructor(
-        private proxy: ProxyResult<ExtExtensionsAPI>,
-        extensionRegistry: ExtensionsService,
-        telemetryService?: TelemetryService
-    ) {
-        // Anonymously log which external extensions are active on sourcegraph.com.
-        // TODO: Send these logs to the backend to anonymously log active extensions from private instances.
-        if (telemetryService) {
-            this.subscriptions.add(
-                extensionRegistry.activeExtensions.subscribe(extensions => {
-                    const activeExtensions = extensions.map(activeExtension => activeExtension.id)
-                    telemetryService.log('activeExtensions', { activeExtensions })
-                })
-            )
-        }
-
+    constructor(private proxy: ProxyResult<ExtExtensionsAPI>, extensionRegistry: ExtensionsService) {
         this.subscriptions.add(
             from(extensionRegistry.activeExtensions)
                 .pipe(startWith([] as ExecutableExtension[]), bufferCount(2, 1))

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -136,7 +136,7 @@ export async function createExtensionHostClientConnection(
     const clientSearch = new ClientSearch(services.queryTransformer)
     const clientCommands = new ClientCommands(services.commands)
     subscription.add(new ClientRoots(proxy.roots, services.workspace))
-    subscription.add(new ClientExtensions(proxy.extensions, services.extensions, services.telemetryService))
+    subscription.add(new ClientExtensions(proxy.extensions, services.extensions))
 
     const clientContent = createClientContent(services.linkPreviews)
 

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -30,7 +30,6 @@ export class Services {
             | 'getScriptURLForExtension'
             | 'clientApplication'
             | 'sideloadedExtensionURL'
-            | 'telemetryService'
         >
     ) {}
 
@@ -52,5 +51,4 @@ export class Services {
     public readonly queryTransformer = new QueryTransformerRegistry()
     public readonly views = new ViewProviderRegistry()
     public readonly completionItems = new CompletionItemProviderRegistry()
-    public readonly telemetryService = this.platformContext.telemetryService
 }


### PR DESCRIPTION
This event fires a _lot_ — it represents nearly 12% of all events on sourcegraph.com in the last few months. We also (fortunately or not) never followed through on using this information, so it is firing with no purpose. 

Additionally, it's not really an _event_ (as no user or server action takes place) — it's just a background logging action that fires periodically, and there are likely better/more idiomatic ways to achieve this that would be worth exploring.

Finally, given fears about overloading postgres with events, and the fact that we can always add it back later, I prefer to simply remove this for now.

CC @ebrodymoore 