### PR TITLE
conf: start watching config on first conf call

### DIFF
--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -22,11 +22,21 @@ type client struct {
 	watchers    []chan struct{}
 }
 
-var defaultClient *client
+var (
+	defaultClientOnce sync.Once
+	defaultClientVal  *client
+)
+
+func defaultClient() *client {
+	defaultClientOnce.Do(func() {
+		defaultClientVal = initDefaultClient()
+	})
+	return defaultClientVal
+}
 
 // Raw returns a copy of the raw configuration.
 func Raw() conftypes.RawUnified {
-	return defaultClient.Raw()
+	return defaultClient().Raw()
 }
 
 // Get returns a copy of the configuration. The returned value should NEVER be
@@ -45,7 +55,7 @@ func Raw() conftypes.RawUnified {
 //
 // Get is a wrapper around client.Get.
 func Get() *Unified {
-	return defaultClient.Get()
+	return defaultClient().Get()
 }
 
 // Raw returns a copy of the raw configuration.
@@ -74,7 +84,7 @@ func (c *client) Get() *Unified {
 //
 // Mock is a wrapper around client.Mock.
 func Mock(mockery *Unified) {
-	defaultClient.Mock(mockery)
+	defaultClient().Mock(mockery)
 }
 
 // Mock sets up mock data for the site configuration.
@@ -92,7 +102,7 @@ func (c *client) Mock(mockery *Unified) {
 // IMPORTANT: Watch will block on config initialization. It therefore should *never* be called
 // synchronously in `init` functions.
 func Watch(f func()) {
-	defaultClient.Watch(f)
+	defaultClient().Watch(f)
 }
 
 // Cached will return a wrapper around f which caches the response. The value
@@ -100,7 +110,7 @@ func Watch(f func()) {
 //
 // IMPORTANT: The first call to wrapped will block on config initialization.
 func Cached(f func() interface{}) (wrapped func() interface{}) {
-	return defaultClient.Cached(f)
+	return defaultClient().Cached(f)
 }
 
 // Watch calls the given function in a separate goroutine whenever the

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -68,9 +68,9 @@ var (
 	configurationServerFrontendOnlyInitialized = make(chan struct{})
 )
 
-func init() {
+func initDefaultClient() *client {
 	clientStore := newStore()
-	defaultClient = &client{store: clientStore}
+	defaultClient := &client{store: clientStore}
 
 	mode := getMode()
 
@@ -88,7 +88,7 @@ func init() {
 		if err != nil {
 			log.Fatalf("received error when setting up the store for the default client during test, err :%s", err)
 		}
-		return
+		return defaultClient
 	}
 
 	// The default client is started in InitConfigurationServerFrontendOnly in
@@ -97,6 +97,8 @@ func init() {
 		go defaultClient.continuouslyUpdate(nil)
 		close(configurationServerFrontendOnlyInitialized)
 	}
+
+	return defaultClient
 }
 
 // cachedConfigurationSource caches reads for a specified duration to reduce
@@ -160,9 +162,9 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	// Install the passthrough configuration source for defaultClient. This is
 	// so that the frontend does not request configuration from itself via HTTP
 	// and instead only relies on the DB.
-	defaultClient.passthrough = source
+	defaultClient().passthrough = source
 
-	go defaultClient.continuouslyUpdate(nil)
+	go defaultClient().continuouslyUpdate(nil)
 	close(configurationServerFrontendOnlyInitialized)
 
 	startSiteConfigEscapeHatchWorker(source)


### PR DESCRIPTION
If you have conf as a transitive dependency we start up a goroutine watching
config. This can lead random utilities we have failing, due to the default
value for sourcegraph internal API address. We move to initializing on first
use of conf protected by a sync.Once.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
