### PR TITLE
Debounce smart search suggestions

### DIFF
--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -8,28 +8,26 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    're',
                     (parseSearchQuery('re') as ParseSuccess<Sequence>).token,
                     { column: 3 },
-                    () =>
-                        of([
-                            {
-                                __typename: 'Repository',
-                                name: 'github.com/sourcegraph/jsonrpc2',
-                            },
-                            {
-                                __typename: 'Symbol',
-                                name: 'RepoRoutes',
-                                kind: 'VARIABLE',
-                                location: {
-                                    resource: {
-                                        repository: {
-                                            name: 'github.com/sourcegraph/jsonrpc2',
-                                        },
+                    of([
+                        {
+                            __typename: 'Repository',
+                            name: 'github.com/sourcegraph/jsonrpc2',
+                        },
+                        {
+                            __typename: 'Symbol',
+                            name: 'RepoRoutes',
+                            kind: 'VARIABLE',
+                            location: {
+                                resource: {
+                                    repository: {
+                                        name: 'github.com/sourcegraph/jsonrpc2',
                                     },
                                 },
                             },
-                        ] as SearchSuggestion[])
+                        },
+                    ] as SearchSuggestion[])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -63,28 +61,26 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'reposi',
                     (parseSearchQuery('reposi') as ParseSuccess<Sequence>).token,
                     { column: 7 },
-                    () =>
-                        of([
-                            {
-                                __typename: 'Repository',
-                                name: 'github.com/sourcegraph/jsonrpc2',
-                            },
-                            {
-                                __typename: 'Symbol',
-                                name: 'RepoRoutes',
-                                kind: 'VARIABLE',
-                                location: {
-                                    resource: {
-                                        repository: {
-                                            name: 'github.com/sourcegraph/jsonrpc2',
-                                        },
+                    of([
+                        {
+                            __typename: 'Repository',
+                            name: 'github.com/sourcegraph/jsonrpc2',
+                        },
+                        {
+                            __typename: 'Symbol',
+                            name: 'RepoRoutes',
+                            kind: 'VARIABLE',
+                            location: {
+                                resource: {
+                                    repository: {
+                                        name: 'github.com/sourcegraph/jsonrpc2',
                                     },
                                 },
                             },
-                        ] as SearchSuggestion[])
+                        },
+                    ] as SearchSuggestion[])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -119,12 +115,7 @@ describe('getCompletionItems()', () => {
     test('returns suggestions for an empty query', async () => {
         expect(
             (
-                await getCompletionItems(
-                    '',
-                    (parseSearchQuery('') as ParseSuccess<Sequence>).token,
-                    { column: 1 },
-                    () => NEVER
-                )
+                await getCompletionItems((parseSearchQuery('') as ParseSuccess<Sequence>).token, { column: 1 }, NEVER)
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
             'after',
@@ -157,16 +148,14 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'a ',
                     (parseSearchQuery('a ') as ParseSuccess<Sequence>).token,
                     { column: 3 },
-                    () =>
-                        of([
-                            {
-                                __typename: 'Repository',
-                                name: 'github.com/sourcegraph/jsonrpc2',
-                            },
-                        ] as SearchSuggestion[])
+                    of([
+                        {
+                            __typename: 'Repository',
+                            name: 'github.com/sourcegraph/jsonrpc2',
+                        },
+                    ] as SearchSuggestion[])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -201,10 +190,9 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'rE',
                     (parseSearchQuery('rE') as ParseSuccess<Sequence>).token,
                     { column: 3 },
-                    () => of([])
+                    of([])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -238,10 +226,9 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'case:y',
                     (parseSearchQuery('case:y') as ParseSuccess<Sequence>).token,
                     { column: 7 },
-                    () => NEVER
+                    NEVER
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(['yes', 'no'])
@@ -251,12 +238,11 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'lang:',
                     (parseSearchQuery('lang:') as ParseSuccess<Sequence>).token,
                     {
                         column: 6,
                     },
-                    () => of([])
+                    of([])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -288,20 +274,18 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    'a',
                     (parseSearchQuery('file:c') as ParseSuccess<Sequence>).token,
                     { column: 7 },
-                    () =>
-                        of([
-                            {
-                                __typename: 'File',
-                                path: 'connect.go',
-                                name: 'connect.go',
-                                repository: {
-                                    name: 'github.com/sourcegraph/jsonrpc2',
-                                },
+                    of([
+                        {
+                            __typename: 'File',
+                            path: 'connect.go',
+                            name: 'connect.go',
+                            repository: {
+                                name: 'github.com/sourcegraph/jsonrpc2',
                             },
-                        ] as SearchSuggestion[])
+                        },
+                    ] as SearchSuggestion[])
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(['connect.go'])

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { Observable, fromEventPattern, of, combineLatest } from 'rxjs'
 import { parseSearchQuery } from './parser'
-import { map, first, takeUntil, publishReplay, refCount, switchMap } from 'rxjs/operators'
+import { map, first, takeUntil, publishReplay, refCount, switchMap, debounceTime, share } from 'rxjs/operators'
 import { getMonacoTokens } from './tokens'
 import { getDiagnostics } from './diagnostics'
 import { getCompletionItems } from './completion'
@@ -42,6 +42,7 @@ export function getProviders(
         publishReplay(1),
         refCount()
     )
+    const debouncedDynamicSuggestions = searchQueries.pipe(debounceTime(300), switchMap(fetchSuggestions), share())
     return {
         tokens: {
             getInitialState: () => PARSER_STATE,
@@ -73,10 +74,10 @@ export function getProviders(
                 parsedQueries
                     .pipe(
                         first(),
-                        switchMap(({ rawQuery, parsed }) =>
+                        switchMap(({ parsed }) =>
                             parsed.type === 'error'
                                 ? of(null)
-                                : getCompletionItems(rawQuery, parsed.token, position, fetchSuggestions)
+                                : getCompletionItems(parsed.token, position, debouncedDynamicSuggestions)
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )


### PR DESCRIPTION
Fixes #9133

Debounces `fetchSuggestions()` calls for smart search completions.