### PR TITLE
dev: fix Caddyfile and change watching for Linux

### DIFF
--- a/dev/Caddyfile
+++ b/dev/Caddyfile
@@ -1,3 +1,6 @@
+{
+  http_port 3088
+}
 {$SOURCEGRAPH_HTTPS_DOMAIN}:{$SOURCEGRAPH_HTTPS_PORT}
 tls internal
 reverse_proxy localhost:3080

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -27,6 +27,10 @@ for i; do
         [ -n "$GOREMAN" ] && $GOREMAN run restart symbols
         exit
         ;;
+    cmd/precise-code-intel/*)
+        [ -n "$GOREMAN" ] && $GOREMAN run restart precise-code-intel-{api-server,bundle-manager,worker}
+        exit
+        ;;
 	cmd/*)
 		cmd=${i#cmd/}
 		cmd=${cmd%%/*}

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -28,7 +28,7 @@ for i; do
         exit
         ;;
     cmd/precise-code-intel/*)
-        [ -n "$GOREMAN" ] && $GOREMAN run restart precise-code-intel-{api-server,bundle-manager,worker}
+        # noop (uses tsc-watch).
         exit
         ;;
 	cmd/*)


### PR DESCRIPTION
Both of these problems occurred on Linux for me, so I'm assuming they are Linux-specific. The first one (the Caddy port 80 one) really puzzles me about why nobody on macOS experienced it.

- fix https://github.com/sourcegraph/sourcegraph/issues/9536 using recommendation at https://github.com/caddyserver/caddy/issues/3219#issuecomment-608236439
- in dev watcher, react to precise-code-intel changes by restarting all `precise-code-intel-*` goreman procs instead of assuming it is a Go binary