### PR TITLE
Fix bundle manager dockerfile EXPORT value

### DIFF
--- a/cmd/precise-code-intel/bundle-manager/Dockerfile
+++ b/cmd/precise-code-intel/bundle-manager/Dockerfile
@@ -38,6 +38,6 @@ USER sourcegraph
 
 COPY --from=precise-code-intel-builder /precise-code-intel /precise-code-intel
 
-EXPOSE 3186
+EXPOSE 3187
 ENV LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "node", "/precise-code-intel/out/bundle-manager/manager.js"]


### PR DESCRIPTION
This fixes an incorrect port value.