### PR TITLE
Release v3.14.0 for Docker Compose deployments

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -4,7 +4,15 @@ This document describes the exact changes needed to update a Docker Compose Sour
 
 Each section comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
+## v3.13 -> 3.14
+
+No manual migration is required.
+
+Simply upgrade using the [`v3.14.0` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.14.0/docker-compose) by following the [standard upgrade procedure](#standard-upgrade-procedure).
+
 ## v3.12 -> v3.13
+
+A manual migration is required. Please follow the [standard upgrade procedure](#standard-upgrade-procedure) to take down the current deployment, perform the manual migration, and then upgrade using the [`v3.13.2` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.13.2/docker-compose).
 
 ### Manual migration step: adjust file permissions
 
@@ -14,14 +22,14 @@ Please adjust the redis-store and redis-cache volume permissions by running the 
 docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'chown -R 999:1000 /docker/volumes/docker-compose_redis-store /docker/volumes/docker-compose_redis-cache'
 ```
 
-### Upgrade
+### Standard upgrade procedure
 
-In your fork of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository:
+In your fork of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository, merge the new version into the `release` branch if you maintain any changes (see: [storing customizations in a fork](https://docs.sourcegraph.com/admin/install/docker-compose#optional-recommended-store-customizations-in-a-fork)):
 
 ```sh
 cd docker-compose/
 git fetch upstream
-git merge upstream v3.13.2
+git merge upstream $NEW_VERSION
 # Address any merge conflicts you may have.
 ```
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -24,7 +24,7 @@ docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'chown -R 999
 
 ### Standard upgrade procedure
 
-In your fork of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository, merge the new version into the `release` branch if you maintain any changes (see: [storing customizations in a fork](https://docs.sourcegraph.com/admin/install/docker-compose#optional-recommended-store-customizations-in-a-fork)):
+In your fork of [the deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) repository, merge the new version into the `release` branch if you maintain any changes (see: [storing customizations in a fork](../install/docker-compose.md#optional-recommended-store-customizations-in-a-fork)):
 
 ```sh
 cd docker-compose/


### PR DESCRIPTION
Tested on an AWS Ubuntu Xenial EC2 instance, no manual migration is needed (this appears to be due to the fact that there is no actual user change in docker-compose deployments).