### PR TITLE
Fix site admin onboarding steps header

### DIFF
--- a/shared/src/components/activation/ActivationChecklist.tsx
+++ b/shared/src/components/activation/ActivationChecklist.tsx
@@ -38,7 +38,7 @@ export class ActivationChecklistItem extends React.PureComponent<ActivationCheck
                 {this.props.link ? (
                     <Link {...this.props.link}>{checkboxElem}</Link>
                 ) : (
-                    <button type="button" className="btn btn-link text-left w-100 p-0">
+                    <button type="button" className="btn btn-link text-left w-100 p-0 border-0">
                         {checkboxElem}
                     </button>
                 )}

--- a/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ActivationChecklist render 0/1 complete 1`] = `
       onClick={[Function]}
     >
       <button
-        className="btn btn-link text-left w-100 p-0"
+        className="btn btn-link text-left w-100 p-0 border-0"
         type="button"
       >
         <div>
@@ -43,7 +43,7 @@ exports[`ActivationChecklist render 0/1 complete 2`] = `
       onClick={[Function]}
     >
       <button
-        className="btn btn-link text-left w-100 p-0"
+        className="btn btn-link text-left w-100 p-0 border-0"
         type="button"
       >
         <div>
@@ -74,7 +74,7 @@ exports[`ActivationChecklist render 1/1 complete 1`] = `
       onClick={[Function]}
     >
       <button
-        className="btn btn-link text-left w-100 p-0"
+        className="btn btn-link text-left w-100 p-0 border-0"
         type="button"
       >
         <div>

--- a/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`ActivationDropdown render 0/2 completed 1`] = `
         onClick={[Function]}
       >
         <button
-          className="btn btn-link text-left w-100 p-0"
+          className="btn btn-link text-left w-100 p-0 border-0"
           type="button"
         >
           <div>
@@ -272,7 +272,7 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
         onClick={[Function]}
       >
         <button
-          className="btn btn-link text-left w-100 p-0"
+          className="btn btn-link text-left w-100 p-0 border-0"
           type="button"
         >
           <div>

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -27,6 +27,11 @@ interface Props {
      * Whether the whole title section should be clickable to expand the content
      */
     wholeTitleClickable?: boolean
+
+    /**
+     * Whether the title should be placed before the chevron icon.
+     */
+    titleAtStart?: true
 }
 
 /**
@@ -36,6 +41,7 @@ interface Props {
 export const Collapsible: React.FunctionComponent<Props> = ({
     title,
     children,
+    titleAtStart = false,
     defaultExpanded = false,
     className = '',
     titleClassName = '',
@@ -50,6 +56,8 @@ export const Collapsible: React.FunctionComponent<Props> = ({
         [isExpanded]
     )
 
+    const titleNode = <span className={titleClassName}>{title}</span>
+
     return (
         <div className={className}>
             <div
@@ -57,6 +65,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
                     isExpanded ? 'mb-3' : ''
                 }`}
             >
+                {titleAtStart && titleNode}
                 <button
                     type="button"
                     className={classNames(
@@ -72,7 +81,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
                         <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
                     )}
                 </button>
-                <span className={titleClassName}>{title}</span>
+                {!titleAtStart && titleNode}
             </div>
             {isExpanded && children}
         </div>

--- a/web/src/site-admin/SiteAdminOverviewPage.test.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.test.tsx
@@ -26,6 +26,55 @@ describe('SiteAdminOverviewPage', () => {
         }
     })
 
