### PR TITLE
Do not allow updating closed campaigns

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -49,10 +49,11 @@ type Mutation {
         patches: [PatchInput!]!
     ): PatchSet!
     # Updates a campaign.
-    # This is not allowed when the campaign has already been closed.
-    # Updating a manual campaign to have a plan is not allowed.
-    # Updating a non-manual campaign while it's being published is not allowed.
-    # Updating the branch of a (partially-) published campaign is not allowed.
+    # Note, updating is not allowed when:
+    # The campaign has already been closed.
+    # A plan is added to a manual campaign.
+    # A non-manual campaign is being published.
+    # The branch of a (partially-) published campaign is changed.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retries creating changesets from the patches in the PatchSet that could not be successfully created on the code host.
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -49,6 +49,10 @@ type Mutation {
         patches: [PatchInput!]!
     ): PatchSet!
     # Updates a campaign.
+    # This is not allowed when the campaign has already been closed.
+    # Updating a manual campaign to have a plan is not allowed.
+    # Updating a non-manual campaign while it's being published is not allowed.
+    # Updating the branch of a (partially-) published campaign is not allowed.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retries creating changesets from the patches in the PatchSet that could not be successfully created on the code host.
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -51,6 +51,10 @@ type Mutation {
         patches: [PatchInput!]!
     ): PatchSet!
     # Updates a campaign.
+    # This is not allowed when the campaign has already been closed.
+    # Updating a manual campaign to have a plan is not allowed.
+    # Updating a non-manual campaign while it's being published is not allowed.
+    # Updating the branch of a (partially-) published campaign is not allowed.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retries creating changesets from the patches in the PatchSet that could not be successfully created on the code host.
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -51,10 +51,11 @@ type Mutation {
         patches: [PatchInput!]!
     ): PatchSet!
     # Updates a campaign.
-    # This is not allowed when the campaign has already been closed.
-    # Updating a manual campaign to have a plan is not allowed.
-    # Updating a non-manual campaign while it's being published is not allowed.
-    # Updating the branch of a (partially-) published campaign is not allowed.
+    # Note, updating is not allowed when:
+    # The campaign has already been closed.
+    # A plan is added to a manual campaign.
+    # A non-manual campaign is being published.
+    # The branch of a (partially-) published campaign is changed.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retries creating changesets from the patches in the PatchSet that could not be successfully created on the code host.
     # Retrying will clear the errors list of a campaign and change its state back to CREATING_CHANGESETS.

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -482,9 +482,9 @@ var ErrPublishedCampaignBranchChange = errors.New("Published campaign branch can
 // specified patch set is already attached to another campaign.
 var ErrPatchSetDuplicate = errors.New("Campaign cannot use the same patch set as another campaign")
 
-// ErrClosedCampaignUpdatePatchIllegal is returned by UpdateCampaign if a patch set
-// is to be attached to a closed campaign.
-var ErrClosedCampaignUpdatePatchIllegal = errors.New("cannot update the patch set of a closed campaign")
+// ErrUpdateClosedCampaign is returned by UpdateCampaign if the Campaign
+// has been closed.
+var ErrUpdateClosedCampaign = errors.New("cannot update a closed Campaign")
 
 // ErrManualCampaignUpdatePatchIllegal is returned by UpdateCampaign if a patch set
 // is to be attached to a manual campaign.
@@ -511,8 +511,8 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		return nil, nil, errors.Wrap(err, "getting campaign")
 	}
 
