### PR TITLE
get webpack-dev-server to connect https

### DIFF
--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -51,16 +51,16 @@ async function webpack() {
 }
 
 async function webpackDevServer() {
-  const host = readEnvString('SOURCEGRAPH_HTTPS_DOMAIN', 'sourcegraph.test')
-  const port = parseInt(readEnvString('SOURCEGRAPH_HTTPS_PORT', '3443'), 10)
+  const sockHost = readEnvString('SOURCEGRAPH_HTTPS_DOMAIN', 'sourcegraph.test')
+  const sockPort = parseInt(readEnvString('SOURCEGRAPH_HTTPS_PORT', '3443'), 10)
 
   /** @type {import('webpack-dev-server').Configuration & { liveReload?: boolean }} */
   const options = {
     hot: !process.env.NO_HOT,
     inline: !process.env.NO_HOT,
     allowedHosts: ['.host.docker.internal'],
-    host,
-    port,
+    host: 'localhost',
+    port: 3080,
     publicPath: '/.assets/',
     contentBase: './ui/assets',
     stats: WEBPACK_STATS_OPTIONS,
@@ -75,11 +75,13 @@ async function webpackDevServer() {
           socket.on('error', err => console.error('WebSocket proxy error:', err)),
       },
     },
+    sockHost,
+    sockPort,
   }
   WebpackDevServer.addDevServerEntrypoints(webpackConfig, options)
   const server = new WebpackDevServer(createWebpackCompiler(webpackConfig), options)
   await new Promise((resolve, reject) => {
-    server.listen(port, '0.0.0.0', err => (err ? reject(err) : resolve()))
+    server.listen(3080, '0.0.0.0', err => (err ? reject(err) : resolve()))
   })
 }
 

--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -7,6 +7,22 @@ const WebpackDevServer = require('webpack-dev-server')
 const { graphQLTypes, schema, watchGraphQLTypes, watchSchema } = require('../shared/gulpfile')
 const webpackConfig = require('./webpack.config')
 
+/**
+ * Looks up an environment variable. Throws when not set and no default is
+ * provided.
+ */
+function readEnvString(variable, defaultValue) {
+  const value = process.env[variable]
+
+  if (!value) {
+    if (defaultValue === undefined) {
+      throw new Error(`Environment variable ${variable} must be set.`)
+    }
+    return defaultValue
+  }
+  return value
+}
+
 const WEBPACK_STATS_OPTIONS = {
   all: false,
   timings: true,
@@ -35,13 +51,16 @@ async function webpack() {
 }
 
 async function webpackDevServer() {
+  const host = readEnvString('SOURCEGRAPH_HTTPS_DOMAIN', 'sourcegraph.test')
+  const port = parseInt(readEnvString('SOURCEGRAPH_HTTPS_PORT', '3443'), 10)
+
   /** @type {import('webpack-dev-server').Configuration & { liveReload?: boolean }} */
   const options = {
     hot: !process.env.NO_HOT,
     inline: !process.env.NO_HOT,
     allowedHosts: ['.host.docker.internal'],
-    host: 'localhost',
-    port: 3080,
+    host,
+    port,
     publicPath: '/.assets/',
     contentBase: './ui/assets',
     stats: WEBPACK_STATS_OPTIONS,
@@ -60,7 +79,7 @@ async function webpackDevServer() {
   WebpackDevServer.addDevServerEntrypoints(webpackConfig, options)
   const server = new WebpackDevServer(createWebpackCompiler(webpackConfig), options)
   await new Promise((resolve, reject) => {
-    server.listen(3080, '0.0.0.0', err => (err ? reject(err) : resolve()))
+    server.listen(port, '0.0.0.0', err => (err ? reject(err) : resolve()))
   })
 }
 


### PR DESCRIPTION
Responding to https://sourcegraph.slack.com/archives/C0EPTDE9L/p1585075209070000?thread_ts=1585071027.067800&cid=C0EPTDE9L

---

I'm really not sure what I'm looking for where, but this PR what I tried. 

Right now, I get this error message when I try run ./enterprise/dev/start.sh

```
 [12:32:54] Error: listen EADDRINUSE: address already in use 0.0.0.0:3443
12:32:54                 web |     at Server.setupListenHandle [as _listen2] (net.js:1313:16)
12:32:54                 web |     at listenInCluster (net.js:1361:12)
12:32:54                 web |     at doListen (net.js:1498:7)
12:32:54                 web |     at processTicksAndRejections (internal/process/task_queues.js:85:21)
12:32:54                 web | [12:32:54] 'watch' errored after 1.88 s
12:32:54                 web | [12:32:54] The following tasks did not complete: watchSchema, watchGraphQLTypes
12:32:54                 web | [12:32:54] Did you forget to signal async completion?
12:32:54                 web | Terminating web
```

---

Another thing to keep in mind is that we may need to tell configure Node to recognize Caddy's custom SSL certificates: https://stackoverflow.com/questions/29283040/how-to-add-custom-certificate-authority-ca-to-nodejs

