### PR TITLE
search: add smart paren handling for and/or queries

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -185,6 +185,42 @@ func ScanParameter(parameter []byte) Parameter {
 	return Parameter{Field: "", Value: string(parameter)}
 }
 
+// ParseSearchPatternWithParens attempts to parse a search pattern containing
+// parentheses at the current position. There are cases where we want to
+// interpret parentheses as part of a search pattern, rather than an and/or
+// expression group. For example, In the regex foo(a|b)bar, we want to preserve
+// parentheses as part of the pattern.
+func (p *parser) ParseSearchPatternWithParens() (Parameter, bool) {
+	start := p.pos
+	balanced := 0
+	for {
+		if p.expect(`\ `) || p.expect(`\(`) || p.expect(`\)`) {
+			continue
+		}
+		if p.expect(LPAREN) {
+			balanced += 1
+			continue
+		}
+		if p.expect(RPAREN) {
+			balanced -= 1
+			continue
+		}
+		if p.done() {
+			break
+		}
+		if isSpace(p.buf[p.pos]) {
+			break
+		}
+		p.pos++
+	}
+	if balanced != 0 {
+		// Trying to parse the pattern is unbalanced, perhaps it is an and/or expression.
+		p.pos = start // Backtrack.
+		return Parameter{Field: "", Value: ""}, false
+	}
+	return ScanParameter(p.buf[start:p.pos]), true
+}
+
 // ParseParameter returns valid leaf node values for AND/OR queries, taking into
 // account escape sequences for special syntax: whitespace and parentheses.
 func (p *parser) ParseParameter() Parameter {
@@ -304,13 +340,21 @@ loop:
 			break loop
 		}
 		switch {
-		case p.expect(LPAREN):
-			p.balanced++
-			result, err := p.parseOr()
-			if err != nil {
-				return nil, err
+		case p.match(LPAREN):
+			// First try parse a parameter as a search pattern containing parens.
+			if parameter, ok := p.ParseSearchPatternWithParens(); ok {
+				nodes = append(nodes, parameter)
+			} else {
+				// If the above failed, we treat this paren
+				// group as part of an and/or expression.
+				_ = p.expect(LPAREN) // Guaranteed to succeed.
+				p.balanced++
+				result, err := p.parseOr()
+				if err != nil {
+					return nil, err
+				}
+				nodes = append(nodes, result...)
 			}
-			nodes = append(nodes, result...)
 		case p.expect(RPAREN):
 			p.balanced--
 			if len(nodes) == 0 {
@@ -322,8 +366,13 @@ loop:
 			// Caller advances.
 			break loop
 		default:
-			parameter := p.ParseParameter()
-			nodes = append(nodes, parameter)
+			// First try parse a parameter as a search pattern containing parens.
+			if parameter, ok := p.ParseSearchPatternWithParens(); ok {
+				nodes = append(nodes, parameter)
+			} else {
+				parameter := p.ParseParameter()
+				nodes = append(nodes, parameter)
+			}
 		}
 	}
 	return partitionParameters(nodes), nil

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -100,6 +100,10 @@ func Test_Parse(t *testing.T) {
 			Want:  "(and a b c)",
 		},
 		{
+			Input: "(f(x)oo((a|b))bar)",
+			Want:  "(f(x)oo((a|b))bar)",
+		},
+		{
 			Input: "aorb",
 			Want:  "aorb",
 		},
@@ -153,7 +157,7 @@ func Test_Parse(t *testing.T) {
 		},
 		{
 			Input: "(a) repo:foo (b)",
-			Want:  "(and repo:foo (concat a b))",
+			Want:  "(and repo:foo (concat (a) (b)))",
 		},
 		{
 			Input: "a b (repo:foo c d)",
@@ -264,12 +268,22 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "empty paren",
 			Input: "()",
-			Want:  "",
+			Want:  "()",
+		},
+		{
+			Name:  "paren inside contiguous string",
+			Input: "foo()bar",
+			Want:  "foo()bar",
+		},
+		{
+			Name:  "paren containing whitespace inside contiguous string",
+			Input: "foo(   )bar",
+			Want:  "(concat foo bar)",
 		},
 		{
 			Name:  "nested empty paren",
 			Input: "(x())",
-			Want:  "x",
+			Want:  "(x())",
 		},
 		{
 			Name:  "interpolated nested empty paren",
@@ -279,17 +293,17 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "empty paren on or",
 			Input: "() or ()",
-			Want:  "",
+			Want:  "(or () ())",
 		},
 		{
 			Name:  "empty left paren on or",
 			Input: "() or (x)",
-			Want:  "x",
+			Want:  "(or () (x))",
 		},
 		{
 			Name:  "complex interpolated nested empty paren",
 			Input: "(()x(  )(y or () or (f))())",
-			Want:  "(concat x (or y f))",
+			Want:  "(concat x (or y () f))",
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
This is part 1 for adding better default paren handling in `and/or` queries. There are cases where parens grouping syntax doesn't gain anything for `and/or` queries, but takes away convenience from other searches. Examples:

- `foo(bar|baz)` <- Here we want to preserve parentheses as part of a regexp search pattern, not treat it as an expression grouping
- `func main(:[args])` <- Here we want to treat parentheses literally as part of a structural search pattern.

Note that both of the above can be expressed by quoting, say. But it's much more convenient and natural to specify these patterns, which are obviously not and/or expressions, without quotes for each respective mode.

This PR is part 1 of smarter parentheses that doesn't handle whitespace. There will be a part 2.
