### PR TITLE
repo-updater: Add rate limit registry.

### DIFF
--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -10,6 +10,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"golang.org/x/time/rate"
 )
 
 // A Sourcer converts the given ExternalServices to Sources
@@ -103,6 +104,12 @@ type ChangesetSource interface {
 	CloseChangeset(context.Context, *Changeset) error
 	// UpdateChangeset can update Changesets.
 	UpdateChangeset(context.Context, *Changeset) error
+}
+
+// RateLimiter source returns a rate limiter that should be used when
+// making external requests.
+type RateLimiter interface {
+	RateLimiter() *rate.Limiter
 }
 
 // ChangesetsNotFoundError is returned by LoadChangesets if any of the passed

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -10,7 +10,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"golang.org/x/time/rate"
 )
 
 // A Sourcer converts the given ExternalServices to Sources
@@ -104,12 +103,6 @@ type ChangesetSource interface {
 	CloseChangeset(context.Context, *Changeset) error
 	// UpdateChangeset can update Changesets.
 	UpdateChangeset(context.Context, *Changeset) error
-}
-
-// RateLimiter source returns a rate limiter that should be used when
-// making external requests.
-type RateLimiter interface {
-	RateLimiter() *rate.Limiter
 }
 
 // ChangesetsNotFoundError is returned by LoadChangesets if any of the passed

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -993,6 +993,11 @@ func (r *RateLimiterRegistry) updateRateLimiter(svc *ExternalService) error {
 		return errors.Wrap(err, "getting external service configuration")
 	}
 
