### PR TITLE
Distribution tracking issue syncer: include PRs

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -43,7 +43,7 @@ jobs:
   distribution:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://sourcegraph/tracking-issue:latest
+      - uses: docker://sourcegraph/tracking-issue:prs
         with:
           args: -milestone 3.15 -labels team/distribution -update
         env:


### PR DESCRIPTION
Experiment to include PRs that have the appropriate team/milestone labels in our tracking issue (thanks to @tsenart ! [context](https://sourcegraph.slack.com/archives/CJX299FGE/p1586460109284100?thread_ts=1586374198.256800&cid=CJX299FGE))

I primarily will use this when I send PRs that do not have issues created, e.g. for work that was not planned or filed as an issue, but did happen (because it was important, was a refactor, etc).