### PR TITLE
search: search pattern partitioning for and/or queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -597,7 +597,7 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 
 	validatedQuery := scopeParameters
 	if pattern != nil {
-		validatedQuery = append(scopeParameters, pattern)
+		validatedQuery = append(validatedQuery, pattern)
 	}
 	r.query = query.AndOrQuery{Query: validatedQuery}
 	return r.evaluateLeaf(ctx)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -590,7 +590,16 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 
 // evaluate evaluates all expressions of a search query.
 func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchResultsResolver, error) {
-	// For now, fall through to evaluating leaf expressions only.
+	scopeParameters, pattern, err := query.PartitionSearchPattern(q)
+	if err != nil {
+		return nil, err
+	}
+
+	validatedQuery := scopeParameters
+	if pattern != nil {
+		validatedQuery = append(scopeParameters, pattern)
+	}
+	r.query = query.AndOrQuery{Query: validatedQuery}
 	return r.evaluateLeaf(ctx)
 }
 

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -1,0 +1,69 @@
+package query
+
+import (
+	"errors"
+)
+
+// isPatternExpression returns true if every leaf node in a tree root at node is
+// a search pattern.
+func isPatternExpression(node Node) bool {
+	result := true
+	VisitParameter([]Node{node}, func(field, _ string, _ bool) {
+		if field != "" && field != "content" {
+			result = false
+		}
+	})
+	return result
+}
+
+// processTopLevel processes the top level of a query. It validates that we can
+// process the query with respect to and/or expressions on file content, but not
+// otherwise for nested parameters.
+func processTopLevel(nodes []Node) ([]Node, error) {
+	if term, ok := nodes[0].(Operator); ok {
+		if term.Kind == And && isPatternExpression(term) {
+			return nodes, nil
+		} else if term.Kind == Or && isPatternExpression(term) {
+			return nodes, nil
+		} else if term.Kind == And {
+			return term.Operands, nil
+		} else if term.Kind == Concat {
+			return nodes, nil
+		} else {
+			return nil, errors.New("cannot evaluate: unable to partition pure search pattern")
+		}
+	}
+	return nodes, nil
+}
+
+// PartitionSearchPattern partitions an and/or query into (1) a single search
+// pattern expression and (2) other parameters that scope the evaluation of
+// search patterns (e.g., to repos, files, etc.). It validates that a query
+// contains at most one search pattern expression and that scope parameters do
+// not contain nested expressions.
+func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err error) {
+	if len(nodes) == 1 {
+		nodes, err = processTopLevel(nodes)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var patterns []Node
+	for _, node := range nodes {
+		if isPatternExpression(node) {
+			patterns = append(patterns, node)
+		} else if term, ok := node.(Parameter); ok {
+			parameters = append(parameters, term)
+		} else {
+			return nil, nil, errors.New("cannot evaluate: unable to partition pure search pattern")
+		}
+	}
+	if len(patterns) > 1 {
+		pattern = Operator{Kind: And, Operands: patterns}
+	} else if len(patterns) == 1 {
+		pattern = patterns[0]
+	}
+
+	return parameters, pattern, nil
+}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -1,0 +1,98 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_PartitionSearchPattern(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "x",
+			want:  "x",
+		},
+		{
+			input: "x y",
+			want:  "(concat x y)",
+		},
+		{
+			input: "x or y",
+			want:  "(or x y)",
+		},
+		{
+			input: "x and y",
+			want:  "(and x y)",
+		},
+		{
+			input: "file:foo x y",
+			want:  "file:foo (concat x y)",
+		},
+		{
+			input: "file:foo (x y)",
+			want:  "file:foo (concat x y)",
+		},
+		{
+			input: "(file:foo x) y",
+			want:  "cannot evaluate: unable to partition pure search pattern",
+		},
+		{
+			input: "file:foo (x and y)",
+			want:  "file:foo (and x y)",
+		},
+		{
+			input: "file:foo x and y",
+			want:  "file:foo (and x y)",
+		},
+		{
+			input: "file:foo (x or y)",
+			want:  "file:foo (or x y)",
+		},
+		{
+			input: "file:foo x or y",
+			want:  "cannot evaluate: unable to partition pure search pattern",
+		},
+		{
+			input: "(file:foo x) or y",
+			want:  "cannot evaluate: unable to partition pure search pattern",
+		},
+		{
+			input: "file:foo and content:x",
+			want:  "file:foo content:x",
+		},
+		{
+			input: "repo:foo and file:bar and x",
+			want:  "repo:foo file:bar x",
+		},
+		{
+			input: "repo:foo and (file:bar or file:baz) and x",
+			want:  "cannot evaluate: unable to partition pure search pattern",
+		},
+	}
+	for _, tt := range cases {
+		t.Run("partition search pattern", func(t *testing.T) {
+			q, _ := ParseAndOr(tt.input)
+			andOrQuery, _ := q.(*AndOrQuery)
+			scopeParameters, pattern, err := PartitionSearchPattern(andOrQuery.Query)
+			if err != nil {
+				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {
+					t.Fatal(diff)
+				}
+				return
+			}
+			result := append(scopeParameters, pattern)
+			var resultStr []string
+			for _, node := range result {
+				resultStr = append(resultStr, node.String())
+			}
+			got := strings.Join(resultStr, " ")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To process and/or expressions for content, we need to separate search patterns expressions from the parameters that scope them (e.g., `file:`, `repo:`). This PR adds a helper function `PartitionSearchPattern` to do that. The function performs rudimentary validation to block certain queries that we won't be able to perform just yet. It is rudimentary because it doesn't cover every query that may match a user's intuition re ambiguity.