### PR TITLE
Improve changeset creation errors

### DIFF
--- a/.storybook/webpack.config.ts
+++ b/.storybook/webpack.config.ts
@@ -1,5 +1,5 @@
-import path from 'path'
-import webpack from 'webpack'
+import * as path from 'path'
+import * as webpack from 'webpack'
 
 export default ({ config }: { config: webpack.Configuration }) => {
     if (!config.module || !config.resolve?.extensions) {
@@ -10,7 +10,7 @@ export default ({ config }: { config: webpack.Configuration }) => {
         test: /\.tsx?$/,
         loader: require.resolve('babel-loader'),
         options: {
-            presets: [['react-app', { flow: false, typescript: true }]],
+            configFile: path.resolve(__dirname, '..', 'babel.config.js'),
         },
     })
     config.resolve.extensions.push('.ts', '.tsx')

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -178,8 +179,13 @@ func ExecChangesetJob(
 	})
 	if err != nil {
 		if diffErr, ok := err.(*protocol.CreateCommitFromPatchError); ok {
-			return errors.Errorf("creating commit from patch for repo %q: %q (command: %q, output: %q)",
-				diffErr.RepositoryName, diffErr.InternalError, diffErr.Command, diffErr.CombinedOutput)
+			return errors.Errorf(
+				"creating commit from patch for repository %q: %s\n"+
+					"```\n"+
+					"$ %s\n"+
+					"%s\n"+
+					"```",
+				diffErr.RepositoryName, diffErr.InternalError, diffErr.Command, strings.TrimSpace(diffErr.CombinedOutput))
 		}
 		return err
 	}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
