### PR TITLE
schema: show `customGitFetch` config option in doc

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -159,8 +159,19 @@
           ]
         }
       },
-      "group": "Experimental",
-      "hide": true
+      "default": {
+        "customGitFetch": [
+          {
+            "domainPath": "somecodehost.com/path/to/repo",
+            "fetch": "customgitbinary someflag"
+          },
+          {
+            "domainPath": "somecodehost.com/path/to/anotherrepo",
+            "fetch": "customgitbinary someflag anotherflag"
+          }
+        ]
+      },
+      "group": "Experimental"
     },
     "automation.readAccess.enabled": {
       "description": "DEPRECATED: The automation feature was renamed to campaigns. Use `campaigns.readAccess.enabled` instead.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -164,8 +164,19 @@ const SiteSchemaJSON = `{
           ]
         }
       },
-      "group": "Experimental",
-      "hide": true
+      "default": {
+        "customGitFetch": [
+          {
+            "domainPath": "somecodehost.com/path/to/repo",
+            "fetch": "customgitbinary someflag"
+          },
+          {
+            "domainPath": "somecodehost.com/path/to/anotherrepo",
+            "fetch": "customgitbinary someflag anotherflag"
+          }
+        ]
+      },
+      "group": "Experimental"
     },
     "automation.readAccess.enabled": {
       "description": "DEPRECATED: The automation feature was renamed to campaigns. Use ` + "`" + `campaigns.readAccess.enabled` + "`" + ` instead.",


### PR DESCRIPTION
This PR removes hide attribute of `experimentalFeatures` and make the `customGitFetch` show in our docs.

![image](https://user-images.githubusercontent.com/2946214/77623208-a6010780-6f7a-11ea-8f75-e127a85bc616.png)


Fixes #9088