### PR TITLE
Make body position: relative

### DIFF
--- a/browser/src/app.scss
+++ b/browser/src/app.scss
@@ -33,6 +33,11 @@ $theme-colors-light: (
     background-color: rgba(255, 192, 120, 0.5);
 }
 
+body {
+    // Needed to position the HoverOverlay
+    position: relative;
+}
+
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';


### PR DESCRIPTION
Fixes #9308

Octotree works by adding `margin-left` to the `<html>` element. We position the  tooltip relative to the `<body>` (`relativeElement: document.body`). However, `body` is not actually `position: relative`. This still works because `<body>` is usually not different from the viewport. But when Octotree adds the `margin-left`, `<body>` gets moved too. The only thing we have to do to fix it it seems is to set `body { position: relative; }` in our CSS.

That still won't react to the sidebar sliding in of course, that is not really detectable since it's a CSS animation, except with MutationObserver on _all_ `style` changes and a significant delay to allow for animations. But I think that's okay, positioning will be correct on the next hover.

Closes #9309

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
