### PR TITLE
Fix yarn test in root

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ const config = require('./jest.config.base')
 
 /** @type {jest.InitialOptions} */
 module.exports = {
-  ...config,
   projects: [
     'browser/jest.config.js',
     'shared/jest.config.js',


### PR DESCRIPTION
Noticed by me and @attfarhan, was caused by latest Jest upgrade. `<rootDir>` is now resolved eagerly. But the base config properties don't need to be added to the root config, it can just reference the subprojects.