### PR TITLE
E2E: Use evaluate to make sure the correct service type is always clicked

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -284,7 +284,13 @@ export class Driver {
         await this.page.waitForSelector(`[data-e2e-external-service-card-link="${kind.toUpperCase()}"]`, {
             visible: true,
         })
-        await this.page.click(`[data-e2e-external-service-card-link="${kind.toUpperCase()}"]`)
+        await this.page.evaluate(selector => {
+            const element = document.querySelector<HTMLElement>(selector)
+            if (!element) {
+                throw new Error('Could not find element to click on for selector ' + selector)
+            }
+            element.click()
+        }, `[data-e2e-external-service-card-link="${kind.toUpperCase()}"]`)
         await this.replaceText({
             selector: '#e2e-external-service-form-display-name',
             newText: displayName,


### PR DESCRIPTION
Might fix known flakes with initial 120000ms setup timeout exceeded and sometimes failing creating the external service because the wrong form is selected for CodeCommit.