### PR TITLE
refactor: rename `extsvc.ExternalAccount` to `extsvc.Account`

### DIFF
--- a/cmd/frontend/authz/iface.go
+++ b/cmd/frontend/authz/iface.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Provider defines a source of truth of which repositories a user is authorized to view. The
-// user is identified by an ExternalAccount instance. Examples of authz providers include the
+// user is identified by an extsvc.Account instance. Examples of authz providers include the
 // following:
 //
 // * Code host
@@ -40,7 +40,7 @@ type Provider interface {
 	// permissions it needs to compute.  In practice, most will probably use a combination of (1)
 	// "list all private repos the user has access to", (2) a mechanism to determine which repos are
 	// public/private, and (3) a cache of some sort.
-	RepoPerms(ctx context.Context, userAccount *extsvc.ExternalAccount, repos []*types.Repo) ([]RepoPerms, error)
+	RepoPerms(ctx context.Context, userAccount *extsvc.Account, repos []*types.Repo) ([]RepoPerms, error)
 
 	// FetchAccount returns the external account that identifies the user to this authz provider,
 	// taking as input the current list of external accounts associated with the
@@ -53,7 +53,7 @@ type Provider interface {
 	//
 	// The `user` argument should always be non-nil. If no external account can be computed for the
 	// provided user, implementations should return nil, nil.
-	FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error)
+	FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error)
 
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -31,7 +31,7 @@ func (err userExternalAccountNotFoundError) NotFound() bool {
 type userExternalAccounts struct{}
 
 // Get gets information about the user external account.
-func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.ExternalAccount, error) {
+func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Account, error) {
 	if Mocks.ExternalAccounts.Get != nil {
 		return Mocks.ExternalAccounts.Get(id)
 	}
@@ -201,7 +201,7 @@ type ExternalAccountsListOptions struct {
 	*LimitOffset
 }
 
-func (s *userExternalAccounts) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.ExternalAccount, err error) {
+func (s *userExternalAccounts) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.Account, err error) {
 	if Mocks.ExternalAccounts.List != nil {
 		return Mocks.ExternalAccounts.List(opt)
 	}
@@ -277,7 +277,7 @@ func (userExternalAccounts) deleteForDeletedUsers(ctx context.Context) error {
 	return err
 }
 
-func (s *userExternalAccounts) getBySQL(ctx context.Context, querySuffix *sqlf.Query) (*extsvc.ExternalAccount, error) {
+func (s *userExternalAccounts) getBySQL(ctx context.Context, querySuffix *sqlf.Query) (*extsvc.Account, error) {
 	results, err := s.listBySQL(ctx, querySuffix)
 	if err != nil {
 		return nil, err
@@ -288,16 +288,16 @@ func (s *userExternalAccounts) getBySQL(ctx context.Context, querySuffix *sqlf.Q
 	return results[0], nil
 }
 
-func (*userExternalAccounts) listBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*extsvc.ExternalAccount, error) {
+func (*userExternalAccounts) listBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*extsvc.Account, error) {
 	q := sqlf.Sprintf(`SELECT t.id, t.user_id, t.service_type, t.service_id, t.client_id, t.account_id, t.auth_data, t.account_data, t.created_at, t.updated_at FROM user_external_accounts t %s`, querySuffix)
 	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return nil, err
 	}
-	var results []*extsvc.ExternalAccount
+	var results []*extsvc.Account
 	defer rows.Close()
 	for rows.Next() {
-		var o extsvc.ExternalAccount
+		var o extsvc.Account
 		if err := rows.Scan(&o.ID, &o.UserID, &o.ServiceType, &o.ServiceID, &o.ClientID, &o.AccountID, &o.AuthData, &o.AccountData, &o.CreatedAt, &o.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -320,11 +320,11 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	Get                  func(id int32) (*extsvc.ExternalAccount, error)
+	Get                  func(id int32) (*extsvc.Account, error)
 	LookupUserAndSave    func(extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
 	AssociateUserAndSave func(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error
 	CreateUserAndSave    func(NewUser, extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
 	Delete               func(id int32) error
-	List                 func(ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error)
+	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)
 }

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -69,7 +69,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.ExternalAccount{UserID: user.ID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: user.ID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }
@@ -110,12 +110,12 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.ExternalAccount{UserID: userID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: userID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }
 
-func simplifyExternalAccount(account *extsvc.ExternalAccount) {
+func simplifyExternalAccount(account *extsvc.Account) {
 	account.CreatedAt = time.Time{}
 	account.UpdatedAt = time.Time{}
 }

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -168,7 +168,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			return nil, errors.Wrap(err, "list external accounts")
 		}
 
-		serviceToAccounts := make(map[string]*extsvc.ExternalAccount)
+		serviceToAccounts := make(map[string]*extsvc.Account)
 		for _, acct := range extAccounts {
 			serviceToAccounts[acct.ServiceType+":"+acct.ServiceID] = acct
 		}
@@ -243,7 +243,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 		return append(filtered, verified...), nil
 	}
 
-	var accts []*extsvc.ExternalAccount
+	var accts []*extsvc.Account
 	if len(authzProviders) > 0 && currentUser != nil {
 		accts, err = ExternalAccounts.List(ctx, ExternalAccountsListOptions{UserID: currentUser.ID})
 		if err != nil {
@@ -270,7 +270,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 	verified := roaring.NewBitmap()
 	for _, authzProvider := range authzProviders {
 		// determine external account to use
-		var providerAcct *extsvc.ExternalAccount
+		var providerAcct *extsvc.Account
 		for _, acct := range accts {
 			if acct.ServiceID == authzProvider.ServiceID() && acct.ServiceType == authzProvider.ServiceType() {
 				providerAcct = acct

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -32,7 +32,7 @@ type authzFilter_call struct {
 	description string
 
 	user         *types.User
-	userAccounts []*extsvc.ExternalAccount
+	userAccounts []*extsvc.Account
 
 	repos []*types.Repo
 	perm  authz.Perms
@@ -66,7 +66,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 		}
 
 		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error { return nil }
-		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) { return c.userAccounts, nil }
+		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
 		if err != nil {
@@ -135,7 +135,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab.mine/sharedPrivate/r0": {},
 						"gitlab.mine/org/r0":           {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab.mine/", "u1"): {
 							"gitlab.mine/u1/r0":            authz.Read,
 							"gitlab.mine/sharedPrivate/r0": authz.Read,
@@ -156,7 +156,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:      "u1 can read its own repo",
 					user:             &types.User{ID: 1},
-					userAccounts:     []*extsvc.ExternalAccount{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
+					userAccounts:     []*extsvc.Account{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
 					repos:            getRepos("gitlab.mine/u1/r0"),
 					perm:             authz.Read,
 					expFilteredRepos: getRepos("gitlab.mine/u1/r0"),
@@ -164,7 +164,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:  "u1 not allowed to read u2's repo",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
+					userAccounts: []*extsvc.Account{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
 					repos: getRepos("gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
 						"gitlab.mine/sharedPrivate/r0",
@@ -180,7 +180,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:  "u2 not allowed to read u0's repo",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(2, "gitlab", "https://gitlab.mine/", "u2")},
+					userAccounts: []*extsvc.Account{acct(2, "gitlab", "https://gitlab.mine/", "u2")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -196,7 +196,7 @@ func Test_authzFilter(t *testing.T) {
 				}, {
 					description:  "u99 not allowed to read anyone's repo",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(99, "gitlab", "https://gitlab.mine/", "u99")},
+					userAccounts: []*extsvc.Account{acct(99, "gitlab", "https://gitlab.mine/", "u99")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -210,7 +210,7 @@ func Test_authzFilter(t *testing.T) {
 				}, {
 					description:  "u99 can read unmanaged repo",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(99, "gitlab", "https://gitlab.mine/", "u99")},
+					userAccounts: []*extsvc.Account{acct(99, "gitlab", "https://gitlab.mine/", "u99")},
 					repos: getRepos(
 						"other.mine/r",
 					),
@@ -221,7 +221,7 @@ func Test_authzFilter(t *testing.T) {
 				}, {
 					description:  "u1 can read its own, public, and unmanaged repos",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
+					userAccounts: []*extsvc.Account{acct(1, "gitlab", "https://gitlab.mine/", "u1")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -304,7 +304,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab1.mine/u2/r0":  {},
 						"gitlab1.mine/org/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab1.mine/", "u1"): {
 							"gitlab1.mine/u1/r0":  authz.Read,
 							"gitlab1.mine/org/r0": authz.Read,
@@ -323,7 +323,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab0.mine/u2/r0":  {},
 						"gitlab0.mine/org/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab0.mine/", "u1"): {
 							"gitlab0.mine/u1/r0":  authz.Read,
 							"gitlab0.mine/org/r0": authz.Read,
@@ -343,7 +343,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab.mine/u2/r0":  {},
 						"gitlab.mine/org/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab.mine/", "u1"): {
 							"gitlab.mine/u1/r0":  authz.Read,
 							"gitlab.mine/org/r0": authz.Read,
@@ -359,7 +359,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description: "u1 can read its own repos, but not others'",
 					user:        &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{
+					userAccounts: []*extsvc.Account{
 						acct(1, "gitlab", "https://gitlab0.mine/", "u1"),
 						acct(1, "gitlab", "https://gitlab1.mine/", "u1"),
 						acct(1, "gitlab", "https://gitlab.mine/", "u1"),
@@ -392,7 +392,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description: "u1 with external account on one instance, can't read repos from the other'",
 					user:        &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{
+					userAccounts: []*extsvc.Account{
 						acct(1, "gitlab", "https://gitlab1.mine/", "u1"),
 					},
 					repos: getRepos(
@@ -430,7 +430,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab0.mine/u2/r0":  {},
 						"gitlab0.mine/org/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab0.mine/", "u1"): {
 							"gitlab0.mine/u1/r0":  authz.Read,
 							"gitlab0.mine/org/r0": authz.Read,
@@ -450,7 +450,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab1.mine/u2/r0":  {},
 						"gitlab1.mine/org/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab1.mine/", "u1"): {
 							"gitlab1.mine/u1/r0":  authz.Read,
 							"gitlab1.mine/org/r0": authz.Read,
@@ -466,7 +466,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description: "u1 can read its own repos, but not others'",
 					user:        &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{
+					userAccounts: []*extsvc.Account{
 						acct(1, "gitlab", "https://gitlab0.mine/", "u1"),
 						acct(1, "gitlab", "https://gitlab1.mine/", "u1"),
 					},
@@ -504,7 +504,7 @@ func Test_authzFilter(t *testing.T) {
 						"gitlab.mine/org/r0":    {},
 						"gitlab.mine/public/r0": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						*acct(1, "gitlab", "https://gitlab.mine/", "u1"): {
 							"gitlab.mine/u1/r0":     authz.Read,
 							"gitlab.mine/org/r0":    authz.Read,
@@ -526,7 +526,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:  "u1 has access to the right repos",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(1, "saml", "https://okta.mine/", "u1")},
+					userAccounts: []*extsvc.Account{acct(1, "saml", "https://okta.mine/", "u1")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -543,7 +543,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:  "u99 has access to public repos only",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(1, "saml", "https://okta.mine/", "u99")},
+					userAccounts: []*extsvc.Account{acct(1, "saml", "https://okta.mine/", "u99")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -558,7 +558,7 @@ func Test_authzFilter(t *testing.T) {
 				{
 					description:  "service ID does not match",
 					user:         &types.User{ID: 1},
-					userAccounts: []*extsvc.ExternalAccount{acct(1, "saml", "https://rando.mine/", "u1")},
+					userAccounts: []*extsvc.Account{acct(1, "saml", "https://rando.mine/", "u1")},
 					repos: getRepos(
 						"gitlab.mine/u1/r0",
 						"gitlab.mine/u2/r0",
@@ -623,7 +623,7 @@ func Test_authzFilter(t *testing.T) {
 					serviceID:   "https://gitlab.mine/",
 					serviceType: "gitlab",
 					repos:       map[api.RepoName]struct{}{},
-					perms:       map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{},
+					perms:       map[extsvc.Account]map[api.RepoName]authz.Perms{},
 				},
 			},
 			calls: []authzFilter_call{
@@ -665,7 +665,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 		associateUserAndSaveCount[userID][spec]++
 		return nil
 	}
-	mockUser23Accounts := []*extsvc.ExternalAccount{{
+	mockUser23Accounts := []*extsvc.Account{{
 		UserID: 23,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: "okta",
@@ -680,7 +680,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 			AccountID:   "99",
 		},
 	}}
-	Mocks.ExternalAccounts.List = func(op ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) {
+	Mocks.ExternalAccounts.List = func(op ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 		if op.UserID == 23 {
 			return mockUser23Accounts, nil
 		}
@@ -698,7 +698,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 			serviceType:  "gitlab",
 			okServiceIDs: map[string]struct{}{"https://okta.mine/": {}},
 			repos:        map[api.RepoName]struct{}{},
-			perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+			perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 				*acct(23, "gitlab", "https://gitlab.mine/", "101"): {},
 			},
 		},
@@ -766,7 +766,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	}
 
 	// Authed filter does NOT trigger new account creation if new account is already provided
-	mockUser23Accounts = append(mockUser23Accounts, &extsvc.ExternalAccount{
+	mockUser23Accounts = append(mockUser23Accounts, &extsvc.Account{
 		UserID: 23,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: "gitlab",
@@ -921,7 +921,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 	})
 
 	t.Run("authenticated user with matching external account should see all repos", func(t *testing.T) {
-		extAccount := extsvc.ExternalAccount{
+		extAccount := extsvc.Account{
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.mine/",
@@ -936,7 +936,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 					okServiceIDs: map[string]struct{}{
 						"https://gitlab.mine/": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						extAccount: nil,
 					},
 				},
@@ -948,8 +948,8 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return user, nil
 		}
-		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) {
-			return []*extsvc.ExternalAccount{&extAccount}, nil
+		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+			return []*extsvc.Account{&extAccount}, nil
 		}
 		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) error {
 			return errors.New("AssociateUserAndSave should not be called")
@@ -989,7 +989,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 					okServiceIDs: map[string]struct{}{
 						"https://gitlab.mirror/": {},
 					},
-					perms: map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms{
+					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						{
 							ExternalAccountSpec: extsvc.ExternalAccountSpec{
 								ServiceType: "gitlab",
@@ -1007,8 +1007,8 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return user, nil
 		}
-		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) {
-			return []*extsvc.ExternalAccount{
+		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+			return []*extsvc.Account{
 				{
 					ExternalAccountSpec: extsvc.ExternalAccountSpec{
 						ServiceType: "gitlab",
@@ -1057,8 +1057,8 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 	})
 }
 
-func acct(userID int32, serviceType, serviceID, accountID string) *extsvc.ExternalAccount {
-	return &extsvc.ExternalAccount{
+func acct(userID int32, serviceType, serviceID, accountID string) *extsvc.Account {
+	return &extsvc.Account{
 		UserID: userID,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: serviceType,
@@ -1078,16 +1078,16 @@ type MockAuthzProvider struct {
 
 	// perms is the map from external user account to repository permissions. The key set must
 	// include all user external accounts that are available in this mock instance.
-	perms map[extsvc.ExternalAccount]map[api.RepoName]authz.Perms
+	perms map[extsvc.Account]map[api.RepoName]authz.Perms
 	repos map[api.RepoName]struct{}
 }
 
-func (m *MockAuthzProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+func (m *MockAuthzProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error) {
 	if user == nil {
 		return nil, nil
 	}
 	for _, acct := range current {
-		if (extsvc.ExternalAccount{}) == *acct {
+		if (extsvc.Account{}) == *acct {
 			continue
 		}
 		if _, ok := m.okServiceIDs[acct.ServiceID]; ok {
@@ -1102,12 +1102,12 @@ func (m *MockAuthzProvider) FetchAccount(ctx context.Context, user *types.User, 
 	return nil, nil
 }
 
-func (m *MockAuthzProvider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, repos []*types.Repo) (retPerms []authz.RepoPerms, _ error) {
+func (m *MockAuthzProvider) RepoPerms(ctx context.Context, acct *extsvc.Account, repos []*types.Repo) (retPerms []authz.RepoPerms, _ error) {
 	if acct == nil {
-		acct = &extsvc.ExternalAccount{}
+		acct = &extsvc.Account{}
 	}
 	if _, existsInPerms := m.perms[*acct]; !existsInPerms {
-		acct = &extsvc.ExternalAccount{}
+		acct = &extsvc.Account{}
 	}
 
 	userPerms := m.perms[*acct]

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -32,7 +32,7 @@ func Benchmark_authzFilter(b *testing.B) {
 			codeHost := extsvc.NewCodeHost(baseURL, "fake")
 			return &fakeProvider{
 				codeHost: codeHost,
-				extAcct: &extsvc.ExternalAccount{
+				extAcct: &extsvc.Account{
 					UserID: user.ID,
 					ExternalAccountSpec: extsvc.ExternalAccountSpec{
 						ServiceType: codeHost.ServiceType,
@@ -48,7 +48,7 @@ func Benchmark_authzFilter(b *testing.B) {
 			codeHost := extsvc.NewCodeHost(baseURL, "github")
 			return &fakeProvider{
 				codeHost: codeHost,
-				extAcct: &extsvc.ExternalAccount{
+				extAcct: &extsvc.Account{
 					UserID: user.ID,
 					ExternalAccountSpec: extsvc.ExternalAccountSpec{
 						ServiceType: codeHost.ServiceType,
@@ -94,7 +94,7 @@ func Benchmark_authzFilter(b *testing.B) {
 	ctx := context.Background()
 
 	Mocks.ExternalAccounts.List = func(opt ExternalAccountsListOptions) (
-		accts []*extsvc.ExternalAccount,
+		accts []*extsvc.Account,
 		err error,
 	) {
 		for _, p := range providers {
@@ -118,12 +118,12 @@ func Benchmark_authzFilter(b *testing.B) {
 
 type fakeProvider struct {
 	codeHost *extsvc.CodeHost
-	extAcct  *extsvc.ExternalAccount
+	extAcct  *extsvc.Account
 }
 
 func (f fakeProvider) RepoPerms(
 	ctx context.Context,
-	userAccount *extsvc.ExternalAccount,
+	userAccount *extsvc.Account,
 	repos []*types.Repo,
 ) ([]authz.RepoPerms, error) {
 	authorized := make([]authz.RepoPerms, 0, len(repos))
@@ -139,8 +139,8 @@ func (f fakeProvider) RepoPerms(
 func (f fakeProvider) FetchAccount(
 	ctx context.Context,
 	user *types.User,
-	current []*extsvc.ExternalAccount,
-) (mine *extsvc.ExternalAccount, err error) {
+	current []*extsvc.Account,
+) (mine *extsvc.Account, err error) {
 	return f.extAcct, nil
 }
 

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -11,7 +11,7 @@ import (
 )
 
 type externalAccountResolver struct {
-	account extsvc.ExternalAccount
+	account extsvc.Account
 }
 
 func externalAccountByID(ctx context.Context, id graphql.ID) (*externalAccountResolver, error) {

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -68,11 +68,11 @@ type externalAccountConnectionResolver struct {
 
 	// cache results because they are used by multiple fields
 	once             sync.Once
-	externalAccounts []*extsvc.ExternalAccount
+	externalAccounts []*extsvc.Account
 	err              error
 }
 
-func (r *externalAccountConnectionResolver) compute(ctx context.Context) ([]*extsvc.ExternalAccount, error) {
+func (r *externalAccountConnectionResolver) compute(ctx context.Context) ([]*extsvc.Account, error) {
 	r.once.Do(func() {
 		opt2 := r.opt
 		if opt2.LimitOffset != nil {

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -76,8 +76,8 @@ func TestDeleteUser(t *testing.T) {
 			{Email: "alice@example.com"},
 		}, nil
 	}
-	db.Mocks.ExternalAccounts.List = func(db.ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) {
-		return []*extsvc.ExternalAccount{
+	db.Mocks.ExternalAccounts.List = func(db.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+		return []*extsvc.Account{
 			{
 				ExternalAccountSpec: extsvc.ExternalAccountSpec{
 					ServiceType: "gitlab",

--- a/enterprise/cmd/frontend/authz/authz_test.go
+++ b/enterprise/cmd/frontend/authz/authz_test.go
@@ -23,7 +23,7 @@ type gitlabAuthzProviderParams struct {
 	SudoOp  gitlab.SudoProviderOp
 }
 
-func (m gitlabAuthzProviderParams) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos []*types.Repo) ([]authz.RepoPerms, error) {
+func (m gitlabAuthzProviderParams) RepoPerms(ctx context.Context, account *extsvc.Account, repos []*types.Repo) ([]authz.RepoPerms, error) {
 	panic("should never be called")
 }
 
@@ -31,7 +31,7 @@ func (m gitlabAuthzProviderParams) Repos(ctx context.Context, repos []*types.Rep
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+func (m gitlabAuthzProviderParams) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error) {
 	panic("should never be called")
 }
 

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1255,7 +1255,7 @@ func (s *PermsStore) batchLoadIDs(ctx context.Context, q *sqlf.Query) (map[int32
 }
 
 // ListExternalAccounts returns all external accounts that are associated with given user.
-func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (accounts []*extsvc.ExternalAccount, err error) {
+func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (accounts []*extsvc.Account, err error) {
 	if Mocks.Perms.ListExternalAccounts != nil {
 		return Mocks.Perms.ListExternalAccounts(ctx, userID)
 	}
@@ -1280,7 +1280,7 @@ ORDER BY id ASC
 	defer rows.Close()
 
 	for rows.Next() {
-		var acct extsvc.ExternalAccount
+		var acct extsvc.Account
 		if err := rows.Scan(
 			&acct.ID, &acct.UserID,
 			&acct.ServiceType, &acct.ServiceID, &acct.ClientID, &acct.AccountID,

--- a/enterprise/cmd/frontend/db/perms_store_mock.go
+++ b/enterprise/cmd/frontend/db/perms_store_mock.go
@@ -16,6 +16,6 @@ type MockPerms struct {
 	SetRepoPermissions           func(ctx context.Context, p *authz.RepoPermissions) error
 	SetRepoPendingPermissions    func(ctx context.Context, accounts *extsvc.ExternalAccounts, p *authz.RepoPermissions) error
 	ListPendingUsers             func(ctx context.Context) ([]string, error)
-	ListExternalAccounts         func(ctx context.Context, userID int32) ([]*extsvc.ExternalAccount, error)
+	ListExternalAccounts         func(ctx context.Context, userID int32) ([]*extsvc.Account, error)
 	GetUserIDsByExternalAccounts func(ctx context.Context, accounts *extsvc.ExternalAccounts) (map[string]int32, error)
 }

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -1772,7 +1772,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				t.Fatal(err)
 			}
 
-			expAccounts := []*extsvc.ExternalAccount{
+			expAccounts := []*extsvc.Account{
 				{
 					ID:     1,
 					UserID: 1,
@@ -1810,7 +1810,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				t.Fatal(err)
 			}
 
-			expAccounts := []*extsvc.ExternalAccount{
+			expAccounts := []*extsvc.Account{
 				{
 					ID:     3,
 					UserID: 2,

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -74,7 +74,7 @@ func (p *Provider) ServiceType() string { return p.codeHost.ServiceType }
 // RepoPerms returns the permissions the given external account has in relation to the given set of repos.
 // It performs a single HTTP request against the Bitbucket Server API which returns all repositories
 // the authenticated user has permissions to read.
-func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, repos []*types.Repo) (
+func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.Account, repos []*types.Repo) (
 	perms []authz.RepoPerms,
 	err error,
 ) {
@@ -149,7 +149,7 @@ func (p *Provider) update(userName string) PermissionsUpdateFunc {
 }
 
 // FetchAccount satisfies the authz.Provider interface.
-func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*extsvc.ExternalAccount) (acct *extsvc.ExternalAccount, err error) {
+func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*extsvc.Account) (acct *extsvc.Account, err error) {
 	if user == nil {
 		return nil, nil
 	}
@@ -178,7 +178,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 		return nil, err
 	}
 
-	return &extsvc.ExternalAccount{
+	return &extsvc.Account{
 		UserID: user.ID,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: p.codeHost.ServiceType,
@@ -199,7 +199,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8296923984
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
 	switch {
 	case account == nil:
 		return nil, errors.New("no account provided")
@@ -227,8 +227,8 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalA
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given repo on the code host. The user ID has the same value as it would
-// be used as extsvc.ExternalAccount.AccountID. The returned list includes both
-// direct access and inherited from the group membership.
+// be used as extsvc.Account.AccountID. The returned list includes both direct access
+// and inherited from the group membership.
 //
 // This method may return partial but valid results in case of error, and it is up to
 // callers to decide whether to discard.

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -189,7 +189,7 @@ func testProviderRepoPerms(db *sql.DB, f *fixtures, cli *bitbucketserver.Client)
 					tc.err = "<nil>"
 				}
 
-				var acct *extsvc.ExternalAccount
+				var acct *extsvc.Account
 				if tc.user != nil {
 					acct = h.externalAccount(int32(i), tc.user)
 				}
@@ -218,7 +218,7 @@ func testProviderFetchAccount(f *fixtures, cli *bitbucketserver.Client) func(*te
 			name string
 			ctx  context.Context
 			user *types.User
-			acct *extsvc.ExternalAccount
+			acct *extsvc.Account
 			err  string
 		}{
 			{
@@ -279,7 +279,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 		for _, tc := range []struct {
 			name string
 			ctx  context.Context
-			acct *extsvc.ExternalAccount
+			acct *extsvc.Account
 			ids  []extsvc.ExternalRepoID
 			err  string
 		}{
@@ -290,12 +290,12 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			},
 			{
 				name: "no account data provided",
-				acct: &extsvc.ExternalAccount{},
+				acct: &extsvc.Account{},
 				err:  "no account data provided",
 			},
 			{
 				name: "not a code host of the account",
-				acct: &extsvc.ExternalAccount{
+				acct: &extsvc.Account{
 					ExternalAccountSpec: extsvc.ExternalAccountSpec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com",
@@ -309,7 +309,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			},
 			{
 				name: "bad account data",
-				acct: &extsvc.ExternalAccount{
+				acct: &extsvc.Account{
 					ExternalAccountSpec: extsvc.ExternalAccountSpec{
 						ServiceType: h.ServiceType,
 						ServiceID:   h.ServiceID,
@@ -613,9 +613,9 @@ func (h codeHost) externalRepo(r *bitbucketserver.Repo) api.ExternalRepoSpec {
 	}
 }
 
-func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc.ExternalAccount {
+func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc.Account {
 	bs := marshalJSON(u)
-	return &extsvc.ExternalAccount{
+	return &extsvc.Account{
 		UserID: userID,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: h.ServiceType,

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -28,7 +28,7 @@ type Provider_RepoPerms_Test struct {
 
 type Provider_RepoPerms_call struct {
 	description string
-	userAccount *extsvc.ExternalAccount
+	userAccount *extsvc.Account
 	repos       []*types.Repo
 	wantPerms   []authz.RepoPerms
 	wantErr     error
@@ -268,8 +268,8 @@ func mustURL(t *testing.T, u string) *url.URL {
 	return parsed
 }
 
-func ua(accountID, token string) *extsvc.ExternalAccount {
-	var a extsvc.ExternalAccount
+func ua(accountID, token string) *extsvc.Account {
+	var a extsvc.Account
 	a.AccountID = accountID
 	github.SetExternalAccountData(&a.ExternalAccountData, nil, &oauth2.Token{
 		AccessToken: token,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -377,7 +377,7 @@ func (m mockAuthnProvider) Refresh(ctx context.Context) error {
 	panic("should not be called")
 }
 
-func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.ExternalAccount {
+func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.Account {
 	var data extsvc.ExternalAccountData
 
 	var authData *oauth2.Token
@@ -396,7 +396,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 		}, authData)
 	}
 
-	return &extsvc.ExternalAccount{
+	return &extsvc.Account{
 		UserID: userID,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: serviceType,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -95,11 +95,11 @@ func (p *OAuthProvider) ServiceType() string {
 	return p.codeHost.ServiceType
 }
 
-func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error) {
 	return nil, nil
 }
 
-func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos []*types.Repo) (
+func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.Account, repos []*types.Repo) (
 	[]authz.RepoPerms, error,
 ) {
 	accountID := "" // empty means public / unauthenticated to the code host

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth_test.go
@@ -18,7 +18,7 @@ import (
 func Test_GitLab_RepoPerms(t *testing.T) {
 	type call struct {
 		description string
-		account     *extsvc.ExternalAccount
+		account     *extsvc.Account
 		repos       []*types.Repo
 		expPerms    []authz.RepoPerms
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -117,7 +117,7 @@ func (p *SudoProvider) ServiceType() string {
 	return p.codeHost.ServiceType
 }
 
-func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos []*types.Repo) ([]authz.RepoPerms, error) {
+func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.Account, repos []*types.Repo) ([]authz.RepoPerms, error) {
 	accountID := "" // empty means public / unauthenticated to the code host
 	if account != nil && account.ServiceID == p.codeHost.ServiceID && account.ServiceType == p.codeHost.ServiceType {
 		accountID = account.AccountID
@@ -253,7 +253,7 @@ func (p *SudoProvider) fetchProjVis(ctx context.Context, sudo string, projID int
 // FetchAccount satisfies the authz.Provider interface. It iterates through the current list of
 // linked external accounts, find the one (if it exists) that matches the authn provider specified
 // in the SudoProvider struct, and fetches the user account from the GitLab API using that identity.
-func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error) {
 	if user == nil {
 		return nil, nil
 	}
@@ -267,7 +267,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 		if authnProvider == nil {
 			return nil, nil
 		}
-		var authnAcct *extsvc.ExternalAccount
+		var authnAcct *extsvc.Account
 		for _, acct := range current {
 			if acct.ServiceID == authnProvider.CachedInfo().ServiceID && acct.ServiceType == authnProvider.ConfigID().Type {
 				authnAcct = acct
@@ -289,7 +289,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 	var accountData extsvc.ExternalAccountData
 	gitlab.SetExternalAccountData(&accountData, glUser, nil)
 
-	glExternalAccount := extsvc.ExternalAccount{
+	glExternalAccount := extsvc.Account{
 		UserID: user.ID,
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: p.codeHost.ServiceType,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
@@ -20,9 +20,9 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 		description string
 
 		user    *types.User
-		current []*extsvc.ExternalAccount
+		current []*extsvc.Account
 
-		expMine *extsvc.ExternalAccount
+		expMine *extsvc.Account
 	}
 	type test struct {
 		description string
@@ -82,13 +82,13 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 				{
 					description: "1 account, matches",
 					user:        &types.User{ID: 123},
-					current:     []*extsvc.ExternalAccount{acct(t, 1, "saml", "https://okta.mine/", "bl", "")},
+					current:     []*extsvc.Account{acct(t, 1, "saml", "https://okta.mine/", "bl", "")},
 					expMine:     acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
 				},
 				{
 					description: "many accounts, none match",
 					user:        &types.User{ID: 123},
-					current: []*extsvc.ExternalAccount{
+					current: []*extsvc.Account{
 						acct(t, 1, "saml", "https://okta.mine/", "nomatch", ""),
 						acct(t, 1, "saml", "nomatch", "bl", ""),
 						acct(t, 1, "nomatch", "https://okta.mine/", "bl", ""),
@@ -98,7 +98,7 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 				{
 					description: "many accounts, 1 match",
 					user:        &types.User{ID: 123},
-					current: []*extsvc.ExternalAccount{
+					current: []*extsvc.Account{
 						acct(t, 1, "saml", "nomatch", "bl", ""),
 						acct(t, 1, "nomatch", "https://okta.mine/", "bl", ""),
 						acct(t, 1, "saml", "https://okta.mine/", "bl", ""),
@@ -172,13 +172,13 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 				{
 					description: "1 authn provider matches",
 					user:        &types.User{ID: 123},
-					current:     []*extsvc.ExternalAccount{acct(t, 1, "openidconnect", "https://onelogin.mine/", "bl", "")},
+					current:     []*extsvc.Account{acct(t, 1, "openidconnect", "https://onelogin.mine/", "bl", "")},
 					expMine:     acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
 				},
 				{
 					description: "0 authn providers match",
 					user:        &types.User{ID: 123},
-					current:     []*extsvc.ExternalAccount{acct(t, 1, "openidconnect", "https://onelogin.mine/", "nomatch", "")},
+					current:     []*extsvc.Account{acct(t, 1, "openidconnect", "https://onelogin.mine/", "nomatch", "")},
 					expMine:     nil,
 				},
 			},
@@ -218,7 +218,7 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 func Test_SudoProvider_RepoPerms(t *testing.T) {
 	type call struct {
 		description string
-		account     *extsvc.ExternalAccount
+		account     *extsvc.Account
 		repos       []*types.Repo
 		expPerms    []authz.RepoPerms
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -17,7 +17,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -38,8 +38,8 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Exte
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
-// be used as extsvc.ExternalAccount.AccountID. The returned list includes both
-// direct access and inherited from the group membership.
+// be used as extsvc.Account.AccountID. The returned list includes both direct access
+// and inherited from the group membership.
 //
 // This method may return partial but valid results in case of error, and it is up to
 // callers to decide whether to discard.

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -41,7 +41,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
-			&extsvc.ExternalAccount{
+			&extsvc.Account{
 				ExternalAccountSpec: extsvc.ExternalAccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
@@ -90,7 +90,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
-		&extsvc.ExternalAccount{
+		&extsvc.Account{
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -19,7 +19,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -73,8 +73,8 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.External
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
-// be used as extsvc.ExternalAccount.AccountID. The returned list includes both
-// direct access and inherited from the group membership.
+// be used as extsvc.Account.AccountID. The returned list includes both direct access
+// and inherited from the group membership.
 //
 // This method may return partial but valid results in case of error, and it is up to
 // callers to decide whether to discard.

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -33,7 +33,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
-			&extsvc.ExternalAccount{
+			&extsvc.Account{
 				ExternalAccountSpec: extsvc.ExternalAccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
@@ -88,7 +88,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 
 	accountData := json.RawMessage(`{"id": 999}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
-		&extsvc.ExternalAccount{
+		&extsvc.Account{
 			ExternalAccountSpec: extsvc.ExternalAccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -60,10 +60,10 @@ type PermsFetcher interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error)
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value
-	// as it would be used as extsvc.ExternalAccount.AccountID. The returned list should
+	// as it would be used as extsvc.Account.AccountID. The returned list should
 	// include both direct access and inherited from the group/organization/team membership.
 	//
 	// Because permissions fetching APIs are often expensive, the implementation should

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -56,15 +56,15 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms func(context.Context, *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error)
 	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error)
 }
 
-func (*mockProvider) RepoPerms(context.Context, *extsvc.ExternalAccount, []*types.Repo) ([]authz.RepoPerms, error) {
+func (*mockProvider) RepoPerms(context.Context, *extsvc.Account, []*types.Repo) ([]authz.RepoPerms, error) {
 	return nil, nil
 }
 
-func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.ExternalAccount) (*extsvc.ExternalAccount, error) {
+func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.Account) (*extsvc.Account, error) {
 	return nil, nil
 }
 
@@ -80,7 +80,7 @@ func (*mockProvider) Validate() []string {
 	return nil
 }
 
-func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
 	return p.fetchUserPerms(ctx, acct)
 }
 
@@ -113,10 +113,10 @@ func (s *mockReposStore) ListAllRepoNames(context.Context) ([]api.RepoName, erro
 }
 
 type mockPermsStore struct {
-	listExternalAccounts func(context.Context, int32) ([]*extsvc.ExternalAccount, error)
+	listExternalAccounts func(context.Context, int32) ([]*extsvc.Account, error)
 }
 
-func (s *mockPermsStore) ListExternalAccounts(ctx context.Context, userID int32) ([]*extsvc.ExternalAccount, error) {
+func (s *mockPermsStore) ListExternalAccounts(ctx context.Context, userID int32) ([]*extsvc.Account, error) {
 	return s.listExternalAccounts(ctx, userID)
 }
 
@@ -128,15 +128,15 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	authz.SetProviders(false, []authz.Provider{p})
 	defer authz.SetProviders(true, nil)
 
-	extAccount := extsvc.ExternalAccount{
+	extAccount := extsvc.Account{
 		ExternalAccountSpec: extsvc.ExternalAccountSpec{
 			ServiceType: p.ServiceType(),
 			ServiceID:   p.ServiceID(),
 		},
 	}
 
-	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.ExternalAccount, error) {
-		return []*extsvc.ExternalAccount{&extAccount}, nil
+	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.Account, error) {
+		return []*extsvc.Account{&extAccount}, nil
 	}
 	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
 		if p.UserID != 1 {
@@ -186,7 +186,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchUserPerms = func(context.Context, *extsvc.ExternalAccount) ([]extsvc.ExternalRepoID, error) {
+			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
 				return []extsvc.ExternalRepoID{"1"}, test.fetchErr
 			}
 

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -41,7 +41,7 @@ func IsHostOfRepo(c *CodeHost, repo *api.ExternalRepoSpec) bool {
 }
 
 // IsHostOfAccount returns true if the account belongs to given code host.
-func IsHostOfAccount(c *CodeHost, account *ExternalAccount) bool {
+func IsHostOfAccount(c *CodeHost, account *Account) bool {
 	return c.ServiceID == account.ServiceID && c.ServiceType == account.ServiceType
 }
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -8,9 +8,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-// ExternalAccount represents a row in the `user_external_accounts` table. See the GraphQL API's
+// Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
-type ExternalAccount struct {
+type Account struct {
 	ID                  int32
 	UserID              int32
 	ExternalAccountSpec // ServiceType, ServiceID, ClientID, AccountID


### PR DESCRIPTION
Simple rename from `extsvc.ExternalAccount` to `extsvc.Account` to align with what we have for `extsvc.Repository`.