### PR TITLE
lsif-server: create /lsif-storage as privileged user

### DIFF
--- a/cmd/lsif-server/Dockerfile
+++ b/cmd/lsif-server/Dockerfile
@@ -34,12 +34,6 @@ RUN apk update && apk add --no-cache \
 USER root
 RUN mkdir -p $PROMETHEUS_STORAGE_DIR && chown -R sourcegraph:sourcegraph $PROMETHEUS_STORAGE_DIR
 RUN mkdir -p $PROMETHEUS_CONFIGURATION_DIR && chown -R sourcegraph:sourcegraph $PROMETHEUS_CONFIGURATION_DIR
-USER sourcegraph
-
-COPY --from=lsif-builder /lsif /lsif
-COPY ./lsif-server /usr/local/bin/lsif-server
-COPY --from=prometheus /bin/prometheus /bin/prometheus
-COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
 # Ensures that a directory with the correct permissions exist in the image.
 # Without this, in Docker Compose deployments the Docker daemon would first
@@ -48,6 +42,12 @@ COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 # be trying to do so in a directory owned by `root` as the user `sourcegraph`.
 # (And no, this is not dumb, this is just Docker. See https://github.com/docker/compose/issues/3270#issuecomment-363478501)
 RUN mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage
+USER sourcegraph
+
+COPY --from=lsif-builder /lsif /lsif
+COPY ./lsif-server /usr/local/bin/lsif-server
+COPY --from=prometheus /bin/prometheus /bin/prometheus
+COPY ./prometheus.yml $PROMETHEUS_CONFIGURATION_DIR/prometheus.yml
 
 # http server, dump manager server, (first) worker metrics server, prometheus
 EXPOSE 3186 3187 3188 9090


### PR DESCRIPTION
Currently CI is failing with this error:

```
_bk;t=1585165949499#24       digest: sha256:6e00cdda7d458254ba56e7c6ac5f53954ec7020f2deac521ccd49cdc05fe1b80

_bk;t=1585165949499#24         name: "[stage-2 9/9] RUN mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage"

_bk;t=1585165949499#24      started: 2020-03-25 19:52:29.498160232 +0000 UTC

_bk;t=1585165949499#24 0.889 mkdir: can't create directory '/lsif-storage': Permission denied

_bk;t=1585165950426#24    completed: 2020-03-25 19:52:30.507564455 +0000 UTC

_bk;t=1585165950508#24     duration: 1.009404223s

_bk;t=1585165950508#24        error: "executor failed running [/bin/sh -c mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage]: exit code: 1"

_bk;t=1585165950508

_bk;t=1585165950508executor failed running [/bin/sh -c mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage]: exit code: 1
```
