### PR TITLE
repo-updater: use value instead of pointer for configuredRepo2

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -336,9 +336,7 @@ func (s *updateScheduler) DebugDump() interface{} {
 		data.Schedule = append(data.Schedule, update)
 	}
 
-	s.updateQueue.mu.RLock()
-	defer s.updateQueue.mu.RUnlock()
-
+	s.updateQueue.mu.Lock()
 	updateQueue := updateQueue{
 		heap: make([]*repoUpdate, len(s.updateQueue.heap)),
 	}
@@ -349,21 +347,13 @@ func (s *updateScheduler) DebugDump() interface{} {
 		updateCopy := *update
 		updateQueue.heap[i] = &updateCopy
 	}
+	s.updateQueue.mu.Unlock()
 
 	for len(updateQueue.heap) > 0 {
-		// Copy values of the repoUpdate so that the repo pointer
+		// Copy the scheduledRepoUpdate as a value so that the repo pointer
 		// won't change concurrently after we release the lock.
 		update := heap.Pop(&updateQueue).(*repoUpdate)
-		data.UpdateQueue = append(data.UpdateQueue, &repoUpdate{
-			Repo: &configuredRepo2{
-				URL:  update.Repo.URL,
-				ID:   update.Repo.ID,
-				Name: update.Repo.Name,
-			},
-			Priority: update.Priority,
-			Seq:      update.Seq,
-			Updating: update.Updating,
-		})
+		data.UpdateQueue = append(data.UpdateQueue, update)
 	}
 
 	return &data
