### PR TITLE
doc: update add repo from local disk instructions

### DIFF
--- a/doc/admin/repo/add_from_local_disk.md
+++ b/doc/admin/repo/add_from_local_disk.md
@@ -8,7 +8,9 @@ The steps documented here are intended for Sourcegraph instances running on a si
 
 If you're using the default `--volume $HOME/.sourcegraph/data:/var/opt/sourcegraph` argument to run the `sourcegraph/server` Docker image, and the repository you want to add is named `github.com/my/repo`, then follow these steps:
 
-1.  If Sourcegraph is running, ensure the repository is disabled so it doesn't attempt to clone it.
+1.  Ensure that the added repository is included in [a code host configuration on Sourcegraph](../external_service/index.md).
+
+1.  Stop Sourcegraph if it is running. This is to ensure it doesn't interfere with the clone.
 
 1.  On the host machine, ensure that a bare Git clone of the repository exists at `$HOME/.sourcegraph/data/repos/github.com/my/repo/.git`.
 
@@ -23,8 +25,5 @@ If you're using the default `--volume $HOME/.sourcegraph/data:/var/opt/sourcegra
     ```
     git clone --mirror --reference PATH-TO-YOUR-EXISTING-LOCAL-CLONE --dissociate YOUR-REPOSITORY-CLONE-URL $HOME/.sourcegraph/data/repos/github.com/my/repo/.git
     ```
-
-1.  Ensure that the added repository is included in [a code host configuration on Sourcegraph](../external_service/index.md).
-1.  Enable the repository on the site admin repositories page.
 
 If this repository exists on a code host that Sourcegraph directly integrates with, then use that code host's configuration (as described in the [code host documentation](../external_service/index.md)). After updating the code host configuration, if you used the correct repository path, Sourcegraph will detect and reuse the existing clone. (For example, if you're working with a repository on GitHub.com, ensure that the repository path name you used is of the form `github.com/my/repo`.)


### PR DESCRIPTION
Note how different the instructions are here. We require the user to configure
the code host first, then shutdown Sourcegraph. This is to prevent a
background Sourcegraph job removing the clone. If the code cost config doesn't
exist a background job could delete the repo thinking it shouldn't be
there. If you keep Sourcegraph running we may delete the repo since it will
appear corrupt while cloning.

We may want to invest in improving this experience. For example we could add
support for a "staging" area on gitserver. This can be consulted for clones.

Fixes https://github.com/sourcegraph/sourcegraph/issues/8412