### PR TITLE
Track Puppeteer coverage

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -5,7 +5,7 @@ env:
   FORCE_COLOR: "3"
   GO111MODULE: "on"
   IMAGE: "server_instrumented"
-  TAG: "latest"
+  TAG: "${BUILDKITE_BUILD_NUMBER}_${BUILDKITE_RETRY_COUNT}"
   COVERAGE_INSTRUMENT: "true"
   TEST_USER_PASSWORD: "SuperSecurePassword"
 

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -4,7 +4,9 @@ env:
   ENTERPRISE: "1"
   FORCE_COLOR: "3"
   GO111MODULE: "on"
-  IMAGE: us.gcr.io/sourcegraph-dev/server:$TAG
+  IMAGE: "server_instrumented"
+  TAG: "latest"
+  COVERAGE_INSTRUMENT: "true"
   TEST_USER_PASSWORD: "SuperSecurePassword"
 
 steps:
@@ -14,18 +16,7 @@ steps:
     - ./cmd/server/pre-build.sh
     - ./cmd/server/build.sh
     - popd
-    - |
-      if [ "$PUSH_CANDIDATE_IMAGE" == "true" ]; then
-        yes | gcloud auth configure-docker
-        docker push "$IMAGE"
-      fi
     - ./dev/ci/e2e.sh
+    - docker image rm -f "$IMAGE"
   timeout_in_minutes: 20
   label: ':docker::arrow_right::chromium:'
-
-- wait
-
-- command: docker image rm -f "$IMAGE"
-  timeout_in_minutes: 10
-  label: ':sparkles:'
-  soft_fail: true

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,24 @@
 // @ts-check
