### PR TITLE
Add repeatUntil() operator to remove kludge

### DIFF
--- a/shared/src/util/rxjs/repeatUntil.test.ts
+++ b/shared/src/util/rxjs/repeatUntil.test.ts
@@ -1,0 +1,54 @@
+import { TestScheduler } from 'rxjs/testing'
+import { from, defer } from 'rxjs'
+import { repeatUntil } from './repeatUntil'
+
+const scheduler = (): TestScheduler => new TestScheduler((a, b) => expect(a).toEqual(b))
+
+describe('repeatUntil()', () => {
+    it('completes if the last emitted value matches select', () => {
+        scheduler().run(({ cold, expectObservable }) => {
+            expectObservable(
+                from(
+                    cold<number>('a|', { a: 5 }).pipe(repeatUntil(v => v === 5))
+                )
+            ).toBe('a|', { a: 5 })
+        })
+    })
+
+    it('resubscribes until the last emitted value matches select', () => {
+        scheduler().run(({ cold, expectObservable }) => {
+            let n = 0
+            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 3))).toBe('abc|', {
+                a: 1,
+                b: 2,
+                c: 3,
+            })
+        })
+    })
+
+    it('never completes if the source observable never completes', () => {
+        scheduler().run(({ cold, expectObservable }) => {
+            expectObservable(
+                from(
+                    cold<number>('a', { a: 5 }).pipe(repeatUntil(v => v === 5))
+                )
+            ).toBe('a-', { a: 5 })
+        })
+    })
+
+    it('delays resubscription if delay is provided', () => {
+        scheduler().run(({ cold, expectObservable }) => {
+            let n = 0
+            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 5, 5000))).toBe(
+                'a 5s b 5s c 5s d 5s e|',
+                {
+                    a: 1,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                }
+            )
+        })
+    })
+})

