### PR TITLE
Dont break GitHub file toolbar

### DIFF
--- a/browser/.stylelintrc.json
+++ b/browser/.stylelintrc.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/stylelintrc",
   "extends": ["@sourcegraph/stylelint-config"],
   "rules": {
-    "declaration-property-unit-whitelist": null
+    "declaration-property-unit-whitelist": null,
+    "selector-class-pattern": null
   }
 }

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -139,7 +139,7 @@ const snippetCodeView: Omit<CodeView, 'element'> = {
 export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolbarMount']> = (
     codeViewElement: HTMLElement
 ): HTMLElement => {
-    const className = 'sourcegraph-app-annotator'
+    const className = 'sourcegraph-github-file-code-view-toolbar-mount'
     const existingMount = codeViewElement.querySelector(`.${className}`) as HTMLElement
     if (existingMount) {
         return existingMount

--- a/browser/src/libs/github/style.scss
+++ b/browser/src/libs/github/style.scss
@@ -16,15 +16,48 @@
 
 .code-view-toolbar--github {
     margin-right: 4px;
-}
-
-// This naturally only has one element but we add the toolbar mount
-// so we need to make sure they don't stack
-.sg-github-file-actions {
-    display: flex;
+    margin-bottom: -4px;
+    text-align: right;
 }
 
 .code-view-toolbar__item--github {
     // The space provides enough margin
     margin-left: 0 !important;
+    margin-bottom: 4px;
+}
+
+// Blob view
+// Make sure only our code view toolbar shrinks and wraps,
+// not GitHub's UI groups
+.repository-content {
+    .Box-header {
+        > .text-mono {
+            // only let Sourcegraph toolbar shrink
+            flex-shrink: 0 !important;
+        }
+        > div:nth-child(2) {
+            > div:not(.sourcegraph-github-file-code-view-toolbar-mount) {
+                // only let Sourcegraph toolbar shrink
+                flex-shrink: 0;
+                display: flex;
+                align-items: center;
+            }
+        }
+    }
+}
+
+// Diff views
+.diff-view {
+    .file-header {
+        .file-info {
+            flex: 0 2 auto !important;
+        }
+        .file-actions {
+            flex: 1 1 50%;
+            margin-left: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+        }
+    }
 }

--- a/browser/src/libs/phabricator/code_intelligence.ts
+++ b/browser/src/libs/phabricator/code_intelligence.ts
@@ -84,7 +84,7 @@ export const commitCodeView = {
     resolveFileInfo: resolveRevisionFileInfo,
     getPositionAdjuster,
     getToolbarMount: (codeView: HTMLElement): HTMLElement => {
-        let mount = codeView.querySelector<HTMLElement>('.sourcegraph-app-annotator')
+        let mount = codeView.querySelector<HTMLElement>('.sourcegraph-phabricator-code-view-toolbar-mount')
         if (mount) {
             return mount
         }
@@ -95,7 +95,7 @@ export const commitCodeView = {
 
         mount = document.createElement('div')
         mount.style.display = 'inline-block'
-        mount.classList.add('sourcegraph-app-annotator')
+        mount.classList.add('sourcegraph-phabricator-code-view-toolbar-mount')
 
         actions.insertAdjacentElement('afterbegin', mount)
 
@@ -109,7 +109,7 @@ export const diffCodeView = {
     resolveFileInfo: resolveDiffFileInfo,
     getPositionAdjuster,
     getToolbarMount: (codeView: HTMLElement): HTMLElement => {
-        const className = 'sourcegraph-app-annotator'
+        const className = 'sourcegraph-phabricator-code-view-toolbar-mount'
         const existingMount = codeView.querySelector<HTMLElement>('.' + className)
         if (existingMount) {
             return existingMount
@@ -152,7 +152,7 @@ const diffusionSourceCodeViewResolver = toCodeViewResolver('.diffusion-source', 
 
         const mount = document.createElement('div')
         mount.style.display = 'inline-block'
-        mount.classList.add('sourcegraph-app-annotator')
+        mount.classList.add('sourcegraph-phabricator-code-view-toolbar-mount')
 
         actions.insertAdjacentElement('afterbegin', mount)
 


### PR DESCRIPTION
Part of #9462
Fixes #4480

This ensures that even if there is an unnatural amount of action items, the GitHub UI does not break (e.g. the button groups stay together).
I chose to let our buttons wrap. If a user chooses to add all these extensions, I think they would expect to see their UI too.

Here are some fabricated, extreme examples with the new styling (see https://github.com/sourcegraph/sourcegraph/issues/4480 for the "before" state):

![image](https://user-images.githubusercontent.com/10532611/78280433-60fc4880-7519-11ea-890b-f391a509a1a4.png)

Here we can nicely see that we will take "the backseat" before GitHub UI in taking up space, but eventually we also let the file name wrap before our buttons become stacked too much. We will never break up button groups though now, which was the case before.

This change also ensures there is some vertical margin when buttons do have to wrap.

File views:

![image](https://user-images.githubusercontent.com/10532611/78280625-b3d60000-7519-11ea-8ebc-27909c86f669.png)

Tested on github.com and GitHub Enterprise, with and without Refined GitHub.