### PR TITLE
search: add test values for grammar spec and heuristic parser

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -49,13 +50,16 @@ type Operator struct {
 }
 
 func (node Parameter) String() string {
-	if node.Field == "" {
-		return node.Value
+	var v string
+	switch {
+	case node.Field == "":
+		v = node.Value
+	case node.Negated:
+		v = fmt.Sprintf("-%s:%s", node.Field, node.Value)
+	default:
+		v = fmt.Sprintf("%s:%s", node.Field, node.Value)
 	}
-	if node.Negated {
-		return fmt.Sprintf("-%s:%s", node.Field, node.Value)
-	}
-	return fmt.Sprintf("%s:%s", node.Field, node.Value)
+	return strconv.Quote(v)
 }
 
 func (node Operator) String() string {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -91,7 +91,7 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 
 func Test_Parse(t *testing.T) {
 	type relation string         // a relation for comparing test outputs of queries parsed according to grammar and heuristics.
-	const Same relation = "Same" // a constant that ays heuristic output is interpreted the same as the grammar spec.
+	const Same relation = "Same" // a constant that says heuristic output is interpreted the same as the grammar spec.
 	type Spec = relation         // constructor for expected output of the grammar spec without heuristics.
 	type Diff = relation         // constructor for expected heuristic output when different to the grammar spec.
 

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -73,260 +74,340 @@ func Test_ScanParameter(t *testing.T) {
 	}
 }
 
+func parseAndOrGrammar(in string) ([]Node, error) {
+	if in == "" {
+		return nil, nil
+	}
+	parser := &parser{buf: []byte(in), heuristic: false}
+	nodes, err := parser.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if parser.balanced != 0 {
+		return nil, errors.New("unbalanced expression")
+	}
+	return newOperator(nodes, And), nil
+}
+
 func Test_Parse(t *testing.T) {
+	type relation string         // a relation for comparing test outputs of queries parsed according to grammar and heuristics.
+	const Same relation = "Same" // a constant that ays heuristic output is interpreted the same as the grammar spec.
+	type Spec = relation         // constructor for expected output of the grammar spec without heuristics.
+	type Diff = relation         // constructor for expected heuristic output when different to the grammar spec.
+
 	cases := []struct {
-		Name  string
-		Input string
-		Want  string
+		Name          string
+		Input         string
+		WantGrammar   relation
+		WantHeuristic relation
 	}{
 		{
-			Name:  "Empty string",
-			Input: "",
-			Want:  "",
+			Name:          "Empty string",
+			Input:         "",
+			WantGrammar:   "",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Single",
-			Input: "a",
-			Want:  "a",
+			Name:          "Single",
+			Input:         "a",
+			WantGrammar:   `"a"`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Whitespace basic",
-			Input: "a b",
-			Want:  "(concat a b)",
+			Name:          "Whitespace basic",
+			Input:         "a b",
+			WantGrammar:   `(concat "a" "b")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Basic",
-			Input: "a and b and c",
-			Want:  "(and a b c)",
+			Name:          "Basic",
+			Input:         "a and b and c",
+			WantGrammar:   `(and "a" "b" "c")`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "(f(x)oo((a|b))bar)",
-			Want:  "(f(x)oo((a|b))bar)",
+			Input:         "(f(x)oo((a|b))bar)",
+			WantGrammar:   Spec(`(concat "f" "x" "oo" "a|b" "bar")`),
+			WantHeuristic: Diff(`"(f(x)oo((a|b))bar)"`),
 		},
 		{
-			Input: "aorb",
-			Want:  "aorb",
+			Input:         "aorb",
+			WantGrammar:   `"aorb"`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "aANDb",
-			Want:  "aANDb",
+			Input:         "aANDb",
+			WantGrammar:   `"aANDb"`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Reduced complex query mixed caps",
-			Input: "a and b AND c or d and (e OR f) g h i or j",
-			Want:  "(or (and a b c) (and d (concat (or e f) g h i)) j)",
+			Name:          "Reduced complex query mixed caps",
+			Input:         "a and b AND c or d and (e OR f) g h i or j",
+			WantGrammar:   `(or (and "a" "b" "c") (and "d" (concat (or "e" "f") "g" "h" "i")) "j")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Basic reduced complex query",
-			Input: "a and b or c and d or e",
-			Want:  "(or (and a b) (and c d) e)",
+			Name:          "Basic reduced complex query",
+			Input:         "a and b or c and d or e",
+			WantGrammar:   `(or (and "a" "b") (and "c" "d") "e")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Reduced complex query, reduction over parens",
-			Input: "(a and b or c and d) or e",
-			Want:  "(or (and a b) (and c d) e)",
+			Name:          "Reduced complex query, reduction over parens",
+			Input:         "(a and b or c and d) or e",
+			WantGrammar:   `(or (and "a" "b") (and "c" "d") "e")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Reduced complex query, nested 'or' trickles up",
-			Input: "(a and b or c) or d",
-			Want:  "(or (and a b) c d)",
+			Name:          "Reduced complex query, nested 'or' trickles up",
+			Input:         "(a and b or c) or d",
+			WantGrammar:   `(or (and "a" "b") "c" "d")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Reduced complex query, nested nested 'or' trickles up",
-			Input: "(a and b or (c and d or f)) or e",
-			Want:  "(or (and a b) (and c d) f e)",
+			Name:          "Reduced complex query, nested nested 'or' trickles up",
+			Input:         "(a and b or (c and d or f)) or e",
+			WantGrammar:   `(or (and "a" "b") (and "c" "d") "f" "e")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "No reduction on precedence defined by parens",
-			Input: "(a and (b or c) and d) or e",
-			Want:  "(or (and a (or b c) d) e)",
+			Name:          "No reduction on precedence defined by parens",
+			Input:         "(a and (b or c) and d) or e",
+			WantGrammar:   `(or (and "a" (or "b" "c") "d") "e")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Paren reduction over operators",
-			Input: "(((a b c))) and d",
-			Want:  "(and (concat (((a b c)))) d)",
+			Name:          "Paren reduction over operators",
+			Input:         "(((a b c))) and d",
+			WantGrammar:   Spec(`(and (concat "a" "b" "c") "d")`),
+			WantHeuristic: Diff(`(and (concat "(((a" "b" "c)))") "d")`),
 		},
 		// Partition parameters and concatenated patterns.
 		{
-			Input: "a (b and c) d",
-			Want:  "(concat a (and b c) d)",
+			Input:         "a (b and c) d",
+			WantGrammar:   `(concat "a" (and "b" "c") "d")`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "(a b c) and (d e f) and (g h i)",
-			Want:  "(and (concat (a b c)) (concat (d e f)) (concat (g h i)))",
+			Input:         "(a b c) and (d e f) and (g h i)",
+			WantGrammar:   Spec(`(and (concat "a" "b" "c") (concat "d" "e" "f") (concat "g" "h" "i"))`),
+			WantHeuristic: Diff(`(and (concat "(a" "b" "c)") (concat "(d" "e" "f)") (concat "(g" "h" "i)"))`),
 		},
 		{
-			Input: "(a) repo:foo (b)",
-			Want:  "(and repo:foo (concat (a) (b)))",
+			Input:         "(a) repo:foo (b)",
+			WantGrammar:   Spec(`(and "repo:foo" (concat "a" "b"))`),
+			WantHeuristic: Diff(`(and "repo:foo" (concat "(a)" "(b)"))`),
 		},
 		{
-			Input: "a b (repo:foo c d)",
-			Want:  "(concat a b (and repo:foo (concat c d)))",
+			Input:         "a b (repo:foo c d)",
+			WantGrammar:   `(concat "a" "b" (and "repo:foo" (concat "c" "d")))`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "a repo:b repo:c (d repo:e repo:f)",
-			Want:  "(and repo:b repo:c (concat a (and repo:e repo:f d)))",
+			Input:         "a repo:b repo:c (d repo:e repo:f)",
+			WantGrammar:   `(and "repo:b" "repo:c" (concat "a" (and "repo:e" "repo:f" "d")))`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "a repo:b repo:c (repo:e repo:f (repo:g repo:h))",
-			Want:  "(and repo:b repo:c repo:e repo:f repo:g repo:h a)",
+			Input:         "a repo:b repo:c (repo:e repo:f (repo:g repo:h))",
+			WantGrammar:   `(and "repo:b" "repo:c" "repo:e" "repo:f" "repo:g" "repo:h" "a")`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "a repo:b repo:c (repo:e repo:f (repo:g repo:h)) b",
-			Want:  "(and repo:b repo:c repo:e repo:f repo:g repo:h (concat a b))",
+			Input:         "a repo:b repo:c (repo:e repo:f (repo:g repo:h)) b",
+			WantGrammar:   `(and "repo:b" "repo:c" "repo:e" "repo:f" "repo:g" "repo:h" (concat "a" "b"))`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "a repo:b repo:c (repo:e repo:f (repo:g repo:h b)) ",
-			Want:  "(and repo:b repo:c (concat a (and repo:e repo:f repo:g repo:h b)))",
+			Input:         "a repo:b repo:c (repo:e repo:f (repo:g repo:h b)) ",
+			WantGrammar:   `(and "repo:b" "repo:c" (concat "a" (and "repo:e" "repo:f" "repo:g" "repo:h" "b")))`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "(repo:foo a (repo:bar b (repo:qux c)))",
-			Want:  "(and repo:foo (concat a (and repo:bar (concat b (and repo:qux c)))))",
+			Input:         "(repo:foo a (repo:bar b (repo:qux c)))",
+			WantGrammar:   `(and "repo:foo" (concat "a" (and "repo:bar" (concat "b" (and "repo:qux" "c")))))`,
+			WantHeuristic: Same,
 		},
 		{
-			Input: "a repo:b repo:c (d repo:e repo:f e)",
-			Want:  "(and repo:b repo:c (concat a (and repo:e repo:f (concat d e))))",
+			Input:         "a repo:b repo:c (d repo:e repo:f e)",
+			WantGrammar:   `(and "repo:b" "repo:c" (concat "a" (and "repo:e" "repo:f" (concat "d" "e"))))`,
+			WantHeuristic: Same,
 		},
 		// Errors.
 		{
-			Name:  "Unbalanced",
-			Input: "(foo) (bar",
-			Want:  "unbalanced expression",
+			Name:          "Unbalanced",
+			Input:         "(foo) (bar",
+			WantGrammar:   "unbalanced expression",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Incomplete expression",
-			Input: "a or",
-			Want:  "expected operand at 4",
+			Name:          "Incomplete expression",
+			Input:         "a or",
+			WantGrammar:   "expected operand at 4",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Illegal expression on the right",
-			Input: "a or or b",
-			Want:  "expected operand at 5",
+			Name:          "Illegal expression on the right",
+			Input:         "a or or b",
+			WantGrammar:   "expected operand at 5",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Illegal expression on the right, mixed operators",
-			Input: "a and OR",
-			Want:  "expected operand at 6",
+			Name:          "Illegal expression on the right, mixed operators",
+			Input:         "a and OR",
+			WantGrammar:   "expected operand at 6",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Illegal expression on the left",
-			Input: "or",
-			Want:  "expected operand at 0",
+			Name:          "Illegal expression on the left",
+			Input:         "or",
+			WantGrammar:   "expected operand at 0",
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "Illegal expression on the left, multiple operators",
-			Input: "or or or",
-			Want:  "expected operand at 0",
+			Name:          "Illegal expression on the left, multiple operators",
+			Input:         "or or or",
+			WantGrammar:   "expected operand at 0",
+			WantHeuristic: Same,
 		},
 		// Reduction.
 		{
-			Name:  "paren reduction with ands",
-			Input: "(a and b) and (c and d)",
-			Want:  "(and a b c d)",
+			Name:          "paren reduction with ands",
+			Input:         "(a and b) and (c and d)",
+			WantGrammar:   `(and "a" "b" "c" "d")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "paren reduction with ors",
-			Input: "(a or b) or (c or d)",
-			Want:  "(or a b c d)",
+			Name:          "paren reduction with ors",
+			Input:         "(a or b) or (c or d)",
+			WantGrammar:   `(or "a" "b" "c" "d")`,
+			WantHeuristic: Same,
 		},
 		{
-			Name:  "nested paren reduction with whitespace",
-			Input: "(((a b c))) d",
-			Want:  "(concat (((a b c))) d)",
+			Name:          "nested paren reduction with whitespace",
+			Input:         "(((a b c))) d",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d")`),
+			WantHeuristic: Diff(`(concat "(((a" "b" "c)))" "d")`),
 		},
 		{
-			Name:  "left paren reduction with whitespace",
-			Input: "(a b) c d",
-			Want:  "(concat (a b) c d)",
+			Name:          "left paren reduction with whitespace",
+			Input:         "(a b) c d",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d")`),
+			WantHeuristic: Diff(`(concat "(a" "b)" "c" "d")`),
 		},
 		{
-			Name:  "right paren reduction with whitespace",
-			Input: "a b (c d)",
-			Want:  "(concat a b (c d))",
+			Name:          "right paren reduction with whitespace",
+			Input:         "a b (c d)",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d")`),
+			WantHeuristic: Diff(`(concat "a" "b" "(c" "d)")`),
 		},
 		{
-			Name:  "grouped paren reduction with whitespace",
-			Input: "(a b) (c d)",
-			Want:  "(concat (a b) (c d))",
+			Name:          "grouped paren reduction with whitespace",
+			Input:         "(a b) (c d)",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d")`),
+			WantHeuristic: Diff(`(concat "(a" "b)" "(c" "d)")`),
 		},
 		{
-			Name:  "multiple grouped paren reduction with whitespace",
-			Input: "(a b) (c d) (e f)",
-			Want:  "(concat (a b) (c d) (e f))",
+			Name:          "multiple grouped paren reduction with whitespace",
+			Input:         "(a b) (c d) (e f)",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d" "e" "f")`),
+			WantHeuristic: Diff(`(concat "(a" "b)" "(c" "d)" "(e" "f)")`),
 		},
 		{
-			Name:  "interpolated grouped paren reduction",
-			Input: "(a b) c d (e f)",
-			Want:  "(concat (a b) c d (e f))",
+			Name:          "interpolated grouped paren reduction",
+			Input:         "(a b) c d (e f)",
+			WantGrammar:   Spec(`(concat "a" "b" "c" "d" "e" "f")`),
+			WantHeuristic: Diff(`(concat "(a" "b)" "c" "d" "(e" "f)")`),
 		},
 		{
-			Name:  "mixed interpolated grouped paren reduction",
-			Input: "(a and b and (z or q)) and (c and d) and (e and f)",
-			Want:  "(and a b (or z q) c d e f)",
+			Name:          "mixed interpolated grouped paren reduction",
+			Input:         "(a and b and (z or q)) and (c and d) and (e and f)",
+			WantGrammar:   `(and "a" "b" (or "z" "q") "c" "d" "e" "f")`,
+			WantHeuristic: Same,
 		},
 		// Parentheses.
 		{
-			Name:  "empty paren",
-			Input: "()",
-			Want:  "()",
+			Name:          "empty paren",
+			Input:         "()",
+			WantGrammar:   Spec(`""`),
+			WantHeuristic: Diff(`"()"`),
 		},
 		{
-			Name:  "paren inside contiguous string",
-			Input: "foo()bar",
-			Want:  "foo()bar",
+			Name:          "paren inside contiguous string",
+			Input:         "foo()bar",
+			WantGrammar:   Spec(`(concat "foo" "bar")`),
+			WantHeuristic: Diff(`"foo()bar"`),
 		},
 		{
-			Name:  "paren containing whitespace inside contiguous string",
-			Input: "foo(   )bar",
-			Want:  "(concat foo( )bar)",
+			Name:          "paren containing whitespace inside contiguous string",
+			Input:         "foo(   )bar",
+			WantGrammar:   Diff(`(concat "foo" "bar")`),
+			WantHeuristic: Spec(`(concat "foo(" ")bar")`),
 		},
 		{
-			Name:  "nested empty paren",
-			Input: "(x())",
-			Want:  "(x())",
+			Name:          "nested empty paren",
+			Input:         "(x())",
+			WantGrammar:   Spec(`"x"`),
+			WantHeuristic: Diff(`"(x())"`),
 		},
 		{
-			Name:  "interpolated nested empty paren",
-			Input: "(()x(  )(())())",
-			Want:  "(concat (()x( )(())()))",
+			Name:          "interpolated nested empty paren",
+			Input:         "(()x(  )(())())",
+			WantGrammar:   Spec(`"x"`),
+			WantHeuristic: Diff(`(concat "(()x(" ")(())())")`),
 		},
 		{
-			Name:  "empty paren on or",
-			Input: "() or ()",
-			Want:  "(or () ())",
+			Name:          "empty paren on or",
+			Input:         "() or ()",
+			WantGrammar:   Spec(`""`),
+			WantHeuristic: Diff(`(or "()" "()")`),
 		},
 		{
-			Name:  "empty left paren on or",
-			Input: "() or (x)",
-			Want:  "(or () (x))",
+			Name:          "empty left paren on or",
+			Input:         "() or (x)",
+			WantGrammar:   Spec(`"x"`),
+			WantHeuristic: Diff(`(or "()" "(x)")`),
 		},
 		{
-			Name:  "empty left paren on or",
-			Input: "() or (x)",
-			Want:  "(or () (x))",
+			Name:          "empty left paren on or",
+			Input:         "() or (x)",
+			WantGrammar:   Spec(`"x"`),
+			WantHeuristic: Diff(`(or "()" "(x)")`),
 		},
 		{
-			Name:  "complex interpolated nested empty paren",
-			Input: "(()x(  )(y or () or (f))())",
-			Want:  "(concat () x () (or y () f) ())",
+			Name:          "complex interpolated nested empty paren",
+			Input:         "(()x(  )(y or () or (f))())",
+			WantGrammar:   Spec(`(concat "x" (or "y" "f"))`),
+			WantHeuristic: Diff(`(concat "()" "x" "()" (or "y" "()" "f") "()")`),
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			result, err := parseAndOr(tt.Input)
-			if err != nil {
-				if diff := cmp.Diff(tt.Want, err.Error()); diff != "" {
-					t.Fatal(diff)
+			check := func(result []Node, err error, want string) {
+				var resultStr []string
+				if err != nil {
+					if diff := cmp.Diff(want, err.Error()); diff != "" {
+						t.Fatal(diff)
+					}
+					return
 				}
-				return
+				for _, node := range result {
+					resultStr = append(resultStr, node.String())
+				}
+				got := strings.Join(resultStr, " ")
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Error(diff)
+				}
 			}
-			var resultStr []string
-			for _, node := range result {
-				resultStr = append(resultStr, node.String())
-			}
-			got := strings.Join(resultStr, " ")
-			if diff := cmp.Diff(tt.Want, got); diff != "" {
-				t.Error(diff)
+			var result []Node
+			var err error
+			result, err = parseAndOrGrammar(tt.Input) // disable heuristic
+			check(result, err, string(tt.WantGrammar))
+			result, err = parseAndOr(tt.Input)
+			if tt.WantHeuristic == Same {
+				check(result, err, string(tt.WantGrammar))
+			} else {
+				check(result, err, string(tt.WantHeuristic))
 			}
 		})
 	}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -401,7 +401,7 @@ func Test_Parse(t *testing.T) {
 			}
 			var result []Node
 			var err error
-			result, err = parseAndOrGrammar(tt.Input) // disable heuristic
+			result, err = parseAndOrGrammar(tt.Input) // Parse without heuristic.
 			check(result, err, string(tt.WantGrammar))
 			result, err = parseAndOr(tt.Input)
 			if tt.WantHeuristic == Same {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -14,27 +14,27 @@ func Test_PartitionSearchPattern(t *testing.T) {
 	}{
 		{
 			input: "x",
-			want:  "x",
+			want:  `"x"`,
 		},
 		{
 			input: "x y",
-			want:  "(concat x y)",
+			want:  `(concat "x" "y")`,
 		},
 		{
 			input: "x or y",
-			want:  "(or x y)",
+			want:  `(or "x" "y")`,
 		},
 		{
 			input: "x and y",
-			want:  "(and x y)",
+			want:  `(and "x" "y")`,
 		},
 		{
 			input: "file:foo x y",
-			want:  "file:foo (concat x y)",
+			want:  `"file:foo" (concat "x" "y")`,
 		},
 		{
 			input: "file:foo (x y)",
-			want:  "file:foo (concat (x y))",
+			want:  `"file:foo" (concat "(x" "y)")`,
 		},
 		{
 			input: "(file:foo x) y",
@@ -42,15 +42,15 @@ func Test_PartitionSearchPattern(t *testing.T) {
 		},
 		{
 			input: "file:foo (x and y)",
-			want:  "file:foo (and x y)",
+			want:  `"file:foo" (and "x" "y")`,
 		},
 		{
 			input: "file:foo x and y",
-			want:  "file:foo (and x y)",
+			want:  `"file:foo" (and "x" "y")`,
 		},
 		{
 			input: "file:foo (x or y)",
-			want:  "file:foo (or x y)",
+			want:  `"file:foo" (or "x" "y")`,
 		},
 		{
 			input: "file:foo x or y",
@@ -62,11 +62,11 @@ func Test_PartitionSearchPattern(t *testing.T) {
 		},
 		{
 			input: "file:foo and content:x",
-			want:  "file:foo content:x",
+			want:  `"file:foo" "content:x"`,
 		},
 		{
 			input: "repo:foo and file:bar and x",
-			want:  "repo:foo file:bar x",
+			want:  `"repo:foo" "file:bar" "x"`,
 		},
 		{
 			input: "repo:foo and (file:bar or file:baz) and x",


### PR DESCRIPTION
I want our parser's heuristic choices to be visible and tractable. I'm sure that we'll want to add heuristic additions in future, and explicit test values will help track the differences. This PR adds a relation for existing parser tests and the new heuristic additions in #9494 and  #9620.

For example, the test output will now quote leaf nodes (e.g., search patterns) so we can distinguish the difference. Here's a representative test introduced in this PR that illustrates how the heuristic is treating parentheses literally, as a sequence of the strings `(((a` `b` `c)))` instead of a group that can be reduced in the original grammar spec. 

```
Input:         "(((a b c))) and d",
WantGrammar:   Spec(`(and (concat "a" "b" "c") "d")`),
WantHeuristic: Diff(`(and (concat "(((a" "b" "c)))") "d")`),
```