### PR TITLE
Fix some unsafe uses of any

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,8 @@
       "problemMatcher": [],
     },
     {
-      "label": "eslint all",
+      "label": "ESLint all",
+      "detail": "Run ESLint once on all TypeScript projects in parallel to get problems in the problems panel",
       "dependsOn": [
         "eslint:web",
         "eslint:shared",

--- a/browser/src/extension/scripts/background.ts
+++ b/browser/src/extension/scripts/background.ts
@@ -154,8 +154,8 @@ async function main(): Promise<void> {
     }
 
     // Handle calls from other scripts
-    browser.runtime.onMessage.addListener(async message => {
-        const method = message.type as keyof typeof handlers
+    browser.runtime.onMessage.addListener(async (message: { type: keyof BackgroundMessageHandlers; payload: any }) => {
+        const method = message.type
         if (!handlers[method]) {
             throw new Error(`Invalid RPC call for "${method}"`)
         }

--- a/browser/src/libs/bitbucket/api.ts
+++ b/browser/src/libs/bitbucket/api.ts
@@ -25,7 +25,8 @@ const buildURL = (project: string, repoSlug: string, path: string): string =>
         project
     )}/repos/${repoSlug}${path}`
 
-const get = <T>(url: string): Observable<T> => fromFetch(url, undefined, response => checkOk(response).json())
+const get = <T>(url: string): Observable<T> =>
+    fromFetch(url, undefined, response => checkOk(response).json() as Promise<T>)
 
 interface Repo {
     project: { key: string }

--- a/browser/src/libs/code_intelligence/util/selections.ts
+++ b/browser/src/libs/code_intelligence/util/selections.ts
@@ -9,5 +9,8 @@ export function getSelectionsFromHash(): Selection[] {
 }
 
 export function observeSelectionsFromHash(): Observable<Selection[]> {
-    return fromEvent(window, 'hashchange').pipe(map(getSelectionsFromHash), distinctUntilChanged(isEqual))
+    return fromEvent(window, 'hashchange').pipe(
+        map(getSelectionsFromHash),
+        distinctUntilChanged((a, b) => isEqual(a, b))
+    )
 }

--- a/browser/src/libs/gitlab/api.ts
+++ b/browser/src/libs/gitlab/api.ts
@@ -38,7 +38,8 @@ interface DiffVersionsResponse {
 const buildURL = (owner: string, projectName: string, path: string): string =>
     `${window.location.origin}/api/v4/projects/${encodeURIComponent(owner)}%2f${projectName}${path}`
 
-const get = <T>(url: string): Observable<T> => fromFetch(url, undefined, response => checkOk(response).json())
+const get = <T>(url: string): Observable<T> =>
+    fromFetch(url, undefined, response => checkOk(response).json() as Promise<T>)
 
 const getRepoNameFromProjectID = memoizeObservable(
     (projectId: string): Observable<string> =>

--- a/browser/src/platform/context.ts
+++ b/browser/src/platform/context.ts
@@ -17,6 +17,7 @@ import { createExtensionHost } from './extensionHost'
 import { editClientSettings, fetchViewerSettings, mergeCascades, storageSettingsCascade } from './settings'
 import { requestGraphQLHelper } from '../shared/backend/requestGraphQL'
 import { failedWithHTTPStatus } from '../../../shared/src/backend/fetch'
+import { asError } from '../../../shared/src/util/errors'
 
 export interface SourcegraphIntegrationURLs {
     /**
@@ -125,7 +126,7 @@ export function createPlatformContext(
             try {
                 await updateSettings(context, subject, edit, mutateSettings)
             } catch (error) {
-                if ('message' in error && error.message.includes('version mismatch')) {
+                if (asError(error).message.includes('version mismatch')) {
                     // The user probably edited the settings in another tab, so
                     // try once more.
                     await context.refreshSettings()

--- a/shared/src/api/extension/api/common.ts
+++ b/shared/src/api/extension/api/common.ts
@@ -2,7 +2,7 @@ import { ProxyResult, ProxyValue, proxyValue, proxyValueSymbol, UnproxyOrClone }
 import { from, isObservable, Observable, Observer, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { ProviderResult, Subscribable, Unsubscribable } from 'sourcegraph'
-import { isPromise, isSubscribable } from '../../util'
+import { isPromiseLike, isSubscribable } from '../../util'
 
 /**
  * A Subscribable that can be exposed by comlink to the other thread.
@@ -54,7 +54,7 @@ export function toProxyableSubscribable<T, R>(
     mapFunc: (value: T | undefined | null) => R
 ): ProxySubscribable<R> {
     let observable: Observable<R>
-    if (result && (isPromise(result) || isObservable<T>(result) || isSubscribable(result))) {
+    if (result && (isPromiseLike(result) || isObservable<T>(result) || isSubscribable(result))) {
         observable = from(result).pipe(map(mapFunc))
     } else {
         observable = of(mapFunc(result))

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -91,20 +91,20 @@ function initializeExtensionHost(
     subscription.add(apiSubscription)
 
     // Make `import 'sourcegraph'` or `require('sourcegraph')` return the extension API.
-    ;(global as any).require = (modulePath: string): any => {
+    globalThis.require = ((modulePath: string): any => {
         if (modulePath === 'sourcegraph') {
             return extensionAPI
         }
         // All other requires/imports in the extension's code should not reach here because their JS
         // bundler should have resolved them locally.
         throw new Error(`require: module not found: ${modulePath}`)
-    }
+    }) as any
     subscription.add(() => {
-        ;(global as any).require = () => {
+        globalThis.require = (() => {
             // Prevent callers from attempting to access the extension API after it was
             // unsubscribed.
             throw new Error('require: Sourcegraph extension API was unsubscribed')
-        }
+        }) as any
     })
 
     return { subscription, extensionAPI, extensionHostAPI }

--- a/shared/src/api/extension/main.worker.ts
+++ b/shared/src/api/extension/main.worker.ts
@@ -5,6 +5,7 @@ import { fromEvent } from 'rxjs'
 import { take } from 'rxjs/operators'
 import { EndpointPair, isEndpointPair } from '../../platform/context'
 import { startExtensionHost } from './extensionHost'
+import { hasProperty } from '../../util/types'
 
 interface InitMessage {
     endpoints: {
@@ -20,7 +21,8 @@ interface InitMessage {
     wrapEndpoints: boolean
 }
 
-const isInitMessage = (value: any): value is InitMessage => value.endpoints && isEndpointPair(value.endpoints)
+const isInitMessage = (value: unknown): value is InitMessage =>
+    typeof value === 'object' && value !== null && hasProperty('endpoints')(value) && isEndpointPair(value.endpoints)
 
 const wrapMessagePort = (port: MessagePort): MessagePort =>
     MessageChannelAdapter.wrap({

--- a/shared/src/api/util.test.ts
+++ b/shared/src/api/util.test.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs'
-import { isPromise, isSubscribable, tryCatchPromise } from './util'
+import { isPromiseLike, isSubscribable, tryCatchPromise } from './util'
 
 describe('tryCatchPromise', () => {
     test('returns a resolved promise with the synchronous result', async () =>
@@ -15,7 +15,9 @@ describe('tryCatchPromise', () => {
         })
         let rejected: any
         return p
-            .then(undefined, v => (rejected = v))
+            .then(undefined, v => {
+                rejected = v
+            })
             .then(() => {
                 expect(rejected).toBe(ERROR)
             })
@@ -25,7 +27,9 @@ describe('tryCatchPromise', () => {
         const p = tryCatchPromise(() => Promise.reject(ERROR))
         let rejected: any
         return p
-            .then(undefined, v => (rejected = v))
+            .then(undefined, v => {
+                rejected = v
+            })
             .then(() => {
                 expect(rejected).toBe(ERROR)
             })
@@ -35,16 +39,16 @@ describe('tryCatchPromise', () => {
 describe('isPromise', () => {
     test('returns true for promises', () =>
         expect(
-            isPromise(
+            isPromiseLike(
                 new Promise<any>(() => {
                     /* noop */
                 })
             )
         ).toBe(true))
     test('returns true for non-promises', () => {
-        expect(isPromise(1)).toBe(false)
-        expect(isPromise({ then: 1 })).toBe(false)
-        expect(isPromise(new Subject<any>())).toBe(false)
+        expect(isPromiseLike(1)).toBe(false)
+        expect(isPromiseLike({ then: 1 })).toBe(false)
+        expect(isPromiseLike(new Subject<any>())).toBe(false)
     })
 })
 

--- a/shared/src/api/util.ts
+++ b/shared/src/api/util.ts
@@ -1,14 +1,18 @@
 import { ProxiedObject, ProxyValue, transferHandlers } from '@sourcegraph/comlink'
 import { Subscription } from 'rxjs'
 import { Subscribable, Unsubscribable } from 'sourcegraph'
+import { hasProperty } from '../util/types'
 
 /**
  * Tests whether a value is a WHATWG URL object.
  */
-export const isURL = (value: any): value is URL =>
-    typeof value !== 'undefined' &&
+export const isURL = (value: unknown): value is URL =>
+    typeof value === 'object' &&
     value !== null &&
+    hasProperty('href')(value) &&
+    hasProperty('toString')(value) &&
     typeof value.toString === 'function' &&
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     value.href === value.toString()
 
 /**
@@ -20,6 +24,7 @@ export function registerComlinkTransferHandlers(): void {
     transferHandlers.set('URL', {
         canHandle: isURL,
         // TODO the comlink types could be better here to avoid the any
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
         serialize: (url: any) => url.href,
         deserialize: (urlString: any) => new URL(urlString),
     })
@@ -51,13 +56,14 @@ export const tryCatchPromise = async <T>(f: () => T | Promise<T>): Promise<T> =>
 /**
  * Reports whether value is a Promise.
  */
-export function isPromise(value: any): value is Promise<any> {
-    return typeof value.then === 'function'
-}
+export const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+    typeof value === 'object' && value !== null && hasProperty('then')(value) && typeof value.then === 'function'
 
 /**
  * Reports whether value is a {@link sourcegraph.Subscribable}.
  */
-export function isSubscribable(value: any): value is Subscribable<any> {
-    return typeof value.subscribe === 'function'
-}
+export const isSubscribable = (value: unknown): value is Subscribable<unknown> =>
+    typeof value === 'object' &&
+    value !== null &&
+    hasProperty('subscribe')(value) &&
+    typeof value.subscribe === 'function'

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -1,7 +1,7 @@
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
 import H from 'history'
-import { isArray, sortBy, uniq, uniqueId } from 'lodash'
+import { sortBy, uniq, uniqueId } from 'lodash'
 import MenuDownIcon from 'mdi-react/MenuDownIcon'
 import MenuIcon from 'mdi-react/MenuIcon'
 import MenuUpIcon from 'mdi-react/MenuUpIcon'
@@ -88,9 +88,9 @@ export class CommandList extends React.PureComponent<CommandListProps, State> {
             return null
         }
         try {
-            const recentActions = JSON.parse(value)
-            if (isArray(recentActions) && recentActions.every(a => typeof a === 'string')) {
-                return recentActions
+            const recentActions: unknown = JSON.parse(value)
+            if (Array.isArray(recentActions) && recentActions.every(a => typeof a === 'string')) {
+                return recentActions as string[]
             }
             return null
         } catch (err) {

--- a/shared/src/e2e/console.ts
+++ b/shared/src/e2e/console.ts
@@ -51,16 +51,17 @@ export async function formatPuppeteerConsoleMessage(message: ConsoleMessage): Pr
                             try {
                                 const json = await (
                                     await argHandle.evaluateHandle(value =>
-                                        JSON.stringify(value, (key, value) => {
+                                        JSON.stringify(value, (key, value: unknown) => {
                                             // Check if value is error, because Errors are not serializable but commonly logged
-                                            if (Object.prototype.toString.call(value) === '[object Error]') {
+                                            if (value instanceof Error) {
                                                 return value.stack
                                             }
                                             return value
                                         })
                                     )
                                 ).jsonValue()
-                                return JSON.parse(json)
+                                const parsed: unknown = JSON.parse(json)
+                                return parsed
                             } catch (err) {
                                 return chalk.italic(`[Could not serialize: ${asError(err).message}]`)
                             }

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -8,7 +8,7 @@ import { Badged, MarkupContent } from 'sourcegraph'
 import { ActionItem, ActionItemAction, ActionItemComponentProps } from '../actions/ActionItem'
 import { HoverMerged } from '../api/client/types/hover'
 import { TelemetryProps } from '../telemetry/telemetryService'
-import { isErrorLike } from '../util/errors'
+import { isErrorLike, asError } from '../util/errors'
 import { highlightCodeSafe, renderMarkdown } from '../util/markdown'
 import { sanitizeClass } from '../util/strings'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../util/url'
@@ -242,7 +242,7 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                                                     )}
                                                     key={i}
                                                 >
-                                                    {upperFirst(err.message)}
+                                                    {upperFirst(asError(err).message)}
                                                 </div>
                                             )
                                         }

--- a/shared/src/settings/settings.ts
+++ b/shared/src/settings/settings.ts
@@ -18,6 +18,9 @@ export interface IClient {
  */
 export interface Settings {
     extensions?: { [extensionID: string]: boolean }
+    experimentalFeatures?: {
+        showBadgeAttachments?: boolean
+    }
     [key: string]: any
 
     // These properties should never exist on Settings but do exist on SettingsCascade. This makes it so the

--- a/shared/src/util/LocalStorageSubject.ts
+++ b/shared/src/util/LocalStorageSubject.ts
@@ -39,7 +39,7 @@ function parseValue<T>(v: string | null, defaultValue: T): T {
         return defaultValue
     }
     try {
-        return JSON.parse(v)
+        return JSON.parse(v) as T
     } catch (err) {
         return defaultValue
     }

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -4,21 +4,21 @@ export interface ErrorLike {
 }
 
 export const isErrorLike = (val: unknown): val is ErrorLike =>
-    typeof val === 'object' && !!val && ('stack' in val || 'message' in val) && !('__typename' in val)
+    typeof val === 'object' && val !== null && ('stack' in val || 'message' in val) && !('__typename' in val)
 
 /**
  * Converts an ErrorLike to a proper Error if needed, copying all properties
  *
- * @param errorLike An Error or object with ErrorLike properties
+ * @param value An Error, object with ErrorLike properties, or other value.
  */
-export const asError = (err: any): Error => {
-    if (err instanceof Error) {
-        return err
+export const asError = (value: unknown): Error => {
+    if (value instanceof Error) {
+        return value
     }
-    if (typeof err === 'object' && err !== null) {
-        return Object.assign(new Error(err.message), err)
+    if (isErrorLike(value)) {
+        return Object.assign(new Error(value.message), value)
     }
-    return new Error(err)
+    return new Error(String(value))
 }
 
 /**

--- a/shared/src/util/searchTestHelpers.ts
+++ b/shared/src/util/searchTestHelpers.ts
@@ -1,26 +1,36 @@
 import { of } from 'rxjs'
 import sinon from 'sinon'
 import { Controller } from '../extensions/controller'
+import {
+    ISearchResults,
+    IFileMatch,
+    ILineMatch,
+    IGitBlob,
+    IGitCommit,
+    IRepository,
+    ISymbol,
+    SearchResult,
+} from '../graphql/schema'
 
 export const RESULT = {
-    __typename: 'FileMatch',
+    __typename: 'FileMatch' as const,
     file: {
         path: '.travis.yml',
         url: '/github.com/golang/oauth2/-/blob/.travis.yml',
-        commit: { oid: 'e64efc72b421e893cbf63f17ba2221e7d6d0b0f3' },
-    },
-    repository: { name: 'github.com/golang/oauth2', url: '/github.com/golang/oauth2' },
+        commit: { oid: 'e64efc72b421e893cbf63f17ba2221e7d6d0b0f3' } as IGitCommit,
+    } as IGitBlob,
+    repository: { name: 'github.com/golang/oauth2', url: '/github.com/golang/oauth2' } as IRepository,
     limitHit: false,
-    symbols: [],
+    symbols: [] as ISymbol[],
     lineMatches: [
         {
             preview: '  - go test -v golang.org/x/oauth2/...',
             lineNumber: 12,
             offsetAndLengths: [[7, 4]],
             limitHit: false,
-        },
+        } as ILineMatch,
     ],
-}
+} as IFileMatch
 
 export const MULTIPLE_MATCH_RESULT = {
     __typename: 'FileMatch',
@@ -105,13 +115,13 @@ export const MULTIPLE_MATCH_RESULT = {
 }
 
 export const SEARCH_RESULT = {
-    __typename: 'SearchResults',
+    __typename: 'SearchResults' as const,
     limitHit: false,
     resultCount: 1,
     approximateResultCount: '1',
-    missing: [],
-    cloning: [],
-    timedout: [],
+    missing: [] as IRepository[],
+    cloning: [] as IRepository[],
+    timedout: [] as IRepository[],
     indexUnavailable: false,
     dynamicFilters: [
         { value: 'file:\\.yml$', label: 'file:\\.yml$', count: 1, limitHit: false, kind: 'file' },
@@ -127,7 +137,7 @@ export const SEARCH_RESULT = {
     results: [RESULT],
     alert: null,
     elapsedMilliseconds: 78,
-}
+} as ISearchResults
 
 export const MULTIPLE_SEARCH_RESULT = {
     ...SEARCH_RESULT,
@@ -144,29 +154,29 @@ export const MULTIPLE_SEARCH_RESULT = {
                 url: '/github.com/golang/oauth2/-/blob/example_test.go',
                 commit: {
                     oid: 'e64efc72b421e893cbf63f17ba2221e7d6d0b0f3',
-                },
-            },
+                } as IGitCommit,
+            } as IGitBlob,
             repository: {
                 name: 'github.com/golang/oauth2',
                 url: '/github.com/golang/oauth2',
-            },
+            } as IRepository,
             limitHit: false,
-            symbols: [],
+            symbols: [] as ISymbol[],
             lineMatches: [
                 {
                     preview: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
-                },
+                } as ILineMatch,
             ],
-        },
-    ],
-}
+        } as IFileMatch,
+    ] as SearchResult[],
+} as ISearchResults
 
 // Result from query: repo:^github\.com/golang/oauth2$ test f:travis
-export const SEARCH_REQUEST = sinon.fake.returns(SEARCH_RESULT)
-export const MULTIPLE_SEARCH_REQUEST = sinon.fake.returns(MULTIPLE_SEARCH_RESULT)
-export const OBSERVABLE_SEARCH_REQUEST = sinon.fake.returns(of(SEARCH_RESULT))
+export const SEARCH_REQUEST = sinon.spy(() => SEARCH_RESULT)
+export const MULTIPLE_SEARCH_REQUEST = sinon.spy(() => MULTIPLE_SEARCH_RESULT)
+export const OBSERVABLE_SEARCH_REQUEST = sinon.spy(() => of(SEARCH_RESULT))
 
 export const HIGHLIGHTED_FILE_LINES = [
     '<tr><td class="line" data-line="1"></td><td class="code"><span style="color:#268bd2;">language</span><span style="color:#657b83;">: </span><span style="color:#2aa198;">go↵</span></td></tr>',

--- a/shared/src/util/types.ts
+++ b/shared/src/util/types.ts
@@ -26,6 +26,15 @@ export const isNot = <TInput, TExclude extends TInput>(isType: (val: TInput) => 
  * Returns a function that returns `true` if the given `key` of the object passes the given type guard.
  *
  * @param key The key of the property to check.
+ */
+export const hasProperty = <O extends object, K extends string | number | symbol>(key: K) => (
+    object: O
+): object is O & { [k in K]: unknown } => key in object
+
+/**
+ * Returns a function that returns `true` if the given `key` of the object passes the given type guard.
+ *
+ * @param key The key of the property to check.
  * @param isType The type guard to evalute on the property value.
  */
 export const property = <O extends object, K extends keyof O, T extends O[K]>(

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -57,6 +57,7 @@ import { RepoSettingsSideBarItem } from './repo/settings/RepoSettingsSidebar'
 import { FiltersToTypeAndValue } from '../../shared/src/search/interactive/util'
 import { generateFiltersQuery } from '../../shared/src/util/url'
 import { NotificationType } from '../../shared/src/api/client/services/notifications'
+import { SettingsExperimentalFeatures } from './schema/settings.schema'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
     exploreSections: readonly ExploreSectionDescriptor[]
@@ -277,8 +278,10 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         this.subscriptions.add(
             from(this.platformContext.settings).subscribe(settingsCascade => {
                 if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-                    const { splitSearchModes, smartSearchField } = settingsCascade.final.experimentalFeatures || {}
-                    this.setState({ splitSearchModes: splitSearchModes !== false, smartSearchField })
+                    const experimentalFeatures: SettingsExperimentalFeatures =
+                        settingsCascade.final.experimentalFeatures || {}
+                    const { splitSearchModes = true, smartSearchField = false } = experimentalFeatures
+                    this.setState({ splitSearchModes, smartSearchField })
                 }
             })
         )

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'
 import React from 'react'
-import { asError } from '../../../shared/src/util/errors'
+import { asError, isErrorLike } from '../../../shared/src/util/errors'
 import { HeroPage } from './HeroPage'
 
 interface Props {
@@ -99,6 +99,6 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
     }
 }
 
-function isWebpackChunkError(err: any): boolean {
-    return typeof err.request === 'string' && err.message.startsWith('Loading chunk')
+function isWebpackChunkError(value: unknown): boolean {
+    return isErrorLike(value) && value.name === 'ChunkLoadError'
 }

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -24,9 +24,11 @@ import { pluralize } from '../../../shared/src/util/strings'
 import { Form } from './Form'
 import { RadioButtons } from './RadioButtons'
 import { ErrorMessage } from './alerts'
+import { hasProperty } from '../../../shared/src/util/types'
 
 /** Checks if the passed value satisfies the GraphQL Node interface */
-const hasID = (obj: any): obj is { id: GQL.ID } => obj && typeof obj.id === 'string'
+const hasID = (value: unknown): value is { id: GQL.ID } =>
+    typeof value === 'object' && value !== null && hasProperty('id')(value) && typeof value.id === 'string'
 
 interface FilterProps {
     /** All filters. */

--- a/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
+++ b/web/src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx
@@ -10,7 +10,7 @@ import React from 'react'
  * precise.
  */
 export const LicenseGenerationKeyWarning: React.FunctionComponent<{ className?: string }> = ({ className = '' }) =>
-    (window as any).context.debug ? (
+    window.context.debug ? (
         <div className={`alert alert-warning ${className}`}>
             License keys generated in dev mode are <strong>NOT VALID</strong>.{' '}
             <a href="https://sourcegraph.com/site-admin/dotcom/product/subscriptions">

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -10,7 +10,7 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
-import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { createAggregateError, ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
@@ -132,7 +132,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
                     switchMap(([extensionID, forceRefresh]) => {
                         type PartialStateUpdate = Pick<ExtensionAreaState, 'extensionOrError'>
                         return queryExtension(extensionID).pipe(
-                            catchError(error => [error]),
+                            catchError((error): [ErrorLike] => [asError(error)]),
                             map((c): PartialStateUpdate => ({ extensionOrError: c })),
 
                             // Don't clear old data while we reload, to avoid unmounting all components during
@@ -224,7 +224,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
     private onDidUpdateExtension = (): void => this.refreshRequests.next()
 }
 
-function queryExtension(extensionID: string): Observable<ConfiguredRegistryExtension> {
+function queryExtension(extensionID: string): Observable<ConfiguredRegistryExtension<GQL.IRegistryExtension>> {
     return queryGraphQL(
         gql`
             query RegistryExtension($extensionID: String!) {

--- a/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -9,6 +9,7 @@ import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorAlert } from '../../components/alerts'
+import { hasProperty } from '../../../../shared/src/util/types'
 
 interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {}
 
@@ -68,11 +69,16 @@ function toContributionsGroups(manifest: ExtensionManifest): ContributionGroup[]
     const settingsGroup: ContributionGroup = { title: 'Settings', columnHeaders: ['Name', 'Description'], rows: [] }
     try {
         if (manifest.contributes.configuration && manifest.contributes.configuration.properties) {
-            for (const [name, schema] of Object.entries<any>(manifest.contributes.configuration.properties)) {
+            for (const [name, schema] of Object.entries(manifest.contributes.configuration.properties)) {
                 settingsGroup.rows.push([
                     // eslint-disable-next-line react/jsx-key
                     <code>{name}</code>,
-                    typeof schema.description === 'string' ? schema.description : null,
+                    typeof schema === 'object' &&
+                    schema !== null &&
+                    hasProperty('description')(schema) &&
+                    typeof schema.description === 'string'
+                        ? schema.description
+                        : null,
                 ])
             }
         }

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -6,11 +6,11 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { combineLatest, merge, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, mapTo, startWith, switchMap } from 'rxjs/operators'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
-import { gql } from '../../../../shared/src/graphql/graphql'
+import { gql, dataOrThrowErrors } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
-import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
@@ -22,7 +22,7 @@ import { PatternTypeProps } from '../../search'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorMessage } from '../../components/alerts'
 
-function queryOrganization(args: { name: string }): Observable<GQL.IOrg | null> {
+function queryOrganization(args: { name: string }): Observable<GQL.IOrg> {
     return queryGraphQL(
         gql`
             query Organization($name: String!) {
@@ -51,9 +51,10 @@ function queryOrganization(args: { name: string }): Observable<GQL.IOrg | null> 
         `,
         args
     ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.organization) {
-                throw createAggregateError(errors)
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.organization) {
+                throw new Error(`Organization not found: ${JSON.stringify(args.name)}`)
             }
             return data.organization
         })
@@ -133,7 +134,7 @@ export class OrgArea extends React.Component<Props> {
                     switchMap(([name, forceRefresh]) => {
                         type PartialStateUpdate = Pick<State, 'orgOrError'>
                         return queryOrganization({ name }).pipe(
-                            catchError(error => [error]),
+                            catchError((error): [ErrorLike] => [asError(error)]),
                             map((c): PartialStateUpdate => ({ orgOrError: c })),
 
                             // Don't clear old org data while we reload, to avoid unmounting all components during

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -6,7 +6,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../shared/src/platform/context'
 import { mutateSettings, updateSettings } from '../../../shared/src/settings/edit'
 import { gqlToCascade } from '../../../shared/src/settings/settings'
-import { createAggregateError } from '../../../shared/src/util/errors'
+import { createAggregateError, asError } from '../../../shared/src/util/errors'
 import { LocalStorageSubject } from '../../../shared/src/util/LocalStorageSubject'
 import { toPrettyBlobURL } from '../../../shared/src/util/url'
 import { queryGraphQL, requestGraphQL } from '../backend/graphql'
@@ -40,7 +40,7 @@ export function createPlatformContext(): PlatformContext {
             try {
                 await updateSettings(context, subject, edit, mutateSettings)
             } catch (error) {
-                if ('message' in error && error.message.includes('version mismatch')) {
+                if (asError(error).message.includes('version mismatch')) {
                     // The user probably edited the settings in another tab, so
                     // try once more.
                     updatedSettings.next(await fetchViewerSettings().toPromise())

--- a/web/src/regression/onboarding.test.ts
+++ b/web/src/regression/onboarding.test.ts
@@ -228,7 +228,7 @@ describe('Onboarding', () => {
         // Wait for status bar to appear but it should be invisible
         await driver.page.waitForFunction(
             statusBarSelector => {
-                const element = document.querySelector(statusBarSelector)
+                const element = document.querySelector<Element>(statusBarSelector)
                 if (!element) {
                     return false
                 }

--- a/web/src/regression/util/ScreenshotVerifier.ts
+++ b/web/src/regression/util/ScreenshotVerifier.ts
@@ -49,7 +49,7 @@ export class ScreenshotVerifier {
         if (waitForSelectorToBeVisibleTimeout > 0) {
             await this.driver.page.waitForFunction(
                 selector => {
-                    const element = document.querySelector(selector)
+                    const element = document.querySelector<Element>(selector)
                     if (!element) {
                         return false
                     }
@@ -62,7 +62,7 @@ export class ScreenshotVerifier {
         }
 
         const clip: BoundingBox | undefined = await this.driver.page.evaluate(selector => {
-            const element = document.querySelector(selector)
+            const element = document.querySelector<Element>(selector)
             if (!element) {
                 throw new Error(`element with selector ${JSON.stringify(selector)} not found`)
             }

--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -123,11 +123,7 @@ export async function createAuthProvider(
     const siteConfig = await fetchSiteConfiguration(gqlClient).toPromise()
     const siteConfigParsed: SiteConfiguration = jsonc.parse(siteConfig.configuration.effectiveContents)
     const authProviders = siteConfigParsed['auth.providers']
-    if (
-        authProviders &&
-        authProviders.filter(p => p.type === authProvider.type && (p as any).displayName === authProvider.displayName)
-            .length > 0
-    ) {
+    if (authProviders?.some(p => p.type === authProvider.type && (p as any).displayName === authProvider.displayName)) {
         return () => Promise.resolve() // provider already exists
     }
     const editFns = [
@@ -156,7 +152,7 @@ export async function ensureNewUser(
             await deleteUser({ requestGraphQL }, username)
         }
     } catch (err) {
-        if (!err.message.includes('user not found')) {
+        if (!asError(err).message.includes('user not found')) {
             throw err
         }
     }

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -9,7 +9,7 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
-import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { createAggregateError, ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../../shared/src/util/memoizeObservable'
 import {
     AbsoluteRepoFile,
@@ -155,9 +155,9 @@ export class BlobPage extends React.PureComponent<Props, State> {
                             isLightTheme,
                             disableTimeout: extendHighlightingTimeout,
                         }).pipe(
-                            catchError(error => {
+                            catchError((error): [ErrorLike] => {
                                 console.error(error)
-                                return [error]
+                                return [asError(error)]
                             })
                         )
                     )

--- a/web/src/repo/blob/discussions/DiscussionsInput.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsInput.tsx
@@ -188,7 +188,7 @@ export class DiscussionsInput extends React.PureComponent<Props, State> {
                                     return [
                                         state => ({
                                             ...state,
-                                            error: new Error('Error rendering Markdown: ' + error.message),
+                                            error: new Error('Error rendering Markdown: ' + asError(error).message),
                                             previewLoading: false,
                                         }),
                                     ]

--- a/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -6,7 +6,7 @@ import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
-import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { createAggregateError, ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../../shared/src/util/memoizeObservable'
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
@@ -91,7 +91,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                     switchMap(({ repo }) => {
                         type PartialStateUpdate = Pick<State, 'dataOrError'>
                         return queryGitBranches({ repo: repo.id, first: 10 }).pipe(
-                            catchError(error => [error]),
+                            catchError((error): [ErrorLike] => [asError(error)]),
                             map((c): PartialStateUpdate => ({ dataOrError: c })),
                             startWith<PartialStateUpdate>({ dataOrError: undefined })
                         )

--- a/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/web/src/repo/settings/RepoSettingsArea.tsx
@@ -13,6 +13,7 @@ import { fetchRepository } from './backend'
 import { RepoSettingsSidebar, RepoSettingsSideBarItems } from './RepoSettingsSidebar'
 import { RouteDescriptor } from '../../util/contributions'
 import { ErrorMessage } from '../../components/alerts'
+import { asError } from '../../../../shared/src/util/errors'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -62,7 +63,7 @@ export class RepoSettingsArea extends React.Component<Props> {
                 )
                 .subscribe(
                     repo => this.setState({ repo }),
-                    err => this.setState({ error: err.message })
+                    err => this.setState({ error: asError(err).message })
                 )
         )
         this.componentUpdates.next(this.props)

--- a/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -16,6 +16,7 @@ import { DirectImportRepoAlert } from '../DirectImportRepoAlert'
 import { fetchRepository } from './backend'
 import { ActionContainer, BaseActionContainer } from './components/ActionContainer'
 import { ErrorAlert } from '../../components/alerts'
+import { asError } from '../../../../shared/src/util/errors'
 
 interface UpdateMirrorRepositoryActionContainerProps {
     repo: GQL.IRepository
@@ -152,7 +153,11 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                     switchMap(() =>
                         checkMirrorRepositoryConnection({ repository: this.props.repo.id }).pipe(
                             catchError(error => {
-                                this.setState({ errorDescription: error.message, result: undefined, loading: false })
+                                this.setState({
+                                    errorDescription: asError(error).message,
+                                    result: undefined,
+                                    loading: false,
+                                })
                                 this.props.onDidUpdateReachability(false)
                                 return []
                             })
@@ -267,7 +272,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(
                 repo => this.setState({ repo }),
-                err => this.setState({ error: err.message })
+                err => this.setState({ error: asError(err).message })
             )
         )
     }

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -11,6 +11,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { fetchRepository } from './backend'
 import { ErrorAlert } from '../../components/alerts'
 import { defaultExternalServices } from '../../site-admin/externalServices'
+import { asError } from '../../../../shared/src/util/errors'
 
 interface Props extends RouteComponentProps<{}> {
     repo: GQL.IRepository
@@ -49,7 +50,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(
                 repo => this.setState({ repo }),
-                err => this.setState({ error: err.message })
+                err => this.setState({ error: asError(err).message })
             )
         )
     }

--- a/web/src/repo/settings/components/ActionContainer.tsx
+++ b/web/src/repo/settings/components/ActionContainer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { ErrorAlert } from '../../../components/alerts'
+import { asError } from '../../../../../shared/src/util/errors'
 
 export const BaseActionContainer: React.FunctionComponent<{
     title: React.ReactFragment
@@ -117,7 +118,7 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                 }
                 this.timeoutHandle = window.setTimeout(() => this.setState({ flash: false }), 1000)
             },
-            err => this.setState({ loading: false, error: err.message })
+            err => this.setState({ loading: false, error: asError(err).message })
         )
     }
 }

--- a/web/src/savedSearches/SavedSearchCreateForm.tsx
+++ b/web/src/savedSearches/SavedSearchCreateForm.tsx
@@ -4,7 +4,7 @@ import { concat, Subject, Subscription } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
+import { ErrorLike, isErrorLike, asError } from '../../../shared/src/util/errors'
 import { NamespaceProps } from '../namespaces'
 import { createSavedSearch } from '../search/backend'
 import { SavedQueryFields, SavedSearchForm } from './SavedSearchForm'
@@ -44,8 +44,8 @@ export class SavedSearchCreateForm extends React.Component<Props, State> {
                                 this.props.namespace.__typename === 'User' ? this.props.namespace.id : null,
                                 this.props.namespace.__typename === 'Org' ? this.props.namespace.id : null
                             ).pipe(
-                                map(() => true),
-                                catchError(error => [error])
+                                map(() => true as const),
+                                catchError((error): [ErrorLike] => [asError(error)])
                             )
                         )
                     )

--- a/web/src/search/ScopePage.tsx
+++ b/web/src/search/ScopePage.tsx
@@ -20,6 +20,7 @@ import { QueryInput } from './input/QueryInput'
 import { SearchButton } from './input/SearchButton'
 import { PatternTypeProps, CaseSensitivityProps } from '.'
 import { ErrorAlert } from '../components/alerts'
+import { asError } from '../../../shared/src/util/errors'
 
 const ScopeNotFound: React.FunctionComponent = () => (
     <HeroPage
@@ -94,7 +95,7 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
                                         map(repositories => ({ repositories, errorMessage: undefined })),
                                         catchError(err => {
                                             console.error(err)
-                                            return [{ errorMessage: err.message, repositories: [], first: 0 }]
+                                            return [{ errorMessage: asError(err).message, repositories: [], first: 0 }]
                                         })
                                     )
                                 )

--- a/web/src/search/queryTelemetry.tsx
+++ b/web/src/search/queryTelemetry.tsx
@@ -2,7 +2,8 @@ import { count } from '../../../shared/src/util/strings'
 import { parseSearchQuery, ParserResult, Sequence } from '../../../shared/src/search/parser/parser'
 import { resolveFilter } from '../../../shared/src/search/parser/filters'
 
-export function queryTelemetryData(query: string, caseSensitive: boolean): { [key: string]: any } {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function queryTelemetryData(query: string, caseSensitive: boolean) {
     return {
         // 🚨 PRIVACY: never provide any private data in { code_search: { query_data: { query } } }.
         query: query ? queryStringTelemetryData(query, caseSensitive) : undefined,
@@ -24,7 +25,8 @@ function filterExistsInQuery(parsedQuery: ParserResult<Sequence>, filterToMatch:
     }
     return false
 }
-function queryStringTelemetryData(q: string, caseSensitive: boolean): { [key: string]: any } {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function queryStringTelemetryData(q: string, caseSensitive: boolean) {
     // 🚨 PRIVACY: never provide any private data in this function's return value.
     // This only takes ~1.7ms per call, so it does not need to be optimized.
     const parsedQuery = parseSearchQuery(q)

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -18,7 +18,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
-import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { PageTitle } from '../../components/PageTitle'
 import { Settings } from '../../schema/settings.schema'
 import { ThemeProps } from '../../../../shared/src/theme'
@@ -181,7 +181,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                                         },
                                         error => {
                                             this.props.telemetryService.log('SearchResultsFetchFailed', {
-                                                code_search: { error_message: error.message },
+                                                code_search: { error_message: asError(error).message },
                                             })
                                             console.error(error)
                                         }

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -20,7 +20,7 @@ import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
-import { isDefined } from '../../../../shared/src/util/types'
+import { isDefined, hasProperty } from '../../../../shared/src/util/types'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { ModalContainer } from '../../components/ModalContainer'
 import { SearchResult } from '../../components/SearchResult'
@@ -31,7 +31,8 @@ import { shouldDisplayPerformanceWarning } from '../backend'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
 import { ErrorAlert } from '../../components/alerts'
 
-const isSearchResults = (val: any): val is GQL.ISearchResults => val && val.__typename === 'SearchResults'
+const isSearchResults = (val: unknown): val is GQL.ISearchResults =>
+    typeof val === 'object' && val !== null && hasProperty('__typename')(val) && val.__typename === 'SearchResults'
 
 export interface SearchResultsListProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -192,8 +192,11 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
     public static isStandaloneCodeEditor(
         editor: monaco.editor.ICodeEditor
     ): editor is monaco.editor.IStandaloneCodeEditor {
-        const editorAny = editor as any
-        return editor.getEditorType() === monaco.editor.EditorType.ICodeEditor && editorAny.addAction
+        const maybeStandaloneEditor: Partial<monaco.editor.IStandaloneCodeEditor> = editor
+        return (
+            editor.getEditorType() === monaco.editor.EditorType.ICodeEditor &&
+            typeof maybeStandaloneEditor.addAction === 'function'
+        )
     }
 
     public static addEditorAction(

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -207,7 +207,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         this.props.onDidUpdate()
                     }
                 },
-                err => this.setState({ loading: false, errorDescription: err.message })
+                err => this.setState({ loading: false, errorDescription: asError(err).message })
             )
     }
 
@@ -235,7 +235,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         resetPasswordURL,
                     })
                 },
-                err => this.setState({ loading: false, errorDescription: err.message })
+                err => this.setState({ loading: false, errorDescription: asError(err).message })
             )
     }
 
@@ -266,7 +266,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         this.props.onDidUpdate()
                     }
                 },
-                err => this.setState({ loading: false, errorDescription: err.message })
+                err => this.setState({ loading: false, errorDescription: asError(err).message })
             )
     }
 }

--- a/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -11,6 +11,7 @@ import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { createUser } from './backend'
 import { ErrorAlert } from '../components/alerts'
+import { asError } from '../../../shared/src/util/errors'
 
 interface Props extends RouteComponentProps<{}> {}
 
@@ -61,7 +62,7 @@ export class SiteAdminCreateUserPage extends React.Component<Props, State> {
                                 this.setState({
                                     createUserResult: undefined,
                                     loading: false,
-                                    errorDescription: error.message,
+                                    errorDescription: asError(error).message,
                                 })
                                 return []
                             })

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -14,6 +14,7 @@ import { ExternalServiceCard } from '../components/ExternalServiceCard'
 import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
 import { ErrorAlert } from '../components/alerts'
 import { defaultExternalServices, codeHostExternalServices } from './externalServices'
+import { hasProperty } from '../../../shared/src/util/types'
 
 interface Props extends RouteComponentProps<{ id: GQL.ID }> {
     isLightTheme: boolean
@@ -112,12 +113,14 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
 
         let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
         if (externalService && externalService.kind === GQL.ExternalServiceKind.GITHUB) {
-            const parsedConfig = parseJSONC(externalService.config)
+            const parsedConfig: unknown = parseJSONC(externalService.config)
             // we have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the url
             if (
-                parsedConfig?.url &&
+                typeof parsedConfig === 'object' &&
+                parsedConfig !== null &&
+                hasProperty('url')(parsedConfig) &&
                 typeof parsedConfig.url === 'string' &&
-                !parsedConfig.url.match(/^https:\/\/github\.com/)
+                !parsedConfig.url.startsWith('https://github.com/')
             ) {
                 externalServiceCategory = codeHostExternalServices.ghe
             }

--- a/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -14,6 +14,7 @@ import { orgURL } from '../org'
 import { eventLogger } from '../tracking/eventLogger'
 import { deleteOrganization, fetchAllOrganizations } from './backend'
 import { ErrorAlert } from '../components/alerts'
+import { asError } from '../../../shared/src/util/errors'
 
 interface OrgNodeProps {
     /**
@@ -104,7 +105,7 @@ class OrgNode extends React.PureComponent<OrgNodeProps, OrgNodeState> {
                         this.props.onDidUpdate()
                     }
                 },
-                err => this.setState({ loading: false, errorDescription: err.message })
+                err => this.setState({ loading: false, errorDescription: asError(err).message })
             )
     }
 }

--- a/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -14,6 +14,7 @@ import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchSite, fetchSiteUpdateCheck } from './backend'
 import { ErrorAlert } from '../components/alerts'
+import { asError } from '../../../shared/src/util/errors'
 
 interface Props extends RouteComponentProps<{}> {}
 
@@ -46,7 +47,7 @@ export class SiteAdminUpdatesPage extends React.Component<Props, State> {
                             updateCheck,
                             error: undefined,
                         }),
-                    error => this.setState({ error: error.message })
+                    error => this.setState({ error: asError(error).message })
                 )
         )
     }

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -17,11 +17,7 @@ interface ChartData {
     dateFormat: string
 }
 
-interface ChartOptions {
-    daus: ChartData
-    waus: ChartData
-    maus: ChartData
-}
+type ChartOptions = Record<'daus' | 'waus' | 'maus', ChartData>
 
 const chartGeneratorOptions: ChartOptions = {
     daus: { label: 'Daily unique users', dateFormat: 'E, MMM d' },

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -387,7 +387,7 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
                 ExternalServiceConfig[]
             >> = data.externalServices.nodes
                 .filter(svc => svc.config)
-                .map((svc): [GQL.ExternalServiceKind, ExternalServiceConfig] => [svc.kind, parseJSONC(svc.config)])
+                .map(svc => [svc.kind, parseJSONC(svc.config) as ExternalServiceConfig] as const)
                 .reduce<Partial<{ [k in GQL.ExternalServiceKind]: ExternalServiceConfig[] }>>(
                     (externalServicesByKind, [kind, config]) => {
                         let services = externalServicesByKind[kind]

--- a/web/src/tracking/analyticsUtils.tsx
+++ b/web/src/tracking/analyticsUtils.tsx
@@ -1,6 +1,7 @@
 import { fromEvent, of } from 'rxjs'
 import { catchError, mapTo, publishReplay, refCount, take, timeout } from 'rxjs/operators'
 import { eventLogger } from './eventLogger'
+import { asError } from '../../../shared/src/util/errors'
 
 interface EventQueryParameters {
     utm_campaign?: string
@@ -32,14 +33,13 @@ export const browserExtensionMessageReceived = (document.getElementById('sourceg
  */
 export const browserExtensionInstalled = browserExtensionMessageReceived.pipe(
     timeout(500),
-    // Replace with code below when https://github.com/ReactiveX/rxjs/issues/3602 is fixed
-    // catchError(err => {
-    //     if (err.name === 'TimeoutError') {
-    //         return [false]
-    //     }
-    //     throw err
-    // }),
-    catchError(err => [false]),
+    catchError(err => {
+        if (asError(err).name === 'TimeoutError') {
+            return [false]
+        }
+        throw err
+    }),
+    catchError(() => [false]),
     // Replay the same latest value for every subscriber
     publishReplay(1),
     refCount()

--- a/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -6,7 +6,7 @@ import { Observable, Subject, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { gql } from '../../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../../shared/src/graphql/schema'
-import { createAggregateError } from '../../../../../shared/src/util/errors'
+import { createAggregateError, asError } from '../../../../../shared/src/util/errors'
 import { mutateGraphQL, queryGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
@@ -113,7 +113,7 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
                         this.props.onDidUpdate()
                     }
                 },
-                error => this.setState({ loading: false, errorDescription: error.message })
+                error => this.setState({ loading: false, errorDescription: asError(error).message })
             )
     }
 
@@ -140,7 +140,7 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
                     this.props.onDidUpdate()
                 }
             },
-            error => this.setState({ loading: false, errorDescription: error.message })
+            error => this.setState({ loading: false, errorDescription: asError(error).message })
         )
     }
 }


### PR DESCRIPTION
I'm doing this now because part of why issues like #9411 is that errors in TypeScript are always `any`, but it can be solved by the `no-unsafe-*` family of ESLint rules. There are a lot of existing violations though, so it's currently just a warning.

This uncovered many real problems, e.g. `fetchUser` was typed to return `null`, but the Observable sequence didn't handle that, and there was no type error because the `catchError(e => [e])` degraded the whole pipeline to `Observable<any>`.

Introduces a new curried type guard `hasProperty()` that works with `unknown` too so we never need `any` again in theory.

Also discovered multiple cases of workaround error handling that was obsolete because related PRs were merged a long time ago.