### PR TITLE
search: expand and/or query visitor

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -225,23 +225,23 @@ func Visit(nodes []Node, f func(node Node)) {
 	}
 }
 
-// VisitParameter calls f on all parameter nodes. f supplies the node's field
-// and value.
-func VisitParameter(nodes []Node, f func(field, value string)) {
+// VisitParameter calls f on all parameter nodes. f supplies the node's field,
+// value, and whether the value is negated.
+func VisitParameter(nodes []Node, f func(field, value string, negated bool)) {
 	visitor := func(node Node) {
 		if v, ok := node.(Parameter); ok {
-			f(v.Field, v.Value)
+			f(v.Field, v.Value, v.Negated)
 		}
 	}
 	Visit(nodes, visitor)
 }
 
 // VisitField calls f on all parameter nodes whose field matches the field
-// argument. f supplies the node's value.
-func VisitField(nodes []Node, field string, f func(value string)) {
-	visitor := func(visitedField, value string) {
+// argument. f supplies the node's value and whether the value is negated.
+func VisitField(nodes []Node, field string, f func(value string, negated bool)) {
+	visitor := func(visitedField, value string, negated bool) {
 		if field == visitedField {
-			f(value)
+			f(value, negated)
 		}
 	}
 	VisitParameter(nodes, visitor)
@@ -251,7 +251,7 @@ func VisitField(nodes []Node, field string, f func(value string)) {
 // (i.e., a parameter where the field is the empty string).
 func containsPattern(node Node) bool {
 	var result bool
-	VisitField([]Node{node}, "", func(_ string) {
+	VisitField([]Node{node}, "", func(_ string, _ bool) {
 		result = true
 	})
 	return result

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -207,46 +207,51 @@ func (p *parser) ParseParameter() Parameter {
 	return ScanParameter(p.buf[start:p.pos])
 }
 
-// Visit calls f on all nodes rooted at node.
-func Visit(node Node, f func(node Node)) {
+// VisitNode calls f on all nodes rooted at node.
+func VisitNode(node Node, f func(node Node)) {
 	switch v := node.(type) {
 	case Parameter:
 		f(v)
 	case Operator:
 		f(v)
-		for _, n := range v.Operands {
-			Visit(n, f)
-		}
+		Visit(v.Operands, f)
+	}
+}
+
+// Visit calls f on all nodes rooted at nodes.
+func Visit(nodes []Node, f func(node Node)) {
+	for _, node := range nodes {
+		VisitNode(node, f)
 	}
 }
 
 // VisitParameter calls f on all parameter nodes. f supplies the node's field
 // and value.
-func VisitParameter(node Node, f func(field, value string)) {
+func VisitParameter(nodes []Node, f func(field, value string)) {
 	visitor := func(node Node) {
 		if v, ok := node.(Parameter); ok {
 			f(v.Field, v.Value)
 		}
 	}
-	Visit(node, visitor)
+	Visit(nodes, visitor)
 }
 
 // VisitField calls f on all parameter nodes whose field matches the field
 // argument. f supplies the node's value.
-func VisitField(node Node, field string, f func(value string)) {
+func VisitField(nodes []Node, field string, f func(value string)) {
 	visitor := func(visitedField, value string) {
 		if field == visitedField {
 			f(value)
 		}
 	}
-	VisitParameter(node, visitor)
+	VisitParameter(nodes, visitor)
 }
 
-// containsPattern returns true if any descendent of node is a search pattern
+// containsPattern returns true if any descendent of nodes is a search pattern
 // (i.e., a parameter where the field is the empty string).
 func containsPattern(node Node) bool {
 	var result bool
-	VisitField(node, "", func(_ string) {
+	VisitField([]Node{node}, "", func(_ string) {
 		result = true
 	})
 	return result


### PR DESCRIPTION
I might expand/refactor this more later. Right now it's a means to an end for and/or eval.

Tests: `containsPattern` depends on this being correct, so I'm punting on additional tests for now.