### PR TITLE
Apply bandaid to symbols restarting in infinite loop

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -115,15 +115,23 @@ do_install() {
     done
     if ( go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race=$race $cmds ); then
         for cmd in $cmdlist ; do
-            # Check whether the binary of each command has changed
-            if ! cmp -s "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}" ; then
-                # Binary updated. Move it to correct location.
-                mv "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}"
-
+            # Symbols is special since it has its own build/install process. So
+            # we don't try to be smart and not compare old/new versions but simply restart.
+            if [ "${cmd}" = "symbols" ]; then
                 # Output name of command so it can be restarted.
                 if $verbose; then
                     echo "$cmd"
                 fi
+            else
+              # Check whether the binary of each command has changed
+              if ! cmp -s "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}" ; then
+                  # Binary updated. Move it to correct location.
+                  mv "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}"
+
+                  if $verbose; then
+                      echo "$cmd"
+                  fi
+              fi
             fi
         done
     else


### PR DESCRIPTION
See my previous cries for help for context:

- https://sourcegraph.slack.com/archives/CHPC7UX16/p1585734381060100
- https://sourcegraph.slack.com/archives/C07KZF47K/p1585635858081000
- https://sourcegraph.slack.com/archives/C07KZF47K/p1583916442139400

Short version: `symbols` keeps restarting for me ever since I made that change in #8912 

<img width="1247" alt="Screen Shot 2020-04-01 at 11 45 33" src="https://user-images.githubusercontent.com/1185253/78129003-27431900-7417-11ea-870c-8a8e4107e84a.png">


My current theory is that the existing check (which I'm changing here) doesn't work for symbols because:

1. In `./dev/go-install` we use `go install` to build the symbols binary
2. Then we restart `symbols`
3. `symbols` "starts" by doing its own compilation, which changes a file in `cmd/symbols/*`
4. That causes `handle-change.sh` to restart the service that's currently compiling???

Yes, it's not complete...

Anyway: this here fixes it for me locally and since nobody else

1. complained about the same bug
2. asked for my changes in #8912

I'm hereby reverting the changes in #8912 for symbols.