### PR TITLE
Exclude GitHub tree pages from CSS selector

### DIFF
--- a/browser/src/libs/github/style.scss
+++ b/browser/src/libs/github/style.scss
@@ -30,17 +30,20 @@
 // Make sure only our code view toolbar shrinks and wraps,
 // not GitHub's UI groups
 .repository-content {
-    .Box-header {
-        > .text-mono {
-            // only let Sourcegraph toolbar shrink
-            flex-shrink: 0 !important;
-        }
-        > div:nth-child(2) {
-            > div:not(.sourcegraph-github-file-code-view-toolbar-mount) {
+    // Exclude tree pages
+    > .Box:not(.Box--condensed) {
+        > .Box-header:not(.Box-header--blue) {
+            > .text-mono {
                 // only let Sourcegraph toolbar shrink
-                flex-shrink: 0;
-                display: flex;
-                align-items: center;
+                flex-shrink: 0 !important;
+            }
+            > div:nth-child(2) {
+                > div:not(.sourcegraph-github-file-code-view-toolbar-mount) {
+                    // only let Sourcegraph toolbar shrink
+                    flex-shrink: 0;
+                    display: flex;
+                    align-items: center;
+                }
             }
         }
     }


### PR DESCRIPTION
Reported by @slimsag and @eseliger