### PR TITLE
LSIF: Update default inter-process address settings

### DIFF
--- a/lsif/src/dump-manager/settings.ts
+++ b/lsif/src/dump-manager/settings.ts
@@ -4,7 +4,7 @@ import { readEnvInt } from '../shared/settings'
 export const HTTP_PORT = readEnvInt('HTTP_PORT', 3187)
 
 /** HTTP address for internal LSIF HTTP API. */
-export const LSIF_SERVER_URL = process.env.LSIF_SERVER_URL || 'http://lsif-server'
+export const LSIF_SERVER_URL = process.env.LSIF_SERVER_URL || 'http://localhost:3186'
 
 /** Where on the file system to store LSIF files. This should be a persistent volume. */
 export const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'

--- a/lsif/src/dump-processor/settings.ts
+++ b/lsif/src/dump-processor/settings.ts
@@ -4,7 +4,7 @@ import { readEnvInt } from '../shared/settings'
 export const METRICS_PORT = readEnvInt('METRICS_PORT', 3188)
 
 /** HTTP address for internal LSIF dump manager server. */
-export const LSIF_DUMP_MANAGER_URL = process.env.LSIF_DUMP_MANAGER_URL || 'http://lsif-dump-manager'
+export const LSIF_DUMP_MANAGER_URL = process.env.LSIF_DUMP_MANAGER_URL || 'http://localhost:3187'
 
 /** Where on the file system to temporarily store LSIF uploads and SQLite files. This is NOT a persistent volume. */
 export const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'

--- a/lsif/src/server/settings.ts
+++ b/lsif/src/server/settings.ts
@@ -4,7 +4,7 @@ import { readEnvInt } from '../shared/settings'
 export const HTTP_PORT = readEnvInt('HTTP_PORT', 3186)
 
 /** HTTP address for internal LSIF dump manager server. */
-export const LSIF_DUMP_MANAGER_URL = process.env.LSIF_DUMP_MANAGER_URL || 'http://lsif-dump-manager'
+export const LSIF_DUMP_MANAGER_URL = process.env.LSIF_DUMP_MANAGER_URL || 'http://localhost:3187'
 
 /** Where on the file system to temporarily store LSIF uploads. This need not be a persistent volume. */
 export const STORAGE_ROOT = process.env.LSIF_STORAGE_ROOT || 'lsif-storage'


### PR DESCRIPTION
We're currently not resolving lsif-server/lsif-dump-manager as every LSIF process is deployed as a single container. This will fix the current behavior on DotCom where the dump manager cannot be resolved by the server or the dump processor.

This will be updated once we plan to break the processes apart in k8s environments.