### PR TITLE
Add Code Intel to the tracking-issue action.

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -16,6 +16,14 @@ on:
     - milestoned
     - demilestoned
 jobs:
+  code-intelligence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://sourcegraph/tracking-issue:latest
+        with:
+          args: -milestone 3.15 -labels team/code-intelligence -update
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRACKING_ISSUE_SYNCER_TOKEN }}
   core-services:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Code Intelligence team is adopting the tracking-issue tool used by several of the other teams. This change adds a job to the actions workflow to keep the issue description up-to-date.

I have already added the magic comments to the issue description, but note that we will still need to do some work to update our issues against the milestone.

We could probably factor `env` higher in the job config but I didn't include that in this PR.