### PR TITLE
discussions: deprecate GraphQL and config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+- The experimental feature discussions is marked as deprecated. GraphQL and configuration fields related to it will be removed in 3.16. [#9649](https://github.com/sourcegraph/sourcegraph/issues/9649)
+
 ## 3.14.2
 
 ### Fixed

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -354,7 +354,9 @@ type Mutation {
     ): Boolean!
     # Manages discussions.
     discussions: DiscussionsMutation
-        @deprecated(reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649")
+        @deprecated(
+            reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649"
+        )
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -354,6 +354,7 @@ type Mutation {
     ): Boolean!
     # Manages discussions.
     discussions: DiscussionsMutation
+        @deprecated(reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649")
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -356,7 +356,9 @@ type Mutation {
     ): Boolean!
     # Manages discussions.
     discussions: DiscussionsMutation
-        @deprecated(reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649")
+        @deprecated(
+            reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649"
+        )
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -356,6 +356,7 @@ type Mutation {
     ): Boolean!
     # Manages discussions.
     discussions: DiscussionsMutation
+        @deprecated(reason: "discussions will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649")
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -313,7 +313,7 @@ type DebugLog struct {
 	ExtsvcGitlab bool `json:"extsvc.gitlab,omitempty"`
 }
 
-// Discussions description: Configures Sourcegraph code discussions.
+// Discussions description: DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Configures Sourcegraph code discussions.
 type Discussions struct {
 	// AbuseEmails description: Email addresses to notify of e.g. new user reports about abusive comments. Otherwise emails will not be sent.
 	AbuseEmails []string `json:"abuseEmails,omitempty"`
@@ -377,7 +377,7 @@ type ExperimentalFeatures struct {
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
-	// Discussions description: Enables the code discussions experiment.
+	// Discussions description: DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Enables the code discussions experiment.
 	Discussions string `json:"discussions,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
@@ -943,7 +943,7 @@ type SiteConfiguration struct {
 	DisableNonCriticalTelemetry bool `json:"disableNonCriticalTelemetry,omitempty"`
 	// DisablePublicRepoRedirects description: Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.
 	DisablePublicRepoRedirects bool `json:"disablePublicRepoRedirects,omitempty"`
-	// Discussions description: Configures Sourcegraph code discussions.
+	// Discussions description: DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Configures Sourcegraph code discussions.
 	Discussions *Discussions `json:"discussions,omitempty"`
 	// DontIncludeSymbolResultsByDefault description: Set to `true` to not include symbol results if no `type:` filter was given
 	DontIncludeSymbolResultsByDefault bool `json:"dontIncludeSymbolResultsByDefault,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -50,7 +50,7 @@
       "additionalProperties": false,
       "properties": {
         "discussions": {
-          "description": "Enables the code discussions experiment.",
+          "description": "DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Enables the code discussions experiment.",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
@@ -512,7 +512,7 @@
       "group": "Extensions"
     },
     "discussions": {
-      "description": "Configures Sourcegraph code discussions.",
+      "description": "DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Configures Sourcegraph code discussions.",
       "type": "object",
       "properties": {
         "abuseProtection": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -55,7 +55,7 @@ const SiteSchemaJSON = `{
       "additionalProperties": false,
       "properties": {
         "discussions": {
-          "description": "Enables the code discussions experiment.",
+          "description": "DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Enables the code discussions experiment.",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
@@ -517,7 +517,7 @@ const SiteSchemaJSON = `{
       "group": "Extensions"
     },
     "discussions": {
-      "description": "Configures Sourcegraph code discussions.",
+      "description": "DEPRECATED. Will be removed in 3.16. https://github.com/sourcegraph/sourcegraph/issues/9649. Configures Sourcegraph code discussions.",
       "type": "object",
       "properties": {
         "abuseProtection": {


### PR DESCRIPTION
This makes it easy to cleanly remove discussions code once we start working on
3.16.

Part of https://github.com/sourcegraph/sourcegraph/issues/9649 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
