### PR TITLE
lsif-server: correct file permissions when deployed in Docker Compose or pure-docker deployments

### DIFF
--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -41,6 +41,14 @@ COPY ./lsif-server /usr/local/bin/lsif-server
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
+# Ensures that a directory with the correct permissions exist in the image.
+# Without this, in Docker Compose deployments the Docker daemon would first
+# create the volume directory and it would be owned by `root` and then
+# lsif-server would be unable to create the `/lsif-storage` because it would
+# be trying to do so in a directory owned by `root` as the user `sourcegraph`.
+# (And no, this is not dumb, this is just Docker. See https://github.com/docker/compose/issues/3270#issuecomment-363478501)
+RUN mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage
+
 # http server, dump manager server, (first) worker metrics server, prometheus
 EXPOSE 3186 3187 3188 9090
 ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug


### PR DESCRIPTION
This fixes lsif-server in Docker Compose and pure-docker deployments. There is zero change
in functionality for Kubernetes or any other deployment types.

See the inline comment for an explanation of why this is needed. Unfortunately, we
do not have testing in place for this today (I hope to get some in the future) so
for now I just ask we all be mindful of ensuring a `mkdir && chown` command exists
in the Dockerfile for any volume-mounted directories a service will try to use.

We will do more extensive testing of Docker Compose at release time in the future,
in order to catch issues like this, as well.

I have already published this change as:

```
index.docker.io/sourcegraph/lsif-server:3.14.0-1@sha256:ed683d2579d807458a892eab2f88fa5618b82a1ae7af02d5e7de1af3f6eea4a7
```

By modifying the base image by hand:

```
docker run --name=base -d sourcegraph/lsif-server:3.14.0
docker exec -u 0 -it base sh -c 'mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage'
docker commit base sourcegraph/lsif-server:3.14.0-1
docker rm -f base
```

So that I can release v3.14.0-1 of docker-compose for a customer who is facing this.