### PR TITLE
Add and/or query parser scaffolding

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -101,7 +101,7 @@ func (r *codemodResultResolver) Commit() *GitCommitResolver { return r.commit }
 
 func (r *codemodResultResolver) RawDiff() string { return r.diff }
 
-func validateQuery(q *query.Query) (*args, error) {
+func validateQuery(q query.QueryInfo) (*args, error) {
 	matchValues := q.Values(query.FieldDefault)
 	var matchTemplates []string
 	for _, v := range matchValues {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -30,7 +30,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -86,9 +85,17 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 		queryString = args.Query
 	}
 
-	q, p, err := query.Process(queryString, searchType)
-	if err != nil {
-		return alertForQuery(queryString, err), nil
+	var queryInfo query.QueryInfo
+	if conf.AndOrQueryEnabled() {
+		queryInfo, err = query.ParseAndOr(args.Query)
+		if err != nil {
+			return alertForQuery(args.Query, err), nil
+		}
+	} else {
+		queryInfo, err = query.Process(queryString, searchType)
+		if err != nil {
+			return alertForQuery(queryString, err), nil
+		}
 	}
 
 	// If the request is a paginated one, decode those arguments now.
@@ -110,8 +117,7 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	}
 
 	return &searchResolver{
-		query:         q,
-		parseTree:     p,
+		query:         queryInfo,
 		originalQuery: args.Query,
 		pagination:    pagination,
 		patternType:   searchType,
@@ -175,8 +181,7 @@ func detectSearchType(version string, patternType *string, input string) (query.
 
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	query         *query.Query          // the validated search query
-	parseTree     syntax.ParseTree      // the parsed search query
+	query         query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
 	originalQuery string                // the raw string of the original search query
 	pagination    *searchPaginationInfo // pagination information, or nil if the request is not paginated.
 	patternType   query.SearchType
@@ -750,13 +755,22 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver, error) {
 	queryString := query.ConvertToLiteral(plainQuery)
 
-	q, err := query.ParseAndCheck(queryString)
-	if err != nil {
-		return nil, err
+	var queryInfo query.QueryInfo
+	var err error
+	if conf.AndOrQueryEnabled() {
+		queryInfo, err = query.ParseAndOr(plainQuery)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		queryInfo, err = query.ParseAndCheck(queryString)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	sr := &searchResolver{
-		query:         q,
+		query:         queryInfo,
 		originalQuery: plainQuery,
 		pagination:    nil,
 		patternType:   query.SearchTypeLiteral,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -84,7 +84,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 		proposedQueries: []*searchQueryDescription{
 			{
 				description: "query with longer timeout",
-				query:       fmt.Sprintf("timeout:%v %s", suggestTime, omitQueryField(r.parseTree, query.FieldTimeout)),
+				query:       fmt.Sprintf("timeout:%v %s", suggestTime, omitQueryField(r.query.ParseTree(), query.FieldTimeout)),
 				patternType: r.patternType,
 			},
 		},
@@ -155,7 +155,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 
 	// TODO(sqs): handle -repo:foo fields.
 
-	withoutRepoFields := omitQueryField(r.parseTree, query.FieldRepo)
+	withoutRepoFields := omitQueryField(r.query.ParseTree(), query.FieldRepo)
 
 	switch {
 	case len(repoGroupFilters) > 1:
@@ -177,7 +177,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			proposedQueries = []*searchQueryDescription{
 				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-					query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
+					query:       omitQueryField(r.query.ParseTree(), query.FieldRepoGroup),
 					patternType: r.patternType,
 				},
 			}
@@ -224,7 +224,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			proposedQueries = []*searchQueryDescription{
 				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-					query:       omitQueryField(r.parseTree, query.FieldRepoGroup),
+					query:       omitQueryField(r.query.ParseTree(), query.FieldRepoGroup),
 					patternType: r.patternType,
 				},
 			}
@@ -419,7 +419,7 @@ outer:
 		// add it to the user's query, but be smart. For example, if the user's
 		// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
 		// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
-		newExpr := addRegexpField(r.parseTree, query.FieldRepo, repoParentPattern)
+		newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, repoParentPattern)
 		alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 			description: "in repositories under " + repoParent + more,
 			query:       newExpr,
@@ -438,7 +438,7 @@ outer:
 			if i >= maxReposToPropose {
 				break
 			}
-			newExpr := addRegexpField(r.parseTree, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
+			newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
 			alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
 				description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
 				query:       newExpr,

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -83,7 +83,7 @@ func (r *commitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query query.QueryInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
 	var terms []string
 	if info.Pattern != "" {
 		terms = append(terms, info.Pattern)

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -41,7 +41,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 	}
 	// Don't return repo results if the search contains fields that aren't on the whitelist.
 	// Matching repositories based whether they contain files at a certain path (etc.) is not yet implemented.
-	for field := range args.Query.Fields {
+	for field := range args.Query.Fields() {
 		if _, ok := fieldWhitelist[field]; !ok {
 			return nil, nil, nil
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -527,7 +527,7 @@ func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32)
 			case r.patternType == query.SearchTypeRegex:
 				types = append(types, "regexp")
 			}
-		} else if len(r.query.Fields["file"]) > 0 {
+		} else if len(r.query.Fields()["file"]) > 0 {
 			// No search pattern specified and file: is specified.
 			types = append(types, "file")
 		} else {
@@ -784,7 +784,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Te
 
 // processSearchPattern processes the search pattern for a query. It handles the interpretation of search patterns
 // as literal, regex, or structural patterns, and applies fuzzy regex matching if applicable.
-func processSearchPattern(q *query.Query, opts *getPatternInfoOptions) (string, bool, bool) {
+func processSearchPattern(q query.QueryInfo, opts *getPatternInfoOptions) (string, bool, bool) {
 	var pattern string
 	var pieces []string
 	var contentFieldSet bool
@@ -841,7 +841,7 @@ func processSearchPattern(q *query.Query, opts *getPatternInfoOptions) (string, 
 }
 
 // getPatternInfo gets the search pattern info for q
-func getPatternInfo(q *query.Query, opts *getPatternInfoOptions) (*search.TextPatternInfo, error) {
+func getPatternInfo(q query.QueryInfo, opts *getPatternInfoOptions) (*search.TextPatternInfo, error) {
 	pattern, isRegExp, isStructuralPat := processSearchPattern(q, opts)
 
 	// Handle file: and -file: filters.
@@ -1010,10 +1010,10 @@ func alertOnSearchLimit(resultTypes []string, args *search.TextParameters) ([]st
 			resultType := resultTypes[0]
 			switch resultType {
 			case "commit", "diff":
-				if _, afterPresent := args.Query.Fields["after"]; afterPresent {
+				if _, afterPresent := args.Query.Fields()["after"]; afterPresent {
 					break
 				}
-				if _, beforePresent := args.Query.Fields["before"]; beforePresent {
+				if _, beforePresent := args.Query.Fields()["before"]; beforePresent {
 					break
 				}
 				resultTypes = []string{}
@@ -1369,7 +1369,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == query.SearchTypeLiteral {
-		alert = alertForQuotesInQueryInLiteralMode(r.parseTree)
+		alert = alertForQuotesInQueryInLiteralMode(r.query.ParseTree())
 	}
 
 	// If we have some results, only log the error instead of returning it,
@@ -1448,9 +1448,9 @@ func orderedFuzzyRegexp(pieces []string) string {
 }
 
 // Validates usage of the `repohasfile` filter
-func validateRepoHasFileUsage(q *query.Query) error {
+func validateRepoHasFileUsage(q query.QueryInfo) error {
 	// Query only contains "repohasfile:" and "type:symbol"
-	if len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "symbol" {
+	if len(q.Fields()) == 2 && q.Fields()["repohasfile"] != nil && q.Fields()["type"] != nil && len(q.Fields()["type"]) == 1 && q.Fields()["type"][0].Value() == "symbol" {
 		return errors.New("repohasfile does not currently return symbol results. Support for symbol results is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4610 for updates")
 	}
 	return nil

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1236,7 +1236,7 @@ func Test_commitAndDiffSearchLimits(t *testing.T) {
 
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
 			Repos: repoRevs,
-			Query: &query.Query{Fields: test.fields},
+			Query: &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
 		})
 
 		haveAlertDescription := ""

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -46,7 +46,7 @@ var (
 func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
 	args.applyDefaultsAndConstraints()
 
-	if len(r.parseTree) == 0 {
+	if len(r.query.ParseTree()) == 0 {
 		return nil, nil
 	}
 
@@ -69,9 +69,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// * If only repo fields (except 1 term in query), show repo suggestions.
 
 		var effectiveRepoFieldValues []string
-		if len(r.query.Values(query.FieldDefault)) == 1 && (len(r.query.Fields) == 1 || (len(r.query.Fields) == 2 && len(r.query.Values(query.FieldRepoGroup)) == 1)) {
+		if len(r.query.Values(query.FieldDefault)) == 1 && (len(r.query.Fields()) == 1 || (len(r.query.Fields()) == 2 && len(r.query.Values(query.FieldRepoGroup)) == 1)) {
 			effectiveRepoFieldValues = append(effectiveRepoFieldValues, r.query.Values(query.FieldDefault)[0].ToString())
-		} else if len(r.query.Values(query.FieldRepo)) > 0 && ((len(r.query.Values(query.FieldRepoGroup)) > 0 && len(r.query.Fields) == 2) || (len(r.query.Values(query.FieldRepoGroup)) == 0 && len(r.query.Fields) == 1)) {
+		} else if len(r.query.Values(query.FieldRepo)) > 0 && ((len(r.query.Values(query.FieldRepoGroup)) > 0 && len(r.query.Fields()) == 2) || (len(r.query.Values(query.FieldRepoGroup)) == 0 && len(r.query.Fields()) == 1)) {
 			effectiveRepoFieldValues, _ = r.query.RegexpPatterns(query.FieldRepo)
 		}
 
@@ -110,7 +110,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// If only repos/repogroups and files are specified (and at most 1 term), then show file
 		// suggestions.  If the query has a single term, then consider it to be a `file:` filter (to
 		// make it easy to jump to files by just typing in their name, not `file:<their name>`).
-		hasOnlyEmptyRepoField := len(r.query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.query.RegexpPatterns(query.FieldRepo)) && len(r.query.Fields) == 1
+		hasOnlyEmptyRepoField := len(r.query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.query.RegexpPatterns(query.FieldRepo)) && len(r.query.Fields()) == 1
 		hasRepoOrFileFields := len(r.query.Values(query.FieldRepoGroup)) > 0 || len(r.query.Values(query.FieldRepo)) > 0 || len(r.query.Values(query.FieldFile)) > 0
 		if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.query.Values(query.FieldDefault)) <= 1 {
 			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -251,7 +251,7 @@ func symbolCount(fmrs []*FileMatchResolver) int {
 	return nsym
 }
 
-func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, query *query.Query, limit int) (res []*FileMatchResolver, err error) {
+func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, query query.QueryInfo, limit int) (res []*FileMatchResolver, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Search symbols in repo")
 	defer func() {
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -379,7 +379,7 @@ func Test_exactlyOneRepo(t *testing.T) {
 func Test_QuoteSuggestions(t *testing.T) {
 	t.Run("regex error", func(t *testing.T) {
 		raw := "*"
-		_, _, err := query.Process(raw, query.SearchTypeRegex)
+		_, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
 			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
@@ -394,7 +394,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 
 	t.Run("type error that is not a regex error should show a suggestion", func(t *testing.T) {
 		raw := "-foobar"
-		_, _, alert := query.Process(raw, query.SearchTypeRegex)
+		_, alert := query.Process(raw, query.SearchTypeRegex)
 		if alert == nil {
 			t.Fatalf("alert returned from query.Process(%q) is nil", raw)
 		}
@@ -402,7 +402,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 
 	t.Run("query parse error", func(t *testing.T) {
 		raw := ":"
-		_, _, err := query.Process(raw, query.SearchTypeRegex)
+		_, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
 			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
@@ -417,7 +417,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 
 	t.Run("negated file field with an invalid regex", func(t *testing.T) {
 		raw := "-f:(a"
-		_, _, err := query.Process(raw, query.SearchTypeRegex)
+		_, err := query.Process(raw, query.SearchTypeRegex)
 		if err == nil {
 			t.Fatal("query.Process failed to detect the invalid regex in the f: field")
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	querytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -464,8 +465,9 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		tr.SetError(err)
 		tr.Finish()
 	}()
+	fields := querytypes.Fields(args.Query.Fields())
 	tr.LogFields(
-		trace.Stringer("query", &args.Query.Fields),
+		trace.Stringer("query", &fields),
 		trace.Stringer("info", args.PatternInfo),
 	)
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -320,6 +320,14 @@ func StructuralSearchEnabled() bool {
 	return val == "enabled"
 }
 
+func AndOrQueryEnabled() bool {
+	e := Get().ExperimentalFeatures
+	if e == nil || e.AndOrQuery == "" {
+		return false
+	}
+	return e.AndOrQuery == "enabled"
+}
+
 func SearchMultipleRevisionsPerRepository() bool {
 	x := ExperimentalFeatures()
 	return x.SearchMultipleRevisionsPerRepository != nil && *x.SearchMultipleRevisionsPerRepository

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1,4 +1,4 @@
-package search
+package query
 
 import (
 	"errors"
@@ -406,7 +406,7 @@ func (p *parser) parseOr() ([]Node, error) {
 }
 
 // Parse parses a raw input string into a parse tree comprising Nodes.
-func Parse(in string) ([]Node, error) {
+func parseAndOr(in string) ([]Node, error) {
 	if in == "" {
 		return nil, nil
 	}
@@ -419,4 +419,12 @@ func Parse(in string) ([]Node, error) {
 		return nil, errors.New("unbalanced expression")
 	}
 	return newOperator(nodes, And), nil
+}
+
+func ParseAndOr(in string) (QueryInfo, error) {
+	query, err := parseAndOr(in)
+	if err != nil {
+		return nil, err
+	}
+	return &AndOrQuery{query: query}, nil
 }

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -1,4 +1,4 @@
-package search
+package query
 
 import (
 	"encoding/json"
@@ -294,7 +294,7 @@ func Test_Parse(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			result, err := Parse(tt.Input)
+			result, err := parseAndOr(tt.Input)
 			if err != nil {
 				if diff := cmp.Diff(tt.Want, err.Error()); diff != "" {
 					t.Fatal(diff)

--- a/internal/search/query/searchquery_test.go
+++ b/internal/search/query/searchquery_test.go
@@ -187,7 +187,8 @@ func TestQuery_CaseInsensitiveFields(t *testing.T) {
 		t.Errorf("unexpected values: want {\"foo\"}, got %v", values)
 	}
 
-	if got, want := query.Fields.String(), `repohasfile~"foo"`; got != want {
+	fields := types.Fields(query.Fields())
+	if got, want := fields.String(), `repohasfile~"foo"`; got != want {
 		t.Errorf("unexpected parsed query:\ngot:  %s\nwant: %s", got, want)
 	}
 }

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -13,6 +13,9 @@ const (
 	SearchTypeStructural
 )
 
+// QueryInfo is an intermediate type for an interface of both ordinary queries
+// and and/or query processing. The and/or query processing will become the
+// canonical query form and the QueryInfo type will be removed.
 type QueryInfo interface {
 	RegexpPatterns(field string) (values, negatedValues []string)
 	StringValues(field string) (values, negatedValues []string)
@@ -59,22 +62,22 @@ func (q OrdinaryQuery) IsCaseSensitive() bool {
 // AndOrQuery satisfies the interface for QueryInfo with empty values. Its
 // methods are not currently used.
 func (AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
-	return []string{}, []string{}
+	return nil, nil
 }
 func (AndOrQuery) StringValues(field string) (values, negatedValues []string) {
-	return []string{}, []string{}
+	return nil, nil
 }
 func (AndOrQuery) StringValue(field string) (value, negatedValue string) {
 	return "", ""
 }
 func (AndOrQuery) Values(field string) []*types.Value {
-	return []*types.Value{}
+	return nil
 }
 func (AndOrQuery) Fields() map[string][]*types.Value {
-	return map[string][]*types.Value{}
+	return nil
 }
 func (AndOrQuery) ParseTree() syntax.ParseTree {
-	return []*syntax.Expr{}
+	return nil
 }
 func (AndOrQuery) IsCaseSensitive() bool {
 	return false

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -1,5 +1,10 @@
 package query
 
+import (
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
+)
+
 type SearchType int
 
 const (
@@ -7,3 +12,70 @@ const (
 	SearchTypeLiteral
 	SearchTypeStructural
 )
+
+type QueryInfo interface {
+	RegexpPatterns(field string) (values, negatedValues []string)
+	StringValues(field string) (values, negatedValues []string)
+	StringValue(field string) (value, negatedValue string)
+	Values(field string) []*types.Value
+	Fields() map[string][]*types.Value
+	IsCaseSensitive() bool
+	ParseTree() syntax.ParseTree
+}
+
+// An ordinary query (not containing and/or expressions).
+type OrdinaryQuery struct {
+	Query     *Query           // the validated search query
+	parseTree syntax.ParseTree // the parsed search query
+}
+
+// A query containing and/or expressions.
+type AndOrQuery struct {
+	query []Node
+}
+
+func (q OrdinaryQuery) RegexpPatterns(field string) (values, negatedValues []string) {
+	return q.Query.RegexpPatterns(field)
+}
+func (q OrdinaryQuery) StringValues(field string) (values, negatedValues []string) {
+	return q.Query.StringValues(field)
+}
+func (q OrdinaryQuery) StringValue(field string) (value, negatedValue string) {
+	return q.Query.StringValue(field)
+}
+func (q OrdinaryQuery) Values(field string) []*types.Value {
+	return q.Query.Values(field)
+}
+func (q OrdinaryQuery) Fields() map[string][]*types.Value {
+	return q.Query.Fields
+}
+func (q OrdinaryQuery) ParseTree() syntax.ParseTree {
+	return q.parseTree
+}
+func (q OrdinaryQuery) IsCaseSensitive() bool {
+	return q.Query.IsCaseSensitive()
+}
+
+// AndOrQuery satisfies the interface for QueryInfo with empty values. Its
+// methods are not currently used.
+func (AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
+	return []string{}, []string{}
+}
+func (AndOrQuery) StringValues(field string) (values, negatedValues []string) {
+	return []string{}, []string{}
+}
+func (AndOrQuery) StringValue(field string) (value, negatedValue string) {
+	return "", ""
+}
+func (AndOrQuery) Values(field string) []*types.Value {
+	return []*types.Value{}
+}
+func (AndOrQuery) Fields() map[string][]*types.Value {
+	return map[string][]*types.Value{}
+}
+func (AndOrQuery) ParseTree() syntax.ParseTree {
+	return []*syntax.Expr{}
+}
+func (AndOrQuery) IsCaseSensitive() bool {
+	return false
+}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -24,7 +24,7 @@ func (t TextParameters) typeParametersValue()    {}
 type CommitParameters struct {
 	RepoRevs           *RepositoryRevisions
 	PatternInfo        *CommitPatternInfo
-	Query              *query.Query
+	Query              query.QueryInfo
 	Diff               bool
 	ExtraMessageValues []string
 }
@@ -78,7 +78,7 @@ type TextParameters struct {
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and
 	// ignored by Pattern, such as index:no
-	Query *query.Query
+	Query query.QueryInfo
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be
@@ -100,7 +100,7 @@ type TextParameters struct {
 type TextParametersForCommitParameters struct {
 	PatternInfo *CommitPatternInfo
 	Repos       []*RepositoryRevisions
-	Query       *query.Query
+	Query       query.QueryInfo
 }
 
 // TextPatternInfo is the struct used by vscode pass on search queries. Keep it in

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -365,6 +365,8 @@ type ExcludedGitoliteRepo struct {
 
 // ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type ExperimentalFeatures struct {
+	// AndOrQuery description: Interpret a search input query as an and/or query.
+	AndOrQuery string `json:"andOrQuery,omitempty"`
 	// Automation description: Enables the experimental code change management campaigns feature. NOTE: The automation feature was renamed to campaigns, but this experimental feature flag name was not changed (because the feature flag will go away soon anyway).
 	Automation string `json:"automation,omitempty"`
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -85,6 +85,12 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "andOrQuery": {
+          "description": "Interpret a search input query as an and/or query.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
+        },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -90,6 +90,12 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "andOrQuery": {
+          "description": "Interpret a search input query as an and/or query.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
+        },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",
           "type": "string",


### PR DESCRIPTION
- Adds a site setting to activate a code path that uses the and/or query parser for input. The setting is not meant to be activated now, but later. Right now it's a way for me to develop against the code path.
- Adds an interim `type QueryInfo` which is an interface that either refers to our current query logic (`type OrdinaryQuery`) or `type AndOrQuery` (which is the new part I'll be filling in).

I introduced `typeQueryInfo` because it's going to be a real challenge for me to migrate the current query logic otherwise. We also want to preserve a fall back while transitioning. I've extracted the essential interface of `Query` so that most dependencies on query-related things do not know what the underlying type is. Over time, I will be trimming/renaming the `QueryInfo` interface. When we are ready to switch over to only `AndOrQuery`, `QueryInfo` will disappear, and `AndOrQuery` will simply become `Query`. 