### PR TITLE
clean up extension schema and docs

### DIFF
--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -84,19 +84,19 @@
             "description": "An action contribution describes a command that can be invoked, along with a title, description, icon, etc.",
             "properties": {
               "actionItem": {
-                "description": "A specification of how to display this action as a button on a toolbar. The client is responsible for\ndisplaying contributions and defining which parts of its interface are considered to be toolbars. Generally,\nitems on a toolbar are always visible and, compared to items in a dropdown menu or list, are expected to be\nsmaller and to convey information (in addition to performing an action).\n\nFor example, a \"Toggle code coverage\" action may prefer to display a summarized status (such as \"Coverage:\n77%\") on a toolbar instead of the full title.\n\nClients: If the label is empty and only an iconURL is set, and the client decides not to display the icon\n(e.g., because the client is not graphical), then the client may hide the item from the toolbar.",
+                "description": "A specification of how to display this action as a button on a toolbar.",
                 "additionalProperties": false,
                 "properties": {
                   "description": {
-                    "description": "A description associated with this action item.\n\nClients: The description should be shown in a tooltip when the user focuses or hovers this toolbar item.",
+                    "description": "A description associated with this action item.",
                     "type": "string"
                   },
                   "iconDescription": {
-                    "description": "A description of the information represented by the icon.\n\nClients: The client should not display this text directly. Instead, the client should use the\naccessibility facilities of the client's platform (such as the <img alt> attribute) to make it available\nto users needing the textual description.",
+                    "description": "A description of the information represented by the icon.",
                     "type": "string"
                   },
                   "iconURL": {
-                    "description": "The icon URL for this action (data: URIs are OK).\n\nClients: The client should this icon before the label (if any), proportionally scaling the dimensions as\nnecessary to avoid unduly enlarging the toolbar item beyond the dimensions necessary to show the label.\nIn space-constrained situations, the client should show only the icon and omit the label. The client\nmust not display a border around the icon. The client may choose not to display this icon.",
+                    "description": "The icon URL for this action (data: URIs are OK).",
                     "type": "string"
                   },
                   "label": {
@@ -111,11 +111,11 @@
                 "type": "object"
               },
               "category": {
-                "description": "The category that describes the group of related actions of which this action is a member.\n\nClients: When displaying this action's title alongside titles of actions from other groups, the client\nshould display each action as \"${category}: ${title}\" if the prefix is set.",
+                "description": "The category that describes the group of related actions of which this action is a member.",
                 "type": "string"
               },
               "command": {
-                "description": "The command that this action invokes. It can refer to a command registered by the same extension or any\nother extension, or to a builtin command.\n\nExtensions: The command must be registered (unless it is a builtin command). Extensions can register\ncommands in the `initialize` response or via `client/registerCapability`.\n\n## Builtin client commands\n\nClients: All clients must handle the following commands as specified.\n\n### `open` {@link ActionContributionClientCommandOpen}\n\nThe builtin command `open` causes the client to open a URL (specified as a string in the first element of\ncommandArguments) using the default URL handler, instead of invoking the command on the extension.\n\nClients: The client should treat the first element of commandArguments as a URL (string) to open with the\ndefault URL handler (instead of sending a request to the extension to execute this command). If the client\nis running in a web browser, the client should render the action as an HTML <a> element so that it behaves\nlike a link.\n\n### `updateConfiguration` {@link ActionContributionClientCommandUpdateConfiguration}\n\nThe builtin command `updateConfiguration` causes the client to apply an update to the configuration settings.",
+                "description": "The command that this action invokes. It can refer to a command registered by the same extension or any other extension, or to a builtin command (https://docs.sourcegraph.com/extensions/authoring/builtin_commands).",
                 "type": "string"
               },
               "commandArguments": {
@@ -124,15 +124,15 @@
                 "type": "array"
               },
               "description": {
-                "description": "A longer description of the action taken by this action.\n\nExtensions: The description should not be unnecessarily repetitive with the title.\n\nClients: If the description is shown, the title must be shown nearby.",
+                "description": "A longer description of the action taken by this action. The description should not be unnecessarily repetitive with the title.",
                 "type": "string"
               },
               "iconURL": {
-                "description": "A URL to an icon for this action (data: URIs are OK).\n\nClients: The client should show this icon before the title, proportionally scaling the dimensions as\nnecessary to avoid unduly enlarging the item beyond the dimensions necessary to render the text. The client\nshould assume the icon is square (or roughly square). The client must not display a border around the icon.\nThe client may choose not to display this icon.",
+                "description": "A URL to an icon for this action (data: URIs are OK).",
                 "type": "string"
               },
               "id": {
-                "description": "The identifier for this action, which must be unique among all contributed actions.\n\nExtensions: By convention, this is a dotted string of the form `myExtensionName.myActionName`. It is common\nto use the same values for `id` and `command` (for the common case where the command has only one action\nthat mentions it).",
+                "description": "The identifier for this action, which must be unique among all contributed actions. By convention, this is a dotted string of the form `myExtensionName.myActionName`. It is common to use the same values for `id` and `command` (for the common case where the command has only one action that mentions it).",
                 "type": "string"
               },
               "title": {
@@ -233,15 +233,15 @@
               "type": "string"
             },
             "alt": {
-              "description": "An alternative action to invoke when the item is selected while pressing the Option/Alt/Meta/Ctrl/Cmd keys\nor using the middle mouse button. The value refers to a {@link ActionContribution#id} value.",
+              "description": "An alternative action to invoke when the item is selected while pressing the Option/Alt/Meta/Ctrl/Cmd keys or using the middle mouse button. The value refers to a {@link ActionContribution#id} value.",
               "type": "string"
             },
             "group": {
-              "description": "The group in which this item is displayed. This defines the sort order of menu items. The group value is an\nopaque string (it is just compared relative to other items' group values); there is no specification set of\nexpected or supported values.\n\nClients: On a toolbar, the client should sort toolbar items by (group, action), with toolbar items lacking a\ngroup sorting last. The client must not display the group value.",
+              "description": "The group in which this item is displayed. This defines the sort order of menu items. The group value is an opaque string (it is just compared relative to other items' group values); there is no specification set of expected or supported values.",
               "type": "string"
             },
             "when": {
-              "description": "An expression that, if given, must evaluate to true (or a truthy value) for this contribution to be\ndisplayed. The expression may use values from the context in which the contribution would be displayed.",
+              "description": "An expression that, if given, must evaluate to true (or a truthy value) for this contribution to be displayed. The expression may use values from the context in which the contribution would be displayed.",
               "type": "string"
             }
           },

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -207,6 +207,7 @@
           "type": "array",
           "description": "Search filters contributed by the extension.",
           "items": {
+            "type": "object",
             "additionalProperties": false,
             "description": "A search filters interface with `name` and `value` to display on a filter chip in the search results filters bar.",
             "properties": {
@@ -218,8 +219,7 @@
                 "description": "The value of the search filter chip (i.e. the literal search query string).",
                 "type": "string"
               }
-            },
-            "type": "array"
+            }
           }
         }
       },


### PR DESCRIPTION
- clean up extension schema documentation
  - Removes unnecessary newlines from descriptions. These were introduced
    when the JSON Schema was auto-generated from TypeScript interfaces (whose
    tsdocs had newlines).
  - Removes excessive duplication with
    https://docs.sourcegraph.com/extensions/authoring/contributions.
  - Removes client directives (i.e., documentation about these fields that is
    intended for extension clients, such as the Sourcegraph web app and our
    code host integrations). That documentation belongs in the TypeScript
    implementation code, not in this JSON Schema that is intended for extension
    authors.
- fix extension searchFilters item type
  - The JSON Schema type for the searchFilters contribution array item should
    be an object (because it has `name` and `value` properties), but it was
    incorrectly typed as an array. This type of contribution is rare, which is
    probably why this bug was not noticed earlier. It would have caused a
    validation warning when editing the extension's package.json file (in some
    cases), but otherwise would have had no other negative consequences.