### PR TITLE
Allow toggling regexp toggle when structural search is active

### DIFF
--- a/web/src/search/input/toggles/Toggles.tsx
+++ b/web/src/search/input/toggles/Toggles.tsx
@@ -83,12 +83,12 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
     }
 
     const toggleRegexp = (): void => {
-        if (props.patternType === SearchPatternType.structural) {
-            return
-        }
-
-        const newPatternType =
+        let newPatternType =
             props.patternType !== SearchPatternType.regexp ? SearchPatternType.regexp : SearchPatternType.literal
+
+        if (props.patternType === SearchPatternType.structural) {
+            newPatternType = SearchPatternType.regexp
+        }
 
         props.setPatternType(newPatternType)
 
@@ -148,8 +148,6 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
                 icon={RegexIcon}
                 className="e2e-regexp-toggle"
                 activeClassName="e2e-regexp-toggle--active"
-                disabledCondition={props.patternType === SearchPatternType.structural}
-                disabledMessage="Structural search uses Comby syntax"
             />
             {!structuralSearchDisabled && (
                 <QueryInputToggle

--- a/web/src/search/input/toggles/Toggles.tsx
+++ b/web/src/search/input/toggles/Toggles.tsx
@@ -83,12 +83,8 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
     }
 
     const toggleRegexp = (): void => {
-        let newPatternType =
+        const newPatternType =
             props.patternType !== SearchPatternType.regexp ? SearchPatternType.regexp : SearchPatternType.literal
-
-        if (props.patternType === SearchPatternType.structural) {
-            newPatternType = SearchPatternType.regexp
-        }
 
         props.setPatternType(newPatternType)
 


### PR DESCRIPTION
Keeps the regexp toggle enabled when structural search is selected. Now, when clicking on the regexp toggle while structural search is enabled, you'll switch to regexp syntax. To get to literal syntax, click the structural search toggle again (same as current behavior).

Fixes https://github.com/sourcegraph/sourcegraph/issues/9078.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
