### PR TITLE
Increase opacity of button focus rings

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -64,6 +64,10 @@ $alert-padding-x: 0.75rem;
 
 $input-btn-focus-width: 2px;
 $input-focus-border-color: $primary;
+// The default focus ring for buttons is very hard to see, raise opacity.
+// We only show the focus ring when using the keyboard, when the focus ring
+// should be clearly visible.
+$btn-focus-box-shadow: 0 0 0 $input-btn-focus-width rgba($primary, 0.8);
 
 // Forms don't manipulate the colors at compile time,
 // which is why we can use CSS variables for theming here


### PR DESCRIPTION
This was a bit more contrived than I thought. In the end, our polyfill actually works correctly. We just have configured the outline to be quite small, and combined with the default 25% opacity on buttons, it is very hard to see.
Since thanks to the polyfill we only show the focus ring on keyboard navigation, it is crucial that the focus ring is clearly visible, and it can't get in the way with regular mouse interaction. I'm therefor simply raising the opacity from 25% to 80%.

After:

![2020-04-03 02 31 05](https://user-images.githubusercontent.com/10532611/78312164-329b5f00-7553-11ea-9f85-e4f631d42cd1.gif)

Closes #9493 