### PR TITLE
Support using port 443 in dev with authbind

### DIFF
--- a/dev/caddy.sh
+++ b/dev/caddy.sh
@@ -30,4 +30,9 @@ chmod +x "${target}"
 
 popd > /dev/null
 
-exec "${target}" "$@"
+if [ ${SOURCEGRAPH_HTTPS_PORT:-"3443"} -lt 1000 ] && ! [ $(id -u) = 0 ] && hash authbind; then
+    # Support using authbind to bind to port 443 as non-root
+    exec authbind "${target}" "$@"
+else
+    exec "${$target}" "$@"
+fi

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -307,6 +307,8 @@ git clone https://github.com/sourcegraph/sourcegraph.git
 
 Sourcegraph's development environment ships with a [Caddy 2](https://caddyserver.com/) HTTPS reverse proxy that allows you to access your local sourcegraph instance via `https://sourcegraph.test:3443` (a fake domain with a self-signed certificate that's added to `/etc/hosts`).
 
+If you'd like Sourcegraph to be accessible under `https://sourcegraph.test` (port 443) instead, you can [set up authbind](https://medium.com/@steve.mu.dev/setup-authbind-on-mac-os-6aee72cb828) and set the environment variable `SOURCEGRAPH_HTTPS_PORT=443`.
+
 ### Prerequisites
 
 In order to configure the HTTPS reverse-proxy, you'll need to edit `/etc/hosts` and initialize Caddy 2.


### PR DESCRIPTION
Binding to a port <1000 doesn't work if the user is not root. The easiest and safest way to enable this is through authbind. This launches caddy with authbind if the port is <1000, the user is not root and authbind is installed. Otherwise it will just launch as usual.