### PR TITLE
Add missing events to saved searches and campaigns areas

### DIFF
--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -102,4 +102,15 @@ export class EventLogger implements TelemetryService {
                 break
         }
     }
+
+    /**
+     * Implements {@link TelemetryService}.
+     *
+     * @param pageTitle The title of the page being viewed.
+     */
+    public async logViewEvent(pageTitle: string): Promise<void> {
+        const anonUserId = await this.getAnonUserID()
+        const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
+        logEvent({ name: `View${pageTitle}`, userCookieID: anonUserId, url: sourcegraphURL }, this.requestGraphQL)
+    }
 }

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`HoverOverlay actions and hover present 1`] = `
       telemetryService={
         Object {
           "log": [Function],
+          "logViewEvent": [Function],
         }
       }
       variant="actionItem"
@@ -273,6 +274,7 @@ exports[`HoverOverlay actions present 1`] = `
       telemetryService={
         Object {
           "log": [Function],
+          "logViewEvent": [Function],
         }
       }
       variant="actionItem"
@@ -342,6 +344,7 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
       telemetryService={
         Object {
           "log": [Function],
+          "logViewEvent": [Function],
         }
       }
       variant="actionItem"
@@ -450,6 +453,7 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
       telemetryService={
         Object {
           "log": [Function],
+          "logViewEvent": [Function],
         }
       }
       variant="actionItem"
@@ -545,6 +549,7 @@ exports[`HoverOverlay hover error, actions present 1`] = `
       telemetryService={
         Object {
           "log": [Function],
+          "logViewEvent": [Function],
         }
       }
       variant="actionItem"

--- a/shared/src/telemetry/telemetryService.ts
+++ b/shared/src/telemetry/telemetryService.ts
@@ -16,6 +16,10 @@ export interface TelemetryService {
      * Log an event (by sending it to the server).
      */
     log(eventName: string, eventProperties?: any): void
+    /**
+     * Log a pageview event (by sending it to the server).
+     */
+    logViewEvent(eventName: string): void
 }
 
 /**
@@ -23,6 +27,9 @@ export interface TelemetryService {
  */
 export const NOOP_TELEMETRY_SERVICE: TelemetryService = {
     log: () => {
+        /* noop */
+    },
+    logViewEvent: () => {
         /* noop */
     },
 }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -8,8 +8,6 @@ import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/tele
 import { PageTitle } from '../../../components/PageTitle'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 import { shallow, mount } from 'enzyme'
-import { eventLogger } from '../../../tracking/eventLogger'
-import sinon from 'sinon'
 
 // This is idempotent, so calling it in multiple tests is not a problem.
 registerHighlightContributions()
@@ -27,18 +25,6 @@ jest.mock('../icons', () => ({ CampaignsIcon: 'CampaignsIcon' }))
 const history = H.createMemoryHistory()
 
 describe('CampaignDetails', () => {
-    let stub: sinon.SinonStub<[string, (boolean | undefined)?], void>
-
-    beforeAll(() => {
-        stub = sinon.stub(eventLogger, 'logViewEvent')
-    })
-
-    afterAll(() => {
-        if (stub) {
-            stub.restore()
-        }
-    })
-
     afterEach(() => {
         PageTitle.titleSet = false
     })

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -8,6 +8,8 @@ import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/tele
 import { PageTitle } from '../../../components/PageTitle'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 import { shallow, mount } from 'enzyme'
+import { eventLogger } from '../../../tracking/eventLogger'
+import sinon from 'sinon'
 
 // This is idempotent, so calling it in multiple tests is not a problem.
 registerHighlightContributions()
@@ -25,9 +27,22 @@ jest.mock('../icons', () => ({ CampaignsIcon: 'CampaignsIcon' }))
 const history = H.createMemoryHistory()
 
 describe('CampaignDetails', () => {
+    let stub: sinon.SinonStub<[string, (boolean | undefined)?], void>
+
+    beforeAll(() => {
+        stub = sinon.stub(eventLogger, 'logViewEvent')
+    })
+
+    afterAll(() => {
+        if (stub) {
+            stub.restore()
+        }
+    })
+
     afterEach(() => {
         PageTitle.titleSet = false
     })
+
     test('creation form for empty manual campaign', () =>
         expect(
             shallow(

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -121,7 +121,6 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     const [campaign, setCampaign] = useState<Campaign | null>()
 
     useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         telemetryService.logViewEvent(campaignID ? 'CampaignDetailsPage' : 'NewCampaignPage')
     }, [campaignID, telemetryService])
 

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -122,10 +122,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     const [campaign, setCampaign] = useState<Campaign | null>()
 
     useEffect(() => {
-        if (campaignID) {
-            return eventLogger.logViewEvent('CampaignDetailsPage')
-        }
-        eventLogger.logViewEvent('NewCampaignPage')
+        eventLogger.logViewEvent(campaignID ? 'CampaignDetailsPage' : 'NewCampaignPage')
     }, [campaignID])
 
     useEffect(() => {

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`CampaignDetails creation form given existing patch set 1`] = `
   telemetryService={
     Object {
       "log": [Function],
+      "logViewEvent": [Function],
     }
   }
 >
