### PR TITLE
Add missing import in observability generator

### DIFF
--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Fixe the following error when running dev/start:

```
./src-observability-generator.go:246:23: undefined: rand
src-observability-generator.go:2: running "go": exit status 2
```

I believe this would also fix the build on master:  https://buildkite.com/sourcegraph/sourcegraph/builds/60393#cd0a50a0-91a4-43a5-b5c5-785ee1a9ae11/608-617
