### PR TITLE
CI: Fix image publishing for precise code intel and symbols

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -314,7 +314,7 @@ func addCanidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 // after the e2e tests pass.
 func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		baseImage := "sourcegraph/" + app
+		baseImage := "sourcegraph/" + strings.ReplaceAll(app, "/", "-")
 
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Tagging final %s image..."`, app)),

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -298,24 +298,7 @@ func addCanidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 
 		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
 
-		getBuildSteps := func() []bk.StepOpt {
-			buildScriptByApp := map[string][]bk.StepOpt{
-				"symbols": {
-					bk.Env("BUILD_TYPE", "dist"),
-					bk.Cmd("./cmd/symbols/build.sh buildSymbolsDockerImage"),
-				},
-			}
-			if buildScript, ok := buildScriptByApp[app]; ok {
-				return buildScript
-			}
-			return []bk.StepOpt{
-				bk.Cmd(cmdDir + "/build.sh"),
-			}
-		}
-
-		cmds = append(cmds,
-			getBuildSteps()...,
-		)
+		cmds = append(cmds, bk.Cmd(cmdDir+"/build.sh"))
 
 		tag := candiateImageTag(c)
 		cmds = append(cmds,


### PR DESCRIPTION
- Fix non-candidate image names for precise code intel
- Simplify the symbols build (which is now just ./build.sh like the rest of the app)