### PR TITLE
Fix test paths for precise-code-intel tests

### DIFF
--- a/cmd/precise-code-intel/src/bundle-manager/backend/database.test.ts
+++ b/cmd/precise-code-intel/src/bundle-manager/backend/database.test.ts
@@ -14,8 +14,11 @@ describe('Database', () => {
     const makeDatabase = async (filename: string): Promise<Database> => {
         // Create a filesystem read stream for the given test file. This will cover
         // the cases where `yarn test` is run from the root or from the lsif directory.
-        const root = (await fs.exists('lsif')) ? 'lsif' : ''
-        const sourceFile = nodepath.join(root, 'test-data', filename)
+        const sourceFile = nodepath.join(
+            (await fs.exists('cmd')) ? 'cmd/precise-code-intel' : '',
+            'test-data',
+            filename
+        )
         const databaseFile = nodepath.join(storageRoot, uuid.v4())
 
         await convertLsif({

--- a/cmd/precise-code-intel/src/shared/test-util.ts
+++ b/cmd/precise-code-intel/src/shared/test-util.ts
@@ -29,7 +29,7 @@ export async function createCleanPostgresDatabase(): Promise<{ connection: Conne
 
     // Determine the path of the migrate script. This will cover the case where `yarn test` is
     // run from within the root or from the precise-code-intel directory.
-    const migrationsPath = nodepath.join((await fs.exists('migrations')) ? '' : '../../migrations')
+    const migrationsPath = nodepath.join((await fs.exists('migrations')) ? '' : '../..', 'migrations')
 
     // Ensure environment gets passed to child commands
     const env = {


### PR DESCRIPTION
These weren't updated after the move, and some were broken for who knows how long.