### PR TITLE
ci: bump parallel run mem free to 500M

### DIFF
--- a/dev/ci/parallel_run.sh
+++ b/dev/ci/parallel_run.sh
@@ -6,7 +6,7 @@ trap "rm -rf $log_file" EXIT
 # Remove parallel citation log spam.
 echo 'will cite' | parallel --citation &>/dev/null
 
-parallel --jobs 4 --memfree 100M --keep-order --line-buffer --joblog $log_file "$@"
+parallel --jobs 4 --memfree 500M --keep-order --line-buffer --joblog $log_file "$@"
 code=$?
 
 echo "--- done - displaying job log:"


### PR DESCRIPTION
saw another flake here https://buildkite.com/sourcegraph/sourcegraph/builds/58664#ec4861bd-6b55-4d61-8312-9f8b8a8e984a



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
