### PR TITLE
github: turn `Client` into an interface

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -32,10 +32,10 @@ type GithubSource struct {
 	excludeForks    bool
 	githubDotCom    bool
 	baseURL         *url.URL
-	client          *github.Client
+	client          github.Client
 	// searchClient is for using the GitHub search API, which has an independent
 	// rate limit much lower than non-search API requests.
-	searchClient *github.Client
+	searchClient github.Client
 
 	// originalHostname is the hostname of config.Url (differs from client APIURL, whose host is api.github.com
 	// for an originalHostname of github.com).
@@ -365,7 +365,7 @@ func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult,
 		}
 
 		if hasNext && cost > 0 {
-			time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(cost))
+			time.Sleep(s.client.RateLimit().RecommendedWaitForBackgroundOp(cost))
 		}
 	}
 }
@@ -387,7 +387,7 @@ func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *gi
 				}
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimit().Get()
 			log15.Debug(
 				"github sync: ListOrgRepositories",
 				"repos", len(repos),
@@ -419,7 +419,7 @@ func (s *GithubSource) listUser(ctx context.Context, user string, results chan *
 				fail, err = err, nil
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimit().Get()
 			log15.Debug(
 				"github sync: ListUserRepositories",
 				"repos", len(repos),
@@ -481,7 +481,7 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string, results ch
 
 		results <- &githubResult{repo: repo}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimit().RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 }
 
@@ -526,7 +526,7 @@ func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResul
 func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult) {
 	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimit().Get()
 			log15.Debug(
 				"github sync: ListAffiliated",
 				"repos", len(repos),
@@ -559,7 +559,7 @@ func (s *GithubSource) listSearch(ctx context.Context, query string, results cha
 		}
 
 		repos, hasNext := reposPage.Repos, reposPage.HasNextPage
-		remaining, reset, retry, ok := s.searchClient.RateLimit.Get()
+		remaining, reset, retry, ok := s.searchClient.RateLimit().Get()
 		log15.Debug(
 			"github sync: ListRepositoriesForSearch",
 			"searchString", query,
@@ -697,7 +697,7 @@ func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, result
 			results <- &githubResult{repo: r}
 		}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimit().RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 
 	return nil

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -126,14 +126,15 @@ func derefInt64(i *int64) int64 {
 	return *i
 }
 
-func (s *sessionIssuerHelper) newClient(token string) *githubsvc.Client {
+// Deprecated: Use client.WithToken instead.
+func (s *sessionIssuerHelper) newClient(token string) githubsvc.Client {
 	apiURL, _ := githubsvc.APIRoot(s.BaseURL)
 	return githubsvc.NewClient(apiURL, token, nil)
 }
 
 // getVerifiedEmails returns the list of user emails that are verified. If the primary email is verified,
 // it will be the first email in the returned list. It only checks the first 100 user emails.
-func getVerifiedEmails(ctx context.Context, ghClient *githubsvc.Client) (verifiedEmails []string) {
+func getVerifiedEmails(ctx context.Context, ghClient githubsvc.Client) (verifiedEmails []string) {
 	emails, err := ghClient.GetAuthenticatedUserEmails(ctx)
 	if err != nil {
 		log15.Warn("Could not get GitHub authenticated user emails", "error", err)
@@ -153,7 +154,7 @@ func getVerifiedEmails(ctx context.Context, ghClient *githubsvc.Client) (verifie
 	return verifiedEmails
 }
 
-func (s *sessionIssuerHelper) verifyUserOrgs(ctx context.Context, ghClient *githubsvc.Client) bool {
+func (s *sessionIssuerHelper) verifyUserOrgs(ctx context.Context, ghClient githubsvc.Client) bool {
 	if len(s.allowOrgs) == 0 {
 		return true
 	}

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -19,7 +19,7 @@ import (
 
 // Provider implements authz.Provider for GitHub repository permissions.
 type Provider struct {
-	client   *github.Client
+	client   github.Client
 	codeHost *extsvc.CodeHost
 	cacheTTL time.Duration
 	cache    cache
@@ -36,7 +36,7 @@ func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, m
 		cacheTTL: cacheTTL,
 	}
 	// Note: this will use the same underlying Redis instance and key namespace for every instance
-	// of Provider.  This is by design, so that different instances, even in different processes,
+	// of Provider. This is by design, so that different instances, even in different processes,
 	// will share cache entries.
 	if p.cache == nil {
 		p.cache = rcache.NewWithTTL(fmt.Sprintf("githubAuthz:%s", githubURL.String()), int(math.Ceil(cacheTTL.Seconds())))

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -419,31 +419,32 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		}
 	})
 
-	github.MockListAffiliatedRepositories = func(ctx context.Context, token string, page int) ([]*github.Repository, bool, int, error) {
-		want := "my_access_token"
-		if token != want {
-			return nil, false, 0, fmt.Errorf("token: want %q but got %q", want, token)
-		}
+	mockClient := &github.MockClient{
+		MockListAffiliatedRepositories: func(ctx context.Context, page int) ([]*github.Repository, bool, int, error) {
+			switch page {
+			case 1:
+				return []*github.Repository{
+					{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="},
+					{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY="},
+				}, true, 1, nil
+			case 2:
+				return []*github.Repository{
+					{ID: "MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA="},
+				}, false, 1, nil
+			}
 
-		switch page {
-		case 1:
-			return []*github.Repository{
-				{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="},
-				{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY="},
-			}, true, 1, nil
-		case 2:
-			return []*github.Repository{
-				{ID: "MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA="},
-			}, false, 1, nil
-		}
-
-		return []*github.Repository{}, false, 1, nil
+			return []*github.Repository{}, false, 1, nil
+		},
 	}
-	t.Cleanup(func() {
-		github.MockListAffiliatedRepositories = nil
-	})
+
+	calledWithToken := false
+	mockClient.MockWithToken = func(token string) github.Client {
+		calledWithToken = true
+		return mockClient
+	}
 
 	p := NewProvider(mustURL(t, "https://github.com"), "admin_token", 3*time.Hour, nil)
+	p.client = mockClient
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 	repoIDs, err := p.FetchUserPerms(context.Background(),
@@ -459,6 +460,10 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !calledWithToken {
+		t.Fatal("!calledWithToken")
 	}
 
 	expRepoIDs := []extsvc.RepoID{
@@ -500,26 +505,24 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 		}
 	})
 
-	github.MockListRepositoryCollaborators = func(ctx context.Context, owner, repo string, page int) ([]*github.Collaborator, bool, error) {
-		switch page {
-		case 1:
-			return []*github.Collaborator{
-				{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="},
-				{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY="},
-			}, true, nil
-		case 2:
-			return []*github.Collaborator{
-				{ID: "MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA="},
-			}, false, nil
-		}
-
-		return []*github.Collaborator{}, false, nil
-	}
-	t.Cleanup(func() {
-		github.MockListRepositoryCollaborators = nil
-	})
-
 	p := NewProvider(mustURL(t, "https://github.com"), "admin_token", 3*time.Hour, nil)
+	p.client = &github.MockClient{
+		MockListRepositoryCollaborators: func(ctx context.Context, owner, repo string, page int) ([]*github.Collaborator, bool, error) {
+			switch page {
+			case 1:
+				return []*github.Collaborator{
+					{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="},
+					{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY="},
+				}, true, nil
+			case 2:
+				return []*github.Collaborator{
+					{ID: "MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA="},
+				}, false, nil
+			}
+
+			return []*github.Collaborator{}, false, nil
+		},
+	}
 
 	accountIDs, err := p.FetchRepoPerms(context.Background(),
 		&extsvc.Repository{

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -117,7 +117,7 @@ func TestClient_WithToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	old := &Client{
+	old := &client{
 		apiURL:       uri,
 		defaultToken: "old_token",
 	}
@@ -338,7 +338,7 @@ func TestClient_GetAuthenticatedUserOrgs(t *testing.T) {
 	)
 }
 
-func newClient(t testing.TB, name string) (*Client, func()) {
+func newClient(t testing.TB, name string) (*client, func()) {
 	t.Helper()
 
 	cassete := filepath.Join("testdata/vcr/", strings.Replace(name, " ", "-", -1))

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -123,7 +123,7 @@ func TestClient_WithToken(t *testing.T) {
 	}
 
 	newToken := "new_token"
-	new := old.WithToken(newToken)
+	new := old.WithToken(newToken).(*client)
 	if old == new {
 		t.Fatal("both clients have the same address")
 	}
@@ -365,7 +365,7 @@ func newClient(t testing.TB, name string) (*client, func()) {
 		uri,
 		os.Getenv("GITHUB_TOKEN"),
 		hc,
-	)
+	).(*client)
 
 	return cli, func() {
 		if err := rec.Stop(); err != nil {

--- a/internal/extsvc/github/mocks.go
+++ b/internal/extsvc/github/mocks.go
@@ -1,0 +1,112 @@
+package github
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+)
+
+var _ Client = (*MockClient)(nil)
+
+type MockClient struct {
+	MockWithToken                      func(token string) Client
+	MockRateLimit                      func() *ratelimit.Monitor
+	MockCreatePullRequest              func(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error)
+	MockClosePullRequest               func(ctx context.Context, pr *PullRequest) error
+	MockLoadPullRequests               func(ctx context.Context, prs ...*PullRequest) error
+	MockUpdatePullRequest              func(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error)
+	MockGetOpenPullRequestByRefs       func(ctx context.Context, owner, name, baseRef, headRef string) (*PullRequest, error)
+	MockGetRepository                  func(ctx context.Context, owner, name string) (*Repository, error)
+	MockGetRepositoryByNodeID          func(ctx context.Context, token, id string) (*Repository, error)
+	MockGetRepositoriesByNodeIDFromAPI func(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error)
+	MockGetReposByNameWithOwner        func(ctx context.Context, namesWithOwners ...string) ([]*Repository, error)
+	MockGetAuthenticatedUserEmails     func(ctx context.Context) ([]*UserEmail, error)
+	MockGetAuthenticatedUserOrgs       func(ctx context.Context) ([]*Org, error)
+	MockListPublicRepositories         func(ctx context.Context, sinceRepoID int64) ([]*Repository, error)
+	MockListRepositoriesForSearch      func(ctx context.Context, searchString string, page int) (RepositoryListPage, error)
+	MockListOrgRepositories            func(ctx context.Context, org string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error)
+	MockListUserRepositories           func(ctx context.Context, user string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error)
+	MockListAffiliatedRepositories     func(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error)
+	MockListInstallationRepositories   func(ctx context.Context) ([]*Repository, error)
+	MockListRepositoryCollaborators    func(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, err error)
+}
+
+func (m *MockClient) WithToken(token string) Client {
+	return m.MockWithToken(token)
+}
+
+func (m *MockClient) RateLimit() *ratelimit.Monitor {
+	return m.MockRateLimit()
+}
+
+func (m *MockClient) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error) {
+	return m.MockCreatePullRequest(ctx, in)
+}
+
+func (m *MockClient) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
+	return m.MockClosePullRequest(ctx, pr)
+}
+
+func (m *MockClient) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
+	return m.MockLoadPullRequests(ctx, prs...)
+}
+
+func (m *MockClient) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {
+	return m.MockUpdatePullRequest(ctx, in)
+}
+
+func (m *MockClient) GetOpenPullRequestByRefs(ctx context.Context, owner, name, baseRef, headRef string) (*PullRequest, error) {
+	return m.MockGetOpenPullRequestByRefs(ctx, owner, name, baseRef, headRef)
+}
+
+func (m *MockClient) GetRepository(ctx context.Context, owner, name string) (*Repository, error) {
+	return m.MockGetRepository(ctx, owner, name)
+}
+
+func (m *MockClient) GetRepositoryByNodeID(ctx context.Context, token, id string) (*Repository, error) {
+	return m.MockGetRepositoryByNodeID(ctx, token, id)
+}
+
+func (m *MockClient) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error) {
+	return m.MockGetRepositoriesByNodeIDFromAPI(ctx, token, nodeIDs)
+}
+
+func (m *MockClient) GetReposByNameWithOwner(ctx context.Context, namesWithOwners ...string) ([]*Repository, error) {
+	return m.MockGetReposByNameWithOwner(ctx, namesWithOwners...)
+}
+
+func (m *MockClient) GetAuthenticatedUserEmails(ctx context.Context) ([]*UserEmail, error) {
+	return m.MockGetAuthenticatedUserEmails(ctx)
+}
+
+func (m *MockClient) GetAuthenticatedUserOrgs(ctx context.Context) ([]*Org, error) {
+	return m.MockGetAuthenticatedUserOrgs(ctx)
+}
+
+func (m *MockClient) ListPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, error) {
+	return m.MockListPublicRepositories(ctx, sinceRepoID)
+}
+
+func (m *MockClient) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (RepositoryListPage, error) {
+	return m.MockListRepositoriesForSearch(ctx, searchString, page)
+}
+
+func (m *MockClient) ListOrgRepositories(ctx context.Context, org string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+	return m.MockListOrgRepositories(ctx, org, page)
+}
+
+func (m *MockClient) ListUserRepositories(ctx context.Context, user string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+	return m.MockListUserRepositories(ctx, user, page)
+}
+
+func (m *MockClient) ListAffiliatedRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+	return m.MockListAffiliatedRepositories(ctx, page)
+}
+
+func (m *MockClient) ListInstallationRepositories(ctx context.Context) ([]*Repository, error) {
+	return m.MockListInstallationRepositories(ctx)
+}
+
+func (m *MockClient) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, err error) {
+	return m.MockListRepositoryCollaborators(ctx, owner, repo, page)
+}

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -459,8 +459,8 @@ type CreatePullRequestInput struct {
 	Body string `json:"body"`
 }
 
-// CreatePullRequest creates a PullRequest on Github.
-func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error) {
+// CreatePullRequest creates a PullRequest on GitHub.
+func (c *client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error) {
 	var q strings.Builder
 	q.WriteString(pullRequestFragments)
 	q.WriteString(`mutation	CreatePullRequest($input:CreatePullRequestInput!) {
@@ -511,8 +511,8 @@ type UpdatePullRequestInput struct {
 	Body string `json:"body"`
 }
 
-// UpdatePullRequest creates a PullRequest on Github.
-func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {
+// UpdatePullRequest creates a PullRequest on GitHub.
+func (c *client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {
 	var q strings.Builder
 	q.WriteString(pullRequestFragments)
 	q.WriteString(`mutation	UpdatePullRequest($input:UpdatePullRequestInput!) {
@@ -551,8 +551,8 @@ func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInp
 	return pr, nil
 }
 
-// ClosePullRequest closes the PullRequest on Github.
-func (c *Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
+// ClosePullRequest closes the PullRequest on GitHub.
+func (c *client) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
 	var q strings.Builder
 	q.WriteString(pullRequestFragments)
 	q.WriteString(`mutation	ClosePullRequest($input:ClosePullRequestInput!) {
@@ -588,8 +588,8 @@ func (c *Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
 	return nil
 }
 
-// LoadPullRequests loads a list of PullRequests from Github.
-func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
+// LoadPullRequests loads a list of PullRequests from GitHub.
+func (c *client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) error {
 	const batchSize = 15
 	// We load prs in batches to avoid hitting Github's GraphQL node limit
 	for i := 0; i < len(prs); i += batchSize {
@@ -604,7 +604,7 @@ func (c *Client) LoadPullRequests(ctx context.Context, prs ...*PullRequest) erro
 	return nil
 }
 
-func (c *Client) loadPullRequests(ctx context.Context, prs ...*PullRequest) error {
+func (c *client) loadPullRequests(ctx context.Context, prs ...*PullRequest) error {
 	type repository struct {
 		Owner string
 		Name  string
@@ -674,10 +674,9 @@ func (c *Client) loadPullRequests(ctx context.Context, prs ...*PullRequest) erro
 	return nil
 }
 
-// GetOpenPullRequestByRefs fetches the the pull request associated with the supplied
-// refs. GitHub only allows one open PR by ref at a time.
-// If nothing is found an error is returned.
-func (c *Client) GetOpenPullRequestByRefs(ctx context.Context, owner, name, baseRef, headRef string) (*PullRequest, error) {
+// GetOpenPullRequestByRefs fetches the the pull request associated with the supplied refs.
+// GitHub only allows one open PR by ref at a time. If nothing is found an error is returned.
+func (c *client) GetOpenPullRequestByRefs(ctx context.Context, owner, name, baseRef, headRef string) (*PullRequest, error) {
 	var q strings.Builder
 	q.WriteString(pullRequestFragments)
 	q.WriteString("query {\n")

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -69,12 +69,12 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func newTestClient(t *testing.T, cli httpcli.Doer) *Client {
+func newTestClient(t *testing.T, cli httpcli.Doer) *client {
 	rcache.SetupForTest(t)
-	return &Client{
+	return &client{
 		apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
 		httpClient:      cli,
-		RateLimit:       &ratelimit.Monitor{},
+		rateLimit:       &ratelimit.Monitor{},
 		repoCache:       map[string]*rcache.Cache{},
 		repoCachePrefix: "__test__gh_repo",
 		repoCacheTTL:    1000,

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -46,7 +46,7 @@ var MockGetAuthenticatedUserEmails func(ctx context.Context) ([]*UserEmail, erro
 
 // GetAuthenticatedUserEmails returns the first 100 emails associated with the currently
 // authenticated user.
-func (c *Client) GetAuthenticatedUserEmails(ctx context.Context) ([]*UserEmail, error) {
+func (c *client) GetAuthenticatedUserEmails(ctx context.Context) ([]*UserEmail, error) {
 	if MockGetAuthenticatedUserEmails != nil {
 		return MockGetAuthenticatedUserEmails(ctx)
 	}
@@ -67,7 +67,7 @@ var MockGetAuthenticatedUserOrgs func(ctx context.Context) ([]*Org, error)
 
 // GetAuthenticatedUserOrgs returns the first 100 organizations associated with the currently
 // authenticated user.
-func (c *Client) GetAuthenticatedUserOrgs(ctx context.Context) ([]*Org, error) {
+func (c *client) GetAuthenticatedUserOrgs(ctx context.Context) ([]*Org, error) {
 	if MockGetAuthenticatedUserOrgs != nil {
 		return MockGetAuthenticatedUserOrgs(ctx)
 	}
@@ -86,16 +86,10 @@ type Collaborator struct {
 	DatabaseID int64  `json:"id"`
 }
 
-var MockListRepositoryCollaborators func(ctx context.Context, owner, repo string, page int) ([]*Collaborator, bool, error)
-
 // ListRepositoryCollaborators lists all GitHub users that has access to the repository.
 // The page is the page of results to return, and is 1-indexed (so the first call should
 // be for page 1).
-func (c *Client) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
-	if MockListRepositoryCollaborators != nil {
-		return MockListRepositoryCollaborators(ctx, owner, repo, page)
-	}
-
+func (c *client) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
 	path := fmt.Sprintf("/repos/%s/%s/collaborators?&page=%d&per_page=100", owner, repo, page)
 	err := c.requestGet(ctx, "", path, &users)
 	if err != nil {


### PR DESCRIPTION
Think this PR more like a proposal of "how to avoid global state mocks", this is a concrete example for GitHub API client.

Things happens:
1. Turned `github.Client` into an interface, the previous client now became `*client` and implements the new `github.Client` interface.
2. Created a `*github.MockClient` that also implements the new `github.Client` interface, but with fields could be used to inject with mock implementations in tests.
3. Updated [`github_test.go`](https://github.com/sourcegraph/sourcegraph/pull/9655/files#diff-7e1e555e56c67495f208903db68c2b7b) to mock a client by assign values to the fields of `MockClient`. (could have updated other places, but not in this PR)

**NOTE**: 
- No functional change should happen in this PR.
- Other than the big `github.Client` interface, I'm pretty happy with this approach.

Any feedback is welcome!