### PR TITLE
allow linking to downloadable data: URIs from notifications

### DIFF
--- a/shared/src/notifications/NotificationItem.tsx
+++ b/shared/src/notifications/NotificationItem.tsx
@@ -86,7 +86,7 @@ export class NotificationItem extends React.PureComponent<Props, State> {
                             className="sourcegraph-notification-item__title"
                             dangerouslySetInnerHTML={{
                                 __html: renderMarkdown(this.props.notification.message || '', {
-                                    allowDataUriDownloads: true,
+                                    allowDataUriLinksAndDownloads: true,
                                 }),
                             }}
                         />

--- a/shared/src/notifications/NotificationItem.tsx
+++ b/shared/src/notifications/NotificationItem.tsx
@@ -84,7 +84,11 @@ export class NotificationItem extends React.PureComponent<Props, State> {
                     <div className="sourcegraph-notification-item__body">
                         <div
                             className="sourcegraph-notification-item__title"
-                            dangerouslySetInnerHTML={{ __html: renderMarkdown(this.props.notification.message || '') }}
+                            dangerouslySetInnerHTML={{
+                                __html: renderMarkdown(this.props.notification.message || '', {
+                                    allowDataUriDownloads: true,
+                                }),
+                            }}
                         />
                         {this.state.progress && (
                             <div

--- a/shared/src/util/markdown.test.ts
+++ b/shared/src/util/markdown.test.ts
@@ -1,0 +1,15 @@
+import { renderMarkdown } from './markdown'
+
+describe('renderMarkdown', () => {
+    test('plainText option', () => expect(renderMarkdown('A **b**', { plainText: true })).toBe('A b\n'))
+
+    describe('allowDataUriDownloads option', () => {
+        const MARKDOWN_WITH_DOWNLOAD = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
+        test('default disabled', () =>
+            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD)).toBe('<p><a>D</a><br /><a>D2</a></p>\n'))
+        test('enabled', () =>
+            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD, { allowDataUriDownloads: true })).toBe(
+                '<p><a href="data:text/plain,foobar" download>D</a><br /><a href="data:text/plain,foobar">D2</a></p>\n'
+            ))
+    })
+})

