### PR TITLE
Unify Monaco themes

### DIFF
--- a/web/src/components/MonacoEditor.tsx
+++ b/web/src/components/MonacoEditor.tsx
@@ -1,10 +1,64 @@
 import classNames from 'classnames'
 import * as monaco from 'monaco-editor'
 import * as React from 'react'
+import { ThemeProps } from '../../../shared/src/theme'
+import { Subscription, Subject } from 'rxjs'
+import { map, distinctUntilChanged } from 'rxjs/operators'
 
-export type BuiltinTheme = monaco.editor.BuiltinTheme | 'sourcegraph-dark'
+const SOURCEGRAPH_LIGHT = 'sourcegraph-light'
 
-interface Props {
+const SOURCEGRAPH_DARK = 'sourcegraph-dark'
+
+monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
+    base: 'vs-dark',
+    inherit: true,
+    colors: {
+        background: '#0E121B',
+        'textLink.activeBackground': '#2a3a51',
+        'editor.background': '#0E121B',
+        'editor.foreground': '#f2f4f8',
+        'editorCursor.foreground': '#ffffff',
+        'editorSuggestWidget.background': '#1c2736',
+        'editorSuggestWidget.foreground': '#F2F4F8',
+        'editorSuggestWidget.highlightForeground': '#569cd6',
+        'editorSuggestWidget.selectedBackground': '#2a3a51',
+        'list.hoverBackground': '#2a3a51',
+        'editorSuggestWidget.border': '#2b3750',
+        'editorHoverWidget.background': '#1c2736',
+        'editorHoverWidget.foreground': '#F2F4F8',
+        'editorHoverWidget.border': '#2b3750',
+    },
+    rules: [
+        { token: 'identifier', foreground: '#f2f4f8' },
+        { token: 'keyword', foreground: '#569cd6' },
+    ],
+})
+
+monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
+    base: 'vs',
+    inherit: true,
+    colors: {
+        background: '#ffffff',
+        'editor.background': '#ffffff',
+        'editor.foreground': '#2b3750',
+        'editorCursor.foreground': '#2b3750',
+        'editorSuggestWidget.background': '#ffffff',
+        'editorSuggestWidget.foreground': '#2b3750',
+        'editorSuggestWidget.border': '#cad2e2',
+        'editorSuggestWidget.highlightForeground': '#268bd2',
+        'editorSuggestWidget.selectedBackground': '#f2f4f8',
+        'list.hoverBackground': '#f2f4f8',
+        'editorHoverWidget.background': '#ffffff',
+        'editorHoverWidget.foreground': '#2b3750',
+        'editorHoverWidget.border': '#cad2e2',
+    },
+    rules: [
+        { token: 'identifier', foreground: '#2b3750' },
+        { token: 'keyword', foreground: '#268bd2' },
+    ],
+})
+
+interface Props extends ThemeProps {
     /** The contents of the document. */
     value?: string
 
@@ -16,9 +70,6 @@ interface Props {
 
     /** The height (in px) of the Monaco editor. */
     height: number
-
-    /** The color theme for the editor. */
-    theme: BuiltinTheme
 
     /** Called when the editor has mounted. */
     editorWillMount: (editor: typeof monaco) => void
@@ -39,6 +90,10 @@ interface Props {
 interface State {}
 
 export class MonacoEditor extends React.PureComponent<Props, State> {
+    private subscriptions = new Subscription()
+
+    private componentUpdates = new Subject<Props>()
+
     private editor: monaco.editor.ICodeEditor | undefined
 
     private setRef = (e: HTMLElement | null): void => {
@@ -49,7 +104,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         const editor = monaco.editor.create(e, {
             value: this.props.value,
             language: this.props.language,
-            theme: this.props.theme,
+            theme: this.props.isLightTheme ? SOURCEGRAPH_LIGHT : SOURCEGRAPH_DARK,
             ...this.props.options,
         })
         if (this.props.onEditorCreated) {
@@ -62,9 +117,23 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         if (this.props.value !== prevProps.value && this.editor && this.editor.getValue() !== this.props.value) {
             this.editor.setValue(this.props.value || '')
         }
+        this.componentUpdates.next(this.props)
+    }
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            this.componentUpdates
+                .pipe(
+                    map(({ isLightTheme }) => (isLightTheme ? SOURCEGRAPH_LIGHT : SOURCEGRAPH_DARK)),
+                    distinctUntilChanged()
+                )
+                .subscribe(theme => monaco.editor.setTheme(theme))
+        )
+        this.componentUpdates.next(this.props)
     }
 
     public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
         if (this.editor) {
             this.editor.dispose()
 

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -5,11 +5,9 @@ import { Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, distinctUntilKeyChanged, map, startWith } from 'rxjs/operators'
 import jsonSchemaMetaSchema from '../../../schema/json-schema-draft-07.schema.json'
 import settingsSchema from '../../../schema/settings.schema.json'
-import { BuiltinTheme, MonacoEditor } from '../components/MonacoEditor'
+import { MonacoEditor } from '../components/MonacoEditor'
 import { ThemeProps } from '../../../shared/src/theme'
 import { eventLogger } from '../tracking/eventLogger'
-
-const isLightThemeToMonacoTheme = (isLightTheme: boolean): BuiltinTheme => (isLightTheme ? 'vs' : 'sourcegraph-dark')
 
 /**
  * Minimal shape of a JSON Schema. These values are treated as opaque, so more specific types are
@@ -73,20 +71,6 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         )
 
         this.subscriptions.add(
-            componentUpdates
-                .pipe(
-                    map(props => props.isLightTheme),
-                    distinctUntilChanged(),
-                    map(isLightThemeToMonacoTheme)
-                )
-                .subscribe(monacoTheme => {
-                    if (this.monaco) {
-                        this.monaco.editor.setTheme(monacoTheme)
-                    }
-                })
-        )
-
-        this.subscriptions.add(
             componentUpdates.pipe(distinctUntilKeyChanged('jsonSchema')).subscribe(props => {
                 if (this.monaco) {
                     setDiagnosticsOptions(this.monaco, props.jsonSchema)
@@ -115,7 +99,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                 className={this.props.className}
                 language={this.props.language || 'json'}
                 height={this.props.height || 400}
-                theme={isLightThemeToMonacoTheme(this.props.isLightTheme)}
+                isLightTheme={this.props.isLightTheme}
                 value={this.props.value}
                 editorWillMount={this.editorWillMount}
                 options={{
@@ -160,20 +144,6 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         }
 
         setDiagnosticsOptions(monaco, this.props)
-
-        monaco.editor.defineTheme('sourcegraph-dark', {
-            base: 'vs-dark',
-            inherit: true,
-            colors: {
-                'editor.background': '#0E121B',
-                'editor.foreground': '#F2F4F8',
-                'editorCursor.foreground': '#A2B0CD',
-                'editor.selectionBackground': '#1C7CD650',
-                'editor.selectionHighlightBackground': '#1C7CD625',
-                'editor.inactiveSelectionBackground': '#1C7CD625',
-            },
-            rules: [],
-        })
 
         // Only listen to 1 event each to avoid receiving events from other Monaco editors on the
         // same page (if there are multiple).


### PR DESCRIPTION
Fixes #7697

It is currently not possible to have two Monaco editors have different themes: https://github.com/microsoft/monaco-editor/issues/338

This caused conflicts when displaying the settings editor on the same page as the Monaco-backed search field. This PR unifies our Monaco themes. The main resulting difference is that in settings editors, hover tooltips will integrate better with our existing theme.

Before:
![image](https://user-images.githubusercontent.com/1741180/77325749-1ad50700-6d19-11ea-8a30-9ea897ce75dd.png)

After:
![image](https://user-images.githubusercontent.com/1741180/77325758-1e688e00-6d19-11ea-9c7b-f7020f1f0f76.png)
