### PR TITLE
search: prefer MatchCount to ResultCount

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -177,10 +177,11 @@ func (sr *SearchResultsResolver) MatchCount() int32 {
 	return totalResults
 }
 
+// Deprecated. Prefer MatchCount.
 func (sr *SearchResultsResolver) ResultCount() int32 { return sr.MatchCount() }
 
 func (sr *SearchResultsResolver) ApproximateResultCount() string {
-	count := sr.ResultCount()
+	count := sr.MatchCount()
 	if sr.LimitHit() || len(sr.cloning) > 0 || len(sr.timedout) > 0 {
 		return fmt.Sprintf("%d+", count)
 	}
@@ -860,7 +861,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
-		if v.ResultCount() > 0 {
+		if v.MatchCount() > 0 {
 			break
 		}
 


### PR DESCRIPTION
In the GQL API we say:

```
# DEPRECATED: Renamed to 'matchCount' for less ambiguity.
resultCount: Int! @deprecated(reason: "renamed to matchCount for less ambiguity")
```

So, let's make [`ResultCount`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ResultCount%28%29&patternType=literal&case=yes) calls be like those using [`MatchCount`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+MatchCount%28%29&patternType=literal).

Background: I want to report more accurate match counts for structural search (see #9426) and doing some cleanups along the way.