### PR TITLE
frontend: use endpoint port if prometheus.io/port annotation is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Users and site administrators can now view a log of their actions/events in the user settings.
-- Site-Admin/Instrumentation in the Kubernetes cluster deployment now includes indexed-search and gitserver.
 
 ### Changed
 
 - Multiple backwards-incompatible changes in the parts of the GraphQL API related to Campaigns:
   - `CampaignPlan.status` has been removed, since we don't need it anymore after moving execution of campaigns to src CLI in [#8008](https://github.com/sourcegraph/sourcegraph/pull/8008).
+- Site-Admin/Instrumentation in the Kubernetes cluster deployment now includes indexed-search.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Users and site administrators can now view a log of their actions/events in the user settings.
+- Site-Admin/Instrumentation in the Kubernetes cluster deployment now includes indexed-search and gitserver.
 
 ### Changed
 

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -143,14 +143,13 @@ func (cs *clusterScanner) scanCluster() {
 			continue
 		}
 
-		portStr := svc.Metadata.Annotations["prometheus.io/port"]
-		if portStr == "" {
-			continue
-		}
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			log15.Debug("k8s prometheus.io/port annotation for service is not an integer", "service", svcName, "port", portStr)
-			continue
+		var port int
+		if portStr := svc.Metadata.Annotations["prometheus.io/port"]; portStr != "" {
+			port, err = strconv.Atoi(portStr)
+			if err != nil {
+				log15.Debug("k8s prometheus.io/port annotation for service is not an integer", "service", svcName, "port", portStr)
+				continue
+			}
 		}
 
 		var endpoints corev1.Endpoints
@@ -161,13 +160,24 @@ func (cs *clusterScanner) scanCluster() {
 		}
 
 		for _, subset := range endpoints.Subsets {
+			var ports []int
+			if port != 0 {
+				ports = []int{port}
+			} else {
+				for _, port := range subset.GetPorts() {
+					ports = append(ports, int(port.GetPort()))
+				}
+			}
+
 			for _, addr := range subset.Addresses {
-				host := addrToHost(addr, port)
-				if host != "" {
-					scanResults = append(scanResults, Endpoint{
-						Service: svcName,
-						Host:    host,
-					})
+				for _, port := range ports {
+					host := addrToHost(addr, port)
+					if host != "" {
+						scanResults = append(scanResults, Endpoint{
+							Service: svcName,
+							Host:    host,
+						})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Previously we excluded indexed-search from scraping. Instead we
use the same behaviour as prometheus and use the endpoint port of the
annotation is missing.

Note: we still won't proxy to zoekt-indexserver. This would require us to
watch the pods as well, since we don't have any services setup for
zoekt-indexserver.

Alternatively we can just add the annotation to indexed-search :)