### PR TITLE
Fix default value of showBadgeAttachments flag

### DIFF
--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -107,14 +107,16 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
 
         this.subscription.add(
             this.props.platformContext.settings.subscribe(s => {
-                this.setState({
-                    showBadges:
-                        s.final &&
-                        !isErrorLike(s.final) &&
-                        s.final.experimentalFeatures &&
-                        // Enabled if true or null
-                        s.final.experimentalFeatures.showBadgeAttachments !== false,
-                })
+                if (s.final && !isErrorLike(s.final)) {
+                    // Default to true if experimentalFeatures or showBadgeAttachments are not set
+                    this.setState({
+                        showBadges:
+                            !s.final.experimentalFeatures ||
+                            s.final.experimentalFeatures.showBadgeAttachments !== false,
+                    })
+                } else {
+                    this.setState({ showBadges: false })
+                }
             })
         )
     }


### PR DESCRIPTION
This was always document as _default true_, but if experimenalFeatures was not set at all it defaults to false.