### PR TITLE
authz: merge `PermsFetcher` into `Provider` interface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -160,6 +160,7 @@
 /cmd/github-proxy/ @sourcegraph/core-services
 /cmd/gitserver/ @sourcegraph/core-services
 /cmd/repo-updater/ @sourcegraph/core-services
+/enterprise/cmd/frontend/authz/ @sourcegraph/core-services
 /enterprise/cmd/frontend/db/ @sourcegraph/core-services
 /enterprise/cmd/frontend/internal/authz/ @sourcegraph/core-services
 /enterprise/cmd/frontend/internal/graphqlbackend/ @sourcegraph/core-services @slimsag

--- a/cmd/frontend/authz/iface.go
+++ b/cmd/frontend/authz/iface.go
@@ -55,6 +55,26 @@ type Provider interface {
 	// provided user, implementations should return nil, nil.
 	FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error)
 
+	// FetchUserPerms returns a list of repository/project IDs (on code host) that the
+	// given account has read access on the code host. The repository ID should be the
+	// same value as it would be used as api.ExternalRepoSpec.ID. The returned list
+	// should only include private repositories/project IDs.
+	//
+	// Because permissions fetching APIs are often expensive, the implementation should
+	// try to return partial but valid results in case of error, and it is up to callers
+	// to decide whether to discard.
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error)
+
+	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
+	// the given repository/project on the code host. The user ID should be the same value
+	// as it would be used as extsvc.Account.AccountID. The returned list should
+	// include both direct access and inherited from the group/organization/team membership.
+	//
+	// Because permissions fetching APIs are often expensive, the implementation should
+	// try to return partial but valid results in case of error, and it is up to callers
+	// to decide whether to discard.
+	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error)
+
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string
 

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -1126,6 +1126,14 @@ func (m *MockAuthzProvider) ServiceID() string   { return m.serviceID }
 func (m *MockAuthzProvider) ServiceType() string { return m.serviceType }
 func (m *MockAuthzProvider) Validate() []string  { return nil }
 
+func (m *MockAuthzProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+	return nil, nil
+}
+
+func (m *MockAuthzProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+	return nil, nil
+}
+
 func makeRepo(name api.RepoName, id api.RepoID, private bool) *types.Repo {
 	extName := string(name)
 	if extName == "" {

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -148,6 +148,14 @@ func (f fakeProvider) ServiceType() string           { return f.codeHost.Service
 func (f fakeProvider) ServiceID() string             { return f.codeHost.ServiceID }
 func (f fakeProvider) Validate() (problems []string) { return nil }
 
+func (f fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+	return nil, nil
+}
+
+func (f fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+	return nil, nil
+}
+
 // 🚨 SECURITY: test necessary to ensure security
 func Test_getBySQL_permissionsCheck(t *testing.T) {
 	if testing.Short() {

--- a/enterprise/cmd/frontend/authz/authz_test.go
+++ b/enterprise/cmd/frontend/authz/authz_test.go
@@ -42,7 +42,16 @@ func (m gitlabAuthzProviderParams) ServiceID() string {
 func (m gitlabAuthzProviderParams) ServiceType() string {
 	return "gitlab"
 }
+
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
+
+func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+	panic("should never be called")
+}
+
+func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+	panic("should never be called")
+}
 
 func Test_authzProvidersFromConfig(t *testing.T) {
 	gitlab.NewOAuthProvider = func(op gitlab.OAuthProviderOp) authz.Provider {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -48,30 +48,6 @@ type PermsSyncer struct {
 	}
 }
 
-// PermsFetcher is an authz.Provider that could also fetch permissions in both
-// user-centric and repository-centric ways.
-type PermsFetcher interface {
-	authz.Provider
-	// FetchUserPerms returns a list of repository/project IDs (on code host) that the
-	// given account has read access on the code host. The repository ID should be the
-	// same value as it would be used as api.ExternalRepoSpec.ID. The returned list
-	// should only include private repositories/project IDs.
-	//
-	// Because permissions fetching APIs are often expensive, the implementation should
-	// try to return partial but valid results in case of error, and it is up to callers
-	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error)
-	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
-	// the given repository/project on the code host. The user ID should be the same value
-	// as it would be used as extsvc.Account.AccountID. The returned list should
-	// include both direct access and inherited from the group/organization/team membership.
-	//
-	// Because permissions fetching APIs are often expensive, the implementation should
-	// try to return partial but valid results in case of error, and it is up to callers
-	// to decide whether to discard.
-	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error)
-}
-
 // NewPermsSyncer returns a new permissions syncing manager.
 func NewPermsSyncer(
 	reposStore repos.Store,
@@ -164,22 +140,15 @@ func (s *PermsSyncer) scheduleRepos(ctx context.Context, repos ...scheduledRepo)
 	}
 }
 
-// fetchers returns a list of authz.Provider that also implemented PermsFetcher.
-// Keys are ServiceID (e.g. https://gitlab.com/). The current approach is to
-// minimize the changes required by keeping the authz.Provider interface as-is,
-// so each authz provider could be opt-in progressively until we fully complete
-// the transition of moving permissions syncing process to the background for
-// all authz providers.
-func (s *PermsSyncer) fetchers() map[string]PermsFetcher {
-	_, providers := authz.GetProviders()
-	fetchers := make(map[string]PermsFetcher, len(providers))
-
-	for i := range providers {
-		if f, ok := providers[i].(PermsFetcher); ok {
-			fetchers[f.ServiceID()] = f
-		}
+// providers returns a list of authz.Provider configured in the external services.
+// Keys are ServiceID, e.g. "https://gitlab.com/".
+func (s *PermsSyncer) providers() map[string]authz.Provider {
+	_, ps := authz.GetProviders()
+	providers := make(map[string]authz.Provider, len(ps))
+	for _, p := range ps {
+		providers[p.ServiceID()] = p
 	}
-	return fetchers
+	return providers
 }
 
 // syncUserPerms processes permissions syncing request in user-centric way. When noPerms is true,
@@ -195,7 +164,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 
 	var repoSpecs []api.ExternalRepoSpec
 	for _, acct := range accts {
-		fetcher := s.fetchers()[acct.ServiceID]
+		fetcher := s.providers()[acct.ServiceID]
 		if fetcher == nil {
 			// We have no authz provider configured for this external account.
 			continue
@@ -273,7 +242,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return nil
 	}
 
-	fetcher := s.fetchers()[repo.ExternalRepo.ServiceID]
+	fetcher := s.providers()[repo.ExternalRepo.ServiceID]
 	if fetcher == nil {
 		// We have no authz provider configured for this repository.
 		return nil

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -50,8 +50,6 @@ func TestPermsSyncer_ScheduleRepos(t *testing.T) {
 	}
 }
 
-var _ PermsFetcher = (*mockProvider)(nil)
-
 type mockProvider struct {
 	serviceType string
 	serviceID   string

--- a/go.sum
+++ b/go.sum
@@ -859,6 +859,7 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20200318141102-0b140b7dc6c9 h1:vUz68uAPzIPdz9ibYgEOvRh33fErNN4LFYnGSCObP28=
 github.com/sourcegraph/zoekt v0.0.0-20200318141102-0b140b7dc6c9/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
+github.com/sourcegraph/zoekt v0.0.0-20200401202556-ef3ec2393b46 h1:4bfwcMwJFWRK/BHzW0yXGy0XGTXGWYs9WwdAWR5dKOQ=
 github.com/sourcegraph/zoekt v0.0.0-20200401202556-ef3ec2393b46/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
We now migrated all authz providers to support fetch permissions in user- and repo-centric, it's time to merge the interface.