### PR TITLE
Treat "merged" as final state for Changesets

### DIFF
--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -682,7 +682,8 @@ func (ce ChangesetEvents) State() ChangesetState {
 		case ChangesetEventKindGitHubClosed, ChangesetEventKindBitbucketServerDeclined:
 			state = ChangesetStateClosed
 		case ChangesetEventKindGitHubMerged, ChangesetEventKindBitbucketServerMerged:
-			state = ChangesetStateMerged
+			// Merged is a final state. We can ignore everything after.
+			return ChangesetStateMerged
 		case ChangesetEventKindGitHubReopened, ChangesetEventKindBitbucketServerReopened:
 			state = ChangesetStateOpen
 		}


### PR DESCRIPTION
This fixes #9396 by making the ChangesetEvents.Events method stable even
when GitHub emits Closed and Merged events at the same time.
