### PR TITLE
Always show burndown chart for 7 days if campaign is not older

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -205,7 +205,11 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		return resolvers, err
 	}
 
+	weekAgo := time.Now().Add(-7 * 24 * time.Hour)
 	start := r.Campaign.CreatedAt.UTC()
+	if start.After(weekAgo) {
+		start = weekAgo
+	}
 	if args.From != nil {
 		start = args.From.Time.UTC()
 	}


### PR DESCRIPTION
Previously we showed the message "Burndown chart will be shown when
there is more than 1 day of data", because we used the Campaign's
`CreatedAt` as the starting point.

This changes the default behaviour and uses `min(campaign.CreatedAt, 7-days-ago)`.

### Before
<img width="1197" alt="before_counts" src="https://user-images.githubusercontent.com/1185253/78112143-12a65700-73fe-11ea-9978-ab7d032572f7.png">

### After

<img width="1193" alt="after_counts" src="https://user-images.githubusercontent.com/1185253/78112164-1934ce80-73fe-11ea-9d4e-149ffd738e56.png">
