### PR TITLE
WIP: expose parser result in GQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -1,0 +1,30 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+)
+
+/*
+type parseSearchQueryResolver struct {
+	Value *JSONValue
+}
+
+func (r *parseSearchQueryResolver)
+*/
+
+func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
+	Query       string
+	PatternType string
+}) (*JSONValue, error) {
+	queryInfo, err := query.ParseAndOr(args.Query)
+	if err != nil {
+		return nil, err
+	}
+	json, err := queryInfo.JSON()
+	if err != nil {
+		return nil, err
+	}
+	return &JSONValue{Value: string(json)}, nil
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1342,7 +1342,7 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
-    // Return the parse tree of a search query.
+   # Return the parse tree of a search query.
     parseSearchQuery(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1342,6 +1342,12 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
+    parseSearchQuery(
+        # The search query (such as "foo" or "repo:myrepo foo").
+        query: String = ""
+        # The parser to use for this query.
+        patternType: SearchPatternType = literal
+    ): JSONValue
     # All saved searches configured for the current user, merged from all configurations.
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1342,6 +1342,7 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
+    // Return the parse tree of a search query.
     parseSearchQuery(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1349,6 +1349,7 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
+    // Return the parse tree of a search query.
     parseSearchQuery(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1349,7 +1349,7 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
-    // Return the parse tree of a search query.
+    # Return the parse tree of a search query.
     parseSearchQuery(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1349,6 +1349,12 @@ type Query {
         # how many results to return per page. It must be in the range of 0-5000.
         first: Int
     ): Search
+    parseSearchQuery(
+        # The search query (such as "foo" or "repo:myrepo foo").
+        query: String = ""
+        # The parser to use for this query.
+        patternType: SearchPatternType = literal
+    ): JSONValue
     # All saved searches configured for the current user, merged from all configurations.
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -34,18 +34,18 @@ type Parameter struct {
 	Negated bool   `json:"negated"` // True if the - prefix exists, as in -repo:sourcegraph.
 }
 
-type operatorKind int
+type operatorKind string
 
 const (
-	Or operatorKind = iota
-	And
-	Concat
+	Or     operatorKind = "or"
+	And                 = "and"
+	Concat              = "concat"
 )
 
 // Operator is a nonterminal node of kind Kind with child nodes Operands.
 type Operator struct {
-	Kind     operatorKind
-	Operands []Node
+	Kind     operatorKind `json:"operator"`
+	Operands []Node       `json:"operands"`
 }
 
 func (node Parameter) String() string {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -30,6 +31,7 @@ type QueryInfo interface {
 	Fields() map[string][]*types.Value
 	IsCaseSensitive() bool
 	ParseTree() syntax.ParseTree
+	JSON() ([]byte, error)
 }
 
 // An ordinary query (not containing and/or expressions).
@@ -63,6 +65,10 @@ func (q OrdinaryQuery) ParseTree() syntax.ParseTree {
 }
 func (q OrdinaryQuery) IsCaseSensitive() bool {
 	return q.Query.IsCaseSensitive()
+}
+
+func (q OrdinaryQuery) JSON() ([]byte, error) {
+	return []byte("TODO"), nil
 }
 
 // AndOrQuery satisfies the interface for QueryInfo with unvalidated string
@@ -174,6 +180,11 @@ func parseBoolOrPanic(field, value string) *bool {
 		}
 		return &b
 	}
+}
+
+func (q AndOrQuery) JSON() ([]byte, error) {
+	json, err := json.Marshal(q.Query)
+	return json, err
 }
 
 // valueToTypedValue approximately preserves the field validation for


### PR DESCRIPTION
```
SRC_ENDPOINT=http://localhost:3080  SRC_ACCESS_TOKEN="<...>" src api -query='query { parseSearchQuery(query: "-repo:foo a or b") }'
```

```
{
  "data": {
    "parseSearchQuery": "[{\"operator\":\"or\",\"operands\":[{\"operator\":\"and\",\"operands\":[{\"field\":\"repo\",\"value\":\"foo\",\"negated\":true},{\"field\":\"\",\"value\":\"a\",\"negated\":false}]},{\"field\":\"\",\"value\":\"b\",\"negated\":false}]}]"
  }
}
```

TODO:

- Call this `parseTree` instead?
- Simplify JSON or parser to distinguish parameter/pattern?
- Document decision above.
- Change format to be `"op" : [ list of children ]`? I think so...
- Return disambiguated query?
 - Have GQL type accomodate suggestions?
 - Have GQL type expose heurstic vs. spec?
- Changelog

