### PR TITLE
repos: add `PrivateOnly` field to argument of `Store.ListRepos` method

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -46,6 +46,8 @@ type StoreListReposArgs struct {
 	Limit int64
 	// PerPage determines the number of repos returned on each page. Zero means it defaults to 10000.
 	PerPage int64
+	// Only include private repositories.
+	PrivateOnly bool
 
 	// UseOr decides between ANDing or ORing the predicates together.
 	UseOr bool
@@ -372,6 +374,10 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 			er = append(er, sqlf.Sprintf("(external_id = %s AND external_service_type = %s AND external_service_id = %s)", spec.ID, spec.ServiceType, spec.ServiceID))
 		}
 		preds = append(preds, sqlf.Sprintf("(%s)", sqlf.Join(er, "\n OR ")))
+	}
+
+	if args.PrivateOnly {
+		preds = append(preds, sqlf.Sprintf("private = TRUE"))
 	}
 
 	if len(preds) == 0 {

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -779,7 +779,8 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	}
 
 	gitlab := repos.Repo{
-		Name: "gitlab.com/bar/foo",
+		Name:    "gitlab.com/bar/foo",
+		Private: true,
 		Sources: map[string]*repos.SourceInfo{
 			"extsvc:123": {
 				ID:       "extsvc:123",
@@ -961,6 +962,17 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 			}
 		},
 		repos: repos.Assert.ReposEqual(&github, &gitlab),
+	})
+
+	testCases = append(testCases, testCase{
+		name: "only include private",
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				PrivateOnly: true,
+			}
+		},
+		stored: repositories,
+		repos:  repos.Assert.ReposEqual(&gitlab),
 	})
 
 	testCases = append(testCases, testCase{

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -245,6 +245,10 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 			continue
 		}
 
+		if args.PrivateOnly && r.Private {
+			continue
+		}
+
 		var preds []bool
 		if len(kinds) > 0 {
 			preds = append(preds, kinds[strings.ToLower(r.ExternalRepo.ServiceType)])

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -245,10 +245,6 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 			continue
 		}
 
-		if args.PrivateOnly && r.Private {
-			continue
-		}
-
 		var preds []bool
 		if len(kinds) > 0 {
 			preds = append(preds, kinds[strings.ToLower(r.ExternalRepo.ServiceType)])
@@ -261,6 +257,9 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		}
 		if len(externalRepos) > 0 {
 			preds = append(preds, externalRepos[r.ExternalRepo])
+		}
+		if args.PrivateOnly {
+			preds = append(preds, r.Private)
 		}
 
 		if (args.UseOr && evalOr(preds...)) || (!args.UseOr && evalAnd(preds...)) {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -218,6 +218,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32) (err erro
 		rs, err = s.reposStore.ListRepos(ctx, repos.StoreListReposArgs{
 			ExternalRepos: repoSpecs,
 			PerPage:       int64(len(repoSpecs)), // We want to get all repositories in one shot
+			PrivateOnly:   true,
 		})
 		if err != nil {
 			return errors.Wrap(err, "list external repositories")

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -154,7 +155,10 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}()
 
 	reposStore := &mockReposStore{
-		listRepos: func(context.Context, repos.StoreListReposArgs) ([]*repos.Repo, error) {
+		listRepos: func(_ context.Context, args repos.StoreListReposArgs) ([]*repos.Repo, error) {
+			if !args.PrivateOnly {
+				return nil, errors.New("PrivateOnly want true but got false")
+			}
 			return []*repos.Repo{{ID: 1}}, nil
 		},
 	}


### PR DESCRIPTION
This PR adds a new argument field to `repos.Store.ListRepos` method to only include private repositories that is currently used by `PermsSyncer`.

Part of #9154