### PR TITLE
gitlab: Add an internal rate limiter

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -198,7 +198,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 					ch <- batch{projs: []*gitlab.Project{proj}}
 				}
 
-				time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1))
+				time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 			}
 		}()
 	}
@@ -251,7 +251,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				url = *nextPageURL
 
 				// 0-duration sleep unless nearing rate limit exhaustion
-				time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1))
+				time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 			}
 		}(projectQuery)
 	}

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -198,7 +198,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 					ch <- batch{projs: []*gitlab.Project{proj}}
 				}
 
-				time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+				time.Sleep(s.client.RecommendedWaitForBackgroundOp(1))
 			}
 		}()
 	}
@@ -251,7 +251,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				url = *nextPageURL
 
 				// 0-duration sleep unless nearing rate limit exhaustion
-				time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+				time.Sleep(s.client.RecommendedWaitForBackgroundOp(1))
 			}
 		}(projectQuery)
 	}

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -82,7 +82,7 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 		exclude:             exclude,
 		baseURL:             baseURL,
 		nameTransformations: nts,
-		client:              gitlab.NewClientProvider(baseURL, cli).GetPATClient(c.Token, ""),
+		client:              gitlab.NewClientProviderWithConfig(baseURL, c, cli).GetPATClient(c.Token, ""),
 	}, nil
 }
 

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -765,7 +765,7 @@ func TestGetLimiter(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := &schema.BitbucketServerConnection{
-		RateLimit: &schema.RateLimit{
+		RateLimit: &schema.BitbucketRateLimit{
 			Enabled:         true,
 			RequestsPerHour: 3600,
 		},

--- a/internal/extsvc/gitlab/projects_test.go
+++ b/internal/extsvc/gitlab/projects_test.go
@@ -43,10 +43,10 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 func newTestClient(t *testing.T) *Client {
 	rcache.SetupForTest(t)
 	return &Client{
-		baseURL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		httpClient: &http.Client{},
-		RateLimit:  &ratelimit.Monitor{},
-		projCache:  rcache.NewWithTTL("__test__gl_proj", 1000),
+		baseURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		httpClient:       &http.Client{},
+		RateLimitMonitor: &ratelimit.Monitor{},
+		projCache:        rcache.NewWithTTL("__test__gl_proj", 1000),
 	}
 }
 

--- a/internal/extsvc/gitlab/projects_test.go
+++ b/internal/extsvc/gitlab/projects_test.go
@@ -47,7 +47,7 @@ func newTestClient(t *testing.T) *Client {
 	return &Client{
 		baseURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
 		httpClient:       &http.Client{},
-		RateLimitMonitor: &ratelimit.Monitor{},
+		rateLimitMonitor: &ratelimit.Monitor{},
 		RateLimiter:      rate.NewLimiter(rate.Inf, 100),
 		projCache:        rcache.NewWithTTL("__test__gl_proj", 1000),
 	}

--- a/internal/extsvc/gitlab/projects_test.go
+++ b/internal/extsvc/gitlab/projects_test.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/time/rate"
-
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"golang.org/x/time/rate"
 )
 
 type mockHTTPResponseBody struct {

--- a/internal/extsvc/gitlab/projects_test.go
+++ b/internal/extsvc/gitlab/projects_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
@@ -46,6 +48,7 @@ func newTestClient(t *testing.T) *Client {
 		baseURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
 		httpClient:       &http.Client{},
 		RateLimitMonitor: &ratelimit.Monitor{},
+		RateLimiter:      rate.NewLimiter(rate.Inf, 100),
 		projCache:        rcache.NewWithTTL("__test__gl_proj", 1000),
 	}
 }

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -25,6 +25,7 @@
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to BitbucketServer.",
       "type": "object",
+      "title": "BitbucketRateLimit",
       "required": ["enabled", "requestsPerHour"],
       "properties": {
         "enabled": {

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -30,6 +30,7 @@ const BitbucketServerSchemaJSON = `{
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to BitbucketServer.",
       "type": "object",
+      "title": "BitbucketRateLimit",
       "required": ["enabled", "requestsPerHour"],
       "properties": {
         "enabled": {

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -24,7 +24,29 @@
       "type": "string",
       "minLength": 1
     },
-    "gitURLType": {
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to GitLab.",
+      "type": "object",
+      "title": "GitLabRateLimit",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 600,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 600
+      }
+    },    "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",
       "enum": ["http", "ssh"],

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -38,13 +38,13 @@
         "requestsPerHour": {
           "description": "Requests per hour permitted. This is an average, calculated per second.",
           "type": "number",
-          "default": 600,
+          "default": 36000,
           "minimum": 0
         }
       },
       "default": {
         "enabled": true,
-        "requestsPerHour": 600
+        "requestsPerHour": 36000
       }
     },    "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -29,7 +29,29 @@ const GitLabSchemaJSON = `{
       "type": "string",
       "minLength": 1
     },
-    "gitURLType": {
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to GitLab.",
+      "type": "object",
+      "title": "GitLabRateLimit",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 600,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 600
+      }
+    },    "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",
       "enum": ["http", "ssh"],

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -557,6 +557,8 @@ type GitLabConnection struct {
 	ProjectQuery []string `json:"projectQuery"`
 	// Projects description: A list of projects to mirror from this GitLab instance. Supports including by name ({"name": "group/name"}) or by ID ({"id": 42}).
 	Projects []*GitLabProject `json:"projects,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to GitLab.
+	RateLimit *GitLabRateLimit `json:"rateLimit,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable "{host}" is replaced with the GitLab URL's host (such as gitlab.example.com), and "{pathWithNamespace}" is replaced with the GitLab project's "namespace/path" (such as "myteam/myproject").
 	//
 	// For example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{pathWithNamespace}" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.
@@ -579,6 +581,14 @@ type GitLabProject struct {
 	Id int `json:"id,omitempty"`
 	// Name description: The name of a GitLab project ("group/name") to mirror.
 	Name string `json:"name,omitempty"`
+}
+
+// GitLabRateLimit description: Rate limit applied when making background API requests to GitLab.
+type GitLabRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // GitoliteConnection description: Configuration for a connection to Gitolite.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -143,6 +143,14 @@ type BitbucketCloudConnection struct {
 	Username string `json:"username"`
 }
 
+// BitbucketRateLimit description: Rate limit applied when making background API requests to BitbucketServer.
+type BitbucketRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	RequestsPerHour float64 `json:"requestsPerHour"`
+}
+
 // BitbucketServerAuthorization description: If non-null, enforces Bitbucket Server repository permissions.
 type BitbucketServerAuthorization struct {
 	// HardTTL description: Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.
@@ -186,7 +194,7 @@ type BitbucketServerConnection struct {
 	// Plugin description: Configuration for Bitbucket Server Sourcegraph plugin
 	Plugin *BitbucketServerPlugin `json:"plugin,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
-	RateLimit *RateLimit `json:"rateLimit,omitempty"`
+	RateLimit *BitbucketRateLimit `json:"rateLimit,omitempty"`
 	// Repos description: An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.
 	Repos []string `json:"repos,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server repository.
@@ -755,14 +763,6 @@ type QuickLink struct {
 	Name string `json:"name"`
 	// Url description: The URL of this quick link (absolute or relative)
 	Url string `json:"url"`
-}
-
-// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
-type RateLimit struct {
-	// Enabled description: true if rate limiting is enabled.
-	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
-	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type Repos struct {
 	// Callsign description: The unique Phabricator identifier for the repository, like 'MUX'.


### PR DESCRIPTION
This adds our own configurable internal rate limiter that is checked before we make API requests to GitLab

Part of: https://github.com/sourcegraph/sourcegraph/issues/8546