### PR TITLE
CODEOWNERS: remove @beyang from many top-level catch-alls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,53 +6,37 @@
 # precedence.
 
 # Top-level catch-alls (these are weaker confidence and might need to be reassigned at some point)
+* @sourcegraph/nobody
 *.js @sourcegraph/web
 *.ts @sourcegraph/web
 *.tsx @sourcegraph/web
-/enterprise/cmd/frontend @beyang @slimsag
-/enterprise/cmd/server @beyang @slimsag
-/enterprise/dev @beyang
-/cmd/frontend/shared @beyang @slimsag
-/cmd/frontend/backend @beyang @slimsag
+/enterprise/cmd/frontend @slimsag
+/enterprise/cmd/server @slimsag
+/cmd/frontend/shared @slimsag
+/cmd/frontend/backend @slimsag
 /cmd/frontend/internal/app/assets @slimsag
 /cmd/frontend/internal/app/templates @slimsag
-/cmd/frontend/internal/app/canonicalurl @beyang
 /cmd/frontend/internal/app/*.go @slimsag
 /cmd/frontend/internal/app/assetsutil @slimsag
 /cmd/frontend/internal/app/ui @slimsag
-/cmd/frontend/internal/app/returnto @beyang
-/cmd/frontend/internal/app/pkg @beyang @slimsag
+/cmd/frontend/internal/app/pkg @slimsag
 /cmd/frontend/internal/app/router @slimsag
-/cmd/frontend/internal/app/errorutil @beyang @slimsag
+/cmd/frontend/internal/app/errorutil @slimsag
 /cmd/frontend/internal/goroutine @slimsag
-/cmd/frontend/internal/inventory @beyang @slimsag
+/cmd/frontend/internal/inventory @slimsag
 /cmd/frontend/internal/cli/middleware @beyang @slimsag
-/cmd/frontend/internal/cli @slimsag @beyang
-/cmd/frontend/internal/pkg/siteid @beyang
-/cmd/frontend/internal/pkg/suspiciousnames @beyang
+/cmd/frontend/internal/cli @slimsag
 /cmd/frontend/internal/pkg/markdown @slimsag
-/cmd/frontend/internal/pkg/handlerutil @slimsag @beyang
+/cmd/frontend/internal/pkg/handlerutil @slimsag
 /cmd/frontend/internal/httpapi @slimsag
 /cmd/frontend/types @slimsag
-/cmd/frontend/hooks @beyang @slimsag
-/cmd/frontend/internal/ @beyang @slimsag
-/internal/randstring/ @beyang
-/internal/pubsub/ @beyang
-/internal/repotrackutil/ @beyang
-/internal/atomicvalue/ @beyang
-/internal/testutil/ @beyang
-/internal/debugserver/ @beyang
-/internal/vfsutil/ @slimsag
-/internal/gituri/ @beyang
+/cmd/frontend/hooks @slimsag
 /internal/comby @rvantonder
 /internal/db/ @keegancsmith
 /internal/processrestart @slimsag @keegancsmith
 /internal/honey @keegancsmith
-/internal/ratelimit @beyang
 /internal/registry @sourcegraph/web
 /internal/slack @slimsag
-/internal/prefixsuffixsaver @beyang
-/internal/gosrc @beyang
 /internal/txemail @slimsag
 /internal/src-cli @efritz
 /internal/linkheader @efritz
@@ -67,21 +51,8 @@
 /.gitattributes @beyang
 /.yarnrc @felixfbecker
 .eslintrc.js @felixfbecker
-/internal/httputil @beyang
-/internal/diskcache @beyang
-/internal/sysreq @beyang
-/internal/errcode @beyang
-/internal/routevar @beyang
-/internal/env @beyang
-/internal/pathmatch @beyang
-/internal/version @beyang
-/internal/httptestutil @beyang
-/internal/mutablelimiter @beyang
 /internal/buildkite @ggilmore
 /internal/httpcli @sourcegraph/core-services
-/packages @beyang
-/cmd/frontend @beyang
-/dev @beyang
 /dev/release-ping.sh @sourcegraph/distribution
 /dev/grafana.sh  @sourcegraph/distribution
 /dev/grafana  @sourcegraph/distribution
@@ -91,28 +62,18 @@
 /dev/src-expose @keegancsmith
 /dev/drop-test-databases.sh @efritz
 /dev/squash_migrations.sh @efritz
-/.buildkite @beyang
 /.storybook @felixfbecker
 /CONTRIBUTING.md @beyang @nicksnyder @slimsag
 /SECURITY.md @beyang @nicksnyder
-/.dockerignore @beyang
 /.mailmap @beyang
 /tsconfig.json @sourcegraph/web
 /.mocharc.json @sourcegraph/web
 .eslintrc.* @sourcegraph/web
-/enterprise/cmd @beyang
-/enterprise/internal @beyang
-/enterprise @beyang
-/doc.go @beyang
-/.gitignore @beyang
 /prettier.config.js @sourcegraph/web
 /.editorconfig @sourcegraph/web
 /jest.config.js @sourcegraph/web
-/cmd @beyang @slimsag
-/internal @beyang @slimsag
-
-# Regression testing
-/web/src/regression @beyang
+/cmd @slimsag
+/internal @slimsag
 
 # Web
 /shared @sourcegraph/web
@@ -122,8 +83,7 @@
 /enterprise/ui @sourcegraph/web
 /cmd/frontend/internal/app/jscontext @sourcegraph/web @slimsag
 /packages/@sourcegraph @sourcegraph/web
-/web/src/site-admin/externalServices.tsx @beyang
-/shared/src/components/activation/ @beyang
+/shared/src/components/activation/ @sourcegraph/web
 
 # Tracking
 /cmd/frontend/internal/app/pkg/updatecheck/ @dadlerj
@@ -143,7 +103,7 @@
 /cmd/frontend/auth/ @beyang @unknwon
 /cmd/frontend/internal/auth/ @beyang @unknwon
 /cmd/frontend/internal/session/ @beyang @unknwon
-/cmd/frontend/external/session/session.go @beyang @unknwon
+/cmd/frontend/external/session/ @beyang @unknwon
 /enterprise/cmd/frontend/auth @beyang @unknwon
 /enterprise/dev/auth-provider @beyang @unknwon
 /cmd/frontend/graphqlbackend/*session* @beyang @unknwon
@@ -203,7 +163,8 @@
 /web/src/SavedQueryRow.tsx @attfarhan
 /cmd/frontend/types/saved_searches.go @attfarhan
 
-# Deployment and distribution
+# Distribution
+## Deployment
 Dockerfile @sourcegraph/distribution
 /observability @sourcegraph/distribution
 /docker-images @sourcegraph/distribution
@@ -215,6 +176,9 @@ Dockerfile @sourcegraph/distribution
 /internal/db/confdb @slimsag
 /internal/db/globalstatedb @slimsag
 /enterprise/docs @sourcegraph/distribution
+/.buildkite @sourcegraph/distribution @ggilmore
+## Regression testing
+/web/src/regression @uwedeportivo @beyang
 
 # Licensing and billing
 /enterprise/cmd/frontend/internal/dotcom @sourcegraph/distribution
@@ -264,10 +228,7 @@ Dockerfile @sourcegraph/distribution
 # Misc and special overrides
 /LICENSE* @sqs @beyang @slimsag
 /enterprise/internal/license @beyang
-/cmd/frontend/external/session @beyang
-/cmd/frontend/external @beyang
 /babel.config.js @felixfbecker
-/cmd/loadtest @beyang
 /internal/hubspot/ @dadlerj
 /internal/highlight/ @slimsag
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,12 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# Top-level catch-alls (these are weaker confidence and might need to be reassigned at some point)
+# The "nobody" team is an alerting mechanism that indicates when there are files in a PR that are
+# not owned by anyone. This is a signal to the PR author that certain modified files are unowned and
+# they need to (1) track down the owners using git blame and (2) update CODEOWNERS.
 * @sourcegraph/nobody
+
+# Top-level catch-alls (these are weaker confidence and might need to be reassigned at some point)
 *.js @sourcegraph/web
 *.ts @sourcegraph/web
 *.tsx @sourcegraph/web


### PR DESCRIPTION
remove @beyang from many top-level catch-alls, add @nobody as top-level catch-all
