### PR TITLE
github: Extract SearchClient

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -35,7 +35,7 @@ type GithubSource struct {
 	client          *github.Client
 	// searchClient is for using the GitHub search API, which has an independent
 	// rate limit much lower than non-search API requests.
-	searchClient *github.Client
+	searchClient *github.SearchClient
 
 	// originalHostname is the hostname of config.Url (differs from client APIURL, whose host is api.github.com
 	// for an originalHostname of github.com).
@@ -114,7 +114,7 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		baseURL:          baseURL,
 		githubDotCom:     githubDotCom,
 		client:           github.NewClient(apiURL, c.Token, cli),
-		searchClient:     github.NewClient(apiURL, c.Token, cli),
+		searchClient:     github.NewSearchClient(apiURL, c.Token, cli),
 		originalHostname: originalHostname,
 	}, nil
 }

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -118,8 +118,10 @@ func TestClient_WithToken(t *testing.T) {
 	}
 
 	old := &Client{
-		apiURL:       uri,
-		defaultToken: "old_token",
+		&client{
+			apiURL:       uri,
+			defaultToken: "old_token",
+		},
 	}
 
 	newToken := "new_token"
@@ -134,7 +136,7 @@ func TestClient_WithToken(t *testing.T) {
 }
 
 func TestClient_LoadPullRequests(t *testing.T) {
-	cli, save := newClient(t, "LoadPullRequests")
+	cli, save := newTestClientWithSave(t, "LoadPullRequests")
 	defer save()
 
 	for i, tc := range []struct {
@@ -192,7 +194,7 @@ func TestClient_LoadPullRequests(t *testing.T) {
 }
 
 func TestClient_CreatePullRequest(t *testing.T) {
-	cli, save := newClient(t, "CreatePullRequest")
+	cli, save := newTestClientWithSave(t, "CreatePullRequest")
 	defer save()
 
 	// Repository used: sourcegraph/automation-testing
@@ -267,7 +269,7 @@ func TestClient_CreatePullRequest(t *testing.T) {
 }
 
 func TestClient_ClosePullRequest(t *testing.T) {
-	cli, save := newClient(t, "ClosePullRequest")
+	cli, save := newTestClientWithSave(t, "ClosePullRequest")
 	defer save()
 
 	// Repository used: sourcegraph/automation-testing
@@ -322,7 +324,7 @@ func TestClient_ClosePullRequest(t *testing.T) {
 }
 
 func TestClient_GetAuthenticatedUserOrgs(t *testing.T) {
-	cli, save := newClient(t, "GetAuthenticatedUserOrgs")
+	cli, save := newTestClientWithSave(t, "GetAuthenticatedUserOrgs")
 	defer save()
 
 	ctx := context.Background()
@@ -338,7 +340,7 @@ func TestClient_GetAuthenticatedUserOrgs(t *testing.T) {
 	)
 }
 
-func newClient(t testing.TB, name string) (*Client, func()) {
+func newTestClientWithSave(t testing.TB, name string) (*Client, func()) {
 	t.Helper()
 
 	cassete := filepath.Join("testdata/vcr/", strings.Replace(name, " ", "-", -1))

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -546,24 +546,3 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		HasNextPage: page*100 < response.TotalCount,
 	}, nil
 }
-
-type restTopicsResponse struct {
-	Names []string `json:"names"`
-}
-
-// ListTopicsOnRepository lists topics on the given repository.
-func (c *Client) ListTopicsOnRepository(ctx context.Context, ownerAndName string) ([]string, error) {
-	owner, name, err := SplitRepositoryNameWithOwner(ownerAndName)
-	if err != nil {
-		return nil, err
-	}
-
-	var result restTopicsResponse
-	if err := c.requestGet(ctx, "", fmt.Sprintf("/repos/%s/%s/topics", owner, name), &result); err != nil {
-		if HTTPErrorCode(err) == http.StatusNotFound {
-			return nil, ErrNotFound
-		}
-		return nil, err
-	}
-	return result.Names, nil
-}

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -39,7 +39,7 @@ type Repository struct {
 
 // repositoryFieldsGraphQLFragment returns a GraphQL fragment that contains the fields needed to populate the
 // Repository struct.
-func (c *Client) repositoryFieldsGraphQLFragment() string {
+func (c *client) repositoryFieldsGraphQLFragment() string {
 	if c.githubDotCom {
 		return `
 fragment RepositoryFields on Repository {
@@ -118,7 +118,7 @@ func (c *Client) GetRepositoryByNodeIDNoCache(ctx context.Context, token, id str
 	return c.getRepositoryByNodeID(ctx, token, id, true)
 }
 
-func (c *Client) getRepositoryByNodeID(ctx context.Context, token, id string, nocache bool) (*Repository, error) {
+func (c *client) getRepositoryByNodeID(ctx context.Context, token, id string, nocache bool) (*Repository, error) {
 	if GetRepositoryByNodeIDMock != nil {
 		return GetRepositoryByNodeIDMock(ctx, token, id)
 	}
@@ -137,7 +137,7 @@ func (c *Client) getRepositoryByNodeID(ctx context.Context, token, id string, no
 }
 
 // cachedGetRepository caches the getRepositoryFromAPI call.
-func (c *Client) cachedGetRepository(ctx context.Context, token, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error), nocache bool) (*Repository, error) {
+func (c *client) cachedGetRepository(ctx context.Context, token, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error), nocache bool) (*Repository, error) {
 	// 🚨 SECURITY: must forward token here to ensure caching by token
 	if !nocache {
 		if cached := c.getRepositoryFromCache(ctx, token, key); cached != nil {
@@ -189,7 +189,7 @@ type cachedRepo struct {
 
 // getRepositoryFromCache attempts to get a response from the redis cache.
 // It returns nil error for cache-hit condition and non-nil error for cache-miss.
-func (c *Client) getRepositoryFromCache(ctx context.Context, token, key string) *cachedRepo {
+func (c *client) getRepositoryFromCache(ctx context.Context, token, key string) *cachedRepo {
 	// 🚨 SECURITY: must forward token here to ensure caching by token
 	b, ok := c.cache(token).Get(strings.ToLower(key))
 	if !ok {
@@ -216,7 +216,7 @@ func firstNonEmpty(strs ...string) string {
 // addRepositoryToCache will cache the value for repo. The caller can provide multiple cache keys
 // for the multiple ways that this repository can be retrieved (e.g., both "owner/name" and the
 // GraphQL node ID).
-func (c *Client) addRepositoryToCache(token string, keys []string, repo *cachedRepo) {
+func (c *client) addRepositoryToCache(token string, keys []string, repo *cachedRepo) {
 	b, err := json.Marshal(repo)
 	if err != nil {
 		return
@@ -228,7 +228,7 @@ func (c *Client) addRepositoryToCache(token string, keys []string, repo *cachedR
 
 // addRepositoriesToCache will cache repositories that exist
 // under relevant cache keys.
-func (c *Client) addRepositoriesToCache(token string, repos []*Repository) {
+func (c *client) addRepositoriesToCache(token string, repos []*Repository) {
 	for _, repo := range repos {
 		keys := []string{nameWithOwnerCacheKey(repo.NameWithOwner), nodeIDCacheKey(repo.ID)} // cache under multiple
 		// 🚨 SECURITY: must forward token here to ensure caching by token
@@ -316,7 +316,7 @@ func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) (
 
 // getRepositoryByNodeIDFromAPI attempts to fetch a repository by GraphQL node ID from the GitHub
 // API without use of the redis cache.
-func (c *Client) getRepositoryByNodeIDFromAPI(ctx context.Context, token, id string) (*Repository, error) {
+func (c *client) getRepositoryByNodeIDFromAPI(ctx context.Context, token, id string) (*Repository, error) {
 	var result struct {
 		Node *Repository `json:"node"`
 	}
@@ -448,7 +448,7 @@ func (c *Client) GetReposByNameWithOwner(ctx context.Context, namesWithOwners ..
 	return repos, nil
 }
 
-func (c *Client) buildGetReposBatchQuery(ctx context.Context, namesWithOwners []string) (string, error) {
+func (c *client) buildGetReposBatchQuery(ctx context.Context, namesWithOwners []string) (string, error) {
 	var b strings.Builder
 	b.WriteString(c.repositoryFieldsGraphQLFragment())
 	b.WriteString("query {\n")
@@ -520,7 +520,7 @@ type RepositoryListPage struct {
 	HasNextPage bool
 }
 
-func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (RepositoryListPage, error) {
+func (c *SearchClient) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (RepositoryListPage, error) {
 	urlValues := url.Values{
 		"q":        []string{searchString},
 		"page":     []string{strconv.Itoa(page)},

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -72,12 +72,28 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 func newTestClient(t *testing.T, cli httpcli.Doer) *Client {
 	rcache.SetupForTest(t)
 	return &Client{
-		apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		httpClient:      cli,
-		RateLimit:       &ratelimit.Monitor{},
-		repoCache:       map[string]*rcache.Cache{},
-		repoCachePrefix: "__test__gh_repo",
-		repoCacheTTL:    1000,
+		&client{
+			apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+			httpClient:      cli,
+			RateLimit:       &ratelimit.Monitor{},
+			repoCache:       map[string]*rcache.Cache{},
+			repoCachePrefix: "__test__gh_repo",
+			repoCacheTTL:    1000,
+		},
+	}
+}
+
+func newTestSearchClient(t *testing.T, cli httpcli.Doer) *SearchClient {
+	rcache.SetupForTest(t)
+	return &SearchClient{
+		&client{
+			apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+			httpClient:      cli,
+			RateLimit:       &ratelimit.Monitor{},
+			repoCache:       map[string]*rcache.Cache{},
+			repoCachePrefix: "__test__gh_repo",
+			repoCacheTTL:    1000,
+		},
 	}
 }
 
@@ -459,7 +475,7 @@ func TestClient_ListRepositoriesForSearch(t *testing.T) {
 }
 `,
 	}
-	c := newTestClient(t, &mock)
+	c := newTestSearchClient(t, &mock)
 
 	wantRepos := []*Repository{
 		{
@@ -512,7 +528,7 @@ func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {
 }
 `,
 	}
-	c := newTestClient(t, &mock)
+	c := newTestSearchClient(t, &mock)
 
 	// If we have incomplete results we want to fail. Our syncer requires all
 	// repositories to be returned, otherwise it will delete the missing


### PR DESCRIPTION
We now expose both Client and SearchClient. They are simple wrappers
aroud the old Client struct which has been renamed 'client'.

This allows us to restrict calls made on SearchClient and prepares us to have
separate rate limiters per client as GitHub uses different rate limits
for search API calls.

Part of: https://github.com/sourcegraph/sourcegraph/issues/8546