@@ -329,6 +330,7 @@ exports[`CampaignDetails editing existing 1`] = `
   telemetryService={
     Object {
       "log": [Function],
+      "logViewEvent": [Function],
     }
   }
 >
@@ -998,6 +1000,7 @@ exports[`CampaignDetails editing existing 1`] = `
     telemetryService={
       Object {
         "log": [Function],
+        "logViewEvent": [Function],
       }
     }
   />
@@ -1021,6 +1024,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
   telemetryService={
     Object {
       "log": [Function],
+      "logViewEvent": [Function],
     }
   }
 >
@@ -1453,6 +1457,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
     telemetryService={
       Object {
         "log": [Function],
+        "logViewEvent": [Function],
       }
     }
   />
@@ -1476,6 +1481,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
   telemetryService={
     Object {
       "log": [Function],
+      "logViewEvent": [Function],
     }
   }
 >
@@ -2145,6 +2151,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
     telemetryService={
       Object {
         "log": [Function],
+        "logViewEvent": [Function],
       }
     }
   />

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.test.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.test.tsx
@@ -2,6 +2,7 @@ import * as H from 'history'
 import React from 'react'
 import { GlobalCampaignListPage } from './GlobalCampaignListPage'
 import { IUser } from '../../../../../../shared/src/graphql/schema'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../../../shared/src/telemetry/telemetryService'
 import { of } from 'rxjs'
 import { mount } from 'enzyme'
 
@@ -21,6 +22,7 @@ describe('GlobalCampaignListPage', () => {
                         location={history.location}
                         authenticatedUser={{ siteAdmin: true } as IUser}
                         queryCampaignsCount={() => of(totalCount)}
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
                     />
                 )
             ).toMatchSnapshot()
