### PR TITLE
authz: fix Grafana panel queries and github fetch perms logic

### DIFF
--- a/docker-images/grafana/jsonnet/perms_sync.jsonnet
+++ b/docker-images/grafana/jsonnet/perms_sync.jsonnet
@@ -127,7 +127,7 @@ local usersSyncRequestsDurationPercentilesPanel = makeDurationPercentilesPanel(
 );
 local usersSyncRequestsErrorRatePanel = makeErrorRatePanel(
     title = 'User permissions sync',
-    metric ='src_repoupdater_perms_syncer_sync_errors_total',
+    metric ='src_repoupdater_perms_syncer_sync',
     filter = 'type="user"'
 );
 
@@ -141,7 +141,7 @@ local reposSyncRequestsDurationPercentilesPanel = makeDurationPercentilesPanel(
 );
 local reposSyncRequestsErrorRatePanel = makeErrorRatePanel(
     title = 'Repo permissions sync',
-    metric ='src_repoupdater_perms_syncer_sync_errors_total',
+    metric ='src_repoupdater_perms_syncer_sync',
     filter = 'type="repo"'
 );
 

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -436,6 +436,8 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) 
 
 	// NOTE: We do not store port or scheme in our URI, so stripping the hostname alone is enough.
 	nameWithOwner := strings.TrimPrefix(repo.URI, p.codeHost.BaseURL.Hostname())
+	nameWithOwner = strings.TrimPrefix(nameWithOwner, "/")
+
 	owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 	if err != nil {
 		return nil, errors.Wrap(err, "split nameWithOwner")


### PR DESCRIPTION
Two minor fixes:
1. Grafana panel queries for error rate.
2. Trim leading `/` when fetch repo perms from GitHub.