### PR TITLE
disable e2e tests on most branches

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -194,6 +194,9 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	// See RFC 137: https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit
 	hardFail := c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
+	// Skip e2e tests for non-master branches (except those where hardFail is true)
+	skipE2E := !hardFail && c.branch != "master"
+
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",
 		"BUILDKITE_PULL_REQUEST_BASE_BRANCH",
@@ -205,6 +208,9 @@ func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["CI_DEBUG_PROFILE"] = commonEnv["CI_DEBUG_PROFILE"]
 
 	return func(pipeline *bk.Pipeline) {
+		if skipE2E {
+			return
+		}
 		pipeline.AddTrigger(":chromium:",
 			bk.Trigger("sourcegraph-e2e"),
 			bk.Async(!hardFail),

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -189,8 +189,10 @@ func wait(pipeline *bk.Pipeline) {
 }
 
 func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
-	// hardFail if we publish docker images
-	hardFail := c.branch == "master" || c.isMasterDryRun || c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+	// hardFail for renovate and release branches
+	// Do not block green master builds on e2e tests until we can make them reliable.
+	// See RFC 137: https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit
+	hardFail := c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -107,7 +107,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		//
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
-			triggerE2E(c, env),
+			// e2e tests are disabled in CI until we can make them reliable. See RFC 137:
+			// https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit
+			// triggerE2E(c, env),
+
 			addLint,    // ~5m
 			addWebApp,  // ~3m
 			addGoTests, // ~2m

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -107,10 +107,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		//
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
-			// e2e tests are disabled in CI until we can make them reliable. See RFC 137:
-			// https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit
-			// triggerE2E(c, env),
-
+			triggerE2E(c, env),
 			addLint,    // ~5m
 			addWebApp,  // ~3m
 			addGoTests, // ~2m


### PR DESCRIPTION
e2e tests and infrastructure are currently flaky enough it is not helpful to have them cause red builds.

This PR makes two changes:
1. e2e tests no longer block green builds on master (they still run async).
2. e2e tests no longer run on non-master branches (except for release branches and renovate branches).

 See [RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit) for more information on why we are doing this.