--- a/shared/src/util/markdown.test.ts
+++ b/shared/src/util/markdown.test.ts
@@ -3,12 +3,12 @@ import { renderMarkdown } from './markdown'
 describe('renderMarkdown', () => {
     test('plainText option', () => expect(renderMarkdown('A **b**', { plainText: true })).toBe('A b\n'))
 
-    describe('allowDataUriDownloads option', () => {
+    describe('allowDataUriLinksAndDownloads option', () => {
         const MARKDOWN_WITH_DOWNLOAD = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
         test('default disabled', () =>
             expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD)).toBe('<p><a>D</a><br /><a>D2</a></p>\n'))
         test('enabled', () =>
-            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD, { allowDataUriDownloads: true })).toBe(
+            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD, { allowDataUriLinksAndDownloads: true })).toBe(
                 '<p><a href="data:text/plain,foobar" download>D</a><br /><a href="data:text/plain,foobar">D2</a></p>\n'
             ))
     })

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -56,8 +56,8 @@ export const renderMarkdown = (
               /** Following options apply to non-plaintext output only. */
               plainText?: false
 
-              /** Allow links that download files from data: URIs. */
-              allowDataUriDownloads?: boolean
+              /** Allow links to data: URIs and that download files. */
+              allowDataUriLinksAndDownloads?: boolean
           } = {}
 ): string => {
     const rendered = marked(markdown, {
@@ -89,7 +89,7 @@ export const renderMarkdown = (
                 h6: ['id'],
             },
         }
-        if (options.allowDataUriDownloads) {
+        if (options.allowDataUriLinksAndDownloads) {
             opt.allowedAttributes.a = [...sanitize.defaults.allowedAttributes.a, 'download']
             opt.allowedSchemesByTag = {
                 ...opt.allowedSchemesByTag,

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -47,10 +47,18 @@ export const highlightCodeSafe = (code: string, language?: string): string => {
  */
 export const renderMarkdown = (
     markdown: string,
-    options: {
-        /** Strip off any HTML and return a plain text string, useful for previews */
-        plainText?: boolean
-    } = {}
+    options:
+        | {
+              /** Strip off any HTML and return a plain text string, useful for previews */
+              plainText: true
+          }
+        | {
+              /** Following options apply to non-plaintext output only. */
+              plainText?: false
+
+              /** Allow links that download files from data: URIs. */
+              allowDataUriDownloads?: boolean
+          } = {}
 ): string => {
     const rendered = marked(markdown, {
         gfm: true,
@@ -58,28 +66,37 @@ export const renderMarkdown = (
         sanitize: false,
         highlight: (code, language) => highlightCodeSafe(code, language),
     })
-    return sanitize(
-        rendered,
-        options.plainText
-            ? { allowedTags: [], allowedAttributes: {} }
-            : {
-                  // Defaults: https://sourcegraph.com/github.com/punkave/sanitize-html@90aac2665011be6fa21a8864d21c604ee984294f/-/blob/src/index.js#L571-589
 
-                  // Allow highligh.js styles, e.g.
-                  // <span class="hljs-keyword">
-                  // <code class="language-javascript">
-                  allowedTags: [...without(sanitize.defaults.allowedTags, 'iframe'), 'h1', 'h2', 'span', 'img'],
-                  allowedAttributes: {
-                      ...sanitize.defaults.allowedAttributes,
-                      span: ['class'],
-                      code: ['class'],
-                      h1: ['id'],
-                      h2: ['id'],
-                      h3: ['id'],
-                      h4: ['id'],
-                      h5: ['id'],
-                      h6: ['id'],
-                  },
-              }
-    )
+    let opt: sanitize.IDefaults
+    if (options.plainText) {
+        opt = { allowedAttributes: {}, allowedSchemes: [], allowedSchemesByTag: {}, allowedTags: [], selfClosing: [] }
+    } else {
+        opt = {
+            ...sanitize.defaults,
+
+            // Allow highligh.js styles, e.g.
+            // <span class="hljs-keyword">
+            // <code class="language-javascript">
+            allowedTags: [...without(sanitize.defaults.allowedTags, 'iframe'), 'h1', 'h2', 'span', 'img'],
+            allowedAttributes: {
+                span: ['class'],
+                code: ['class'],
+                h1: ['id'],
+                h2: ['id'],
+                h3: ['id'],
+                h4: ['id'],
+                h5: ['id'],
+                h6: ['id'],
+            },
+        }
+        if (options.allowDataUriDownloads) {
+            opt.allowedAttributes.a = [...sanitize.defaults.allowedAttributes.a, 'download']
+            opt.allowedSchemesByTag = {
+                ...opt.allowedSchemesByTag,
+                a: [...(opt.allowedSchemesByTag.a || opt.allowedSchemes), 'data'],
+            }
+        }
+    }
+
+    return sanitize(rendered, opt)
 }

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -79,6 +79,7 @@ export const renderMarkdown = (
             // <code class="language-javascript">
             allowedTags: [...without(sanitize.defaults.allowedTags, 'iframe'), 'h1', 'h2', 'span', 'img'],
             allowedAttributes: {
+                ...sanitize.defaults.allowedAttributes,
                 span: ['class'],
                 code: ['class'],
                 h1: ['id'],

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -49,7 +49,6 @@ export const renderMarkdown = (
     markdown: string,
     options: {
         /** Strip off any HTML and return a plain text string, useful for previews */
-
         plainText?: boolean
     } = {}
 ): string => {


### PR DESCRIPTION
This makes it possible for extensions to show notifications with messages that contain a link that, when clicked, will download a file in the user's browser. To do this, the extension would call
```ts
sourcegraph.app.activeWindow.showMessage(
  '<a href="data:text/plain,foo" download="bar.txt">Download</a>',
  ...
)
```
This will be used by an extension that allows users to export the search results as CSV (https://github.com/sourcegraph/sourcegraph-search-export).

![image](https://user-images.githubusercontent.com/1976/78422440-20352a00-7614-11ea-8a3b-b34c43fda0c8.png)


SECURITY: Previously, `<a href>` `data:` URIs and the `<a download>` attribute were removed by the Markdown sanitizer. This commit allows those (if an option `allowDataUriDownloads` is set), and the NotificationItem sets `allowDataUriDownloads` to true. Any relaxation of HTML sanitization should be examined carefully for risk. In this case, there is no additional risk because this relaxation only allows a link to be displayed that triggers a download. An extension could already effectively call `window.open` or print a normal `https:` link to another cross-domain page that could immediately trigger the same download upon page load.