### PR TITLE
Use error names instead of error codes

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -41,7 +41,7 @@ import {
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
 import { DecorationMapByLine } from '../../../../shared/src/api/client/services/decoration'
 import { CodeEditorData, CodeEditorWithPartialModel } from '../../../../shared/src/api/client/services/editorService'
-import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../../shared/src/backend/errors'
+import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../../../../shared/src/backend/errors'
 import {
     CommandListClassProps,
     CommandListPopoverButtonClassProps,
@@ -713,7 +713,7 @@ export function handleCodeHost({
                 ),
                 catchError(err => {
                     // Ignore PrivateRepoPublicSourcegraph errors (don't initialize those code views)
-                    if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                    if (err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
                         return EMPTY
                     }
                     throw err

--- a/browser/src/libs/code_intelligence/code_views.ts
+++ b/browser/src/libs/code_intelligence/code_views.ts
@@ -3,7 +3,7 @@ import { Selection } from '@sourcegraph/extension-api-types'
 import { Observable, of, zip, OperatorFunction } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import { Omit } from 'utility-types'
-import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../../shared/src/backend/errors'
+import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../../../../shared/src/backend/errors'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { isErrorLike } from '../../../../shared/src/util/errors'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
@@ -133,7 +133,7 @@ export const fetchFileContents = (
             )
         }),
         catchError((err: any) => {
-            if (isErrorLike(err) && err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+            if (isErrorLike(err) && err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
                 return [info]
             }
             throw err

--- a/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/browser/src/libs/code_intelligence/util/file_info.ts
@@ -1,7 +1,7 @@
 import { Observable, of, zip } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 
-import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../../../shared/src/backend/errors'
+import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../../../../../shared/src/backend/errors'
 import { PlatformContext } from '../../../../../shared/src/platform/context'
 import { resolveRepo, resolveRev, retryWhenCloneInProgressError } from '../../../shared/repo/backend'
 import { FileInfo, FileInfoWithRepoNames } from '../code_intelligence'
@@ -53,7 +53,7 @@ export const resolveRepoNames = (
         // has access to that code. In that case, it's impossible to resolve the repo names,
         // so we keep the repo names inferred from the code host's DOM.
         catchError(err => {
-            if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+            if (err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
                 return [{ rawRepoName, baseRawRepoName, repoName: rawRepoName, baseRepoName: baseRawRepoName, ...rest }]
             }
             throw err

--- a/browser/src/libs/options/OptionsContainer.tsx
+++ b/browser/src/libs/options/OptionsContainer.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap, concatMap } from 'rxjs/operators'
-import { ERAUTHREQUIRED } from '../../../../shared/src/backend/errors'
+import { AUTH_REQUIRED_ERROR_NAME } from '../../../../shared/src/backend/errors'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { getExtensionVersion } from '../../shared/util/context'
 import { OptionsMenu, OptionsMenuProps } from './OptionsMenu'
@@ -87,7 +87,9 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                     this.setState({
                         status: 'error',
                         connectionError:
-                            res.code === ERAUTHREQUIRED ? ConnectionErrors.AuthError : ConnectionErrors.UnableToConnect,
+                            res.name === AUTH_REQUIRED_ERROR_NAME
+                                ? ConnectionErrors.AuthError
+                                : ConnectionErrors.UnableToConnect,
                     })
                     url = this.state.sourcegraphURL
                 } else {

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -8,7 +8,7 @@ import { storage } from '../../browser/storage'
 import { isExtension } from '../../context'
 import { resolveRepo } from '../../shared/repo/backend'
 import { normalizeRepoName } from './util'
-import { EREPONOTFOUND } from '../../../../shared/src/backend/errors'
+import { REPO_NOT_FOUND_ERROR_NAME } from '../../../../shared/src/backend/errors'
 import { RepoSpec, FileSpec, ResolvedRevSpec } from '../../../../shared/src/util/url'
 import { RevisionSpec, DiffSpec, BaseDiffSpec } from '.'
 import { checkOk } from '../../../../shared/src/backend/fetch'
@@ -576,7 +576,7 @@ export function resolveDiffRev(
                 // Otherwise, create a one-off commit containing the patch on the Sourcegraph instance,
                 // and resolve to the commit ID returned by the Sourcegraph instance.
                 catchError(error => {
-                    if (error.code !== EREPONOTFOUND) {
+                    if (error.name !== REPO_NOT_FOUND_ERROR_NAME) {
                         throw error
                     }
                     return getRawDiffFromConduit(props.diffID, queryConduit).pipe(

--- a/browser/src/shared/repo/backend.tsx
+++ b/browser/src/shared/repo/backend.tsx
@@ -1,16 +1,15 @@
 import { from, Observable } from 'rxjs'
 import { catchError, delay, filter, map, retryWhen } from 'rxjs/operators'
 import {
-    AggregateError,
     CloneInProgressError,
-    ECLONEINPROGESS,
+    CLONE_IN_PROGRESS_ERROR_NAME,
     RepoNotFoundError,
     RevNotFoundError,
 } from '../../../../shared/src/backend/errors'
 import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
-import { isErrorLike } from '../../../../shared/src/util/errors'
+import { isErrorLike, createAggregateError } from '../../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../../shared/src/util/memoizeObservable'
 import { FileSpec, makeRepoURI, RawRepoSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 
@@ -96,7 +95,7 @@ export function retryWhenCloneInProgressError<T>(): (v: Observable<T>) => Observ
             retryWhen(errors =>
                 errors.pipe(
                     filter(err => {
-                        if (isErrorLike(err) && err.code === ECLONEINPROGESS) {
+                        if (isErrorLike(err) && err.name === CLONE_IN_PROGRESS_ERROR_NAME) {
                             return true
                         }
 
@@ -153,7 +152,7 @@ export const fetchBlobContentLines = memoizeObservable(
                             return []
                         }
                     }
-                    throw new AggregateError(errors)
+                    throw createAggregateError(errors)
                 }
                 const { repository } = data
                 if (!repository || !repository.commit || !repository.commit.file || !repository.commit.file.content) {

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@primer/octicons-react": "^9.6.0",
     "@sentry/browser": "^5.13.2",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^6.3.2",
+    "@sourcegraph/codeintellify": "^6.3.3",
     "@sourcegraph/comlink": "^3.1.1-fork.3",
     "@sourcegraph/extension-api-classes": "^1.0.3",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -121,10 +121,9 @@ export interface EditorService {
     removeAllEditors(): void
 }
 
-const EEDITORNOTFOUND = 'EditorNotFoundError'
+const EDITOR_NOT_FOUND_ERROR_NAME = 'EditorNotFoundError'
 class EditorNotFoundError extends Error {
-    public readonly name = EEDITORNOTFOUND
-    public readonly code = EEDITORNOTFOUND
+    public readonly name = EDITOR_NOT_FOUND_ERROR_NAME
     constructor(editorId: string) {
         super(`editor not found: ${editorId}`)
     }

--- a/shared/src/api/extension/api/common.ts
+++ b/shared/src/api/extension/api/common.ts
@@ -32,7 +32,7 @@ const proxySubscribable = <T>(subscribable: Subscribable<T>): ProxySubscribable<
                     // Only pass a few well-known Error properties
                     // TODO should pass all properties serialized recursively, best handled on comlink level
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    observer.error(err && { message: err.message, name: err.name, code: err.code, stack: err.stack })
+                    observer.error(err && { message: err.message, name: err.name, stack: err.stack })
                 },
                 complete: () => {
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/shared/src/api/extension/api/documents.ts
+++ b/shared/src/api/extension/api/documents.ts
@@ -9,10 +9,9 @@ export interface ExtDocumentsAPI extends ProxyValue {
     $acceptDocumentData(modelUpdates: readonly TextModelUpdate[]): void
 }
 
-const EDOCUMENTNOTFOUND = 'DocumentNotFoundError'
+const DOCUMENT_NOT_FOUND_ERROR_NAME = 'DocumentNotFoundError'
 class DocumentNotFoundError extends Error {
-    public readonly name = EDOCUMENTNOTFOUND
-    public readonly code = EDOCUMENTNOTFOUND
+    public readonly name = DOCUMENT_NOT_FOUND_ERROR_NAME
     constructor(resource: string) {
         super(`document not found: ${resource}`)
     }

--- a/shared/src/backend/errors.ts
+++ b/shared/src/backend/errors.ts
@@ -1,49 +1,30 @@
-import { asError, ErrorLike } from '../util/errors'
-
-export const EAGGREGATE = 'AggregateError'
-/**
- * An Error that aggregates multiple errors
- */
-export class AggregateError extends Error {
-    public readonly name = EAGGREGATE
-    public readonly code = EAGGREGATE
-    constructor(public readonly errors: ErrorLike[] = []) {
-        super(errors.map(({ message }) => message).join('\n'))
-        this.errors = errors.map(asError)
-    }
-}
-
-export const ECLONEINPROGESS = 'CloneInProgressError'
+export const CLONE_IN_PROGRESS_ERROR_NAME = 'CloneInProgressError'
 export class CloneInProgressError extends Error {
-    public readonly name = ECLONEINPROGESS
-    public readonly code = ECLONEINPROGESS
+    public readonly name = CLONE_IN_PROGRESS_ERROR_NAME
     constructor(repoName: string, public readonly progress?: string) {
         super(`${repoName} is clone in progress`)
     }
 }
 
-export const EREPONOTFOUND = 'RepoNotFoundError'
+export const REPO_NOT_FOUND_ERROR_NAME = 'RepoNotFoundError'
 export class RepoNotFoundError extends Error {
-    public readonly name = EREPONOTFOUND
-    public readonly code = EREPONOTFOUND
+    public readonly name = REPO_NOT_FOUND_ERROR_NAME
     constructor(repoName: string) {
         super(`repo ${repoName} not found`)
     }
 }
 
-export const EREVNOTFOUND = 'RevNotFoundError'
+export const REV_NOT_FOUND_ERROR_NAME = 'RevNotFoundError'
 export class RevNotFoundError extends Error {
-    public readonly name = EREVNOTFOUND
-    public readonly code = EREVNOTFOUND
+    public readonly name = REV_NOT_FOUND_ERROR_NAME
     constructor(rev?: string) {
         super(`rev ${String(rev)} not found`)
     }
 }
 
-export const EREPOSEEOTHER = 'ERREPOSEEOTHER'
+export const REPO_SEE_OTHER_ERROR_NAME = 'RepoSeeOtherError'
 export class RepoSeeOtherError extends Error {
-    public readonly name = EREPOSEEOTHER
-    public readonly code = EREPOSEEOTHER
+    public readonly name = REPO_SEE_OTHER_ERROR_NAME
     constructor(public readonly redirectURL: string) {
         super(`Repository not found at this location, but might exist at ${redirectURL}`)
     }
@@ -56,10 +37,9 @@ export class RepoSeeOtherError extends Error {
  * `requestMightContainPrivateInfo` argument to `requestGraphQL` is explicitly
  * set to false (defaults to true to be conservative).
  */
-export const ERPRIVATEREPOPUBLICSOURCEGRAPHCOM = 'PrivateRepoPublicSourcegraph'
+export const PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME = 'PrivateRepoPublicSourcegraphError'
 export class PrivateRepoPublicSourcegraphComError extends Error {
-    public readonly name = ERPRIVATEREPOPUBLICSOURCEGRAPHCOM
-    public readonly code = ERPRIVATEREPOPUBLICSOURCEGRAPHCOM
+    public readonly name = PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME
     constructor(graphQLName: string) {
         super(
             `A ${graphQLName} GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.`
@@ -67,4 +47,4 @@ export class PrivateRepoPublicSourcegraphComError extends Error {
     }
 }
 
-export const ERAUTHREQUIRED = 'AuthRequiredError'
+export const AUTH_REQUIRED_ERROR_NAME = 'AuthRequiredError'

--- a/shared/src/backend/fetch.ts
+++ b/shared/src/backend/fetch.ts
@@ -4,7 +4,6 @@ const EHTTPSTATUS = 'HTTPStatusError'
 
 export class HTTPStatusError extends Error {
     public readonly name = EHTTPSTATUS
-    public readonly code = EHTTPSTATUS
     public readonly status: number
 
     constructor(response: Response) {

--- a/shared/src/graphql/graphql.ts
+++ b/shared/src/graphql/graphql.ts
@@ -25,14 +25,14 @@ export type GraphQLResult<T extends GQL.IQuery | GQL.IMutation> = SuccessGraphQL
 /**
  * Guarantees that the GraphQL query resulted in an error.
  */
-export function isGraphQLError<T extends GQL.IQuery | GQL.IMutation>(
+export function isErrorGraphQLResult<T extends GQL.IQuery | GQL.IMutation>(
     result: GraphQLResult<T>
 ): result is ErrorGraphQLResult {
     return !!(result as ErrorGraphQLResult).errors && (result as ErrorGraphQLResult).errors.length > 0
 }
 
 export function dataOrThrowErrors<T extends GQL.IQuery | GQL.IMutation>(result: GraphQLResult<T>): T {
-    if (isGraphQLError(result)) {
+    if (isErrorGraphQLResult(result)) {
         throw createAggregateError(result.errors)
     }
     return result.data

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -169,13 +169,13 @@ describe('HoverOverlay', () => {
 
     test('actions error', () => {
         expect(
-            renderShallow(<HoverOverlay {...commonProps} actionsOrError={{ message: 'm', code: 'c' }} />)
+            renderShallow(<HoverOverlay {...commonProps} actionsOrError={{ message: 'm', name: 'c' }} />)
         ).toMatchSnapshot()
     })
 
     test('hover error', () => {
         expect(
-            renderShallow(<HoverOverlay {...commonProps} hoverOrError={{ message: 'm', code: 'c' }} />)
+            renderShallow(<HoverOverlay {...commonProps} hoverOrError={{ message: 'm', name: 'c' }} />)
         ).toMatchSnapshot()
     })
 
@@ -184,8 +184,8 @@ describe('HoverOverlay', () => {
             renderShallow(
                 <HoverOverlay
                     {...commonProps}
-                    actionsOrError={{ message: 'm1', code: 'c1' }}
-                    hoverOrError={{ message: 'm2', code: 'c2' }}
+                    actionsOrError={{ message: 'm1', name: 'c1' }}
+                    hoverOrError={{ message: 'm2', name: 'c2' }}
                 />
             )
         ).toMatchSnapshot()
@@ -196,7 +196,7 @@ describe('HoverOverlay', () => {
             renderShallow(
                 <HoverOverlay
                     {...commonProps}
-                    actionsOrError={{ message: 'm', code: 'c' }}
+                    actionsOrError={{ message: 'm', name: 'c' }}
                     hoverOrError={{ contents: [{ kind: MarkupKind.Markdown, value: 'v' }] }}
                 />
             )
@@ -209,7 +209,7 @@ describe('HoverOverlay', () => {
                 <HoverOverlay
                     {...commonProps}
                     actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
-                    hoverOrError={{ message: 'm', code: 'c' }}
+                    hoverOrError={{ message: 'm', name: 'c' }}
                 />
             )
         ).toMatchSnapshot()

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -20,7 +20,7 @@ import { parse, parseTemplate } from '../api/client/context/expr/evaluator'
 import { Services } from '../api/client/services'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { ContributableMenu, TextDocumentPositionParams } from '../api/protocol'
-import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../backend/errors'
+import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../backend/errors'
 import { resolveRawRepoName } from '../backend/repo'
 import { getContributedActionItems } from '../contributions/contributions'
 import { ExtensionsControllerProps } from '../extensions/controller'
@@ -231,7 +231,7 @@ export function getDefinitionURL(
                 // we're executing in a browser extension pointed to the public sourcegraph.com,
                 // in which case repoName === rawRepoName.
                 catchError(err => {
-                    if (isErrorLike(err) && err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                    if (isErrorLike(err) && err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
                         return [uri.repoName]
                     }
                     throw err

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -1,10 +1,10 @@
 export interface ErrorLike {
     message: string
-    code?: string
+    name?: string
 }
 
 export const isErrorLike = (val: unknown): val is ErrorLike =>
-    typeof val === 'object' && !!val && ('stack' in val || 'message' in val || 'code' in val) && !('__typename' in val)
+    typeof val === 'object' && !!val && ('stack' in val || 'message' in val) && !('__typename' in val)
 
 /**
  * Converts an ErrorLike to a proper Error if needed, copying all properties

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -6,13 +6,17 @@ import {
     gql,
     dataOrThrowErrors,
     createInvalidGraphQLMutationResponseError,
-    isGraphQLError,
+    isErrorGraphQLResult,
 } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { GraphQLClient } from './GraphQLClient'
 import { map, tap, retryWhen, delayWhen, take, mergeMap } from 'rxjs/operators'
 import { zip, timer, concat, throwError, defer, Observable } from 'rxjs'
-import { CloneInProgressError, ECLONEINPROGESS, EREPONOTFOUND } from '../../../../shared/src/backend/errors'
+import {
+    CloneInProgressError,
+    CLONE_IN_PROGRESS_ERROR_NAME,
+    REPO_NOT_FOUND_ERROR_NAME,
+} from '../../../../shared/src/backend/errors'
 import { isErrorLike, createAggregateError } from '../../../../shared/src/util/errors'
 import { ResourceDestructor } from './TestResourceManager'
 import { Config } from '../../../../shared/src/e2e/config'
@@ -87,7 +91,10 @@ export function waitForRepo(
         ? request.pipe(
               map(result => {
                   // map to true if repo is not found, false if repo is found, throw other errors
-                  if (isGraphQLError(result) && result.errors.some(err => err.code === EREPONOTFOUND)) {
+                  if (
+                      isErrorGraphQLResult(result) &&
+                      result.errors.some(err => err.name === REPO_NOT_FOUND_ERROR_NAME)
+                  ) {
                       return undefined
                   }
                   const { repository } = dataOrThrowErrors(result)
@@ -138,7 +145,7 @@ export function waitForRepo(
                   concat(
                       errors.pipe(
                           delayWhen((error, retryCount) => {
-                              if (isErrorLike(error) && error.code === ECLONEINPROGESS) {
+                              if (isErrorLike(error) && error.name === CLONE_IN_PROGRESS_ERROR_NAME) {
                                   // Delay retry by 2s.
                                   if (logStatusMessages) {
                                       console.log(

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -6,7 +6,11 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Subject, Subscription, concat, combineLatest } from 'rxjs'
 import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
 import { redirectToExternalHost } from '.'
-import { EREPONOTFOUND, EREPOSEEOTHER, RepoSeeOtherError } from '../../../shared/src/backend/errors'
+import {
+    REPO_NOT_FOUND_ERROR_NAME,
+    REPO_SEE_OTHER_ERROR_NAME,
+    RepoSeeOtherError,
+} from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -151,8 +155,8 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             [undefined],
                             fetchRepository({ repoName }).pipe(
                                 catchError(error => {
-                                    switch (error.code) {
-                                        case EREPOSEEOTHER:
+                                    switch (error.name) {
+                                        case REPO_SEE_OTHER_ERROR_NAME:
                                             redirectToExternalHost((error as RepoSeeOtherError).redirectURL)
                                             return []
                                     }
@@ -277,8 +281,8 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
 
         if (isErrorLike(this.state.repoOrError)) {
             // Display error page
-            switch (this.state.repoOrError.code) {
-                case EREPONOTFOUND:
+            switch (this.state.repoOrError.name) {
+                case REPO_NOT_FOUND_ERROR_NAME:
                     return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
                 default:
                     return (

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -7,7 +7,12 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { UncontrolledPopover } from 'reactstrap'
 import { defer, Subject, Subscription } from 'rxjs'
 import { catchError, delay, distinctUntilChanged, map, retryWhen, switchMap, tap } from 'rxjs/operators'
-import { CloneInProgressError, ECLONEINPROGESS, EREPONOTFOUND, EREVNOTFOUND } from '../../../shared/src/backend/errors'
+import {
+    CloneInProgressError,
+    CLONE_IN_PROGRESS_ERROR_NAME,
+    REPO_NOT_FOUND_ERROR_NAME,
+    REV_NOT_FOUND_ERROR_NAME,
+} from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -119,8 +124,8 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                             retryWhen(errors =>
                                 errors.pipe(
                                     tap(error => {
-                                        switch (error.code) {
-                                            case ECLONEINPROGESS:
+                                        switch (error.name) {
+                                            case CLONE_IN_PROGRESS_ERROR_NAME:
                                                 // Display cloning screen to the user and retry
                                                 this.props.onResolvedRevOrError(error)
                                                 return
@@ -170,15 +175,15 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
 
         if (isErrorLike(this.props.resolvedRevOrError)) {
             // Show error page
-            switch (this.props.resolvedRevOrError.code) {
-                case ECLONEINPROGESS:
+            switch (this.props.resolvedRevOrError.name) {
+                case CLONE_IN_PROGRESS_ERROR_NAME:
                     return (
                         <RepositoryCloningInProgressPage
                             repoName={this.props.repo.name}
                             progress={(this.props.resolvedRevOrError as CloneInProgressError).progress}
                         />
                     )
-                case EREPONOTFOUND:
+                case REPO_NOT_FOUND_ERROR_NAME:
                     return (
                         <HeroPage
                             icon={MapSearchIcon}
@@ -186,7 +191,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                             subtitle="The requested repository was not found."
                         />
                     )
-                case EREVNOTFOUND:
+                case REV_NOT_FOUND_ERROR_NAME:
                     if (!this.props.rev) {
                         return <EmptyRepositoryPage />
                     }

--- a/web/src/repo/RepositoryGitDataContainer.tsx
+++ b/web/src/repo/RepositoryGitDataContainer.tsx
@@ -3,7 +3,11 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import * as React from 'react'
 import { defer, Subject, Subscription } from 'rxjs'
 import { catchError, delay, distinctUntilChanged, map, retryWhen, switchMap, tap } from 'rxjs/operators'
-import { CloneInProgressError, ECLONEINPROGESS, EREVNOTFOUND } from '../../../shared/src/backend/errors'
+import {
+    CloneInProgressError,
+    CLONE_IN_PROGRESS_ERROR_NAME,
+    REV_NOT_FOUND_ERROR_NAME,
+} from '../../../shared/src/backend/errors'
 import { RepoQuestionIcon } from '../../../shared/src/components/icons'
 import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
@@ -71,8 +75,8 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
                             retryWhen(errors =>
                                 errors.pipe(
                                     tap(error => {
-                                        switch (error.code) {
-                                            case ECLONEINPROGESS:
+                                        switch (error.name) {
+                                            case CLONE_IN_PROGRESS_ERROR_NAME:
                                                 // Display cloning screen to the user and retry
                                                 this.setState({ gitDataPresentOrError: error })
                                                 return
@@ -116,15 +120,15 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
 
         if (isErrorLike(this.state.gitDataPresentOrError)) {
             // Show error page
-            switch (this.state.gitDataPresentOrError.code) {
-                case ECLONEINPROGESS:
+            switch (this.state.gitDataPresentOrError.name) {
+                case CLONE_IN_PROGRESS_ERROR_NAME:
                     return (
                         <RepositoryCloningInProgressPage
                             repoName={this.props.repoName}
                             progress={(this.state.gitDataPresentOrError as CloneInProgressError).progress}
                         />
                     )
-                case EREVNOTFOUND:
+                case REV_NOT_FOUND_ERROR_NAME:
                     return <EmptyRepositoryPage />
                 default:
                     return (

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -137,7 +137,7 @@ describe('SearchResultsList', () => {
     it('shows error message when the search GraphQL request returns an error', () => {
         const { container } = render(
             <BrowserRouter>
-                <SearchResultsList {...defaultProps} resultsOrError={{ message: 'test error', code: 'error' }} />
+                <SearchResultsList {...defaultProps} resultsOrError={{ message: 'test error', name: 'TestError' }} />
             </BrowserRouter>
         )
         expect(getByTestId(container, 'search-results-list-error')).toBeTruthy()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,10 +1791,10 @@
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.4"
 
-"@sourcegraph/codeintellify@^6.3.2":
-  version "6.3.2"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.3.2.tgz#8b7fc0f308bf84d273161da6320a6960f4dff269"
-  integrity sha512-RJ4w5WmToIkcAeA0TKdKTcOj4dyG1TMpsrpnRfLfSw8vP5go1HtAHYz7tdJqkFZ/UGq5onuGTl56jVFeEhHnJg==
+"@sourcegraph/codeintellify@^6.3.3":
+  version "6.3.3"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.3.3.tgz#f2a7c82a01841a496677dfc12a45bad15b878da6"
+  integrity sha512-1Tl4PE2EhSTN7TJIqsha82o1ffXrqRJIrnR3ybLi4fSB5neb1tAmKrXRFa8jnC4XrZP4KVUL1C+uLkz/D6fuSQ==
   dependencies:
     "@sourcegraph/event-positions" "^1.0.4"
     "@sourcegraph/extension-api-types" "^2.0.0"
@@ -1846,7 +1846,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -18399,7 +18400,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.0.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Errors in ECMAScript have a `message` and a `name`. `code` is something Node-specific (`ErrNoException` interface in TS), and those errors still all have `name`. Native errors like `TypeError`, `URIError`, `AggregateError` (coming soon) all only have `name`.

When we send errors to/from background pages or web workers, we can only reasonably expect `name` to be present, so we should never rely on `code`. See e.g. https://github.com/mozilla/webextension-polyfill/issues/210 or `comlink` source code. This is a preliminary requirement to fix and prevent bugs like https://github.com/sourcegraph/sourcegraph/issues/9411.

Using both in our codebase inconsistently opens the risk to checking for the wrong property, (especially because errors are `any` in TypeScript) and adds additional code.

This change removes all uses of `code` in favor of `name`. There is still a case for having `name` be optional (e.g. GraphQL errors don't have a `name`, but do have `message`), so `ErrorLike` is still kept for now but we could think about just using the native `Error` interface in the future.

The error code constants were following NodeJS/Unix `errno` conventions, which don't make a lot of sense for error names and can become very unreadable. I propose the more readable CONSTANT_CASE we use elsewhere.

Depends on https://github.com/sourcegraph/codeintellify/pull/240