### PR TITLE
extsvc: remove `External` prefix from types

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -16,7 +16,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
-	ExternalAccount     extsvc.ExternalAccountSpec
+	ExternalAccount     extsvc.AccountSpec
 	ExternalAccountData extsvc.ExternalAccountData
 	CreateIfNotExist    bool
 	LookUpByUsername    bool

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -41,7 +41,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		expErr     error
 
 		// expected side effects
-		expSavedExtAccts                 map[int32][]extsvc.ExternalAccountSpec
+		expSavedExtAccts                 map[int32][]extsvc.AccountSpec
 		expUpdatedUsers                  map[int32][]db.UserUpdate
 		expCreatedUsers                  map[int32]db.NewUser
 		expCalledGrantPendingPermissions bool
@@ -56,7 +56,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 	oneUser := []userInfo{{
 		user: types.User{ID: 1, Username: "u1"},
-		extAccts: []extsvc.ExternalAccountSpec{
+		extAccts: []extsvc.AccountSpec{
 			ext("st1", "s1", "c1", "s1/u1"),
 		},
 		emails: []string{"u1@example.com"},
@@ -77,21 +77,21 @@ func TestGetAndSaveUser(t *testing.T) {
 			userInfos: []userInfo{
 				{
 					user: types.User{ID: 1, Username: "u1"},
-					extAccts: []extsvc.ExternalAccountSpec{
+					extAccts: []extsvc.AccountSpec{
 						ext("st1", "s1", "c1", "s1/u1"),
 					},
 					emails: []string{"u1@example.com"},
 				},
 				{
 					user: types.User{ID: 2, Username: "u2"},
-					extAccts: []extsvc.ExternalAccountSpec{
+					extAccts: []extsvc.AccountSpec{
 						ext("st1", "s1", "c1", "s1/u2"),
 					},
 					emails: []string{"u2@example.com"},
 				},
 				{
 					user:     types.User{ID: 3, Username: "u3"},
-					extAccts: []extsvc.ExternalAccountSpec{},
+					extAccts: []extsvc.AccountSpec{},
 					emails:   []string{},
 				},
 			},
@@ -106,7 +106,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -120,7 +120,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -134,7 +134,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -146,7 +146,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -171,7 +171,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -184,7 +184,7 @@ func TestGetAndSaveUser(t *testing.T) {
 					CreateIfNotExist: true,
 				},
 				expUserID: 10001,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					10001: {ext("st1", "s1", "c1", "s1/u-new")},
 				},
 				expCreatedUsers: map[int32]db.NewUser{
@@ -211,7 +211,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				createIfNotExistIrrelevant: true,
 				actorUID:                   2,
 				expUserID:                  2,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					2: {ext("st1", "s1", "c1", "s1/u2")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -225,7 +225,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -240,7 +240,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -258,7 +258,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -272,7 +272,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.ExternalAccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "doesnotexist")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -362,7 +362,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		t.Run(oc.description, func(t *testing.T) {
 			for _, c := range oc.innerCases {
 				if c.expSavedExtAccts == nil {
-					c.expSavedExtAccts = map[int32][]extsvc.ExternalAccountSpec{}
+					c.expSavedExtAccts = map[int32][]extsvc.AccountSpec{}
 				}
 				if c.expUpdatedUsers == nil {
 					c.expUpdatedUsers = map[int32][]db.UserUpdate{}
@@ -424,7 +424,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 type userInfo struct {
 	user     types.User
-	extAccts []extsvc.ExternalAccountSpec
+	extAccts []extsvc.AccountSpec
 	emails   []string
 }
 
@@ -462,7 +462,7 @@ func newMocks(t *testing.T, m mockParams) *mocks {
 	return &mocks{
 		mockParams:    m,
 		t:             t,
-		savedExtAccts: make(map[int32][]extsvc.ExternalAccountSpec),
+		savedExtAccts: make(map[int32][]extsvc.AccountSpec),
 		updatedUsers:  make(map[int32][]db.UserUpdate),
 		createdUsers:  make(map[int32]db.NewUser),
 		nextUserID:    10001,
@@ -511,7 +511,7 @@ type mocks struct {
 	t *testing.T
 
 	// savedExtAccts tracks all ext acct "saves" for a given user ID
-	savedExtAccts map[int32][]extsvc.ExternalAccountSpec
+	savedExtAccts map[int32][]extsvc.AccountSpec
 
 	// createdUsers tracks user creations by user ID
 	createdUsers map[int32]db.NewUser
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.ExternalAccountSpec, data extsvc.E
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.ExternalAccoun
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}
@@ -663,8 +663,8 @@ func (m *mocks) GrantPendingPermissions(context.Context, *db.GrantPendingPermiss
 	return nil
 }
 
-func ext(serviceType, serviceID, clientID, accountID string) extsvc.ExternalAccountSpec {
-	return extsvc.ExternalAccountSpec{
+func ext(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
+	return extsvc.AccountSpec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/cmd/frontend/authz/iface.go
+++ b/cmd/frontend/authz/iface.go
@@ -63,7 +63,7 @@ type Provider interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error)
 
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value
@@ -73,7 +73,7 @@ type Provider interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error)
+	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
 
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string

--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -177,10 +177,10 @@ func (p *RepoPermissions) TracingFields() []otlog.Field {
 type UserPendingPermissions struct {
 	// The auto-generated internal database ID.
 	ID int32
-	// The type of the code host as if it would be used as ExternalAccountSpec.ServiceType,
+	// The type of the code host as if it would be used as extsvc.AccountSpec.ServiceType,
 	// e.g. "github", "gitlab", "bitbucketServer" and "sourcegraph".
 	ServiceType string
-	// The ID of the code host as if it would be used as ExternalAccountSpec.ServiceID,
+	// The ID of the code host as if it would be used as extsvc.AccountSpec.ServiceID,
 	// e.g. "https://github.com/", "https://gitlab.com/" and "https://sourcegraph.com/".
 	ServiceID string
 	// The account ID that a code host (and its authz provider) uses to identify a user,

--- a/cmd/frontend/db/authz.go
+++ b/cmd/frontend/db/authz.go
@@ -39,7 +39,7 @@ type RevokeUserPermissionsArgs struct {
 	UserID int32
 	// The list of external accounts related to the user. This is list because a user could have
 	// multiple external accounts, including ones from code hosts and/or Sourcegraph authz provider.
-	Accounts []*extsvc.ExternalAccounts
+	Accounts []*extsvc.Accounts
 }
 
 // AuthzStore contains methods for manipulating user permissions.

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -41,10 +41,10 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 // LookupUserAndSave is used for authenticating a user (when both their Sourcegraph account and the
 // association with the external account already exist).
 //
-// It looks up the existing user associated with the external account's ExternalAccountSpec. If
+// It looks up the existing user associated with the external account's extsvc.AccountSpec. If
 // found, it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error
-	CreateUserAndSave    func(NewUser, extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error
+	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -17,7 +17,7 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.ExternalAccountSpec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -49,7 +49,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	spec := extsvc.ExternalAccountSpec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -69,7 +69,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: user.ID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: user.ID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }
@@ -81,7 +81,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.ExternalAccountSpec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -110,7 +110,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: userID, ExternalAccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: userID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.ExternalAccountSpec, acct.ExternalAccountData)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.ExternalAccountData)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.ExternalAccountSpec, providerAcct.ExternalAccountData)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.ExternalAccountData)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -1126,11 +1126,11 @@ func (m *MockAuthzProvider) ServiceID() string   { return m.serviceID }
 func (m *MockAuthzProvider) ServiceType() string { return m.serviceType }
 func (m *MockAuthzProvider) Validate() []string  { return nil }
 
-func (m *MockAuthzProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (m *MockAuthzProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
 	return nil, nil
 }
 
-func (m *MockAuthzProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (m *MockAuthzProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	return nil, nil
 }
 

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -657,24 +657,24 @@ func Test_authzFilter(t *testing.T) {
 }
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
-	associateUserAndSaveCount := make(map[int32]map[extsvc.ExternalAccountSpec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.ExternalAccountSpec, data extsvc.ExternalAccountData) error {
+	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
-			associateUserAndSaveCount[userID] = make(map[extsvc.ExternalAccountSpec]int)
+			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
 		}
 		associateUserAndSaveCount[userID][spec]++
 		return nil
 	}
 	mockUser23Accounts := []*extsvc.Account{{
 		UserID: 23,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "okta",
 			ServiceID:   "https://okta.mine/",
 			AccountID:   "101",
 		},
 	}, {
 		UserID: 23,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "other",
 			ServiceID:   "https://other.mine/",
 			AccountID:   "99",
@@ -705,23 +705,23 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	})
 
 	var (
-		expNewAcct           = extsvc.ExternalAccountSpec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
+		expNewAcct           = extsvc.AccountSpec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
 		unAuthdCtx           = context.Background()
 		authd23Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 23})
 		authd99Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 99})
-		account23CreatedOnce = map[int32]map[extsvc.ExternalAccountSpec]int{
+		account23CreatedOnce = map[int32]map[extsvc.AccountSpec]int{
 			23: {
 				expNewAcct: 1,
 			},
 		}
-		account23CreatedTwice = map[int32]map[extsvc.ExternalAccountSpec]int{
+		account23CreatedTwice = map[int32]map[extsvc.AccountSpec]int{
 			23: {
 				expNewAcct: 2,
 			},
 		}
 	)
 	// Initial counts 0
-	if exp := map[int32]map[extsvc.ExternalAccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -729,7 +729,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	if _, err := authzFilter(unAuthdCtx, makeReposFromIDs(77), authz.Read); err != nil {
 		t.Fatal(err)
 	}
-	if exp := map[int32]map[extsvc.ExternalAccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -768,7 +768,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	// Authed filter does NOT trigger new account creation if new account is already provided
 	mockUser23Accounts = append(mockUser23Accounts, &extsvc.Account{
 		UserID: 23,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.mine/",
 			AccountID:   "101",
@@ -922,7 +922,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 	t.Run("authenticated user with matching external account should see all repos", func(t *testing.T) {
 		extAccount := extsvc.Account{
-			ExternalAccountSpec: extsvc.ExternalAccountSpec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.mine/",
 				AccountID:   "alice",
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -991,7 +991,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 					},
 					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						{
-							ExternalAccountSpec: extsvc.ExternalAccountSpec{
+							AccountSpec: extsvc.AccountSpec{
 								ServiceType: "gitlab",
 								ServiceID:   "https://gitlab.mine/",
 								AccountID:   "alice",
@@ -1010,7 +1010,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{
 				{
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.mirror/",
 						AccountID:   "alice",
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.ExternalAccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}
@@ -1060,7 +1060,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 func acct(userID int32, serviceType, serviceID, accountID string) *extsvc.Account {
 	return &extsvc.Account{
 		UserID: userID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -148,11 +148,11 @@ func (f fakeProvider) ServiceType() string           { return f.codeHost.Service
 func (f fakeProvider) ServiceID() string             { return f.codeHost.ServiceID }
 func (f fakeProvider) Validate() (problems []string) { return nil }
 
-func (f fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (f fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
 	return nil, nil
 }
 
-func (f fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (f fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	return nil, nil
 }
 

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -34,7 +34,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
@@ -50,7 +50,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -41,14 +41,14 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		return nil, errors.Wrap(err, "get user by ID")
 	}
 
-	var accounts []*extsvc.ExternalAccounts
+	var accounts []*extsvc.Accounts
 
 	extAccounts, err := db.ExternalAccounts.List(ctx, db.ExternalAccountsListOptions{UserID: userID})
 	if err != nil {
 		return nil, errors.Wrap(err, "list external accounts")
 	}
 	for _, acct := range extAccounts {
-		accounts = append(accounts, &extsvc.ExternalAccounts{
+		accounts = append(accounts, &extsvc.Accounts{
 			ServiceType: acct.ServiceType,
 			ServiceID:   acct.ServiceID,
 			AccountIDs:  []string{acct.AccountID},
@@ -66,7 +66,7 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	for i := range verifiedEmails {
 		emailStrs[i] = verifiedEmails[i].Email
 	}
-	accounts = append(accounts, &extsvc.ExternalAccounts{
+	accounts = append(accounts, &extsvc.Accounts{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  append(emailStrs, user.Username),

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -79,7 +79,7 @@ func TestDeleteUser(t *testing.T) {
 	db.Mocks.ExternalAccounts.List = func(db.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 		return []*extsvc.Account{
 			{
-				ExternalAccountSpec: extsvc.ExternalAccountSpec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "gitlab",
 					ServiceID:   "https://gitlab.com/",
 					AccountID:   "alice_gitlab",

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -92,7 +92,7 @@ func TestDeleteUser(t *testing.T) {
 			return fmt.Errorf("args.UserID: want 6 but got %v", args.UserID)
 		}
 
-		expAccounts := []*extsvc.ExternalAccounts{
+		expAccounts := []*extsvc.Accounts{
 			{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",

--- a/cmd/frontend/internal/auth/override.go
+++ b/cmd/frontend/internal/auth/override.go
@@ -41,7 +41,7 @@ func OverrideAuthMiddleware(next http.Handler) http.Handler {
 					Email:           username + "+override@example.com",
 					EmailIsVerified: true,
 				},
-				ExternalAccount: extsvc.ExternalAccountSpec{
+				ExternalAccount: extsvc.AccountSpec{
 					ServiceType: "override",
 					AccountID:   username,
 				},

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -74,7 +74,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 				DisplayName:     deref(ghUser.Name),
 				AvatarURL:       deref(ghUser.AvatarURL),
 			},
-			ExternalAccount: extsvc.ExternalAccountSpec{
+			ExternalAccount: extsvc.AccountSpec{
 				ServiceType: s.ServiceType,
 				ServiceID:   s.ServiceID,
 				ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -249,8 +249,8 @@ func u(username, email string, emailIsVerified bool) db.NewUser {
 	}
 }
 
-func acct(serviceType, serviceID, clientID, accountID string) extsvc.ExternalAccountSpec {
-	return extsvc.ExternalAccountSpec{
+func acct(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
+	return extsvc.AccountSpec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -49,7 +49,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			DisplayName:     gUser.Name,
 			AvatarURL:       gUser.AvatarURL,
 		},
-		ExternalAccount: extsvc.ExternalAccountSpec{
+		ExternalAccount: extsvc.AccountSpec{
 			ServiceType: s.ServiceType,
 			ServiceID:   s.ServiceID,
 			ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/httpheader/middleware.go
+++ b/enterprise/cmd/frontend/auth/httpheader/middleware.go
@@ -75,7 +75,7 @@ func middleware(next http.Handler) http.Handler {
 		}
 		userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), auth.GetAndSaveUserOp{
 			UserProps: db.NewUser{Username: username},
-			ExternalAccount: extsvc.ExternalAccountSpec{
+			ExternalAccount: extsvc.AccountSpec{
 				ServiceType: providerType,
 				// Store rawUsername, not normalized username, to prevent two users with distinct
 				// pre-normalization usernames from being merged into the same normalized username

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -63,7 +63,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 			DisplayName:     displayName,
 			AvatarURL:       claims.Picture,
 		},
-		ExternalAccount: extsvc.ExternalAccountSpec{
+		ExternalAccount: extsvc.AccountSpec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -15,7 +15,7 @@ import (
 )
 
 type authnResponseInfo struct {
-	spec                 extsvc.ExternalAccountSpec
+	spec                 extsvc.AccountSpec
 	email, displayName   string
 	unnormalizedUsername string
 	accountData          interface{}
@@ -58,7 +58,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 		email = pn
 	}
 	info := authnResponseInfo{
-		spec: extsvc.ExternalAccountSpec{
+		spec: extsvc.AccountSpec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/saml/user_test.go
+++ b/enterprise/cmd/frontend/auth/saml/user_test.go
@@ -32,7 +32,7 @@ func TestReadAuthnResponse(t *testing.T) {
 	}
 	info.accountData = nil // skip checking this field
 	if want := (&authnResponseInfo{
-		spec: extsvc.ExternalAccountSpec{
+		spec: extsvc.AccountSpec{
 			ServiceType: "saml",
 			ServiceID:   "http://localhost:3220/auth/realms/master",
 			ClientID:    "http://localhost:3080/.auth/saml/metadata",

--- a/enterprise/cmd/frontend/authz/authz_test.go
+++ b/enterprise/cmd/frontend/authz/authz_test.go
@@ -45,11 +45,11 @@ func (m gitlabAuthzProviderParams) ServiceType() string {
 
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
 
-func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	panic("should never be called")
 }
 

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -77,7 +77,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 
 	// Each update corresponds to a SetRepoPendingPermssions call
 	type update struct {
-		accounts *extsvc.ExternalAccounts
+		accounts *extsvc.Accounts
 		repoID   int32
 	}
 	tests := []struct {
@@ -99,21 +99,21 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			},
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice@example.com"},
 					},
 					repoID: 1,
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice2@example.com"},
 					},
 					repoID: 2,
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice3@example.com"},
@@ -135,14 +135,14 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			},
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
 					},
 					repoID: 1,
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob"},
@@ -164,21 +164,21 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			},
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "github",
 						ServiceID:   "https://github.com/",
 						AccountIDs:  []string{"alice_github"},
 					},
 					repoID: 1,
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountIDs:  []string{"alice_gitlab"},
 					},
 					repoID: 2,
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "bitbucketServer",
 						ServiceID:   "https://bitbucketServer.com/",
 						AccountIDs:  []string{"alice_bitbucketServer"},
@@ -340,7 +340,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	accounts := &extsvc.ExternalAccounts{
+	accounts := &extsvc.Accounts{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  []string{"alice", "alice@example.com"},
@@ -355,7 +355,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	// Revoke all of them
 	if err := s.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
 		UserID:   1,
-		Accounts: []*extsvc.ExternalAccounts{accounts},
+		Accounts: []*extsvc.Accounts{accounts},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -51,7 +51,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 
 	// Add two external accounts
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.ExternalAccountSpec{
+		extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
@@ -62,7 +62,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.ExternalAccountSpec{
+		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -624,7 +624,7 @@ func (s *PermsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.
 }
 
 func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sqlf.Query) (
-	idToSpecs map[int32]extsvc.ExternalAccountSpec,
+	idToSpecs map[int32]extsvc.AccountSpec,
 	loaded map[int32]*roaring.Bitmap,
 	err error,
 ) {
@@ -642,11 +642,11 @@ func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sql
 	}
 	defer rows.Close()
 
-	idToSpecs = make(map[int32]extsvc.ExternalAccountSpec)
+	idToSpecs = make(map[int32]extsvc.AccountSpec)
 	loaded = make(map[int32]*roaring.Bitmap)
 	for rows.Next() {
 		var id int32
-		var spec extsvc.ExternalAccountSpec
+		var spec extsvc.AccountSpec
 		var ids []byte
 		if err = rows.Scan(&id, &spec.ServiceType, &spec.ServiceID, &spec.AccountID, &ids); err != nil {
 			return nil, nil, err

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -458,12 +458,12 @@ AND bind_id = %s
 // This method starts its own transaction for update consistency if the caller hasn't started one already.
 //
 // Example input:
-//  &ExternalAccounts{
+//  &extsvc.Accounts{
 //      ServiceType: "sourcegraph",
 //      ServiceID:   "https://sourcegraph.com/",
 //      AccountIDs:  []string{"alice", "bob"},
 //  }
-//  &RepoPermissions{
+//  &authz.RepoPermissions{
 //      RepoID: 1,
 //      Perm: authz.Read,
 //  }
@@ -479,7 +479,7 @@ AND bind_id = %s
 //   repo_id | permission |   user_ids   | updated_at
 //  ---------+------------+--------------+------------
 //         1 |       read | bitmap{1, 2} | <DateTime>
-func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *extsvc.ExternalAccounts, p *authz.RepoPermissions) (err error) {
+func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) (err error) {
 	if Mocks.Perms.SetRepoPendingPermissions != nil {
 		return Mocks.Perms.SetRepoPendingPermissions(ctx, accounts, p)
 	}
@@ -672,7 +672,7 @@ func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sql
 }
 
 func insertUserPendingPermissionsBatchQuery(
-	accounts *extsvc.ExternalAccounts,
+	accounts *extsvc.Accounts,
 	p *authz.RepoPermissions,
 ) (*sqlf.Query, error) {
 	const format = `
@@ -1099,7 +1099,7 @@ func (s *PermsStore) DeleteAllUserPermissions(ctx context.Context, userID int32)
 
 // DeleteAllUserPendingPermissions deletes all rows with given bind IDs from the "user_pending_permissions" table.
 // It accepts list of bind IDs because a user has multiple bind IDs, e.g. username and email addresses.
-func (s *PermsStore) DeleteAllUserPendingPermissions(ctx context.Context, accounts *extsvc.ExternalAccounts) (err error) {
+func (s *PermsStore) DeleteAllUserPendingPermissions(ctx context.Context, accounts *extsvc.Accounts) (err error) {
 	ctx, save := s.observe(ctx, "DeleteAllUserPendingPermissions", "")
 	defer func() { save(&err, accounts.TracingFields()...) }()
 
@@ -1302,7 +1302,7 @@ ORDER BY id ASC
 // The returned set has mapping relation as "account ID -> user ID". The number of results
 // could be less than the candidate list due to some users are not associated with any external
 // account.
-func (s *PermsStore) GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.ExternalAccounts) (_ map[string]int32, err error) {
+func (s *PermsStore) GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.Accounts) (_ map[string]int32, err error) {
 	if Mocks.Perms.GetUserIDsByExternalAccounts != nil {
 		return Mocks.Perms.GetUserIDsByExternalAccounts(ctx, accounts)
 	}

--- a/enterprise/cmd/frontend/db/perms_store_mock.go
+++ b/enterprise/cmd/frontend/db/perms_store_mock.go
@@ -14,8 +14,8 @@ type MockPerms struct {
 	LoadUserPendingPermissions   func(ctx context.Context, p *authz.UserPendingPermissions) error
 	SetUserPermissions           func(ctx context.Context, p *authz.UserPermissions) error
 	SetRepoPermissions           func(ctx context.Context, p *authz.RepoPermissions) error
-	SetRepoPendingPermissions    func(ctx context.Context, accounts *extsvc.ExternalAccounts, p *authz.RepoPermissions) error
+	SetRepoPendingPermissions    func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error
 	ListPendingUsers             func(ctx context.Context) ([]string, error)
 	ListExternalAccounts         func(ctx context.Context, userID int32) ([]*extsvc.Account, error)
-	GetUserIDsByExternalAccounts func(ctx context.Context, accounts *extsvc.ExternalAccounts) (map[string]int32, error)
+	GetUserIDsByExternalAccounts func(ctx context.Context, accounts *extsvc.Accounts) (map[string]int32, error)
 }

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -570,7 +570,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 				cleanupPermsTables(t, s)
 			})
 
-			accounts := &extsvc.ExternalAccounts{
+			accounts := &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
@@ -603,7 +603,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 				cleanupPermsTables(t, s)
 			})
 
-			accounts := &extsvc.ExternalAccounts{
+			accounts := &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
@@ -636,7 +636,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 				cleanupPermsTables(t, s)
 			})
 
-			accounts := &extsvc.ExternalAccounts{
+			accounts := &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
@@ -669,7 +669,7 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 				cleanupPermsTables(t, s)
 			})
 
-			accounts := &extsvc.ExternalAccounts{
+			accounts := &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice", "bob"},
@@ -867,7 +867,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 	}
 
 	type update struct {
-		accounts *extsvc.ExternalAccounts
+		accounts *extsvc.Accounts
 		perm     *authz.RepoPermissions
 	}
 	tests := []struct {
@@ -880,7 +880,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "empty",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  nil,
@@ -896,7 +896,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
@@ -906,7 +906,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob"},
@@ -916,7 +916,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "github",
 						ServiceID:   "https://github.com/",
 						AccountIDs:  []string{"cindy"},
@@ -942,7 +942,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add and update",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob"},
@@ -952,7 +952,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob", "cindy"},
@@ -962,7 +962,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "github",
 						ServiceID:   "https://github.com/",
 						AccountIDs:  []string{"cindy"},
@@ -988,7 +988,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 			name: "add and clear",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice", "bob", "cindy"},
@@ -998,7 +998,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{},
@@ -1071,7 +1071,7 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 
 func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 	type update struct {
-		accounts *extsvc.ExternalAccounts
+		accounts *extsvc.Accounts
 		perm     *authz.RepoPermissions
 	}
 	tests := []struct {
@@ -1087,7 +1087,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 			name: "has user with pending permissions",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"alice"},
@@ -1104,7 +1104,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 			name: "has user but with empty object_ids",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  []string{"bob@example.com"},
@@ -1114,7 +1114,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 						Perm:   authz.Read,
 					},
 				}, {
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: authz.SourcegraphServiceType,
 						ServiceID:   authz.SourcegraphServiceID,
 						AccountIDs:  nil,
@@ -1131,7 +1131,7 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 			name: "has user but with different service ID",
 			updates: []update{
 				{
-					accounts: &extsvc.ExternalAccounts{
+					accounts: &extsvc.Accounts{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountIDs:  []string{"bob@example.com"},
@@ -1192,7 +1192,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 	}
 
 	type pending struct {
-		accounts *extsvc.ExternalAccounts
+		accounts *extsvc.Accounts
 		perm     *authz.RepoPermissions
 	}
 	type update struct {
@@ -1244,7 +1244,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice"},
@@ -1254,7 +1254,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"bob"},
@@ -1313,7 +1313,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice"},
@@ -1324,7 +1324,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 							},
 						},
 						{
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: "gitlab",
 								ServiceID:   "https://gitlab.com/",
 								AccountIDs:  []string{"alice"},
@@ -1334,7 +1334,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"bob"},
@@ -1403,7 +1403,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 					pendings: []pending{
 						{
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice@example.com"},
@@ -1413,7 +1413,7 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 								Perm:   authz.Read,
 							},
 						}, {
-							accounts: &extsvc.ExternalAccounts{
+							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
 								AccountIDs:  []string{"alice2@example.com"},
@@ -1582,7 +1582,7 @@ func testPermsStore_DeleteAllUserPendingPermissions(db *sql.DB) func(*testing.T)
 
 		ctx := context.Background()
 
-		accounts := &extsvc.ExternalAccounts{
+		accounts := &extsvc.Accounts{
 			ServiceType: authz.SourcegraphServiceType,
 			ServiceID:   authz.SourcegraphServiceID,
 			AccountIDs:  []string{"alice", "bob"},
@@ -1658,7 +1658,7 @@ func testPermsStore_DatabaseDeadlocks(db *sql.DB) func(*testing.T) {
 			}
 		}
 		setRepoPendingPermissions := func(ctx context.Context, t *testing.T) {
-			accounts := &extsvc.ExternalAccounts{
+			accounts := &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},
@@ -1861,7 +1861,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 			}
 		}
 
-		accounts := &extsvc.ExternalAccounts{
+		accounts := &extsvc.Accounts{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
 			AccountIDs:  []string{"alice_gitlab", "bob_gitlab", "david_gitlab"},
@@ -1996,7 +1996,7 @@ func testPermsStore_RepoIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 			t.Fatal(err)
 		}
 		err = s.SetRepoPendingPermissions(ctx,
-			&extsvc.ExternalAccounts{
+			&extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"alice"},

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -735,9 +735,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 func checkUserPendingPermsTable(
 	ctx context.Context,
 	s *PermsStore,
-	expects map[extsvc.ExternalAccountSpec][]uint32,
+	expects map[extsvc.AccountSpec][]uint32,
 ) (
-	idToSpecs map[int32]extsvc.ExternalAccountSpec,
+	idToSpecs map[int32]extsvc.AccountSpec,
 	err error,
 ) {
 	q := `SELECT id, service_type, service_id, bind_id, object_ids FROM user_pending_permissions`
@@ -747,10 +747,10 @@ func checkUserPendingPermsTable(
 	}
 
 	// Collect id -> account mappings for later used by checkRepoPendingPermsTable.
-	idToSpecs = make(map[int32]extsvc.ExternalAccountSpec)
+	idToSpecs = make(map[int32]extsvc.AccountSpec)
 	for rows.Next() {
 		var id int32
-		var spec extsvc.ExternalAccountSpec
+		var spec extsvc.AccountSpec
 		var ids []byte
 		if err := rows.Scan(&id, &spec.ServiceType, &spec.ServiceID, &spec.AccountID, &ids); err != nil {
 			return nil, err
@@ -789,8 +789,8 @@ func checkUserPendingPermsTable(
 func checkRepoPendingPermsTable(
 	ctx context.Context,
 	s *PermsStore,
-	idToSpecs map[int32]extsvc.ExternalAccountSpec,
-	expects map[int32][]extsvc.ExternalAccountSpec,
+	idToSpecs map[int32]extsvc.AccountSpec,
+	expects map[int32][]extsvc.AccountSpec,
 ) error {
 	rows, err := s.db.QueryContext(ctx, `SELECT repo_id, user_ids FROM repo_pending_permissions`)
 	if err != nil {
@@ -815,7 +815,7 @@ func checkRepoPendingPermsTable(
 		}
 		sort.Ints(userIDs)
 
-		haveSpecs := make([]extsvc.ExternalAccountSpec, 0, len(userIDs))
+		haveSpecs := make([]extsvc.AccountSpec, 0, len(userIDs))
 		for _, userID := range userIDs {
 			spec, ok := idToSpecs[int32(userID)]
 			if !ok {
@@ -845,22 +845,22 @@ func checkRepoPendingPermsTable(
 }
 
 func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
-	alice := extsvc.ExternalAccountSpec{
+	alice := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
-	bob := extsvc.ExternalAccountSpec{
+	bob := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
 	}
-	cindy := extsvc.ExternalAccountSpec{
+	cindy := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "cindy",
 	}
-	cindyGitHub := extsvc.ExternalAccountSpec{
+	cindyGitHub := extsvc.AccountSpec{
 		ServiceType: "github",
 		ServiceID:   "https://github.com/",
 		AccountID:   "cindy",
@@ -873,8 +873,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 	tests := []struct {
 		name                   string
 		updates                []update
-		expectUserPendingPerms map[extsvc.ExternalAccountSpec][]uint32 // account -> object_ids
-		expectRepoPendingPerms map[int32][]extsvc.ExternalAccountSpec  // repo_id -> accounts
+		expectUserPendingPerms map[extsvc.AccountSpec][]uint32 // account -> object_ids
+		expectRepoPendingPerms map[int32][]extsvc.AccountSpec  // repo_id -> accounts
 	}{
 		{
 			name: "empty",
@@ -927,12 +927,12 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice:       {1, 2},
 				bob:         {2},
 				cindyGitHub: {3},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {alice},
 				2: {alice, bob},
 				3: {cindyGitHub},
@@ -973,13 +973,13 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice:       {},
 				bob:         {1},
 				cindy:       {1},
 				cindyGitHub: {2},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {bob, cindy},
 				2: {cindyGitHub},
 			},
@@ -1009,12 +1009,12 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice: {},
 				bob:   {},
 				cindy: {},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 			},
 		},
@@ -1180,12 +1180,12 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 }
 
 func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
-	alice := extsvc.ExternalAccountSpec{
+	alice := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
-	bob := extsvc.ExternalAccountSpec{
+	bob := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
@@ -1207,10 +1207,10 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 		name                   string
 		updates                []update
 		grants                 []grant
-		expectUserPerms        map[int32][]uint32                      // user_id -> object_ids
-		expectRepoPerms        map[int32][]uint32                      // repo_id -> user_ids
-		expectUserPendingPerms map[extsvc.ExternalAccountSpec][]uint32 // account -> object_ids
-		expectRepoPendingPerms map[int32][]extsvc.ExternalAccountSpec  // repo_id -> accounts
+		expectUserPerms        map[int32][]uint32              // user_id -> object_ids
+		expectRepoPerms        map[int32][]uint32              // repo_id -> user_ids
+		expectUserPendingPerms map[extsvc.AccountSpec][]uint32 // account -> object_ids
+		expectRepoPendingPerms map[int32][]extsvc.AccountSpec  // repo_id -> accounts
 	}{
 		{
 			name: "empty",
@@ -1287,11 +1287,11 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1},
 				2: {1, 2},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice: {1},
 				bob:   {2},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {alice},
 				2: {bob},
 			},
@@ -1377,10 +1377,10 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1, 3},
 				2: {1, 2, 3},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				bob: {3},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 				2: {},
 				3: {bob},
@@ -1456,8 +1456,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1, 3},
 				2: {1, 2, 3},
 			},
-			expectUserPendingPerms: map[extsvc.ExternalAccountSpec][]uint32{},
-			expectRepoPendingPerms: map[int32][]extsvc.ExternalAccountSpec{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{},
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 				2: {},
 			},
@@ -1776,7 +1776,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     1,
 					UserID: 1,
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountID:   "alice_gitlab",
@@ -1788,7 +1788,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     2,
 					UserID: 1,
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com/",
 						AccountID:   "alice_github",
@@ -1814,7 +1814,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     3,
 					UserID: 2,
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountID:   "bob_gitlab",

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -199,7 +199,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8296923984
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
 	switch {
 	case account == nil:
 		return nil, errors.New("no account provided")
@@ -217,9 +217,9 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 
 	ids, err := p.repoIDs(ctx, user.Name, false)
 
-	extIDs := make([]extsvc.ExternalRepoID, 0, len(ids))
+	extIDs := make([]extsvc.RepoID, 0, len(ids))
 	for _, id := range ids {
-		extIDs = append(extIDs, extsvc.ExternalRepoID(strconv.FormatUint(uint64(id), 10)))
+		extIDs = append(extIDs, extsvc.RepoID(strconv.FormatUint(uint64(id), 10)))
 	}
 
 	return extIDs, err
@@ -234,7 +234,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8283203728
-func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
 	switch {
 	case repo == nil:
 		return nil, errors.New("no repo provided")
@@ -245,9 +245,9 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) 
 
 	ids, err := p.userIDs(ctx, repo.ID)
 
-	extIDs := make([]extsvc.ExternalAccountID, 0, len(ids))
+	extIDs := make([]extsvc.AccountID, 0, len(ids))
 	for _, id := range ids {
-		extIDs = append(extIDs, extsvc.ExternalAccountID(strconv.FormatInt(int64(id), 10)))
+		extIDs = append(extIDs, extsvc.AccountID(strconv.FormatInt(int64(id), 10)))
 	}
 
 	return extIDs, err

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -180,7 +180,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 
 	return &extsvc.Account{
 		UserID: user.ID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
@@ -207,7 +207,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account data provided")
 	case !extsvc.IsHostOfAccount(p.codeHost, account):
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			p.codeHost.ServiceID, account.ExternalAccountSpec.ServiceID)
+			p.codeHost.ServiceID, account.AccountSpec.ServiceID)
 	}
 
 	var user bitbucketserver.User

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -267,10 +267,10 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 
 		h := codeHost{CodeHost: p.codeHost}
 
-		repoIDs := func(names ...string) (ids []extsvc.ExternalRepoID) {
+		repoIDs := func(names ...string) (ids []extsvc.RepoID) {
 			for _, name := range names {
 				if r, ok := f.repos[name]; ok {
-					ids = append(ids, extsvc.ExternalRepoID(strconv.FormatInt(int64(r.ID), 10)))
+					ids = append(ids, extsvc.RepoID(strconv.FormatInt(int64(r.ID), 10)))
 				}
 			}
 			return ids
@@ -280,7 +280,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			name string
 			ctx  context.Context
 			acct *extsvc.Account
-			ids  []extsvc.ExternalRepoID
+			ids  []extsvc.RepoID
 			err  string
 		}{
 			{
@@ -361,10 +361,10 @@ func testProviderFetchRepoPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 
 		h := codeHost{CodeHost: p.codeHost}
 
-		userIDs := func(names ...string) (ids []extsvc.ExternalAccountID) {
+		userIDs := func(names ...string) (ids []extsvc.AccountID) {
 			for _, name := range names {
 				if r, ok := f.users[name]; ok {
-					ids = append(ids, extsvc.ExternalAccountID(strconv.FormatInt(int64(r.ID), 10)))
+					ids = append(ids, extsvc.AccountID(strconv.FormatInt(int64(r.ID), 10)))
 				}
 			}
 			return ids
@@ -374,7 +374,7 @@ func testProviderFetchRepoPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			name string
 			ctx  context.Context
 			repo *extsvc.Repository
-			ids  []extsvc.ExternalAccountID
+			ids  []extsvc.AccountID
 			err  string
 		}{
 			{

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -296,7 +296,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "not a code host of the account",
 				acct: &extsvc.Account{
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
@@ -310,7 +310,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "bad account data",
 				acct: &extsvc.Account{
-					ExternalAccountSpec: extsvc.ExternalAccountSpec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: h.ServiceType,
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
@@ -617,7 +617,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 	bs := marshalJSON(u)
 	return &extsvc.Account{
 		UserID: userID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: h.ServiceType,
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -389,7 +389,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.ExternalAccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := github.GetExternalAccountData(&account.ExternalAccountData)

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -384,7 +384,7 @@ func (p *Provider) Validate() (problems []string) {
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -400,7 +400,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
-	repoIDs := make([]extsvc.ExternalRepoID, 0, 100)
+	repoIDs := make([]extsvc.RepoID, 0, 100)
 	hasNextPage := true
 	for page := 1; hasNextPage; page++ {
 		var repos []*github.Repository
@@ -410,7 +410,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		}
 
 		for _, r := range repos {
-			repoIDs = append(repoIDs, extsvc.ExternalRepoID(r.ID))
+			repoIDs = append(repoIDs, extsvc.RepoID(r.ID))
 		}
 	}
 
@@ -426,7 +426,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v4/object/repositorycollaboratorconnection/
-func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {
@@ -443,7 +443,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) 
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
-	userIDs := make([]extsvc.ExternalAccountID, 0, 100)
+	userIDs := make([]extsvc.AccountID, 0, 100)
 	hasNextPage := true
 	for page := 1; hasNextPage; page++ {
 		var err error
@@ -454,7 +454,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) 
 		}
 
 		for _, u := range users {
-			userIDs = append(userIDs, extsvc.ExternalAccountID(u.ID))
+			userIDs = append(userIDs, extsvc.AccountID(u.ID))
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -398,7 +398,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 
 	return &extsvc.Account{
 		UserID: userID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -291,7 +291,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 
 	glExternalAccount := extsvc.Account{
 		UserID: user.ID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -17,7 +17,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -45,7 +45,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -22,7 +22,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.ExternalAccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -104,7 +104,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expRepoIDs := []extsvc.ExternalRepoID{"1", "2", "3"}
+	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
 	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
 		t.Fatal(diff)
 	}
@@ -196,7 +196,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	}
 
 	// 1 should not be included because of "access_level" < 20
-	expAccountIDs := []extsvc.ExternalAccountID{"2", "3"}
+	expAccountIDs := []extsvc.AccountID{"2", "3"}
 	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
 		t.Fatal(diff)
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -42,7 +42,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				ExternalAccountSpec: extsvc.ExternalAccountSpec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -91,7 +91,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			ExternalAccountSpec: extsvc.ExternalAccountSpec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -19,7 +19,7 @@ import (
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -40,7 +40,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide
 // whether to discard.
-func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.ExternalRepoID, error) {
+func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.RepoID, error) {
 	q := make(url.Values)
 	q.Add("visibility", "private")  // This method is meant to return only private projects
 	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
@@ -51,7 +51,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.External
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
-	projectIDs := make([]extsvc.ExternalRepoID, 0, 100)
+	projectIDs := make([]extsvc.RepoID, 0, 100)
 	for {
 		projects, next, err := client.ListProjects(ctx, nextURL)
 		if err != nil {
@@ -59,7 +59,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.External
 		}
 
 		for _, p := range projects {
-			projectIDs = append(projectIDs, extsvc.ExternalRepoID(strconv.Itoa(p.ID)))
+			projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
 		}
 
 		if next == nil {
@@ -80,7 +80,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.External
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
 	if repo == nil {
 		return nil, errors.New("no repository provided")
 	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {
@@ -97,7 +97,7 @@ func (p *SudoProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Reposito
 // both direct access and inherited from the group membership. It may return partial
 // but valid results in case of error, and it is up to callers to decide whether to
 // discard.
-func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]extsvc.ExternalAccountID, error) {
+func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]extsvc.AccountID, error) {
 	q := make(url.Values)
 	q.Add("per_page", "100") // 100 is the maximum page size
 
@@ -106,7 +106,7 @@ func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]e
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
-	userIDs := make([]extsvc.ExternalAccountID, 0, 100)
+	userIDs := make([]extsvc.AccountID, 0, 100)
 
 	for {
 		members, next, err := client.ListMembers(ctx, nextURL)
@@ -120,7 +120,7 @@ func listMembers(ctx context.Context, client *gitlab.Client, repoID string) ([]e
 				continue
 			}
 
-			userIDs = append(userIDs, extsvc.ExternalAccountID(strconv.Itoa(int(m.ID))))
+			userIDs = append(userIDs, extsvc.AccountID(strconv.Itoa(int(m.ID))))
 		}
 
 		if next == nil {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -24,7 +24,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.ExternalAccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -102,7 +102,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expRepoIDs := []extsvc.ExternalRepoID{"1", "2", "3"}
+	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
 	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
 		t.Fatal(diff)
 	}
@@ -194,7 +194,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 	}
 
 	// 1 should not be included because of "access_level" < 20
-	expAccountIDs := []extsvc.ExternalAccountID{"2", "3"}
+	expAccountIDs := []extsvc.AccountID{"2", "3"}
 	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
 		t.Fatal(diff)
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -34,7 +34,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				ExternalAccountSpec: extsvc.ExternalAccountSpec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -89,7 +89,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	accountData := json.RawMessage(`{"id": 999}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			ExternalAccountSpec: extsvc.ExternalAccountSpec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -104,7 +104,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	}
 	defer txs.Done(&err)
 
-	accounts := &extsvc.ExternalAccounts{
+	accounts := &extsvc.Accounts{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  pendingBindIDs,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -68,7 +68,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 		mockUsers          []*types.User
 		gqlTests           []*gqltesting.Test
 		expUserIDs         []uint32
-		expAccounts        *extsvc.ExternalAccounts
+		expAccounts        *extsvc.Accounts
 	}{
 		{
 			name: "set permissions via email",
@@ -103,7 +103,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				},
 			},
 			expUserIDs: []uint32{1},
-			expAccounts: &extsvc.ExternalAccounts{
+			expAccounts: &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
@@ -142,7 +142,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				},
 			},
 			expUserIDs: []uint32{1},
-			expAccounts: &extsvc.ExternalAccounts{
+			expAccounts: &extsvc.Accounts{
 				ServiceType: authz.SourcegraphServiceType,
 				ServiceID:   authz.SourcegraphServiceID,
 				AccountIDs:  []string{"bob"},
@@ -175,7 +175,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				}
 				return nil
 			}
-			edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *extsvc.ExternalAccounts, _ *authz.RepoPermissions) error {
+			edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *extsvc.Accounts, _ *authz.RepoPermissions) error {
 				if diff := cmp.Diff(test.expAccounts, accounts); diff != "" {
 					return fmt.Errorf("accounts: %v", diff)
 				}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -269,7 +269,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		}
 
 		// Get corresponding internal database IDs
-		userIDs, err = s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.ExternalAccounts{
+		userIDs, err = s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.Accounts{
 			ServiceType: provider.ServiceType(),
 			ServiceID:   provider.ServiceID(),
 			AccountIDs:  accountIDs,
@@ -311,7 +311,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	}
 	defer txs.Done(&err)
 
-	accounts := &extsvc.ExternalAccounts{
+	accounts := &extsvc.Accounts{
 		ServiceType: provider.ServiceType(),
 		ServiceID:   provider.ServiceID(),
 		AccountIDs:  pendingAccountIDs,

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -207,7 +207,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	edb.Mocks.Perms.Transact = func(context.Context) (*edb.PermsStore, error) {
 		return &edb.PermsStore{}, nil
 	}
-	edb.Mocks.Perms.GetUserIDsByExternalAccounts = func(context.Context, *extsvc.ExternalAccounts) (map[string]int32, error) {
+	edb.Mocks.Perms.GetUserIDsByExternalAccounts = func(context.Context, *extsvc.Accounts) (map[string]int32, error) {
 		return map[string]int32{"user": 1}, nil
 	}
 	edb.Mocks.Perms.SetRepoPermissions = func(_ context.Context, p *authz.RepoPermissions) error {
@@ -221,8 +221,8 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		}
 		return nil
 	}
-	edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *extsvc.ExternalAccounts, _ *authz.RepoPermissions) error {
-		expAccounts := &extsvc.ExternalAccounts{
+	edb.Mocks.Perms.SetRepoPendingPermissions = func(_ context.Context, accounts *extsvc.Accounts, _ *authz.RepoPermissions) error {
+		expAccounts := &extsvc.Accounts{
 			ServiceType: p.ServiceType(),
 			ServiceID:   p.ServiceID(),
 			AccountIDs:  []string{"pending_user"},

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -127,7 +127,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	defer authz.SetProviders(true, nil)
 
 	extAccount := extsvc.Account{
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.ServiceType(),
 			ServiceID:   p.ServiceID(),
 		},

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -54,8 +54,8 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error)
-	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.RepoID, error)
+	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
 }
 
 func (*mockProvider) RepoPerms(context.Context, *extsvc.Account, []*types.Repo) ([]authz.RepoPerms, error) {
@@ -78,11 +78,11 @@ func (*mockProvider) Validate() []string {
 	return nil
 }
 
-func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
+func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.RepoID, error) {
 	return p.fetchUserPerms(ctx, acct)
 }
 
-func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
+func (p *mockProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error) {
 	return p.fetchRepoPerms(ctx, repo)
 }
 
@@ -184,8 +184,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.ExternalRepoID, error) {
-				return []extsvc.ExternalRepoID{"1"}, test.fetchErr
+			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
+				return []extsvc.RepoID{"1"}, test.fetchErr
 			}
 
 			err := s.syncUserPerms(context.Background(), 1, test.noPerms)
@@ -274,8 +274,8 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchRepoPerms = func(context.Context, *extsvc.Repository) ([]extsvc.ExternalAccountID, error) {
-				return []extsvc.ExternalAccountID{"user", "pending_user"}, test.fetchErr
+			p.fetchRepoPerms = func(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
+				return []extsvc.AccountID{"user", "pending_user"}, test.fetchErr
 			}
 
 			err := s.syncRepoPerms(context.Background(), 1, test.noPerms)

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -13,16 +13,16 @@ import (
 type Account struct {
 	ID                  int32
 	UserID              int32
-	ExternalAccountSpec // ServiceType, ServiceID, ClientID, AccountID
+	AccountSpec         // ServiceType, ServiceID, ClientID, AccountID
 	ExternalAccountData // AuthData, AccountData
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
 
-// ExternalAccountSpec specifies a user external account by its external identifier (i.e., by
-// the identifier provided by the account's owner service), instead of by our database's serial
+// AccountSpec specifies a user external account by its external identifier (i.e., by the
+// identifier provided by the account's owner service), instead of by our database's serial
 // ID. See the GraphQL API's corresponding fields in "ExternalAccount" for documentation.
-type ExternalAccountSpec struct {
+type AccountSpec struct {
 	ServiceType string
 	ServiceID   string
 	ClientID    string
@@ -44,8 +44,8 @@ type Repository struct {
 }
 
 // ExternalAccounts contains a list of accounts that belong to the same external service.
-// All fields have a same meaning to ExternalAccountSpec. See GraphQL API's corresponding
-// fields in "ExternalAccount" for documentation.
+// All fields have a same meaning to AccountSpec. See GraphQL API's corresponding fields
+// in "ExternalAccount" for documentation.
 type ExternalAccounts struct {
 	ServiceType string
 	ServiceID   string

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -61,12 +61,12 @@ func (s *ExternalAccounts) TracingFields() []otlog.Field {
 	}
 }
 
-// ExternalAccountID is a descriptive type for the external identifier of an external account
-// on the code host. It can be the string representation of an integer (e.g. GitLab), a GraphQL
-// ID (e.g. GitHub), or a username (e.g. Bitbucket Server) depends on the code host type.
-type ExternalAccountID string
+// AccountID is a descriptive type for the external identifier of an external account on the
+// code host. It can be the string representation of an integer (e.g. GitLab), a GraphQL ID
+// (e.g. GitHub), or a username (e.g. Bitbucket Server) depends on the code host type.
+type AccountID string
 
-// ExternalRepoID is a descriptive type for the external identifier of an external repository
-// on the code host. It can be the string representation of an integer (e.g. GitLab and Bitbucket
+// RepoID is a descriptive type for the external identifier of an external repository on the
+// code host. It can be the string representation of an integer (e.g. GitLab and Bitbucket
 // Server) or a GraphQL ID (e.g. GitHub) depends on the code host type.
-type ExternalRepoID string
+type RepoID string

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -43,21 +43,21 @@ type Repository struct {
 	api.ExternalRepoSpec
 }
 
-// ExternalAccounts contains a list of accounts that belong to the same external service.
+// Accounts contains a list of accounts that belong to the same external service.
 // All fields have a same meaning to AccountSpec. See GraphQL API's corresponding fields
 // in "ExternalAccount" for documentation.
-type ExternalAccounts struct {
+type Accounts struct {
 	ServiceType string
 	ServiceID   string
 	AccountIDs  []string
 }
 
 // TracingFields returns tracing fields for the opentracing log.
-func (s *ExternalAccounts) TracingFields() []otlog.Field {
+func (s *Accounts) TracingFields() []otlog.Field {
 	return []otlog.Field{
-		otlog.String("ExternalAccounts.ServiceType", s.ServiceType),
-		otlog.String("ExternalAccounts.Perm", s.ServiceID),
-		otlog.Int("ExternalAccounts.AccountIDs.Count", len(s.AccountIDs)),
+		otlog.String("Accounts.ServiceType", s.ServiceType),
+		otlog.String("Accounts.Perm", s.ServiceID),
+		otlog.Int("Accounts.AccountIDs.Count", len(s.AccountIDs)),
 	}
 }
 


### PR DESCRIPTION
It is redundant to have `External` prefix since they all live under `extsvc` namespace.

Better to review by commit.

NOTE: I left out `ExternalAccountData` because a simple rename breaks some code logic (it also has a field named `AccountData`), so I would like to do that in a subsequent PR.