### PR TITLE
Fix GitHub file actions wrapping

### DIFF
--- a/browser/src/libs/github/style.scss
+++ b/browser/src/libs/github/style.scss
@@ -52,11 +52,12 @@
 // Diff views
 .diff-view {
     .file-header {
+        flex-wrap: wrap;
         .file-info {
             flex: 0 2 auto !important;
         }
         .file-actions {
-            flex: 1 1 50%;
+            flex: 1 1 auto;
             margin-left: 1rem;
             display: flex;
             align-items: center;


### PR DESCRIPTION
I decided it looks better to have them wrap in two rows than two columns.

![image](https://user-images.githubusercontent.com/10532611/78940648-83143e80-7ab6-11ea-9c71-33f5ae573103.png)

Fixes #9675 

cc @imtommyroberts 