@@ -33,6 +35,7 @@ describe('GlobalCampaignListPage', () => {
                         location={history.location}
                         authenticatedUser={{ siteAdmin: false } as IUser}
                         queryCampaignsCount={() => of(totalCount)}
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
                     />
                 )
             ).toMatchSnapshot()

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -43,7 +43,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
     queryCampaignsCount = _queryCampaignsCount,
     ...props
 }) => {
-    useEffect(() => eventLogger.logViewEvent('CampaignsListPage'))
+    useEffect(() => eventLogger.logViewEvent('CampaignsListPage'), [])
 
     const totalCount = useObservable(useMemo(() => queryCampaignsCount(), [queryCampaignsCount]))
     return (

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { queryCampaigns, queryCampaignsCount as _queryCampaignsCount } from './backend'
 import AddIcon from 'mdi-react/AddIcon'
 import { Link } from '../../../../../../shared/src/components/Link'
@@ -7,6 +7,7 @@ import { FilteredConnection, FilteredConnectionFilter } from '../../../../compon
 import { IUser, CampaignState } from '../../../../../../shared/src/graphql/schema'
 import { CampaignNode, CampaignNodeCampaign, CampaignNodeProps } from '../../list/CampaignNode'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
+import { eventLogger } from '../../../../tracking/eventLogger'
 import { Observable } from 'rxjs'
 
 interface Props extends Pick<RouteComponentProps, 'history' | 'location'> {
@@ -42,6 +43,8 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
     queryCampaignsCount = _queryCampaignsCount,
     ...props
 }) => {
+    useEffect(() => eventLogger.logViewEvent('CampaignsListPage'))
+
     const totalCount = useObservable(useMemo(() => queryCampaignsCount(), [queryCampaignsCount]))
     return (
         <>

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -43,7 +43,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
     queryCampaignsCount = _queryCampaignsCount,
     ...props
 }) => {
-    useEffect(() => props.telemetryService.logViewEvent('CampaignsListPage'), [])
+    useEffect(() => props.telemetryService.logViewEvent('CampaignsListPage'), [props.telemetryService])
 
     const totalCount = useObservable(useMemo(() => queryCampaignsCount(), [queryCampaignsCount]))
     return (

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -6,11 +6,11 @@ import { RouteComponentProps } from 'react-router'
 import { FilteredConnection, FilteredConnectionFilter } from '../../../../components/FilteredConnection'
 import { IUser, CampaignState } from '../../../../../../shared/src/graphql/schema'
 import { CampaignNode, CampaignNodeCampaign, CampaignNodeProps } from '../../list/CampaignNode'
+import { TelemetryProps } from '../../../../../../shared/src/telemetry/telemetryService'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
-import { eventLogger } from '../../../../tracking/eventLogger'
 import { Observable } from 'rxjs'
 
-interface Props extends Pick<RouteComponentProps, 'history' | 'location'> {
+interface Props extends TelemetryProps, Pick<RouteComponentProps, 'history' | 'location'> {
     authenticatedUser: IUser
     queryCampaignsCount?: () => Observable<number>
 }
@@ -43,7 +43,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
     queryCampaignsCount = _queryCampaignsCount,
     ...props
 }) => {
-    useEffect(() => eventLogger.logViewEvent('CampaignsListPage'), [])
+    useEffect(() => props.telemetryService.logViewEvent('CampaignsListPage'), [])
 
     const totalCount = useObservable(useMemo(() => queryCampaignsCount(), [queryCampaignsCount]))
     return (

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -10,6 +10,12 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
   history="[History]"
   location="[Location path=/]"
   queryCampaignsCount={[Function]}
+  telemetryService={
+    Object {
+      "log": [Function],
+      "logViewEvent": [Function],
+    }
+  }
 >
   <div
     className="d-flex justify-content-between align-items-end mb-3"
@@ -86,6 +92,12 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
   history="[History]"
   location="[Location path=/]"
   queryCampaignsCount={[Function]}
+  telemetryService={
+    Object {
+      "log": [Function],
+      "logViewEvent": [Function],
+    }
+  }
 >
   <div
     className="d-flex justify-content-between align-items-end mb-3"
@@ -194,6 +206,12 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
     noun="campaign"
     pluralNoun="campaigns"
     queryConnection={[Function]}
+    telemetryService={
+      Object {
+        "log": [Function],
+        "logViewEvent": [Function],
+      }
+    }
   />
 </GlobalCampaignListPage>
 `;
@@ -208,6 +226,12 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
   history="[History]"
   location="[Location path=/]"
   queryCampaignsCount={[Function]}
+  telemetryService={
+    Object {
+      "log": [Function],
+      "logViewEvent": [Function],
+    }
+  }
 >
   <div
     className="d-flex justify-content-between align-items-end mb-3"
@@ -310,6 +334,12 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
   history="[History]"
   location="[Location path=/]"
   queryCampaignsCount={[Function]}
+  telemetryService={
+    Object {
+      "log": [Function],
+      "logViewEvent": [Function],
+    }
+  }
 >
   <div
     className="d-flex justify-content-between align-items-end mb-3"
@@ -444,6 +474,12 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
     noun="campaign"
     pluralNoun="campaigns"
     queryConnection={[Function]}
+    telemetryService={
+      Object {
+        "log": [Function],
+        "logViewEvent": [Function],
+      }
+    }
   />
 </GlobalCampaignListPage>
 `;

--- a/web/src/savedSearches/SavedSearchCreateForm.tsx
+++ b/web/src/savedSearches/SavedSearchCreateForm.tsx
@@ -7,6 +7,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { ErrorLike, isErrorLike, asError } from '../../../shared/src/util/errors'
 import { NamespaceProps } from '../namespaces'
 import { createSavedSearch } from '../search/backend'
+import { eventLogger } from '../tracking/eventLogger'
 import { SavedQueryFields, SavedSearchForm } from './SavedSearchForm'
 
 interface Props extends RouteComponentProps, NamespaceProps {
@@ -53,10 +54,12 @@ export class SavedSearchCreateForm extends React.Component<Props, State> {
                 .subscribe(createdOrError => {
                     this.setState({ createdOrError })
                     if (createdOrError === true) {
+                        eventLogger.log('SavedSearchCreated')
                         this.props.history.push(`${this.props.namespace.url}/searches`)
                     }
                 })
         )
+        eventLogger.logViewEvent('NewSavedSearchPage')
     }
 
     public render(): JSX.Element | null {

--- a/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/web/src/savedSearches/SavedSearchListPage.tsx
@@ -15,6 +15,7 @@ import { deleteSavedSearch, fetchSavedSearches } from '../search/backend'
 import { PatternTypeProps } from '../search'
 import { ErrorAlert } from '../components/alerts'
 import * as H from 'history'
+import { eventLogger } from '../tracking/eventLogger'
 
 interface NodeProps extends RouteComponentProps, Omit<PatternTypeProps, 'setPatternType'> {
     savedSearch: GQL.ISavedSearch
@@ -49,6 +50,7 @@ class SavedSearchNode extends React.PureComponent<NodeProps, NodeState> {
                     )
                 )
                 .subscribe(() => {
+                    eventLogger.log('SavedSearchDeleted')
                     this.setState({ isDeleting: false })
                     this.props.onDelete()
                 })
@@ -130,6 +132,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                 )
                 .subscribe(newState => this.setState(newState as State))
         )
+        eventLogger.logViewEvent('SavedSearchListPage')
     }
 
     public render(): JSX.Element | null {


### PR DESCRIPTION
After running through the site to check for missing event logging for site admins, I found two areas that were missing some. This PR adds missing events to:

* Saved searches pages
* Campaigns pages

I've tagged @attfarhan for the former, and @eseliger for the latter, but let me know if those are incorrect.

And I'm brand new to hooks, so forgive any sins on that front in the campaigns code :)

(if you want to audit these changes, you can run `localStorage.eventLogDebug="true"` in your JS console, and you'll see the events being fired there)

CC @ebrodymoore 