### PR TITLE
LSIF: Adjust positions on location connection resolver

### DIFF
--- a/enterprise/internal/codeintel/resolvers/location.go
+++ b/enterprise/internal/codeintel/resolvers/location.go
@@ -3,14 +3,23 @@ package resolvers
 import (
 	"context"
 
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lsif"
 )
 
+type locationWithSourceCommit struct {
+	*lsif.LSIFLocation
+	uploadCommit string
+}
+
 type locationConnectionResolver struct {
-	locations []*lsif.LSIFLocation
+	repo      *types.Repo
+	commit    graphqlbackend.GitObjectID
+	locations []locationWithSourceCommit
 	endCursor string
 }
 
@@ -23,7 +32,12 @@ func (r *locationConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacken
 
 	var l []graphqlbackend.LocationResolver
 	for _, location := range r.locations {
-		treeResolver, err := collectionResolver.resolve(ctx, location.RepositoryID, location.Commit, location.Path)
+		adjustedCommit, adjustedRange, err := r.adjustLocation(ctx, location)
+		if err != nil {
+			return nil, err
+		}
+
+		treeResolver, err := collectionResolver.resolve(ctx, location.RepositoryID, adjustedCommit, location.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -32,10 +46,7 @@ func (r *locationConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacken
 			continue
 		}
 
-		l = append(l, graphqlbackend.NewLocationResolver(
-			treeResolver,
-			&location.Range,
-		))
+		l = append(l, graphqlbackend.NewLocationResolver(treeResolver, &adjustedRange))
 	}
 
 	return l, nil
@@ -46,4 +57,26 @@ func (r *locationConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil
 		return graphqlutil.NextPageCursor(r.endCursor), nil
 	}
 	return graphqlutil.HasNextPage(false), nil
+}
+
+// locationConnectionResolver transforms the given position in the location's commit into
+// a position in the commit the user original requested. This method will return the given
+// position untouched if the location is not in the repo where the request originated.
+func (r *locationConnectionResolver) adjustLocation(ctx context.Context, location locationWithSourceCommit) (string, lsp.Range, error) {
+	if location.RepositoryID != r.repo.ID {
+		return location.Commit, location.Range, nil
+	}
+
+	adjuster, err := newPositionAdjuster(ctx, r.repo, location.Commit, string(r.commit), location.Path)
+	if err != nil {
+		return "", lsp.Range{}, err
+	}
+
+	if adjustedRange, ok := adjuster.adjustRange(location.Range); ok {
+		return string(r.commit), adjustedRange, nil
+	}
+
+	// Couldn't adjust range, return original result which is precise but
+	// jump the user to another into another commit context on navigation.
+	return location.Commit, location.Range, nil
 }

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -56,15 +56,10 @@ func (r *lsifQueryResolver) Definitions(ctx context.Context, args *graphqlbacken
 		}
 
 		if len(locations) > 0 {
-			locationsWithSourceCommit := make([]locationWithSourceCommit, len(locations))
-			for i, location := range locations {
-				locationsWithSourceCommit[i] = locationWithSourceCommit{location, upload.Commit}
-			}
-
 			return &locationConnectionResolver{
 				repo:      r.repositoryResolver.Type(),
 				commit:    r.commit,
-				locations: locationsWithSourceCommit,
+				locations: locations,
 			}, nil
 		}
 	}
@@ -87,7 +82,7 @@ func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend
 	// this request.
 	newCursors := map[int64]string{}
 
-	var allLocations []locationWithSourceCommit
+	var allLocations []*lsif.LSIFLocation
 	for _, upload := range r.uploads {
 		adjustedPosition, ok, err := r.adjustPosition(ctx, upload.Commit, args.Line, args.Character)
 		if err != nil {
@@ -130,10 +125,7 @@ func (r *lsifQueryResolver) References(ctx context.Context, args *graphqlbackend
 		if err != nil {
 			return nil, err
 		}
-
-		for _, location := range locations {
-			allLocations = append(allLocations, locationWithSourceCommit{location, upload.Commit})
-		}
+		allLocations = append(allLocations, locations...)
 
 		if nextURL != "" {
 			newCursors[upload.ID] = nextURL


### PR DESCRIPTION
Current behavior:

- hover over a definition in commit `c`
- get a definition result from LSIF index at nearest commit `c-n`
- click on it, takes you to commit `c-n`

New behavior:

- hover over a definition in commit `c`
- get a definition result from LSIF index at nearest commit `c-n`
- attempt to map the position in commit `c-n` to the equivalent position in commit `c`
- click on it, keeps you in same commit

If there are edits or we can't otherwise adjust the position, the current behavior will still occur.