### PR TITLE
Fix: add more valid yes, no, only values

### DIFF
--- a/shared/src/search/parser/filters.ts
+++ b/shared/src/search/parser/filters.ts
@@ -141,6 +141,12 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     },
 }
 
+export const discreteValueAliases: { [key: string]: string[] } = {
+    yes: ['yes', 'y', 'Y', 'YES', 'Yes', '1', 't', 'T', 'true', 'TRUE', 'True'],
+    no: ['n', 'N', 'no', 'NO', 'No', '0', 'f', 'F', 'false', 'FALSE', 'False'],
+    only: ['o', 'only', 'ONLY', 'Only'],
+}
+
 /**
  * Returns the {@link FilterDefinition} for the given filterType if it exists, or `undefined` otherwise.
  */
@@ -198,8 +204,14 @@ export const validateFilter = (
         definition.discreteValues &&
         (!filterValue ||
             (filterValue.token.type !== 'literal' && filterValue.token.type !== 'quoted') ||
-            (filterValue.token.type === 'literal' && !definition.discreteValues.includes(filterValue.token.value)) ||
-            (filterValue.token.type === 'quoted' && !definition.discreteValues.includes(filterValue.token.quotedValue)))
+            (filterValue.token.type === 'literal' &&
+                ![...definition.discreteValues, ...discreteValueAliases[filterValue.token.value]].includes(
+                    filterValue.token.value
+                )) ||
+            (filterValue.token.type === 'quoted' &&
+                ![...definition.discreteValues, ...discreteValueAliases[filterValue.token.quotedValue]].includes(
+                    filterValue.token.quotedValue
+                )))
     ) {
         return {
             valid: false,

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -5,6 +5,7 @@ import { FiltersToTypeAndValue } from '../search/interactive/util'
 import { isEmpty } from 'lodash'
 import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
 import { replaceRange } from './strings'
+import { discreteValueAliases } from '../search/parser/filters'
 
 export interface RepoSpec {
     /**
@@ -572,7 +573,7 @@ export function buildSearchURLQuery(
         fullQuery = replaceRange(fullQuery, caseInQuery.range)
         searchParams.set('q', fullQuery)
 
-        if (caseInQuery.value === 'yes') {
+        if (discreteValueAliases.yes.includes(caseInQuery.value)) {
             fullQuery = replaceRange(fullQuery, caseInQuery.range)
             searchParams.set('case', caseInQuery.value)
         } else {

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -79,7 +79,7 @@ export function parseSearchURL(
 
         if (discreteValueAliases.yes.includes(caseInQuery.value)) {
             caseSensitive = true
-        } else if (discreteValueAliases.yes.includes(caseInQuery.value)) {
+        } else if (discreteValueAliases.no.includes(caseInQuery.value)) {
             caseSensitive = false
         }
     }

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -3,6 +3,7 @@ import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import { FiltersToTypeAndValue } from '../../../shared/src/search/interactive/util'
 import { parseCaseSensitivityFromQuery, parsePatternTypeFromQuery } from '../../../shared/src/util/url'
 import { replaceRange } from '../../../shared/src/util/strings'
+import { discreteValueAliases } from '../../../shared/src/search/parser/filters'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -41,11 +42,11 @@ export function searchURLIsCaseSensitive(query: string): boolean {
     const queryCaseSensitivity = parseCaseSensitivityFromQuery(query)
     if (queryCaseSensitivity) {
         // if `case:` filter exists in the query, override the existing case: query param
-        return queryCaseSensitivity.value === 'yes'
+        return discreteValueAliases.yes.includes(queryCaseSensitivity.value)
     }
     const searchParams = new URLSearchParams(query)
     const caseSensitive = searchParams.get('case')
-    return caseSensitive === 'yes'
+    return discreteValueAliases.yes.includes(caseSensitive || '')
 }
 
 /**
@@ -76,9 +77,9 @@ export function parseSearchURL(
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
         finalQuery = replaceRange(finalQuery, caseInQuery.range)
 
-        if (caseInQuery.value === 'yes') {
+        if (discreteValueAliases.yes.includes(caseInQuery.value)) {
             caseSensitive = true
-        } else if (caseInQuery.value === 'no') {
+        } else if (discreteValueAliases.yes.includes(caseInQuery.value)) {
             caseSensitive = false
         }
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8790.

Our backend specifies a bunch of aliases for [yes, no, and only](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ff28ccb0c4aa4bf1690e5fa9e7f654649b2837c3/-/blob/cmd/frontend/graphqlbackend/yesnoonly.go#L5:6), including all true/false values from Go's strconv package. 

We should accept these values on the frontend.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
