### PR TITLE
ci: add enable-profiling/ branch prefix

### DIFF
--- a/cmd/server/go-build.sh
+++ b/cmd/server/go-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+PACKAGE="$1"
+
+go build \
+    -trimpath \
+    -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION"  \
+    -buildmode exe \
+    -installsuffix netgo \
+    -tags "dist netgo" \
+    -o "$BINDIR/$(basename "$PACKAGE")" "$PACKAGE"

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -27,7 +27,12 @@ CHECKS=(
 
 echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"
 
-parallel_run {} ::: "${CHECKS[@]}"
+MAYBE_TIME_PREFIX=""
+if [[ "${CI_DEBUG_PROFILE:-"false"}" == "true" ]]; then
+    MAYBE_TIME_PREFIX="env time -v"
+fi
+
+parallel_run "${MAYBE_TIME_PREFIX}" {} ::: "${CHECKS[@]}"
 
 # TODO(sqs): Reenable this check when about.sourcegraph.com is reliable. Most failures come from its
 # downtime, not from broken URLs.

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -21,11 +21,17 @@ DIRS=(
 )
 
 run_command() {
+    local MAYBE_TIME_PREFIX=""
+    if [[ "${CI_DEBUG_PROFILE:-"false"}" == "true" ]]; then
+        MAYBE_TIME_PREFIX="env time -v"
+    fi
+
     dir=$1
     echo "--- $dir: $ARGS"
-    (set -x; cd "$dir" && $ARGS)
+    (set -x; cd "$dir" && eval "${MAYBE_TIME_PREFIX} ${ARGS}")
 }
 export -f run_command
+
 
 if [[ "${CI:-"false"}" == "true" ]]; then
     echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -13,14 +13,19 @@ echo "--- yarn root"
 # TODO: This is no longer needed since the management console was removed.
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
+MAYBE_TIME_PREFIX=""
+if [[ "${CI_DEBUG_PROFILE:-"false"}" == "true" ]]; then
+    MAYBE_TIME_PREFIX="env time -v"
+fi
+
 build_browser() {
     echo "--- yarn browser"
-    (cd browser && TARGETS=phabricator yarn build)
+    (cd browser && TARGETS=phabricator eval "${MAYBE_TIME_PREFIX} yarn build")
 }
 
 build_web() {
     echo "--- yarn web"
-    (cd web && NODE_ENV=production yarn -s run build --color)
+    (cd web && NODE_ENV=production eval "${MAYBE_TIME_PREFIX} yarn -s run build --color")
 }
 
 export -f build_browser

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -32,6 +32,10 @@ type Config struct {
 	patchNoTest         bool
 	isQuick             bool
 	isMasterDryRun      bool
+
+	// profilingEnabled, if true, tells buildkite to print timing and resource utilization information
+	// for each command
+	profilingEnabled bool
 }
 
 func ComputeConfig() Config {
@@ -64,6 +68,8 @@ func ComputeConfig() Config {
 
 	isQuick := strings.HasPrefix(branch, "quick/")
 
+	profilingEnabled := strings.HasPrefix(branch, "enable-profiling/")
+
 	var mustIncludeCommits []string
 	if rawMustIncludeCommit := os.Getenv("MUST_INCLUDE_COMMIT"); rawMustIncludeCommit != "" {
 		mustIncludeCommits = strings.Split(rawMustIncludeCommit, ",")
@@ -86,6 +92,7 @@ func ComputeConfig() Config {
 		patchNoTest:         patchNoTest,
 		isQuick:             isQuick,
 		isMasterDryRun:      isMasterDryRun,
+		profilingEnabled:    profilingEnabled,
 	}
 }
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -200,6 +200,7 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["DATE"] = commonEnv["DATE"]
 	env["VERSION"] = commonEnv["VERSION"]
 	env["TAG"] = candiateImageTag(c)
+	env["CI_DEBUG_PROFILE"] = commonEnv["CI_DEBUG_PROFILE"]
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":chromium:",

--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -49,9 +49,13 @@ type AutomaticRetryOptions struct {
 
 var Plugins = make(map[string]interface{})
 
-// OnEveryStepOpts are e.g. commands that are run on every AddStep, similar to
+// BeforeEveryStepOpts are e.g. commands that are run before every AddStep, similar to
 // Plugins.
-var OnEveryStepOpts []StepOpt
+var BeforeEveryStepOpts []StepOpt
+
+// AfterEveryStepOpts are e.g. that are run at the ende of every AddStep, helpful for
+// post-processing
+var AfterEveryStepOpts []StepOpt
 
 func (p *Pipeline) AddStep(label string, opts ...StepOpt) {
 	step := &Step{
@@ -59,10 +63,13 @@ func (p *Pipeline) AddStep(label string, opts ...StepOpt) {
 		Env:     make(map[string]string),
 		Plugins: Plugins,
 	}
-	for _, opt := range OnEveryStepOpts {
+	for _, opt := range BeforeEveryStepOpts {
 		opt(step)
 	}
 	for _, opt := range opts {
+		opt(step)
+	}
+	for _, opt := range AfterEveryStepOpts {
 		opt(step)
 	}
 	p.Steps = append(p.Steps, step)


### PR DESCRIPTION
When pusing to a branch prefixed with `enable-profiling/` (example: https://github.com/sourcegraph/sourcegraph/tree/enable-profiling/ggilmore)
- `env time -v` gets prefixed to every buildkite command
- a fair number of our scripts get more detailed timing information

Example output: https://buildkite.com/sourcegraph/sourcegraph/builds/58883#dd202d96-f6e3-458a-aacd-9d5715672ab9

```

 Command exited with non-zero status 1
  Command being timed: "./dev/check/all.sh"
  User time (seconds): 510.14
  System time (seconds): 171.30
  Percent of CPU this job got: 802%
  Elapsed (wall clock) time (h:mm:ss or m:ss): 1:24.95
  Average shared text size (kbytes): 0
  Average unshared data size (kbytes): 0
  Average stack size (kbytes): 0
  Average total size (kbytes): 0
  Maximum resident set size (kbytes): 12316844
  Average resident set size (kbytes): 0
  Major (requiring I/O) page faults: 14061
  Minor (reclaiming a frame) page faults: 10709094
  Voluntary context switches: 1946015
  Involuntary context switches: 325300
  Swaps: 0
  File system inputs: 2211272
  File system outputs: 3671368
  Socket messages sent: 0
  Socket messages received: 0
  Signals delivered: 0
  Page size (bytes): 4096
  Exit status: 1

```
