### PR TITLE
search: heuristic whitespace and paren handling for and/or queries

### DIFF
--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -144,7 +144,7 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "Paren reduction over operators",
 			Input: "(((a b c))) and d",
-			Want:  "(and (concat a b c) d)",
+			Want:  "(and (concat (((a b c)))) d)",
 		},
 		// Partition parameters and concatenated patterns.
 		{
@@ -153,7 +153,7 @@ func Test_Parse(t *testing.T) {
 		},
 		{
 			Input: "(a b c) and (d e f) and (g h i)",
-			Want:  "(and (concat a b c) (concat d e f) (concat g h i))",
+			Want:  "(and (concat (a b c)) (concat (d e f)) (concat (g h i)))",
 		},
 		{
 			Input: "(a) repo:foo (b)",
@@ -232,32 +232,32 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "nested paren reduction with whitespace",
 			Input: "(((a b c))) d",
-			Want:  "(concat a b c d)",
+			Want:  "(concat (((a b c))) d)",
 		},
 		{
 			Name:  "left paren reduction with whitespace",
 			Input: "(a b) c d",
-			Want:  "(concat a b c d)",
+			Want:  "(concat (a b) c d)",
 		},
 		{
 			Name:  "right paren reduction with whitespace",
 			Input: "a b (c d)",
-			Want:  "(concat a b c d)",
+			Want:  "(concat a b (c d))",
 		},
 		{
 			Name:  "grouped paren reduction with whitespace",
 			Input: "(a b) (c d)",
-			Want:  "(concat a b c d)",
+			Want:  "(concat (a b) (c d))",
 		},
 		{
 			Name:  "multiple grouped paren reduction with whitespace",
 			Input: "(a b) (c d) (e f)",
-			Want:  "(concat a b c d e f)",
+			Want:  "(concat (a b) (c d) (e f))",
 		},
 		{
 			Name:  "interpolated grouped paren reduction",
 			Input: "(a b) c d (e f)",
-			Want:  "(concat a b c d e f)",
+			Want:  "(concat (a b) c d (e f))",
 		},
 		{
 			Name:  "mixed interpolated grouped paren reduction",
@@ -278,7 +278,7 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "paren containing whitespace inside contiguous string",
 			Input: "foo(   )bar",
-			Want:  "(concat foo bar)",
+			Want:  "(concat foo( )bar)",
 		},
 		{
 			Name:  "nested empty paren",
@@ -288,7 +288,7 @@ func Test_Parse(t *testing.T) {
 		{
 			Name:  "interpolated nested empty paren",
 			Input: "(()x(  )(())())",
-			Want:  "x",
+			Want:  "(concat (()x( )(())()))",
 		},
 		{
 			Name:  "empty paren on or",
@@ -301,9 +301,14 @@ func Test_Parse(t *testing.T) {
 			Want:  "(or () (x))",
 		},
 		{
+			Name:  "empty left paren on or",
+			Input: "() or (x)",
+			Want:  "(or () (x))",
+		},
+		{
 			Name:  "complex interpolated nested empty paren",
 			Input: "(()x(  )(y or () or (f))())",
-			Want:  "(concat x (or y () f))",
+			Want:  "(concat () x () (or y () f) ())",
 		},
 	}
 	for _, tt := range cases {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -34,7 +34,7 @@ func Test_PartitionSearchPattern(t *testing.T) {
 		},
 		{
 			input: "file:foo (x y)",
-			want:  "file:foo (concat x y)",
+			want:  "file:foo (concat (x y))",
 		},
 		{
 			input: "(file:foo x) y",

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -18,6 +18,17 @@ func Visit(nodes []Node, f func(node Node)) {
 	}
 }
 
+// VisitOperator calls f on all operator nodes. f supplies the node's field,
+// value, and whether the value is negated.
+func VisitOperator(nodes []Node, f func(kind operatorKind, operands []Node)) {
+	visitor := func(node Node) {
+		if v, ok := node.(Operator); ok {
+			f(v.Kind, v.Operands)
+		}
+	}
+	Visit(nodes, visitor)
+}
+
 // VisitParameter calls f on all parameter nodes. f supplies the node's field,
 // value, and whether the value is negated.
 func VisitParameter(nodes []Node, f func(field, value string, negated bool)) {


### PR DESCRIPTION
Before this change, the parser had a heuristic way of interpreting potential search patterns like `foo(bar)`, where the parentheses would be interpreted as part of the search pattern (#9494).

But, this heuristic doesn't work if the search pattern contains spaces between paren groups. So a pattern like:

`(foo(bar, baz))`

would imply a concatenation `foo bar, baz` in the traditional way. This PR expands the heuristic to now detect these cases and interpret parentheses literally in the presence of whitespace. The gist is that we interpret it as a pattern as long as the pattern doesn't contain `and` or `or` operators, or parameters like `repo:foo`. 

Note again this is a convenience heuristic--patterns can be enclosed in quotes to disambiguate. But the convenience is important, because there's no real reason to force users to quote patterns when we can detect unambiguous cases (except that this is ❤️❤️❤️❤️ hard to implement). I've tried hard to keep the implementation clean and make the heuristic toggle-able

In next PRs I will:
- separate test cases for parsing with/without the heuristic
- Add/fix proper scanner code, I've been taking shortcuts
