### PR TITLE
Fix error handling

### DIFF
--- a/browser/src/libs/code_intelligence/SignInButton.tsx
+++ b/browser/src/libs/code_intelligence/SignInButton.tsx
@@ -42,7 +42,7 @@ export const SignInButton: React.FunctionComponent<{
             href={signInUrl}
             label="Sign in to Sourcegraph"
             title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
-            aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
+            ariaLabel="Sign into Sourcegraph to get hover tooltips, go to definition and more"
             className={className}
             iconClassName={iconClassName}
             onClick={nextSignInClick}

--- a/browser/src/libs/code_intelligence/SignInButton.tsx
+++ b/browser/src/libs/code_intelligence/SignInButton.tsx
@@ -39,10 +39,10 @@ export const SignInButton: React.FunctionComponent<{
 
     return (
         <SourcegraphIconButton
-            url={signInUrl}
+            href={signInUrl}
             label="Sign in to Sourcegraph"
             title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
-            ariaLabel="Sign into Sourcegraph to get hover tooltips, go to definition and more"
+            aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
             className={className}
             iconClassName={iconClassName}
             onClick={nextSignInClick}

--- a/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
+++ b/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
 <a
   aria-label="Something unknown happened!"
   className="open-on-sourcegraph test"
-  href="https://docs.sourcegraph.com/integration/test_codehost"
+  href="https://test.com/test@test"
   rel="noopener noreferrer"
   target="_blank"
   title="Something unknown happened!"

--- a/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
+++ b/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button 
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
+  label="Sign in to Sourcegraph"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -39,6 +40,7 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button w
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
+  label="Sign in to Sourcegraph"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -72,6 +74,11 @@ exports[`<ViewOnSourcegraphButton /> renders a button with an error label if the
 <a
   aria-label="Something unknown happened!"
   className="open-on-sourcegraph test"
+  href="https://docs.sourcegraph.com/integration/test_codehost"
+  iconClassName="open-on-sourcegraph__icon--muted"
+  label="Error"
+  rel="noopener noreferrer"
+  target="_blank"
   title="Something unknown happened!"
 >
   <svg
@@ -165,12 +172,13 @@ exports[`<ViewOnSourcegraphButton /> renders a link with the rev when provided 1
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist 1`] = `
+exports[`<ViewOnSourcegraphButton /> renders a repository not found message if the repository does not exist on the instance and not pointing at sourcegraph.com 1`] = `
 <a
-  aria-label="Install Sourcegraph for search and code intelligence on private instance"
-  className="open-on-sourcegraph test"
-  onClick={[Function]}
-  title="Install Sourcegraph for search and code intelligence on private instance"
+  aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
+  href="https://sourcegraph.test/test@test"
+  iconClassName="open-on-sourcegraph__icon--muted"
+  label="Repository not found"
+  title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
 >
   <svg
     className="open-on-sourcegraph__icon--muted"
@@ -195,20 +203,20 @@ exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when p
     </g>
   </svg>
    
-  Configure Sourcegraph
+  Repository not found
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> renders nothing in minimal UI mode 1`] = `null`;
-
-exports[`<ViewOnSourcegraphButton /> still renders a button to a private instance if repo does not exist 1`] = `
+exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist 1`] = `
 <a
-  aria-label="View repository on Sourcegraph"
-  className="open-on-sourcegraph test"
-  href="https://test.com/test@test"
-  title="View repository on Sourcegraph"
+  aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
+  href="https://sourcegraph.com/test@test"
+  iconClassName="open-on-sourcegraph__icon--muted"
+  label="Repository not found"
+  title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
 >
   <svg
+    className="open-on-sourcegraph__icon--muted"
     viewBox="0 0 40 40"
   >
     <g
@@ -230,5 +238,43 @@ exports[`<ViewOnSourcegraphButton /> still renders a button to a private instanc
     </g>
   </svg>
    
+  Repository not found
+</a>
+`;
+
+exports[`<ViewOnSourcegraphButton /> renders nothing in minimal UI mode 1`] = `null`;
+
+exports[`<ViewOnSourcegraphButton /> still renders a button to a private instance if repo does not exist 1`] = `
+<a
+  aria-label="The repository does not exist on the configured Sourcegraph instance https://test.com"
+  href="https://test.com/test@test"
+  iconClassName="open-on-sourcegraph__icon--muted"
+  label="Repository not found"
+  title="The repository does not exist on the configured Sourcegraph instance https://test.com"
+>
+  <svg
+    className="open-on-sourcegraph__icon--muted"
+    viewBox="0 0 40 40"
+  >
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
+        fill="#F96316"
+      />
+      <path
+        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
+        fill="#B200F8"
+      />
+      <path
+        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
+        fill="#00B4F2"
+      />
+    </g>
+  </svg>
+   
+  Repository not found
 </a>
 `;

--- a/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
+++ b/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button when authentication failed and showSignInButton = true 1`] = `
+exports[`<ViewOnSourcegraphButton /> existence could not be determined  because of an authentication failure minimalUI = false renders a sign in button if showSignInButton = true 1`] = `
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
@@ -34,7 +34,7 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button 
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button when authentication failed and showSignInButton = true 1`] = `
+exports[`<ViewOnSourcegraphButton /> existence could not be determined  because of an authentication failure minimalUI = true renders a sign in button if showSignInButton = true 1`] = `
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
@@ -68,7 +68,7 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button w
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> renders a button with an error label if the repo exists check failed with an unknown error 1`] = `
+exports[`<ViewOnSourcegraphButton /> existence could not be determined  because of an unknown error renders a button with an error label 1`] = `
 <a
   aria-label="Something unknown happened!"
   className="open-on-sourcegraph test"
