### PR TITLE
e2e: add reasonable timeout for each build step

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -17,6 +17,7 @@ steps:
   - docker push "$IMAGE"
   env:
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+  timeout_in_minutes: 10
   label: ':docker:'
 
 - wait
@@ -27,10 +28,12 @@ steps:
     - ./dev/ci/e2e.sh
   concurrency: 1
   concurrency_group: e2e
+  timeout_in_minutes: 10
   label: ':chromium:'
 
 - wait
 
 - command: docker image rm -f "$IMAGE"
+  timeout_in_minutes: 10
   label: ':sparkles:'
   soft_fail: true


### PR DESCRIPTION
Does not fix the underlying problem with https://sourcegraph.slack.com/archives/C07KZF47K/p1585151621006300. However, no individual build step should take longer than 10 minutes (if so, most likely explanation is that something stalled or died).