### PR TITLE
search: succinct TextPatternInfo for searchFilesInRepos traces

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -459,11 +459,13 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return mockSearchFilesInRepos(args)
 	}
 
-	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s, numRepoRevs: %d", args.PatternInfo.Pattern, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
+	tr.LazyLog(&args.Query.Fields, false)
+	tr.LazyLog(args.PatternInfo, false)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -112,6 +112,13 @@ func (p *PatternInfo) String() string {
 	if p.IsRegExp {
 		args = append(args, "re")
 	}
+	if p.IsStructuralPat {
+		if p.CombyRule != "" {
+			args = append(args, fmt.Sprintf("comby:%s", p.CombyRule))
+		} else {
+			args = append(args, "comby")
+		}
+	}
 	if p.IsWordMatch {
 		args = append(args, "word")
 	}
@@ -127,6 +134,9 @@ func (p *PatternInfo) String() string {
 	if p.FileMatchLimit > 0 {
 		args = append(args, fmt.Sprintf("filematchlimit:%d", p.FileMatchLimit))
 	}
+	for _, lang := range p.Languages {
+		args = append(args, fmt.Sprintf("lang:%s", lang))
+	}
 
 	path := "glob"
 	if p.PathPatternsAreRegExps {
@@ -138,10 +148,8 @@ func (p *PatternInfo) String() string {
 	if p.ExcludePattern != "" {
 		args = append(args, fmt.Sprintf("-%s:%q", path, p.ExcludePattern))
 	}
-	if incs := p.IncludePatterns; len(incs) > 0 {
-		for _, inc := range incs {
-			args = append(args, fmt.Sprintf("%s:%q", path, inc))
-		}
+	for _, inc := range p.IncludePatterns {
+		args = append(args, fmt.Sprintf("%s:%q", path, inc))
 	}
 
 	return fmt.Sprintf("PatternInfo{%s}", strings.Join(args, ","))


### PR DESCRIPTION
We just put the query string in the title instead of the whole TextPatternInfo
into the title. We then log the TextPatternInfo. We also log the parsed query
which should help with a current problem we are facing.

Additionally searcher.protocol.PatternInfo is a type that is duplicated with
search.TextPatternInfo. We need to unify them in a later commit, but for now
it is easier to copy the succinct string function for PatternInfo to
TextPatternInfo. This will produce much easier to read log output, since
usually most fields are just the default empty value.

This change was motivated by struggling to read traces when investigating a
search issue.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
