### PR TITLE
campaigns: Add tests for executing ChangesetJobs

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -57,7 +57,8 @@ func enterpriseInit(
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
 
-	go campaigns.RunWorkers(ctx, campaignsStore, clock, gitserver.DefaultClient, 5*time.Second)
+	sourcer := repos.NewSourcer(cf)
+	go campaigns.RunWorkers(ctx, campaignsStore, clock, gitserver.DefaultClient, sourcer, 5*time.Second)
 
 	// Set up syncer
 	go syncer.Run(ctx)

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -297,6 +297,9 @@ func ExecChangesetJob(
 		}
 		events = clone.Events()
 		clone.SetDerivedState(events)
+
+		clone.CampaignIDs = append(clone.CampaignIDs, job.CampaignID)
+
 		if err = store.UpdateChangesets(ctx, clone); err != nil {
 			return err
 		}

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -30,7 +29,7 @@ const defaultWorkerCount = 8
 // RunWorkers should be executed in a background goroutine and is responsible
 // for finding pending ChangesetJobs and executing them.
 // ctx should be canceled to terminate the function.
-func RunWorkers(ctx context.Context, s *Store, clock func() time.Time, gitClient GitserverClient, backoffDuration time.Duration) {
+func RunWorkers(ctx context.Context, s *Store, clock func() time.Time, gitClient GitserverClient, sourcer repos.Sourcer, backoffDuration time.Duration) {
 	workerCount, err := strconv.Atoi(maxWorkers)
 	if err != nil {
 		log15.Error("Parsing max worker count failed. Falling back to default.", "default", defaultWorkerCount, "err", err)
@@ -43,7 +42,8 @@ func RunWorkers(ctx context.Context, s *Store, clock func() time.Time, gitClient
 		if err != nil {
 			return errors.Wrap(err, "getting campaign")
 		}
-		if runErr := ExecChangesetJob(ctx, clock, s, gitClient, nil, c, &job); runErr != nil {
+
+		if runErr := ExecChangesetJob(ctx, clock, s, gitClient, sourcer, c, &job); runErr != nil {
 			log15.Error("ExecChangesetJob", "jobID", job.ID, "err", err)
 		}
 		// We don't assign to err here so that we don't roll back the transaction
@@ -80,7 +80,7 @@ func ExecChangesetJob(
 	clock func() time.Time,
 	store *Store,
 	gitClient GitserverClient,
-	cf *httpcli.Factory,
+	sourcer repos.Sourcer,
 	c *campaigns.Campaign,
 	job *campaigns.ChangesetJob,
 ) (err error) {
@@ -223,10 +223,14 @@ func ExecChangesetJob(
 		return errors.Errorf("no external services found for repo %q", repo.Name)
 	}
 
-	src, err := repos.NewSource(externalService, cf)
+	sources, err := sourcer(externalService)
 	if err != nil {
 		return err
 	}
+	if len(sources) != 1 {
+		return errors.New("invalid number of sources for external service")
+	}
+	src := sources[0]
 
 	baseRef := "refs/heads/master"
 	if patch.BaseRef != "" {

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -57,20 +57,20 @@ func TestExecChangesetJob(t *testing.T) {
 		},
 		{
 			name:              "BitbucketServer_NewChangeset",
-			createRepoExtSvc:  createBBSRepo,
-			changesetMetadata: buildBBSPR,
+			createRepoExtSvc:  createBitbucketServerRepo,
+			changesetMetadata: buildBitbucketServerPR,
 		},
 		{
 			name:              "BitbucketServer_ChangesetExistsOnCodehost",
-			createRepoExtSvc:  createBBSRepo,
-			changesetMetadata: buildBBSPR,
+			createRepoExtSvc:  createBitbucketServerRepo,
+			changesetMetadata: buildBitbucketServerPR,
 			existsOnCodehost:  true,
 		},
 
 		{
 			name:              "BitbucketServer_ChangesetExistsInDB",
-			createRepoExtSvc:  createBBSRepo,
-			changesetMetadata: buildBBSPR,
+			createRepoExtSvc:  createBitbucketServerRepo,
+			changesetMetadata: buildBitbucketServerPR,
 			existsInDB:        true,
 		},
 	}
@@ -267,7 +267,7 @@ func createGitHubRepo(t *testing.T, ctx context.Context, now time.Time, s *Store
 	return repo, ext
 }
 
-func createBBSRepo(t *testing.T, ctx context.Context, now time.Time, s *Store) (*repos.Repo, *repos.ExternalService) {
+func createBitbucketServerRepo(t *testing.T, ctx context.Context, now time.Time, s *Store) (*repos.Repo, *repos.ExternalService) {
 	t.Helper()
 
 	reposStore := repos.NewDBStore(s.DB(), sql.TxOptions{})
@@ -359,7 +359,7 @@ func buildGithubPR(now time.Time, c *cmpgn.Campaign, headRef string) interface{}
 	}
 }
 
-func buildBBSPR(now time.Time, c *cmpgn.Campaign, headRef string) interface{} {
+func buildBitbucketServerPR(now time.Time, c *cmpgn.Campaign, headRef string) interface{} {
 	return &bitbucketserver.PullRequest{
 		ID:          999,
 		Title:       c.Name,

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -49,16 +49,12 @@ func TestExecChangesetJob(t *testing.T) {
 		t.Fatal(t)
 	}
 
-	var rs []*repos.Repo
-	for i := 0; i < 4; i++ {
-		r := testRepo(i, github.ServiceType)
-		r.Sources = map[string]*repos.SourceInfo{githubExtSvc.URN(): {
-			ID:       githubExtSvc.URN(),
-			CloneURL: "https://TOKENTOKENTOKEN@github.com/foobar/foobar",
-		}}
-		rs = append(rs, r)
-	}
-	if err := reposStore.UpsertRepos(ctx, rs...); err != nil {
+	repo := testRepo(0, github.ServiceType)
+	repo.Sources = map[string]*repos.SourceInfo{githubExtSvc.URN(): {
+		ID:       githubExtSvc.URN(),
+		CloneURL: "https://TOKENTOKENTOKEN@github.com/foobar/foobar",
+	}}
+	if err := reposStore.UpsertRepos(ctx, repo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +67,7 @@ func TestExecChangesetJob(t *testing.T) {
 	}
 
 	patch := &cmpgn.Patch{
-		RepoID:     rs[0].ID,
+		RepoID:     repo.ID,
 		PatchSetID: patchSet.ID,
 		Diff:       testDiff,
 		Rev:        "f00b4r",

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -1,0 +1,199 @@
+package campaigns
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestExecChangesetJob(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup global test db in dbconn.Global
+	dbtesting.SetupGlobalTestDB(t)
+	// Wrap test db in transaction that's rolled back at end of test
+	tx := dbtest.NewTx(t, dbconn.Global)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+
+	// Create repositories and external service
+	reposStore := repos.NewDBStore(tx, sql.TxOptions{})
+
+	githubExtSvc := &repos.ExternalService{
+		Kind:        "GITHUB",
+		DisplayName: "GitHub",
+		Config: marshalJSON(t, &schema.GitHubConnection{
+			Url:   "https://github.com",
+			Token: os.Getenv("GITHUB_TOKEN"),
+			Repos: []string{},
+		}),
+	}
+
+	if err := reposStore.UpsertExternalServices(ctx, githubExtSvc); err != nil {
+		t.Fatal(t)
+	}
+
+	var rs []*repos.Repo
+	for i := 0; i < 4; i++ {
+		r := testRepo(i, github.ServiceType)
+		r.Sources = map[string]*repos.SourceInfo{githubExtSvc.URN(): {
+			ID:       githubExtSvc.URN(),
+			CloneURL: "https://TOKENTOKENTOKEN@github.com/foobar/foobar",
+		}}
+		rs = append(rs, r)
+	}
+	if err := reposStore.UpsertRepos(ctx, rs...); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create PatchSet, Patch, Campaign and ChangesetJob
+	s := NewStoreWithClock(tx, clock)
+
+	patchSet := &cmpgn.PatchSet{}
+	if err := s.CreatePatchSet(ctx, patchSet); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := &cmpgn.Patch{
+		RepoID:     rs[0].ID,
+		PatchSetID: patchSet.ID,
+		Diff:       testDiff,
+		Rev:        "f00b4r",
+		BaseRef:    "refs/heads/master",
+	}
+	if err := s.CreatePatch(ctx, patch); err != nil {
+		t.Fatal(err)
+	}
+
+	campaign := &cmpgn.Campaign{
+		Name:            "Remove dead code",
+		Description:     "This campaign removes dead code.",
+		Branch:          "dead-code-b-gone",
+		AuthorID:        888,
+		NamespaceUserID: 888,
+		PatchSetID:      patchSet.ID,
+		ClosedAt:        now,
+	}
+	if err := s.CreateCampaign(ctx, campaign); err != nil {
+		t.Fatal(err)
+	}
+
+	changesetJob := &cmpgn.ChangesetJob{
+		CampaignID: campaign.ID,
+		PatchID:    patch.ID,
+	}
+	if err := s.CreateChangesetJob(ctx, changesetJob); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup the dependencies
+	gitClient := &dummyGitserverClient{response: "refs/heads/campaigns/TEST-REF", responseErr: nil}
+
+	githubActor := github.Actor{
+		AvatarURL: "https://avatars2.githubusercontent.com/u/1185253",
+		Login:     "mrnugget",
+		URL:       "https://github.com/mrnugget",
+	}
+
+	githubPR := &github.PullRequest{
+		ID:           "FOOBARID",
+		Title:        campaign.Name,
+		Body:         campaign.Description,
+		URL:          "https://github.com/sourcegraph/sourcegraph/pull/12345",
+		Number:       12345,
+		State:        "OPEN",
+		Author:       githubActor,
+		Participants: []github.Actor{githubActor},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	fakeSource := fakeChangesetSource{
+		svc:          githubExtSvc,
+		err:          nil,
+		exists:       false,
+		wantHeadRef:  gitClient.response,
+		wantBaseRef:  patch.BaseRef,
+		fakeMetadata: githubPR,
+	}
+
+	sourcer := repos.NewFakeSourcer(nil, fakeSource)
+
+	// Execute the ChangesetJob
+	err := ExecChangesetJob(ctx, clock, s, gitClient, sourcer, campaign, changesetJob)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+const testDiff = `diff --git foobar.c foobar.c
+index d75b080..cf04b5b 100644
+--- foobar.c
++++ foobar.c
+@@ -1 +1 @@
+-onto monto(int argc, char *argv[]) { printf("Nice."); }
++int main(int argc, char *argv[]) { printf("Nice."); }
+`
+
+type fakeChangesetSource struct {
+	svc *repos.ExternalService
+
+	wantHeadRef string
+	wantBaseRef string
+
+	fakeMetadata interface{}
+	exists       bool
+	err          error
+}
+
+func (s fakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
+	if s.err != nil {
+		return s.exists, s.err
+	}
+
+	if c.HeadRef != s.wantHeadRef {
+		return s.exists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.wantHeadRef, c.HeadRef)
+	}
+
+	if c.BaseRef != s.wantBaseRef {
+		return s.exists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
+	}
+
+	c.SetMetadata(s.fakeMetadata)
+
+	return s.exists, s.err
+}
+
+var fakeNotImplemented = errors.New("not implement in fakeChangesetSource")
+
+func (s fakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
+	results <- repos.SourceResult{Source: s, Err: fakeNotImplemented}
+}
+
+func (s fakeChangesetSource) ExternalServices() repos.ExternalServices {
+	return repos.ExternalServices{s.svc}
+}
+func (s fakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Changeset) error {
+	return fakeNotImplemented
+}
+func (s fakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
+	return fakeNotImplemented
+}
+func (s fakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Changeset) error {
+	return fakeNotImplemented
+}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/9103. It doesn't test every branch, but it is enough for now to give us more confidence in that function and to add more tests later.