### PR TITLE
search: add search alert improvements

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -38,6 +38,7 @@ import (
 
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
+var mockResolveRepositories func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error)
 
 func maxReposToSearch() int {
 	switch max := conf.Get().MaxReposToSearch; {
@@ -287,6 +288,10 @@ func exactlyOneRepo(repoFilters []string) bool {
 // resolveRepositories calls doResolveRepositories, caching the result for the common
 // case where effectiveRepoFieldValues == nil.
 func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
+	if mockResolveRepositories != nil {
+		return mockResolveRepositories(effectiveRepoFieldValues)
+	}
+
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("effectiveRepoFieldValues: %v", effectiveRepoFieldValues))
 	defer func() {
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -341,23 +341,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 	}
 }
 
-func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert, error) {
-	alert := &searchAlert{
-		prometheusType: "over_repo_limit",
-		title:          "Too many matching repositories",
-	}
-
-	if envvar.SourcegraphDotComMode() {
-		alert.description = "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results or set up a self-hosted Sourcegraph instance to search an unlimited number of repositories."
-	} else {
-		alert.description = "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results."
-	}
-
-	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
-	if isSiteAdmin {
-		alert.description += " As a site admin, you can increase the limit by changing maxReposToSearch in site config."
-	}
-
+func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert) {
 	// Try to suggest the most helpful repo: filters to narrow the query.
 	//
 	// For example, suppose the query contains "repo:kubern" and it matches > 30
@@ -370,84 +354,97 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAler
 	//
 	// TODO(sqs): this logic can be significantly improved, but it's better than
 	// nothing for now.
-	repos, _, _, err := r.resolveRepositories(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	paths := make([]string, len(repos))
-	pathPatterns := make([]string, len(repos))
-	for i, repo := range repos {
-		paths[i] = string(repo.Repo.Name)
-		pathPatterns[i] = "^" + regexp.QuoteMeta(string(repo.Repo.Name)) + "$"
-	}
+	var proposedQueries []*searchQueryDescription
+	repos, _, _, _ := r.resolveRepositories(ctx, nil)
 
-	// See if we can narrow it down by using filters like
-	// repo:github.com/myorg/.
-	const maxParentsToPropose = 4
-	ctx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
-	defer cancel()
-outer:
-	for i, repoParent := range pathParentsByFrequency(paths) {
-		if i >= maxParentsToPropose || ctx.Err() == nil {
-			break
-		}
-		repoParentPattern := "^" + regexp.QuoteMeta(repoParent) + "/"
-		repoFieldValues, _ := r.query.RegexpPatterns(query.FieldRepo)
-
-		for _, v := range repoFieldValues {
-			if strings.HasPrefix(v, strings.TrimSuffix(repoParentPattern, "/")) {
-				continue outer // this repo: filter is already applied
-			}
+	if len(repos) > 0 {
+		paths := make([]string, len(repos))
+		pathPatterns := make([]string, len(repos))
+		for i, repo := range repos {
+			paths[i] = string(repo.Repo.Name)
+			pathPatterns[i] = "^" + regexp.QuoteMeta(string(repo.Repo.Name)) + "$"
 		}
 
-		repoFieldValues = append(repoFieldValues, repoParentPattern)
-		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		// See if we can narrow it down by using filters like
+		// repo:github.com/myorg/.
+		const maxParentsToPropose = 4
+		ctx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
 		defer cancel()
-		_, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
-		if ctx.Err() != nil {
-			continue
-		} else if err != nil {
-			return nil, err
-		}
-
-		var more string
-		if overLimit {
-			more = " (further filtering required)"
-		}
-
-		// We found a more specific repo: filter that may be narrow enough. Now
-		// add it to the user's query, but be smart. For example, if the user's
-		// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
-		// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
-		newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, repoParentPattern)
-		alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
-			description: "in repositories under " + repoParent + more,
-			query:       newExpr,
-			patternType: r.patternType,
-		})
-	}
-	if len(alert.proposedQueries) == 0 || ctx.Err() == context.DeadlineExceeded {
-		// Propose specific repos' paths if we aren't able to propose
-		// anything else.
-		const maxReposToPropose = 4
-		shortest := append([]string{}, paths...) // prefer shorter repo names
-		sort.Slice(shortest, func(i, j int) bool {
-			return len(shortest[i]) < len(shortest[j]) || (len(shortest[i]) == len(shortest[j]) && shortest[i] < shortest[j])
-		})
-		for i, pathToPropose := range shortest {
-			if i >= maxReposToPropose {
+	outer:
+		for i, repoParent := range pathParentsByFrequency(paths) {
+			if i >= maxParentsToPropose || ctx.Err() == nil {
 				break
 			}
-			newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
-			alert.proposedQueries = append(alert.proposedQueries, &searchQueryDescription{
-				description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
+			repoParentPattern := "^" + regexp.QuoteMeta(repoParent) + "/"
+			repoFieldValues, _ := r.query.RegexpPatterns(query.FieldRepo)
+
+			for _, v := range repoFieldValues {
+				if strings.HasPrefix(v, strings.TrimSuffix(repoParentPattern, "/")) {
+					continue outer // this repo: filter is already applied
+				}
+			}
+
+			repoFieldValues = append(repoFieldValues, repoParentPattern)
+			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			defer cancel()
+			_, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
+			if ctx.Err() != nil {
+				continue
+			} else if err != nil {
+				return nil
+			}
+
+			var more string
+			if overLimit {
+				more = " (further filtering required)"
+			}
+			// We found a more specific repo: filter that may be narrow enough. Now
+			// add it to the user's query, but be smart. For example, if the user's
+			// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
+			// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
+			newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, repoParentPattern)
+			proposedQueries = append(proposedQueries, &searchQueryDescription{
+				description: "in repositories under " + repoParent + more,
 				query:       newExpr,
 				patternType: r.patternType,
 			})
 		}
+		if len(proposedQueries) == 0 || ctx.Err() == context.DeadlineExceeded {
+			// Propose specific repos' paths if we aren't able to propose
+			// anything else.
+			const maxReposToPropose = 4
+			shortest := append([]string{}, paths...) // prefer shorter repo names
+			sort.Slice(shortest, func(i, j int) bool {
+				return len(shortest[i]) < len(shortest[j]) || (len(shortest[i]) == len(shortest[j]) && shortest[i] < shortest[j])
+			})
+			for i, pathToPropose := range shortest {
+				if i >= maxReposToPropose {
+					break
+				}
+				newExpr := addRegexpField(r.query.ParseTree(), query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
+				proposedQueries = append(proposedQueries, &searchQueryDescription{
+					description: "in the repository " + strings.TrimPrefix(pathToPropose, "github.com/"),
+					query:       newExpr,
+					patternType: r.patternType,
+				})
+			}
+		}
 	}
 
-	return alert, nil
+	description := "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results."
+	if envvar.SourcegraphDotComMode() {
+		description = "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results or set up a self-hosted Sourcegraph instance to search an unlimited number of repositories."
+	}
+	if backend.CheckCurrentUserIsSiteAdmin(ctx) == nil {
+		description += " As a site admin, you can increase the limit by changing maxReposToSearch in site config."
+	}
+
+	return &searchAlert{
+		prometheusType: "over_repo_limit",
+		title:          "Too many matching repositories",
+		proposedQueries: proposedQueries,
+		description: 	 description,
+	}
 }
 
 // alertForStructuralSearch filters certain errors from multiErr and converts

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -341,7 +341,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 	}
 }
 
-func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAlert) {
+func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert {
 	// Try to suggest the most helpful repo: filters to narrow the query.
 	//
 	// For example, suppose the query contains "repo:kubern" and it matches > 30
@@ -366,10 +366,10 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAler
 
 	buildAlert := func(proposedQueries []*searchQueryDescription, description string) *searchAlert {
 		return &searchAlert{
-			prometheusType: "over_repo_limit",
-			title:          "Too many matching repositories",
+			prometheusType:  "over_repo_limit",
+			title:           "Too many matching repositories",
 			proposedQueries: proposedQueries,
-			description: 	 description,
+			description:     description,
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -255,7 +255,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				prometheusType: "over_repo_limit",
 				title:          "Too many matching repositories",
 				proposedQueries: []*searchQueryDescription{
-					&searchQueryDescription{
+					{
 						"in the repository a/repoName0",
 						"a query repo:^a/repoName0$",
 						query.SearchType(0),

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -1,9 +1,14 @@
 package graphqlbackend
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
@@ -188,5 +193,104 @@ func Test_ErrorToAlertStructuralSearch(t *testing.T) {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
 		}
 
+	}
+}
+
+func TestAlertForOverRepoLimit(t *testing.T) {
+	ctx := context.Background()
+	calledResolveRepositories := false
+
+	generateRepoRevs := func (numRepos int) []*search.RepositoryRevisions {
+		repoRevs := make([]*search.RepositoryRevisions, numRepos)
+		chars := []string{"a","b","c"} // create some parent names
+		j := 0
+		for i := range repoRevs {
+			repoRevs[i] = &search.RepositoryRevisions{
+				Repo: &types.Repo{
+					ID: api.RepoID(i),
+					Name: api.RepoName(chars[j] + "/repoName" + strconv.Itoa(i)),
+				},
+			}
+			if j == 2 {
+				j = 0
+			} else {
+				j++
+			}
+		}
+		return repoRevs
+	}
+
+	setMockResolveRepositories := func (numRepos int) {
+		mockResolveRepositories = func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
+			calledResolveRepositories = true
+			missingRepoRevs = make([]*search.RepositoryRevisions, 0)
+			repoRevs = generateRepoRevs(numRepos)
+			return repoRevs, missingRepoRevs, true, nil
+		}
+	}
+	defer func() { mockResolveRepositories = nil }()
+
+	cases := []struct {
+		name      string
+		repoRevs  int
+		query	  string
+		wantAlert *searchAlert
+	}{
+		{
+			name:      "should return default alert",
+			repoRevs:  0,
+			query:	   "a query",
+			wantAlert: &searchAlert{
+				prometheusType: "over_repo_limit",
+				title:          "Too many matching repositories",
+				proposedQueries: nil,
+				description: 	 "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
+			},
+		},
+		{
+			name:      "should return default alert",
+			repoRevs:  1,
+			query:	   "a query",
+			wantAlert: &searchAlert{
+				prometheusType: "over_repo_limit",
+				title:          "Too many matching repositories",
+				proposedQueries: []*searchQueryDescription{
+					&searchQueryDescription{"in the repository a/repoName0",
+					"a query repo:^a/repoName0$",
+					query.SearchType(0),
+					},
+				},
+				description: 	 "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
+			},
+		},
+	}
+	for _, test := range cases {
+		setMockResolveRepositories(test.repoRevs)
+		calledResolveRepositories = false
+		q, err := query.ParseAndCheck(test.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sr := searchResolver{query: q}
+		alert := sr.alertForOverRepoLimit(ctx)
+
+		if !calledResolveRepositories {
+			t.Error("!calledSearchRepositories")
+		}
+		wantAlert := test.wantAlert
+		fmt.Println("YEYE", alert)
+		fmt.Println("YEYE", test.wantAlert)
+		if !reflect.DeepEqual(alert, wantAlert) {
+			t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
+		}
+		//if alert.title != wantAlert.title || alert.description != wantAlert.description || alert.prometheusType != wantAlert.prometheusType {
+		//	t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
+		//}
+		//for i, wantQuery := range wantAlert.proposedQueries {
+		//	query := alert.proposedQueries[i]
+		//	if wantQuery.description != query.description || wantQuery.patternType != query.patternType || wantQuery.query != query.query {
+		//		t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
+		//	}
+		//}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -200,14 +200,14 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	ctx := context.Background()
 	calledResolveRepositories := false
 
-	generateRepoRevs := func (numRepos int) []*search.RepositoryRevisions {
+	generateRepoRevs := func(numRepos int) []*search.RepositoryRevisions {
 		repoRevs := make([]*search.RepositoryRevisions, numRepos)
-		chars := []string{"a","b","c"} // create some parent names
+		chars := []string{"a", "b", "c"} // create some parent names
 		j := 0
 		for i := range repoRevs {
 			repoRevs[i] = &search.RepositoryRevisions{
 				Repo: &types.Repo{
-					ID: api.RepoID(i),
+					ID:   api.RepoID(i),
 					Name: api.RepoName(chars[j] + "/repoName" + strconv.Itoa(i)),
 				},
 			}
@@ -220,7 +220,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 		return repoRevs
 	}
 
-	setMockResolveRepositories := func (numRepos int) {
+	setMockResolveRepositories := func(numRepos int) {
 		mockResolveRepositories = func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
 			calledResolveRepositories = true
 			missingRepoRevs = make([]*search.RepositoryRevisions, 0)
@@ -233,34 +233,34 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	cases := []struct {
 		name      string
 		repoRevs  int
-		query	  string
+		query     string
 		wantAlert *searchAlert
 	}{
 		{
-			name:      "should return default alert",
-			repoRevs:  0,
-			query:	   "a query",
+			name:     "should return default alert",
+			repoRevs: 0,
+			query:    "a query",
 			wantAlert: &searchAlert{
-				prometheusType: "over_repo_limit",
-				title:          "Too many matching repositories",
+				prometheusType:  "over_repo_limit",
+				title:           "Too many matching repositories",
 				proposedQueries: nil,
-				description: 	 "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
+				description:     "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
 			},
 		},
 		{
-			name:      "should return default alert",
-			repoRevs:  1,
-			query:	   "a query",
+			name:     "should return default alert",
+			repoRevs: 1,
+			query:    "a query",
 			wantAlert: &searchAlert{
 				prometheusType: "over_repo_limit",
 				title:          "Too many matching repositories",
 				proposedQueries: []*searchQueryDescription{
 					&searchQueryDescription{"in the repository a/repoName0",
-					"a query repo:^a/repoName0$",
-					query.SearchType(0),
+						"a query repo:^a/repoName0$",
+						query.SearchType(0),
 					},
 				},
-				description: 	 "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
+				description: "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
 			},
 		},
 	}
@@ -278,19 +278,8 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 			t.Error("!calledSearchRepositories")
 		}
 		wantAlert := test.wantAlert
-		fmt.Println("YEYE", alert)
-		fmt.Println("YEYE", test.wantAlert)
 		if !reflect.DeepEqual(alert, wantAlert) {
 			t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
 		}
-		//if alert.title != wantAlert.title || alert.description != wantAlert.description || alert.prometheusType != wantAlert.prometheusType {
-		//	t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
-		//}
-		//for i, wantQuery := range wantAlert.proposedQueries {
-		//	query := alert.proposedQueries[i]
-		//	if wantQuery.description != query.description || wantQuery.patternType != query.patternType || wantQuery.query != query.query {
-		//		t.Fatalf("test %s, have alert %+v, want: %+v", test.name, alert, test.wantAlert)
-		//	}
-		//}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -255,7 +255,8 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				prometheusType: "over_repo_limit",
 				title:          "Too many matching repositories",
 				proposedQueries: []*searchQueryDescription{
-					&searchQueryDescription{"in the repository a/repoName0",
+					&searchQueryDescription{
+						"in the repository a/repoName0",
 						"a query repo:^a/repoName0$",
 						query.SearchType(0),
 					},

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1139,10 +1139,7 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 		return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 	}
 	if overLimit {
-		alert, err := r.alertForOverRepoLimit(ctx)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+		alert := r.alertForOverRepoLimit(ctx)
 		return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 	}
 	return repos, missingRepoRevs, nil, nil


### PR DESCRIPTION
This PR adds some improvements and tests on [alertForOverRepoLimit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@master/-/blob/cmd/frontend/graphqlbackend/search_alert.go#L344-451). This is a continuation of the refactors made by @rvantonder on [#8874](https://github.com/sourcegraph/sourcegraph/pull/8874).

Fixes #9640 