### PR TITLE
search: implement minimal and/or interface for existing search

### DIFF
--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -1,8 +1,14 @@
 package query
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 type SearchType int
@@ -59,26 +65,172 @@ func (q OrdinaryQuery) IsCaseSensitive() bool {
 	return q.Query.IsCaseSensitive()
 }
 
-// AndOrQuery satisfies the interface for QueryInfo with empty values. Its
-// methods are not currently used.
-func (AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
-	return nil, nil
+// AndOrQuery satisfies the interface for QueryInfo with unvalidated string
+// values. These methods and dependent functions are only callable via an
+// andOrQuery site flag and not intended for use.
+func (q AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
+	VisitField(q.query, field, func(visitedValue string, negated bool) {
+		if negated {
+			negatedValues = append(negatedValues, visitedValue)
+		} else {
+			values = append(values, visitedValue)
+		}
+	})
+	log15.Info("Query", "RegexpPatterns", field)
+	return values, negatedValues
 }
-func (AndOrQuery) StringValues(field string) (values, negatedValues []string) {
-	return nil, nil
+
+func (q AndOrQuery) StringValues(field string) (values, negatedValues []string) {
+	VisitField(q.query, field, func(visitedValue string, negated bool) {
+		if negated {
+			negatedValues = append(negatedValues, visitedValue)
+		} else {
+			values = append(values, visitedValue)
+		}
+	})
+	log15.Info("Query", "StringValues", field)
+	return values, negatedValues
 }
-func (AndOrQuery) StringValue(field string) (value, negatedValue string) {
-	return "", ""
+
+func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
+	VisitField(q.query, field, func(visitedValue string, negated bool) {
+		if negated {
+			negatedValue = visitedValue
+		} else {
+			value = visitedValue
+		}
+	})
+	log15.Info("Query", "StringValue", field)
+	return value, negatedValue
 }
-func (AndOrQuery) Values(field string) []*types.Value {
-	return nil
+
+func (q AndOrQuery) Values(field string) []*types.Value {
+	var values []*types.Value
+	VisitField(q.query, field, func(value string, _ bool) {
+		values = append(values, valueToTypedValue(field, value)...)
+	})
+	log15.Info("Query", "Values", field)
+	return values
 }
-func (AndOrQuery) Fields() map[string][]*types.Value {
-	return nil
+
+func (q AndOrQuery) Fields() map[string][]*types.Value {
+	fields := make(map[string][]*types.Value)
+	VisitParameter(q.query, func(field, value string, _ bool) {
+		fields[field] = valueToTypedValue(field, value)
+	})
+	log15.Info("Query", "Fields", fmt.Sprintf("size: %d", len(fields)))
+	return fields
 }
-func (AndOrQuery) ParseTree() syntax.ParseTree {
-	return nil
+
+// ParseTree returns a flat, mock-like parse tree of an and/or query. The parse
+// tree values are currently only significant in alerts. Whether it is empty or
+// not is significant for surfacing suggestions.
+func (q AndOrQuery) ParseTree() syntax.ParseTree {
+	var tree syntax.ParseTree
+	VisitParameter(q.query, func(field, value string, negated bool) {
+		expr := &syntax.Expr{
+			Field: field,
+			Value: value,
+			Not:   negated,
+		}
+		tree = append(tree, expr)
+	})
+	log15.Info("Query", "ParseTree", tree)
+	return tree
 }
-func (AndOrQuery) IsCaseSensitive() bool {
-	return false
+
+func (q AndOrQuery) IsCaseSensitive() bool {
+	var result bool
+	VisitField(q.query, "case", func(value string, _ bool) {
+		switch strings.ToLower(value) {
+		case "y", "yes", "true":
+			result = true
+		}
+	})
+	log15.Info("Query", "IsCaseSensitive", result)
+	return result
+}
+
+func parseRegexpOrPanic(field, value string) *regexp.Regexp {
+	regexp, err := regexp.Compile(value)
+	if err != nil {
+		panic(fmt.Sprintf("Value %s for field %s invalid regex: %s", field, value, err.Error()))
+	}
+	return regexp
+}
+
+func parseBoolOrPanic(field, value string) *bool {
+	var b bool
+	switch strings.ToLower(value) {
+	case "y", "yes":
+		b = true
+		return &b
+	case "n", "no":
+		return &b
+	default:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			panic(fmt.Sprintf("Value %s for field %s invalid bool-like value: %s", field, value, err.Error()))
+		}
+		return &b
+	}
+}
+
+// valueToTypedValue approximately preserves the field validation for
+// OrdinaryQuery processing. It does not check the validity of field negation or
+// if the same field is specified more than once.
+func valueToTypedValue(field, value string) []*types.Value {
+	switch field {
+	case FieldDefault:
+		// Treat as string for sipmplicity. The type could be regexp or
+		// string depending on quotes or search kind.
+		return []*types.Value{{String: &value}}
+
+	case FieldCase:
+		return []*types.Value{{Bool: parseBoolOrPanic(field, value)}}
+
+	case FieldRepo, "r":
+		return []*types.Value{{Regexp: parseRegexpOrPanic(field, value)}}
+
+	case FieldRepoGroup, "g":
+		return []*types.Value{{String: &value}}
+
+	case FieldFile, "f":
+		return []*types.Value{{Regexp: parseRegexpOrPanic(field, value)}}
+
+	case
+		FieldFork,
+		FieldArchived,
+		FieldLang, "l", "language",
+		FieldType,
+		FieldPatternType,
+		FieldContent:
+		return []*types.Value{{String: &value}}
+
+	case FieldRepoHasFile:
+		return []*types.Value{{Regexp: parseRegexpOrPanic(field, value)}}
+
+	case
+		FieldRepoHasCommitAfter,
+		FieldBefore, "until",
+		FieldAfter, "since":
+		return []*types.Value{{String: &value}}
+
+	case
+		FieldAuthor,
+		FieldCommitter,
+		FieldMessage, "m", "msg":
+		return []*types.Value{{Regexp: parseRegexpOrPanic(field, value)}}
+
+	case
+		FieldIndex,
+		FieldCount,
+		FieldMax,
+		FieldTimeout,
+		FieldReplace,
+		FieldCombyRule:
+		return []*types.Value{{String: &value}}
+	}
+	log15.Info("Unhandled typed value conversion", field, value)
+	return []*types.Value{{String: &value}}
 }

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
-	"gopkg.in/inconshreveable/log15.v2"
 )
 
 type SearchType int


### PR DESCRIPTION
Stacked on #9244.

What this does is make it possible to run our search with its full functionality (i.e., get search results), but without using any of the existing scanner/parser code. It relies only and/or queries and its parsing. 

This is primarily for me to develop against, so that the code path can reach `Results()` where it'll be possible to implement intersection/union of and/or expressions. None of the code added here is reachable without a site flag, and that site flag is not intended to be activated by anyone other than me :)

I put in some hard panics for query validation that is not immediately important, but will matter later. I want to know about them if they happen.

All of this code will be replaced/removed by the time the switchover happens.