### PR TITLE
Fix sourcegraph.configuration

### DIFF
--- a/shared/src/api/extension/api/configuration.test.ts
+++ b/shared/src/api/extension/api/configuration.test.ts
@@ -1,0 +1,45 @@
+import * as sinon from 'sinon'
+import { ExtConfiguration } from './configuration'
+
+describe('ExtConfiguration', () => {
+    const PROXY: any = {}
+    describe('get()', () => {
+        test("throws if initial settings haven't been received", () => {
+            const configuration = new ExtConfiguration(PROXY)
+            expect(() => configuration.get()).toThrow('unexpected internal error: settings data is not yet available')
+        })
+        test('returns the latest settings', () => {
+            const configuration = new ExtConfiguration<{ a: string }>(PROXY)
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'b' } })
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'c' } })
+            expect(configuration.get().get('a')).toBe('c')
+        })
+    })
+    describe('subscribe()', () => {
+        test('emits as soon as initial settings are received', () => {
+            const configuration = new ExtConfiguration(PROXY)
+            const subscriber = sinon.spy()
+            configuration.subscribe(subscriber)
+            sinon.assert.notCalled(subscriber)
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'b' } })
+            sinon.assert.calledOnce(subscriber)
+        })
+        test('emits immediately on subscription if initial settings have already been received', () => {
+            const configuration = new ExtConfiguration(PROXY)
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'b' } })
+            const subscriber = sinon.spy()
+            configuration.subscribe(subscriber)
+            sinon.assert.calledOnce(subscriber)
+        })
+
+        test('emits when settings are updated', () => {
+            const configuration = new ExtConfiguration(PROXY)
+            const subscriber = sinon.spy()
+            configuration.subscribe(subscriber)
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'b' } })
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'c' } })
+            configuration.$acceptConfigurationData({ subjects: [], final: { a: 'd' } })
+            sinon.assert.calledThrice(subscriber)
+        })
+    })
+})

