### PR TITLE
docs: caddy http/https configurataion - follow up on PR comments 

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -1,5 +1,12 @@
 # Sourcegraph HTTP and HTTPS/SSL configuration
 
+Overview: 
+
+- [Single Docker image (`sourcegraph/server`): NGINX](#sourcegraph-single-instance-docker)
+- [Sourcegraph Cluster (Kubernetes): NGINX](#sourcegraph-cluster-kubernetes)
+- [Docker Compose: Caddy 2](#sourcegraph-via-docker-compose-caddy-2)
+- [Other Sourcegraph clusters (e.g. pure-docker)](#other-sourcegraph-clusters-e-g-pure-docker)
+
 ## Sourcegraph single Docker image and Sourcegraph Cluster (Kubernetes): NGINX
 
 Sourcegraph's single Docker image and Kubernetes deployments use [NGINX](https://www.nginx.com/resources/glossary/nginx/) as a [reverse proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) for the Sourcegraph front-end server, meaning NGINX proxies external HTTP (and [HTTPS](#nginx-ssl-https-configuration)) requests to the Sourcegraph front-end.

--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -1,6 +1,6 @@
 # Sourcegraph HTTP and HTTPS/SSL configuration
 
-Overview: 
+Overview:
 
 - [Single Docker image (`sourcegraph/server`): NGINX](#sourcegraph-single-instance-docker)
 - [Sourcegraph Cluster (Kubernetes): NGINX](#sourcegraph-cluster-kubernetes)

--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -10,9 +10,6 @@ Sourcegraph's single Docker image and Kubernetes deployments use [NGINX](https:/
 
 ### Sourcegraph single instance (Docker)
 
-<!-- TODO(ryan): Change heading to ## The default `nginx.conf` file and how to extend/override default configuration and add section
-on how to extend NGINX configuration without (in most cases), editing the `nginx.conf` file. -->
-
 The first time Sourcegraph is run, it will create an [`nginx.conf`](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx.conf) file at:
 
 - `~/.sourcegraph/config/nginx.conf` on the Docker/Sourcegraph host (presuming you're using the [quickstart `docker run` command](../index.md#quickstart))

--- a/doc/admin/nginx.md
+++ b/doc/admin/nginx.md
@@ -2,6 +2,6 @@
 ignoreDisconnectedPageCheck: true
 ---
 
-# Sourcegraph Nginx sHTTP and HTTPS/SSL configuration
+# Sourcegraph Nginx HTTP and HTTPS/SSL configuration
 
 This documentation page has been moved to "[Sourcegraph HTTP and HTTPS/SSL configuration](http_https_configuration.md)".


### PR DESCRIPTION
Follows up on PR comments from https://github.com/sourcegraph/sourcegraph/pull/9363