### PR TITLE
Fix duplicated query when using a toggle after switching search modes

### DIFF
--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -321,6 +321,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             this.setState(state => ({
                 interactiveSearchMode: !state.interactiveSearchMode,
                 navbarSearchQueryState: { query: newQuery, cursorPosition: newQuery.length },
+                filtersInQuery: {},
             }))
         } else {
             this.setState(state => ({

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -62,7 +62,6 @@ interface Props
      */
     lowProfile: boolean
 
-    filtersInQuery: FiltersToTypeAndValue
     splitSearchModes: boolean
     interactiveSearchMode: boolean
     toggleSearchMode: (event: React.MouseEvent<HTMLAnchorElement>) => void

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -108,7 +108,6 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
     }
 
     public render(): JSX.Element {
-        console.log('MonacoQueryInput render filtersInQUery', (this.props as any).filtersInQuery)
         const options: Monaco.editor.IEditorOptions = {
             readOnly: false,
             lineNumbers: 'off',

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -15,7 +15,7 @@ import { Toggles, TogglesProps } from './toggles/Toggles'
 import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 
 export interface MonacoQueryInputProps
-    extends Omit<TogglesProps, 'navbarSearchQuery'>,
+    extends Omit<TogglesProps, 'navbarSearchQuery' | 'filtersInQuery'>,
         ThemeProps,
         CaseSensitivityProps,
         PatternTypeProps {
@@ -108,6 +108,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
     }
 
     public render(): JSX.Element {
+        console.log('MonacoQueryInput render filtersInQUery', (this.props as any).filtersInQuery)
         const options: Monaco.editor.IEditorOptions = {
             readOnly: false,
             lineNumbers: 'off',

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -18,7 +18,7 @@ import {
 import { eventLogger } from '../../tracking/eventLogger'
 import { scrollIntoView } from '../../util'
 import { Suggestion, SuggestionItem, createSuggestion, fuzzySearchFilters } from './Suggestion'
-import { PatternTypeProps, CaseSensitivityProps } from '..'
+import { PatternTypeProps, CaseSensitivityProps, InteractiveSearchProps } from '..'
 import Downshift from 'downshift'
 import { searchFilterSuggestions } from '../searchFilterSuggestions'
 import {
@@ -34,7 +34,7 @@ import { isDefined } from '../../../../shared/src/util/types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { once } from 'lodash'
 import { dedupeWhitespace } from '../../../../shared/src/util/strings'
-import { FiltersToTypeAndValue, FilterType } from '../../../../shared/src/search/interactive/util'
+import { FilterType } from '../../../../shared/src/search/interactive/util'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { Toggles } from './toggles/Toggles'
 
@@ -44,7 +44,11 @@ import { Toggles } from './toggles/Toggles'
  */
 export const queryUpdates = new Subject<string>()
 
-interface Props extends PatternTypeProps, CaseSensitivityProps, SettingsCascadeProps {
+interface Props
+    extends PatternTypeProps,
+        CaseSensitivityProps,
+        SettingsCascadeProps,
+        Partial<Pick<InteractiveSearchProps, 'filtersInQuery'>> {
     location: H.Location
     history: H.History
 
@@ -75,11 +79,6 @@ interface Props extends PatternTypeProps, CaseSensitivityProps, SettingsCascadeP
      * At most one query input per page should have this behavior.
      */
     hasGlobalQueryBehavior?: boolean
-
-    /**
-     * The filters in the query when in interactive search mode.
-     */
-    filterQuery?: FiltersToTypeAndValue
 
     /**
      * Whether to display the query input without any suggestions.
@@ -445,7 +444,6 @@ export class QueryInput extends React.Component<Props, State> {
                                 <Toggles
                                     {...this.props}
                                     navbarSearchQuery={this.props.value.query}
-                                    filtersInQuery={this.props.filterQuery}
                                     className="query-input2__toggle-container"
                                 />
                             </div>

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -29,7 +29,7 @@ import {
     filterStaticSuggestions,
 } from '../../helpers'
 import { dedupeWhitespace, isQuoted } from '../../../../../shared/src/util/strings'
-import { FiltersToTypeAndValue, FilterType, isNegatableFilter } from '../../../../../shared/src/search/interactive/util'
+import { FilterType, isNegatableFilter } from '../../../../../shared/src/search/interactive/util'
 import { startCase, isEqual } from 'lodash'
 import { searchFilterSuggestions } from '../../searchFilterSuggestions'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -37,13 +37,9 @@ import { CheckButton } from './CheckButton'
 import { isTextFilter, finiteFilters, isFiniteFilter, FilterTypeToProseNames } from './filters'
 import classNames from 'classnames'
 import { generateFiltersQuery } from '../../../../../shared/src/util/url'
+import { InteractiveSearchProps } from '../..'
 
-interface Props {
-    /**
-     * The filters currently added to the query.
-     */
-    filtersInQuery: FiltersToTypeAndValue
-
+interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
     /**
      * The query in the main query input.
      */

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -243,7 +243,7 @@ export class InteractiveModeInput extends React.Component<InteractiveModeProps, 
                                     caseSensitive={this.props.caseSensitive}
                                     setCaseSensitivity={this.props.setCaseSensitivity}
                                     autoFocus={true}
-                                    filterQuery={this.props.filtersInQuery}
+                                    filtersInQuery={this.props.filtersInQuery}
                                     withoutSuggestions={true}
                                     withSearchModeToggle={true}
                                 />

--- a/web/src/search/input/interactive/SelectedFiltersRow.tsx
+++ b/web/src/search/input/interactive/SelectedFiltersRow.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react'
 import { FilterInput } from './FilterInput'
 import { QueryState } from '../../helpers'
-import { FiltersToTypeAndValue, FilterType } from '../../../../../shared/src/search/interactive/util'
+import { FilterType } from '../../../../../shared/src/search/interactive/util'
+import { InteractiveSearchProps } from '../..'
 
-interface Props {
-    /**
-     * The filters currently added to the query.
-     */
-    filtersInQuery: FiltersToTypeAndValue
-
+interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
     /**
      * The query in the main query input.
      */

--- a/web/src/search/results/SearchResultTab.tsx
+++ b/web/src/search/results/SearchResultTab.tsx
@@ -5,15 +5,16 @@ import { NavLink } from 'react-router-dom'
 import { toggleSearchType } from '../helpers'
 import { buildSearchURLQuery, generateFiltersQuery } from '../../../../shared/src/util/url'
 import { constant } from 'lodash'
-import { PatternTypeProps, CaseSensitivityProps, parseSearchURLQuery } from '..'
-import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
+import { PatternTypeProps, CaseSensitivityProps, parseSearchURLQuery, InteractiveSearchProps } from '..'
 import { parseSearchQuery } from '../../../../shared/src/search/parser/parser'
 
-interface Props extends Omit<PatternTypeProps, 'setPatternType'>, Omit<CaseSensitivityProps, 'setCaseSensitivity'> {
+interface Props
+    extends Omit<PatternTypeProps, 'setPatternType'>,
+        Omit<CaseSensitivityProps, 'setCaseSensitivity'>,
+        Pick<InteractiveSearchProps, 'filtersInQuery'> {
     location: H.Location
     type: SearchType
     query: string
-    filtersInQuery: FiltersToTypeAndValue
 }
 
 const typeToProse: Record<Exclude<SearchType, null>, string> = {

--- a/web/src/search/results/SearchResultTypeTabs.tsx
+++ b/web/src/search/results/SearchResultTypeTabs.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react'
 import * as H from 'history'
 import { SearchResultTabHeader } from './SearchResultTab'
-import { PatternTypeProps, CaseSensitivityProps } from '..'
-import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
+import { PatternTypeProps, CaseSensitivityProps, InteractiveSearchProps } from '..'
 
-interface Props extends Omit<PatternTypeProps, 'setPatternType'>, Omit<CaseSensitivityProps, 'setCaseSensitivity'> {
+interface Props
+    extends Omit<PatternTypeProps, 'setPatternType'>,
+        Omit<CaseSensitivityProps, 'setCaseSensitivity'>,
+        Pick<InteractiveSearchProps, 'filtersInQuery'> {
     location: H.Location
     history: H.History
     query: string
-    filtersInQuery: FiltersToTypeAndValue
 }
 
 export const SearchResultTypeTabs: React.FunctionComponent<Props> = props => (

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -29,7 +29,6 @@ import { SearchResultsFilterBars, SearchScopeWithOptionalName } from './SearchRe
 import { SearchResultsList } from './SearchResultsList'
 import { SearchResultTypeTabs } from './SearchResultTypeTabs'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
-import { FiltersToTypeAndValue } from '../../../../shared/src/search/interactive/util'
 import { convertPlainTextToInteractiveQuery } from '../input/helpers'
 
 export interface SearchResultsProps
@@ -55,8 +54,6 @@ export interface SearchResultsProps
     ) => Observable<GQL.ISearchResults | ErrorLike>
     isSourcegraphDotCom: boolean
     deployType: DeployType
-    filtersInQuery: FiltersToTypeAndValue
-    interactiveSearchMode: boolean
 }
 
 interface SearchResultsState {


### PR DESCRIPTION
Fixes #9407 

Review by commit.

A better fix here might be to model query state in a way that would [make invalid states impossible](https://docs.sourcegraph.com/dev/typescript/patterns#making-invalid-states-impossible-through-union-types): having non-empty `filtersInQuery` state while in plain text mode is an invalid state. We could avoid this by removing the individual `interactiveSearchMode`, `filtersInQuery` state members in favour of an union like this:

```typescript
type QueryState =
    | {
          mode: 'plaintext'
          query: string
          cursorPosition: number
      }
    | {
        mode: 'interactive'
        filters: FiltersToTypeAndValue
        searchPattern: string
    }
```

This doesn't solve the pain point of nested components having to know about the search mode when they want to update the query (see https://github.com/sourcegraph/sourcegraph/pull/9225#discussion_r400034693)

cc @attfarhan 