### PR TITLE
frontend: counter metrics for raw endpoint

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -13,6 +13,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	log15 "gopkg.in/inconshreveable/log15.v2"
@@ -158,6 +160,11 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		}
 		w.Header().Set("Content-Length", strconv.FormatInt(fi.Size(), 10))
 		log15.Debug("raw endpoint sending archive", "repo", common.Repo.Name, "commit", common.CommitID, "format", format, "path", relativePath, "size", fi.Size())
+		if relativePath == "." {
+			metricRawTotal.WithLabelValues("rootarchive").Inc()
+		} else {
+			metricRawTotal.WithLabelValues("patharchive").Inc()
+		}
 
 		_, err = io.Copy(w, f)
 		return err
@@ -210,6 +217,7 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			if os.IsNotExist(err) {
 				log15.Debug("raw endpoint sending file", "repo", common.Repo.Name, "commit", common.CommitID, "path", requestedPath, "type", "404")
+				metricRawTotal.WithLabelValues("404").Inc()
 				http.Error(w, html.EscapeString(err.Error()), http.StatusNotFound)
 				return nil // request handled
 			}
@@ -230,6 +238,7 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 			}
 			result := strings.Join(names, "\n")
 			log15.Debug("raw endpoint sending file", "repo", common.Repo.Name, "commit", common.CommitID, "path", requestedPath, "type", "dir", "size", len(infos))
+			metricRawTotal.WithLabelValues("dir").Inc()
 			fmt.Fprintf(w, "%s", template.HTMLEscapeString(result))
 			return nil
 		}
@@ -241,7 +250,13 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		}
 		defer f.Close()
 		log15.Debug("raw endpoint sending file", "repo", common.Repo.Name, "commit", common.CommitID, "path", requestedPath, "type", "file", "size", fi.Size())
+		metricRawTotal.WithLabelValues("file").Inc()
 		_, err = io.Copy(w, f)
 		return err
 	}
 }
+
+var metricRawTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "src_http_raw_endpoint_total",
+	Help: "The total number of requests to the raw endpoint API.",
+}, []string{"type"})


### PR DESCRIPTION
I added some logs recently. I took a quick look at the data collected so far,
and realised it would now be useful to add some high level counters. From the
little bit of data I have seen, most extensions seem to just use "root
archive" endpoint. Once I have collected enough evidence, we can adjust this
endpoint to optimize for that use case.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
