### PR TITLE
search: add delimiter scanner

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -183,6 +183,57 @@ func (p *parser) skipSpaces() error {
 	return nil
 }
 
+// ScanDelimited takes a delimited (e.g., quoted) value for some arbitrary
+// delimiter, returning the undelimited value, and the end position of the
+// original delimited value (i.e., including quotes). `\` is treated as an
+// escape character for the delimiter and traditional string escape sequences.
+// The input buffer must start with the chosen delimiter.
+func ScanDelimited(buf []byte, delimiter rune) (string, int, error) {
+	var count, advance int
+	var r rune
+	result := []rune{}
+
+	next := func() {
+		r, advance = utf8.DecodeRune(buf)
+		count += advance
+		buf = buf[advance:]
+	}
+
+	next()
+	if r != delimiter {
+		panic(fmt.Sprintf("ScanDelimited expects the input buffer to start with delimiter %s, but it starts with %s.", string(delimiter), string(r)))
+	}
+
+loop:
+	for len(buf) > 0 {
+		next()
+		switch {
+		case r == delimiter:
+			break loop
+		case r == '\\':
+			// Handle escape sequence.
+			if len(buf[advance:]) > 0 {
+				next()
+				switch r {
+				case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', delimiter:
+					result = append(result, r)
+				default:
+					return "", count, errors.New("unrecognized escape sequence")
+				}
+			} else {
+				return "", count, errors.New("unterminated escape sequence")
+			}
+		default:
+			result = append(result, r)
+		}
+	}
+
+	if r != delimiter {
+		return "", count, errors.New("unterminated literal: expected " + string(delimiter))
+	}
+	return string(result), count, nil
+}
+
 var fieldValuePattern = lazyregexp.New("(^-?[a-zA-Z0-9]+):(.*)")
 
 // ScanParameter returns a leaf node value usable by _any_ kind of search (e.g.,

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -449,7 +449,7 @@ func Test_ScanDelimited(t *testing.T) {
 		{
 			input:     `"\\\"`,
 			delimiter: '"',
-			want:      result{Value: "", Count: 4, ErrMsg: "unterminated escape sequence"},
+			want:      result{Value: "", Count: 5, ErrMsg: `unterminated literal: expected "`},
 		},
 		{
 			input:     `"\\\""`,


### PR DESCRIPTION
This PR implements a scanner for delimited values (like quoted strings), for arbitrary delimiters. The use case is scanning strings, but also the `/.../` regex pattern syntax we currently support (where the delimiter is `/`). 

I thought deeply about (re)using the [existing scanner code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@24514aa48e0c95a0fd853f79c5a28dfa64461a3b/-/blob/internal/search/query/syntax/scanner.go#L33), but I think it will bite me in the long run. The main reasons is that I want standalone functions for scanning because I want to reuse the units in different contexts, e.g., for regex vs literal search, or to parameterize the parser with different scanners based on heuristics. It's useful if the standalone functions works like [`DecodeRune`](https://golang.org/pkg/unicode/utf8/#DecodeRune), where I get back the 'decoded' value, and the amount 'decoded', which is how I've written this. Our existing scanner doesn't expose standalone functions and assumes a tight relationship between different tokens in the input (since each token scanner returns a continuation), which is a fine and elegant approach if we're only dealing with one way to scan the input. But, we support different search input interpretations, and standalone functions will help with that complexity.

You'll find I use the same structure in #9729 to implement a scanner for patterns. There's a higher-level scanner abstraction here that can lift the duplicated parts out (e.g., the `next()` helper function, and so on) with higher order functions. I will be doing that in a later PR--keeping the scanners separate means I don't have to overengineer a common abstraction first, and helps me refine what it would look like.

Note: this function is not used in this PR, but will be in later PRs.