-    "@babel/preset-react": "^7.9.1",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.2",
     "@gql2ts/from-schema": "^1.10.1",

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.story.tsx
@@ -1,0 +1,40 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { CampaignStatus } from './CampaignStatus'
+import { BackgroundProcessState } from '../../../../../shared/src/graphql/schema'
+import '../../../main.scss'
+import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
+
+const { add } = storiesOf('CampaignStatus', module).addDecorator(story => (
+    <div className="theme-light container">{story()}</div>
+))
+
+add('Errored', () => (
+    <CampaignStatus
+        campaign={{
+            viewerCanAdminister: boolean('Viewer can administer', true),
+            status: {
+                state: BackgroundProcessState.ERRORED,
+                completedCount: 0,
+                pendingCount: 2,
+                errors: Array.from({ length: 3 }).map(
+                    () =>
+                        'creating commit from patch for repository "github.com/go-macaron/switcher": gitserver: pushing ref: exit status 128\n' +
+                        '```\n' +
+                        '$ git push --force https://@github.com/go-macaron/switcher b1275f86053a021c630b354b414e522ce73244a1:refs/heads/campaign/migrate-from-travis-to-github-actions\n' +
+                        'remote: Permission to go-macaron/switcher.git denied to foobar.\n' +
+                        "fatal: unable to access 'https://github.com/go-macaron/switcher': The requested URL returned error: 403\n" +
+                        '```'
+                ),
+            },
+            changesets: {
+                totalCount: 0,
+            },
+            publishedAt: boolean('Is draft', false) ? null : new Date().toISOString(),
+            closedAt: null,
+        }}
+        onPublish={action('Publish')}
+        onRetry={action('Retry')}
+    />
+))

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
@@ -42,10 +42,8 @@ export const CampaignStatus: React.FunctionComponent<CampaignStatusProps> = ({ c
         <ul className="mt-2">
             {status.errors.map((error, i) => (
                 <li className="mb-2" key={i}>
-                    <p className="mb-0 text-monospace">
-                        <small>
-                            <ErrorMessage error={error} />
-                        </small>
+                    <p className="mb-0">
+                        <ErrorMessage error={error} />
                     </p>
                 </li>
             ))}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
@@ -19,26 +19,22 @@ exports[`CampaignStatus viewerCanAdminister: false campaign errored 1`] = `
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="a"
-                />
-              </small>
+              <ErrorMessage
+                error="a"
+              />
             </p>
           </li>
           <li
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="b"
-                />
-              </small>
+              <ErrorMessage
+                error="b"
+              />
             </p>
           </li>
         </ul>
@@ -91,26 +87,22 @@ exports[`CampaignStatus viewerCanAdminister: false campaign processing 1`] = `
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="a"
-                />
-              </small>
+              <ErrorMessage
+                error="a"
+              />
             </p>
           </li>
           <li
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="b"
-                />
-              </small>
+              <ErrorMessage
+                error="b"
+              />
             </p>
           </li>
         </ul>
@@ -191,26 +183,22 @@ exports[`CampaignStatus viewerCanAdminister: true campaign errored 1`] = `
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="a"
-                />
-              </small>
+              <ErrorMessage
+                error="a"
+              />
             </p>
           </li>
           <li
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="b"
-                />
-              </small>
+              <ErrorMessage
+                error="b"
+              />
             </p>
           </li>
         </ul>
@@ -270,26 +258,22 @@ exports[`CampaignStatus viewerCanAdminister: true campaign processing 1`] = `
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="a"
-                />
-              </small>
+              <ErrorMessage
+                error="a"
+              />
             </p>
           </li>
           <li
             className="mb-2"
           >
             <p
-              className="mb-0 text-monospace"
+              className="mb-0"
             >
-              <small>
-                <ErrorMessage
-                  error="b"
-                />
-              </small>
+              <ErrorMessage
+                error="b"
+              />
             </p>
           </li>
         </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,9 +713,9 @@
     "@babel/plugin-syntax-jsx" "^7.8.3"
 
 "@babel/plugin-transform-react-jsx@^7.9.1":
-  version "7.9.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.1.tgz#d03af29396a6dc51bfa24eefd8005a9fd381152a"
-  integrity sha512-+xIZ6fPoix7h57CNO/ZeYADchg1tFyX9NDsnmNFFua8e1JNPln156mzS+8AQe1On2X2GLlANHJWHIXbMCqWDkQ==
+  version "7.9.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.4.tgz#86f576c8540bd06d0e95e0b61ea76d55f6cbd03f"
+  integrity sha512-Mjqf3pZBNLt854CK0C/kRuXAnE6H/bo7xYojP+WGtX8glDGSibcwnsWwhwoSuRg0+EBnxPC1ouVnuetUIlPSAw==
   dependencies:
     "@babel/helper-builder-react-jsx" "^7.9.0"
     "@babel/helper-builder-react-jsx-experimental" "^7.9.0"
@@ -893,7 +893,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@7.9.1", "@babel/preset-react@^7.0.0", "@babel/preset-react@^7.9.1":
+"@babel/preset-react@7.9.1", "@babel/preset-react@^7.0.0":
   version "7.9.1"
   resolved "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.9.1.tgz#b346403c36d58c3bb544148272a0cefd9c28677a"
   integrity sha512-aJBYF23MPj0RNdp/4bHnAP0NVqqZRr9kl0NAOP4nJCex6OYVio59+dnQzsAWFuogdLyeaKA1hmfUIVZkY5J+TQ==
@@ -1852,7 +1852,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -18412,7 +18413,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.0.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
I noticed in [@unknwon's excellent write-up](https://gist.github.com/unknwon/b7c80d23e6b2a624e50e4073454959e0) that the error display could be better.

![screenshot](https://user-images.githubusercontent.com/2946214/77819068-088d0b80-7113-11ea-8522-39c5cb5f00db.png)

Here's what I noticed:
- The entire error being monospace is making it harder to read, and makes it feel like these are some "raw" errors from outside of our system that are not actionable. This makes me trust the system less, and it is inconsistent with error display elsewhere. In reality, these errors come from _our_ system, and the output actually hints at how to fix the error (403 means something is wrong with the authorization). I think we should display in a normal non-small font, to encourage and ease reading them.
- There are escaped newlines in the output, which stem from the command and output being embedded in a key=value style. It would be more readable if we could actually display the newlines. We already treat error messages as markdownish, so I took an approach of combining command and output into a code block, and prefixing the command with `$` to mirror a shell command. I think this should give enough of a distinction so that we don't need the key=value style. Since markdown is designed to be plaintext-human-readable, I think this doesn't make the error worse for any non-web-UI environments (for example, it would look great in the CLI too imo!)
- The link incorrectly includes the trailing single quote. This is not easily fixable as it is done by `marked`. The link is not particularly useful here though because it is a _git clone URL_, not necessarily a browser URL, and if we use the code block approach the link won't be linkified, so I think this is a nice solution from that perspective too.

To allow easier testing of such components now and in the future, I added a storybook (and fixed storybooks in general). This allows testing without having to create any campaigns, with toggling different states. I hope this will also be useful especially to non-engineers!

After:

![image](https://user-images.githubusercontent.com/10532611/78036998-3d939b00-736b-11ea-8b3f-a3208d775e9d.png)

@sourcegraph/campaigns-core please check if my Go is correct 🙈