### PR TITLE
LSIF: Fix bad dump manager interface

### DIFF
--- a/lsif/docs/manager.yaml
+++ b/lsif/docs/manager.yaml
@@ -261,7 +261,7 @@ paths:
           required: true
           schema:
             type: number
-        - name: model
+        - name: modelType
           in: query
           description: The type of query.
           required: true
@@ -324,7 +324,9 @@ paths:
           description: The identifier of the target package information data.
           required: true
           schema:
-            type: number
+            oneOf:
+              - type: number
+              - type: string
       responses:
         '200':
           description: OK

--- a/lsif/src/dump-manager/backend/database.ts
+++ b/lsif/src/dump-manager/backend/database.ts
@@ -250,7 +250,7 @@ export class Database {
      */
     public async packageInformation(
         path: string,
-        packageInformationId: number,
+        packageInformationId: string,
         ctx: TracingContext = {}
     ): Promise<sqliteModels.PackageInformationData | undefined> {
         const document = await this.getDocumentByPath(path, ctx)
@@ -258,7 +258,11 @@ export class Database {
             return undefined
         }
 
-        return document.packageInformation.get(packageInformationId)
+        return (
+            // TODO - normalize ids before we serialize them in the database
+            document.packageInformation.get(parseInt(packageInformationId, 10)) ||
+            document.packageInformation.get(packageInformationId)
+        )
     }
 
     //

--- a/lsif/src/dump-manager/routes/database.ts
+++ b/lsif/src/dump-manager/routes/database.ts
@@ -202,14 +202,17 @@ export function createDatabaseRouter(logger: Logger): express.Router {
 
     interface PackageInformationQueryArgs {
         path: string
-        packageInformationId: number
+        packageInformationId: string
     }
 
     type PackageInformationResponse = sqliteModels.PackageInformationData | undefined
 
     router.get(
-        '/:id([0-9]+)/packageInformation',
-        validation.validationMiddleware([validation.validateNonEmptyString('path')]),
+        '/dbs/:id([0-9]+)/packageInformation',
+        validation.validationMiddleware([
+            validation.validateNonEmptyString('path'),
+            validation.validateNonEmptyString('packageInformationId'),
+        ]),
         wrap(
             async (req: express.Request, res: express.Response<PackageInformationResponse>): Promise<void> => {
                 const { path, packageInformationId }: PackageInformationQueryArgs = req.query

--- a/lsif/src/dump-manager/routes/database.ts
+++ b/lsif/src/dump-manager/routes/database.ts
@@ -164,7 +164,7 @@ export function createDatabaseRouter(logger: Logger): express.Router {
     )
 
     interface MonikerResultsQueryArgs {
-        model: string
+        modelType: string
         scheme: string
         identifier: string
         skip?: number
@@ -179,7 +179,7 @@ export function createDatabaseRouter(logger: Logger): express.Router {
     router.get(
         '/dbs/:id([0-9]+)/monikerResults',
         validation.validationMiddleware([
-            validation.validateNonEmptyString('model'),
+            validation.validateNonEmptyString('modelType'),
             validation.validateNonEmptyString('scheme'),
             validation.validateNonEmptyString('identifier'),
             validation.validateOptionalInt('skip'),
@@ -187,10 +187,10 @@ export function createDatabaseRouter(logger: Logger): express.Router {
         ]),
         wrap(
             async (req: express.Request, res: express.Response<MonikerResultsResponse>): Promise<void> => {
-                const { model, scheme, identifier, skip, take }: MonikerResultsQueryArgs = req.query
+                const { modelType, scheme, identifier, skip, take }: MonikerResultsQueryArgs = req.query
                 await withDatabase(req, res, (database, ctx) =>
                     database.monikerResults(
-                        model === 'definition' ? sqliteModels.DefinitionModel : sqliteModels.ReferenceModel,
+                        modelType === 'definition' ? sqliteModels.DefinitionModel : sqliteModels.ReferenceModel,
                         { scheme, identifier },
                         { skip, take },
                         ctx


### PR DESCRIPTION
 Splitting the lsif-server into an api and a dump manager caused some issues with find refs. The packageInformation endpoint and the monikerResult endpoints both had some issues:

- the api was passing `modelType`, not `model`, causing a 422 on all find refs
- the api is passing an Id, which can be string|number, but we assumed it was always number

The later can be fixed more permanently with some updates to the processor (which we are currently discussing).