### PR TITLE
codecov check diffs for at least 5% coverage

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -2,7 +2,9 @@ coverage:
   range: 50...75
   status:
     project: off
-    patch: off
+    patch:
+      default:
+        threshold: 5%
 comment:
   require_changes: yes
   layout: 'diff, files'


### PR DESCRIPTION
If a change doesn't have any unit test coverage, this will result in a failing status from codecov. This failing status will be information and not block merging.