### PR TITLE
trace: remove ancestors from family name

### DIFF
--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -39,11 +39,12 @@ func (t Tracer) New(ctx context.Context, family, title string) (*Trace, context.
 		family,
 		opentracing.Tag{Key: "title", Value: title},
 	)
-	if parent := TraceFromContext(ctx); parent != nil {
-		family = parent.family + " > " + family
-	}
 	tr := nettrace.New(family, title)
 	trace := &Trace{span: span, trace: tr, family: family}
+	if parent := TraceFromContext(ctx); parent != nil {
+		tr.LazyPrintf("parent: %s", parent.family)
+		trace.family = parent.family + " > " + family
+	}
 	return trace, ContextWithTrace(ctx, trace)
 }
 


### PR DESCRIPTION
This "flattens" the net/trace debug page. I find this much more readable and
for common "leaf" traces this makes it much easier to understand its
performance. For example we can now get a good idea on how "sql" is
performing overall.

To compensate for the missing ancestor state, it is logged as an event in the
trace.

![image](https://user-images.githubusercontent.com/187831/77140434-438f9f00-6a82-11ea-97ae-e2b206272495.png)