### PR TITLE
Dockerize src-expose volume 1

### DIFF
--- a/dev/src-expose/Dockerfile
+++ b/dev/src-expose/Dockerfile
@@ -9,9 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-
 # hadolint ignore=DL3018
 RUN apk add --no-cache git
 

--- a/dev/src-expose/Dockerfile
+++ b/dev/src-expose/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcegraph/alpine:3.10
+FROM sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -12,10 +12,18 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache git
 
+# Ensures that a directory with the correct permissions exist in the image. Without this, in Docker Compose
+# deployments the Docker daemon would first create the volume directory and it would be owned by `root` and
+# then a non-root process would be unable to create the `/app/data` because it
+# would  be trying to do so in a directory owned by `root` as the user `sourcegraph`. And no, this is not
+# dumb, this is just Docker: https://github.com/docker/compose/issues/3270#issuecomment-363478501.
+USER root
+RUN mkdir -p /app/data && chown -R sourcegraph:sourcegraph /app/data
 USER sourcegraph
+
 WORKDIR /app/data/
+VOLUME ["/app/data"]
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/src-expose"]
 EXPOSE 3434
 
-COPY src-expose /usr/local/bin/
-COPY entry.sh /app/bin/
+COPY entry.sh src-expose /usr/local/bin/

--- a/dev/src-expose/Dockerfile
+++ b/dev/src-expose/Dockerfile
@@ -1,0 +1,24 @@
+FROM sourcegraph/alpine:3.10
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache git
+
+USER sourcegraph
+WORKDIR /app/data/
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/src-expose"]
+EXPOSE 3434
+
+COPY src-expose /usr/local/bin/
+COPY entry.sh /app/bin/

--- a/dev/src-expose/build.sh
+++ b/dev/src-expose/build.sh
@@ -20,7 +20,7 @@ export CGO_ENABLED=0
 
 # Entrypoint script and src-expose binary
 cp -a ./dev/src-expose/entry.sh "$OUTPUT"
-go build -trimpath -o $OUTPUT/$(basename src-expose) github.com/sourcegraph/sourcegraph/dev/src-expose
+go build -trimpath -o "$OUTPUT/src-expose" github.com/sourcegraph/sourcegraph/dev/src-expose
 
 docker build -f dev/src-expose/Dockerfile -t $IMAGE $OUTPUT \
     --progress=plain \

--- a/dev/src-expose/build.sh
+++ b/dev/src-expose/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script builds the src-expose docker image.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -eu
+
+OUTPUT=`mktemp -d -t sgdockerbuild_XXXXXXX`
+
+cleanup() {
+    rm -rf "$OUTPUT"
+}
+trap cleanup EXIT
+
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
+
+# Entrypoint script and src-expose binary
+cp -a ./dev/src-expose/entry.sh "$OUTPUT"
+go build -trimpath -o $OUTPUT/$(basename src-expose) github.com/sourcegraph/sourcegraph/dev/src-expose
+
+docker build -f dev/src-expose/Dockerfile -t $IMAGE $OUTPUT \
+    --progress=plain \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/dev/src-expose/docker-publish.sh
+++ b/dev/src-expose/docker-publish.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+# Manual publishing of Docker image until automated through CI
+
+set -e
+
+export COMMIT_SHA=$(git rev-parse --short HEAD)
+export VERSION=$COMMIT_SHA
+export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export IMAGE=sourcegraph/src-expose
+
+. ./build.sh
+
+docker image push sourcegraph/src-expose:latest
+docker image tag sourcegraph/src-expose:latest sourcegraph/src-expose:$VERSION
+docker image push sourcegraph/src-expose:$VERSION

--- a/dev/src-expose/entry.sh
+++ b/dev/src-expose/entry.sh
@@ -2,4 +2,4 @@
 
 # Feed every directory in /app/data to src-expose
 codedirs=$(cd /app/data && ls -d * | xargs)
-/usr/local/bin/src-expose $codedirs
+exec /usr/local/bin/src-expose $codedirs

--- a/dev/src-expose/entry.sh
+++ b/dev/src-expose/entry.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# Feed every directory in /app/data to src-expose
+codedirs=$(cd /app/data && ls -d * | xargs)
+/usr/local/bin/src-expose $codedirs


### PR DESCRIPTION
A potential customer requested a Dockerized version of `src-expose`.

The main thing to note about the Dockerfile, is that the container can be used in one of 2 ways:

1. Using the standard `ENTRYPOINT` in which it is used in the same was as if it were a local binary
2. Using the `entry.sh` script which will pass `src-expose` a list of directories mounted in the `WORKDIR` (`/app/data`).

The use-case for number 2 is for simplicity, where all a consumer has to do is mount a parent folder at `/app/data` and the `entry.sh` script will take care of the rest. 

I'll have a Kubernetes sample to go along with this shortly that will further illustrate the need for use case 2.