+	// Rate limit config can be in a few states:
+	// 1. Not defined: We fall back to default specified in code.
+	// 2. Defined and enabled: We use their defined limit.
+	// 3. Defined and disabled: We use an infinite limiter.
+
 	var limit rate.Limit
 	switch c := config.(type) {
 	case *schema.GitLabConnection:

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -933,14 +933,16 @@ type RateLimiterRegistry struct {
 	rateLimiters map[int64]*rate.Limiter
 }
 
+// NewRateLimitRegistry returns a new registry and attempts to populate it. On error, an
+// empty registry is returned which can still to handle syncs.
 func NewRateLimiterRegistry(ctx context.Context, store Store) (*RateLimiterRegistry, error) {
-	svcs, err := store.ListExternalServices(ctx, StoreListExternalServicesArgs{})
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching external services")
-	}
-
 	r := &RateLimiterRegistry{
 		rateLimiters: make(map[int64]*rate.Limiter),
+	}
+
+	svcs, err := store.ListExternalServices(ctx, StoreListExternalServicesArgs{})
+	if err != nil {
+		return r, errors.Wrap(err, "fetching external services")
 	}
 
 	for _, svc := range svcs {

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -11,10 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/goware/urlx"
 	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -930,7 +929,7 @@ func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices
 
 type RateLimiterRegistry struct {
 	mu sync.Mutex
-	// Rate limiters per external service
+	// Rate limiter per external service
 	rateLimiters map[int64]*rate.Limiter
 }
 

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -929,7 +929,7 @@ func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices
 
 type RateLimiterRegistry struct {
 	mu sync.Mutex
-	// Rate limiter per external service
+	// Rate limiter per external service, keys are database ID of external services.
 	rateLimiters map[int64]*rate.Limiter
 }
 

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -13,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"golang.org/x/time/rate"
 )
 
 func TestExternalService_Exclude(t *testing.T) {

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -466,4 +468,68 @@ func formatJSON(t testing.TB, s string) string {
 	}
 
 	return formatted
+}
+
+func TestRateLimiterRegistry(t *testing.T) {
+	r := &RateLimiterRegistry{
+		rateLimiters: make(map[int64]*rate.Limiter),
+	}
+
+	l := r.GetRateLimiter(1)
+	if l == nil {
+		t.Fatalf("Expected a limiter")
+	}
+	expectedLimit := rate.Inf
+	if l.Limit() != expectedLimit {
+		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
+	}
+
+	now := time.Now()
+	s := api.ExternalService{
+		ID:          1,
+		Kind:        "GitLab",
+		DisplayName: "GitLab",
+		Config:      "",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		DeletedAt:   nil,
+	}
+	err := r.HandleExternalServiceSync(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have default limit
+	l = r.GetRateLimiter(1)
+	if l == nil {
+		t.Fatalf("Expected a limiter")
+	}
+	expectedLimit = rate.Limit(10)
+	if l.Limit() != expectedLimit {
+		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
+	}
+
+	// Add config
+	s.Config = `
+{
+  "RateLimit": {
+    "Enabled": true,
+    "RequestsPerHour": 3600,
+  }
+}
+`
+	err = r.HandleExternalServiceSync(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have new limit
+	l = r.GetRateLimiter(1)
+	if l == nil {
+		t.Fatalf("Expected a limiter")
+	}
+	expectedLimit = rate.Limit(1)
+	if l.Limit() != expectedLimit {
+		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
+	}
 }

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -44,9 +44,15 @@ func enterpriseInit(
 	ctx := context.Background()
 	campaignsStore := campaigns.NewStore(db)
 
-	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf)
+	rateLimiterRegistry, err := repos.NewRateLimiterRegistry(ctx, repoStore)
+	if err != nil {
+		log15.Error("Creating rate limit registry", "err", err)
+	}
+
+	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf, rateLimiterRegistry)
 	if server != nil {
 		server.ChangesetSyncRegistry = syncRegistry
+		server.RateLimiterRegistry = rateLimiterRegistry
 	}
 
 	clock := func() time.Time {

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -16,10 +16,11 @@ import (
 
 // SyncRegistry manages a ChangesetSyncer per external service.
 type SyncRegistry struct {
-	Ctx         context.Context
-	SyncStore   SyncStore
-	RepoStore   RepoStore
-	HTTPFactory *httpcli.Factory
+	Ctx                 context.Context
+	SyncStore           SyncStore
+	RepoStore           RepoStore
+	HTTPFactory         *httpcli.Factory
+	RateLimiterRegistry *repos.RateLimiterRegistry
 
 	priorityNotify chan []int64
 
@@ -34,14 +35,15 @@ type RepoStore interface {
 
 // NewSycnRegistry creates a new sync registry which starts a syncer for each external service and will update them
 // when external services are changed, added or removed.
-func NewSyncRegistry(ctx context.Context, store SyncStore, repoStore RepoStore, cf *httpcli.Factory) *SyncRegistry {
+func NewSyncRegistry(ctx context.Context, store SyncStore, repoStore RepoStore, cf *httpcli.Factory, rateLimiterRegistry *repos.RateLimiterRegistry) *SyncRegistry {
 	r := &SyncRegistry{
-		Ctx:            ctx,
-		SyncStore:      store,
-		RepoStore:      repoStore,
-		HTTPFactory:    cf,
-		priorityNotify: make(chan []int64, 500),
-		syncers:        make(map[int64]*ChangesetSyncer),
+		Ctx:                 ctx,
+		SyncStore:           store,
+		RepoStore:           repoStore,
+		HTTPFactory:         cf,
+		RateLimiterRegistry: rateLimiterRegistry,
+		priorityNotify:      make(chan []int64, 500),
+		syncers:             make(map[int64]*ChangesetSyncer),
 	}
 
 	services, err := repoStore.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -382,7 +382,7 @@ func TestSyncRegistry(t *testing.T) {
 		},
 	}
 
-	r := NewSyncRegistry(ctx, syncStore, repoStore, nil)
+	r := NewSyncRegistry(ctx, syncStore, repoStore, nil, nil)
 
 	assertSyncerCount := func(want int) {
 		r.mu.Lock()

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -765,7 +765,7 @@ func TestGetLimiter(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := &schema.BitbucketServerConnection{
-		RateLimit: &schema.RateLimit{
+		RateLimit: &schema.BitbucketServerRateLimit{
 			Enabled:         true,
 			RequestsPerHour: 3600,
 		},

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -24,6 +24,7 @@
   "properties": {
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to BitbucketServer.",
+      "title": "BitbucketServerRateLimit",
       "type": "object",
       "required": ["enabled", "requestsPerHour"],
       "properties": {

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -29,6 +29,7 @@ const BitbucketServerSchemaJSON = `{
   "properties": {
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to BitbucketServer.",
+      "title": "BitbucketServerRateLimit",
       "type": "object",
       "required": ["enabled", "requestsPerHour"],
       "properties": {

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -24,6 +24,29 @@
       "type": "string",
       "minLength": 1
     },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to GitLab.",
+      "title": "GitLabRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 36000,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 36000
+      }
+    },
     "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -29,6 +29,29 @@ const GitLabSchemaJSON = `{
       "type": "string",
       "minLength": 1
     },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to GitLab.",
+      "title": "GitLabRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 36000,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 36000
+      }
+    },
     "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -186,7 +186,7 @@ type BitbucketServerConnection struct {
 	// Plugin description: Configuration for Bitbucket Server Sourcegraph plugin
 	Plugin *BitbucketServerPlugin `json:"plugin,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
-	RateLimit *RateLimit `json:"rateLimit,omitempty"`
+	RateLimit *BitbucketServerRateLimit `json:"rateLimit,omitempty"`
 	// Repos description: An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.
 	Repos []string `json:"repos,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server repository.
@@ -257,6 +257,14 @@ type BitbucketServerPlugin struct {
 type BitbucketServerPluginWebhooks struct {
 	// Secret description: Secret for authenticating incoming webhook payloads
 	Secret string `json:"secret"`
+}
+
+// BitbucketServerRateLimit description: Rate limit applied when making background API requests to BitbucketServer.
+type BitbucketServerRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type BitbucketServerUsernameIdentity struct {
 	Type string `json:"type"`
@@ -549,6 +557,8 @@ type GitLabConnection struct {
 	ProjectQuery []string `json:"projectQuery"`
 	// Projects description: A list of projects to mirror from this GitLab instance. Supports including by name ({"name": "group/name"}) or by ID ({"id": 42}).
 	Projects []*GitLabProject `json:"projects,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to GitLab.
+	RateLimit *GitLabRateLimit `json:"rateLimit,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable "{host}" is replaced with the GitLab URL's host (such as gitlab.example.com), and "{pathWithNamespace}" is replaced with the GitLab project's "namespace/path" (such as "myteam/myproject").
 	//
 	// For example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{pathWithNamespace}" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.
@@ -571,6 +581,14 @@ type GitLabProject struct {
 	Id int `json:"id,omitempty"`
 	// Name description: The name of a GitLab project ("group/name") to mirror.
 	Name string `json:"name,omitempty"`
+}
+
+// GitLabRateLimit description: Rate limit applied when making background API requests to GitLab.
+type GitLabRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // GitoliteConnection description: Configuration for a connection to Gitolite.
@@ -755,14 +773,6 @@ type QuickLink struct {
 	Name string `json:"name"`
 	// Url description: The URL of this quick link (absolute or relative)
 	Url string `json:"url"`
-}
-
-// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
-type RateLimit struct {
-	// Enabled description: true if rate limiting is enabled.
-	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
-	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type Repos struct {
 	// Callsign description: The unique Phabricator identifier for the repository, like 'MUX'.


### PR DESCRIPTION
The registry is responsible for keeping track of rate limiters per external service. It is created during startup in repo-updater is intended to be passed around as a dependency, see `ChangesetSyncRegistry` as an example.

Initially added support for GitLab, other service types will be added in followup PRs

Part of: https://github.com/sourcegraph/sourcegraph/issues/8546