--- a/shared/src/util/rxjs/repeatUntil.test.ts
+++ b/shared/src/util/rxjs/repeatUntil.test.ts
@@ -5,17 +5,17 @@ import { repeatUntil } from './repeatUntil'
 const scheduler = (): TestScheduler => new TestScheduler((a, b) => expect(a).toEqual(b))
 
 describe('repeatUntil()', () => {
-    it('completes if the last emitted value matches select', () => {
+    it('completes if the emitted value matches select', () => {
         scheduler().run(({ cold, expectObservable }) => {
             expectObservable(
                 from(
                     cold<number>('a|', { a: 5 }).pipe(repeatUntil(v => v === 5))
                 )
-            ).toBe('a|', { a: 5 })
+            ).toBe('(a|)', { a: 5 })
         })
     })
 
-    it('resubscribes until the last emitted value matches select', () => {
+    it('resubscribes until an emitted value matches select', () => {
         scheduler().run(({ cold, expectObservable }) => {
             let n = 0
             expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 3))).toBe('abc|', {
@@ -26,21 +26,11 @@ describe('repeatUntil()', () => {
         })
     })
 
-    it('never completes if the source observable never completes', () => {
-        scheduler().run(({ cold, expectObservable }) => {
-            expectObservable(
-                from(
-                    cold<number>('a', { a: 5 }).pipe(repeatUntil(v => v === 5))
-                )
-            ).toBe('a-', { a: 5 })
-        })
-    })
-
     it('delays resubscription if delay is provided', () => {
         scheduler().run(({ cold, expectObservable }) => {
             let n = 0
             expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 5, 5000))).toBe(
-                'a 5s b 5s c 5s d 5s e|',
+                'a 5s b 5s c 5s d 5s (e|)',
                 {
                     a: 1,
                     b: 2,

--- a/shared/src/util/rxjs/repeatUntil.test.ts
+++ b/shared/src/util/rxjs/repeatUntil.test.ts
@@ -18,7 +18,7 @@ describe('repeatUntil()', () => {
     it('resubscribes until an emitted value matches select', () => {
         scheduler().run(({ cold, expectObservable }) => {
             let n = 0
-            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 3))).toBe('abc|', {
+            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 3))).toBe('ab(c|)', {
                 a: 1,
                 b: 2,
                 c: 3,

--- a/shared/src/util/rxjs/repeatUntil.test.ts
+++ b/shared/src/util/rxjs/repeatUntil.test.ts
@@ -29,7 +29,7 @@ describe('repeatUntil()', () => {
     it('delays resubscription if delay is provided', () => {
         scheduler().run(({ cold, expectObservable }) => {
             let n = 0
-            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 5, 5000))).toBe(
+            expectObservable(defer(() => cold('a|', { a: ++n })).pipe(repeatUntil(v => v === 5, { delay: 5000 }))).toBe(
                 'a 5s b 5s c 5s d 5s (e|)',
                 {
                     a: 1,

--- a/shared/src/util/rxjs/repeatUntil.ts
+++ b/shared/src/util/rxjs/repeatUntil.ts
@@ -1,0 +1,22 @@
+import { Observable, merge, EMPTY, timer, of, defer } from 'rxjs'
+import { share, last, switchMap, switchMapTo } from 'rxjs/operators'
+
+/**
+ * Mirrors values from the source observable and resubscribes to the source observable when it completes,
+ * unless its last emitted value passes the provided condition. Resubscription is optionally delayed.
+ */
+export const repeatUntil = <T>(shouldComplete: (lastValue: T) => boolean, delay?: number) => (
+    source: Observable<T>
+): Observable<T> =>
+    defer(() => {
+        const sharedSource = source.pipe(share())
+        const repeatedSource = source.pipe(repeatUntil(shouldComplete, delay))
+        return merge(
+            sharedSource,
+            sharedSource.pipe(
+                last(),
+                switchMap(lastValue => (shouldComplete(lastValue) ? EMPTY : delay ? timer(delay) : of(null))),
+                switchMapTo(repeatedSource)
+            )
+        )
+    })

--- a/shared/src/util/rxjs/repeatUntil.ts
+++ b/shared/src/util/rxjs/repeatUntil.ts
@@ -5,11 +5,17 @@ import { repeatWhen, delay, takeWhile, repeat } from 'rxjs/operators'
  * Mirrors values from the source observable and resubscribes to the source observable when it completes,
  * until an emission matches the provided condition. Resubscription is optionally delayed.
  */
-export const repeatUntil = <T>(select: (value: T) => boolean, delayTime?: number) => (
-    source: Observable<T>
-): Observable<T> =>
+export const repeatUntil = <T>(
+    select: (value: T) => boolean,
+    options?: {
+        /**
+         * The delay in milliseconds between resubscriptions.
+         */
+        delay: number
+    }
+) => (source: Observable<T>): Observable<T> =>
     source.pipe(
-        delayTime ? repeatWhen(completions => completions.pipe(delay(delayTime))) : repeat(),
+        options ? repeatWhen(completions => completions.pipe(delay(options.delay))) : repeat(),
         // Inclusive takeWhile so that the first value matching `select()` is emitted.
         takeWhile(value => !select(value), true)
     )

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -27,7 +27,7 @@ import { Subject, of, merge, Observable, NEVER } from 'rxjs'
 import { renderMarkdown, highlightCodeSafe } from '../../../../../shared/src/util/markdown'
 import { ErrorAlert } from '../../../components/alerts'
 import { Markdown } from '../../../../../shared/src/components/Markdown'
-import { switchMap, tap, takeWhile, repeatWhen, delay, distinctUntilChanged } from 'rxjs/operators'
+import { switchMap, distinctUntilChanged } from 'rxjs/operators'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { CampaignDescriptionField } from './form/CampaignDescriptionField'
 import { CampaignStatus } from './CampaignStatus'
@@ -43,6 +43,7 @@ import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetrySer
 import { CampaignPatches } from './patches/CampaignPatches'
 import { PatchSetPatches } from './patches/PatchSetPatches'
 import { CampaignBranchField } from './form/CampaignBranchField'
+import { repeatUntil } from '../../../../../shared/src/util/rxjs/repeatUntil'
 
 export type CampaignUIMode = 'viewing' | 'editing' | 'saving' | 'deleting' | 'closing' | 'publishing'
 
@@ -129,24 +130,15 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         // on the very first fetch, a reload of the changesets is not required
         let isFirstCampaignFetch = true
 
-        let currentCampaign: Campaign | null
         // Fetch campaign if ID was given
         const subscription = merge(of(undefined), _noSubject ? new Observable<void>() : campaignUpdates)
             .pipe(
                 switchMap(() =>
                     _fetchCampaignById(campaignID).pipe(
-                        tap(campaign => {
-                            currentCampaign = campaign
-                        }),
                         // repeat fetching the campaign as long as the state is still processing
-                        repeatWhen(obs =>
-                            obs.pipe(
-                                takeWhile(
-                                    () => currentCampaign?.status?.state === GQL.BackgroundProcessState.PROCESSING
-                                ),
-                                delay(2000)
-                            )
-                        )
+                        repeatUntil(campaign => campaign?.status?.state !== GQL.BackgroundProcessState.PROCESSING, {
+                            delay: 2000,
+                        })
                     )
                 ),
                 distinctUntilChanged((a, b) => isEqual(a, b))

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -3,8 +3,8 @@ import CloudCheckIcon from 'mdi-react/CloudCheckIcon'
 import CloudSyncIcon from 'mdi-react/CloudSyncIcon'
 import React from 'react'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
-import { Observable, Subscription, of } from 'rxjs'
-import { catchError, map, repeatWhen, delay, tap, switchMap } from 'rxjs/operators'
+import { Observable, Subscription } from 'rxjs'
+import { catchError, map, repeatWhen, delay } from 'rxjs/operators'
 import { Link } from '../../../shared/src/components/Link'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -13,6 +13,7 @@ import { queryGraphQL } from '../backend/graphql'
 import classNames from 'classnames'
 import { ErrorAlert } from '../components/alerts'
 import * as H from 'history'
+import { repeatUntil } from '../../../shared/src/util/rxjs/repeatUntil'
 
 export function fetchAllStatusMessages(): Observable<GQL.StatusMessage[]> {
     return queryGraphQL(
@@ -118,24 +119,14 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
     private toggleIsOpen = (): void => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
 
     public componentDidMount(): void {
-        let lastWasSuccess = true
         this.subscriptions.add(
             this.props
                 .fetchMessages()
                 .pipe(
                     catchError(err => [asError(err) as ErrorLike]),
-                    tap(messagesOrError => {
-                        lastWasSuccess = !isErrorLike(messagesOrError) && messagesOrError.length === 0
-                    }),
-                    repeatWhen(obs =>
-                        obs.pipe(
-                            switchMap(() =>
-                                of(undefined).pipe(
-                                    delay(lastWasSuccess ? REFRESH_INTERVAL_MS : REFRESH_INTERVAL_AFTER_ERROR_MS)
-                                )
-                            )
-                        )
-                    )
+                    // Poll on REFRESH_INTERVAL_MS, or REFRESH_INTERVAL_AFTER_ERROR_MS if there is an error.
+                    repeatUntil(messagesOrError => isErrorLike(messagesOrError), { delay: REFRESH_INTERVAL_MS }),
+                    repeatWhen(completions => completions.pipe(delay(REFRESH_INTERVAL_AFTER_ERROR_MS)))
                 )
                 .subscribe(messagesOrError => this.setState({ messagesOrError }))
         )

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -1,6 +1,7 @@
 import { parse as parseJSONC } from '@sqs/jsonc-parser'
-import { Observable, Subject } from 'rxjs'
-import { map, mergeMap, startWith, tap } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+import { map, tap } from 'rxjs/operators'
+import { repeatUntil } from '../../../shared/src/util/rxjs/repeatUntil'
 import { createInvalidGraphQLMutationResponseError, dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { resetAllMemoizationCaches } from '../../../shared/src/util/memoizeObservable'
@@ -153,18 +154,15 @@ function fetchAllRepositories(args: RepositoryArgs): Observable<GQL.IRepositoryC
 export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
     args: RepositoryArgs
 ): Observable<GQL.IRepositoryConnection> {
-    // Poll if there are repositories that are being cloned or the list is empty.
-    //
-    // TODO(sqs): This is hacky, but I couldn't figure out a better way.
-    const subject = new Subject<null>()
-    return subject.pipe(
-        startWith(null),
-        mergeMap(() => fetchAllRepositories(args)),
-        tap(result => {
-            if (result.nodes && (result.nodes.length === 0 || result.nodes.some(n => !n.mirrorInfo.cloned))) {
-                setTimeout(() => subject.next(), 5000)
-            }
-        })
+    return fetchAllRepositories(args).pipe(
+        // Poll every 5000ms if repositories are being cloned or the list is empty.
+        repeatUntil(
+            result =>
+                result.nodes &&
+                result.nodes.length > 0 &&
+                result.nodes.every(n => !n.mirrorInfo.cloneInProgress && n.mirrorInfo.cloned),
+            5000
+        )
     )
 }
 

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -161,7 +161,7 @@ export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
                 result.nodes &&
                 result.nodes.length > 0 &&
                 result.nodes.every(n => !n.mirrorInfo.cloneInProgress && n.mirrorInfo.cloned),
-            5000
+            { delay: 5000 }
         )
     )
 }


### PR DESCRIPTION
I came across this kludge while reading through code, and thought I'd try to find the Right Way ™️ to fix it because it seemed fun. The use case for the new `repeatUntil()` operator here seems legit to me: polling until a condition is met, while still mirroring values (vs. `retryWhen()` polling, which only emits in the absence of an error).

There may be an even simpler way to do this, in which case I'd love to be further enlightened. This is obviously fairly low-priority to review 🙂 