### PR TITLE
Fix: escape when input to FilterInput is one double quote

### DIFF
--- a/web/src/search/input/helpers.test.ts
+++ b/web/src/search/input/helpers.test.ts
@@ -1,4 +1,4 @@
-import { convertPlainTextToInteractiveQuery } from './helpers'
+import { convertPlainTextToInteractiveQuery, escapeDoubleQuote } from './helpers'
 
 describe('Search input helpers', () => {
     describe('convertPlainTextToInteractiveQuery', () => {
@@ -10,36 +10,36 @@ describe('Search input helpers', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes')
             expect(
                 newQuery.navbarQuery === 'foo' &&
-                    newQuery.filtersInQuery ===
-                        {
-                            case: {
-                                type: 'case' as const,
-                                value: 'yes',
-                                editable: false,
-                                negated: false,
-                            },
-                        }
+                newQuery.filtersInQuery ===
+                {
+                    case: {
+                        type: 'case' as const,
+                        value: 'yes',
+                        editable: false,
+                        negated: false,
+                    },
+                }
             )
         })
         test('converts query with multiple filters', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes archived:no')
             expect(
                 newQuery.navbarQuery === 'foo' &&
-                    newQuery.filtersInQuery ===
-                        {
-                            case: {
-                                type: 'case' as const,
-                                value: 'yes',
-                                editable: false,
-                                negated: false,
-                            },
-                            archived: {
-                                type: 'archived' as const,
-                                value: 'no',
-                                editable: false,
-                                negated: false,
-                            },
-                        }
+                newQuery.filtersInQuery ===
+                {
+                    case: {
+                        type: 'case' as const,
+                        value: 'yes',
+                        editable: false,
+                        negated: false,
+                    },
+                    archived: {
+                        type: 'archived' as const,
+                        value: 'no',
+                        editable: false,
+                        negated: false,
+                    },
+                }
             )
         })
 
@@ -47,22 +47,38 @@ describe('Search input helpers', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes archived:no asdf:no')
             expect(
                 newQuery.navbarQuery === 'foo asdf:no' &&
-                    newQuery.filtersInQuery ===
-                        {
-                            case: {
-                                type: 'case' as const,
-                                value: 'yes',
-                                editable: false,
-                                negated: false,
-                            },
-                            archived: {
-                                type: 'archived' as const,
-                                value: 'no',
-                                editable: false,
-                                negated: false,
-                            },
-                        }
+                newQuery.filtersInQuery ===
+                {
+                    case: {
+                        type: 'case' as const,
+                        value: 'yes',
+                        editable: false,
+                        negated: false,
+                    },
+                    archived: {
+                        type: 'archived' as const,
+                        value: 'no',
+                        editable: false,
+                        negated: false,
+                    },
+                }
             )
+        })
+    })
+
+    describe('escapeDoubleQuote', () => {
+        test('Correctly converts input when it is one double quote', () => {
+            const newQuery = escapeDoubleQuote('"')
+            expect(newQuery === '"\\""')
+        })
+        test('Does not convert input when it is actually a quoted input', () => {
+            const newQuery = escapeDoubleQuote('"test query"')
+            expect(newQuery === '"test query"')
+        })
+
+        test('Does not convert input when it is two double quotes', () => {
+            const newQuery = escapeDoubleQuote('""')
+            expect(newQuery === '"test query"')
         })
     })
 })

--- a/web/src/search/input/helpers.test.ts
+++ b/web/src/search/input/helpers.test.ts
@@ -10,36 +10,36 @@ describe('Search input helpers', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes')
             expect(
                 newQuery.navbarQuery === 'foo' &&
-                newQuery.filtersInQuery ===
-                {
-                    case: {
-                        type: 'case' as const,
-                        value: 'yes',
-                        editable: false,
-                        negated: false,
-                    },
-                }
+                    newQuery.filtersInQuery ===
+                        {
+                            case: {
+                                type: 'case' as const,
+                                value: 'yes',
+                                editable: false,
+                                negated: false,
+                            },
+                        }
             )
         })
         test('converts query with multiple filters', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes archived:no')
             expect(
                 newQuery.navbarQuery === 'foo' &&
-                newQuery.filtersInQuery ===
-                {
-                    case: {
-                        type: 'case' as const,
-                        value: 'yes',
-                        editable: false,
-                        negated: false,
-                    },
-                    archived: {
-                        type: 'archived' as const,
-                        value: 'no',
-                        editable: false,
-                        negated: false,
-                    },
-                }
+                    newQuery.filtersInQuery ===
+                        {
+                            case: {
+                                type: 'case' as const,
+                                value: 'yes',
+                                editable: false,
+                                negated: false,
+                            },
+                            archived: {
+                                type: 'archived' as const,
+                                value: 'no',
+                                editable: false,
+                                negated: false,
+                            },
+                        }
             )
         })
 
@@ -47,21 +47,21 @@ describe('Search input helpers', () => {
             const newQuery = convertPlainTextToInteractiveQuery('foo case:yes archived:no asdf:no')
             expect(
                 newQuery.navbarQuery === 'foo asdf:no' &&
-                newQuery.filtersInQuery ===
-                {
-                    case: {
-                        type: 'case' as const,
-                        value: 'yes',
-                        editable: false,
-                        negated: false,
-                    },
-                    archived: {
-                        type: 'archived' as const,
-                        value: 'no',
-                        editable: false,
-                        negated: false,
-                    },
-                }
+                    newQuery.filtersInQuery ===
+                        {
+                            case: {
+                                type: 'case' as const,
+                                value: 'yes',
+                                editable: false,
+                                negated: false,
+                            },
+                            archived: {
+                                type: 'archived' as const,
+                                value: 'no',
+                                editable: false,
+                                negated: false,
+                            },
+                        }
             )
         })
     })

--- a/web/src/search/input/helpers.ts
+++ b/web/src/search/input/helpers.ts
@@ -53,3 +53,11 @@ export function convertPlainTextToInteractiveQuery(
 
     return { filtersInQuery: newFiltersInQuery, navbarQuery: newNavbarQuery }
 }
+
+// Checks whether an input string is ONLY one double quote. If so, quote and escape it.
+export function escapeDoubleQuote(input: string): string {
+    if (input !== '"') {
+        return input
+    }
+    return JSON.stringify(input)
+}

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -37,6 +37,7 @@ import { CheckButton } from './CheckButton'
 import { isTextFilter, finiteFilters, isFiniteFilter, FilterTypeToProseNames } from './filters'
 import classNames from 'classnames'
 import { generateFiltersQuery } from '../../../../../shared/src/util/url'
+import { escapeDoubleQuote } from '../helpers'
 
 interface Props {
     /**
@@ -282,6 +283,8 @@ export class FilterInput extends React.Component<Props, State> {
                 // The content and message filters should always be quoted.
                 inputValue = isQuoted(inputValue) ? inputValue : JSON.stringify(inputValue)
             }
+
+            inputValue = escapeDoubleQuote(inputValue)
 
             // Update the top-level filtersInQueryMap with the new value for this filter.
             this.props.onFilterEdited(this.props.mapKey, inputValue)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8418.

Now we'll just detect if the user has typed in `"` as the input, and escape it if so. I'm not sure this is the correct solution, it seems like the `content` field has trouble with quotes more generally. cc @rvantonder as described in https://github.com/sourcegraph/sourcegraph/issues/8418#issuecomment-603633755

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
