### PR TITLE
Remove PatchInput from campaigns package

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -551,7 +551,7 @@ func (r *Resolver) CreatePatchSetFromPatches(ctx context.Context, args graphqlba
 		return nil, backend.ErrNotAuthenticated
 	}
 
-	patches := make([]campaigns.PatchInput, len(args.Patches))
+	patches := make([]*campaigns.Patch, len(args.Patches))
 	for i, patch := range args.Patches {
 		repo, err := graphqlbackend.UnmarshalRepositoryID(patch.Repository)
 		if err != nil {
@@ -570,11 +570,11 @@ func (r *Resolver) CreatePatchSetFromPatches(ctx context.Context, args graphqlba
 			}
 		}
 
-		patches[i] = campaigns.PatchInput{
-			Repo:         repo,
-			BaseRevision: patch.BaseRevision,
-			BaseRef:      patch.BaseRef,
-			Patch:        patch.Patch,
+		patches[i] = &campaigns.Patch{
+			RepoID:  repo,
+			Rev:     patch.BaseRevision,
+			BaseRef: patch.BaseRef,
+			Diff:    patch.Patch,
 		}
 	}
 

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -50,7 +50,7 @@ type Service struct {
 // computed by the caller. There is no diff execution or computation performed during creation of
 // the Patches in this case (unlike when using Runner to create a PatchSet from a
 // specification).
-func (s *Service) CreatePatchSetFromPatches(ctx context.Context, patches []campaigns.PatchInput, userID int32) (*campaigns.PatchSet, error) {
+func (s *Service) CreatePatchSetFromPatches(ctx context.Context, patches []*campaigns.Patch, userID int32) (*campaigns.PatchSet, error) {
 	if userID == 0 {
 		return nil, backend.ErrNotAuthenticated
 	}
@@ -58,7 +58,7 @@ func (s *Service) CreatePatchSetFromPatches(ctx context.Context, patches []campa
 	reposStore := repos.NewDBStore(s.store.DB(), sql.TxOptions{})
 	repoIDs := make([]api.RepoID, len(patches))
 	for i, patch := range patches {
-		repoIDs[i] = api.RepoID(patch.Repo)
+		repoIDs[i] = api.RepoID(patch.RepoID)
 	}
 	allRepos, err := reposStore.ListRepos(ctx, repos.StoreListReposArgs{IDs: repoIDs})
 	if err != nil {
@@ -82,21 +82,15 @@ func (s *Service) CreatePatchSetFromPatches(ctx context.Context, patches []campa
 	}
 
 	for _, patch := range patches {
-		repo := reposByID[patch.Repo]
+		repo := reposByID[patch.RepoID]
 		if repo == nil {
-			return nil, fmt.Errorf("repository ID %d not found", patch.Repo)
+			return nil, fmt.Errorf("repository ID %d not found", patch.RepoID)
 		}
 		if !campaigns.IsRepoSupported(&repo.ExternalRepo) {
 			continue
 		}
 
-		patch := &campaigns.Patch{
-			PatchSetID: patchSet.ID,
-			RepoID:     patch.Repo,
-			BaseRef:    patch.BaseRef,
-			Rev:        patch.BaseRevision,
-			Diff:       patch.Patch,
-		}
+		patch.PatchSetID = patchSet.ID
 		if err := tx.CreatePatch(ctx, patch); err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -67,9 +67,9 @@ func TestService(t *testing.T) {
 +x
  y
 `
-		patches := []campaigns.PatchInput{
-			{Repo: api.RepoID(rs[0].ID), BaseRevision: "deadbeef", BaseRef: "refs/heads/master", Patch: patch},
-			{Repo: api.RepoID(rs[1].ID), BaseRevision: "f00b4r", BaseRef: "refs/heads/master", Patch: patch},
+		patches := []*campaigns.Patch{
+			{RepoID: api.RepoID(rs[0].ID), Rev: "deadbeef", BaseRef: "refs/heads/master", Diff: patch},
+			{RepoID: api.RepoID(rs[1].ID), Rev: "f00b4r", BaseRef: "refs/heads/master", Diff: patch},
 		}
 
 		patchSet, err := svc.CreatePatchSetFromPatches(ctx, patches, user.ID)
@@ -92,10 +92,10 @@ func TestService(t *testing.T) {
 		for i, patch := range patches {
 			wantJobs[i] = &campaigns.Patch{
 				PatchSetID: patchSet.ID,
-				RepoID:     patch.Repo,
-				Rev:        patch.BaseRevision,
+				RepoID:     patch.RepoID,
+				Rev:        patch.Rev,
 				BaseRef:    patch.BaseRef,
-				Diff:       patch.Patch,
+				Diff:       patch.Diff,
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -32,16 +32,6 @@ func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
 	return ok
 }
 
-// PatchInput is a patch applied to a repository (to create a new branch).
-type PatchInput struct {
-	Repo api.RepoID
-	// The commit SHA this patch is based on (e.g.: "4095572721c6234cd72013fd49dff4fb48f0f8a4").
-	BaseRevision api.CommitID
-	// The ref name that pointed to the BaseRevision at the time of patch creation (e.g.: "refs/heads/master").
-	BaseRef string
-	Patch   string
-}
-
 // A PatchSet is a collection of multiple Patchs.
 type PatchSet struct {
 	ID int64


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/9106 and removes the PatchInput definition from the campaigns package, since there was a lot of duplication between this type and the new Patch type.