@@ -400,7 +390,7 @@ func (s *updateScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedu
 // updateQueue is a priority queue of repos to update.
 // A repo can't have more than one location in the queue.
 type updateQueue struct {
-	mu sync.RWMutex
+	mu sync.Mutex
 
 	heap  []*repoUpdate
 	index map[api.RepoID]*repoUpdate

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -180,13 +180,13 @@ func (s *updateScheduler) runUpdateLoop(ctx context.Context) {
 				return
 			}
 
-			repo := s.updateQueue.acquireNext()
-			if repo == nil {
+			repo, ok := s.updateQueue.acquireNext()
+			if !ok {
 				cancel()
 				break
 			}
 
-			go func(ctx context.Context, repo *configuredRepo2, cancel context.CancelFunc) {
+			go func(ctx context.Context, repo configuredRepo2, cancel context.CancelFunc) {
 				defer cancel()
 				defer s.updateQueue.remove(repo, true)
 
@@ -207,7 +207,7 @@ func (s *updateScheduler) runUpdateLoop(ctx context.Context) {
 }
 
 // requestRepoUpdate sends a request to gitserver to request an update.
-var requestRepoUpdate = func(ctx context.Context, repo *configuredRepo2, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+var requestRepoUpdate = func(ctx context.Context, repo configuredRepo2, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
 	return gitserver.DefaultClient.RequestRepoUpdate(ctx, gitserver.Repo{Name: repo.Name, URL: repo.URL}, since)
 }
 
@@ -281,7 +281,7 @@ func (s *updateScheduler) remove(r *Repo) {
 	}
 }
 
-func configuredRepo2FromRepo(r *Repo) *configuredRepo2 {
+func configuredRepo2FromRepo(r *Repo) configuredRepo2 {
 	repo := configuredRepo2{
 		ID:   r.ID,
 		Name: api.RepoName(r.Name),
@@ -291,13 +291,13 @@ func configuredRepo2FromRepo(r *Repo) *configuredRepo2 {
 		repo.URL = urls[0]
 	}
 
-	return &repo
+	return repo
 }
 
 // UpdateOnce causes a single update of the given repository.
 // It neither adds nor removes the repo from the schedule.
 func (s *updateScheduler) UpdateOnce(id api.RepoID, name api.RepoName, url string) {
-	repo := &configuredRepo2{
+	repo := configuredRepo2{
 		ID:   id,
 		Name: name,
 		URL:  url,
@@ -312,10 +312,8 @@ func (s *updateScheduler) DebugDump() interface{} {
 		Name        string
 		UpdateQueue []*repoUpdate
 		Schedule    []*scheduledRepoUpdate
-		SourceRepos map[string][]configuredRepo2
 	}{
-		Name:        "repos",
-		SourceRepos: map[string][]configuredRepo2{},
+		Name: "repos",
 	}
 
 	s.schedule.mu.Lock()
@@ -412,7 +410,7 @@ const (
 
 // repoUpdate is a repository that has been queued for an update.
 type repoUpdate struct {
-	Repo     *configuredRepo2
+	Repo     configuredRepo2
 	Priority priority
 	Seq      uint64 // the sequence number of the update
 	Updating bool   // whether the repo has been acquired for update
@@ -436,7 +434,7 @@ func (q *updateQueue) reset() {
 //
 // If the given priority is higher than the one in the queue,
 // the repo's position in the queue is updated accordingly.
-func (q *updateQueue) enqueue(repo *configuredRepo2, p priority) (updated bool) {
+func (q *updateQueue) enqueue(repo configuredRepo2, p priority) (updated bool) {
 	if repo.ID == 0 {
 		panic("repo.id is zero")
 	}
@@ -481,7 +479,7 @@ func (q *updateQueue) nextSeq() uint64 {
 }
 
 // remove removes the repo from the queue if the repo.Updating matches the updating argument.
-func (q *updateQueue) remove(repo *configuredRepo2, updating bool) (removed bool) {
+func (q *updateQueue) remove(repo configuredRepo2, updating bool) (removed bool) {
 	if repo.ID == 0 {
 		panic("repo.id is zero")
 	}
@@ -501,20 +499,20 @@ func (q *updateQueue) remove(repo *configuredRepo2, updating bool) (removed bool
 // acquireNext acquires the next repo for update.
 // The acquired repo must be removed from the queue
 // when the update finishes (independent of success or failure).
-func (q *updateQueue) acquireNext() *configuredRepo2 {
+func (q *updateQueue) acquireNext() (configuredRepo2, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if len(q.heap) == 0 {
-		return nil
+		return configuredRepo2{}, false
 	}
 	update := q.heap[0]
 	if update.Updating {
 		// Everything in the queue is already updating.
-		return nil
+		return configuredRepo2{}, false
 	}
 	update.Updating = true
 	heap.Fix(q, update.Index)
-	return update.Repo
+	return update.Repo, true
 }
 
 // The following methods implement heap.Interface based on the priority queue example:
@@ -577,14 +575,14 @@ type schedule struct {
 
 // scheduledRepoUpdate is the update schedule for a single repo.
 type scheduledRepoUpdate struct {
-	Repo     *configuredRepo2 // the repo to update
-	Interval time.Duration    // how regularly the repo is updated
-	Due      time.Time        // the next time that the repo will be enqueued for a update
-	Index    int              `json:"-"` // the index in the heap
+	Repo     configuredRepo2 // the repo to update
+	Interval time.Duration   // how regularly the repo is updated
+	Due      time.Time       // the next time that the repo will be enqueued for a update
+	Index    int             `json:"-"` // the index in the heap
 }
 
 // upsert inserts or updates a repo in the schedule.
-func (s *schedule) upsert(repo *configuredRepo2) (updated bool) {
+func (s *schedule) upsert(repo configuredRepo2) (updated bool) {
 	if repo.ID == 0 {
 		panic("repo.id is zero")
 	}
@@ -610,7 +608,7 @@ func (s *schedule) upsert(repo *configuredRepo2) (updated bool) {
 
 // updateInterval updates the update interval of a repo in the schedule.
 // It does nothing if the repo is not in the schedule.
-func (s *schedule) updateInterval(repo *configuredRepo2, interval time.Duration) {
+func (s *schedule) updateInterval(repo configuredRepo2, interval time.Duration) {
 	if repo.ID == 0 {
 		panic("repo.id is zero")
 	}
@@ -634,7 +632,7 @@ func (s *schedule) updateInterval(repo *configuredRepo2, interval time.Duration)
 }
 
 // remove removes a repo from the schedule.
-func (s *schedule) remove(repo *configuredRepo2) (removed bool) {
+func (s *schedule) remove(repo configuredRepo2) (removed bool) {
 	if repo.ID == 0 {
 		panic("repo.id is zero")
 	}

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -81,7 +81,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityLow,
 					Seq:      1,
 				},
@@ -95,7 +95,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      1,
 				},
@@ -110,12 +110,12 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      2,
 				},
 				{
-					Repo:     &b,
+					Repo:     b,
 					Priority: priorityLow,
 					Seq:      1,
 				},
@@ -130,12 +130,12 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      1,
 				},
 				{
-					Repo:     &b,
+					Repo:     b,
 					Priority: priorityLow,
 					Seq:      2,
 				},
@@ -150,7 +150,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityLow,
 					Seq:      1,
 				},
@@ -165,7 +165,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      1,
 				},
@@ -180,7 +180,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      2,
 				},
@@ -195,7 +195,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a2,
+					Repo:     a2,
 					Priority: priorityHigh,
 					Seq:      1, // Priority remains high
 				},
@@ -211,7 +211,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			acquire: 1,
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Updating: true,
 					Seq:      1,
@@ -236,27 +236,27 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			},
 			expectedUpdates: []*repoUpdate{
 				{
-					Repo:     &a,
+					Repo:     a,
 					Priority: priorityHigh,
 					Seq:      6,
 				},
 				{
-					Repo:     &b,
+					Repo:     b,
 					Priority: priorityHigh,
 					Seq:      7,
 				},
 				{
-					Repo:     &c,
+					Repo:     c,
 					Priority: priorityHigh,
 					Seq:      8,
 				},
 				{
-					Repo:     &d,
+					Repo:     d,
 					Priority: priorityHigh,
 					Seq:      9,
 				},
 				{
-					Repo:     &e,
+					Repo:     e,
 					Priority: priorityHigh,
 					Seq:      10,
 				},
@@ -273,7 +273,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			s := NewUpdateScheduler()
 
 			for _, call := range test.calls {
-				s.updateQueue.enqueue(&call.repo, call.priority)
+				s.updateQueue.enqueue(call.repo, call.priority)
 				if test.acquire > 0 {
 					s.updateQueue.acquireNext()
 					test.acquire--
@@ -296,12 +296,12 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 }
 
 func TestUpdateQueue_remove(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
-	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type removeCall struct {
-		repo     *configuredRepo2
+		repo     configuredRepo2
 		updating bool
 	}
 
@@ -456,8 +456,8 @@ func TestUpdateQueue_remove(t *testing.T) {
 }
 
 func TestUpdateQueue_acquireNext(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
 
 	tests := []struct {
 		name           string
@@ -474,7 +474,7 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 			initialQueue: []*repoUpdate{
 				{Repo: a, Updating: false, Seq: 1},
 			},
-			acquireResults: []*configuredRepo2{a},
+			acquireResults: []*configuredRepo2{&a},
 			finalQueue: []*repoUpdate{
 				{Repo: a, Updating: true, Seq: 1},
 			},
@@ -485,7 +485,7 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 				{Repo: a, Updating: false, Seq: 1},
 				{Repo: b, Updating: false, Seq: 2},
 			},
-			acquireResults: []*configuredRepo2{a},
+			acquireResults: []*configuredRepo2{&a},
 			finalQueue: []*repoUpdate{
 				{Repo: b, Updating: false, Seq: 2},
 				{Repo: a, Updating: true, Seq: 1},
@@ -513,8 +513,13 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 
 			// Test aquireNext.
 			for i, expected := range test.acquireResults {
-				if actual := s.updateQueue.acquireNext(); !reflect.DeepEqual(expected, actual) {
-					t.Fatalf("\nacquireNext expected %d\n%s\ngot\n%s", i, spew.Sdump(expected), spew.Sdump(actual))
+				actual, ok := s.updateQueue.acquireNext()
+				got := &actual
+				if !ok {
+					got = nil
+				}
+				if !reflect.DeepEqual(expected, got) {
+					t.Fatalf("\nacquireNext expected %d\n%s\ngot\n%s", i, spew.Sdump(expected), spew.Sdump(got))
 				}
 			}
 
@@ -551,8 +556,8 @@ func verifyQueue(t *testing.T, s *updateScheduler, expected []*repoUpdate) {
 }
 
 func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
 
 	tests := []struct {
 		name            string
@@ -655,13 +660,13 @@ func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
 }
 
 func TestSchedule_upsert(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	a2 := &configuredRepo2{ID: 1, Name: "a2", URL: "a2.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	a2 := configuredRepo2{ID: 1, Name: "a2", URL: "a2.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
 
 	type upsertCall struct {
 		time time.Time
-		repo *configuredRepo2
+		repo configuredRepo2
 	}
 
 	tests := []struct {
@@ -803,15 +808,15 @@ func TestSchedule_upsert(t *testing.T) {
 }
 
 func TestSchedule_updateInterval(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
-	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
-	d := &configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
-	e := &configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	d := configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
+	e := configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
 
 	type updateCall struct {
 		time     time.Time
-		repo     *configuredRepo2
+		repo     configuredRepo2
 		interval time.Duration
 	}
 
@@ -981,13 +986,13 @@ func TestSchedule_updateInterval(t *testing.T) {
 }
 
 func TestSchedule_remove(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
-	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type removeCall struct {
 		time time.Time
-		repo *configuredRepo2
+		repo configuredRepo2
 	}
 
 	tests := []struct {
@@ -1118,11 +1123,11 @@ func verifyScheduleRecording(t *testing.T, s *updateScheduler, timeAfterFuncDela
 }
 
 func TestUpdateScheduler_runSchedule(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
-	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
-	d := &configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
-	e := &configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	d := configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
+	e := configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
 
 	tests := []struct {
 		name                  string
@@ -1240,12 +1245,12 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 }
 
 func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
-	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
-	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
-	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type mockRequestRepoUpdate struct {
-		repo *configuredRepo2
+		repo configuredRepo2
 		resp *gitserverprotocol.RepoUpdateResponse
 		err  error
 	}
@@ -1343,7 +1348,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			// intentionally don't close the channel so any further receives just block
 
 			contexts := make(chan context.Context, expectedRequestCount)
-			requestRepoUpdate = func(ctx context.Context, repo *configuredRepo2, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+			requestRepoUpdate = func(ctx context.Context, repo configuredRepo2, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
 				select {
 				case mock := <-mockRequestRepoUpdates:
 					if !reflect.DeepEqual(mock.repo, repo) {


### PR DESCRIPTION
This prevents any race conditions around us updating the pointers we had to configuredRepo2. Additionally it may reduce garbage we produce in the heap.

Previously we added a coarse lock and adjusted the mutex to an RWMutex. The coarse lock went from holding during an O(n) operation to an O(nlogn).  Additionally RWMutex was inappropriate since RLock would only happen very rarely and there would be lots of quick Lock calls. RWMutex is not appropriate for that pattern.

This was done by a bunch of find replaces. The type system should catch any mistakes in the refactoring. Luckily we have extensive test coverage as well.

Follow-up of https://github.com/sourcegraph/sourcegraph/pull/9262
Fixes #9045