### PR TITLE
dev: postgres exporter starter script checks unix socket

### DIFF
--- a/dev/postgres_exporter.sh
+++ b/dev/postgres_exporter.sh
@@ -16,7 +16,7 @@ PGUSER=${PGUSER-$(get_pg_env USER)}
 PGPORT=${PGPORT-$(get_pg_env PORT)}
 
 ADJUSTED_HOST=${PGHOST:-127.0.0.1}
-if [[ ("$ADJUSTED_HOST" == "localhost" || "$ADJUSTED_HOST" == "127.0.0.1") &&  "$OSTYPE" != "linux-gnu" ]]; then
+if [[ ("$ADJUSTED_HOST" == "localhost" || "$ADJUSTED_HOST" == "127.0.0.1" || -f "$ADJUSTED_HOST") &&  "$OSTYPE" != "linux-gnu" ]]; then
     ADJUSTED_HOST="host.docker.internal"
 fi
 


### PR DESCRIPTION
addresses https://github.com/sourcegraph/sourcegraph/issues/9229

for macOS with PGHOST set to unix socket  (some socket in /tmp) the logic in 
the starter script fails to adjust to host.docker.internal