+const logger = require('gulplog')
 
 /** @type {import('@babel/core').ConfigFunction} */
 module.exports = api => {
   const isTest = api.env('test')
   api.cache.forever()
 
+  /**
+   * Whether to instrument files with istanbul for code coverage.
+   * This is needed for e2e test coverage.
+   */
+  const instrument = Boolean(process.env.COVERAGE_INSTRUMENT && JSON.parse(process.env.COVERAGE_INSTRUMENT))
+  if (instrument) {
+    logger.info('Instrumenting code for coverage tracking')
+  }
+
   return {
     presets: [
+      // Can't put this in plugins because it needs to run as the last plugin.
+      ...(instrument ? [{ plugins: [['babel-plugin-istanbul', { exclude: ['node_modules/**'] }]] }] : []),
       [
         '@babel/preset-env',
         {

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -45,5 +45,8 @@ echo "--- yarn run test-e2e"
 pushd web
 # `-pix_fmt yuv420p` makes a QuickTime-compatible mp4.
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &
-env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
-popd
+env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run cover-e2e
+
+yarn nyc report -r json
+# Upload the coverage under the "e2e" flag (toggleable in the CodeCov UI)
+bash <(curl -s https://codecov.io/bash) -F e2e

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -42,7 +42,6 @@ set -e
 echo "Waiting for $URL... done"
 
 echo "--- yarn run test-e2e"
-pushd web
 # `-pix_fmt yuv420p` makes a QuickTime-compatible mp4.
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run cover-e2e

--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -5,6 +5,6 @@ coverage:
     patch: off
 comment:
   require_changes: yes
-  layout: 'diff, files'
+  layout: 'diff, flags, files'
 ignore:
   - '**/bindata.go'

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -54,7 +54,7 @@ Retrying the Buildkite step can help determine whether the test is flaky or brok
 To run all e2e tests locally against your dev server, **create a user `test` with password `testtesttest`, promote as site admin**, then run:
 
 ```
-env TEST_USER_PASSWORD=testtesttest GITHUB_TOKEN=<token> yarn --cwd web run test-e2e
+env TEST_USER_PASSWORD=testtesttest GITHUB_TOKEN=<token> yarn test-e2e
 ```
 
 There's a GitHub test token in `../dev-private/enterprise/dev/external-services-config.json`.

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	bk "github.com/sourcegraph/sourcegraph/internal/buildkite"
@@ -193,9 +192,6 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	// hardFail if we publish docker images
 	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
-	// push the server candidate image only if it's required
-	imageCandidatePush := c.branch == "master" || c.isMasterDryRun || c.releaseBranch || c.taggedRelease || c.patch
-
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",
 		"BUILDKITE_PULL_REQUEST_BASE_BRANCH",
@@ -204,9 +200,7 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["COMMIT_SHA"] = commonEnv["COMMIT_SHA"]
 	env["DATE"] = commonEnv["DATE"]
 	env["VERSION"] = commonEnv["VERSION"]
-	env["TAG"] = candiateImageTag(c)
 	env["CI_DEBUG_PROFILE"] = commonEnv["CI_DEBUG_PROFILE"]
-	env["PUSH_CANDIDATE_IMAGE"] = strconv.FormatBool(imageCandidatePush)
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":chromium:",
@@ -273,10 +267,6 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 // tags once the e2e tests pass.
 func addCanidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		if app == "server" {
-			// The candiate server image is built by the e2e pipeline.
-			return
-		}
 
 		baseImage := "sourcegraph/" + strings.ReplaceAll(app, "/", "-")
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -138,7 +138,7 @@ func addCodeCov(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":codecov:",
 		bk.Cmd("buildkite-agent artifact download 'coverage.txt' . || true"), // ignore error when no report exists
 		bk.Cmd("buildkite-agent artifact download '*/coverage-final.json' . || true"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -X xcode"))
+		bk.Cmd("bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -X xcode -F unit"))
 }
 
 // Release the browser extension.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "graphql-lint": "graphql-schema-linter --old-implements-syntax --comment-descriptions cmd/frontend/graphqlbackend/schema.graphql",
     "prepublish": "gulp generate",
     "test": "jest --testPathIgnorePatterns e2e regression integration",
+    "test-e2e": "TS_NODE_PROJECT=web/src/e2e/tsconfig.json mocha ./web/src/e2e/e2e.test.ts",
+    "cover-e2e": "nyc --hook-require=false yarn test-e2e",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "build-storybook -c .storybook",
     "storybook:smoke-test": "yarn run storybook --smoke-test",
@@ -33,6 +35,21 @@
     "last 1 Chrome versions",
     "not IE > 0"
   ],
+  "nyc": {
+    "all": true,
+    "extension": [
+      ".tsx",
+      ".ts"
+    ],
+    "include": [
+      "@(web|shared)/src/**/*.ts?(x)"
+    ],
+    "exclude": [
+      "node_modules",
+      "**/*.d.ts",
+      "**/*.@(test|story).ts?(x)"
+    ]
+  },
   "jscpd": {
     "gitignore": true,
     "ignore": [
@@ -176,6 +193,7 @@
     "mz": "^2.7.0",
     "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
+    "nyc": "^15.0.0",
     "open": "^7.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "p-retry": "^4.2.0",

--- a/shared/src/e2e/coverage.ts
+++ b/shared/src/e2e/coverage.ts
@@ -1,0 +1,54 @@
+import { Driver } from './driver'
+import { writeFile, mkdir } from 'mz/fs'
+
+declare global {
+    interface FileCoverage {
+        /** Absolute path. */
+        path: string
+        hash: string
+        // fnMap, branchMap, statementMap, s, f, b, _coverageSchema
+    }
+
+    // eslint-disable-next-line no-var
+    var __coverage__: Record<string, FileCoverage> | undefined
+}
+
+let warnedNoCoverage = false
+
+/**
+ * Saves coverage recorded by the instrumented code in `.nyc_output`.
+ */
+export function afterEachRecordCoverage(getDriver: () => Driver): void {
+    afterEach('Record coverage', async () => {
+        await mkdir('.nyc_output', { recursive: true })
+        // Get pages, web workers, background pages, etc.
+        const targets = await getDriver().browser.targets()
+        await Promise.all(
+            targets.map(async target => {
+                const executionContext = (await target.worker()) ?? (await target.page())
+                if (!executionContext) {
+                    return
+                }
+                const coverage: typeof __coverage__ = await executionContext.evaluate(() => globalThis.__coverage__)
+                if (!coverage) {
+                    if (!warnedNoCoverage && target.url() !== 'about:blank') {
+                        console.error(
+                            `No coverage found in target ${target.url()}\n` +
+                                'Run the dev Sourcegraph instance with COVERAGE_INSTRUMENT=true to track coverage.'
+                        )
+                        warnedNoCoverage = true
+                    }
+                    return
+                }
+                await Promise.all(
+                    Object.values(coverage).map(async fileCoverage => {
+                        await writeFile(
+                            `.nyc_output/${fileCoverage.hash}.json`,
+                            JSON.stringify({ [fileCoverage.path]: fileCoverage })
+                        )
+                    })
+                )
+            })
+        )
+    })
+}

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "scripts": {
     "test": "jest --testPathIgnorePatterns e2e --testPathIgnorePatterns regression",
-    "test-e2e": "mocha ./src/e2e/e2e.test.ts",
     "test:regression": "mocha './src/regression/**/*.test.ts'",
     "test:regression:auth": "mocha ./src/regression/auth.test.ts",
     "test:regression:codeintel": "mocha ./src/regression/codeintel.test.ts",

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, before, beforeEach, after, afterEach } from 'mocha'
 import { saveScreenshotsUponFailures } from '../../../shared/src/e2e/screenshotReporter'
+import { afterEachRecordCoverage } from '../../../shared/src/e2e/coverage'
 import { retry } from '../../../shared/src/e2e/e2e-test-utils'
 import { createDriverForTest, Driver, percySnapshot } from '../../../shared/src/e2e/driver'
 import got from 'got'
@@ -60,15 +61,10 @@ describe('e2e test suite', () => {
         })
     })
 
-    // Close browser.
-    after('Close browser', async () => {
-        if (driver) {
-            await driver.close()
-        }
-    })
+    after('Close browser', () => driver?.close())
 
-    // Take a screenshot when a test fails.
     saveScreenshotsUponFailures(() => driver.page)
+    afterEachRecordCoverage(() => driver)
 
     beforeEach(async () => {
         if (driver) {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -6,9 +6,10 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const path = require('path')
 const TerserPlugin = require('terser-webpack-plugin')
 const webpack = require('webpack')
+const logger = require('gulplog')
 
 const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
-console.error('Using mode', mode)
+logger.info('Using mode', mode)
 
 const devtool = mode === 'production' ? 'source-map' : 'cheap-module-eval-source-map'
 
@@ -97,6 +98,14 @@ const config = {
   resolve: {
     extensions: ['.mjs', '.ts', '.tsx', '.js'],
     mainFields: ['es2015', 'module', 'browser', 'main'],
+    alias: {
+      // react-visibility-sensor's main field points to a UMD bundle instead of ESM
+      // https://github.com/joshwnj/react-visibility-sensor/issues/148
+      'react-visibility-sensor': path.resolve(
+        __dirname,
+        '../node_modules/react-visibility-sensor/visibility-sensor.js'
+      ),
+    },
   },
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,7 +1852,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -4030,6 +4031,13 @@ append-buffer@^1.0.2:
   dependencies:
     buffer-equal "^1.0.0"
 
+append-transform@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"
+  integrity sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==
+  dependencies:
+    default-require-extensions "^3.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2, "aproba@^1.1.2 || 2":
   version "1.2.0"
   resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -5433,6 +5441,16 @@ cacheable-request@^7.0.1:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^2.0.0"
+
+caching-transform@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz#00d297a4206d71e2163c39eaffa8157ac0651f0f"
+  integrity sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==
+  dependencies:
+    hasha "^5.0.0"
+    make-dir "^3.0.0"
+    package-hash "^4.0.0"
+    write-file-atomic "^3.0.0"
 
 call-limit@^1.1.1:
   version "1.1.1"
@@ -7154,6 +7172,13 @@ default-gateway@^4.2.0:
     execa "^1.0.0"
     ip-regex "^2.1.0"
 
+default-require-extensions@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz#e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96"
+  integrity sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==
+  dependencies:
+    strip-bom "^4.0.0"
+
 default-resolution@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz#bcb82baa72ad79b426a76732f1a81ad6df26d684"
@@ -7891,7 +7916,7 @@ es5-shim@^4.5.13:
   resolved "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.13.tgz#5d88062de049f8969f83783f4a4884395f21d28b"
   integrity sha512-xi6hh6gsvDE0MaW4Vp1lgNEBpVcCXRWfPXj5egDvtgLz4L9MEvNwYEMdJH+JJinWkwa8c3c3o5HduV7dB/e1Hw==
 
-es6-error@4.1.1:
+es6-error@4.1.1, es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
@@ -9098,6 +9123,14 @@ foreachasync@^3.0.0:
   resolved "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
   integrity sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=
 
+foreground-child@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
+  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^3.0.2"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -9177,6 +9210,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fromentries@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz#e6aa06f240d6267f913cea422075ef88b63e7897"
+  integrity sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -10188,6 +10226,14 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hasha@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz#33094d1f69c40a4a6ac7be53d5fe3ff95a269e0c"
+  integrity sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==
+  dependencies:
+    is-stream "^2.0.0"
+    type-fest "^0.8.0"
 
 hast-util-from-parse5@^5.0.0:
   version "5.0.0"
@@ -11450,10 +11496,17 @@ istanbul-lib-coverage@^2.0.3:
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#0b891e5ad42312c2b9488554f603795f9a2211ba"
   integrity sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==
 
-istanbul-lib-coverage@^3.0.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.0.0-alpha.1:
   version "3.0.0"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
   integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
+istanbul-lib-hook@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz#8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6"
+  integrity sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==
+  dependencies:
+    append-transform "^2.0.0"
 
 istanbul-lib-instrument@^3.0.0:
   version "3.1.0"
@@ -11480,6 +11533,19 @@ istanbul-lib-instrument@^4.0.0:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-coverage "^3.0.0"
     semver "^6.3.0"
+
+istanbul-lib-processinfo@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz#e1426514662244b2f25df728e8fd1ba35fe53b9c"
+  integrity sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==
+  dependencies:
+    archy "^1.0.0"
+    cross-spawn "^7.0.0"
+    istanbul-lib-coverage "^3.0.0-alpha.1"
+    make-dir "^3.0.0"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    uuid "^3.3.3"
 
 istanbul-lib-report@^3.0.0:
   version "3.0.0"
@@ -12865,6 +12931,11 @@ lodash.flatmap@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
   integrity sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -14081,6 +14152,13 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
+node-preload@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
+  integrity sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==
+  dependencies:
+    process-on-spawn "^1.0.0"
+
 node-releases@^1.1.13, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -14457,6 +14535,40 @@ nwsapi@^2.0.7, nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+
+nyc@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz#eb32db2c0f29242c2414fe46357f230121cfc162"
+  integrity sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==
+  dependencies:
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    caching-transform "^4.0.0"
+    convert-source-map "^1.7.0"
+    decamelize "^1.2.0"
+    find-cache-dir "^3.2.0"
+    find-up "^4.1.0"
+    foreground-child "^2.0.0"
+    glob "^7.1.6"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-hook "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-processinfo "^2.0.2"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    js-yaml "^3.13.1"
+    make-dir "^3.0.0"
+    node-preload "^0.2.0"
+    p-map "^3.0.0"
+    process-on-spawn "^1.0.0"
+    resolve-from "^5.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    spawn-wrap "^2.0.0"
+    test-exclude "^6.0.0"
+    uuid "^3.3.3"
+    yargs "^15.0.2"
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -14929,6 +15041,16 @@ p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
+
+package-hash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz#3537f654665ec3cc38827387fc904c163c54f506"
+  integrity sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==
+  dependencies:
+    graceful-fs "^4.1.15"
+    hasha "^5.0.0"
+    lodash.flattendeep "^4.4.0"
+    release-zalgo "^1.0.0"
 
 package-json@^4.0.0:
   version "4.0.1"
@@ -16001,6 +16123,13 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+process-on-spawn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz#95b05a23073d30a17acfdc92a440efd2baefdc93"
+  integrity sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==
+  dependencies:
+    fromentries "^1.2.0"
 
 process@^0.11.10:
   version "0.11.10"
@@ -17202,6 +17331,13 @@ relaxed-json@1.0.3:
   dependencies:
     chalk "^2.4.2"
     commander "^2.6.0"
+
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+  dependencies:
+    es6-error "^4.0.1"
 
 remark-parse@^6.0.0:
   version "6.0.3"
@@ -18427,7 +18563,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.0.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -18448,6 +18585,18 @@ spawn-sync@1.0.15:
   dependencies:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
+
+spawn-wrap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz#103685b8b8f9b79771318827aa78650a610d457e"
+  integrity sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==
+  dependencies:
+    foreground-child "^2.0.0"
+    is-windows "^1.0.2"
+    make-dir "^3.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    which "^2.0.1"
 
 spdx-correct@^3.0.0:
   version "3.0.2"
@@ -19746,7 +19895,7 @@ type-fest@^0.6.0:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-fest@^0.8.1:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -21062,7 +21211,7 @@ yargs@13.3.2, yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@15.1.0, yargs@~15.1.0:
+yargs@15.1.0, yargs@^15.0.2, yargs@~15.1.0:
   version "15.1.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
   integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==


### PR DESCRIPTION
Track test coverage of e2e tests and record it under a separate `e2e` [flag](https://docs.codecov.io/docs/flags). Especially with enforcing coverage thresholds, it's important that we track all actual test coverage (else codecov may reject a PR even though it's covered by integration tests). This currently only includes e2e, but this PR is also required for web integration tests because they will run in Puppeteer too, as well as Percy storybook tests #9565.

The different "kinds" of coverage can be toggled in the codecov UI. Example: https://codecov.io/gh/sourcegraph/sourcegraph/src/istanbul-e2e-coverage/web/src/nav/UserNavItem.tsx

New stats on this branch:

| Category   | Coverage |
|------------|----------|
| Total | ![total](https://codecov.io/gh/sourcegraph/sourcegraph/branch/istanbul-e2e-coverage/graph/badge.svg) |
| E2E tests  | ![e2e coverage](https://codecov.io/gh/sourcegraph/sourcegraph/branch/istanbul-e2e-coverage/graph/badge.svg?flag=e2e) |
| Unit tests | ![unit coverage](https://codecov.io/gh/sourcegraph/sourcegraph/branch/istanbul-e2e-coverage/graph/badge.svg?flag=unit) |

This works by creating a special _instrumented_ image for e2e tests using `babel-plugin-istanbul`. I moved building the _actual_ release image back into the main pipeline. Since we're going to disable e2e tests this is needed anyway