+    test('activation in progress', done => {
+        const component = renderer.create(
+            <SiteAdminOverviewPage
+                {...baseProps}
+                activation={{
+                    steps: [
+                        {
+                            id: 'ConnectedCodeHost' as const,
+                            title: 'Add repositories',
+                            detail: 'Configure Sourcegraph to talk to your code host',
+                            link: {
+                                to: '/site-admin/external-services/new',
+                            },
+                        },
+                    ],
+                    completed: {
+                        ConnectedCodeHost: false,
+                    },
+                    update: sinon.stub(),
+                    refetch: sinon.stub(),
+                }}
+                _fetchOverview={() =>
+                    of({
+                        repositories: 0,
+                        users: 1,
+                        orgs: 1,
+                        surveyResponses: {
+                            totalCount: 0,
+                            averageScore: 0,
+                        },
+                    })
+                }
+                _fetchWeeklyActiveUsers={() =>
+                    of({
+                        __typename: 'SiteUsageStatistics',
+                        daus: [],
+                        waus: [],
+                        maus: [],
+                    })
+                }
+            />
+        )
+        // ensure the hooks ran and the "API response" has been received
+        setTimeout(() => {
+            expect(component.toJSON()).toMatchSnapshot()
+            done()
+        })
+    })
+
     test('< 2 users', done => {
         const component = renderer.create(
             <SiteAdminOverviewPage

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -141,6 +141,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                 defaultExpanded={setupPercentage < 100}
                                 className="list-group-item e2e-site-admin-overview-menu"
                                 titleClassName="h4 mb-0 mt-2 font-weight-normal p-2"
+                                titleAtStart={true}
                             >
                                 {activation.completed && (
                                     <ActivationChecklist

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -201,6 +201,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                     defaultExpanded={true}
                                     className="list-group-item"
                                     titleClassName="h5 mb-0 font-weight-normal p-2"
+                                    titleAtStart={true}
                                 >
                                     {stats && (
                                         <UsageChart

--- a/web/src/site-admin/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/web/src/site-admin/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -137,3 +137,89 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
   </div>
 </div>
 `;
+
+exports[`SiteAdminOverviewPage activation in progress 1`] = `
+<div
+  className="site-admin-overview-page"
+>
+  <div
+    className="list-group"
+  >
+    <div
+      className="list-group-item e2e-site-admin-overview-menu"
+    >
+      <div
+        className="d-flex justify-content-between align-items-center position-relative mb-3"
+      >
+        <span
+          className="h4 mb-0 mt-2 font-weight-normal p-2"
+        >
+          Get started with Sourcegraph
+        </span>
+        <button
+          aria-label="Collapse section"
+          className="btn btn-icon collapsible__expand-btn stretched-link"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-label="Close section"
+            className="mdi-icon icon-inline"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        className="list-group list-group-flush "
+      >
+        <div
+          className="list-group-item list-group-item-action"
+        >
+          <div
+            data-tooltip="Configure Sourcegraph to talk to your code host"
+            onClick={[Function]}
+          >
+            <a
+              href="/site-admin/external-services/new"
+            >
+              <div>
+                <svg
+                  className="mdi-icon icon-inline text-muted"
+                  fill="currentColor"
+                  height={24}
+                  viewBox="0 0 24 24"
+                  width={24}
+                >
+                  <path
+                    d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+                  />
+                </svg>
+                <span
+                  className="mr-2 ml-2"
+                >
+                  Add repositories
+                </span>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <a
+      className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
+      href="/site-admin/repositories"
+    >
+      0
+       
+      repositories
+    </a>
+  </div>
+</div>
+`;

--- a/web/src/site-admin/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/web/src/site-admin/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -64,6 +64,14 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
       <div
         className="d-flex justify-content-between align-items-center position-relative mb-3"
       >
+        <span
+          className="h5 mb-0 font-weight-normal p-2"
+        >
+          10
+           
+          active users
+           last week
+        </span>
         <button
           aria-label="Collapse section"
           className="btn btn-icon collapsible__expand-btn stretched-link"
@@ -83,14 +91,6 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
             />
           </svg>
         </button>
-        <span
-          className="h5 mb-0 font-weight-normal p-2"
-        >
-          10
-           
-          active users
-           last week
-        </span>
       </div>
       <div
         className="site-admin-usage-statistics-page"


### PR DESCRIPTION
Fixes #9187

https://github.com/sourcegraph/sourcegraph/pull/8030 changed `Collapsible` to show the title after the chevron, but this looks really odd on the site admin page, where the title (`Get started with Sourcegraph`) is more of a section header.

Before:
![image](https://user-images.githubusercontent.com/1741180/77177493-e4537e00-6ac5-11ea-8e4a-34b32518efca.png)

After:
![image](https://user-images.githubusercontent.com/1741180/77177428-c7b74600-6ac5-11ea-8d7a-c03d9e40697c.png)

