### PR TITLE
authz: expose metrics of `authzFilter` duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Users and site administrators can now view a log of their actions/events in the user settings.
+- monitoring: new Permissions dashboard to show stats of repository permissions.
 
 ### Changed
 

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -67,11 +67,10 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 	began := time.Now()
 	tr, ctx := trace.New(ctx, "authzFilter", "")
 	defer func() {
-		took := time.Now().Sub(began).Seconds()
 		defer tr.Finish()
 
 		success := err == nil
-		authzFilterDuration.WithLabelValues(strconv.FormatBool(success)).Observe(took)
+		authzFilterDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(began).Seconds())
 
 		if !success {
 			tr.SetError(err)

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -2,11 +2,15 @@ package db
 
 import (
 	"context"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/RoaringBitmap/roaring"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -15,6 +19,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"gopkg.in/inconshreveable/log15.v2"
 )
+
+var authzFilterDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "src",
+	Subsystem: "frontend",
+	Name:      "authz_filter_duration_seconds",
+	Help:      "Time spent on performing authorization",
+}, []string{"success"})
 
 var MockAuthzFilter func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error)
 
@@ -53,9 +64,16 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 
 	var currentUser *types.User
 
+	began := time.Now()
 	tr, ctx := trace.New(ctx, "authzFilter", "")
 	defer func() {
-		if err != nil {
+		took := time.Now().Sub(began).Seconds()
+		defer tr.Finish()
+
+		success := err == nil
+		authzFilterDuration.WithLabelValues(strconv.FormatBool(success)).Observe(took)
+
+		if !success {
 			tr.SetError(err)
 		}
 
@@ -70,8 +88,6 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 		}
 
 		tr.LogFields(fields...)
-
-		tr.Finish()
 	}()
 
 	if isInternalActor(ctx) {

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -15,7 +15,7 @@ zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
 zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
 zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
 keycloak: ./dev/auth-provider/keycloak.sh
-jaeger:./dev/jaeger.sh
+jaeger: ./dev/jaeger.sh
 docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
 lsif-server: yarn --cwd lsif run run:server
 lsif-dump-manager: yarn --cwd lsif run run:dump-manager

--- a/docker-images/grafana/jsonnet/perms_sync.jsonnet
+++ b/docker-images/grafana/jsonnet/perms_sync.jsonnet
@@ -8,7 +8,7 @@ local common = import './common.libsonnet';
 local timeRange = '1m';
 
 // The duration percentiles to display
-local percentiles = ['0.99'];
+local percentiles = ['0.95'];
 
 // Colors to pair to percentiles above
 local percentileColors = ['#7eb26d'];
@@ -154,6 +154,10 @@ local queueSizePanel = common.makePanel(
         ),
     ]
 );
+local authzFilterDurationPercentilesPanel = makeDurationPercentilesPanel(
+    title = 'Authorization duration',
+    metric = 'src_frontend_authz_filter_duration_seconds_bucket{success="true"}',
+);
 
 //
 // Dashboard Construction
@@ -175,4 +179,7 @@ common.makeDashboard(
 ).addRow(
     title = 'Syncer stats',
     panels = [queueSizePanel]
+).addRow(
+    title = 'General stats',
+    panels = [authzFilterDurationPercentilesPanel]
 )

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -633,8 +633,6 @@ func (s *PermsSyncer) observe(ctx context.Context, family, title string) (contex
 	tr, ctx := trace.New(ctx, family, title)
 
 	return ctx, func(typ requestType, id int32, err *error) {
-		took := s.clock().Sub(began).Seconds()
-
 		defer tr.Finish()
 		tr.LogFields(otlog.Int32("id", id))
 
@@ -650,7 +648,7 @@ func (s *PermsSyncer) observe(ctx context.Context, family, title string) (contex
 		}
 
 		success := err == nil || *err == nil
-		s.metrics.syncDuration.WithLabelValues(typLabel, strconv.FormatBool(success)).Observe(took)
+		s.metrics.syncDuration.WithLabelValues(typLabel, strconv.FormatBool(success)).Observe(time.Since(began).Seconds())
 
 		if !success {
 			tr.SetError(*err)

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -633,8 +633,7 @@ func (s *PermsSyncer) observe(ctx context.Context, family, title string) (contex
 	tr, ctx := trace.New(ctx, family, title)
 
 	return ctx, func(typ requestType, id int32, err *error) {
-		now := s.clock()
-		took := now.Sub(began).Seconds()
+		took := s.clock().Sub(began).Seconds()
 
 		defer tr.Finish()
 		tr.LogFields(otlog.Int32("id", id))


### PR DESCRIPTION
This PR adds a p95 panel for `authzFilter` duration:
![image](https://user-images.githubusercontent.com/2946214/77397340-5b4b8800-6de0-11ea-88c6-679431519584.png)

Fixes #8612
