### PR TITLE
Only apply ActionItem max-width inside nav links

### DIFF
--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -6,6 +6,7 @@
 $body-bg-color-light: #ffffff;
 
 @import '../../shared/src/actions/ActionItem';
+@import '../../shared/src/actions/ActionsNavItems';
 @import '../../shared/src/commandPalette/CommandList';
 @import '../../shared/src/components/completion/CompletionWidget.scss';
 @import '../../shared/src/components/Toggle';

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -1,9 +1,4 @@
 .action-item {
-    height: 100%;
-    max-width: 10rem;
-    text-overflow: ellipsis;
-    overflow: hidden;
-
     &__content {
         display: flex;
         align-items: center;

--- a/shared/src/actions/ActionsNavItems.scss
+++ b/shared/src/actions/ActionsNavItems.scss
@@ -1,0 +1,7 @@
+.actions-nav-items {
+    &__action-item {
+        max-width: 10rem;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+}

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -7,6 +7,7 @@ import { TelemetryProps } from '../telemetry/telemetryService'
 import { ActionItem, ActionItemProps } from './ActionItem'
 import { ActionsState } from './actions'
 import { ActionsProps } from './ActionsContainer'
+import classNames from 'classnames'
 
 export interface ActionNavItemsClassProps {
     /**
@@ -98,7 +99,7 @@ export class ActionsNavItems extends React.PureComponent<ActionsNavItemsProps, A
                         {...this.props}
                         variant="actionItem"
                         iconClassName={this.props.actionItemIconClass}
-                        className={this.props.actionItemClass}
+                        className={classNames('actions-nav-items__action-item', this.props.actionItemClass)}
                         pressedClassName={this.props.actionItemPressedClass}
                     />
                 </li>

--- a/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   " ",
   <li>
     <span
-      className="action-item  action-item--variant-action-item"
+      className="action-item actions-nav-items__action-item action-item--variant-action-item"
       data-tooltip="This is Action A"
     >
        

--- a/shared/src/index.scss
+++ b/shared/src/index.scss
@@ -1,4 +1,5 @@
 @import './actions/ActionItem';
+@import './actions/ActionsNavItems';
 @import './commandPalette/CommandList';
 @import './components/completion/CompletionWidget';
 @import './components/CodeExcerpt';


### PR DESCRIPTION
My previous PR had a bug in it, because ActionItems are also used in HoverOverlay and command palette