### PR TITLE
requireRestart: useJaeger, lightstepAccessToken, and lightstepProject

### DIFF
--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -57,6 +57,9 @@ var requireRestart = []string{
 	"auth.providers",
 	"externalURL",
 	"update.channel",
+	"useJaeger",
+	"lightstepAccessToken",
+	"lightstepProject",
 }
 
 // NeedRestartToApply determines if a restart is needed to apply the changes


### PR DESCRIPTION
Necessary because these fields may still be set, and if they are, changing them requires a pod restart.