### PR TITLE
Wrap many action items in Bitbucket

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -33,8 +33,6 @@ export const getToolbarMount = (codeView: HTMLElement): HTMLElement => {
         throw new Error('Unable to find mount location')
     }
 
-    fileActions.style.display = 'flex'
-
     const mount = document.createElement('div')
     mount.classList.add('btn-group')
     mount.classList.add('sg-toolbar-mount')
@@ -225,7 +223,7 @@ export const bitbucketServerCodeHost: CodeHost = {
         iconClassName,
     },
     codeViewToolbarClassProps: {
-        className: 'aui-buttons',
+        className: 'code-view-toolbar--bitbucket aui-buttons',
         actionItemClass: 'aui-button action-item--bitbucket-server',
         // actionItemPressedClass is not needed because Bitbucket applies styling to aria-pressed="true"
         actionItemIconClass: 'aui-icon',

--- a/browser/src/libs/bitbucket/style.scss
+++ b/browser/src/libs/bitbucket/style.scss
@@ -28,8 +28,41 @@
     margin-left: 2px; // same as other buttons in the row
 }
 
+.code-view-toolbar--bitbucket {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    margin-top: -5px !important;
+}
+
 .action-nav-item--bitbucket {
     margin-left: 5px;
+    margin-top: 5px;
+}
+
+// Use flexbox instead of float, so we can handle wrapping action items
+.file-toolbar {
+    display: flex;
+    > .primary {
+        flex: 1 0 auto;
+        order: 1;
+
+        display: flex;
+        align-items: center;
+    }
+    > .secondary {
+        // Overrides
+        float: none;
+        white-space: normal;
+        line-height: initial;
+
+        flex: 1 1 auto;
+        order: 2;
+
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+    }
 }
 
 // Hover overlay buttons


### PR DESCRIPTION
Same as #9517 but for Bitbucket

<img width="990" alt="Screen Shot 2020-04-02 at 23 24 52" src="https://user-images.githubusercontent.com/10532611/78302062-67e78300-753a-11ea-8230-279808ea995a.png">
