### PR TITLE
extsvc: rename `AccountSpec` to `Spec`

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -16,7 +16,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
-	ExternalAccount     extsvc.AccountSpec
+	ExternalAccount     extsvc.Spec
 	ExternalAccountData extsvc.Data
 	CreateIfNotExist    bool
 	LookUpByUsername    bool

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -41,7 +41,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		expErr     error
 
 		// expected side effects
-		expSavedExtAccts                 map[int32][]extsvc.AccountSpec
+		expSavedExtAccts                 map[int32][]extsvc.Spec
 		expUpdatedUsers                  map[int32][]db.UserUpdate
 		expCreatedUsers                  map[int32]db.NewUser
 		expCalledGrantPendingPermissions bool
@@ -56,7 +56,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 	oneUser := []userInfo{{
 		user: types.User{ID: 1, Username: "u1"},
-		extAccts: []extsvc.AccountSpec{
+		extAccts: []extsvc.Spec{
 			ext("st1", "s1", "c1", "s1/u1"),
 		},
 		emails: []string{"u1@example.com"},
@@ -77,21 +77,21 @@ func TestGetAndSaveUser(t *testing.T) {
 			userInfos: []userInfo{
 				{
 					user: types.User{ID: 1, Username: "u1"},
-					extAccts: []extsvc.AccountSpec{
+					extAccts: []extsvc.Spec{
 						ext("st1", "s1", "c1", "s1/u1"),
 					},
 					emails: []string{"u1@example.com"},
 				},
 				{
 					user: types.User{ID: 2, Username: "u2"},
-					extAccts: []extsvc.AccountSpec{
+					extAccts: []extsvc.Spec{
 						ext("st1", "s1", "c1", "s1/u2"),
 					},
 					emails: []string{"u2@example.com"},
 				},
 				{
 					user:     types.User{ID: 3, Username: "u3"},
-					extAccts: []extsvc.AccountSpec{},
+					extAccts: []extsvc.Spec{},
 					emails:   []string{},
 				},
 			},
@@ -106,7 +106,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -120,7 +120,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -134,7 +134,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -146,7 +146,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -171,7 +171,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -184,7 +184,7 @@ func TestGetAndSaveUser(t *testing.T) {
 					CreateIfNotExist: true,
 				},
 				expUserID: 10001,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					10001: {ext("st1", "s1", "c1", "s1/u-new")},
 				},
 				expCreatedUsers: map[int32]db.NewUser{
@@ -211,7 +211,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				createIfNotExistIrrelevant: true,
 				actorUID:                   2,
 				expUserID:                  2,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					2: {ext("st1", "s1", "c1", "s1/u2")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -225,7 +225,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -240,7 +240,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -258,7 +258,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -272,7 +272,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+				expSavedExtAccts: map[int32][]extsvc.Spec{
 					1: {ext("st1", "s1", "c1", "doesnotexist")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -362,7 +362,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		t.Run(oc.description, func(t *testing.T) {
 			for _, c := range oc.innerCases {
 				if c.expSavedExtAccts == nil {
-					c.expSavedExtAccts = map[int32][]extsvc.AccountSpec{}
+					c.expSavedExtAccts = map[int32][]extsvc.Spec{}
 				}
 				if c.expUpdatedUsers == nil {
 					c.expUpdatedUsers = map[int32][]db.UserUpdate{}
@@ -424,7 +424,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 type userInfo struct {
 	user     types.User
-	extAccts []extsvc.AccountSpec
+	extAccts []extsvc.Spec
 	emails   []string
 }
 
@@ -462,7 +462,7 @@ func newMocks(t *testing.T, m mockParams) *mocks {
 	return &mocks{
 		mockParams:    m,
 		t:             t,
-		savedExtAccts: make(map[int32][]extsvc.AccountSpec),
+		savedExtAccts: make(map[int32][]extsvc.Spec),
 		updatedUsers:  make(map[int32][]db.UserUpdate),
 		createdUsers:  make(map[int32]db.NewUser),
 		nextUserID:    10001,
@@ -511,7 +511,7 @@ type mocks struct {
 	t *testing.T
 
 	// savedExtAccts tracks all ext acct "saves" for a given user ID
-	savedExtAccts map[int32][]extsvc.AccountSpec
+	savedExtAccts map[int32][]extsvc.Spec
 
 	// createdUsers tracks user creations by user ID
 	createdUsers map[int32]db.NewUser
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.Spec, data extsvc.Data) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (us
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.Spec, data extsvc.Data) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, d
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.Spec, data extsvc.Data) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}
@@ -663,8 +663,8 @@ func (m *mocks) GrantPendingPermissions(context.Context, *db.GrantPendingPermiss
 	return nil
 }
 
-func ext(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
-	return extsvc.AccountSpec{
+func ext(serviceType, serviceID, clientID, accountID string) extsvc.Spec {
+	return extsvc.Spec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -177,10 +177,10 @@ func (p *RepoPermissions) TracingFields() []otlog.Field {
 type UserPendingPermissions struct {
 	// The auto-generated internal database ID.
 	ID int32
-	// The type of the code host as if it would be used as extsvc.AccountSpec.ServiceType,
+	// The type of the code host as if it would be used as extsvc.Spec.ServiceType,
 	// e.g. "github", "gitlab", "bitbucketServer" and "sourcegraph".
 	ServiceType string
-	// The ID of the code host as if it would be used as extsvc.AccountSpec.ServiceID,
+	// The ID of the code host as if it would be used as extsvc.Spec.ServiceID,
 	// e.g. "https://github.com/", "https://gitlab.com/" and "https://sourcegraph.com/".
 	ServiceID string
 	// The account ID that a code host (and its authz provider) uses to identify a user,

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -38,13 +38,13 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 	return s.getBySQL(ctx, sqlf.Sprintf("WHERE id=%d AND deleted_at IS NULL LIMIT 1", id))
 }
 
-// LookupUserAndSave is used for authenticating a user (when both their Sourcegraph account and the
-// association with the external account already exist).
+// LookupUserAndSave is used for authenticating a user (when both their Sourcegraph account
+// and the association with the external account already exist).
 //
-// It looks up the existing user associated with the external account's extsvc.AccountSpec. If
-// found, it updates the account's data and returns the user. It NEVER creates a user; you must call
+// It looks up the existing user associated with the external account's extsvc.Spec. If found,
+// it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.Spec, data extsvc.Data) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.Spec, data extsvc.Data) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.Spec, data extsvc.Data) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.Spec, data extsvc.Data) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.Data) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error
-	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.Data) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.Spec, extsvc.Data) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.Spec, data extsvc.Data) error
+	CreateUserAndSave    func(NewUser, extsvc.Spec, extsvc.Data) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -17,7 +17,7 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.AccountSpec{
+	spec := extsvc.Spec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -49,7 +49,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	spec := extsvc.AccountSpec{
+	spec := extsvc.Spec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -69,7 +69,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: user.ID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: user.ID, Spec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }
@@ -81,7 +81,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.AccountSpec{
+	spec := extsvc.Spec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -110,7 +110,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: userID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: userID, Spec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.Data)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.Spec, acct.Data)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.Data)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.Spec, providerAcct.Data)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.Spec, data extsvc.Data) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -657,24 +657,24 @@ func Test_authzFilter(t *testing.T) {
 }
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
-	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
+	associateUserAndSaveCount := make(map[int32]map[extsvc.Spec]int)
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.Spec, data extsvc.Data) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
-			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
+			associateUserAndSaveCount[userID] = make(map[extsvc.Spec]int)
 		}
 		associateUserAndSaveCount[userID][spec]++
 		return nil
 	}
 	mockUser23Accounts := []*extsvc.Account{{
 		UserID: 23,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: "okta",
 			ServiceID:   "https://okta.mine/",
 			AccountID:   "101",
 		},
 	}, {
 		UserID: 23,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: "other",
 			ServiceID:   "https://other.mine/",
 			AccountID:   "99",
@@ -705,23 +705,23 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	})
 
 	var (
-		expNewAcct           = extsvc.AccountSpec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
+		expNewAcct           = extsvc.Spec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
 		unAuthdCtx           = context.Background()
 		authd23Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 23})
 		authd99Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 99})
-		account23CreatedOnce = map[int32]map[extsvc.AccountSpec]int{
+		account23CreatedOnce = map[int32]map[extsvc.Spec]int{
 			23: {
 				expNewAcct: 1,
 			},
 		}
-		account23CreatedTwice = map[int32]map[extsvc.AccountSpec]int{
+		account23CreatedTwice = map[int32]map[extsvc.Spec]int{
 			23: {
 				expNewAcct: 2,
 			},
 		}
 	)
 	// Initial counts 0
-	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.Spec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -729,7 +729,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	if _, err := authzFilter(unAuthdCtx, makeReposFromIDs(77), authz.Read); err != nil {
 		t.Fatal(err)
 	}
-	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.Spec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -768,7 +768,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	// Authed filter does NOT trigger new account creation if new account is already provided
 	mockUser23Accounts = append(mockUser23Accounts, &extsvc.Account{
 		UserID: 23,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.mine/",
 			AccountID:   "101",
@@ -922,7 +922,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 	t.Run("authenticated user with matching external account should see all repos", func(t *testing.T) {
 		extAccount := extsvc.Account{
-			AccountSpec: extsvc.AccountSpec{
+			Spec: extsvc.Spec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.mine/",
 				AccountID:   "alice",
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.Spec, extsvc.Data) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -991,7 +991,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 					},
 					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						{
-							AccountSpec: extsvc.AccountSpec{
+							Spec: extsvc.Spec{
 								ServiceType: "gitlab",
 								ServiceID:   "https://gitlab.mine/",
 								AccountID:   "alice",
@@ -1010,7 +1010,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{
 				{
-					AccountSpec: extsvc.AccountSpec{
+					Spec: extsvc.Spec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.mirror/",
 						AccountID:   "alice",
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.Spec, extsvc.Data) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}
@@ -1060,7 +1060,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 func acct(userID int32, serviceType, serviceID, accountID string) *extsvc.Account {
 	return &extsvc.Account{
 		UserID: userID,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -34,7 +34,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					AccountSpec: extsvc.AccountSpec{
+					Spec: extsvc.Spec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
@@ -50,7 +50,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					AccountSpec: extsvc.AccountSpec{
+					Spec: extsvc.Spec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -79,7 +79,7 @@ func TestDeleteUser(t *testing.T) {
 	db.Mocks.ExternalAccounts.List = func(db.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 		return []*extsvc.Account{
 			{
-				AccountSpec: extsvc.AccountSpec{
+				Spec: extsvc.Spec{
 					ServiceType: "gitlab",
 					ServiceID:   "https://gitlab.com/",
 					AccountID:   "alice_gitlab",

--- a/cmd/frontend/internal/auth/override.go
+++ b/cmd/frontend/internal/auth/override.go
@@ -41,7 +41,7 @@ func OverrideAuthMiddleware(next http.Handler) http.Handler {
 					Email:           username + "+override@example.com",
 					EmailIsVerified: true,
 				},
-				ExternalAccount: extsvc.AccountSpec{
+				ExternalAccount: extsvc.Spec{
 					ServiceType: "override",
 					AccountID:   username,
 				},

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -74,7 +74,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 				DisplayName:     deref(ghUser.Name),
 				AvatarURL:       deref(ghUser.AvatarURL),
 			},
-			ExternalAccount: extsvc.AccountSpec{
+			ExternalAccount: extsvc.Spec{
 				ServiceType: s.ServiceType,
 				ServiceID:   s.ServiceID,
 				ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -249,8 +249,8 @@ func u(username, email string, emailIsVerified bool) db.NewUser {
 	}
 }
 
-func acct(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
-	return extsvc.AccountSpec{
+func acct(serviceType, serviceID, clientID, accountID string) extsvc.Spec {
+	return extsvc.Spec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -49,7 +49,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			DisplayName:     gUser.Name,
 			AvatarURL:       gUser.AvatarURL,
 		},
-		ExternalAccount: extsvc.AccountSpec{
+		ExternalAccount: extsvc.Spec{
 			ServiceType: s.ServiceType,
 			ServiceID:   s.ServiceID,
 			ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/httpheader/middleware.go
+++ b/enterprise/cmd/frontend/auth/httpheader/middleware.go
@@ -75,7 +75,7 @@ func middleware(next http.Handler) http.Handler {
 		}
 		userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), auth.GetAndSaveUserOp{
 			UserProps: db.NewUser{Username: username},
-			ExternalAccount: extsvc.AccountSpec{
+			ExternalAccount: extsvc.Spec{
 				ServiceType: providerType,
 				// Store rawUsername, not normalized username, to prevent two users with distinct
 				// pre-normalization usernames from being merged into the same normalized username

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -63,7 +63,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 			DisplayName:     displayName,
 			AvatarURL:       claims.Picture,
 		},
-		ExternalAccount: extsvc.AccountSpec{
+		ExternalAccount: extsvc.Spec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -15,7 +15,7 @@ import (
 )
 
 type authnResponseInfo struct {
-	spec                 extsvc.AccountSpec
+	spec                 extsvc.Spec
 	email, displayName   string
 	unnormalizedUsername string
 	accountData          interface{}
@@ -58,7 +58,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 		email = pn
 	}
 	info := authnResponseInfo{
-		spec: extsvc.AccountSpec{
+		spec: extsvc.Spec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/saml/user_test.go
+++ b/enterprise/cmd/frontend/auth/saml/user_test.go
@@ -32,7 +32,7 @@ func TestReadAuthnResponse(t *testing.T) {
 	}
 	info.accountData = nil // skip checking this field
 	if want := (&authnResponseInfo{
-		spec: extsvc.AccountSpec{
+		spec: extsvc.Spec{
 			ServiceType: "saml",
 			ServiceID:   "http://localhost:3220/auth/realms/master",
 			ClientID:    "http://localhost:3080/.auth/saml/metadata",

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -51,7 +51,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 
 	// Add two external accounts
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.AccountSpec{
+		extsvc.Spec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
@@ -62,7 +62,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.AccountSpec{
+		extsvc.Spec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -624,7 +624,7 @@ func (s *PermsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.
 }
 
 func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sqlf.Query) (
-	idToSpecs map[int32]extsvc.AccountSpec,
+	idToSpecs map[int32]extsvc.Spec,
 	loaded map[int32]*roaring.Bitmap,
 	err error,
 ) {
@@ -642,11 +642,11 @@ func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sql
 	}
 	defer rows.Close()
 
-	idToSpecs = make(map[int32]extsvc.AccountSpec)
+	idToSpecs = make(map[int32]extsvc.Spec)
 	loaded = make(map[int32]*roaring.Bitmap)
 	for rows.Next() {
 		var id int32
-		var spec extsvc.AccountSpec
+		var spec extsvc.Spec
 		var ids []byte
 		if err = rows.Scan(&id, &spec.ServiceType, &spec.ServiceID, &spec.AccountID, &ids); err != nil {
 			return nil, nil, err

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -180,7 +180,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 
 	return &extsvc.Account{
 		UserID: user.ID,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
@@ -207,7 +207,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account data provided")
 	case !extsvc.IsHostOfAccount(p.codeHost, account):
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			p.codeHost.ServiceID, account.AccountSpec.ServiceID)
+			p.codeHost.ServiceID, account.Spec.ServiceID)
 	}
 
 	var user bitbucketserver.User

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -296,7 +296,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "not a code host of the account",
 				acct: &extsvc.Account{
-					AccountSpec: extsvc.AccountSpec{
+					Spec: extsvc.Spec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
@@ -310,7 +310,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "bad account data",
 				acct: &extsvc.Account{
-					AccountSpec: extsvc.AccountSpec{
+					Spec: extsvc.Spec{
 						ServiceType: h.ServiceType,
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
@@ -617,7 +617,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 	bs := marshalJSON(u)
 	return &extsvc.Account{
 		UserID: userID,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: h.ServiceType,
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -389,7 +389,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.Spec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := github.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -398,7 +398,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 
 	return &extsvc.Account{
 		UserID: userID,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -291,7 +291,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 
 	glExternalAccount := extsvc.Account{
 		UserID: user.ID,
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -22,7 +22,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.Spec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -42,7 +42,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				AccountSpec: extsvc.AccountSpec{
+				Spec: extsvc.Spec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -91,7 +91,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			AccountSpec: extsvc.AccountSpec{
+			Spec: extsvc.Spec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -24,7 +24,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
+			account.Spec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	user, _, err := gitlab.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -34,7 +34,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				AccountSpec: extsvc.AccountSpec{
+				Spec: extsvc.Spec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -89,7 +89,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	accountData := json.RawMessage(`{"id": 999}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			AccountSpec: extsvc.AccountSpec{
+			Spec: extsvc.Spec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -127,7 +127,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	defer authz.SetProviders(true, nil)
 
 	extAccount := extsvc.Account{
-		AccountSpec: extsvc.AccountSpec{
+		Spec: extsvc.Spec{
 			ServiceType: p.ServiceType(),
 			ServiceID:   p.ServiceID(),
 		},

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -11,18 +11,18 @@ import (
 // Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
 type Account struct {
-	ID          int32
-	UserID      int32
-	AccountSpec // ServiceType, ServiceID, ClientID, AccountID
-	Data        // AuthData, AccountData
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID        int32
+	UserID    int32
+	Spec      // ServiceType, ServiceID, ClientID, AccountID
+	Data      // AuthData, AccountData
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
-// AccountSpec specifies a user external account by its external identifier (i.e., by the
-// identifier provided by the account's owner service), instead of by our database's serial
-// ID. See the GraphQL API's corresponding fields in "ExternalAccount" for documentation.
-type AccountSpec struct {
+// Spec specifies a user external account by its external identifier (i.e. by the identifier
+// provided by the account's owner service), instead of by our database's serial ID. See the
+// GraphQL API's corresponding fields in "ExternalAccount" for documentation.
+type Spec struct {
 	ServiceType string
 	ServiceID   string
 	ClientID    string
@@ -44,7 +44,7 @@ type Repository struct {
 }
 
 // Accounts contains a list of accounts that belong to the same external service.
-// All fields have a same meaning to AccountSpec. See GraphQL API's corresponding fields
+// All fields have a same meaning to Spec. See GraphQL API's corresponding fields
 // in "ExternalAccount" for documentation.
 type Accounts struct {
 	ServiceType string


### PR DESCRIPTION
To be consistent on field and type naming. 

It is not an ideal name if we only look at the type alone, but makes a lot more sense when we actually use the field, e.g.

```go
var acct extsvc.Account
acct.Spec = xyz
// Not acct.AccountSpec which feels redundant
````