--- a/shared/src/api/extension/api/configuration.ts
+++ b/shared/src/api/extension/api/configuration.ts
@@ -1,5 +1,5 @@
 import { ProxyResult, ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
-import { ReplaySubject, BehaviorSubject, Subscribable } from 'rxjs'
+import { ReplaySubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { SettingsCascade } from '../../../settings/settings'
 import { ClientConfigurationAPI } from '../../client/api/configuration'

--- a/shared/src/api/extension/api/configuration.ts
+++ b/shared/src/api/extension/api/configuration.ts
@@ -1,5 +1,5 @@
 import { ProxyResult, ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
-import { BehaviorSubject, PartialObserver, Unsubscribable } from 'rxjs'
+import { BehaviorSubject, PartialObserver, Unsubscribable, ReplaySubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { SettingsCascade } from '../../../settings/settings'
 import { ClientConfigurationAPI } from '../../client/api/configuration'
@@ -39,58 +39,38 @@ export interface ExtConfigurationAPI<C> extends ProxyValue {
     $acceptConfigurationData(data: Readonly<SettingsCascade<C>>): void
 }
 
+const BUFFER_SIZE = 1
+
 /**
  * @internal
  * @template C - The configuration schema.
  */
-export class ExtConfiguration<C extends object> implements ExtConfigurationAPI<C>, ProxyValue {
+export class ExtConfiguration<C extends object> extends ReplaySubject<void>
+    implements ExtConfigurationAPI<C>, ProxyValue {
     public readonly [proxyValueSymbol] = true
 
     /**
      * The settings data observable, assigned when the initial data is received from the client. Extensions should
      * never be able to call {@link ExtConfiguration}'s methods before the initial data is received.
      */
-    private data?: BehaviorSubject<Readonly<SettingsCascade<C>>>
+    private data?: Readonly<SettingsCascade<C>>
 
-    constructor(private proxy: ProxyResult<ClientConfigurationAPI>) {}
-
-    public $acceptConfigurationData(data: Readonly<SettingsCascade<C>>): void {
-        if (!this.data) {
-            this.data = new BehaviorSubject(data)
-        } else {
-            this.data.next(Object.freeze(data))
-        }
+    constructor(private proxy: ProxyResult<ClientConfigurationAPI>) {
+        // Call super() with a buffer size of 1, so that sourcegraph.configuration
+        // doesn't emit until initial settings have been received, but emits immediately
+        // for all subsequent subscribers as soon as initial settings have been received.
+        super(BUFFER_SIZE)
     }
 
-    private getData(): BehaviorSubject<Readonly<SettingsCascade<C>>> {
-        if (!this.data) {
-            throw new Error('unexpected internal error: settings data is not yet available')
-        }
-        return this.data
+    public $acceptConfigurationData(data: Readonly<SettingsCascade<C>>): void {
+        this.data = Object.freeze(data)
+        this.next()
     }
 
     public get(): sourcegraph.Configuration<C> {
-        return Object.freeze(new ExtConfigurationSection<C>(this.proxy, this.getData().value.final))
-    }
-
-    public subscribe(observer?: PartialObserver<void>): Unsubscribable
-    /** @deprecated Use an observer instead of a complete callback */
-    public subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable
-    /** @deprecated Use an observer instead of an error callback */
-    public subscribe(
-        next: null | undefined,
-        error: (error: any) => void,
-        complete?: (() => void) | null
-    ): Unsubscribable
-    /** @deprecated Use an observer instead of a complete callback */
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
-    public subscribe(next: (value: void) => void, error: null | undefined, complete: () => void): Unsubscribable
-    public subscribe(
-        next?: ((value: void) => void) | null,
-        error?: ((error: any) => void) | null,
-        complete?: (() => void) | null
-    ): Unsubscribable
-    public subscribe(...args: any[]): sourcegraph.Unsubscribable {
-        return this.getData().subscribe(...args)
+        if (!this.data) {
+            throw new Error('unexpected internal error: settings data is not yet available')
+        }
+        return Object.freeze(new ExtConfigurationSection<C>(this.proxy, this.data.final))
     }
 }

--- a/shared/src/api/extension/api/configuration.ts
+++ b/shared/src/api/extension/api/configuration.ts
@@ -56,9 +56,9 @@ export class ExtConfiguration<C extends object> extends ReplaySubject<void>
     private data?: Readonly<SettingsCascade<C>>
 
     constructor(private proxy: ProxyResult<ClientConfigurationAPI>) {
-        // Call super() with a buffer size of 1, so that sourcegraph.configuration
-        // doesn't emit until initial settings have been received, but emits immediately
-        // for all subsequent subscribers as soon as initial settings have been received.
+        // Call super() with a buffer size of 1, so that sourcegraph.configuration:
+        // - doesn't emit until initial settings have been received.
+        // - emits immediately on subscription after initial settings have been received.
         super(BUFFER_SIZE)
     }
 

--- a/shared/src/api/extension/api/configuration.ts
+++ b/shared/src/api/extension/api/configuration.ts
@@ -1,5 +1,5 @@
 import { ProxyResult, ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
-import { BehaviorSubject, PartialObserver, Unsubscribable, ReplaySubject } from 'rxjs'
+import { ReplaySubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { SettingsCascade } from '../../../settings/settings'
 import { ClientConfigurationAPI } from '../../client/api/configuration'

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -195,10 +195,7 @@ function createExtensionAPI(
             rootChanges: roots.changes,
         },
 
-        configuration: {
-            get: () => configuration.get(),
-            subscribe: configuration.subscribe.bind(configuration),
-        },
+        configuration,
 
         languages: {
             registerHoverProvider: (selector: sourcegraph.DocumentSelector, provider: sourcegraph.HoverProvider) =>

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -199,7 +199,7 @@ function createExtensionAPI(
         },
 
         configuration: Object.assign(
-            new Observable<void>(observer => configuration.changes.subscribe(observer)),
+            configuration.changes.asObservable(),
             {
                 get: () => configuration.get(),
             }

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,6 +1,6 @@
 import * as comlink from '@sourcegraph/comlink'
 import { Location, MarkupKind, Position, Range, Selection } from '@sourcegraph/extension-api-classes'
-import { Subscription, Unsubscribable, Observable } from 'rxjs'
+import { Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair } from '../../platform/context'
 import { ClientAPI } from '../client/api/api'
@@ -198,12 +198,9 @@ function createExtensionAPI(
             rootChanges: roots.changes,
         },
 
-        configuration: Object.assign(
-            configuration.changes.asObservable(),
-            {
-                get: () => configuration.get(),
-            }
-        ),
+        configuration: Object.assign(configuration.changes.asObservable(), {
+            get: () => configuration.get(),
+        }),
 
         languages: {
             registerHoverProvider: (selector: sourcegraph.DocumentSelector, provider: sourcegraph.HoverProvider) =>


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/7235 did not actually allow using `from(sourcegraph.configuration)` in extensions: since `{ subscribe: configuration.subscribe.bind(configuration) }` does not expose `Symbol_observable`, subscription fails with `TypeError: You provided an invalid object where a stream was expected`.

This is my best shot at fixing this, by implementing `ExtConfiguration` as a subclass of `ReplaySubject`. It removes a fair bit of internal boilerplate, and actually fixes an existing race condition: subscribing to `soucegraph.configuration` before initial settings were received would throw -- even though this is precisely what exposing a Subscribable is designed to avoid! I added tests to verify this.

