### PR TITLE
Quickfix the debug menu background

### DIFF
--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -65,6 +65,11 @@ $body-color-dark: #f2f4f8;
     background-color: var(--body-bg);
 }
 
+.extension-status {
+    // TODO make the CSS classes configurable
+    background: var(--body-bg);
+}
+
 .toggle--off::-webkit-slider-runnable-track {
     color: #eeeeee;
 }


### PR DESCRIPTION
The proper fix for this would be to make CSS classes configurable and pass the correct classes for every code host. But since this is only for debugging, this is a minimal-effort fix.

Fixes #5731