### PR TITLE
Add back default log level in precise-code-intel docker containers

### DIFF
--- a/cmd/precise-code-intel/api-server/Dockerfile
+++ b/cmd/precise-code-intel/api-server/Dockerfile
@@ -39,4 +39,5 @@ USER sourcegraph
 COPY --from=precise-code-intel-builder /precise-code-intel /precise-code-intel
 
 EXPOSE 3186
+ENV LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "node", "/precise-code-intel/out/api-server/api.js"]

--- a/cmd/precise-code-intel/bundle-manager/Dockerfile
+++ b/cmd/precise-code-intel/bundle-manager/Dockerfile
@@ -39,4 +39,5 @@ USER sourcegraph
 COPY --from=precise-code-intel-builder /precise-code-intel /precise-code-intel
 
 EXPOSE 3186
+ENV LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "node", "/precise-code-intel/out/bundle-manager/manager.js"]


### PR DESCRIPTION
This was removed by accident when the dockerfiles were split.