### PR TITLE
dev: handle failures during docsite binary download

### DIFF
--- a/dev/docsite.sh
+++ b/dev/docsite.sh
@@ -11,9 +11,11 @@ binname="docsite_${version}_$(go env GOOS)_$(go env GOARCH)"
 target="$PWD/.bin/${binname}"
 
 if [ ! -f "${target}" ]; then
-    curl -s -L "https://github.com/sourcegraph/docsite/releases/download/${version}/${binname}" -o "${target}"
-    chmod +x "${target}"
+    curl -s -L "https://github.com/sourcegraph/docsite/releases/download/${version}/${binname}" -o "${target}.tmp"
+    mv "${target}.tmp" "${target}"
 fi
+
+chmod +x "${target}"
 
 popd > /dev/null
 


### PR DESCRIPTION
If docsite.sh is killed while fetching a binary a partial binary will exist at
target. Following runs will try and fail to execute the binary. We now
download to a temporary location and move it into place, so if we fail we will
retry the download. Additionally we just always ensure the binary is
executable.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
