### PR TITLE
authz: add site admin page for repositories permissions

### DIFF
--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -139,8 +139,7 @@ func (p *UserPermissions) TracingFields() []otlog.Field {
 	return fs
 }
 
-// RepoPermissions declares which users have access to a given repository, as
-// defined by the permissions provider (either Bitbucket Server or Sourcegraph).
+// RepoPermissions declares which users have access to a given repository.
 type RepoPermissions struct {
 	RepoID    int32
 	Perm      Perms

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -5,23 +5,25 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
 // NewAuthzResolver will be set by enterprise
 var NewAuthzResolver func() AuthzResolver
 
 type AuthzResolver interface {
-	SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error)
+	SetRepositoryPermissionsForUsers(ctx context.Context, args *SetRepoPermsArgs) (*EmptyResponse, error)
 	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
+	RepositoriesPermissions(ctx context.Context, args *ReposPermsArgs) (RepositoryPermissionsConnectionResolver, error)
 }
 
 var authzInEnterprise = errors.New("authorization mutations and queries are only available in enterprise")
 
 type defaultAuthzResolver struct{}
 
-func (defaultAuthzResolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error) {
+func (defaultAuthzResolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *SetRepoPermsArgs) (*EmptyResponse, error) {
 	return nil, authzInEnterprise
 }
 
@@ -37,7 +39,18 @@ func (defaultAuthzResolver) AuthorizedUsers(ctx context.Context, args *RepoAutho
 	return nil, authzInEnterprise
 }
 
-type RepoPermsArgs struct {
+func (defaultAuthzResolver) RepositoriesPermissions(ctx context.Context, args *ReposPermsArgs) (RepositoryPermissionsConnectionResolver, error) {
+	return nil, authzInEnterprise
+}
+
+type ReposPermsArgs struct {
+	graphqlutil.ConnectionArgs
+	Query      *string
+	OrderBy    string
+	Descending bool
+}
+
+type SetRepoPermsArgs struct {
 	Repository graphql.ID
 	BindIDs    []string
 	Perm       string
@@ -49,4 +62,20 @@ type AuthorizedRepoArgs struct {
 	Perm     string
 	First    int32
 	After    *string
+}
+
+type RepositoryPermissionsConnectionResolver interface {
+	Nodes(ctx context.Context) ([]RepositoryPermissionsResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type RepositoryPermissionsResolver interface {
+	Repository() *RepositoryResolver
+	Permissions() RepositoryPermissionsInfoResolver
+}
+
+type RepositoryPermissionsInfoResolver interface {
+	Perm() string
+	UpdatedAt() DateTime
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1402,7 +1402,7 @@ enum RepositoryPermissionsOrderBy {
 # A list of repositories along with their permissions information.
 type RepositoryPermissionsConnection {
     # The list of nodes that contains actual repositories and their permissions.
-    nodes: [RepositoryPermissionsNode!]!
+    nodes: [RepositoryPermissions!]!
     # The total count of repositories in the connection.
     totalCount: Int!
     # Pagination information.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1380,6 +1380,49 @@ type Query {
     # Returns a list of usernames or emails that have associated pending permissions.
     # The returned list can be used to query authorizedUserRepositories for pending permissions.
     usersWithPendingPermissions: [String!]!
+
+    # Returns a list of repositories with their permissions information.
+    repositoriesPermissions(
+        # The number of repositories to return.
+        first: Int
+        # Return repositories whose names match the query.
+        query: String
+        # Sort field.
+        orderBy: RepositoryPermissionsOrderBy = REPOSITORY_PERMISSIONS_UPDATED_AT
+        # Sort direction.
+        descending: Boolean = true
+    ): RepositoryPermissionsConnection!
+}
+
+# RepositoryPermissionsOrderBy enumerates the ways a repositories permissions list can be ordered.
+enum RepositoryPermissionsOrderBy {
+    REPOSITORY_PERMISSIONS_UPDATED_AT
+}
+
+# A list of repositories along with their permissions information.
+type RepositoryPermissionsConnection {
+    # The list of nodes that contains actual repositories and their permissions.
+    nodes: [RepositoryPermissionsNode!]!
+    # The total count of repositories in the connection.
+    totalCount: Int!
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A repository with its permissions.
+type RepositoryPermissions {
+    # The repository itself.
+    repository: Repository!
+    # Permissions of the repository.
+    permissions: RepositoryPermissionsInfo!
+}
+
+# Permissions information of a repository.
+type RepositoryPermissionsInfo {
+    # Permission that users has on the repository.
+    perm: RepositoryPermission!
+    # When the permissions were last updated.
+    updatedAt: DateTime!
 }
 
 # The version of the search syntax.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1387,6 +1387,49 @@ type Query {
     # Returns a list of usernames or emails that have associated pending permissions.
     # The returned list can be used to query authorizedUserRepositories for pending permissions.
     usersWithPendingPermissions: [String!]!
+
+    # Returns a list of repositories with their permissions information.
+    repositoriesPermissions(
+        # The number of repositories to return.
+        first: Int
+        # Return repositories whose names match the query.
+        query: String
+        # Sort field.
+        orderBy: RepositoryPermissionsOrderBy = REPOSITORY_PERMISSIONS_UPDATED_AT
+        # Sort direction.
+        descending: Boolean = true
+    ): RepositoryPermissionsConnection!
+}
+
+# RepositoryPermissionsOrderBy enumerates the ways a repositories permissions list can be ordered.
+enum RepositoryPermissionsOrderBy {
+    REPOSITORY_PERMISSIONS_UPDATED_AT
+}
+
+# A list of repositories along with their permissions information.
+type RepositoryPermissionsConnection {
+    # The list of nodes that contains actual repositories and their permissions.
+    nodes: [RepositoryPermissions!]!
+    # The total count of repositories in the connection.
+    totalCount: Int!
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# A repository with its permissions.
+type RepositoryPermissions {
+    # The repository itself.
+    repository: Repository!
+    # Permissions of the repository.
+    permissions: RepositoryPermissionsInfo!
+}
+
+# Permissions information of a repository.
+type RepositoryPermissionsInfo {
+    # Permission that users has on the repository.
+    perm: RepositoryPermission!
+    # When the permissions were last updated.
+    updatedAt: DateTime!
 }
 
 # The version of the search syntax.

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-var _ graphqlbackend.RepositoryConnectionResolver = &repositoryConnectionResolver{}
+var _ graphqlbackend.RepositoryConnectionResolver = (*repositoryConnectionResolver)(nil)
 
 // repositoryConnectionResolver resolves a list of repositories from the roaring bitmap with pagination.
 type repositoryConnectionResolver struct {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repository_permissions.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repository_permissions.go
@@ -1,0 +1,121 @@
+package resolvers
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+var _ graphqlbackend.RepositoryPermissionsConnectionResolver = (*repositoryPermissionsConnectionResolver)(nil)
+
+type repositoryPermissionsConnectionResolver struct {
+	perms      []*authz.RepoPermissions
+	totalCount int
+	limit      int
+
+	// cache results because they are used by multiple fields
+	once      sync.Once
+	repoPerms []graphqlbackend.RepositoryPermissionsResolver
+	pageInfo  *graphqlutil.PageInfo
+	err       error
+}
+
+var _ graphqlbackend.RepositoryPermissionsResolver = (*repositoryPermissionsResolver)(nil)
+
+type repositoryPermissionsResolver struct {
+	repo  *graphqlbackend.RepositoryResolver
+	perms graphqlbackend.RepositoryPermissionsInfoResolver
+}
+
+func (r *repositoryPermissionsResolver) Repository() *graphqlbackend.RepositoryResolver {
+	return r.repo
+}
+
+func (r *repositoryPermissionsResolver) Permissions() graphqlbackend.RepositoryPermissionsInfoResolver {
+	return r.perms
+}
+
+var _ graphqlbackend.RepositoryPermissionsInfoResolver = (*repositoryPermissionsInfoResolver)(nil)
+
+type repositoryPermissionsInfoResolver struct {
+	perms *authz.RepoPermissions
+}
+
+func (r *repositoryPermissionsInfoResolver) Perm() string {
+	return strings.ToUpper(r.perms.Perm.String())
+}
+
+func (r *repositoryPermissionsInfoResolver) UpdatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.perms.UpdatedAt}
+}
+
+// 🚨 SECURITY: It is the caller's responsibility to ensure the current authenticated user
+// is the site admin because this method computes data from all available information in
+// the database.
+func (r *repositoryPermissionsConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.RepositoryPermissionsResolver, *graphqlutil.PageInfo, error) {
+	r.once.Do(func() {
+		repoIDs := make([]api.RepoID, 0, len(r.perms))
+		for _, p := range r.perms {
+			repoIDs = append(repoIDs, api.RepoID(p.RepoID))
+		}
+
+		var repos []*types.Repo
+		repos, r.err = db.Repos.GetByIDs(ctx, repoIDs...)
+		if r.err != nil {
+			return
+		}
+
+		reposSet := make(map[api.RepoID]*types.Repo, len(repos))
+		for _, r := range repos {
+			reposSet[r.ID] = r
+		}
+
+		r.repoPerms = make([]graphqlbackend.RepositoryPermissionsResolver, 0, len(r.perms))
+		for _, p := range r.perms {
+			r.repoPerms = append(r.repoPerms, &repositoryPermissionsResolver{
+				repo:  graphqlbackend.NewRepositoryResolver(reposSet[api.RepoID(p.RepoID)]),
+				perms: &repositoryPermissionsInfoResolver{perms: p},
+			})
+		}
+
+		r.pageInfo = graphqlutil.HasNextPage(r.limit > 0 && r.totalCount > r.limit)
+	})
+	return r.repoPerms, r.pageInfo, r.err
+}
+
+func (r *repositoryPermissionsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.RepositoryPermissionsResolver, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	repoPerms, _, err := r.compute(ctx)
+	return repoPerms, err
+}
+
+func (r *repositoryPermissionsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return 0, err
+	}
+
+	return int32(r.totalCount), nil
+}
+
+func (r *repositoryPermissionsConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	// 🚨 SECURITY: Only site admins may access this method.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	_, pageInfo, err := r.compute(ctx)
+	return pageInfo, err
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repository_permissions.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repository_permissions.go
@@ -80,8 +80,14 @@ func (r *repositoryPermissionsConnectionResolver) compute(ctx context.Context) (
 
 		r.repoPerms = make([]graphqlbackend.RepositoryPermissionsResolver, 0, len(r.perms))
 		for _, p := range r.perms {
+			// In case there is no associated repository
+			repo, ok := reposSet[api.RepoID(p.RepoID)]
+			if !ok {
+				continue
+			}
+
 			r.repoPerms = append(r.repoPerms, &repositoryPermissionsResolver{
-				repo:  graphqlbackend.NewRepositoryResolver(reposSet[api.RepoID(p.RepoID)]),
+				repo:  graphqlbackend.NewRepositoryResolver(repo),
 				perms: &repositoryPermissionsInfoResolver{perms: p},
 			})
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -52,7 +52,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 		}()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).SetRepositoryPermissionsForUsers(ctx, &graphqlbackend.RepoPermsArgs{})
+		result, err := (&Resolver{}).SetRepositoryPermissionsForUsers(ctx, &graphqlbackend.SetRepoPermsArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}

--- a/web/src/site-admin/SiteAdminRepositoriesPermissionsPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPermissionsPage.tsx
@@ -7,7 +7,6 @@ import { RepoLink } from '../../../shared/src/components/RepoLink'
 import * as GQL from '../../../shared/src/graphql/schema'
 import {
     FilteredConnection,
-    // FilteredConnectionFilter,
     FilteredConnectionQueryArgs,
     FilteredConnectionFilter,
 } from '../components/FilteredConnection'
@@ -60,7 +59,7 @@ class FilteredRepositoryPermissionsConnection extends FilteredConnection<
 > {}
 
 /**
- * A page displaying the repositories on this site.
+ * A page displaying the repositories permissions on this site.
  */
 export class SiteAdminRepositoriesPermissionsPage extends React.PureComponent<Props> {
     private static FILTERS: FilteredConnectionFilter[] = [

--- a/web/src/site-admin/SiteAdminRepositoriesPermissionsPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPermissionsPage.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react'
+import { RouteComponentProps } from 'react-router'
+import { Link } from 'react-router-dom'
+import { Subject, Observable } from 'rxjs'
+import { ActivationProps } from '../../../shared/src/components/activation/Activation'
+import { RepoLink } from '../../../shared/src/components/RepoLink'
+import * as GQL from '../../../shared/src/graphql/schema'
+import {
+    FilteredConnection,
+    // FilteredConnectionFilter,
+    FilteredConnectionQueryArgs,
+    FilteredConnectionFilter,
+} from '../components/FilteredConnection'
+import { PageTitle } from '../components/PageTitle'
+import { refreshSiteFlags } from '../site/backend'
+import { eventLogger } from '../tracking/eventLogger'
+import { fetchAllRepositoriesPermissions } from './backend'
+import { ErrorAlert } from '../components/alerts'
+import { Timestamp } from '../components/time/Timestamp'
+
+interface RepositoryPermissionsNodeProps extends ActivationProps {
+    node: GQL.IRepositoryPermissions
+    onDidUpdate?: () => void
+}
+
+interface RepositoryPermissionsNodeState {
+    errorDescription?: string
+}
+
+class RepositoryPermissionsNode extends React.PureComponent<
+    RepositoryPermissionsNodeProps,
+    RepositoryPermissionsNodeState
+> {
+    public state: RepositoryPermissionsNodeState = {}
+
+    public render(): JSX.Element | null {
+        return (
+            <li className="repository-node list-group-item py-2" data-e2e-repository={this.props.node.repository.name}>
+                <div className="d-flex align-items-center justify-content-between">
+                    <div>
+                        <RepoLink repoName={this.props.node.repository.name} to={this.props.node.repository.url} />
+                    </div>
+                    <div className="repository-node__actions">
+                        <small className="ml-2 text-muted">
+                            <Timestamp date={this.props.node.permissions.updatedAt} />
+                        </small>{' '}
+                    </div>
+                </div>
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
+            </li>
+        )
+    }
+}
+
+interface Props extends RouteComponentProps<{}>, ActivationProps {}
+
+class FilteredRepositoryPermissionsConnection extends FilteredConnection<
+    GQL.IRepositoryPermissions,
+    Pick<RepositoryPermissionsNodeProps, 'onDidUpdate'>
+> {}
+
+/**
+ * A page displaying the repositories on this site.
+ */
+export class SiteAdminRepositoriesPermissionsPage extends React.PureComponent<Props> {
+    private static FILTERS: FilteredConnectionFilter[] = [
+        {
+            label: 'Most recent synced',
+            id: 'most-recent-synced',
+            tooltip: 'Sort by most recent synced',
+            args: {},
+        },
+        {
+            label: 'Least recent synced',
+            id: 'least-recent-synced',
+            tooltip: 'Sort by least recent synced',
+            args: { descending: false },
+        },
+    ]
+
+    private repositoryUpdates = new Subject<void>()
+
+    public componentDidMount(): void {
+        eventLogger.logViewEvent('SiteAdminReposPerms')
+
+        // Refresh global alert about enabling repositories when the user visits here.
+        refreshSiteFlags()
+            .toPromise()
+            .then(null, err => console.error(err))
+    }
+
+    public componentWillUnmount(): void {
+        // Remove global alert about enabling repositories when the user navigates away from here.
+        refreshSiteFlags()
+            .toPromise()
+            .then(null, err => console.error(err))
+    }
+
+    public render(): JSX.Element | null {
+        const nodeProps: Pick<RepositoryPermissionsNodeProps, 'onDidUpdate' | 'activation'> = {
+            onDidUpdate: this.onDidUpdateRepository,
+            activation: this.props.activation,
+        }
+
+        return (
+            <div className="site-admin-repositories-page">
+                <PageTitle title="Repositories permissions - Admin" />
+                <h2>Repositories permissions</h2>
+                <p>
+                    Repositories permissions are synced from connected{' '}
+                    <Link to="/site-admin/external-services">code host connections</Link>.
+                </p>
+                <FilteredRepositoryPermissionsConnection
+                    className="list-group list-group-flush mt-3"
+                    noun="entry"
+                    pluralNoun="entries"
+                    queryConnection={this.queryRepositoriesPermissions}
+                    nodeComponent={RepositoryPermissionsNode}
+                    nodeComponentProps={nodeProps}
+                    updates={this.repositoryUpdates}
+                    filters={SiteAdminRepositoriesPermissionsPage.FILTERS}
+                    history={this.props.history}
+                    location={this.props.location}
+                />
+            </div>
+        )
+    }
+
+    private queryRepositoriesPermissions = (
+        args: FilteredConnectionQueryArgs
+    ): Observable<GQL.IRepositoryPermissionsConnection> => fetchAllRepositoriesPermissions({ ...args })
+
+    private onDidUpdateRepository = (): void => this.repositoryUpdates.next()
+}

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -168,6 +168,42 @@ export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
     )
 }
 
+interface RepositoriesPermissionsArgs {}
+
+export function fetchAllRepositoriesPermissions(
+    args: RepositoriesPermissionsArgs
+): Observable<GQL.IRepositoryPermissionsConnection> {
+    args = {
+        descending: true,
+        ...args,
+    } // apply defaults
+    return queryGraphQL(
+        gql`
+            query RepositoriesPermissions($first: Int, $query: String, $descending: Boolean) {
+                repositoriesPermissions(first: $first, query: $query, descending: $descending) {
+                    nodes {
+                        repository {
+                            name
+                            url
+                        }
+                        permissions {
+                            updatedAt
+                        }
+                    }
+                    totalCount
+                    pageInfo {
+                        hasNextPage
+                    }
+                }
+            }
+        `,
+        args
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.repositoriesPermissions)
+    )
+}
+
 export function updateMirrorRepository(args: { repository: GQL.ID }): Observable<void> {
     return mutateGraphQL(
         gql`

--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -52,6 +52,14 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
     {
+        path: '/repositories-permissions',
+        render: lazyComponent(
+            () => import('./SiteAdminRepositoriesPermissionsPage'),
+            'SiteAdminRepositoriesPermissionsPage'
+        ),
+        exact: true,
+    },
+    {
         path: '/organizations',
         render: lazyComponent(() => import('./SiteAdminOrgsPage'), 'SiteAdminOrgsPage'),
         exact: true,

--- a/web/src/site-admin/sidebaritems.ts
+++ b/web/src/site-admin/sidebaritems.ts
@@ -57,6 +57,10 @@ const repositoriesGroup: SiteAdminSideBarGroup = {
             label: 'Repository status',
             to: '/site-admin/repositories',
         },
+        {
+            label: 'Permissions',
+            to: '/site-admin/repositories-permissions',
+        },
     ],
 }
 


### PR DESCRIPTION
This PR adds a new page in the site admin to show the list of repository permissions, it can:

- Search by repository name
- Sort by most and least recent updated
- Display last updated time

The UX was discussed together with @imtommyroberts and @ryanslade.

Preview:

![image](https://user-images.githubusercontent.com/2946214/77878459-e7e7c180-728a-11ea-812a-b155e7104814.png)

TODO: Tests will be added after approval.