### PR TITLE
Bump src CLI MinimumVersion to 3.11.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.10.12"
+const MinimumVersion = "3.11.0"


### PR DESCRIPTION
After the changes in
https://github.com/sourcegraph/sourcegraph/pull/9196 (part of
https://github.com/sourcegraph/sourcegraph/issues/9106) we need to
ensure that src CLI users use the correct version.

The correct version is src CLI >3.11: https://github.com/sourcegraph/src-cli/releases/tag/3.11.0