@@ -104,111 +104,7 @@ exports[`<ViewOnSourcegraphButton /> renders a button with an error label if the
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> renders a link to the repository on the Sourcegraph instance 1`] = `
-<a
-  aria-label="View repository on Sourcegraph"
-  className="open-on-sourcegraph test"
-  href="https://test.com/test"
-  rel="noopener noreferrer"
-  target="_blank"
-  title="View repository on Sourcegraph"
->
-  <svg
-    viewBox="0 0 40 40"
-  >
-    <g
-      fill="none"
-      fillRule="evenodd"
-    >
-      <path
-        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
-        fill="#F96316"
-      />
-      <path
-        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
-        fill="#B200F8"
-      />
-      <path
-        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
-        fill="#00B4F2"
-      />
-    </g>
-  </svg>
-   
-</a>
-`;
-
-exports[`<ViewOnSourcegraphButton /> renders a link with the rev when provided 1`] = `
-<a
-  aria-label="View repository on Sourcegraph"
-  className="open-on-sourcegraph test"
-  href="https://test.com/test@test"
-  rel="noopener noreferrer"
-  target="_blank"
-  title="View repository on Sourcegraph"
->
-  <svg
-    viewBox="0 0 40 40"
-  >
-    <g
-      fill="none"
-      fillRule="evenodd"
-    >
-      <path
-        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
-        fill="#F96316"
-      />
-      <path
-        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
-        fill="#B200F8"
-      />
-      <path
-        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
-        fill="#00B4F2"
-      />
-    </g>
-  </svg>
-   
-</a>
-`;
-
-exports[`<ViewOnSourcegraphButton /> renders a repository not found message if the repository does not exist on the instance and not pointing at sourcegraph.com 1`] = `
-<a
-  aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
-  className="open-on-sourcegraph test"
-  href="https://sourcegraph.test/test@test"
-  rel="noopener noreferrer"
-  target="_blank"
-  title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
->
-  <svg
-    className="open-on-sourcegraph__icon--muted"
-    viewBox="0 0 40 40"
-  >
-    <g
-      fill="none"
-      fillRule="evenodd"
-    >
-      <path
-        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
-        fill="#F96316"
-      />
-      <path
-        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
-        fill="#B200F8"
-      />
-      <path
-        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
-        fill="#00B4F2"
-      />
-    </g>
-  </svg>
-   
-  Repository not found
-</a>
-`;
-
-exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist 1`] = `
+exports[`<ViewOnSourcegraphButton /> repository does not exist on the instance renders "Configure Sourcegraph" button when pointing at sourcegraph.com 1`] = `
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
   className="open-on-sourcegraph test"
@@ -244,16 +140,14 @@ exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when p
 </a>
 `;
 
-exports[`<ViewOnSourcegraphButton /> renders nothing in minimal UI mode 1`] = `null`;
-
-exports[`<ViewOnSourcegraphButton /> still renders a button to a private instance if repo does not exist 1`] = `
+exports[`<ViewOnSourcegraphButton /> repository does not exist on the instance renders a "Repository not found" button when not pointing at sourcegraph.com 1`] = `
 <a
-  aria-label="The repository does not exist on the configured Sourcegraph instance https://test.com"
+  aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
   className="open-on-sourcegraph test"
-  href="https://test.com/test@test"
+  href="https://sourcegraph.test/test@test"
   rel="noopener noreferrer"
   target="_blank"
-  title="The repository does not exist on the configured Sourcegraph instance https://test.com"
+  title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
 >
   <svg
     className="open-on-sourcegraph__icon--muted"
