### PR TITLE
bitbucket: Switch to rate limit registry

### DIFF
--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -1020,6 +1020,16 @@ func (r *RateLimiterRegistry) updateRateLimiter(svc *ExternalService) error {
 				limit = rate.Inf
 			}
 		}
+	case *schema.BitbucketServerConnection:
+		// 8/s is the default limit we enforce
+		limit = rate.Limit(8)
+		if c != nil && c.RateLimit != nil {
+			if c.RateLimit.Enabled {
+				limit = rate.Limit(c.RateLimit.RequestsPerHour / 3600)
+			} else {
+				limit = rate.Inf
+			}
+		}
 	default:
 		return fmt.Errorf("internal rate limiting not support for %s", svc.Kind)
 	}

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -1030,6 +1030,16 @@ func (r *RateLimiterRegistry) updateRateLimiter(svc *ExternalService) error {
 				limit = rate.Inf
 			}
 		}
+	case *schema.BitbucketCloudConnection:
+		// 2/s is the default limit we enforce
+		limit = rate.Limit(2)
+		if c != nil && c.RateLimit != nil {
+			if c.RateLimit.Enabled {
+				limit = rate.Limit(c.RateLimit.RequestsPerHour / 3600)
+			} else {
+				limit = rate.Inf
+			}
+		}
 	default:
 		return fmt.Errorf("internal rate limiting not support for %s", svc.Kind)
 	}

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -40,8 +40,8 @@ const (
 
 // Global limiter cache so that we reuse the same rate limiter for
 // the same code host, even between config changes.
-// The longer term plan is to have a rate limiter that is shared across
-// all services so the below is just a short term solution.
+// This is a failsafe to protect bitbucket as they do not impose their own
+// rate limiting.
 var limiterMu sync.Mutex
 var limiterCache = make(map[string]*rate.Limiter)
 

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -31,7 +31,7 @@
       "examples": ["https://api.bitbucket.org"]
     },
     "rateLimit": {
-      "description": "Rate limit applied when making background API requests to BitbucketCloud.",
+      "description": "Rate limit applied when making background API requests to Bitbucket Cloud.",
       "title": "BitbucketCloudRateLimit",
       "type": "object",
       "required": ["enabled", "requestsPerHour"],

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -30,6 +30,29 @@
       "format": "uri",
       "examples": ["https://api.bitbucket.org"]
     },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to BitbucketCloud.",
+      "title": "BitbucketCloudRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 7200,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 7200
+      }
+    },
     "username": {
       "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",
       "type": "string"

--- a/schema/bitbucket_cloud_stringdata.go
+++ b/schema/bitbucket_cloud_stringdata.go
@@ -36,7 +36,7 @@ const BitbucketCloudSchemaJSON = `{
       "examples": ["https://api.bitbucket.org"]
     },
     "rateLimit": {
-      "description": "Rate limit applied when making background API requests to BitbucketCloud.",
+      "description": "Rate limit applied when making background API requests to Bitbucket Cloud.",
       "title": "BitbucketCloudRateLimit",
       "type": "object",
       "required": ["enabled", "requestsPerHour"],

--- a/schema/bitbucket_cloud_stringdata.go
+++ b/schema/bitbucket_cloud_stringdata.go
@@ -35,6 +35,29 @@ const BitbucketCloudSchemaJSON = `{
       "format": "uri",
       "examples": ["https://api.bitbucket.org"]
     },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to BitbucketCloud.",
+      "title": "BitbucketCloudRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "type": "number",
+          "default": 7200,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 7200
+      }
+    },
     "username": {
       "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",
       "type": "string"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -127,7 +127,7 @@ type BitbucketCloudConnection struct {
 	//
 	// If "ssh", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
 	GitURLType string `json:"gitURLType,omitempty"`
-	// RateLimit description: Rate limit applied when making background API requests to BitbucketCloud.
+	// RateLimit description: Rate limit applied when making background API requests to Bitbucket Cloud.
 	RateLimit *BitbucketCloudRateLimit `json:"rateLimit,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.
 	//
@@ -145,7 +145,7 @@ type BitbucketCloudConnection struct {
 	Username string `json:"username"`
 }
 
-// BitbucketCloudRateLimit description: Rate limit applied when making background API requests to BitbucketCloud.
+// BitbucketCloudRateLimit description: Rate limit applied when making background API requests to Bitbucket Cloud.
 type BitbucketCloudRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -127,6 +127,8 @@ type BitbucketCloudConnection struct {
 	//
 	// If "ssh", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
 	GitURLType string `json:"gitURLType,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to BitbucketCloud.
+	RateLimit *BitbucketCloudRateLimit `json:"rateLimit,omitempty"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.
 	//
 	//  - "{host}" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and "{nameWithOwner}" is replaced with the Bitbucket Cloud repository's "owner/path" (such as "myorg/myrepo").
@@ -141,6 +143,14 @@ type BitbucketCloudConnection struct {
 	Url string `json:"url"`
 	// Username description: The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding "appPassword" field.
 	Username string `json:"username"`
+}
+
+// BitbucketCloudRateLimit description: Rate limit applied when making background API requests to BitbucketCloud.
+type BitbucketCloudRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // BitbucketServerAuthorization description: If non-null, enforces Bitbucket Server repository permissions.


### PR DESCRIPTION
We'll now explicitly check rate limiting at different layer, specifically
when running background changeset and permission syncers. We still keep
the old failsafe rate limiter in place because Bitbucket doesn't provide
rate limiting on their side.

This change makes the way rate limiting works across different code
hosts more consistent.

Part of: https://github.com/sourcegraph/sourcegraph/issues/8546