### PR TITLE
extsvc: rename `ExternalAccountData` to `Data`

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -17,7 +17,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
 	ExternalAccount     extsvc.AccountSpec
-	ExternalAccountData extsvc.ExternalAccountData
+	ExternalAccountData extsvc.Data
 	CreateIfNotExist    bool
 	LookUpByUsername    bool
 }

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalA
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, d
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -44,7 +44,7 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 // It looks up the existing user associated with the external account's extsvc.AccountSpec. If
 // found, it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error
-	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.Data) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error
+	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.Data) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -23,12 +23,12 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.Data{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.ExternalAccountData{})
+	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.Data{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.ExternalAccountData{}); err != nil {
+	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.Data{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -87,7 +87,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.Data{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.ExternalAccountData)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.Data)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.ExternalAccountData)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.Data)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -658,7 +658,7 @@ func Test_authzFilter(t *testing.T) {
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
 	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
 			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
 		}
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -39,7 +39,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
+					Data: extsvc.Data{AccountData: nil},
 				},
 			}
 		}(),
@@ -55,7 +55,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
+					Data: extsvc.Data{AccountData: nil},
 				},
 			}
 		}(),

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -59,7 +59,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	// Try every verified email in succession until the first that succeeds
-	var data extsvc.ExternalAccountData
+	var data extsvc.Data
 	githubsvc.SetExternalAccountData(&data, ghUser, token)
 	var (
 		firstSafeErrMsg string

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -202,7 +202,7 @@ func TestGetOrCreateUser(t *testing.T) {
 					if gotAuthUserOp != nil {
 						t.Fatal("GetAndSaveUser called more than once")
 					}
-					op.ExternalAccountData = extsvc.ExternalAccountData{} // ignore ExternalAccountData value
+					op.ExternalAccountData = extsvc.Data{} // ignore Data value
 					gotAuthUserOp = &op
 
 					if uid, ok := authSaveableUsers[op.UserProps.Username]; ok {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -35,7 +35,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.ExternalAccountData
+	var data extsvc.Data
 	gitlab.SetExternalAccountData(&data, gUser, token)
 
 	// Unlike with GitHub, we can *only* use the primary email to resolve the user's identity,

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -48,7 +48,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.ExternalAccountData
+	var data extsvc.Data
 	data.SetAccountData(struct {
 		IDToken    *oidc.IDToken  `json:"idToken"`
 		UserInfo   *oidc.UserInfo `json:"userInfo"`

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -85,7 +85,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
 func getOrCreateUser(ctx context.Context, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
-	var data extsvc.ExternalAccountData
+	var data extsvc.Data
 	data.SetAccountData(info.accountData)
 
 	username, err := auth.NormalizeUsername(info.unnormalizedUsername)

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -56,7 +56,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
 		},
-		extsvc.ExternalAccountData{},
+		extsvc.Data{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",
 		},
-		extsvc.ExternalAccountData{},
+		extsvc.Data{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -185,7 +185,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
 		},
-		ExternalAccountData: extsvc.ExternalAccountData{
+		Data: extsvc.Data{
 			AccountData: (*json.RawMessage)(&accountData),
 		},
 	}, nil

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -301,7 +301,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{
+					Data: extsvc.Data{
 						AccountData: new(json.RawMessage),
 					},
 				},
@@ -315,7 +315,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{
+					Data: extsvc.Data{
 						AccountData: new(json.RawMessage),
 					},
 				},
@@ -622,7 +622,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),
 		},
-		ExternalAccountData: extsvc.ExternalAccountData{
+		Data: extsvc.Data{
 			AccountData: (*json.RawMessage)(&bs),
 		},
 	}

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -324,7 +324,7 @@ func (p *Provider) getCachedUserRepos(ctx context.Context, userAccount *extsvc.A
 }
 
 func (p *Provider) fetchUserRepos(ctx context.Context, userAccount *extsvc.Account, repoIDs []string) (canAccess map[string]bool, isPublic map[string]bool, err error) {
-	_, tok, err := github.GetExternalAccountData(&userAccount.ExternalAccountData)
+	_, tok, err := github.GetExternalAccountData(&userAccount.Data)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,7 +392,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := github.GetExternalAccountData(&account.ExternalAccountData)
+	_, tok, err := github.GetExternalAccountData(&account.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -271,7 +271,7 @@ func mustURL(t *testing.T, u string) *url.URL {
 func ua(accountID, token string) *extsvc.Account {
 	var a extsvc.Account
 	a.AccountID = accountID
-	github.SetExternalAccountData(&a.ExternalAccountData, nil, &oauth2.Token{
+	github.SetExternalAccountData(&a.Data, nil, &oauth2.Token{
 		AccessToken: token,
 	})
 	return &a

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -378,7 +378,7 @@ func (m mockAuthnProvider) Refresh(ctx context.Context) error {
 }
 
 func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.Account {
-	var data extsvc.ExternalAccountData
+	var data extsvc.Data
 
 	var authData *oauth2.Token
 	if oauthTok != "" {
@@ -403,7 +403,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 			ServiceID:   serviceID,
 			AccountID:   accountID,
 		},
-		ExternalAccountData: data,
+		Data: data,
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -146,7 +146,7 @@ func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.Account, 
 
 	var oauthToken string
 	if account != nil {
-		_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+		_, tok, err := gitlab.GetExternalAccountData(&account.Data)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -156,7 +156,7 @@ func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.Account, r
 		// API (and update the user repo-visibility and user-can-access-repo permissions, as well)
 		var sudo string
 		if account != nil {
-			usr, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+			usr, _, err := gitlab.GetExternalAccountData(&account.Data)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +286,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 		return nil, nil
 	}
 
-	var accountData extsvc.ExternalAccountData
+	var accountData extsvc.Data
 	gitlab.SetExternalAccountData(&accountData, glUser, nil)
 
 	glExternalAccount := extsvc.Account{
@@ -296,7 +296,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),
 		},
-		ExternalAccountData: accountData,
+		Data: accountData,
 	}
 	return &glExternalAccount, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -25,7 +25,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	_, tok, err := gitlab.GetExternalAccountData(&account.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	} else if tok == nil {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -95,7 +95,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			ExternalAccountData: extsvc.ExternalAccountData{
+			Data: extsvc.Data{
 				AuthData: &authData,
 			},
 		},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -27,7 +27,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	user, _, err := gitlab.GetExternalAccountData(&account.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -93,7 +93,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			ExternalAccountData: extsvc.ExternalAccountData{
+			Data: extsvc.Data{
 				AccountData: &accountData,
 			},
 		},

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -23,25 +23,25 @@ func setJSONOrError(field **json.RawMessage, value interface{}) {
 
 // SetAccountData sets the AccountData field to the (JSON-encoded) value. If an error occurs during
 // JSON encoding, a JSON object describing the error is written to the field, instead.
-func (d *ExternalAccountData) SetAccountData(v interface{}) {
+func (d *Data) SetAccountData(v interface{}) {
 	setJSONOrError(&d.AccountData, v)
 }
 
 // SetAuthData sets the AuthData field to the (JSON-encoded) value. If an error occurs during JSON
 // encoding, a JSON object describing the error is written to the field, instead.
-func (d *ExternalAccountData) SetAuthData(v interface{}) {
+func (d *Data) SetAuthData(v interface{}) {
 	setJSONOrError(&d.AuthData, v)
 }
 
 // GetAccountData reads the AccountData field into the value. The value should be a pointer type to
 // the type that was passed to SetAccountData.
-func (d *ExternalAccountData) GetAccountData(v interface{}) error {
+func (d *Data) GetAccountData(v interface{}) error {
 	return getJSONOrError(d.AccountData, v)
 }
 
 // GetAuthData reads the AuthData field into the value. The value should be a pointer type to the
 // type that was passed to SetAuthData.
-func (d *ExternalAccountData) GetAuthData(v interface{}) error {
+func (d *Data) GetAuthData(v interface{}) error {
 	return getJSONOrError(d.AuthData, v)
 }
 

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.Data) (usr *github.User, tok *oauth2.Token, err error) {
 	var (
 		u github.User
 		t oauth2.Token
@@ -30,7 +30,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User,
 	return usr, tok, nil
 }
 
-func SetExternalAccountData(data *extsvc.ExternalAccountData, user *github.User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.Data, user *github.User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/gitlab/user.go
+++ b/internal/extsvc/gitlab/user.go
@@ -7,7 +7,7 @@ import (
 
 // GetExternalAccountData returns the deserialized user and token from the external account data
 // JSON blob in a typesafe way.
-func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.Data) (usr *User, tok *oauth2.Token, err error) {
 	var (
 		u User
 		t oauth2.Token
@@ -29,7 +29,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *o
 }
 
 // SetExternalAccountData sets the user and token into the external account data blob.
-func SetExternalAccountData(data *extsvc.ExternalAccountData, user *User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.Data, user *User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -11,12 +11,12 @@ import (
 // Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
 type Account struct {
-	ID                  int32
-	UserID              int32
-	AccountSpec         // ServiceType, ServiceID, ClientID, AccountID
-	ExternalAccountData // AuthData, AccountData
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID          int32
+	UserID      int32
+	AccountSpec // ServiceType, ServiceID, ClientID, AccountID
+	Data        // AuthData, AccountData
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // AccountSpec specifies a user external account by its external identifier (i.e., by the
@@ -29,9 +29,9 @@ type AccountSpec struct {
 	AccountID   string
 }
 
-// ExternalAccountData contains data that can be freely updated in the user external account
-// after it has been created. See the GraphQL API's corresponding fields for documentation.
-type ExternalAccountData struct {
+// Data contains data that can be freely updated in the user external account after it has been
+// created. See the GraphQL API's corresponding fields for documentation.
+type Data struct {
 	AuthData    *json.RawMessage
 	AccountData *json.RawMessage
 }


### PR DESCRIPTION
Ideally, it should be renamed to `AccountData`, but it conflicts with its field which has the same name as `AccountData`.

And we use `auth_data` and `account_data` as column names in the `user_external_account` table, so changing the field name do not feel like a good option.