### PR TITLE
ci: remove "unused" staticcheck

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -19,4 +19,5 @@ asdf reshim
 
 echo "--- lint"
 
-golangci-lint run ${pkgs}
+# Disable unused since it uses too much CPU/mem
+golangci-lint run -e unused ${pkgs}


### PR DESCRIPTION
CI is currently broken due to unused using too much memory and CPU. We recently
re-enabled the unused check so it is likely due to that.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
