### PR TITLE
Add IsFork and IsArchive to GraphQL API

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -152,6 +152,8 @@ var getBySQLColumns = []string{
 	"uri",
 	"description",
 	"language",
+	"fork",
+	"archived",
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
@@ -218,6 +220,8 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		&dbutil.NullString{S: &r.URI},
 		&r.Description,
 		&r.Language,
+		&r.Fork,
+		&r.Archived,
 	)
 }
 

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -206,5 +207,51 @@ func TestRepos_Upsert(t *testing.T) {
 	}
 	if !reflect.DeepEqual(rp.ExternalRepo, ext) {
 		t.Fatalf("rp.ExternalRepo: %s != %s", rp.ExternalRepo, ext)
+	}
+
+	if err := Repos.Delete(ctx, rp.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
+
+	for _, fork := range []bool{true, false} {
+		for _, archived := range []bool{true, false} {
+			fmt.Printf("%v %v\n", fork, archived)
+			if _, err := Repos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
+				if err == nil {
+					t.Fatal("myrepo already present")
+				} else {
+					t.Fatal(err)
+				}
+			}
+
+			if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Fork: fork, Archived: archived}); err != nil {
+				t.Fatal(err)
+			}
+
+			rp, err := Repos.GetByName(ctx, "myrepo")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if rp.Fork != fork {
+				t.Fatalf("rp.Fork: %v != %v", rp.Fork, fork)
+			}
+			if rp.Archived != archived {
+				t.Fatalf("rp.Archived: %v != %v", rp.Archived, archived)
+			}
+
+			if err := Repos.Delete(ctx, rp.ID); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -78,6 +78,22 @@ func (r *RepositoryResolver) ExternalRepo() *api.ExternalRepoSpec {
 	return &r.repo.ExternalRepo
 }
 
+func (r *RepositoryResolver) IsFork(ctx context.Context) (bool, error) {
+	err := r.hydrate(ctx)
+	if err != nil {
+		return false, err
+	}
+	return r.repo.RepoFields.Fork, nil
+}
+
+func (r *RepositoryResolver) IsArchived(ctx context.Context) (bool, error) {
+	err := r.hydrate(ctx)
+	if err != nil {
+		return false, err
+	}
+	return r.repo.RepoFields.Archived, nil
+}
+
 func (r *RepositoryResolver) URI(ctx context.Context) (string, error) {
 	err := r.hydrate(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1817,6 +1817,10 @@ type Repository implements Node & GenericSearchResultInterface {
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
     externalRepository: ExternalRepository
+    # Whether the repository is a fork.
+    isFork: Boolean!
+    # Whether the repository has been archived.
+    isArchived: Boolean!
     # Lists all external services which yield this repository.
     externalServices(
         # Returns the first n external services from the list.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1824,6 +1824,10 @@ type Repository implements Node & GenericSearchResultInterface {
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
     externalRepository: ExternalRepository
+    # Whether the repository is a fork.
+    isFork: Boolean!
+    # Whether the repository has been archived.
+    isArchived: Boolean!
     # Lists all external services which yield this repository.
     externalServices(
         # Returns the first n external services from the list.

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -24,6 +24,9 @@ type RepoFields struct {
 
 	// Fork is whether this repository is a fork of another repository.
 	Fork bool
+
+	// Archived is whether this repository has been archived.
+	Archived bool
 }
 
 // Repo represents a source code repository.


### PR DESCRIPTION
We need a way to determine if a repo is forked or archived within extensions to handle the case described by https://github.com/sourcegraph/sourcegraph/issues/9634.