### PR TITLE
Smart search field: place cursor at the end of the field

### DIFF
--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -7,7 +7,7 @@ import { QueryState } from '../helpers'
 import { getProviders } from '../../../../shared/src/search/parser/providers'
 import { Subscription, Observable, Subject, Unsubscribable } from 'rxjs'
 import { fetchSuggestions } from '../backend'
-import { toArray, map, distinctUntilChanged, publishReplay, refCount } from 'rxjs/operators'
+import { toArray, map, distinctUntilChanged, publishReplay, refCount, filter } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { CaseSensitivityProps, PatternTypeProps } from '..'
@@ -166,7 +166,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
 
     private onChange = (query: string): void => {
         // Cursor position is irrelevant for the Monaco query input.
-        this.props.onChange({ query, cursorPosition: 0 })
+        this.props.onChange({ query, cursorPosition: 0, fromUserInput: true })
     }
 
     private onSubmit = (): void => {
@@ -179,17 +179,27 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
     }
 
     private onEditorCreated = (editor: Monaco.editor.IStandaloneCodeEditor): void => {
-        if (this.props.autoFocus) {
-            // Focus the editor with cursor at end, and reveal that position.
-            editor.focus()
-            const position = {
-                // +2 as Monaco is 1-indexed, and the cursor should be placed after the query.
-                column: editor.getValue().length + 2,
-                lineNumber: 1,
-            }
-            editor.setPosition(position)
-            editor.revealPosition(position)
-        }
+        this.subscriptions.add(
+            this.componentUpdates
+                .pipe(
+                    filter(({ autoFocus }) => !!autoFocus),
+                    map(({ queryState }) => queryState),
+                    filter(({ fromUserInput }) => !fromUserInput),
+                    distinctUntilChanged((a, b) => a.query === b.query)
+                )
+                .subscribe(() => {
+                    // Focus the editor with cursor at end, and reveal that position.
+                    editor.focus()
+                    const position = {
+                        // +2 as Monaco is 1-indexed, and the cursor should be placed after the query.
+                        column: editor.getValue().length + 2,
+                        lineNumber: 1,
+                    }
+                    editor.setPosition(position)
+                    editor.revealPosition(position)
+                })
+        )
+
         // Prevent newline insertion in model, and surface query changes with stripped newlines.
         this.subscriptions.add(
             toUnsubscribable(


### PR DESCRIPTION
Fixes #8731

Combined with the scoping introduced in https://github.com/sourcegraph/sourcegraph/pull/9225, this brings the nice added benefit of a zero-click search in current file using Sourcegraph: 

<details>
    <img src="https://user-images.githubusercontent.com/1741180/77903663-82440700-7283-11ea-9281-697c49d7a08b.gif"/>
</details>