### PR TITLE
search: return accurate match count for multiline matches

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -67,6 +67,7 @@ type FileMatchResolver struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`
 	JLimitHit    bool         `json:"LimitHit"`
+	MatchCount   int          // Number of matches. Different from len(JLineMatches), as multiple lines may correspond to one logical match.
 	symbols      []*searchSymbolResult
 	uri          string
 	Repo         *types.Repo
@@ -147,7 +148,7 @@ func (fm *FileMatchResolver) searchResultURIs() (string, string) {
 }
 
 func (fm *FileMatchResolver) resultCount() int32 {
-	rc := len(fm.symbols) + len(fm.LineMatches())
+	rc := len(fm.symbols) + fm.MatchCount
 	if rc > 0 {
 		return int32(rc)
 	}

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -170,6 +170,8 @@ type Response struct {
 type FileMatch struct {
 	Path        string
 	LineMatches []LineMatch
+	// MatchCount is the number of matches. Different from len(LineMatches), as multiple lines may correspond to one logical match.
+	MatchCount int
 
 	// LimitHit is true if LineMatches may not include all LineMatches.
 	LimitHit bool

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -289,6 +289,7 @@ func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.Fil
 	return protocol.FileMatch{
 		Path:        f.Name,
 		LineMatches: lm,
+		MatchCount:  len(lm),
 		LimitHit:    limitHit,
 	}, err
 }

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -74,8 +74,9 @@ func ToFileMatch(combyMatches []comby.FileMatch) (matches []protocol.FileMatch) 
 		matches = append(matches,
 			protocol.FileMatch{
 				Path:        m.URI,
-				LimitHit:    false,
 				LineMatches: lineMatches,
+				MatchCount:  len(m.Matches),
+				LimitHit:    false,
 			})
 	}
 	return matches


### PR DESCRIPTION
Multiple line matches can correspond to the same logical match (block of code). There's no way to communicate such logical matches in the searcher protocol, since all matches are calculated from `len(lineMatches)` per file. This affects structural search, see #9426. It is also a problem for our regexp functionality that can include newlines `\n`s, but I'm not dealing with making those result counts accurate in this PR.

This PR adds a `matchCount` for `FileMatch` to the frontend <-> searcher protocol, which is then used to calculate the number of results, instead of `len(lineMatches)`, and returns the correct count for structural searches in the top left of the webapp. Example:

<img width="1432" alt="Screen Shot 2020-04-03 at 12 13 38 AM" src="https://user-images.githubusercontent.com/888624/78337427-cd8d3c80-7545-11ea-893e-3e117be83d4f.png">

As you can see, this does not address the number of matches reported on the right hand side of the expand tab, which says `Show 33 more matches`. That `33` number is derived directly from `len(lineMatches)`, and to fix, we need to expose the `matchCount` here to the GQL API and then update the webapp. I may do that later, but for now this PR is much better than the current state.
