### PR TITLE
dev: remove dlv from go-install

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -45,7 +45,6 @@ export GOBIN="${PWD}/.bin"
 export GO111MODULE=on
 
 INSTALL_GO_TOOLS="github.com/mattn/goreman@v0.3.4 \
-github.com/go-delve/delve/cmd/dlv@v1.4.0
 "
 
 # Need to go to a temp directory for tools or we update our go.mod. We use


### PR DESCRIPTION
From what I can tell we don't actually use ".bin/dlv" anywhere. Our development
instructions tell you to install it onto your $PATH (which I assume is the same
place vscode would look). I've never used delve, so I could be mistaken.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
