### PR TITLE
Use unicode-friendly query parsing

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -93,7 +93,7 @@ func isSpace(buf []byte) bool {
 	return unicode.IsSpace(r)
 }
 
-// skipSpace returns the number of spaces, corresponding to runes, skipped from the beginning of a buffer buf.
+// skipSpace returns the number of whitespace bytes skipped from the beginning of a buffer buf.
 func skipSpace(buf []byte) int {
 	pos := 0
 	for {


### PR DESCRIPTION
Converts the `peek` and whitespace-scanner helper functions to use runes. This is just preserving the existing interface before I write other scanner code that relies on `next()` using runes instead of bytes.