### PR TITLE
github: add tests for `FetchUserPerms` and `FetchRepoPerms`

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -395,7 +395,11 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 	_, tok, err := github.GetExternalAccountData(&account.AccountData)
 	if err != nil {
 		return nil, errors.Wrap(err, "get external account data")
+	} else if tok == nil {
+		return nil, errors.New("no token found in the external account data")
 	}
+
+	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
 	client := p.client.WithToken(tok.AccessToken)
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -129,7 +129,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(),
 			&extsvc.Repository{
-				URI: "https://github.com/user/repo",
+				URI: "github.com/user/repo",
 				ExternalRepoSpec: api.ExternalRepoSpec{
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
@@ -183,7 +183,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 
 	accountIDs, err := p.FetchRepoPerms(context.Background(),
 		&extsvc.Repository{
-			URI: "https://gitlab.com/user/repo",
+			URI: "gitlab.com/user/repo",
 			ExternalRepoSpec: api.ExternalRepoSpec{
 				ServiceType: "gitlab",
 				ServiceID:   "https://gitlab.com/",

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -476,10 +476,16 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 	return repos, nil
 }
 
+var MockListAffiliatedRepositories func(ctx context.Context, token string, page int) ([]*Repository, bool, int, error)
+
 // ListAffiliatedRepositories lists GitHub repositories affiliated with the client
 // token. page is the page of results to return. Pages are 1-indexed (so the
 // first call should be for page 1).
 func (c *Client) ListAffiliatedRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+	if MockListAffiliatedRepositories != nil {
+		return MockListAffiliatedRepositories(ctx, c.defaultToken, page)
+	}
+
 	path := fmt.Sprintf("user/repos?sort=created&page=%d&per_page=100", page)
 	repos, err = c.listRepositories(ctx, path)
 	if err == nil {

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -86,10 +86,16 @@ type Collaborator struct {
 	DatabaseID int64  `json:"id"`
 }
 
+var MockListRepositoryCollaborators func(ctx context.Context, owner, repo string, page int) ([]*Collaborator, bool, error)
+
 // ListRepositoryCollaborators lists all GitHub users that has access to the repository.
 // The page is the page of results to return, and is 1-indexed (so the first call should
 // be for page 1).
 func (c *Client) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
+	if MockListRepositoryCollaborators != nil {
+		return MockListRepositoryCollaborators(ctx, owner, repo, page)
+	}
+
 	path := fmt.Sprintf("/repos/%s/%s/collaborators?&page=%d&per_page=100", owner, repo, page)
 	err := c.requestGet(ctx, "", path, &users)
 	if err != nil {


### PR DESCRIPTION
Adds tests for `FetchUserPerms` and `FetchRepoPerms` of GitHub authz provider.

**NOTE**: Did not use VCR because I think we should only do VCR in the API client layer (the layer that directly interacts with external services, i.e. `internal/extsvc/{github,gitlab,bitbucketserver,bitbucketcloud}`). Similar to we mock DB methods in application layer and only do real DB testing in the DB layer.