### PR TITLE
extsvc: better type names

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -17,7 +17,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
 	ExternalAccount     extsvc.AccountSpec
-	ExternalAccountData extsvc.Data
+	ExternalAccountData extsvc.ExternalAccountData
 	CreateIfNotExist    bool
 	LookUpByUsername    bool
 }

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -17,7 +17,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
 	ExternalAccount     extsvc.AccountSpec
-	ExternalAccountData extsvc.ExternalAccountData
+	ExternalAccountData extsvc.AccountData
 	CreateIfNotExist    bool
 	LookUpByUsername    bool
 }

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -16,7 +16,7 @@ var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID in
 
 type GetAndSaveUserOp struct {
 	UserProps           db.NewUser
-	ExternalAccount     extsvc.Spec
+	ExternalAccount     extsvc.AccountSpec
 	ExternalAccountData extsvc.Data
 	CreateIfNotExist    bool
 	LookUpByUsername    bool

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -41,7 +41,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		expErr     error
 
 		// expected side effects
-		expSavedExtAccts                 map[int32][]extsvc.Spec
+		expSavedExtAccts                 map[int32][]extsvc.AccountSpec
 		expUpdatedUsers                  map[int32][]db.UserUpdate
 		expCreatedUsers                  map[int32]db.NewUser
 		expCalledGrantPendingPermissions bool
@@ -56,7 +56,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 	oneUser := []userInfo{{
 		user: types.User{ID: 1, Username: "u1"},
-		extAccts: []extsvc.Spec{
+		extAccts: []extsvc.AccountSpec{
 			ext("st1", "s1", "c1", "s1/u1"),
 		},
 		emails: []string{"u1@example.com"},
@@ -77,21 +77,21 @@ func TestGetAndSaveUser(t *testing.T) {
 			userInfos: []userInfo{
 				{
 					user: types.User{ID: 1, Username: "u1"},
-					extAccts: []extsvc.Spec{
+					extAccts: []extsvc.AccountSpec{
 						ext("st1", "s1", "c1", "s1/u1"),
 					},
 					emails: []string{"u1@example.com"},
 				},
 				{
 					user: types.User{ID: 2, Username: "u2"},
-					extAccts: []extsvc.Spec{
+					extAccts: []extsvc.AccountSpec{
 						ext("st1", "s1", "c1", "s1/u2"),
 					},
 					emails: []string{"u2@example.com"},
 				},
 				{
 					user:     types.User{ID: 3, Username: "u3"},
-					extAccts: []extsvc.Spec{},
+					extAccts: []extsvc.AccountSpec{},
 					emails:   []string{},
 				},
 			},
@@ -106,7 +106,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -120,7 +120,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -134,7 +134,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 			},
@@ -146,7 +146,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -171,7 +171,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -184,7 +184,7 @@ func TestGetAndSaveUser(t *testing.T) {
 					CreateIfNotExist: true,
 				},
 				expUserID: 10001,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					10001: {ext("st1", "s1", "c1", "s1/u-new")},
 				},
 				expCreatedUsers: map[int32]db.NewUser{
@@ -211,7 +211,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				createIfNotExistIrrelevant: true,
 				actorUID:                   2,
 				expUserID:                  2,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					2: {ext("st1", "s1", "c1", "s1/u2")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -225,7 +225,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -240,7 +240,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -258,7 +258,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s-new", "c1", "s-new/u1")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -272,7 +272,7 @@ func TestGetAndSaveUser(t *testing.T) {
 				},
 				createIfNotExistIrrelevant: true,
 				expUserID:                  1,
-				expSavedExtAccts: map[int32][]extsvc.Spec{
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
 					1: {ext("st1", "s1", "c1", "doesnotexist")},
 				},
 				expCalledGrantPendingPermissions: true,
@@ -362,7 +362,7 @@ func TestGetAndSaveUser(t *testing.T) {
 		t.Run(oc.description, func(t *testing.T) {
 			for _, c := range oc.innerCases {
 				if c.expSavedExtAccts == nil {
-					c.expSavedExtAccts = map[int32][]extsvc.Spec{}
+					c.expSavedExtAccts = map[int32][]extsvc.AccountSpec{}
 				}
 				if c.expUpdatedUsers == nil {
 					c.expUpdatedUsers = map[int32][]db.UserUpdate{}
@@ -424,7 +424,7 @@ func TestGetAndSaveUser(t *testing.T) {
 
 type userInfo struct {
 	user     types.User
-	extAccts []extsvc.Spec
+	extAccts []extsvc.AccountSpec
 	emails   []string
 }
 
@@ -462,7 +462,7 @@ func newMocks(t *testing.T, m mockParams) *mocks {
 	return &mocks{
 		mockParams:    m,
 		t:             t,
-		savedExtAccts: make(map[int32][]extsvc.Spec),
+		savedExtAccts: make(map[int32][]extsvc.AccountSpec),
 		updatedUsers:  make(map[int32][]db.UserUpdate),
 		createdUsers:  make(map[int32]db.NewUser),
 		nextUserID:    10001,
@@ -511,7 +511,7 @@ type mocks struct {
 	t *testing.T
 
 	// savedExtAccts tracks all ext acct "saves" for a given user ID
-	savedExtAccts map[int32][]extsvc.Spec
+	savedExtAccts map[int32][]extsvc.AccountSpec
 
 	// createdUsers tracks user creations by user ID
 	createdUsers map[int32]db.NewUser
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.Spec, data extsvc.Data) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.Spec, data extsvc.Data) (userID in
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.Spec, data extsvc.Data) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.Spec, data ext
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.Spec, data extsvc.Data) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}
@@ -663,8 +663,8 @@ func (m *mocks) GrantPendingPermissions(context.Context, *db.GrantPendingPermiss
 	return nil
 }
 
-func ext(serviceType, serviceID, clientID, accountID string) extsvc.Spec {
-	return extsvc.Spec{
+func ext(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
+	return extsvc.AccountSpec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.Data) (us
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, d
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -527,7 +527,7 @@ type mocks struct {
 }
 
 // LookupUserAndSave mocks db.ExternalAccounts.LookupUserAndSave
-func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.AccountData) (userID int32, err error) {
 	if m.lookupUserAndSaveErr != nil {
 		return 0, m.lookupUserAndSaveErr
 	}
@@ -544,7 +544,7 @@ func (m *mocks) LookupUserAndSave(spec extsvc.AccountSpec, data extsvc.ExternalA
 }
 
 // CreateUserAndSave mocks db.ExternalAccounts.CreateUserAndSave
-func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, data extsvc.AccountData) (createdUserID int32, err error) {
 	if m.createUserAndSaveErr != nil {
 		return 0, m.createUserAndSaveErr
 	}
@@ -579,7 +579,7 @@ func (m *mocks) CreateUserAndSave(newUser db.NewUser, spec extsvc.AccountSpec, d
 }
 
 // AssociateUserAndSave mocks db.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (m *mocks) AssociateUserAndSave(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) (err error) {
 	if m.associateUserAndSaveErr != nil {
 		return m.associateUserAndSaveErr
 	}

--- a/cmd/frontend/authz/perms.go
+++ b/cmd/frontend/authz/perms.go
@@ -177,10 +177,10 @@ func (p *RepoPermissions) TracingFields() []otlog.Field {
 type UserPendingPermissions struct {
 	// The auto-generated internal database ID.
 	ID int32
-	// The type of the code host as if it would be used as extsvc.Spec.ServiceType,
+	// The type of the code host as if it would be used as extsvc.AccountSpec.ServiceType,
 	// e.g. "github", "gitlab", "bitbucketServer" and "sourcegraph".
 	ServiceType string
-	// The ID of the code host as if it would be used as extsvc.Spec.ServiceID,
+	// The ID of the code host as if it would be used as extsvc.AccountSpec.ServiceID,
 	// e.g. "https://github.com/", "https://gitlab.com/" and "https://sourcegraph.com/".
 	ServiceID string
 	// The account ID that a code host (and its authz provider) uses to identify a user,

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -44,7 +44,7 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 // It looks up the existing user associated with the external account's extsvc.AccountSpec. If
 // found, it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.Data) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error
-	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.Data) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error
+	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -44,7 +44,7 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 // It looks up the existing user associated with the external account's extsvc.AccountSpec. If
 // found, it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.AccountData) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.AccountData) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.ExternalAccountData) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error
-	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.ExternalAccountData) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.AccountData) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error
+	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -38,13 +38,13 @@ func (s *userExternalAccounts) Get(ctx context.Context, id int32) (*extsvc.Accou
 	return s.getBySQL(ctx, sqlf.Sprintf("WHERE id=%d AND deleted_at IS NULL LIMIT 1", id))
 }
 
-// LookupUserAndSave is used for authenticating a user (when both their Sourcegraph account
-// and the association with the external account already exist).
+// LookupUserAndSave is used for authenticating a user (when both their Sourcegraph account and the
+// association with the external account already exist).
 //
-// It looks up the existing user associated with the external account's extsvc.Spec. If found,
-// it updates the account's data and returns the user. It NEVER creates a user; you must call
+// It looks up the existing user associated with the external account's extsvc.AccountSpec. If
+// found, it updates the account's data and returns the user. It NEVER creates a user; you must call
 // CreateUserAndSave for that.
-func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.Spec, data extsvc.Data) (userID int32, err error) {
+func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.Data) (userID int32, err error) {
 	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
 		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
 	}
@@ -68,7 +68,7 @@ RETURNING user_id
 //
 // - the same user: it updates the data and returns a nil error; or
 // - a different user: it performs no update and returns a non-nil error
-func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.Spec, data extsvc.Data) (err error) {
+func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.Data) (err error) {
 	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
 		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
 	}
@@ -136,7 +136,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND u
 //
 // It creates a new user and associates it with the specified external account. If the user to
 // create already exists, it returns an error.
-func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.Spec, data extsvc.Data) (createdUserID int32, err error) {
+func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.Data) (createdUserID int32, err error) {
 	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
@@ -166,7 +166,7 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.Spec, data extsvc.Data) error {
+func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
@@ -321,9 +321,9 @@ func (*userExternalAccounts) listSQL(opt ExternalAccountsListOptions) (conds []*
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
 	Get                  func(id int32) (*extsvc.Account, error)
-	LookupUserAndSave    func(extsvc.Spec, extsvc.Data) (userID int32, err error)
-	AssociateUserAndSave func(userID int32, spec extsvc.Spec, data extsvc.Data) error
-	CreateUserAndSave    func(NewUser, extsvc.Spec, extsvc.Data) (createdUserID int32, err error)
+	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.Data) (userID int32, err error)
+	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error
+	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.Data) (createdUserID int32, err error)
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)

--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -53,7 +53,7 @@ func (s *userExternalAccounts) LookupUserAndSave(ctx context.Context, spec extsv
 UPDATE user_external_accounts SET auth_data=$5, account_data=$6, updated_at=now()
 WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND deleted_at IS NULL
 RETURNING user_id
-`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.AccountData).Scan(&userID)
+`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.Data).Scan(&userID)
 	if err == sql.ErrNoRows {
 		err = userExternalAccountNotFoundError{[]interface{}{spec}}
 	}
@@ -117,7 +117,7 @@ WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND d
 	res, err := tx.ExecContext(ctx, `
 UPDATE user_external_accounts SET auth_data=$6, account_data=$7, updated_at=now()
 WHERE service_type=$1 AND service_id=$2 AND client_id=$3 AND account_id=$4 AND user_id=$5 AND deleted_at IS NULL
-`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, userID, data.AuthData, data.AccountData)
+`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, userID, data.AuthData, data.Data)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID in
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
 VALUES($1, $2, $3, $4, $5, $6, $7)
-`, userID, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.AccountData)
+`, userID, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.Data)
 	return err
 }
 
@@ -298,7 +298,7 @@ func (*userExternalAccounts) listBySQL(ctx context.Context, querySuffix *sqlf.Qu
 	defer rows.Close()
 	for rows.Next() {
 		var o extsvc.Account
-		if err := rows.Scan(&o.ID, &o.UserID, &o.ServiceType, &o.ServiceID, &o.ClientID, &o.AccountID, &o.AuthData, &o.AccountData, &o.CreatedAt, &o.UpdatedAt); err != nil {
+		if err := rows.Scan(&o.ID, &o.UserID, &o.ServiceType, &o.ServiceID, &o.ClientID, &o.AccountID, &o.AuthData, &o.Data, &o.CreatedAt, &o.UpdatedAt); err != nil {
 			return nil, err
 		}
 		results = append(results, &o)

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -23,12 +23,12 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.ExternalAccountData{})
+	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.ExternalAccountData{}); err != nil {
+	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.AccountData{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -87,7 +87,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -17,7 +17,7 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.Spec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -49,7 +49,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	spec := extsvc.Spec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -69,7 +69,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: user.ID, Spec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: user.ID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }
@@ -81,7 +81,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	spec := extsvc.Spec{
+	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
 		ServiceID:   "xb",
 		ClientID:    "xc",
@@ -110,7 +110,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	account := *accounts[0]
 	simplifyExternalAccount(&account)
 	account.ID = 0
-	if want := (extsvc.Account{UserID: userID, Spec: spec}); !reflect.DeepEqual(account, want) {
+	if want := (extsvc.Account{UserID: userID, AccountSpec: spec}); !reflect.DeepEqual(account, want) {
 		t.Errorf("got %+v, want %+v", account, want)
 	}
 }

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -23,12 +23,12 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.Data{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.Data{})
+	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.ExternalAccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.Data{}); err != nil {
+	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, extsvc.ExternalAccountData{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -87,7 +87,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.Data{})
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.ExternalAccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.Spec, acct.Data)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.Data)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.Spec, providerAcct.Data)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.Data)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.Data)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.ExternalAccountData)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.Data)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.ExternalAccountData)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -204,7 +204,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			}
 
 			// Save the external account and grant pending permissions for it later.
-			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.ExternalAccountData)
+			err = ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, acct.AccountSpec, acct.AccountData)
 			if err != nil {
 				return nil, errors.Wrap(err, "associate external account to user")
 			}
@@ -282,7 +282,7 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 			if pr, err := authzProvider.FetchAccount(ctx, currentUser, accts); err == nil {
 				providerAcct = pr
 				if providerAcct != nil {
-					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.ExternalAccountData)
+					err := ExternalAccounts.AssociateUserAndSave(ctx, currentUser.ID, providerAcct.AccountSpec, providerAcct.AccountData)
 					if err != nil {
 						return nil, err
 					}

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.Spec, data extsvc.Data) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -657,24 +657,24 @@ func Test_authzFilter(t *testing.T) {
 }
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
-	associateUserAndSaveCount := make(map[int32]map[extsvc.Spec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.Spec, data extsvc.Data) error {
+	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
-			associateUserAndSaveCount[userID] = make(map[extsvc.Spec]int)
+			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
 		}
 		associateUserAndSaveCount[userID][spec]++
 		return nil
 	}
 	mockUser23Accounts := []*extsvc.Account{{
 		UserID: 23,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "okta",
 			ServiceID:   "https://okta.mine/",
 			AccountID:   "101",
 		},
 	}, {
 		UserID: 23,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "other",
 			ServiceID:   "https://other.mine/",
 			AccountID:   "99",
@@ -705,23 +705,23 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	})
 
 	var (
-		expNewAcct           = extsvc.Spec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
+		expNewAcct           = extsvc.AccountSpec{ServiceID: "https://gitlab.mine/", ServiceType: "gitlab", AccountID: "101"}
 		unAuthdCtx           = context.Background()
 		authd23Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 23})
 		authd99Ctx           = actor.WithActor(unAuthdCtx, &actor.Actor{UID: 99})
-		account23CreatedOnce = map[int32]map[extsvc.Spec]int{
+		account23CreatedOnce = map[int32]map[extsvc.AccountSpec]int{
 			23: {
 				expNewAcct: 1,
 			},
 		}
-		account23CreatedTwice = map[int32]map[extsvc.Spec]int{
+		account23CreatedTwice = map[int32]map[extsvc.AccountSpec]int{
 			23: {
 				expNewAcct: 2,
 			},
 		}
 	)
 	// Initial counts 0
-	if exp := map[int32]map[extsvc.Spec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -729,7 +729,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	if _, err := authzFilter(unAuthdCtx, makeReposFromIDs(77), authz.Read); err != nil {
 		t.Fatal(err)
 	}
-	if exp := map[int32]map[extsvc.Spec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
+	if exp := map[int32]map[extsvc.AccountSpec]int{}; !reflect.DeepEqual(associateUserAndSaveCount, exp) {
 		t.Errorf("expected counts to be %s, but was %s", asJSON(t, exp), asJSON(t, associateUserAndSaveCount))
 	}
 
@@ -768,7 +768,7 @@ func Test_authzFilter_createsNewUsers(t *testing.T) {
 	// Authed filter does NOT trigger new account creation if new account is already provided
 	mockUser23Accounts = append(mockUser23Accounts, &extsvc.Account{
 		UserID: 23,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.mine/",
 			AccountID:   "101",
@@ -922,7 +922,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 	t.Run("authenticated user with matching external account should see all repos", func(t *testing.T) {
 		extAccount := extsvc.Account{
-			Spec: extsvc.Spec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.mine/",
 				AccountID:   "alice",
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.Spec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -991,7 +991,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 					},
 					perms: map[extsvc.Account]map[api.RepoName]authz.Perms{
 						{
-							Spec: extsvc.Spec{
+							AccountSpec: extsvc.AccountSpec{
 								ServiceType: "gitlab",
 								ServiceID:   "https://gitlab.mine/",
 								AccountID:   "alice",
@@ -1010,7 +1010,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{
 				{
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.mirror/",
 						AccountID:   "alice",
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.Spec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}
@@ -1060,7 +1060,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 func acct(userID int32, serviceType, serviceID, accountID string) *extsvc.Account {
 	return &extsvc.Account{
 		UserID: userID,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -658,7 +658,7 @@ func Test_authzFilter(t *testing.T) {
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
 	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.Data) error {
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
 			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
 		}
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.Data) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -65,7 +65,7 @@ func (r authzFilter_Test) run(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: c.user.ID})
 		}
 
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error { return nil }
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error { return nil }
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) { return c.userAccounts, nil }
 
 		filteredRepos, err := authzFilter(ctx, c.repos, c.perm)
@@ -658,7 +658,7 @@ func Test_authzFilter(t *testing.T) {
 
 func Test_authzFilter_createsNewUsers(t *testing.T) {
 	associateUserAndSaveCount := make(map[int32]map[extsvc.AccountSpec]int)
-	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.ExternalAccountData) error {
+	Mocks.ExternalAccounts.AssociateUserAndSave = func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error {
 		if _, ok := associateUserAndSaveCount[userID]; !ok {
 			associateUserAndSaveCount[userID] = make(map[extsvc.AccountSpec]int)
 		}
@@ -951,7 +951,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		Mocks.ExternalAccounts.List = func(ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 			return []*extsvc.Account{&extAccount}, nil
 		}
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.AccountData) error {
 			return errors.New("AssociateUserAndSave should not be called")
 		}
 		Mocks.Authz.GrantPendingPermissions = func(context.Context, *GrantPendingPermissionsArgs) error {
@@ -1021,7 +1021,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 
 		calledAssociateUserAndSave := false
 		callGrantPendingPermissions := false
-		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.ExternalAccountData) error {
+		Mocks.ExternalAccounts.AssociateUserAndSave = func(int32, extsvc.AccountSpec, extsvc.AccountData) error {
 			calledAssociateUserAndSave = true
 			return nil
 		}

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -34,7 +34,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
@@ -50,7 +50,7 @@ func Benchmark_authzFilter(b *testing.B) {
 				codeHost: codeHost,
 				extAcct: &extsvc.Account{
 					UserID: user.ID,
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: codeHost.ServiceType,
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -39,7 +39,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
+					ExternalAccountData: extsvc.ExternalAccountData{Data: nil},
 				},
 			}
 		}(),
@@ -55,7 +55,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
+					ExternalAccountData: extsvc.ExternalAccountData{Data: nil},
 				},
 			}
 		}(),

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -39,7 +39,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{Data: nil},
+					AccountData: extsvc.AccountData{Data: nil},
 				},
 			}
 		}(),
@@ -55,7 +55,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{Data: nil},
+					AccountData: extsvc.AccountData{Data: nil},
 				},
 			}
 		}(),

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -39,7 +39,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					Data: extsvc.Data{AccountData: nil},
+					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
 				},
 			}
 		}(),
@@ -55,7 +55,7 @@ func Benchmark_authzFilter(b *testing.B) {
 						ServiceID:   codeHost.ServiceID,
 						AccountID:   "42_ext",
 					},
-					Data: extsvc.Data{AccountData: nil},
+					ExternalAccountData: extsvc.ExternalAccountData{AccountData: nil},
 				},
 			}
 		}(),

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -62,8 +62,8 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 		return nil, err
 	}
 
-	if r.account.AccountData != nil {
-		return &JSONValue{r.account.AccountData}, nil
+	if r.account.Data != nil {
+		return &JSONValue{r.account.Data}, nil
 	}
 	return nil, nil
 }

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -79,7 +79,7 @@ func TestDeleteUser(t *testing.T) {
 	db.Mocks.ExternalAccounts.List = func(db.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
 		return []*extsvc.Account{
 			{
-				Spec: extsvc.Spec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "gitlab",
 					ServiceID:   "https://gitlab.com/",
 					AccountID:   "alice_gitlab",

--- a/cmd/frontend/internal/auth/override.go
+++ b/cmd/frontend/internal/auth/override.go
@@ -41,7 +41,7 @@ func OverrideAuthMiddleware(next http.Handler) http.Handler {
 					Email:           username + "+override@example.com",
 					EmailIsVerified: true,
 				},
-				ExternalAccount: extsvc.Spec{
+				ExternalAccount: extsvc.AccountSpec{
 					ServiceType: "override",
 					AccountID:   username,
 				},

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -59,7 +59,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	// Try every verified email in succession until the first that succeeds
-	var data extsvc.Data
+	var data extsvc.ExternalAccountData
 	githubsvc.SetExternalAccountData(&data, ghUser, token)
 	var (
 		firstSafeErrMsg string

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -59,7 +59,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	// Try every verified email in succession until the first that succeeds
-	var data extsvc.ExternalAccountData
+	var data extsvc.AccountData
 	githubsvc.SetExternalAccountData(&data, ghUser, token)
 	var (
 		firstSafeErrMsg string

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -74,7 +74,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 				DisplayName:     deref(ghUser.Name),
 				AvatarURL:       deref(ghUser.AvatarURL),
 			},
-			ExternalAccount: extsvc.Spec{
+			ExternalAccount: extsvc.AccountSpec{
 				ServiceType: s.ServiceType,
 				ServiceID:   s.ServiceID,
 				ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -249,8 +249,8 @@ func u(username, email string, emailIsVerified bool) db.NewUser {
 	}
 }
 
-func acct(serviceType, serviceID, clientID, accountID string) extsvc.Spec {
-	return extsvc.Spec{
+func acct(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec {
+	return extsvc.AccountSpec{
 		ServiceType: serviceType,
 		ServiceID:   serviceID,
 		ClientID:    clientID,

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -202,7 +202,7 @@ func TestGetOrCreateUser(t *testing.T) {
 					if gotAuthUserOp != nil {
 						t.Fatal("GetAndSaveUser called more than once")
 					}
-					op.ExternalAccountData = extsvc.Data{} // ignore Data value
+					op.ExternalAccountData = extsvc.ExternalAccountData{} // ignore ExternalAccountData value
 					gotAuthUserOp = &op
 
 					if uid, ok := authSaveableUsers[op.UserProps.Username]; ok {

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -202,7 +202,7 @@ func TestGetOrCreateUser(t *testing.T) {
 					if gotAuthUserOp != nil {
 						t.Fatal("GetAndSaveUser called more than once")
 					}
-					op.ExternalAccountData = extsvc.ExternalAccountData{} // ignore ExternalAccountData value
+					op.ExternalAccountData = extsvc.AccountData{} // ignore AccountData value
 					gotAuthUserOp = &op
 
 					if uid, ok := authSaveableUsers[op.UserProps.Username]; ok {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -35,7 +35,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.Data
+	var data extsvc.ExternalAccountData
 	gitlab.SetExternalAccountData(&data, gUser, token)
 
 	// Unlike with GitHub, we can *only* use the primary email to resolve the user's identity,

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -35,7 +35,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.ExternalAccountData
+	var data extsvc.AccountData
 	gitlab.SetExternalAccountData(&data, gUser, token)
 
 	// Unlike with GitHub, we can *only* use the primary email to resolve the user's identity,

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -49,7 +49,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			DisplayName:     gUser.Name,
 			AvatarURL:       gUser.AvatarURL,
 		},
-		ExternalAccount: extsvc.Spec{
+		ExternalAccount: extsvc.AccountSpec{
 			ServiceType: s.ServiceType,
 			ServiceID:   s.ServiceID,
 			ClientID:    s.clientID,

--- a/enterprise/cmd/frontend/auth/httpheader/middleware.go
+++ b/enterprise/cmd/frontend/auth/httpheader/middleware.go
@@ -75,7 +75,7 @@ func middleware(next http.Handler) http.Handler {
 		}
 		userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), auth.GetAndSaveUserOp{
 			UserProps: db.NewUser{Username: username},
-			ExternalAccount: extsvc.Spec{
+			ExternalAccount: extsvc.AccountSpec{
 				ServiceType: providerType,
 				// Store rawUsername, not normalized username, to prevent two users with distinct
 				// pre-normalization usernames from being merged into the same normalized username

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -63,7 +63,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 			DisplayName:     displayName,
 			AvatarURL:       claims.Picture,
 		},
-		ExternalAccount: extsvc.Spec{
+		ExternalAccount: extsvc.AccountSpec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -48,7 +48,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.ExternalAccountData
+	var data extsvc.AccountData
 	data.SetAccountData(struct {
 		IDToken    *oidc.IDToken  `json:"idToken"`
 		UserInfo   *oidc.UserInfo `json:"userInfo"`

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -48,7 +48,7 @@ func getOrCreateUser(ctx context.Context, p *provider, idToken *oidc.IDToken, us
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", login), err
 	}
 
-	var data extsvc.Data
+	var data extsvc.ExternalAccountData
 	data.SetAccountData(struct {
 		IDToken    *oidc.IDToken  `json:"idToken"`
 		UserInfo   *oidc.UserInfo `json:"userInfo"`

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -85,7 +85,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
 func getOrCreateUser(ctx context.Context, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
-	var data extsvc.Data
+	var data extsvc.ExternalAccountData
 	data.SetAccountData(info.accountData)
 
 	username, err := auth.NormalizeUsername(info.unnormalizedUsername)

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -85,7 +85,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
 func getOrCreateUser(ctx context.Context, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
-	var data extsvc.ExternalAccountData
+	var data extsvc.AccountData
 	data.SetAccountData(info.accountData)
 
 	username, err := auth.NormalizeUsername(info.unnormalizedUsername)

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -15,7 +15,7 @@ import (
 )
 
 type authnResponseInfo struct {
-	spec                 extsvc.Spec
+	spec                 extsvc.AccountSpec
 	email, displayName   string
 	unnormalizedUsername string
 	accountData          interface{}
@@ -58,7 +58,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 		email = pn
 	}
 	info := authnResponseInfo{
-		spec: extsvc.Spec{
+		spec: extsvc.AccountSpec{
 			ServiceType: providerType,
 			ServiceID:   pi.ServiceID,
 			ClientID:    pi.ClientID,

--- a/enterprise/cmd/frontend/auth/saml/user_test.go
+++ b/enterprise/cmd/frontend/auth/saml/user_test.go
@@ -32,7 +32,7 @@ func TestReadAuthnResponse(t *testing.T) {
 	}
 	info.accountData = nil // skip checking this field
 	if want := (&authnResponseInfo{
-		spec: extsvc.Spec{
+		spec: extsvc.AccountSpec{
 			ServiceType: "saml",
 			ServiceID:   "http://localhost:3220/auth/realms/master",
 			ClientID:    "http://localhost:3080/.auth/saml/metadata",

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -56,7 +56,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
 		},
-		extsvc.Data{},
+		extsvc.ExternalAccountData{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",
 		},
-		extsvc.Data{},
+		extsvc.ExternalAccountData{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -51,7 +51,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 
 	// Add two external accounts
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.Spec{
+		extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
@@ -62,7 +62,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
-		extsvc.Spec{
+		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",

--- a/enterprise/cmd/frontend/db/authz_test.go
+++ b/enterprise/cmd/frontend/db/authz_test.go
@@ -56,7 +56,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://gitlab.com/",
 			AccountID:   "alice_gitlab",
 		},
-		extsvc.ExternalAccountData{},
+		extsvc.AccountData{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 			ServiceID:   "https://github.com/",
 			AccountID:   "alice_github",
 		},
-		extsvc.ExternalAccountData{},
+		extsvc.AccountData{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -624,7 +624,7 @@ func (s *PermsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.
 }
 
 func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sqlf.Query) (
-	idToSpecs map[int32]extsvc.Spec,
+	idToSpecs map[int32]extsvc.AccountSpec,
 	loaded map[int32]*roaring.Bitmap,
 	err error,
 ) {
@@ -642,11 +642,11 @@ func (s *PermsStore) batchLoadUserPendingPermissions(ctx context.Context, q *sql
 	}
 	defer rows.Close()
 
-	idToSpecs = make(map[int32]extsvc.Spec)
+	idToSpecs = make(map[int32]extsvc.AccountSpec)
 	loaded = make(map[int32]*roaring.Bitmap)
 	for rows.Next() {
 		var id int32
-		var spec extsvc.Spec
+		var spec extsvc.AccountSpec
 		var ids []byte
 		if err = rows.Scan(&id, &spec.ServiceType, &spec.ServiceID, &spec.AccountID, &ids); err != nil {
 			return nil, nil, err

--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1284,7 +1284,7 @@ ORDER BY id ASC
 		if err := rows.Scan(
 			&acct.ID, &acct.UserID,
 			&acct.ServiceType, &acct.ServiceID, &acct.ClientID, &acct.AccountID,
-			&acct.AuthData, &acct.AccountData,
+			&acct.AuthData, &acct.Data,
 			&acct.CreatedAt, &acct.UpdatedAt,
 		); err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -735,9 +735,9 @@ func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 func checkUserPendingPermsTable(
 	ctx context.Context,
 	s *PermsStore,
-	expects map[extsvc.Spec][]uint32,
+	expects map[extsvc.AccountSpec][]uint32,
 ) (
-	idToSpecs map[int32]extsvc.Spec,
+	idToSpecs map[int32]extsvc.AccountSpec,
 	err error,
 ) {
 	q := `SELECT id, service_type, service_id, bind_id, object_ids FROM user_pending_permissions`
@@ -747,10 +747,10 @@ func checkUserPendingPermsTable(
 	}
 
 	// Collect id -> account mappings for later used by checkRepoPendingPermsTable.
-	idToSpecs = make(map[int32]extsvc.Spec)
+	idToSpecs = make(map[int32]extsvc.AccountSpec)
 	for rows.Next() {
 		var id int32
-		var spec extsvc.Spec
+		var spec extsvc.AccountSpec
 		var ids []byte
 		if err := rows.Scan(&id, &spec.ServiceType, &spec.ServiceID, &spec.AccountID, &ids); err != nil {
 			return nil, err
@@ -789,8 +789,8 @@ func checkUserPendingPermsTable(
 func checkRepoPendingPermsTable(
 	ctx context.Context,
 	s *PermsStore,
-	idToSpecs map[int32]extsvc.Spec,
-	expects map[int32][]extsvc.Spec,
+	idToSpecs map[int32]extsvc.AccountSpec,
+	expects map[int32][]extsvc.AccountSpec,
 ) error {
 	rows, err := s.db.QueryContext(ctx, `SELECT repo_id, user_ids FROM repo_pending_permissions`)
 	if err != nil {
@@ -815,7 +815,7 @@ func checkRepoPendingPermsTable(
 		}
 		sort.Ints(userIDs)
 
-		haveSpecs := make([]extsvc.Spec, 0, len(userIDs))
+		haveSpecs := make([]extsvc.AccountSpec, 0, len(userIDs))
 		for _, userID := range userIDs {
 			spec, ok := idToSpecs[int32(userID)]
 			if !ok {
@@ -845,22 +845,22 @@ func checkRepoPendingPermsTable(
 }
 
 func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
-	alice := extsvc.Spec{
+	alice := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
-	bob := extsvc.Spec{
+	bob := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
 	}
-	cindy := extsvc.Spec{
+	cindy := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "cindy",
 	}
-	cindyGitHub := extsvc.Spec{
+	cindyGitHub := extsvc.AccountSpec{
 		ServiceType: "github",
 		ServiceID:   "https://github.com/",
 		AccountID:   "cindy",
@@ -873,8 +873,8 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 	tests := []struct {
 		name                   string
 		updates                []update
-		expectUserPendingPerms map[extsvc.Spec][]uint32 // account -> object_ids
-		expectRepoPendingPerms map[int32][]extsvc.Spec  // repo_id -> accounts
+		expectUserPendingPerms map[extsvc.AccountSpec][]uint32 // account -> object_ids
+		expectRepoPendingPerms map[int32][]extsvc.AccountSpec  // repo_id -> accounts
 	}{
 		{
 			name: "empty",
@@ -927,12 +927,12 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice:       {1, 2},
 				bob:         {2},
 				cindyGitHub: {3},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {alice},
 				2: {alice, bob},
 				3: {cindyGitHub},
@@ -973,13 +973,13 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice:       {},
 				bob:         {1},
 				cindy:       {1},
 				cindyGitHub: {2},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {bob, cindy},
 				2: {cindyGitHub},
 			},
@@ -1009,12 +1009,12 @@ func testPermsStore_SetRepoPendingPermissions(db *sql.DB) func(*testing.T) {
 					},
 				},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice: {},
 				bob:   {},
 				cindy: {},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 			},
 		},
@@ -1180,12 +1180,12 @@ func testPermsStore_ListPendingUsers(db *sql.DB) func(*testing.T) {
 }
 
 func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
-	alice := extsvc.Spec{
+	alice := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "alice",
 	}
-	bob := extsvc.Spec{
+	bob := extsvc.AccountSpec{
 		ServiceType: authz.SourcegraphServiceType,
 		ServiceID:   authz.SourcegraphServiceID,
 		AccountID:   "bob",
@@ -1207,10 +1207,10 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 		name                   string
 		updates                []update
 		grants                 []grant
-		expectUserPerms        map[int32][]uint32       // user_id -> object_ids
-		expectRepoPerms        map[int32][]uint32       // repo_id -> user_ids
-		expectUserPendingPerms map[extsvc.Spec][]uint32 // account -> object_ids
-		expectRepoPendingPerms map[int32][]extsvc.Spec  // repo_id -> accounts
+		expectUserPerms        map[int32][]uint32              // user_id -> object_ids
+		expectRepoPerms        map[int32][]uint32              // repo_id -> user_ids
+		expectUserPendingPerms map[extsvc.AccountSpec][]uint32 // account -> object_ids
+		expectRepoPendingPerms map[int32][]extsvc.AccountSpec  // repo_id -> accounts
 	}{
 		{
 			name: "empty",
@@ -1287,11 +1287,11 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1},
 				2: {1, 2},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				alice: {1},
 				bob:   {2},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {alice},
 				2: {bob},
 			},
@@ -1377,10 +1377,10 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1, 3},
 				2: {1, 2, 3},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{
 				bob: {3},
 			},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 				2: {},
 				3: {bob},
@@ -1456,8 +1456,8 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 				1: {1, 3},
 				2: {1, 2, 3},
 			},
-			expectUserPendingPerms: map[extsvc.Spec][]uint32{},
-			expectRepoPendingPerms: map[int32][]extsvc.Spec{
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{},
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
 				2: {},
 			},
@@ -1776,7 +1776,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     1,
 					UserID: 1,
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountID:   "alice_gitlab",
@@ -1788,7 +1788,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     2,
 					UserID: 1,
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com/",
 						AccountID:   "alice_github",
@@ -1814,7 +1814,7 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 				{
 					ID:     3,
 					UserID: 2,
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "gitlab",
 						ServiceID:   "https://gitlab.com/",
 						AccountID:   "bob_gitlab",

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -101,7 +101,7 @@ func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.Account, repos []
 
 	if acct != nil && acct.ServiceID == p.codeHost.ServiceID && acct.ServiceType == p.codeHost.ServiceType {
 		var user bitbucketserver.User
-		if err := json.Unmarshal(*acct.AccountData, &user); err != nil {
+		if err := json.Unmarshal(*acct.Data, &user); err != nil {
 			return nil, err
 		}
 
@@ -186,7 +186,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
 		},
 		ExternalAccountData: extsvc.ExternalAccountData{
-			AccountData: (*json.RawMessage)(&accountData),
+			Data: (*json.RawMessage)(&accountData),
 		},
 	}, nil
 }
@@ -203,7 +203,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 	switch {
 	case account == nil:
 		return nil, errors.New("no account provided")
-	case account.AccountData == nil:
+	case account.Data == nil:
 		return nil, errors.New("no account data provided")
 	case !extsvc.IsHostOfAccount(p.codeHost, account):
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
@@ -211,7 +211,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 	}
 
 	var user bitbucketserver.User
-	if err := json.Unmarshal(*account.AccountData, &user); err != nil {
+	if err := json.Unmarshal(*account.Data, &user); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling account data")
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -185,7 +185,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
 		},
-		Data: extsvc.Data{
+		ExternalAccountData: extsvc.ExternalAccountData{
 			AccountData: (*json.RawMessage)(&accountData),
 		},
 	}, nil

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -180,7 +180,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 
 	return &extsvc.Account{
 		UserID: user.ID,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
@@ -207,7 +207,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account data provided")
 	case !extsvc.IsHostOfAccount(p.codeHost, account):
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			p.codeHost.ServiceID, account.Spec.ServiceID)
+			p.codeHost.ServiceID, account.AccountSpec.ServiceID)
 	}
 
 	var user bitbucketserver.User

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -185,7 +185,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(bitbucketUser.ID),
 		},
-		ExternalAccountData: extsvc.ExternalAccountData{
+		AccountData: extsvc.AccountData{
 			Data: (*json.RawMessage)(&accountData),
 		},
 	}, nil

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -301,7 +301,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
 					},
-					Data: extsvc.Data{
+					ExternalAccountData: extsvc.ExternalAccountData{
 						AccountData: new(json.RawMessage),
 					},
 				},
@@ -315,7 +315,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
 					},
-					Data: extsvc.Data{
+					ExternalAccountData: extsvc.ExternalAccountData{
 						AccountData: new(json.RawMessage),
 					},
 				},
@@ -622,7 +622,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),
 		},
-		Data: extsvc.Data{
+		ExternalAccountData: extsvc.ExternalAccountData{
 			AccountData: (*json.RawMessage)(&bs),
 		},
 	}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -301,7 +301,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{
+					AccountData: extsvc.AccountData{
 						Data: new(json.RawMessage),
 					},
 				},
@@ -315,7 +315,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
 					},
-					ExternalAccountData: extsvc.ExternalAccountData{
+					AccountData: extsvc.AccountData{
 						Data: new(json.RawMessage),
 					},
 				},
@@ -622,7 +622,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),
 		},
-		ExternalAccountData: extsvc.ExternalAccountData{
+		AccountData: extsvc.AccountData{
 			Data: (*json.RawMessage)(&bs),
 		},
 	}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -296,7 +296,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "not a code host of the account",
 				acct: &extsvc.Account{
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: "github",
 						ServiceID:   "https://github.com",
 						AccountID:   "john",
@@ -310,7 +310,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 			{
 				name: "bad account data",
 				acct: &extsvc.Account{
-					Spec: extsvc.Spec{
+					AccountSpec: extsvc.AccountSpec{
 						ServiceType: h.ServiceType,
 						ServiceID:   h.ServiceID,
 						AccountID:   "john",
@@ -617,7 +617,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 	bs := marshalJSON(u)
 	return &extsvc.Account{
 		UserID: userID,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: h.ServiceType,
 			ServiceID:   h.ServiceID,
 			AccountID:   strconv.Itoa(u.ID),

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -302,7 +302,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						AccountID:   "john",
 					},
 					ExternalAccountData: extsvc.ExternalAccountData{
-						AccountData: new(json.RawMessage),
+						Data: new(json.RawMessage),
 					},
 				},
 				err: `not a code host of the account: want "${INSTANCEURL}" but have "https://github.com"`,
@@ -316,7 +316,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 						AccountID:   "john",
 					},
 					ExternalAccountData: extsvc.ExternalAccountData{
-						AccountData: new(json.RawMessage),
+						Data: new(json.RawMessage),
 					},
 				},
 				err: "unmarshaling account data: unexpected end of JSON input",
@@ -623,7 +623,7 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 			AccountID:   strconv.Itoa(u.ID),
 		},
 		ExternalAccountData: extsvc.ExternalAccountData{
-			AccountData: (*json.RawMessage)(&bs),
+			Data: (*json.RawMessage)(&bs),
 		},
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -389,7 +389,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.Spec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := github.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -324,7 +324,7 @@ func (p *Provider) getCachedUserRepos(ctx context.Context, userAccount *extsvc.A
 }
 
 func (p *Provider) fetchUserRepos(ctx context.Context, userAccount *extsvc.Account, repoIDs []string) (canAccess map[string]bool, isPublic map[string]bool, err error) {
-	_, tok, err := github.GetExternalAccountData(&userAccount.Data)
+	_, tok, err := github.GetExternalAccountData(&userAccount.ExternalAccountData)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,7 +392,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := github.GetExternalAccountData(&account.Data)
+	_, tok, err := github.GetExternalAccountData(&account.ExternalAccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -324,7 +324,7 @@ func (p *Provider) getCachedUserRepos(ctx context.Context, userAccount *extsvc.A
 }
 
 func (p *Provider) fetchUserRepos(ctx context.Context, userAccount *extsvc.Account, repoIDs []string) (canAccess map[string]bool, isPublic map[string]bool, err error) {
-	_, tok, err := github.GetExternalAccountData(&userAccount.ExternalAccountData)
+	_, tok, err := github.GetExternalAccountData(&userAccount.AccountData)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,7 +392,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := github.GetExternalAccountData(&account.ExternalAccountData)
+	_, tok, err := github.GetExternalAccountData(&account.AccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -271,7 +271,7 @@ func mustURL(t *testing.T, u string) *url.URL {
 func ua(accountID, token string) *extsvc.Account {
 	var a extsvc.Account
 	a.AccountID = accountID
-	github.SetExternalAccountData(&a.Data, nil, &oauth2.Token{
+	github.SetExternalAccountData(&a.ExternalAccountData, nil, &oauth2.Token{
 		AccessToken: token,
 	})
 	return &a

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -271,7 +271,7 @@ func mustURL(t *testing.T, u string) *url.URL {
 func ua(accountID, token string) *extsvc.Account {
 	var a extsvc.Account
 	a.AccountID = accountID
-	github.SetExternalAccountData(&a.ExternalAccountData, nil, &oauth2.Token{
+	github.SetExternalAccountData(&a.AccountData, nil, &oauth2.Token{
 		AccessToken: token,
 	})
 	return &a

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -378,7 +378,7 @@ func (m mockAuthnProvider) Refresh(ctx context.Context) error {
 }
 
 func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.Account {
-	var data extsvc.Data
+	var data extsvc.ExternalAccountData
 
 	var authData *oauth2.Token
 	if oauthTok != "" {
@@ -403,7 +403,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 			ServiceID:   serviceID,
 			AccountID:   accountID,
 		},
-		Data: data,
+		ExternalAccountData: data,
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -378,7 +378,7 @@ func (m mockAuthnProvider) Refresh(ctx context.Context) error {
 }
 
 func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.Account {
-	var data extsvc.ExternalAccountData
+	var data extsvc.AccountData
 
 	var authData *oauth2.Token
 	if oauthTok != "" {
@@ -403,7 +403,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 			ServiceID:   serviceID,
 			AccountID:   accountID,
 		},
-		ExternalAccountData: data,
+		AccountData: data,
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -398,7 +398,7 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 
 	return &extsvc.Account{
 		UserID: userID,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 			AccountID:   accountID,

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -146,7 +146,7 @@ func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.Account, 
 
 	var oauthToken string
 	if account != nil {
-		_, tok, err := gitlab.GetExternalAccountData(&account.Data)
+		_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_oauth.go
@@ -146,7 +146,7 @@ func (p *OAuthProvider) RepoPerms(ctx context.Context, account *extsvc.Account, 
 
 	var oauthToken string
 	if account != nil {
-		_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+		_, tok, err := gitlab.GetExternalAccountData(&account.AccountData)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -156,7 +156,7 @@ func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.Account, r
 		// API (and update the user repo-visibility and user-can-access-repo permissions, as well)
 		var sudo string
 		if account != nil {
-			usr, _, err := gitlab.GetExternalAccountData(&account.Data)
+			usr, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +286,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 		return nil, nil
 	}
 
-	var accountData extsvc.Data
+	var accountData extsvc.ExternalAccountData
 	gitlab.SetExternalAccountData(&accountData, glUser, nil)
 
 	glExternalAccount := extsvc.Account{
@@ -296,7 +296,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),
 		},
-		Data: accountData,
+		ExternalAccountData: accountData,
 	}
 	return &glExternalAccount, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -156,7 +156,7 @@ func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.Account, r
 		// API (and update the user repo-visibility and user-can-access-repo permissions, as well)
 		var sudo string
 		if account != nil {
-			usr, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+			usr, _, err := gitlab.GetExternalAccountData(&account.AccountData)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +286,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 		return nil, nil
 	}
 
-	var accountData extsvc.ExternalAccountData
+	var accountData extsvc.AccountData
 	gitlab.SetExternalAccountData(&accountData, glUser, nil)
 
 	glExternalAccount := extsvc.Account{
@@ -296,7 +296,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),
 		},
-		ExternalAccountData: accountData,
+		AccountData: accountData,
 	}
 	return &glExternalAccount, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -291,7 +291,7 @@ func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, curre
 
 	glExternalAccount := extsvc.Account{
 		UserID: user.ID,
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.codeHost.ServiceType,
 			ServiceID:   p.codeHost.ServiceID,
 			AccountID:   strconv.Itoa(int(glUser.ID)),

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
@@ -199,9 +199,9 @@ func Test_GitLab_FetchAccount(t *testing.T) {
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
-					// ignore AccountData field in comparison
+					// ignore Data field in comparison
 					if acct != nil {
-						acct.AccountData, c.expMine.AccountData = nil, nil
+						acct.Data, c.expMine.Data = nil, nil
 					}
 
 					if !reflect.DeepEqual(acct, c.expMine) {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -25,7 +25,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := gitlab.GetExternalAccountData(&account.Data)
+	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	} else if tok == nil {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -25,7 +25,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	_, tok, err := gitlab.GetExternalAccountData(&account.AccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	} else if tok == nil {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth.go
@@ -22,7 +22,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.Spec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -95,7 +95,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			ExternalAccountData: extsvc.ExternalAccountData{
+			AccountData: extsvc.AccountData{
 				AuthData: &authData,
 			},
 		},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -95,7 +95,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			Data: extsvc.Data{
+			ExternalAccountData: extsvc.ExternalAccountData{
 				AuthData: &authData,
 			},
 		},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -42,7 +42,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				Spec: extsvc.Spec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -91,7 +91,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			Spec: extsvc.Spec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -24,7 +24,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
 		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
-			account.Spec.ServiceID, p.codeHost.ServiceID)
+			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	user, _, err := gitlab.GetExternalAccountData(&account.Data)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -27,7 +27,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	user, _, err := gitlab.GetExternalAccountData(&account.Data)
+	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo.go
@@ -27,7 +27,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
-	user, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+	user, _, err := gitlab.GetExternalAccountData(&account.AccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
 	}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -93,7 +93,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			Data: extsvc.Data{
+			ExternalAccountData: extsvc.ExternalAccountData{
 				AccountData: &accountData,
 			},
 		},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -34,7 +34,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
-				Spec: extsvc.Spec{
+				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				},
@@ -89,7 +89,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	accountData := json.RawMessage(`{"id": 999}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
-			Spec: extsvc.Spec{
+			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -93,7 +93,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",
 			},
-			ExternalAccountData: extsvc.ExternalAccountData{
+			AccountData: extsvc.AccountData{
 				Data: &accountData,
 			},
 		},

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -94,7 +94,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				ServiceID:   "https://gitlab.com/",
 			},
 			ExternalAccountData: extsvc.ExternalAccountData{
-				AccountData: &accountData,
+				Data: &accountData,
 			},
 		},
 	)

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -127,7 +127,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	defer authz.SetProviders(true, nil)
 
 	extAccount := extsvc.Account{
-		Spec: extsvc.Spec{
+		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.ServiceType(),
 			ServiceID:   p.ServiceID(),
 		},

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -23,25 +23,25 @@ func setJSONOrError(field **json.RawMessage, value interface{}) {
 
 // SetAccountData sets the Data field to the (JSON-encoded) value. If an error occurs during
 // JSON encoding, a JSON object describing the error is written to the field, instead.
-func (d *ExternalAccountData) SetAccountData(v interface{}) {
+func (d *AccountData) SetAccountData(v interface{}) {
 	setJSONOrError(&d.Data, v)
 }
 
 // SetAuthData sets the AuthData field to the (JSON-encoded) value. If an error occurs during JSON
 // encoding, a JSON object describing the error is written to the field, instead.
-func (d *ExternalAccountData) SetAuthData(v interface{}) {
+func (d *AccountData) SetAuthData(v interface{}) {
 	setJSONOrError(&d.AuthData, v)
 }
 
 // GetAccountData reads the Data field into the value. The value should be a pointer type to
 // the type that was passed to SetAccountData.
-func (d *ExternalAccountData) GetAccountData(v interface{}) error {
+func (d *AccountData) GetAccountData(v interface{}) error {
 	return getJSONOrError(d.Data, v)
 }
 
 // GetAuthData reads the AuthData field into the value. The value should be a pointer type to the
 // type that was passed to SetAuthData.
-func (d *ExternalAccountData) GetAuthData(v interface{}) error {
+func (d *AccountData) GetAuthData(v interface{}) error {
 	return getJSONOrError(d.AuthData, v)
 }
 

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -21,10 +21,10 @@ func setJSONOrError(field **json.RawMessage, value interface{}) {
 	*field = (*json.RawMessage)(&b)
 }
 
-// SetAccountData sets the AccountData field to the (JSON-encoded) value. If an error occurs during
+// SetAccountData sets the Data field to the (JSON-encoded) value. If an error occurs during
 // JSON encoding, a JSON object describing the error is written to the field, instead.
 func (d *ExternalAccountData) SetAccountData(v interface{}) {
-	setJSONOrError(&d.AccountData, v)
+	setJSONOrError(&d.Data, v)
 }
 
 // SetAuthData sets the AuthData field to the (JSON-encoded) value. If an error occurs during JSON
@@ -33,10 +33,10 @@ func (d *ExternalAccountData) SetAuthData(v interface{}) {
 	setJSONOrError(&d.AuthData, v)
 }
 
-// GetAccountData reads the AccountData field into the value. The value should be a pointer type to
+// GetAccountData reads the Data field into the value. The value should be a pointer type to
 // the type that was passed to SetAccountData.
 func (d *ExternalAccountData) GetAccountData(v interface{}) error {
-	return getJSONOrError(d.AccountData, v)
+	return getJSONOrError(d.Data, v)
 }
 
 // GetAuthData reads the AuthData field into the value. The value should be a pointer type to the

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -23,25 +23,25 @@ func setJSONOrError(field **json.RawMessage, value interface{}) {
 
 // SetAccountData sets the AccountData field to the (JSON-encoded) value. If an error occurs during
 // JSON encoding, a JSON object describing the error is written to the field, instead.
-func (d *Data) SetAccountData(v interface{}) {
+func (d *ExternalAccountData) SetAccountData(v interface{}) {
 	setJSONOrError(&d.AccountData, v)
 }
 
 // SetAuthData sets the AuthData field to the (JSON-encoded) value. If an error occurs during JSON
 // encoding, a JSON object describing the error is written to the field, instead.
-func (d *Data) SetAuthData(v interface{}) {
+func (d *ExternalAccountData) SetAuthData(v interface{}) {
 	setJSONOrError(&d.AuthData, v)
 }
 
 // GetAccountData reads the AccountData field into the value. The value should be a pointer type to
 // the type that was passed to SetAccountData.
-func (d *Data) GetAccountData(v interface{}) error {
+func (d *ExternalAccountData) GetAccountData(v interface{}) error {
 	return getJSONOrError(d.AccountData, v)
 }
 
 // GetAuthData reads the AuthData field into the value. The value should be a pointer type to the
 // type that was passed to SetAuthData.
-func (d *Data) GetAuthData(v interface{}) error {
+func (d *ExternalAccountData) GetAuthData(v interface{}) error {
 	return getJSONOrError(d.AuthData, v)
 }
 

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func GetExternalAccountData(data *extsvc.Data) (usr *github.User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User, tok *oauth2.Token, err error) {
 	var (
 		u github.User
 		t oauth2.Token
@@ -30,7 +30,7 @@ func GetExternalAccountData(data *extsvc.Data) (usr *github.User, tok *oauth2.To
 	return usr, tok, nil
 }
 
-func SetExternalAccountData(data *extsvc.Data, user *github.User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.ExternalAccountData, user *github.User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -15,7 +15,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User,
 		t oauth2.Token
 	)
 
-	if data.AccountData != nil {
+	if data.Data != nil {
 		if err := data.GetAccountData(&u); err != nil {
 			return nil, nil, err
 		}

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.AccountData) (usr *github.User, tok *oauth2.Token, err error) {
 	var (
 		u github.User
 		t oauth2.Token
@@ -30,7 +30,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *github.User,
 	return usr, tok, nil
 }
 
-func SetExternalAccountData(data *extsvc.ExternalAccountData, user *github.User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.AccountData, user *github.User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/gitlab/user.go
+++ b/internal/extsvc/gitlab/user.go
@@ -13,7 +13,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *o
 		t oauth2.Token
 	)
 
-	if data.AccountData != nil {
+	if data.Data != nil {
 		if err := data.GetAccountData(&u); err != nil {
 			return nil, nil, err
 		}

--- a/internal/extsvc/gitlab/user.go
+++ b/internal/extsvc/gitlab/user.go
@@ -7,7 +7,7 @@ import (
 
 // GetExternalAccountData returns the deserialized user and token from the external account data
 // JSON blob in a typesafe way.
-func GetExternalAccountData(data *extsvc.Data) (usr *User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *oauth2.Token, err error) {
 	var (
 		u User
 		t oauth2.Token
@@ -29,7 +29,7 @@ func GetExternalAccountData(data *extsvc.Data) (usr *User, tok *oauth2.Token, er
 }
 
 // SetExternalAccountData sets the user and token into the external account data blob.
-func SetExternalAccountData(data *extsvc.Data, user *User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.ExternalAccountData, user *User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/gitlab/user.go
+++ b/internal/extsvc/gitlab/user.go
@@ -7,7 +7,7 @@ import (
 
 // GetExternalAccountData returns the deserialized user and token from the external account data
 // JSON blob in a typesafe way.
-func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *oauth2.Token, err error) {
+func GetExternalAccountData(data *extsvc.AccountData) (usr *User, tok *oauth2.Token, err error) {
 	var (
 		u User
 		t oauth2.Token
@@ -29,7 +29,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *o
 }
 
 // SetExternalAccountData sets the user and token into the external account data blob.
-func SetExternalAccountData(data *extsvc.ExternalAccountData, user *User, token *oauth2.Token) {
+func SetExternalAccountData(data *extsvc.AccountData, user *User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -11,18 +11,18 @@ import (
 // Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
 type Account struct {
-	ID        int32
-	UserID    int32
-	Spec      // ServiceType, ServiceID, ClientID, AccountID
-	Data      // AuthData, AccountData
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID          int32
+	UserID      int32
+	AccountSpec // ServiceType, ServiceID, ClientID, AccountID
+	Data        // AuthData, AccountData
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
-// Spec specifies a user external account by its external identifier (i.e. by the identifier
-// provided by the account's owner service), instead of by our database's serial ID. See the
-// GraphQL API's corresponding fields in "ExternalAccount" for documentation.
-type Spec struct {
+// AccountSpec specifies a user external account by its external identifier (i.e., by the
+// identifier provided by the account's owner service), instead of by our database's serial
+// ID. See the GraphQL API's corresponding fields in "ExternalAccount" for documentation.
+type AccountSpec struct {
 	ServiceType string
 	ServiceID   string
 	ClientID    string
@@ -44,7 +44,7 @@ type Repository struct {
 }
 
 // Accounts contains a list of accounts that belong to the same external service.
-// All fields have a same meaning to Spec. See GraphQL API's corresponding fields
+// All fields have a same meaning to AccountSpec. See GraphQL API's corresponding fields
 // in "ExternalAccount" for documentation.
 type Accounts struct {
 	ServiceType string

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -11,12 +11,12 @@ import (
 // Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
 type Account struct {
-	ID          int32
-	UserID      int32
-	AccountSpec // ServiceType, ServiceID, ClientID, AccountID
-	Data        // AuthData, AccountData
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                  int32
+	UserID              int32
+	AccountSpec         // ServiceType, ServiceID, ClientID, AccountID
+	ExternalAccountData // AuthData, AccountData
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 // AccountSpec specifies a user external account by its external identifier (i.e., by the
@@ -29,9 +29,9 @@ type AccountSpec struct {
 	AccountID   string
 }
 
-// Data contains data that can be freely updated in the user external account after it has been
-// created. See the GraphQL API's corresponding fields for documentation.
-type Data struct {
+// ExternalAccountData contains data that can be freely updated in the user external account
+// after it has been created. See the GraphQL API's corresponding fields for documentation.
+type ExternalAccountData struct {
 	AuthData    *json.RawMessage
 	AccountData *json.RawMessage
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -14,7 +14,7 @@ type Account struct {
 	ID                  int32
 	UserID              int32
 	AccountSpec         // ServiceType, ServiceID, ClientID, AccountID
-	ExternalAccountData // AuthData, AccountData
+	ExternalAccountData // AuthData, Data
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
@@ -32,8 +32,8 @@ type AccountSpec struct {
 // ExternalAccountData contains data that can be freely updated in the user external account
 // after it has been created. See the GraphQL API's corresponding fields for documentation.
 type ExternalAccountData struct {
-	AuthData    *json.RawMessage
-	AccountData *json.RawMessage
+	AuthData *json.RawMessage
+	Data     *json.RawMessage
 }
 
 // Repository contains necessary information to identify an external repository on the code host.

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -11,12 +11,12 @@ import (
 // Account represents a row in the `user_external_accounts` table. See the GraphQL API's
 // corresponding fields in "ExternalAccount" for documentation.
 type Account struct {
-	ID                  int32
-	UserID              int32
-	AccountSpec         // ServiceType, ServiceID, ClientID, AccountID
-	ExternalAccountData // AuthData, Data
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID          int32
+	UserID      int32
+	AccountSpec // ServiceType, ServiceID, ClientID, AccountID
+	AccountData // AuthData, Data
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // AccountSpec specifies a user external account by its external identifier (i.e., by the
@@ -29,9 +29,9 @@ type AccountSpec struct {
 	AccountID   string
 }
 
-// ExternalAccountData contains data that can be freely updated in the user external account
-// after it has been created. See the GraphQL API's corresponding fields for documentation.
-type ExternalAccountData struct {
+// AccountData contains data that can be freely updated in the user external account after it
+// has been created. See the GraphQL API's corresponding fields for documentation.
+type AccountData struct {
 	AuthData *json.RawMessage
 	Data     *json.RawMessage
 }


### PR DESCRIPTION
Better to review by commit.

First two commits reverts https://github.com/sourcegraph/sourcegraph/pull/9545 and https://github.com/sourcegraph/sourcegraph/pull/9515.

Then we would have consistent naming for all types defined in the `extsvc` package.