### PR TITLE
authz: make `PermsSyncer` use default page size to list repos

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -217,7 +217,6 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32) (err erro
 		// Get corresponding internal database IDs
 		rs, err = s.reposStore.ListRepos(ctx, repos.StoreListReposArgs{
 			ExternalRepos: repoSpecs,
-			PerPage:       int64(len(repoSpecs)), // We want to get all repositories in one shot
 			PrivateOnly:   true,
 		})
 		if err != nil {


### PR DESCRIPTION
As I found out the `ListRepos` method always return all repos, the page size is only used to determine the batch size of a query, and default 10000 is pretty good.