### PR TITLE
Remove global queryUpdates subject

### DIFF
--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -16,7 +16,6 @@ import { makeRepoURI } from '../../../shared/src/util/url'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { searchQueryForRepoRev, PatternTypeProps, CaseSensitivityProps } from '../search'
-import { queryUpdates } from '../search/input/QueryInput'
 import { EventLoggerProps } from '../tracking/eventLogger'
 import { RouteDescriptor } from '../util/contributions'
 import { parseBrowserRepoURL, ParsedRepoRev, parseRepoRev } from '../util/url'
@@ -29,6 +28,7 @@ import { RepositoryNotFoundPage } from './RepositoryNotFoundPage'
 import { ThemeProps } from '../../../shared/src/theme'
 import { RepoSettingsAreaRoute } from './settings/RepoSettingsArea'
 import { RepoSettingsSideBarItem } from './settings/RepoSettingsSidebar'
+import { QueryState } from '../search/helpers'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -78,6 +78,7 @@ interface RepoContainerProps
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarItems: readonly RepoSettingsSideBarItem[]
     authenticatedUser: GQL.IUser | null
+    onNavbarQueryChange: (state: QueryState) => void
 }
 
 interface RepoRevContainerState extends ParsedRepoRev {
@@ -159,12 +160,14 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
         // Update resolved revision in state
         this.subscriptions.add(this.revResolves.subscribe(resolvedRevOrError => this.setState({ resolvedRevOrError })))
 
-        // Update header and other global state.
         this.subscriptions.add(
             parsedRouteChanges.subscribe(({ repoName, rev, rawRev }) => {
                 this.setState({ repoName, rev, rawRev })
-
-                queryUpdates.next(searchQueryForRepoRev(repoName, rev))
+                const query = searchQueryForRepoRev(repoName, rev)
+                this.props.onNavbarQueryChange({
+                    query,
+                    cursorPosition: query.length,
+                })
             })
         )
 

--- a/web/src/search/ScopePage.tsx
+++ b/web/src/search/ScopePage.tsx
@@ -16,7 +16,7 @@ import { SearchScope, Settings } from '../schema/settings.schema'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchReposByQuery } from './backend'
 import { submitSearch, QueryState } from './helpers'
-import { QueryInput, queryUpdates } from './input/QueryInput'
+import { QueryInput } from './input/QueryInput'
 import { SearchButton } from './input/SearchButton'
 import { PatternTypeProps, CaseSensitivityProps } from '.'
 import { ErrorAlert } from '../components/alerts'
@@ -41,6 +41,7 @@ interface ScopePageProps
         PatternTypeProps,
         CaseSensitivityProps {
     authenticatedUser: GQL.IUser | null
+    onNavbarQueryChange: (queryState: QueryState) => void
 }
 
 interface State {
@@ -82,7 +83,10 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
                         const matchedScope = searchScopes.find(o => o.id === props.match.params.id)
                         if (matchedScope) {
                             const markdownDescription = renderMarkdown(matchedScope.description || '')
-                            queryUpdates.next(matchedScope.value)
+                            this.props.onNavbarQueryChange({
+                                query: matchedScope.value,
+                                cursorPosition: matchedScope.value.length,
+                            })
                             if (matchedScope.value.includes('repo:') || matchedScope.value.includes('repogroup:')) {
                                 return concat(
                                     of({ ...matchedScope, markdownDescription }),
@@ -95,7 +99,6 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
                                     )
                                 )
                             }
-                            queryUpdates.next(matchedScope.value)
                             return [
                                 {
                                     ...matchedScope,

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -38,12 +38,6 @@ import { FiltersToTypeAndValue, FilterType } from '../../../../shared/src/search
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { Toggles } from './toggles/Toggles'
 
-/**
- * The query input field is clobbered and updated to contain this subject's values, as
- * they are received. This is used to trigger an update; the source of truth is still the URL.
- */
-export const queryUpdates = new Subject<string>()
-
 interface Props extends PatternTypeProps, CaseSensitivityProps, SettingsCascadeProps {
     location: H.Location
     history: H.History
@@ -308,17 +302,6 @@ export class QueryInput extends React.Component<Props, State> {
                             this.inputElement.current.setSelectionRange(0, this.inputElement.current.value.length)
                         }
                     })
-            )
-
-            // Allow other components to update the query (e.g., to be relevant to what the user is
-            // currently viewing).
-            this.subscriptions.add(
-                queryUpdates.pipe(distinctUntilChanged()).subscribe(query =>
-                    this.inputValues.next({
-                        query,
-                        cursorPosition: query.length,
-                    })
-                )
             )
 
             /** Whenever the URL query has a "focus" property, remove it and focus the query input. */


### PR DESCRIPTION
Fixes #8839

Removes global `queryUpdates` subject in favour of passing down `onNavbarQueryChange()` through props to relevant components, to allow them to update the search query displayed in the global navbar.