@@ -281,3 +175,73 @@ exports[`<ViewOnSourcegraphButton /> still renders a button to a private instanc
   Repository not found
 </a>
 `;
+
+exports[`<ViewOnSourcegraphButton /> repository exists on the instance renders a link to the repository on the Sourcegraph instance 1`] = `
+<a
+  aria-label="View repository on Sourcegraph"
+  className="open-on-sourcegraph test"
+  href="https://test.com/test"
+  rel="noopener noreferrer"
+  target="_blank"
+  title="View repository on Sourcegraph"
+>
+  <svg
+    viewBox="0 0 40 40"
+  >
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
+        fill="#F96316"
+      />
+      <path
+        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
+        fill="#B200F8"
+      />
+      <path
+        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
+        fill="#00B4F2"
+      />
+    </g>
+  </svg>
+   
+</a>
+`;
+
+exports[`<ViewOnSourcegraphButton /> repository exists on the instance renders a link with the rev when provided 1`] = `
+<a
+  aria-label="View repository on Sourcegraph"
+  className="open-on-sourcegraph test"
+  href="https://test.com/test@test"
+  rel="noopener noreferrer"
+  target="_blank"
+  title="View repository on Sourcegraph"
+>
+  <svg
+    viewBox="0 0 40 40"
+  >
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M11.5941935,5.12629921 L20.4929032,36.888189 C21.0909677,39.0226772 23.3477419,40.279685 25.5325806,39.6951181 C27.7190323,39.1105512 29.0051613,36.9064567 28.4067742,34.7722835 L19.5064516,3.00944882 C18.9080645,0.875590551 16.6516129,-0.381732283 14.4667742,0.203149606 C12.2822581,0.786771654 10.9958065,2.99149606 11.5941935,5.12598425 L11.5941935,5.12629921 Z"
+        fill="#F96316"
+      />
+      <path
+        d="M28.0722581,5.00598425 L5.7883871,29.5748031 C4.28516129,31.2314961 4.44225806,33.7647244 6.13741935,35.2327559 C7.83258065,36.7004724 10.4245161,36.5474016 11.9277419,34.8913386 L34.2116129,10.3228346 C35.7148387,8.66614173 35.5577419,6.13385827 33.8625806,4.66551181 C32.1667742,3.19653543 29.5741935,3.34992126 28.0722581,5.00566929 L28.0722581,5.00598425 Z"
+        fill="#B200F8"
+      />
+      <path
+        d="M2.82258065,18.6204724 L34.6019355,28.8866142 C36.7525806,29.5811024 39.0729032,28.4412598 39.7841935,26.3395276 C40.4970968,24.2381102 39.3293548,21.9716535 37.1777419,21.2762205 L5.39935484,11.0110236 C3.24774194,10.3159055 0.928387097,11.455748 0.216774194,13.5574803 C-0.494193548,15.6588976 0.673548387,17.9259843 2.82322581,18.6204724 L2.82258065,18.6204724 Z"
+        fill="#00B4F2"
+      />
+    </g>
+  </svg>
+   
+</a>
+`;
+
+exports[`<ViewOnSourcegraphButton /> repository exists on the instance renders nothing in minimal UI mode 1`] = `null`;

--- a/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
+++ b/browser/src/libs/code_intelligence/__snapshots__/external_links.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = false renders a sign in button 
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
-  label="Sign in to Sourcegraph"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -40,7 +39,6 @@ exports[`<ViewOnSourcegraphButton /> minimalUI = true renders a sign in button w
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true"
-  label="Sign in to Sourcegraph"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -75,8 +73,6 @@ exports[`<ViewOnSourcegraphButton /> renders a button with an error label if the
   aria-label="Something unknown happened!"
   className="open-on-sourcegraph test"
   href="https://docs.sourcegraph.com/integration/test_codehost"
-  iconClassName="open-on-sourcegraph__icon--muted"
-  label="Error"
   rel="noopener noreferrer"
   target="_blank"
   title="Something unknown happened!"
@@ -113,6 +109,8 @@ exports[`<ViewOnSourcegraphButton /> renders a link to the repository on the Sou
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
   href="https://test.com/test"
+  rel="noopener noreferrer"
+  target="_blank"
   title="View repository on Sourcegraph"
 >
   <svg
@@ -145,6 +143,8 @@ exports[`<ViewOnSourcegraphButton /> renders a link with the rev when provided 1
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
   href="https://test.com/test@test"
+  rel="noopener noreferrer"
+  target="_blank"
   title="View repository on Sourcegraph"
 >
   <svg
@@ -175,9 +175,10 @@ exports[`<ViewOnSourcegraphButton /> renders a link with the rev when provided 1
 exports[`<ViewOnSourcegraphButton /> renders a repository not found message if the repository does not exist on the instance and not pointing at sourcegraph.com 1`] = `
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
+  className="open-on-sourcegraph test"
   href="https://sourcegraph.test/test@test"
-  iconClassName="open-on-sourcegraph__icon--muted"
-  label="Repository not found"
+  rel="noopener noreferrer"
+  target="_blank"
   title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
 >
   <svg
@@ -210,9 +211,10 @@ exports[`<ViewOnSourcegraphButton /> renders a repository not found message if t
 exports[`<ViewOnSourcegraphButton /> renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist 1`] = `
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
+  className="open-on-sourcegraph test"
   href="https://sourcegraph.com/test@test"
-  iconClassName="open-on-sourcegraph__icon--muted"
-  label="Repository not found"
+  rel="noopener noreferrer"
+  target="_blank"
   title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
 >
   <svg
@@ -247,9 +249,10 @@ exports[`<ViewOnSourcegraphButton /> renders nothing in minimal UI mode 1`] = `n
 exports[`<ViewOnSourcegraphButton /> still renders a button to a private instance if repo does not exist 1`] = `
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://test.com"
+  className="open-on-sourcegraph test"
   href="https://test.com/test@test"
-  iconClassName="open-on-sourcegraph__icon--muted"
-  label="Repository not found"
+  rel="noopener noreferrer"
+  target="_blank"
   title="The repository does not exist on the configured Sourcegraph instance https://test.com"
 >
   <svg

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -571,8 +571,6 @@ export function handleCodeHost({
     const subscriptions = new Subscription()
     const { requestGraphQL } = platformContext
 
-    const openOptionsMenu = (): Promise<void> => browser.runtime.sendMessage({ type: 'openOptionsPage' })
-
     const addedElements = mutations.pipe(
         concatAll(),
         concatMap(mutation => mutation.addedNodes),
@@ -674,6 +672,10 @@ export function handleCodeHost({
                 )
             })
         )
+        const onConfigureSourcegraphClick: React.MouseEventHandler<HTMLAnchorElement> = async event => {
+            event.preventDefault()
+            await browser.runtime.sendMessage({ type: 'openOptionsPage' })
+        }
 
         subscriptions.add(
             combineLatest([
@@ -688,13 +690,14 @@ export function handleCodeHost({
                 render(
                     <ViewOnSourcegraphButton
                         {...viewOnSourcegraphButtonClassProps}
+                        codeHostType={codeHost.type}
                         getContext={getContext}
                         minimalUI={minimalUI}
                         sourcegraphURL={sourcegraphURL}
                         repoExistsOrError={repoExistsOrError}
                         showSignInButton={showSignInButton}
                         onSignInClose={nextSignInClose}
-                        onConfigureSourcegraphClick={isInPage ? undefined : openOptionsMenu}
+                        onConfigureSourcegraphClick={isInPage ? undefined : onConfigureSourcegraphClick}
                     />,
                     mount
                 )

--- a/browser/src/libs/code_intelligence/code_views.ts
+++ b/browser/src/libs/code_intelligence/code_views.ts
@@ -3,9 +3,8 @@ import { Selection } from '@sourcegraph/extension-api-types'
 import { Observable, of, zip, OperatorFunction } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import { Omit } from 'utility-types'
-import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../../../../shared/src/backend/errors'
+import { isPrivateRepoPublicSourcegraphComErrorLike } from '../../../../shared/src/backend/errors'
 import { PlatformContext } from '../../../../shared/src/platform/context'
-import { isErrorLike } from '../../../../shared/src/util/errors'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 import { ButtonProps } from '../../shared/components/CodeViewToolbar'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
@@ -136,7 +135,7 @@ export const fetchFileContents = (
             )
         }),
         catchError(err => {
-            if (isErrorLike(err) && err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
+            if (isPrivateRepoPublicSourcegraphComErrorLike(err)) {
                 return [info]
             }
             throw err

--- a/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -10,6 +10,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://test.com"
                     getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
                     className="test"
@@ -26,6 +27,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://test.com"
                     getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
                     className="test"
@@ -42,6 +44,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://test.com"
                     getContext={() => ({
                         rawRepoName: 'test',
@@ -64,6 +67,7 @@ describe('<ViewOnSourcegraphButton />', () => {
                 renderer.act(() => {
                     root = renderer.create(
                         <ViewOnSourcegraphButton
+                            codeHostType="test-codehost"
                             sourcegraphURL="https://test.com"
                             getContext={() => ({
                                 rawRepoName: 'test',
@@ -87,6 +91,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://test.com"
                     getContext={() => ({
                         rawRepoName: 'test',
@@ -108,7 +113,30 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://sourcegraph.com"
+                    getContext={() => ({
+                        rawRepoName: 'test',
+                        rev: 'test',
+                        privateRepository: false,
+                    })}
+                    className="test"
+                    repoExistsOrError={false}
+                    onConfigureSourcegraphClick={noop}
+                    minimalUI={false}
+                />
+            )
+        })
+        expect(root!).toMatchSnapshot()
+    })
+
+    it('renders a repository not found message if the repository does not exist on the instance and not pointing at sourcegraph.com', () => {
+        let root: ReactTestRenderer
+        renderer.act(() => {
+            root = renderer.create(
+                <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
+                    sourcegraphURL="https://sourcegraph.test"
                     getContext={() => ({
                         rawRepoName: 'test',
                         rev: 'test',
@@ -129,6 +157,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         renderer.act(() => {
             root = renderer.create(
                 <ViewOnSourcegraphButton
+                    codeHostType="test-codehost"
                     sourcegraphURL="https://test.com"
                     getContext={() => ({
                         rawRepoName: 'test',

--- a/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -5,64 +5,140 @@ import renderer, { ReactTestRenderer } from 'react-test-renderer'
 import { noop } from 'lodash'
 
 describe('<ViewOnSourcegraphButton />', () => {
-    it('renders a link to the repository on the Sourcegraph instance', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://test.com"
-                    getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
-                    className="test"
-                    repoExistsOrError={true}
-                    minimalUI={false}
-                />
-            )
+    describe('repository exists on the instance', () => {
+        it('renders a link to the repository on the Sourcegraph instance', () => {
+            let root: ReactTestRenderer
+            renderer.act(() => {
+                root = renderer.create(
+                    <ViewOnSourcegraphButton
+                        codeHostType="test-codehost"
+                        sourcegraphURL="https://test.com"
+                        getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
+                        className="test"
+                        repoExistsOrError={true}
+                        minimalUI={false}
+                    />
+                )
+            })
+            expect(root!).toMatchSnapshot()
         })
-        expect(root!).toMatchSnapshot()
+
+        it('renders nothing in minimal UI mode', () => {
+            let root: ReactTestRenderer
+            renderer.act(() => {
+                root = renderer.create(
+                    <ViewOnSourcegraphButton
+                        codeHostType="test-codehost"
+                        sourcegraphURL="https://test.com"
+                        getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
+                        className="test"
+                        repoExistsOrError={true}
+                        minimalUI={true}
+                    />
+                )
+            })
+            expect(root!).toMatchSnapshot()
+        })
+
+        it('renders a link with the rev when provided', () => {
+            let root: ReactTestRenderer
+            renderer.act(() => {
+                root = renderer.create(
+                    <ViewOnSourcegraphButton
+                        codeHostType="test-codehost"
+                        sourcegraphURL="https://test.com"
+                        getContext={() => ({
+                            rawRepoName: 'test',
+                            rev: 'test',
+                            privateRepository: false,
+                        })}
+                        className="test"
+                        repoExistsOrError={true}
+                        minimalUI={false}
+                    />
+                )
+            })
+            expect(root!).toMatchSnapshot()
+        })
     })
 
-    it('renders nothing in minimal UI mode', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://test.com"
-                    getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
-                    className="test"
-                    repoExistsOrError={true}
-                    minimalUI={true}
-                />
-            )
+    describe('repository does not exist on the instance', () => {
+        it('renders "Configure Sourcegraph" button when pointing at sourcegraph.com', () => {
+            let root: ReactTestRenderer
+            renderer.act(() => {
+                root = renderer.create(
+                    <ViewOnSourcegraphButton
+                        codeHostType="test-codehost"
+                        sourcegraphURL="https://sourcegraph.com"
+                        getContext={() => ({
+                            rawRepoName: 'test',
+                            rev: 'test',
+                            privateRepository: false,
+                        })}
+                        className="test"
+                        repoExistsOrError={false}
+                        onConfigureSourcegraphClick={noop}
+                        minimalUI={false}
+                    />
+                )
+            })
+            expect(root!).toMatchSnapshot()
         })
-        expect(root!).toMatchSnapshot()
+
+        it('renders a "Repository not found" button when not pointing at sourcegraph.com', () => {
+            let root: ReactTestRenderer
+            renderer.act(() => {
+                root = renderer.create(
+                    <ViewOnSourcegraphButton
+                        codeHostType="test-codehost"
+                        sourcegraphURL="https://sourcegraph.test"
+                        getContext={() => ({
+                            rawRepoName: 'test',
+                            rev: 'test',
+                            privateRepository: false,
+                        })}
+                        className="test"
+                        repoExistsOrError={false}
+                        onConfigureSourcegraphClick={noop}
+                        minimalUI={false}
+                    />
+                )
+            })
+            expect(root!).toMatchSnapshot()
+        })
     })
 
-    it('renders a link with the rev when provided', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://test.com"
-                    getContext={() => ({
-                        rawRepoName: 'test',
-                        rev: 'test',
-                        privateRepository: false,
-                    })}
-                    className="test"
-                    repoExistsOrError={true}
-                    minimalUI={false}
-                />
-            )
+    describe('existence could not be determined ', () => {
+        describe('because of an authentication failure', () => {
+            for (const minimalUI of [true, false]) {
+                describe(`minimalUI = ${String(minimalUI)}`, () => {
+                    it('renders a sign in button if showSignInButton = true', () => {
+                        let root: ReactTestRenderer
+                        renderer.act(() => {
+                            root = renderer.create(
+                                <ViewOnSourcegraphButton
+                                    codeHostType="test-codehost"
+                                    sourcegraphURL="https://test.com"
+                                    getContext={() => ({
+                                        rawRepoName: 'test',
+                                        rev: 'test',
+                                        privateRepository: false,
+                                    })}
+                                    showSignInButton={true}
+                                    className="test"
+                                    repoExistsOrError={new HTTPStatusError(new Response('', { status: 401 }))}
+                                    minimalUI={minimalUI}
+                                />
+                            )
+                        })
+                        expect(root!).toMatchSnapshot()
+                    })
+                })
+            }
         })
-        expect(root!).toMatchSnapshot()
-    })
 
-    for (const minimalUI of [true, false]) {
-        describe(`minimalUI = ${String(minimalUI)}`, () => {
-            it('renders a sign in button when authentication failed and showSignInButton = true', () => {
+        describe('because of an unknown error', () => {
+            it('renders a button with an error label', () => {
                 let root: ReactTestRenderer
                 renderer.act(() => {
                     root = renderer.create(
@@ -76,100 +152,13 @@ describe('<ViewOnSourcegraphButton />', () => {
                             })}
                             showSignInButton={true}
                             className="test"
-                            repoExistsOrError={new HTTPStatusError(new Response('', { status: 401 }))}
-                            minimalUI={minimalUI}
+                            repoExistsOrError={new Error('Something unknown happened!')}
+                            minimalUI={false}
                         />
                     )
                 })
                 expect(root!).toMatchSnapshot()
             })
         })
-    }
-
-    it('renders a button with an error label if the repo exists check failed with an unknown error', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://test.com"
-                    getContext={() => ({
-                        rawRepoName: 'test',
-                        rev: 'test',
-                        privateRepository: false,
-                    })}
-                    showSignInButton={true}
-                    className="test"
-                    repoExistsOrError={new Error('Something unknown happened!')}
-                    minimalUI={false}
-                />
-            )
-        })
-        expect(root!).toMatchSnapshot()
-    })
-
-    it('renders configure sourcegraph button when pointing at sourcegraph.com and the repo does not exist', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://sourcegraph.com"
-                    getContext={() => ({
-                        rawRepoName: 'test',
-                        rev: 'test',
-                        privateRepository: false,
-                    })}
-                    className="test"
-                    repoExistsOrError={false}
-                    onConfigureSourcegraphClick={noop}
-                    minimalUI={false}
-                />
-            )
-        })
-        expect(root!).toMatchSnapshot()
-    })
-
-    it('renders a repository not found message if the repository does not exist on the instance and not pointing at sourcegraph.com', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://sourcegraph.test"
-                    getContext={() => ({
-                        rawRepoName: 'test',
-                        rev: 'test',
-                        privateRepository: false,
-                    })}
-                    className="test"
-                    repoExistsOrError={false}
-                    onConfigureSourcegraphClick={noop}
-                    minimalUI={false}
-                />
-            )
-        })
-        expect(root!).toMatchSnapshot()
-    })
-
-    it('still renders a button to a private instance if repo does not exist', () => {
-        let root: ReactTestRenderer
-        renderer.act(() => {
-            root = renderer.create(
-                <ViewOnSourcegraphButton
-                    codeHostType="test-codehost"
-                    sourcegraphURL="https://test.com"
-                    getContext={() => ({
-                        rawRepoName: 'test',
-                        rev: 'test',
-                        privateRepository: false,
-                    })}
-                    className="test"
-                    repoExistsOrError={false}
-                    minimalUI={false}
-                />
-            )
-        })
-        expect(root!).toMatchSnapshot()
     })
 })

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -74,14 +74,26 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return null
     }
 
-    // If repo doesn't exist and the instance is sourcegraph.com, prompt
-    // user to configure Sourcegraph.
-    if (!repoExistsOrError && sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && onConfigureSourcegraphClick) {
+    if (!repoExistsOrError) {
+        // If repo doesn't exist and the instance is sourcegraph.com, prompt
+        // user to configure Sourcegraph.
+        if (sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && onConfigureSourcegraphClick) {
+            return (
+                <SourcegraphIconButton
+                    label="Configure Sourcegraph"
+                    title="Install Sourcegraph for search and code intelligence on private instance"
+                    ariaLabel="Install Sourcegraph for search and code intelligence on private instance"
+                    className={className}
+                    iconClassName={classNames('open-on-sourcegraph__icon--muted', iconClassName)}
+                    onClick={onConfigureSourcegraphClick}
+                />
+            )
+        }
         return (
             <SourcegraphIconButton
-                label="Configure Sourcegraph"
-                title="Install Sourcegraph for search and code intelligence on private instance"
-                ariaLabel="Install Sourcegraph for search and code intelligence on private instance"
+                label="Repository not found"
+                title={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
+                ariaLabel={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
                 className={className}
                 iconClassName={classNames('open-on-sourcegraph__icon--muted', iconClassName)}
                 onClick={onConfigureSourcegraphClick}

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -54,6 +54,9 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return null
     }
 
+    const { rawRepoName, rev } = getContext()
+    const url = new URL(`/${rawRepoName}${rev ? `@${rev}` : ''}`, sourcegraphURL).href
+
     if (isErrorLike(repoExistsOrError)) {
         // If the problem is the user is not signed in, show a sign in CTA (if not shown elsewhere)
         if (failedWithHTTPStatus(repoExistsOrError, 401)) {
@@ -90,19 +93,20 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
             )
         }
 
-        // If there was an unexpected error, show it in the tooltip
+        // If there was an unexpected error, show it in the tooltip.
+        // Still link to the Sourcegraph instance in native integrations
+        // as that might explain the error (e.g. not reachable).
+        // In the browser extension, let the onConfigureSourcegraphClick handler can handle this.
         return (
             <SourcegraphIconButton
                 {...commonErrorCaseProps}
+                href={url}
                 label="Error"
                 title={repoExistsOrError.message}
                 aria-label={repoExistsOrError.message}
             />
         )
     }
-
-    const { rawRepoName, rev } = getContext()
-    const url = new URL(`/${rawRepoName}${rev ? `@${rev}` : ''}`, sourcegraphURL).href
 
     // If the repository does not exist, communicate that to explain why e.g. code intelligence does not work
     if (!repoExistsOrError) {

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -103,7 +103,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
                 href={url}
                 label="Error"
                 title={repoExistsOrError.message}
-                aria-label={repoExistsOrError.message}
+                ariaLabel={repoExistsOrError.message}
             />
         )
     }
@@ -117,7 +117,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
                 iconClassName={mutedIconClassName}
                 label="Repository not found"
                 title={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
-                aria-label={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
+                ariaLabel={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
             />
         )
     }
@@ -133,7 +133,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
             {...commonProps}
             href={url}
             title="View repository on Sourcegraph"
-            aria-label="View repository on Sourcegraph"
+            ariaLabel="View repository on Sourcegraph"
         />
     )
 }

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -43,6 +43,11 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
 }) => {
     className = classNames('open-on-sourcegraph', className)
     const mutedIconClassName = classNames('open-on-sourcegraph__icon--muted', iconClassName)
+    const commonProps: Partial<SourcegraphIconButtonProps> = {
+        className,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+    }
 
     // Show nothing while loading
     if (repoExistsOrError === undefined) {
@@ -53,27 +58,18 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         // If the problem is the user is not signed in, show a sign in CTA (if not shown elsewhere)
         if (failedWithHTTPStatus(repoExistsOrError, 401)) {
             if (showSignInButton) {
-                return (
-                    <SignInButton
-                        sourcegraphURL={sourcegraphURL}
-                        onSignInClose={onSignInClose}
-                        className={className}
-                        iconClassName={iconClassName}
-                    />
-                )
+                return <SignInButton {...commonProps} sourcegraphURL={sourcegraphURL} onSignInClose={onSignInClose} />
             }
             // Sign in button may already be shown elsewhere on the page
             return null
         }
 
         const commonErrorCaseProps: Partial<SourcegraphIconButtonProps> = {
-            className,
+            ...commonProps,
             iconClassName: mutedIconClassName,
             // If we are not running in the browser extension where we can open the options menu,
             // open the documentation for how to configure the code host we are on.
             href: new URL(snakeCase(codeHostType), 'https://docs.sourcegraph.com/integration/').href,
-            target: '_blank',
-            rel: 'noopener noreferrer',
             // onClick can call preventDefault() to prevent that and take a different action (opening the options menu).
             onClick: onConfigureSourcegraphClick,
         }
@@ -112,8 +108,8 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     if (!repoExistsOrError) {
         return (
             <SourcegraphIconButton
+                {...commonProps}
                 href={url} // Still link to the repository (which will show a not found page, and can link to further actions)
-                className={className}
                 iconClassName={mutedIconClassName}
                 label="Repository not found"
                 title={`The repository does not exist on the configured Sourcegraph instance ${sourcegraphURL}`}
@@ -130,11 +126,10 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     // Render a "View on Sourcegraph" button
     return (
         <SourcegraphIconButton
+            {...commonProps}
             href={url}
             title="View repository on Sourcegraph"
             aria-label="View repository on Sourcegraph"
-            className={className}
-            iconClassName={iconClassName}
         />
     )
 }

--- a/browser/src/libs/code_intelligence/external_links.tsx
+++ b/browser/src/libs/code_intelligence/external_links.tsx
@@ -88,7 +88,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
                     {...commonErrorCaseProps}
                     label="Configure Sourcegraph"
                     title="Setup Sourcegraph for search and code intelligence on private repositories"
-                    aria-label="Setup Sourcegraph for search and code intelligence on private repositories"
+                    ariaLabel="Setup Sourcegraph for search and code intelligence on private repositories"
                 />
             )
         }

--- a/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/browser/src/libs/code_intelligence/util/file_info.ts
@@ -1,7 +1,7 @@
 import { Observable, of, zip } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 
-import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../../../../../shared/src/backend/errors'
+import { isPrivateRepoPublicSourcegraphComErrorLike } from '../../../../../shared/src/backend/errors'
 import { PlatformContext } from '../../../../../shared/src/platform/context'
 import { resolveRepo, resolveRev, retryWhenCloneInProgressError } from '../../../shared/repo/backend'
 import { FileInfo, FileInfoWithRepoNames } from '../code_intelligence'
@@ -53,7 +53,7 @@ export const resolveRepoNames = (
         // has access to that code. In that case, it's impossible to resolve the repo names,
         // so we keep the repo names inferred from the code host's DOM.
         catchError(err => {
-            if (err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
+            if (isPrivateRepoPublicSourcegraphComErrorLike(err)) {
                 return [{ rawRepoName, baseRawRepoName, repoName: rawRepoName, baseRepoName: baseRawRepoName, ...rest }]
             }
             throw err

--- a/browser/src/libs/options/OptionsContainer.tsx
+++ b/browser/src/libs/options/OptionsContainer.tsx
@@ -3,11 +3,11 @@
 import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap, concatMap } from 'rxjs/operators'
-import { AUTH_REQUIRED_ERROR_NAME } from '../../../../shared/src/backend/errors'
-import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { getExtensionVersion } from '../../shared/util/context'
 import { OptionsMenu, OptionsMenuProps } from './OptionsMenu'
 import { ConnectionErrors } from './ServerURLForm'
+import { failedWithHTTPStatus } from '../../../../shared/src/backend/fetch'
 
 export interface OptionsContainerProps {
     sourcegraphURL: string
@@ -72,10 +72,10 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                 this.setState({ status: 'connecting', connectionError: undefined })
                 return this.props.ensureValidSite(url).pipe(
                     map(() => url),
-                    catchError(err => of(err))
+                    catchError(err => of(asError(err)))
                 )
             }),
-            catchError(err => of(err)),
+            catchError(err => of(asError(err))),
             share()
         )
 
@@ -86,10 +86,9 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                 if (isErrorLike(res)) {
                     this.setState({
                         status: 'error',
-                        connectionError:
-                            res.name === AUTH_REQUIRED_ERROR_NAME
-                                ? ConnectionErrors.AuthError
-                                : ConnectionErrors.UnableToConnect,
+                        connectionError: failedWithHTTPStatus(res, 401)
+                            ? ConnectionErrors.AuthError
+                            : ConnectionErrors.UnableToConnect,
                     })
                     url = this.state.sourcegraphURL
                 } else {

--- a/browser/src/libs/phabricator/backend.tsx
+++ b/browser/src/libs/phabricator/backend.tsx
@@ -8,7 +8,7 @@ import { storage } from '../../browser/storage'
 import { isExtension } from '../../context'
 import { resolveRepo } from '../../shared/repo/backend'
 import { normalizeRepoName } from './util'
-import { REPO_NOT_FOUND_ERROR_NAME } from '../../../../shared/src/backend/errors'
+import { isRepoNotFoundErrorLike } from '../../../../shared/src/backend/errors'
 import { RepoSpec, FileSpec, ResolvedRevSpec } from '../../../../shared/src/util/url'
 import { RevisionSpec, DiffSpec, BaseDiffSpec } from '.'
 import { checkOk } from '../../../../shared/src/backend/fetch'
@@ -595,7 +595,7 @@ export function resolveDiffRev(
                 // Otherwise, create a one-off commit containing the patch on the Sourcegraph instance,
                 // and resolve to the commit ID returned by the Sourcegraph instance.
                 catchError(error => {
-                    if (error.name !== REPO_NOT_FOUND_ERROR_NAME) {
+                    if (!isRepoNotFoundErrorLike(error)) {
                         throw error
                     }
                     return getRawDiffFromConduit({ diffID: props.diffID, queryConduit }).pipe(

--- a/browser/src/shared/backend/server.ts
+++ b/browser/src/shared/backend/server.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
-import { catchError, map } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
@@ -19,8 +19,5 @@ export const fetchSite = (requestGraphQL: PlatformContext['requestGraphQL']): Ob
         mightContainPrivateInfo: false,
     }).pipe(
         map(dataOrThrowErrors),
-        map(
-            ({ site }) => site,
-            catchError((err, caught) => caught)
-        )
+        map(({ site }) => site)
     )

--- a/browser/src/shared/components/Button.tsx
+++ b/browser/src/shared/components/Button.tsx
@@ -1,29 +1,21 @@
 import * as React from 'react'
 import { SourcegraphIcon } from './Icons'
 
-interface Props {
-    url?: string
-
-    /** The HTML hover tooltip title */
-    title?: string
-
-    className?: string
+export interface SourcegraphIconButtonProps
+    extends Pick<
+        JSX.IntrinsicElements['a'],
+        'href' | 'title' | 'rel' | 'className' | 'onClick' | 'target' | 'aria-label'
+    > {
     iconClassName?: string
-    ariaLabel?: string
-    onClick?: (e: React.MouseEvent<HTMLElement>) => void
-    target?: string
     label?: string
 }
 
-export const SourcegraphIconButton: React.FunctionComponent<Props> = (props: Props) => (
-    <a
-        href={props.url}
-        title={props.title}
-        aria-label={props.ariaLabel}
-        className={props.className}
-        onClick={props.onClick}
-        target={props.target}
-    >
-        <SourcegraphIcon className={props.iconClassName} /> {props.label}
+export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButtonProps> = ({
+    iconClassName,
+    label,
+    ...anchorProps
+}) => (
+    <a {...anchorProps}>
+        <SourcegraphIcon className={iconClassName} /> {label}
     </a>
 )

--- a/browser/src/shared/components/Button.tsx
+++ b/browser/src/shared/components/Button.tsx
@@ -2,20 +2,35 @@ import * as React from 'react'
 import { SourcegraphIcon } from './Icons'
 
 export interface SourcegraphIconButtonProps
-    extends Pick<
-        JSX.IntrinsicElements['a'],
-        'href' | 'title' | 'rel' | 'className' | 'onClick' | 'target' | 'aria-label'
-    > {
+    extends Pick<JSX.IntrinsicElements['a'], 'href' | 'title' | 'rel' | 'className' | 'onClick' | 'target'> {
+    /** CSS class applied to the icon */
     iconClassName?: string
+    /** Text label shown next to the button */
     label?: string
+    /** aria-label attribute */
+    ariaLabel?: string
 }
 
 export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButtonProps> = ({
     iconClassName,
     label,
-    ...anchorProps
+    ariaLabel,
+    className,
+    href,
+    onClick,
+    rel,
+    target,
+    title,
 }) => (
-    <a {...anchorProps}>
+    <a
+        href={href}
+        className={className}
+        target={target}
+        rel={rel}
+        title={title}
+        aria-label={ariaLabel}
+        onClick={onClick}
+    >
         <SourcegraphIcon className={iconClassName} /> {label}
     </a>
 )

--- a/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -76,7 +76,7 @@ export class OpenDiffOnSourcegraph extends React.Component<Props, State> {
                 {...this.props}
                 className={classNames('open-on-sourcegraph', this.props.className)}
                 iconClassName={this.props.iconClassName}
-                url={url}
+                aria-label={url}
             />
         )
     }

--- a/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -76,7 +76,7 @@ export class OpenDiffOnSourcegraph extends React.Component<Props, State> {
                 {...this.props}
                 className={classNames('open-on-sourcegraph', this.props.className)}
                 iconClassName={this.props.iconClassName}
-                aria-label={url}
+                ariaLabel={url}
             />
         )
     }

--- a/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -20,7 +20,7 @@ export class OpenOnSourcegraph extends React.Component<Props, {}> {
                 {...this.props}
                 iconClassName={this.props.iconClassName}
                 className={classNames('open-on-sourcegraph', this.props.className)}
-                aria-label={url}
+                ariaLabel={url}
             />
         )
     }

--- a/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -20,7 +20,7 @@ export class OpenOnSourcegraph extends React.Component<Props, {}> {
                 {...this.props}
                 iconClassName={this.props.iconClassName}
                 className={classNames('open-on-sourcegraph', this.props.className)}
-                url={url}
+                aria-label={url}
             />
         )
     }

--- a/shared/src/backend/errors.test.ts
+++ b/shared/src/backend/errors.test.ts
@@ -1,0 +1,62 @@
+import {
+    isRepoSeeOtherErrorLike,
+    RepoSeeOtherError,
+    isPrivateRepoPublicSourcegraphComErrorLike,
+    PrivateRepoPublicSourcegraphComError,
+    RepoNotFoundError,
+    isRevNotFoundErrorLike,
+    RevNotFoundError,
+    CloneInProgressError,
+    isCloneInProgressErrorLike,
+    isRepoNotFoundErrorLike,
+} from './errors'
+
+describe('backend errors', () => {
+    describe('isCloneInProgressErrorLike()', () => {
+        it('returns true for CloneInProgressError', () => {
+            expect(isCloneInProgressErrorLike(new CloneInProgressError('foobar'))).toBe(true)
+        })
+    })
+    describe('isRevNotFoundErrorLike()', () => {
+        it('returns true for RevNotFoundError', () => {
+            expect(isRevNotFoundErrorLike(new RevNotFoundError('foobar'))).toBe(true)
+        })
+    })
+    describe('isRepoNotFoundErrorLike()', () => {
+        it('returns true for RepoNotFoundError', () => {
+            expect(isRepoNotFoundErrorLike(new RepoNotFoundError('foobar'))).toBe(true)
+        })
+    })
+    describe('isRepoSeeOtherErrorLike()', () => {
+        it('returns the redirect URL for RepoSeeOtherErrors', () => {
+            expect(isRepoSeeOtherErrorLike(new RepoSeeOtherError('https://sourcegraph.test'))).toBe(
+                'https://sourcegraph.test'
+            )
+        })
+        it('returns the redirect URL for plain RepoSeeOtherErrors', () => {
+            expect(
+                isRepoSeeOtherErrorLike({ message: new RepoSeeOtherError('https://sourcegraph.test').message })
+            ).toBe('https://sourcegraph.test')
+        })
+        it('returns false for other errors', () => {
+            expect(isRepoSeeOtherErrorLike(new Error())).toBe(false)
+        })
+        it('returns false for other values', () => {
+            expect(isRepoSeeOtherErrorLike('foo')).toBe(false)
+        })
+    })
+    describe('isPrivateRepoPublicSourcegraphComErrorLike()', () => {
+        it('returns true for PrivateRepoPublicSourcegraphComError', () => {
+            expect(
+                isPrivateRepoPublicSourcegraphComErrorLike(new PrivateRepoPublicSourcegraphComError('ResolveFoo'))
+            ).toBe(true)
+        })
+        it('returns true for plain PrivateRepoPublicSourcegraphComError', () => {
+            expect(
+                isPrivateRepoPublicSourcegraphComErrorLike({
+                    message: new PrivateRepoPublicSourcegraphComError('ResolveFoo').message,
+                })
+            ).toBe(true)
+        })
+    })
+})

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -20,7 +20,7 @@ import { parse, parseTemplate } from '../api/client/context/expr/evaluator'
 import { Services } from '../api/client/services'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { ContributableMenu, TextDocumentPositionParams } from '../api/protocol'
-import { PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME } from '../backend/errors'
+import { isPrivateRepoPublicSourcegraphComErrorLike } from '../backend/errors'
 import { resolveRawRepoName } from '../backend/repo'
 import { getContributedActionItems } from '../contributions/contributions'
 import { ExtensionsControllerProps } from '../extensions/controller'
@@ -231,7 +231,7 @@ export function getDefinitionURL(
                 // we're executing in a browser extension pointed to the public sourcegraph.com,
                 // in which case repoName === rawRepoName.
                 catchError(err => {
-                    if (isErrorLike(err) && err.name === PRIVATE_REPO_PUBLIC_SOURCEGRAPH_COM_ERROR_NAME) {
+                    if (isPrivateRepoPublicSourcegraphComErrorLike(err)) {
                         return [uri.repoName]
                     }
                     throw err

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -6,11 +6,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Subject, Subscription, concat, combineLatest } from 'rxjs'
 import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
 import { redirectToExternalHost } from '.'
-import {
-    REPO_NOT_FOUND_ERROR_NAME,
-    REPO_SEE_OTHER_ERROR_NAME,
-    RepoSeeOtherError,
-} from '../../../shared/src/backend/errors'
+import { isRepoNotFoundErrorLike, isRepoSeeOtherErrorLike } from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -155,10 +151,10 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             [undefined],
                             fetchRepository({ repoName }).pipe(
                                 catchError(error => {
-                                    switch (error.name) {
-                                        case REPO_SEE_OTHER_ERROR_NAME:
-                                            redirectToExternalHost((error as RepoSeeOtherError).redirectURL)
-                                            return []
+                                    const redirect = isRepoSeeOtherErrorLike(error)
+                                    if (redirect) {
+                                        redirectToExternalHost(redirect)
+                                        return []
                                     }
                                     return [asError(error)]
                                 })
@@ -281,18 +277,16 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
 
         if (isErrorLike(this.state.repoOrError)) {
             // Display error page
-            switch (this.state.repoOrError.name) {
-                case REPO_NOT_FOUND_ERROR_NAME:
-                    return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
-                default:
-                    return (
-                        <HeroPage
-                            icon={AlertCircleIcon}
-                            title="Error"
-                            subtitle={<ErrorMessage error={this.state.repoOrError} />}
-                        />
-                    )
+            if (isRepoNotFoundErrorLike(this.state.repoOrError)) {
+                return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
             }
+            return (
+                <HeroPage
+                    icon={AlertCircleIcon}
+                    title="Error"
+                    subtitle={<ErrorMessage error={this.state.repoOrError} />}
+                />
+            )
         }
 
         const repoMatchURL = `/${this.state.repoOrError.name}`

--- a/web/src/repo/index.tsx
+++ b/web/src/repo/index.tsx
@@ -6,7 +6,6 @@ export function redirectToExternalHost(externalRedirectURL: string): void {
     const redirectURL = new URL(window.location.href)
     // Preserve the path of the current URL and redirect to the repo on the external host.
     redirectURL.host = externalHostURL.host
-    redirectURL.port = externalHostURL.port
     redirectURL.protocol = externalHostURL.protocol
-    window.location.replace(redirectURL.toString())
+    window.location.replace(redirectURL.href)
 }


### PR DESCRIPTION
Fixes #9411, fixes #7599

Until #9693 and #9697 are fixed we unfortunately have no alternative than to assert error message strings.

I overhauled the "Open on Sourcegraph" logic, and decided to link to the integration docs if we can't open the options menu (in native integrations). In the case where the repo is simply not found (but not because it is private + instance is sourcegraph.com), I show that in the button but still link to the repo on the instance, where it will get the 404 page that could have more instructions or a button to configure external services depending on the site admin status of the user etc.

Example:

![image](https://user-images.githubusercontent.com/10532611/78905753-c2bf3400-7a7e-11ea-813c-7cc8c49affd5.png)
