### PR TITLE
Use explicit CSS classes in RepoHeader over child selectors

### DIFF
--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -12,25 +12,38 @@
     border-style: solid;
     border-width: 0 0 1px;
 
+    &__action-list-item {
+        // Have a small gap between buttons so they are visually distinct when pressed
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        margin-left: 1px;
+
+        &:hover {
+            .theme-dark & {
+                background: $color-bg-1;
+            }
+            .theme-light & {
+                background: $color-light-bg-2;
+            }
+        }
+    }
+
+    &__action-item--pressed {
+        .theme-dark & {
+            background-color: $color-bg-2;
+            color: $color-text-3;
+        }
+        .theme-light & {
+            background-color: $color-light-bg-4;
+            color: $color-light-text-1;
+        }
+    }
+
     .navbar-nav {
         white-space: nowrap;
 
         .nav-item {
             display: flex;
             align-items: center;
-
-            // Have a small gap between buttons so they are visually distinct when pressed
-            // stylelint-disable-next-line declaration-property-unit-whitelist
-            margin-left: 1px;
-
-            &:hover {
-                .theme-dark & {
-                    background: $color-bg-1;
-                }
-                .theme-light & {
-                    background: $color-light-bg-2;
-                }
-            }
 
             .nav-link {
                 user-select: none;
@@ -71,16 +84,5 @@
 
     .theme-light & {
         border-color: $color-light-border;
-    }
-
-    .action-item--pressed {
-        .theme-dark & {
-            background-color: $color-bg-2;
-            color: $color-text-3;
-        }
-        .theme-light & {
-            background-color: $color-light-bg-4;
-            color: $color-light-text-1;
-        }
     }
 }

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -227,7 +227,12 @@ export class RepoHeader extends React.PureComponent<Props, State> {
                 </ul>
                 <div className="repo-header__spacer" />
                 <ul className="navbar-nav">
-                    <WebActionsNavItems {...this.props} menu={ContributableMenu.EditorTitle} />
+                    <WebActionsNavItems
+                        {...this.props}
+                        listItemClass="repo-header__action-list-item"
+                        actionItemPressedClass="repo-header__action-item--pressed"
+                        menu={ContributableMenu.EditorTitle}
+                    />
                 </ul>
                 <ul className="navbar-nav">
                     {this.props.actionButtons.map(


### PR DESCRIPTION
The child selector also matched on the "copy" button and gave it the same background.
The solution is to use explicit classes. Should have done that in the first place, duh.