### PR TITLE
docs: add section for permissions background sync

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -179,19 +179,41 @@ By installing the [Bitbucket Server plugin](../../../integration/bitbucket_serve
 
 Finally, **save the configuration**. You're done!
 
+## Background permissions sync
+
+Starting at 3.14, Sourcegraph supports syncing permissions in the background, it helps better handle repository permissions at scale. Rather than updating a user’s permissions when they log in and potentially blocking them from seeing search results, Sourcegraph now syncs these permissions proactively, and opportunistically refreshing these permissions in a timely manner, as part of a background service.
+
+It is currently behind a feature flag in the [site configuration](../config/site_config.md):
+
+```json
+"permissions.backgroundSync": {
+	"enabled": true
+}
+```
+
+>NOTE: Only GitLab and Bitbucket Server are supported at this time, GitHub and other code hosts are coming soon.
+
+However, with changing the permissions sync model, there are few things to expect:
+
+1. While kicking off the the initial round of syncing for all repositories and users, users are able to gradually see search results from more repositories they have access to.
+1. It takes time to complete the initial round of syncing. Depending on how many private repositoreis and users you have on the Sourcegraph instance, it could take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see expected repositories to appear in the search results because the permissions syncing hasn't finished yet.
+2. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
+
+Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
+
 ## Explicit permissions API
 
 Sourcegraph exposes a GraphQL API to explicitly set repository ACLs. This will become the primary
 way to specify permissions in the future and will eventually replace the other repository
 permissions mechanisms.
 
-To enable the permissions API, add the following to the [site config](../config/site_config.md):
+To enable the permissions API, add the following to the [site configuration](../config/site_config.md):
 
 ```json
 "permissions.userMapping": {
     "enabled": true,
     "bindID": "email"
-},
+}
 ```
 
 > The `bindID` value is used to uniquely identify users when setting permissions. Alternatively, it

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -179,11 +179,11 @@ By installing the [Bitbucket Server plugin](../../../integration/bitbucket_serve
 
 Finally, **save the configuration**. You're done!
 
-## Background permissions sync
+## Background permissions syncing
 
 Starting with 3.14, Sourcegraph supports syncing permissions in the background to better handle repository permissions at scale. Rather than syncing a user's permissions when they log in and potentially blocking them from seeing search results, Sourcegraph syncs these permissions asynchronously in the background, opportunistically refreshing them in a timely manner.
 
-Background permissions sync is currently behind a feature flag in the [site configuration](../config/site_config.md):
+Background permissions syncing is currently behind a feature flag in the [site configuration](../config/site_config.md):
 
 ```json
 "permissions.backgroundSync": {
@@ -191,19 +191,19 @@ Background permissions sync is currently behind a feature flag in the [site conf
 }
 ```
 
->NOTE: Only GitLab and Bitbucket Server are supported at this time, GitHub and other code hosts are coming soon.
+>NOTE: Only GitLab and Bitbucket Server are supported at this time. Support for GitHub is coming soon in 3.15.
 
-There are some advantages to sync permissions in the background:
+Background permissions syncing has the following benefits:
 
-1. It keeps of schedule of when to sync permissions, resulting in a more predictable load on the code host API.
-1. It proactively syncs permissions as soon as new repositories are added to the Sourcegraph instance.
+1. More predictable load on the code host API due to maintaining a schedule of permission updates.
+1. Permissions are quickly synced for new repositories added to the Sourcegraph instance.
 1. Users who sign up on the Sourcegraph instance can immediately get search results from the repositories they have access to on the code host.
 
 Since the syncing of permissions happens in the background, there are a few things to keep in mind:
 
 1. While the initial sync for all repositories and users is happening, users can gradually see more and more search results from repositories they have access to.
-1. It takes time to complete the first sync. Depending on how many private repositories and users you have on the Sourcegraph instance, it can take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see the repositories they expect in search results because the permissions syncing hasn't finished yet.
-1. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
+1. It takes time to complete the first sync. Depending on how many private repositories and users you have on the Sourcegraph instance, it can take from a few minutes to several hours. This is generally not a problem for fresh installations, since admins should only make the instance available after it's ready, but for existing installations, active users may not see the repositories they expect in search results because the initial permissions syncing hasn't finished yet.
+1. More requests to the code host API need to be done during the first sync, but their pace is controlled with rate limiting.
 
 Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -181,9 +181,9 @@ Finally, **save the configuration**. You're done!
 
 ## Background permissions sync
 
-Starting at 3.14, Sourcegraph supports syncing permissions in the background, it helps better handle repository permissions at scale. Rather than updating a user’s permissions when they log in and potentially blocking them from seeing search results, Sourcegraph now syncs these permissions proactively, and opportunistically refreshing these permissions in a timely manner, as part of a background service.
+Starting with 3.14, Sourcegraph supports syncing permissions in the background to better handle repository permissions at scale. Rather than syncing a user's permissions when they log in and potentially blocking them from seeing search results, Sourcegraph syncs these permissions asynchronously in the background, opportunistically refreshing them in a timely manner.
 
-It is currently behind a feature flag in the [site configuration](../config/site_config.md):
+Background permissions sync is currently behind a feature flag in the [site configuration](../config/site_config.md):
 
 ```json
 "permissions.backgroundSync": {
@@ -195,14 +195,14 @@ It is currently behind a feature flag in the [site configuration](../config/site
 
 There are some advantages to sync permissions in the background:
 
-1. It schedules the syncing, thus it has more predictable API consumption to the code host.
+1. It keeps of schedule of when to sync permissions, resulting in a more predictable load on the code host API.
 1. It proactively syncs permissions as soon as new repositories are added to the Sourcegraph instance.
-1. For users who haven't yet created their accounts on the Sourcegraph instance, they are able to instantly get search results from the repositories they have access on the code host after sign up.
+1. Users who sign up on the Sourcegraph instance can immediately get search results from the repositories they have access to on the code host.
 
-However, there are also few things to expect:
+Since the syncing of permissions happens in the background, there are a few things to keep in mind:
 
-1. While kicking off the the initial round of syncing for all repositories and users, users are able to gradually see search results from more repositories they have access to.
-1. It takes time to complete the initial round of syncing. Depending on how many private repositoreis and users you have on the Sourcegraph instance, it could take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see expected repositories to appear in the search results because the permissions syncing hasn't finished yet.
+1. While the initial sync for all repositories and users is happening, users can gradually see more and more search results from repositories they have access to.
+1. It takes time to complete the first sync. Depending on how many private repositories and users you have on the Sourcegraph instance, it can take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see the repositories they expect in search results because the permissions syncing hasn't finished yet.
 1. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
 
 Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -193,11 +193,17 @@ It is currently behind a feature flag in the [site configuration](../config/site
 
 >NOTE: Only GitLab and Bitbucket Server are supported at this time, GitHub and other code hosts are coming soon.
 
-However, with changing the permissions sync model, there are few things to expect:
+There are some advantages to sync permissions in the background:
+
+1. It has more predictable API consumption to the code host.
+1. It proactively syncs permissions as soon as new repositories are added to the Sourcegraph instance.
+1. For users who haven't yet created their accounts on the Sourcegraph instance, they are able to instantly get search results from the repositories they have access on the code host after sign up.
+
+However, there are also few things to expect:
 
 1. While kicking off the the initial round of syncing for all repositories and users, users are able to gradually see search results from more repositories they have access to.
 1. It takes time to complete the initial round of syncing. Depending on how many private repositoreis and users you have on the Sourcegraph instance, it could take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see expected repositories to appear in the search results because the permissions syncing hasn't finished yet.
-1. It has more predictable API consumption to the code host, but it could put more pressure on the code host during the initial round of syncing.
+1. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
 
 Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -195,7 +195,7 @@ It is currently behind a feature flag in the [site configuration](../config/site
 
 There are some advantages to sync permissions in the background:
 
-1. It has more predictable API consumption to the code host.
+1. It schedules the syncing, thus it has more predictable API consumption to the code host.
 1. It proactively syncs permissions as soon as new repositories are added to the Sourcegraph instance.
 1. For users who haven't yet created their accounts on the Sourcegraph instance, they are able to instantly get search results from the repositories they have access on the code host after sign up.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -197,7 +197,7 @@ However, with changing the permissions sync model, there are few things to expec
 
 1. While kicking off the the initial round of syncing for all repositories and users, users are able to gradually see search results from more repositories they have access to.
 1. It takes time to complete the initial round of syncing. Depending on how many private repositoreis and users you have on the Sourcegraph instance, it could take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see expected repositories to appear in the search results because the permissions syncing hasn't finished yet.
-1. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
+1. It has more predictable API consumption to the code host, but it could put more pressure on the code host during the initial round of syncing.
 
 Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -197,7 +197,7 @@ However, with changing the permissions sync model, there are few things to expec
 
 1. While kicking off the the initial round of syncing for all repositories and users, users are able to gradually see search results from more repositories they have access to.
 1. It takes time to complete the initial round of syncing. Depending on how many private repositoreis and users you have on the Sourcegraph instance, it could take from few minutes to several hours. This is generally not a problem for fresh installations, but for existing installations, users may not see expected repositories to appear in the search results because the permissions syncing hasn't finished yet.
-2. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
+1. Although we have rate limiting mechanism in place, it consumes more API requests (i.e. more pressure on the code host) during the initial round of syncing.
 
 Please contact Sourcegraph support if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
 


### PR DESCRIPTION
This PR adds a section for background permissions sync in the repository permissions page.

**NOTE**: Grafana dashboard screenshots are not included because the 3.14 final release tag has been made before my day starts. My plan is to roll out this initial docs version with 3.14 and do a patch release for a more comprehensive Grafana dashboard with updated docs.