### PR TITLE
metrics: introduce MustRegisterDiskMonitor

### DIFF
--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
 func (s *Server) RegisterMetrics() {
@@ -36,6 +37,12 @@ func (s *Server) RegisterMetrics() {
 		log15.Error("ReposDir is not set, cannot export disk_space_available metric.")
 		return
 	}
+
+	metrics.MustRegisterDiskMonitor(s.ReposDir)
+
+	// TODO(keegan) these are older names for the above disk metric. Keeping
+	// them to prevent breaking dashboards. Can remove once no
+	// alert/dashboards use them.
 	c := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "src",
 		Subsystem: "gitserver",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,12 +4,16 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
+
+// registerer exists so we can override it in tests
+var registerer = prometheus.DefaultRegisterer
 
 // RequestMeter wraps a Prometheus request meter (counter + duration histogram) updated by requests made by derived
 // http.RoundTrippers.
@@ -27,7 +31,7 @@ func NewRequestMeter(subsystem, help string) *RequestMeter {
 		Name:      "requests_total",
 		Help:      help,
 	}, []string{"category", "code", "host"})
-	prometheus.MustRegister(requestCounter)
+	registerer.MustRegister(requestCounter)
 
 	// TODO(uwedeportivo):
 	// A prometheus histogram has a request counter built in.
@@ -40,7 +44,7 @@ func NewRequestMeter(subsystem, help string) *RequestMeter {
 		Help:      "Time (in seconds) spent on request.",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"category", "code", "host"})
-	prometheus.MustRegister(requestDuration)
+	registerer.MustRegister(requestDuration)
 
 	return &RequestMeter{counter: requestCounter, duration: requestDuration, subsystem: subsystem}
 }
@@ -98,4 +102,43 @@ func (t *requestCounterMiddleware) RoundTrip(r *http.Request) (resp *http.Respon
 
 func (t *requestCounterMiddleware) Do(req *http.Request) (*http.Response, error) {
 	return t.RoundTrip(req)
+}
+
+// MustRegisterDiskMonitor exports two prometheus metrics
+// "src_disk_space_available_bytes{path=$path}" and
+// "src_disk_space_total_bytes{path=$path}". The values exported are for the
+// filesystem that path is on.
+//
+// It is safe to call this function more than once for the same path.
+func MustRegisterDiskMonitor(path string) {
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_disk_space_available_bytes",
+		Help:        "Amount of free space disk space.",
+		ConstLabels: prometheus.Labels{"path": path},
+	}, func() float64 {
+		var stat syscall.Statfs_t
+		_ = syscall.Statfs(path, &stat)
+		return float64(stat.Bavail * uint64(stat.Bsize))
+	}))
+
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_disk_space_total_bytes",
+		Help:        "Amount of total disk space.",
+		ConstLabels: prometheus.Labels{"path": path},
+	}, func() float64 {
+		var stat syscall.Statfs_t
+		_ = syscall.Statfs(path, &stat)
+		return float64(stat.Blocks * uint64(stat.Bsize))
+	}))
+
+}
+
+func mustRegisterOnce(c prometheus.Collector) {
+	err := registerer.Register(c)
+	if err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return
+		}
+		panic(err)
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -102,6 +104,8 @@ func (s *Store) Start() {
 			BackgroundTimeout: 2 * time.Minute,
 			BeforeEvict:       s.ZipCache.delete,
 		}
+		_ = os.MkdirAll(s.Path, 0700)
+		metrics.MustRegisterDiskMonitor(s.Path)
 		go s.watchAndEvict()
 	})
 }

--- a/internal/vfsutil/cache.go
+++ b/internal/vfsutil/cache.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
 // ArchiveCacheDir is the location on disk that archives are cached. It is
@@ -42,6 +44,7 @@ func (f *cachedFile) Evict() {
 // fetcher will fill the cache first. cachedFetch also performs
 // single-flighting.
 func cachedFetch(ctx context.Context, component, key string, fetcher func(context.Context) (io.ReadCloser, error)) (ff *cachedFile, err error) {
+	initArchiveCacheDir()
 	s := &diskcache.Store{
 		// Dir uses component as a subdir to prevent conflicts between
 		// components with the same key.
@@ -64,6 +67,15 @@ func zipNewFileReader(f *os.File) (*zip.Reader, error) {
 		return nil, err
 	}
 	return zip.NewReader(f, fi.Size())
+}
+
+var initOnce sync.Once
+
+func initArchiveCacheDir() {
+	initOnce.Do(func() {
+		_ = os.MkdirAll(ArchiveCacheDir, 0700)
+		metrics.MustRegisterDiskMonitor(ArchiveCacheDir)
+	})
 }
 
 var cachedFileEvict = prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
This will register a generic metric which can be used across all sourcegraph
services. It reports how much space is available and free for the FS that a
path is part of. It is generic version of our existing metrics
"src_gitserver_disk_space_available" and "src_gitserver_disk_space_total".

This PR adds this metric for the services frontend, searcher, replacer and gitserver.

Note: We don't set subsystem since we want to be able to see the space used
across services with one metric family. To differentiate between services we
will rely on the labels prometheus adds on collection and the path.

Part of https://github.com/sourcegraph/sourcegraph/issues/8308