### PR TITLE
Display sign in buttons in code view toolbar

### DIFF
--- a/browser/src/libs/bitbucket/context.tsx
+++ b/browser/src/libs/bitbucket/context.tsx
@@ -48,8 +48,7 @@ export function getContext(): CodeHostContext {
     try {
         revSpec = getRevSpecFromRevisionSelector()
     } catch (err) {
-        // RevSpec is optional in CodeHostContext, log the error for debug purposes
-        console.error('Could not determine revSpec from revision selector', err)
+        // RevSpec is optional in CodeHostContext
     }
     return {
         ...repoSpec,

--- a/browser/src/libs/code_intelligence/SignInButton.tsx
+++ b/browser/src/libs/code_intelligence/SignInButton.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback } from 'react'
+import { SourcegraphIconButton } from '../../shared/components/Button'
+import { interval, Observable } from 'rxjs'
+import { switchMap, filter, take, tap } from 'rxjs/operators'
+import { useEventObservable } from '../../../../shared/src/util/useObservable'
+
+export const SignInButton: React.FunctionComponent<{
+    className?: string
+    iconClassName?: string
+    sourcegraphURL: string
+    /**
+     * Gets called when the user closed the sign in tab.
+     * Does not guarantee the sign in was sucessful.
+     */
+    onSignInClose?: () => void
+}> = ({ className, iconClassName, sourcegraphURL, onSignInClose }) => {
+    const signInUrl = new URL('/sign-in?close=true', sourcegraphURL).href
+
+    const [nextSignInClick] = useEventObservable(
+        useCallback(
+            (signInClicks: Observable<React.MouseEvent>) =>
+                signInClicks.pipe(
+                    switchMap(event => {
+                        const tab = window.open(signInUrl, '_blank')
+                        if (!tab) {
+                            return []
+                        }
+                        event.preventDefault()
+                        return interval(300).pipe(
+                            filter(() => tab.closed),
+                            take(1)
+                        )
+                    }),
+                    tap(onSignInClose)
+                ),
+            [onSignInClose, signInUrl]
+        )
+    )
+
+    return (
+        <SourcegraphIconButton
+            url={signInUrl}
+            label="Sign in to Sourcegraph"
+            title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
+            ariaLabel="Sign into Sourcegraph to get hover tooltips, go to definition and more"
+            className={className}
+            iconClassName={iconClassName}
+            onClick={nextSignInClick}
+        />
+    )
+}

--- a/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
+++ b/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button when authentication failed 1`] = `
+exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button when authentication failed and showSignInButton = true 1`] = `
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
   onClick={[Function]}
+  title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
   <svg
     viewBox="0 0 40 40"
@@ -33,12 +34,13 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button 
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button when authentication failed 1`] = `
+exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button when authentication failed and showSignInButton = true 1`] = `
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
   onClick={[Function]}
+  title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
   <svg
     viewBox="0 0 40 40"
@@ -63,6 +65,39 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button w
   </svg>
    
   Sign in to Sourcegraph
+</a>
+`;
+
+exports[`<ViewOnSourcegraphButton /> renders a button with an error label if the repo exists check failed with an unknown error 1`] = `
+<a
+  aria-label="Something unknown happened!"
+  className="open-on-sourcegraph test"
+  title="Something unknown happened!"
+>
+  <svg
+    className="open-on-sourcegraph__icon--muted"
+    viewBox="0 0 40 40"
+  >
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
+        fill="#F96316"
+      />
+      <path
+        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
+        fill="#B200F8"
+      />
+      <path
+        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
+        fill="#00B4F2"
+      />
+    </g>
+  </svg>
+   
+  Error
 </a>
 `;
 
@@ -71,6 +106,7 @@ exports[`<ViewOnSourcegraphButton /> renders a link to the repository on the Sou
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
   href="https://test.com/test"
+  title="View repository on Sourcegraph"
 >
   <svg
     viewBox="0 0 40 40"
@@ -102,6 +138,7 @@ exports[`<ViewOnSourcegraphButton /> renders a link with the rev when provided 1
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
   href="https://test.com/test@test"
+  title="View repository on Sourcegraph"
 >
   <svg
     viewBox="0 0 40 40"
@@ -133,6 +170,7 @@ exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when p
   aria-label="Install Sourcegraph for search and code intelligence on private instance"
   className="open-on-sourcegraph test"
   onClick={[Function]}
+  title="Install Sourcegraph for search and code intelligence on private instance"
 >
   <svg
     className="open-on-sourcegraph__icon--muted"
@@ -168,6 +206,7 @@ exports[`<ViewOnSourcegraphButton /> still renders a button to a private instanc
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
   href="https://test.com/test@test"
+  title="View repository on Sourcegraph"
 >
   <svg
     viewBox="0 0 40 40"

--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -75,7 +75,7 @@ const createMockPlatformContext = (
     requestGraphQL: mockRequestGraphQL(),
     sideloadedExtensionURL: new Subject<string | null>(),
     settings: NEVER,
-    refreshSettings: () => Promise.reject(new Error('Not implemented')),
+    refreshSettings: () => Promise.resolve(),
     ...partialMocks,
 })
 

--- a/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -1,4 +1,3 @@
-import { of, throwError } from 'rxjs'
 import { ViewOnSourcegraphButton } from './external_links'
 import { HTTPStatusError } from '../../../../shared/src/backend/fetch'
 import * as React from 'react'
@@ -12,9 +11,9 @@ describe('<ViewOnSourcegraphButton />', () => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
                     sourcegraphURL="https://test.com"
-                    context={{ rawRepoName: 'test', privateRepository: false }}
+                    getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
                     className="test"
-                    ensureRepoExists={() => of(true)}
+                    repoExistsOrError={true}
                     minimalUI={false}
                 />
             )
@@ -28,9 +27,9 @@ describe('<ViewOnSourcegraphButton />', () => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
                     sourcegraphURL="https://test.com"
-                    context={{ rawRepoName: 'test', privateRepository: false }}
+                    getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
                     className="test"
-                    ensureRepoExists={() => of(true)}
+                    repoExistsOrError={true}
                     minimalUI={true}
                 />
             )
@@ -44,13 +43,13 @@ describe('<ViewOnSourcegraphButton />', () => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
                     sourcegraphURL="https://test.com"
-                    context={{
+                    getContext={() => ({
                         rawRepoName: 'test',
                         rev: 'test',
                         privateRepository: false,
-                    }}
+                    })}
                     className="test"
-                    ensureRepoExists={() => of(true)}
+                    repoExistsOrError={true}
                     minimalUI={false}
                 />
             )
@@ -60,19 +59,20 @@ describe('<ViewOnSourcegraphButton />', () => {
 
     for (const minimalUI of [true, false]) {
         describe(`minimalUI = ${String(minimalUI)}`, () => {
-            it('renders a sign in button when authentication failed', () => {
+            it('renders a sign in button when authentication failed and showSignInButton = true', () => {
                 let root: ReactTestRenderer
                 renderer.act(() => {
                     root = renderer.create(
                         <ViewOnSourcegraphButton
                             sourcegraphURL="https://test.com"
-                            context={{
+                            getContext={() => ({
                                 rawRepoName: 'test',
                                 rev: 'test',
                                 privateRepository: false,
-                            }}
+                            })}
+                            showSignInButton={true}
                             className="test"
-                            ensureRepoExists={() => throwError(new HTTPStatusError(new Response('', { status: 401 })))}
+                            repoExistsOrError={new HTTPStatusError(new Response('', { status: 401 }))}
                             minimalUI={minimalUI}
                         />
                     )
@@ -82,19 +82,40 @@ describe('<ViewOnSourcegraphButton />', () => {
         })
     }
 
+    it('renders a button with an error label if the repo exists check failed with an unknown error', () => {
+        let root: ReactTestRenderer
+        renderer.act(() => {
+            root = renderer.create(
+                <ViewOnSourcegraphButton
+                    sourcegraphURL="https://test.com"
+                    getContext={() => ({
+                        rawRepoName: 'test',
+                        rev: 'test',
+                        privateRepository: false,
+                    })}
+                    showSignInButton={true}
+                    className="test"
+                    repoExistsOrError={new Error('Something unknown happened!')}
+                    minimalUI={false}
+                />
+            )
+        })
+        expect(root!).toMatchSnapshot()
+    })
+
     it('renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist', () => {
         let root: ReactTestRenderer
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
                     sourcegraphURL="https://sourcegraph.com"
-                    context={{
+                    getContext={() => ({
                         rawRepoName: 'test',
                         rev: 'test',
                         privateRepository: false,
-                    }}
+                    })}
                     className="test"
-                    ensureRepoExists={() => of(false)}
+                    repoExistsOrError={false}
                     onConfigureSourcegraphClick={noop}
                     minimalUI={false}
                 />
@@ -109,13 +130,13 @@ describe('<ViewOnSourcegraphButton />', () => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
                     sourcegraphURL="https://test.com"
-                    context={{
+                    getContext={() => ({
                         rawRepoName: 'test',
                         rev: 'test',
                         privateRepository: false,
-                    }}
+                    })}
                     className="test"
-                    ensureRepoExists={() => of(false)}
+                    repoExistsOrError={false}
                     minimalUI={false}
                 />
             )

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -1,14 +1,11 @@
 import classNames from 'classnames'
-import React, { useMemo } from 'react'
-import { render } from 'react-dom'
-import { Observable, interval, Subject, concat } from 'rxjs'
-import { switchMap, catchError, filter, tap, take } from 'rxjs/operators'
+import React from 'react'
 import { SourcegraphIconButton } from '../../shared/components/Button'
 import { DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
-import { CodeHost, CodeHostContext } from './code_intelligence'
-import { asError } from '../../../../shared/src/util/errors'
-import { useObservable } from '../../../../shared/src/util/useObservable'
+import { CodeHostContext } from './code_intelligence'
+import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { failedWithHTTPStatus } from '../../../../shared/src/backend/fetch'
+import { SignInButton } from './SignInButton'
 
 export interface ViewOnSourcegraphButtonClassProps {
     className?: string
@@ -16,10 +13,11 @@ export interface ViewOnSourcegraphButtonClassProps {
 }
 
 interface ViewOnSourcegraphButtonProps extends ViewOnSourcegraphButtonClassProps {
-    context: CodeHostContext
+    getContext: () => CodeHostContext
     sourcegraphURL: string
     minimalUI: boolean
-    ensureRepoExists: (context: CodeHostContext, sourcegraphUrl: string) => Observable<boolean>
+    repoExistsOrError?: boolean | ErrorLike
+    showSignInButton?: boolean
     onConfigureSourcegraphClick?: () => void
 
     /**
@@ -30,71 +28,44 @@ interface ViewOnSourcegraphButtonProps extends ViewOnSourcegraphButtonClassProps
 }
 
 export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphButtonProps> = ({
-    ensureRepoExists,
+    repoExistsOrError,
     sourcegraphURL,
-    context,
+    getContext,
     minimalUI,
     onConfigureSourcegraphClick,
+    showSignInButton,
     onSignInClose,
     className,
     iconClassName,
 }) => {
-    const signInUrl = new URL('/sign-in?close=true', sourcegraphURL).href
-
-    /** Clicks on the "Sign in" CTA (if rendered) */
-    const signInClicks = useMemo(() => new Subject<React.MouseEvent>(), [])
-    const nextSignInClick = useMemo(() => signInClicks.next.bind(signInClicks), [signInClicks])
-
-    /**
-     * Emits when the user closed the sign in tab again.
-     * Does not guarantee the sign in was sucessful.
-     */
-    const signInCloses = useMemo(
-        () =>
-            signInClicks.pipe(
-                switchMap(event => {
-                    const tab = window.open(signInUrl, '_blank')
-                    if (!tab) {
-                        return []
-                    }
-                    event.preventDefault()
-                    return interval(300).pipe(
-                        filter(() => tab.closed),
-                        take(1)
-                    )
-                }),
-                tap(onSignInClose)
-            ),
-        [onSignInClose, signInClicks, signInUrl]
-    )
-
-    /** Whether or not the repo exists on the configured Sourcegraph instance. */
-    const repoExistsOrError = useObservable(
-        useMemo(
-            () =>
-                concat([null], signInCloses).pipe(
-                    switchMap(() =>
-                        ensureRepoExists(context, sourcegraphURL).pipe(catchError(error => [asError(error)]))
-                    )
-                ),
-            [context, ensureRepoExists, signInCloses, sourcegraphURL]
-        )
-    )
+    className = classNames('open-on-sourcegraph', className)
 
     if (repoExistsOrError === undefined) {
         return null
     }
-    className = classNames('open-on-sourcegraph', className)
-
-    if (failedWithHTTPStatus(repoExistsOrError, 401)) {
+    if (isErrorLike(repoExistsOrError)) {
+        if (failedWithHTTPStatus(repoExistsOrError, 401)) {
+            if (showSignInButton) {
+                return (
+                    <SignInButton
+                        sourcegraphURL={sourcegraphURL}
+                        onSignInClose={onSignInClose}
+                        className={className}
+                        iconClassName={iconClassName}
+                    />
+                )
+            }
+            // Sign in button may already be shown elsewhere on the page
+            return null
+        }
         return (
             <SourcegraphIconButton
-                url={signInUrl}
-                label="Sign in to Sourcegraph"
-                ariaLabel="Sign into Sourcegraph to get hover tooltips, go to definition and more"
+                label="Error"
+                title={repoExistsOrError.message}
+                ariaLabel={repoExistsOrError.message}
                 className={className}
-                iconClassName={iconClassName}
-                onClick={nextSignInClick}
+                iconClassName={classNames('open-on-sourcegraph__icon--muted', iconClassName)}
+                onClick={onConfigureSourcegraphClick}
             />
         )
     }
@@ -109,6 +80,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return (
             <SourcegraphIconButton
                 label="Configure Sourcegraph"
+                title="Install Sourcegraph for search and code intelligence on private instance"
                 ariaLabel="Install Sourcegraph for search and code intelligence on private instance"
                 className={className}
                 iconClassName={classNames('open-on-sourcegraph__icon--muted', iconClassName)}
@@ -117,39 +89,15 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         )
     }
 
-    const url = new URL(`/${context.rawRepoName}${context.rev ? `@${context.rev}` : ''}`, sourcegraphURL).href
+    const { rawRepoName, rev } = getContext()
+    const url = new URL(`/${rawRepoName}${rev ? `@${rev}` : ''}`, sourcegraphURL).href
     return (
         <SourcegraphIconButton
             url={url}
+            title="View repository on Sourcegraph"
             ariaLabel="View repository on Sourcegraph"
             className={className}
             iconClassName={iconClassName}
         />
-    )
-}
-
-export const renderViewContextOnSourcegraph = ({
-    sourcegraphURL,
-    getContext,
-    ensureRepoExists,
-    viewOnSourcegraphButtonClassProps,
-    onConfigureSourcegraphClick,
-    minimalUI,
-}: Pick<
-    ViewOnSourcegraphButtonProps,
-    'sourcegraphURL' | 'ensureRepoExists' | 'onConfigureSourcegraphClick' | 'minimalUI'
-> &
-    Required<Pick<CodeHost, 'getContext'>> &
-    Pick<CodeHost, 'viewOnSourcegraphButtonClassProps'>) => (mount: HTMLElement): void => {
-    render(
-        <ViewOnSourcegraphButton
-            {...viewOnSourcegraphButtonClassProps}
-            context={getContext()}
-            minimalUI={minimalUI}
-            sourcegraphURL={sourcegraphURL}
-            ensureRepoExists={ensureRepoExists}
-            onConfigureSourcegraphClick={onConfigureSourcegraphClick}
-        />,
-        mount
     )
 }

--- a/browser/src/shared/components/Button.tsx
+++ b/browser/src/shared/components/Button.tsx
@@ -3,6 +3,10 @@ import { SourcegraphIcon } from './Icons'
 
 interface Props {
     url?: string
+
+    /** The HTML hover tooltip title */
+    title?: string
+
     className?: string
     iconClassName?: string
     ariaLabel?: string
@@ -14,6 +18,7 @@ interface Props {
 export const SourcegraphIconButton: React.FunctionComponent<Props> = (props: Props) => (
     <a
         href={props.url}
+        title={props.title}
         aria-label={props.ariaLabel}
         className={props.className}
         onClick={props.onClick}

--- a/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/browser/src/shared/components/CodeViewToolbar.tsx
@@ -10,6 +10,9 @@ import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryServic
 import { FileInfoWithContents } from '../../libs/code_intelligence/code_views'
 import { OpenDiffOnSourcegraph } from './OpenDiffOnSourcegraph'
 import { OpenOnSourcegraph } from './OpenOnSourcegraph'
+import { SignInButton } from '../../libs/code_intelligence/SignInButton'
+import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { failedWithHTTPStatus } from '../../../../shared/src/backend/fetch'
 
 export interface ButtonProps {
     className?: string
@@ -30,12 +33,17 @@ export interface CodeViewToolbarClassProps extends ActionNavItemsClassProps {
 export interface CodeViewToolbarProps
     extends PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'requestGraphQL'>,
         ExtensionsControllerProps,
-        FileInfoWithContents,
         TelemetryProps,
         CodeViewToolbarClassProps {
     sourcegraphURL: string
-    onEnabledChange?: (enabled: boolean) => void
+
+    /**
+     * Information about the file or diff the toolbar is displayed on.
+     */
+    fileInfoOrError: FileInfoWithContents | ErrorLike
+
     buttonProps?: ButtonProps
+    onSignInClose: () => void
     location: H.Location
 }
 
@@ -50,47 +58,62 @@ export const CodeViewToolbar: React.FunctionComponent<CodeViewToolbarProps> = pr
             location={props.location}
             scope={props.scope}
         />{' '}
-        {props.baseCommitID && props.baseHasFileContents && (
-            <li className={classNames('code-view-toolbar__item', props.listItemClass)}>
-                <OpenDiffOnSourcegraph
-                    ariaLabel="View file diff on Sourcegraph"
-                    platformContext={props.platformContext}
+        {isErrorLike(props.fileInfoOrError) ? (
+            failedWithHTTPStatus(props.fileInfoOrError, 401) ? (
+                <SignInButton
+                    sourcegraphURL={props.sourcegraphURL}
+                    onSignInClose={props.onSignInClose}
                     className={props.actionItemClass}
                     iconClassName={props.actionItemIconClass}
-                    openProps={{
-                        sourcegraphURL: props.sourcegraphURL,
-                        repoName: props.baseRepoName || props.repoName,
-                        filePath: props.baseFilePath || props.filePath,
-                        rev: props.baseRev || props.baseCommitID,
-                        query: {
-                            diff: {
-                                rev: props.baseCommitID,
-                            },
-                        },
-                        commit: {
-                            baseRev: props.baseRev || props.baseCommitID,
-                            headRev: props.rev || props.commitID,
-                        },
-                    }}
                 />
-            </li>
-        )}{' '}
-        {// Only show the "View file" button if we were able to fetch the file contents
-        // from the Sourcegraph instance
-        !props.baseCommitID && (props.content !== undefined || props.baseContent !== undefined) && (
-            <li className={classNames('code-view-toolbar__item', props.listItemClass)}>
-                <OpenOnSourcegraph
-                    ariaLabel="View file on Sourcegraph"
-                    className={props.actionItemClass}
-                    iconClassName={props.actionItemIconClass}
-                    openProps={{
-                        sourcegraphURL: props.sourcegraphURL,
-                        repoName: props.repoName,
-                        filePath: props.filePath,
-                        rev: props.rev || props.commitID,
-                    }}
-                />
-            </li>
+            ) : null
+        ) : (
+            <>
+                {props.fileInfoOrError.baseCommitID && props.fileInfoOrError.baseHasFileContents && (
+                    <li className={classNames('code-view-toolbar__item', props.listItemClass)}>
+                        <OpenDiffOnSourcegraph
+                            ariaLabel="View file diff on Sourcegraph"
+                            platformContext={props.platformContext}
+                            className={props.actionItemClass}
+                            iconClassName={props.actionItemIconClass}
+                            openProps={{
+                                sourcegraphURL: props.sourcegraphURL,
+                                repoName: props.fileInfoOrError.baseRepoName || props.fileInfoOrError.repoName,
+                                filePath: props.fileInfoOrError.baseFilePath || props.fileInfoOrError.filePath,
+                                rev: props.fileInfoOrError.baseRev || props.fileInfoOrError.baseCommitID,
+                                query: {
+                                    diff: {
+                                        rev: props.fileInfoOrError.baseCommitID,
+                                    },
+                                },
+                                commit: {
+                                    baseRev: props.fileInfoOrError.baseRev || props.fileInfoOrError.baseCommitID,
+                                    headRev: props.fileInfoOrError.rev || props.fileInfoOrError.commitID,
+                                },
+                            }}
+                        />
+                    </li>
+                )}{' '}
+                {// Only show the "View file" button if we were able to fetch the file contents
+                // from the Sourcegraph instance
+                !props.fileInfoOrError.baseCommitID &&
+                    (props.fileInfoOrError.content !== undefined ||
+                        props.fileInfoOrError.baseContent !== undefined) && (
+                        <li className={classNames('code-view-toolbar__item', props.listItemClass)}>
+                            <OpenOnSourcegraph
+                                ariaLabel="View file on Sourcegraph"
+                                className={props.actionItemClass}
+                                iconClassName={props.actionItemIconClass}
+                                openProps={{
+                                    sourcegraphURL: props.sourcegraphURL,
+                                    repoName: props.fileInfoOrError.repoName,
+                                    filePath: props.fileInfoOrError.filePath,
+                                    rev: props.fileInfoOrError.rev || props.fileInfoOrError.commitID,
+                                }}
+                            />
+                        </li>
+                    )}
+            </>
         )}
     </ul>
 )


### PR DESCRIPTION
The sign in button currently shipped is only shown on the repo-level view on Sourcegraph button, which is not shown on Bitbucket PR views.

This shows them in code views instead, if there is a code view on the page. This connects the call to action closer to the context where the user gets the benefit.

<img width="1680" alt="Screen Shot 2020-03-24 at 17 59 43" src="https://user-images.githubusercontent.com/10532611/77455445-264c2f00-6dfa-11ea-8aa2-7a51e339fbda.png">

<img width="985" alt="Screen Shot 2020-03-24 at 17 58 34" src="https://user-images.githubusercontent.com/10532611/77455453-2a784c80-6dfa-11ea-92fb-bde3f35df307.png">

Closes #9276

cc @christinaforney 