### PR TITLE
Update non-git code host, src-expose, and Perforce docs

### DIFF
--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -9,4 +9,6 @@ Sourcegraph can sync repositories from code hosts and other similar services.
 - [Phabricator](phabricator.md)
 - [Gitolite](gitolite.md)
 - [AWS CodeCommit](aws_codecommit.md)
-- [Other repository host (Git URL)](other.md)
+- [Other Git code hosts (using a Git URL)](other.md)
+- [Non-Git code hosts](non-git.md)
+  - [Perforce](../repo/perforce.md)

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -1,6 +1,6 @@
 # Non-Git code hosts (Perforce, Mercurial, Subversion, raw text, etc.)
 
-Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
+Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a CLI tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
 
 **Guides for specific non-Git code hosts**:
 - [Perforce](../repo/perforce.md)

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -1,4 +1,4 @@
- # Non-Git code hosts (Perforce, Mercurial, Subversion, raw text, etc.)
+# Non-Git code hosts (Perforce, Mercurial, Subversion, raw text, etc.)
 
 Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
 
@@ -111,4 +111,3 @@ If you have a small enough code base, it is possible to use a tool for convertin
 To achieve this 
 
 **Retaining code change history**
-

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -1,0 +1,114 @@
+ # Non-Git code hosts (Perforce, Mercurial, Subversion, raw text, etc.)
+
+Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
+
+**Guides for specific non-Git code hosts**:
+- [Perforce](../repo/perforce.md)
+
+## Installing `src-expose`
+
+Navigate to the directory that contains the Git repositories that you want to serve, then run:
+
+``` shell
+wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/darwin-amd64/src-expose
+# For linux comment the above and uncomment the below
+# wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/linux-amd64/src-expose
+
+chmod +x src-expose
+```
+
+You can run `src-expose -h` any time for help. 
+
+## Using `src-expose`
+
+`src-expose` provides two main functions:
+
+- Serving local Git repositories over the network, and making them available to Sourcegraph (as if they were available on a traditional code host). See [serving repositories](#serving-repositories), or run `src-expose serve -h`.
+- Periodically running a command to sync changes to the code, and then combining those changes into a new Git commit in the local repositories. See [syncing repositories](#syncing-repositories), or run `src-expose sync -h`.
+
+By default, if you exclude the first argument to `src-expose` (i.e., you run `src-expose` without `sync` or `serve`), it will perform both of these functions simultaneously.
+
+### Serving repositories
+
+`src-expose` serves a list of local Git repositories over HTTP, making them available to Sourcegraph. In addition to simply providing a Git endpoint, it also provides a repository listing API that Sourcegraph expects a code host to have. 
+
+If you wish to serve a local directory without running any syncing commands automatically, you can run `src-expose serve` (instead of the default `src-expose`) to only perform this function.
+
+### Syncing repositories
+
+In addition to serving a local directory, `src-expose` will periodically run a command of your choice to fetch changes from a remote and combine them into a new Git commit. 
+
+For example, if your provided configuration YAML file contains:
+
+```
+# before is a command run before sync. before is run from root.
+before: p4 sync
+# duration defines how often sync should happen. Defaults to 10s.
+duration: 10s
+```
+
+Then Sourcegraph will run `p4 sync` every 10 seconds, and combine all of the fetched changes into a new Git commit. The new Git commit's author will be `src-expose`, and will contain all changes since the last time the syncing command was run.
+
+While this syncing functionality means that the original change history will be lost, it eliminates any slow and costly Perforce-to-Git or Hg-to-Git or similar conversions that would otherwise be required. If you prefer to retain history, see [choosing the right src-expose setup](#choosing-the-rigth-src-expose-setup).
+
+## Quickstart
+
+1. Start up a Sourcegraph instance (using our [Quickstart](../../../index.md) or our [full installation documentation](../../install/index.md)).
+
+1. [Install `src-expose`](#installing-src-expose)
+
+1. Pick the directory you want to export from, then run:
+
+``` shell
+./src-expose dir1 dir2 dir3
+```
+
+or
+
+``` shell
+./src-expose serve dir1 dir2 dir3
+```
+
+depending on whether you want to automatically sync changes and serve the local directories, or just serve the local directories.
+
+1. `src-expose` will output a configuration to use. It may scroll by quickly due to logging, so if so, just scroll up. However, this configuration should work:
+
+``` json
+ {
+    // url is the http url to src-expose (listening on 127.0.0.1:3434)
+    // url should be reachable by Sourcegraph.
+    // "http://host.docker.internal:3434" works from Sourcegraph when using Docker for Desktop.
+    "url": "http://host.docker.internal:3434",
+    // repos should have the special value ("src-expose") below, and it will pull all of the repositories that src-expose is serving.
+    "repos": ["src-expose"]
+}
+```
+
+**IMPORTANT:** If you are using a Linux host machine, replace `host.docker.internal` in the above with the IP address of your actual host machine because `host.docker.internal` [does not work on Linux](https://github.com/docker/for-linux/issues/264). You should use the network-accessible IP shown by `ifconfig` (not e.g. 127.0.0.1 or localhost).
+
+Go to **Admin > Manage Repositories > Add repositories > Single Git repositories**. Input the above configuration. Your directories should now be syncing in Sourcegraph.
+
+### Next steps: advanced configuration
+
+Please consult `src-expose -help` to learn more about the options available. 
+
+For more complex setups, configure your `src-expose` by providing a local configuration file:
+
+``` shell
+src-expose -snapshot-config config.yaml
+```
+
+See [an example YAML file containing available configuration options](https://github.com/sourcegraph/sourcegraph/blob/master/dev/src-expose/examples/example.yaml). 
+
+## Choosing the right `src-expose` setup
+
+`src-expose` provides a spectrum of ways to access non-Git code in Sourcegraph, trading off freshness of the code against completeness of the code history. 
+
+**Retaining code change history**
+
+If you have a small enough code base, it is possible to use a tool for converting the full non-Git code host's history into Git history, and to keep them synced. For example, for Perforce, by using `git p4 sync` (which converts the full Perforce change history into Git commits) rather than using `p4 sync` in conjunction with `src-expose` to squash all changes into a single new commit (see the [Syncing repositories](#syncing-repositories) section above).
+
+To achieve this 
+
+**Retaining code change history**
+

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -53,7 +53,7 @@ While this syncing functionality means that the original change history will be 
 
 ## Quickstart
 
-1. Start up a Sourcegraph instance (using our [Quickstart](../../../index.md) or our [full installation documentation](../../install/index.md)).
+1. Start up a Sourcegraph instance (using our [Quickstart](../../index.md) or our [full installation documentation](../install/index.md)).
 
 1. [Install `src-expose`](#installing-src-expose)
 

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -2,7 +2,7 @@
 
 Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a CLI tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
 
-**Guides for specific non-Git code hosts**:
+<span class="x x-first x-last">&gt; NOTE: If using Perforce, see the [Perforce repositories with Sourcegraph guide](../repo/perforce.md).</span>
 - [Perforce](../repo/perforce.md)
 
 ## Installing `src-expose`

--- a/doc/admin/external_service/non-git.md
+++ b/doc/admin/external_service/non-git.md
@@ -2,8 +2,7 @@
 
 Sourcegraph natively supports all Git-based Version Control Systems (VCSs) and code hosts. For non-Git code hosts, Sourcegraph provides a CLI tool called `src-expose` to periodically sync and continuously serve local directories as Git repositories over HTTP. 
 
-<span class="x x-first x-last">&gt; NOTE: If using Perforce, see the [Perforce repositories with Sourcegraph guide](../repo/perforce.md).</span>
-- [Perforce](../repo/perforce.md)
+>NOTE: If using Perforce, see the [Perforce repositories with Sourcegraph guide](../repo/perforce.md).
 
 ## Installing `src-expose`
 
@@ -12,7 +11,7 @@ Navigate to the directory that contains the Git repositories that you want to se
 For Linux:
 
 ```bash
-# wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/linux-amd64/src-expose
+wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/linux-amd64/src-expose
 
 chmod +x src-expose
 ```
@@ -45,7 +44,7 @@ If you wish to serve a local directory without running any syncing commands auto
 
 In order to keep the code in the local repository up to date, you will need to run another command periodically to fetch changes. For example, if you are using Perforce, you can set up a cron job to run `git p4 sync` every few minutes or hours to fetch changes and convert them to Git commits that can then be served. Similar options exist for other non-Git VCSs.
 
-### Syncing and service repositories
+### Syncing and serving repositories
 
 In addition to serving a local directory, `src-expose` can periodically run a command of your choice to fetch changes from a remote and combine them into a single new Git commit.
 

--- a/doc/admin/external_service/other.md
+++ b/doc/admin/external_service/other.md
@@ -53,57 +53,6 @@ Repositories must be listed individually:
   ]
 ```
 
-## Experimental: src-expose
-
-`src-expose` is a tool to periodically snapshot local directories and serve them as Git repositories over HTTP. This is a useful way to get code from other version control systems or textual artifacts from non version controlled systems (eg configuration) into Sourcegraph.
-
-### Quick start
-
-Start up a Sourcegraph instance
-
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.14.1</code></pre>
-
-Pick a directory you want to export from, then run:
-
-``` shell
-wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/darwin-amd64/src-expose
-# For linux comment the above and uncomment the below
-# wget https://storage.googleapis.com/sourcegraph-artifacts/src-expose/latest/linux-amd64/src-expose
-
-chmod +x src-expose
-./src-expose dir1 dir2 dir3
-```
-
-`src-expose` will output a configuration to use. It may scroll by quickly due to snapshot logging, so scroll up. However, this configuration should work:
-
-``` javascript
- {
-    // url is the http url to src-expose (listening on 127.0.0.1:3434)
-    // url should be reachable by Sourcegraph.
-    // "http://host.docker.internal:3434" works from Sourcegraph when using Docker for Desktop.
-    "url": "http://host.docker.internal:3434",
-    "repos": ["src-expose"]
-}
-```
-
-**IMPORTANT:** If you are using a Linux host machine, replace `host.docker.internal` in the above with the IP address of your actual host machine because `host.docker.internal` [does not work on Linux](https://github.com/docker/for-linux/issues/264). You should use the network-accessible IP shown by `ifconfig` (not e.g. 127.0.0.1 or localhost).
-
-Go to Admin > Manage Repositories > Add repositories > Single Git repositories. Input the above configuration. Your directories should now be syncing in Sourcegraph.
-
-### Advanced configuration
-
-The command line argument used by the quick start is for quickly validating the approach. However, you may have more complicated scenarios for snapshotting. In that case you can pass a YAML configuration file:
-
-``` shell
-src-expose -snapshot-config config.yaml
-```
-
-To see the configuration please consult `src-expose -help`. The [example.yaml](https://github.com/sourcegraph/sourcegraph/blob/master/dev/src-expose/example.yaml) also documents the possibilities.
-
-### Serving git repositories
-
-Alternatively you can serve git repositories. See `src-expose serve -help`.
-
 ## Configuration
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/other_external_service.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/other) to see rendered content.</div>

--- a/doc/admin/repo/add.md
+++ b/doc/admin/repo/add.md
@@ -2,7 +2,8 @@
 
 - [Add repositories from a code host](../external_service/index.md) (GitHub, GitLab, Bitbucket Server, AWS CodeCommit, Phabricator, or Gitolite)
 - [Add repositories by Git clone URLs](../external_service/other.md)
-- [Add Perforce repositories](perforce.md)
+- [Add repositories from non-Git code hosts](../external_service/non-git.md)
+  - [Add Perforce repositories](perforce.md)
 - [Add repositories from the local disk](add_from_local_disk.md)
 
 ## Troubleshooting

--- a/doc/admin/repo/index.md
+++ b/doc/admin/repo/index.md
@@ -4,4 +4,5 @@
 - [Repository update frequency](update_frequency.md)
 - [Repository webhooks](webhooks.md)
 - [Repositories that need HTTP(S) or SSH authentication](auth.md)
-- [Using Perforce repositories](perforce.md)
+- [Adding non-Git repositories](../external_service/non-git.md)
+  - [Adding Perforce repositories](perforce.md)

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -38,7 +38,7 @@ If you do this, the repositories you created on your Git host are normal Git rep
 
 ### Alternative for extra-large codebases
 
-The instructions below will help you get Perforce repositories on Sourcegraph quickly and easily, while retaining all code change history. If your Perforce codebase is large enough that converting it to Git takes long enough to cause noticeable staleness on Sourcegraph, you can use `src-expose`'s [optional syncing functionality](../extenral_service/non-git.md#syncing-repositories) along with a faster fetching command (like `p4 sync` instead of `git p4 sync`) to periodically fetch and squash changes without trying to preserve the original Perforce history.
+The instructions below will help you get Perforce repositories on Sourcegraph quickly and easily, while retaining all code change history. If your Perforce codebase is large enough that converting it to Git takes long enough to cause noticeable staleness on Sourcegraph, you can use `src-expose`'s [optional syncing functionality](../external_service/non-git.md#syncing-repositories) along with a faster fetching command (like `p4 sync` instead of `git p4 sync`) to periodically fetch and squash changes without trying to preserve the original Perforce history.
 
 ## Known issues
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -1,14 +1,10 @@
 # Using Perforce repositories with Sourcegraph
 
-You can use [Perforce](https://perforce.com) repositories with Sourcegraph by using the [git p4](https://git-scm.com/docs/git-p4) adapter, which creates an equivalent Git repository from a Perforce repository. Sourcegraph doesn't yet support Perforce repositories natively.
+You can use [Perforce](https://perforce.com) repositories with Sourcegraph by using the [git p4](https://git-scm.com/docs/git-p4) adapter, which creates an equivalent Git repository from a Perforce repository, and [`src-expose`](../external_service/non-git.md), Sourcegraph's tool for serving local directories.
 
 Screenshot of using Sourcegraph for code navigation in a Perforce repository:
 
 ![Viewing a Perforce repository on Sourcegraph](https://storage.googleapis.com/sourcegraph-assets/git-p4-example.png)
-
-## src-expose
-
-We have an experimental alternative for importing Perforce code into Sourcegraph: [src-expose](../external_service/other.md#experimental-src-expose).
 
 ## Instructions
 
@@ -17,30 +13,36 @@ We have an experimental alternative for importing Perforce code into Sourcegraph
 - Git
 - Perforce `p4` CLI configured to access your Perforce repository
 - `git p4` (see "[Adding `git p4` to an existing install](https://git.wiki.kernel.org/index.php/GitP4#Adding_git-p4_to_an_existing_install)")
-- A Git host (such as GitHub or GitLab) where you can push new Git repositories
+- [`src-expose`](../external_service/non-git.md)
 
-### Create an equivalent Git repository from a Perforce repository
+### Create an equivalent Git repository and serve it to Sourcegraph
 
 For each Perforce repository you want to use with Sourcegraph, follow these steps:
 
 1. Create a local Git repository with the contents of your Perforce repository: `git p4 clone //DEPOT/PATH@all` (replace `//DEPOT/PATH` with the Perforce repository path).
 1. `cd PATH` to enter the directory of the new local Git repository.
-1. Create a new Git repository on your Git host (such as GitHub or GitLab) for this repository.
-1. Add the repository you just created on the Git host as a remote: `git remote add origin https://git-host.example.com/my/repo.git`
-1. Push the repository to the Git host: `git push -u origin master`
+1. Run `src-expose serve dir1 dir2 dir3`, replacing the directories here with the directories that contain the new local Git repository.
+1. Follow the instructions in the [`src-expose` Quickstart](../external_service/non-git.md#quickstart) to add the repositories to your Sourcegraph instance.
 
-#### Updating Perforce repositories
+### Updating Perforce repositories
 
-To update the repository after new Perforce commits are made, run `git p4 sync && git push` in the local repository directory. Sourcegraph does not yet automatically sync repositories from Perforce, so you must do this manually or script it yourself.
+To update the repository after new Perforce commits are made, run `git p4 sync` in the local repository directory. These changes will be automatically reflected in Sourcegraph as long as `src-expose serve` is running.
 
-### Add the converted Perforce repositories from your Git host to Sourcegraph
+We recommend running this command on a periodic basis using a cron job, or some other scheduler. The frequency will dictate how fresh the code is in Sourcegraph, and can range from once every 10s to once per day, depending on how large your codebase is and how long it takes `git p4 sync` to complete.
 
-The repositories you created on your Git host are normal Git repositories, so you can [add the repositories to Sourcegraph](index.md) as you would any other Git repositories.
+### Alternative to `src-expose`: push the new Git repository to a code host
+
+If you prefer, you can skip using `src-expose`, and instead push the new local Git repository to a Git-based code host of your choice. For updates, you would run `git p4 sync && git push` periodically.
+
+If you do this, the repositories you created on your Git host are normal Git repositories, so you can [add the repositories to Sourcegraph](index.md) as you would any other Git repositories.
+
+### Alternative for extra-large codebases
+
+The instructions below will help you get Perforce repositories on Sourcegraph quickly and easily, while retaining all code change history. If your Perforce codebase is large enough that converting it to Git takes long enough to cause noticeable staleness on Sourcegraph, you can use `src-expose`'s [optional syncing functionality](../extenral_service/non-git.md#syncing-repositories) along with a faster fetching command (like `p4 sync` instead of `git p4 sync`) to periodically fetch and squash changes without trying to preserve the original Perforce history.
 
 ## Known issues
 
 We intend to improve Sourcegraph's Perforce support in the future. Please [file an issue](https://github.com/sourcegraph/sourcegraph/issues) to help us prioritize any specific improvements you'd like to see.
 
 - Sourcegraph was initially built for Git repositories only, so it exposes Git concepts that are meaningless for converted Perforce repositories, such as the commit SHA, branches, and tags.
-- There is no automatic updating of converted repositories when new Perforce commits are made. See the "[Updating Perforce repositories](#updating-perforce-repositories)" section for manual steps.
 - The commit messages for a Perforce repository converted to a Git repository have an extra line at the end with Perforce information, such as `[git-p4: depot-paths = "//guest/acme_org/myproject/": change = 12345]`.


### PR DESCRIPTION
Completely changed our docs for src-expose and non-git code hosts to emphasize one specific setup, and to better clarify . 

That is, to use:

* `git p4 clone` and `git p4 sync` (and equivalent for other non-Git VCSs) to preserve change history.
* `src-expose serve` to serve them to Sourcegraph.

This intentionally discourages a few other paths, namely:

* Using `src-expose` (without the `serve` argument)... I'm not sure how big a codebase has to be before using `git p4 sync` is too slow after the initial clone, but I'll be getting a data point on this shortly from https://app.hubspot.com/contacts/2762526/company/693777200 who are going through this setup now.
* Cloning a non-Git project and pushing changes to a Git code host as a workaround.

An additional goal would be to use this to point customers to, to solve issues such as https://github.com/sourcegraph/customer/issues/39
