### PR TITLE
CI E2E: skip pushing the image to docker registry

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -14,6 +14,11 @@ steps:
     - ./cmd/server/pre-build.sh
     - ./cmd/server/build.sh
     - popd
+    - |
+      if [ "$BUILDKITE_BRANCH" == "master" ] || [[ "$BUILDKITE_BRANCH" = master-dry-run/* ]]; then
+        yes | gcloud auth configure-docker
+        docker push "$IMAGE"
+      fi
     - ./dev/ci/e2e.sh
   timeout_in_minutes: 20
   label: ':docker::arrow_right::chromium:'

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -15,7 +15,7 @@ steps:
     - ./cmd/server/build.sh
     - popd
     - |
-      if [ "$BUILDKITE_BRANCH" == "master" ] || [[ "$BUILDKITE_BRANCH" = master-dry-run/* ]]; then
+      if [ -n "$PUSH_CANDIDATE_IMAGE" ]; then
         yes | gcloud auth configure-docker
         docker push "$IMAGE"
       fi

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -15,7 +15,7 @@ steps:
     - ./cmd/server/build.sh
     - popd
     - |
-      if [ -n "$PUSH_CANDIDATE_IMAGE" ]; then
+      if [ "$PUSH_CANDIDATE_IMAGE" == "true" ]; then
         yes | gcloud auth configure-docker
         docker push "$IMAGE"
       fi

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -8,26 +8,15 @@ env:
   TEST_USER_PASSWORD: "SuperSecurePassword"
 
 steps:
-- command:
-  - yes | gcloud auth configure-docker
-  - pushd enterprise
-  - ./cmd/server/pre-build.sh
-  - ./cmd/server/build.sh
-  - popd
-  - docker push "$IMAGE"
-  env:
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-  timeout_in_minutes: 10
-  label: ':docker:'
-
-- wait
-
 - artifact_paths: ./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log
   command:
-    - yes | gcloud auth configure-docker
+    - pushd enterprise
+    - ./cmd/server/pre-build.sh
+    - ./cmd/server/build.sh
+    - popd
     - ./dev/ci/e2e.sh
-  timeout_in_minutes: 10
-  label: ':chromium:'
+  timeout_in_minutes: 20
+  label: ':docker::arrow_right::chromium:'
 
 - wait
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	bk "github.com/sourcegraph/sourcegraph/internal/buildkite"
@@ -205,9 +206,7 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["VERSION"] = commonEnv["VERSION"]
 	env["TAG"] = candiateImageTag(c)
 	env["CI_DEBUG_PROFILE"] = commonEnv["CI_DEBUG_PROFILE"]
-	if imageCandidatePush {
-		env["PUSH_CANDIDATE_IMAGE"] = "1"
-	}
+	env["PUSH_CANDIDATE_IMAGE"] = strconv.FormatBool(imageCandidatePush)
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":chromium:",

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -192,6 +192,9 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	// hardFail if we publish docker images
 	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
+	// push the server candidate image only if it's required
+	imageCandidatePush := c.branch == "master" || c.isMasterDryRun || c.releaseBranch || c.taggedRelease || c.patch
+
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",
 		"BUILDKITE_PULL_REQUEST_BASE_BRANCH",
@@ -202,6 +205,9 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["VERSION"] = commonEnv["VERSION"]
 	env["TAG"] = candiateImageTag(c)
 	env["CI_DEBUG_PROFILE"] = commonEnv["CI_DEBUG_PROFILE"]
+	if imageCandidatePush {
+		env["PUSH_CANDIDATE_IMAGE"] = "1"
+	}
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":chromium:",


### PR DESCRIPTION
This also saves a second `yarn` execution.

It feels like this is a quick win and it shaves off around 20-30% runtime

**Edit**: Turns out we use the candidate image in the release process, so on the master branch we still need to push that image. But the above is still valid for non-master branches and it still saves around 1.5min on not running yarn twice and pulling the image again