-	if args.PatchSet != nil && !campaign.ClosedAt.IsZero() {
-		return nil, nil, ErrClosedCampaignUpdatePatchIllegal
+	if !campaign.ClosedAt.IsZero() {
+		return nil, nil, ErrUpdateClosedCampaign
 	}
 
 	var updateAttributes, updatePatchSetID, updateBranch bool

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -280,6 +280,7 @@ func TestService(t *testing.T) {
 			name    string
 			branch  *string
 			draft   bool
+			closed  bool
 			process bool
 			err     string
 		}{
@@ -291,6 +292,12 @@ func TestService(t *testing.T) {
 			{
 				name:  "draft campaign",
 				draft: true,
+			},
+
+			{
+				name:   "closed campaign",
+				closed: true,
+				err:    ErrUpdateClosedCampaign.Error(),
 			},
 			{
 				name:    "change campaign branch",
@@ -332,6 +339,10 @@ func TestService(t *testing.T) {
 
 				svc := NewServiceWithClock(store, gitClient, cf, clock)
 				campaign := testCampaign(user.ID, patchSet.ID)
+
+				if tc.closed {
+					campaign.ClosedAt = now
+				}
 
 				err = svc.CreateCampaign(ctx, campaign, tc.draft)
 				if err != nil {
@@ -680,7 +691,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 			newPatches: []newPatchSpec{
 				{repo: "repo-0", modifiedDiff: true},
 			},
-			wantErr: ErrClosedCampaignUpdatePatchIllegal,
+			wantErr: ErrUpdateClosedCampaign,
 		},
 		{
 			name:            "1 unmodified merged, 1 new changeset",

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.test.tsx
@@ -67,7 +67,7 @@ describe('CampaignActionsBar', () => {
                 />
             )
         ).toMatchSnapshot())
-    test('editable but closed', () =>
+    test('closed', () =>
         expect(
             createRenderer().render(
                 <CampaignActionsBar

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -36,6 +36,7 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({
     const showSpinner = mode === 'saving' || mode === 'deleting' || mode === 'closing'
     const editingCampaign = mode === 'editing' || mode === 'saving'
 
+    const campaignClosed = campaign?.closedAt
     const campaignProcessing = campaign ? campaign.status.state === GQL.BackgroundProcessState.PROCESSING : false
     const actionsDisabled = mode === 'deleting' || mode === 'closing' || mode === 'publishing' || campaignProcessing
 
@@ -49,7 +50,7 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({
 
     if (!campaign) {
         stateBadge = <CampaignsIcon className="icon-inline campaign-actions-bar__campaign-icon text-muted mr-2" />
-    } else if (campaign.closedAt) {
+    } else if (campaignClosed) {
         stateBadge = (
             <span className="badge badge-danger mr-2">
                 <CampaignsIcon className="icon-inline campaign-actions-bar__campaign-icon" /> Closed
@@ -104,16 +105,18 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({
                         </>
                     ) : (
                         <>
-                            <button
-                                type="button"
-                                id="e2e-campaign-edit"
-                                className="btn btn-secondary mr-1"
-                                onClick={onEdit}
-                                disabled={actionsDisabled}
-                            >
-                                Edit
-                            </button>
-                            {!campaign.closedAt && (
+                            {!campaignClosed && (
+                                <button
+                                    type="button"
+                                    id="e2e-campaign-edit"
+                                    className="btn btn-secondary mr-1"
+                                    onClick={onEdit}
+                                    disabled={actionsDisabled}
+                                >
+                                    Edit
+                                </button>
+                            )}
+                            {!campaignClosed && (
                                 <CloseDeleteCampaignPrompt
                                     disabled={actionsDisabled}
                                     disabledTooltip="Cannot close while campaign is being created"

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -106,30 +106,30 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({
                     ) : (
                         <>
                             {!campaignClosed && (
-                                <button
-                                    type="button"
-                                    id="e2e-campaign-edit"
-                                    className="btn btn-secondary mr-1"
-                                    onClick={onEdit}
-                                    disabled={actionsDisabled}
-                                >
-                                    Edit
-                                </button>
-                            )}
-                            {!campaignClosed && (
-                                <CloseDeleteCampaignPrompt
-                                    disabled={actionsDisabled}
-                                    disabledTooltip="Cannot close while campaign is being created"
-                                    message={
-                                        <p>
-                                            Close campaign <strong>{campaign.name}</strong>?
-                                        </p>
-                                    }
-                                    changesetsCount={openChangesetsCount}
-                                    buttonText="Close"
-                                    onButtonClick={onClose}
-                                    buttonClassName="btn-secondary mr-1"
-                                />
+                                <>
+                                    <button
+                                        type="button"
+                                        id="e2e-campaign-edit"
+                                        className="btn btn-secondary mr-1"
+                                        onClick={onEdit}
+                                        disabled={actionsDisabled}
+                                    >
+                                        Edit
+                                    </button>
+                                    <CloseDeleteCampaignPrompt
+                                        disabled={actionsDisabled}
+                                        disabledTooltip="Cannot close while campaign is being created"
+                                        message={
+                                            <p>
+                                                Close campaign <strong>{campaign.name}</strong>?
+                                            </p>
+                                        }
+                                        changesetsCount={openChangesetsCount}
+                                        buttonText="Close"
+                                        onButtonClick={onClose}
+                                        buttonClassName="btn-secondary mr-1"
+                                    />
+                                </>
                             )}
                             <CloseDeleteCampaignPrompt
                                 disabled={actionsDisabled}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignActionsBar.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignActionsBar.test.tsx.snap
@@ -83,6 +83,63 @@ exports[`CampaignActionsBar all changesets not open 1`] = `
 </div>
 `;
 
+exports[`CampaignActionsBar closed 1`] = `
+<div
+  className="d-flex mb-2 position-relative"
+>
+  <h2
+    className="m-0"
+  >
+    <span
+      className="badge badge-danger mr-2"
+    >
+      <Memo(ImageAutoAdjustIcon)
+        className="icon-inline campaign-actions-bar__campaign-icon"
+      />
+       Closed
+    </span>
+    <span>
+      <AnchorLink
+        to="/campaigns"
+      >
+        Campaigns
+      </AnchorLink>
+    </span>
+    <span
+      className="text-muted d-inline-block mx-2"
+    >
+      /
+    </span>
+    <span>
+      Super campaign
+    </span>
+  </h2>
+  <span
+    className="flex-grow-1 d-flex justify-content-end align-items-center"
+  >
+    <React.Fragment>
+      <CloseDeleteCampaignPrompt
+        buttonClassName="btn-danger"
+        buttonText="Delete"
+        changesetsCount={0}
+        disabled={false}
+        disabledTooltip="Cannot delete while campaign is being created"
+        message={
+          <p>
+            Delete campaign 
+            <strong>
+              Super campaign
+            </strong>
+            ?
+          </p>
+        }
+        onButtonClick={[Function]}
+      />
+    </React.Fragment>
+  </span>
+</div>
+`;
+
 exports[`CampaignActionsBar edit mode 1`] = `
 <div
   className="d-flex mb-2 position-relative"
@@ -200,72 +257,6 @@ exports[`CampaignActionsBar editable 1`] = `
         }
         onButtonClick={[Function]}
       />
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-danger"
-        buttonText="Delete"
-        changesetsCount={0}
-        disabled={false}
-        disabledTooltip="Cannot delete while campaign is being created"
-        message={
-          <p>
-            Delete campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
-    </React.Fragment>
-  </span>
-</div>
-`;
-
-exports[`CampaignActionsBar editable but closed 1`] = `
-<div
-  className="d-flex mb-2 position-relative"
->
-  <h2
-    className="m-0"
-  >
-    <span
-      className="badge badge-danger mr-2"
-    >
-      <Memo(ImageAutoAdjustIcon)
-        className="icon-inline campaign-actions-bar__campaign-icon"
-      />
-       Closed
-    </span>
-    <span>
-      <AnchorLink
-        to="/campaigns"
-      >
-        Campaigns
-      </AnchorLink>
-    </span>
-    <span
-      className="text-muted d-inline-block mx-2"
-    >
-      /
-    </span>
-    <span>
-      Super campaign
-    </span>
-  </h2>
-  <span
-    className="flex-grow-1 d-flex justify-content-end align-items-center"
-  >
-    <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={false}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignActionsBar.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignActionsBar.test.tsx.snap
@@ -35,32 +35,34 @@ exports[`CampaignActionsBar all changesets not open 1`] = `
     className="flex-grow-1 d-flex justify-content-end align-items-center"
   >
     <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={false}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-secondary mr-1"
-        buttonText="Close"
-        changesetsCount={0}
-        disabled={false}
-        disabledTooltip="Cannot close while campaign is being created"
-        message={
-          <p>
-            Close campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
+      <React.Fragment>
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={false}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <CloseDeleteCampaignPrompt
+          buttonClassName="btn-secondary mr-1"
+          buttonText="Close"
+          changesetsCount={0}
+          disabled={false}
+          disabledTooltip="Cannot close while campaign is being created"
+          message={
+            <p>
+              Close campaign 
+              <strong>
+                Super campaign
+              </strong>
+              ?
+            </p>
+          }
+          onButtonClick={[Function]}
+        />
+      </React.Fragment>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"
@@ -231,32 +233,34 @@ exports[`CampaignActionsBar editable 1`] = `
     className="flex-grow-1 d-flex justify-content-end align-items-center"
   >
     <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={false}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-secondary mr-1"
-        buttonText="Close"
-        changesetsCount={0}
-        disabled={false}
-        disabledTooltip="Cannot close while campaign is being created"
-        message={
-          <p>
-            Close campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
+      <React.Fragment>
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={false}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <CloseDeleteCampaignPrompt
+          buttonClassName="btn-secondary mr-1"
+          buttonText="Close"
+          changesetsCount={0}
+          disabled={false}
+          disabledTooltip="Cannot close while campaign is being created"
+          message={
+            <p>
+              Close campaign 
+              <strong>
+                Super campaign
+              </strong>
+              ?
+            </p>
+          }
+          onButtonClick={[Function]}
+        />
+      </React.Fragment>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"
@@ -317,32 +321,34 @@ exports[`CampaignActionsBar mode: closing 1`] = `
       className="mr-2"
     />
     <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={true}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-secondary mr-1"
-        buttonText="Close"
-        changesetsCount={0}
-        disabled={true}
-        disabledTooltip="Cannot close while campaign is being created"
-        message={
-          <p>
-            Close campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
+      <React.Fragment>
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={true}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <CloseDeleteCampaignPrompt
+          buttonClassName="btn-secondary mr-1"
+          buttonText="Close"
+          changesetsCount={0}
+          disabled={true}
+          disabledTooltip="Cannot close while campaign is being created"
+          message={
+            <p>
+              Close campaign 
+              <strong>
+                Super campaign
+              </strong>
+              ?
+            </p>
+          }
+          onButtonClick={[Function]}
+        />
+      </React.Fragment>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"
@@ -403,32 +409,34 @@ exports[`CampaignActionsBar mode: deleting 1`] = `
       className="mr-2"
     />
     <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={true}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-secondary mr-1"
-        buttonText="Close"
-        changesetsCount={0}
-        disabled={true}
-        disabledTooltip="Cannot close while campaign is being created"
-        message={
-          <p>
-            Close campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
+      <React.Fragment>
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={true}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <CloseDeleteCampaignPrompt
+          buttonClassName="btn-secondary mr-1"
+          buttonText="Close"
+          changesetsCount={0}
+          disabled={true}
+          disabledTooltip="Cannot close while campaign is being created"
+          message={
+            <p>
+              Close campaign 
+              <strong>
+                Super campaign
+              </strong>
+              ?
+            </p>
+          }
+          onButtonClick={[Function]}
+        />
+      </React.Fragment>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"
@@ -702,32 +710,34 @@ exports[`CampaignActionsBar some changesets still open 1`] = `
     className="flex-grow-1 d-flex justify-content-end align-items-center"
   >
     <React.Fragment>
-      <button
-        className="btn btn-secondary mr-1"
-        disabled={false}
-        id="e2e-campaign-edit"
-        onClick={[Function]}
-        type="button"
-      >
-        Edit
-      </button>
-      <CloseDeleteCampaignPrompt
-        buttonClassName="btn-secondary mr-1"
-        buttonText="Close"
-        changesetsCount={1}
-        disabled={false}
-        disabledTooltip="Cannot close while campaign is being created"
-        message={
-          <p>
-            Close campaign 
-            <strong>
-              Super campaign
-            </strong>
-            ?
-          </p>
-        }
-        onButtonClick={[Function]}
-      />
+      <React.Fragment>
+        <button
+          className="btn btn-secondary mr-1"
+          disabled={false}
+          id="e2e-campaign-edit"
+          onClick={[Function]}
+          type="button"
+        >
+          Edit
+        </button>
+        <CloseDeleteCampaignPrompt
+          buttonClassName="btn-secondary mr-1"
+          buttonText="Close"
+          changesetsCount={1}
+          disabled={false}
+          disabledTooltip="Cannot close while campaign is being created"
+          message={
+            <p>
+              Close campaign 
+              <strong>
+                Super campaign
+              </strong>
+              ?
+            </p>
+          }
+          onButtonClick={[Function]}
+        />
+      </React.Fragment>
       <CloseDeleteCampaignPrompt
         buttonClassName="btn-danger"
         buttonText="Delete"


### PR DESCRIPTION
This fixes the backend part of #9395 by not allowing the update of a closed campaign.
