### PR TITLE
conf: unexport Store

### DIFF
--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 type client struct {
-	store       *Store
+	store       *store
 	passthrough ConfigurationSource
 	watchersMu  sync.Mutex
 	watchers    []chan struct{}

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -69,7 +69,7 @@ var (
 )
 
 func init() {
-	clientStore := NewStore()
+	clientStore := newStore()
 	defaultClient = &client{store: clientStore}
 
 	mode := getMode()

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -24,7 +24,7 @@ type ConfigurationSource interface {
 type Server struct {
 	Source ConfigurationSource
 
-	store *Store
+	store *store
 
 	needRestartMu sync.RWMutex
 	needRestart   bool
@@ -45,7 +45,7 @@ func NewServer(source ConfigurationSource) *Server {
 	fileWrite := make(chan chan struct{}, 1)
 	return &Server{
 		Source:    source,
-		store:     NewStore(),
+		store:     newStore(),
 		fileWrite: fileWrite,
 	}
 }


### PR DESCRIPTION
Store is only used by the conf package, so we should keep it internal to it.