### PR TITLE
ci: run slowest steps first

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -108,16 +108,16 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addLint,    // ~5m
-			addWebApp,  // ~3m
-			addGoTests, // ~2m
-			addGoBuild, // ~2m
-			addCheck,   // ~2m
-			addBrowserExt,
-			addPreciseCodeIntelSystem,
-			addSharedTests,
-			addPostgresBackcompat,
-			addDockerfileLint,
+			addLint,                   // ~3.5m
+			addWebApp,                 // ~3m
+			addSharedTests,            // ~3m
+			addBrowserExt,             // ~2m
+			addGoTests,                // ~1.5m
+			addPreciseCodeIntelSystem, // ~1.5m
+			addCheck,                  // ~1m
+			addGoBuild,                // ~0.5m
+			addPostgresBackcompat,     // ~0.25m
+			addDockerfileLint,         // ~0.2m
 			addDockerImages(c, false),
 			wait,
 			addCodeCov,


### PR DESCRIPTION
This has been updated with recent timings. Times have changed and new steps
have been added. The timings are unscientifically collected by looking at a
random build. Steps are assigned agents in the order they are specified. So as
a performance improvement we want to greedily run the slower steps first.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
