### PR TITLE
Add button to tweet feedback after completing NPS survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [`sourcegraph/git-extras`](https://sourcegraph.com/extensions/sourcegraph/git-extras) is now enabled by default on new instances [#3501](https://github.com/sourcegraph/sourcegraph/issues/3501)
 - The Sourcegraph Docker image will now copy `/etc/sourcegraph/gitconfig` to `$HOME/.gitconfig`. This is a convenience similiar to what we provide for [repositories that need HTTP(S) or SSH authentication](https://docs.sourcegraph.com/admin/repo/auth). [#658](https://github.com/sourcegraph/sourcegraph/issues/658)
 - search: Adding `stable:true` to a query ensures a deterministic search result order. This is an experimental parameter. It applies only to file contents, and is limited to at max 5,000 results (consider using [the paginated search API](https://docs.sourcegraph.com/api/graphql/search#sourcegraph-3-9-experimental-paginated-search) if you need more than that.).
+- After completing the Sourcegraph user feedback survey, a button may appear for tweeting this feedback at [@srcgraph](https://twitter.copm/srcgraph).
 
 ### Changed
 

--- a/web/src/marketing/SurveyPage.tsx
+++ b/web/src/marketing/SurveyPage.tsx
@@ -13,6 +13,8 @@ import { submitSurvey } from './backend'
 import { SurveyCTA } from './SurveyToast'
 import { Subscription } from 'rxjs'
 import { ThemeProps } from '../../../shared/src/theme'
+import TwitterIcon from 'mdi-react/TwitterIcon'
+
 interface SurveyFormProps {
     location: H.Location
     history: H.History
@@ -161,7 +163,13 @@ class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
                     if (this.props.onSubmit) {
                         this.props.onSubmit()
                     }
-                    this.props.history.push('/survey/thanks')
+                    this.props.history.push({
+                        pathname: '/survey/thanks',
+                        state: {
+                            score: this.props.score,
+                            feedback: this.state.reason,
+                        },
+                    })
                 })
         )
     }
@@ -169,6 +177,35 @@ class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
 
 interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
     authenticatedUser: GQL.IUser | null
+}
+
+export interface TweetFeedbackProps {
+    score: number
+    feedback: string
+}
+
+const SCORE_TO_TWEET = 8
+class TweetFeedback extends React.Component<TweetFeedbackProps> {
+    private getMessage(): string {
+        return `After using @srcgraph: ${encodeURIComponent(this.props.feedback)}`
+    }
+
+    public render(): JSX.Element | null {
+        if (this.props.score >= SCORE_TO_TWEET) {
+            return (
+                <a
+                    className="btn btn-primary mt-3"
+                    href={`https://twitter.com/intent/tweet?text=${this.getMessage()}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    <TwitterIcon className="icon-inline mr-2" />
+                    Tweet feedback
+                </a>
+            )
+        }
+        return null
+    }
 }
 
 export class SurveyPage extends React.Component<SurveyPageProps> {
@@ -183,6 +220,12 @@ export class SurveyPage extends React.Component<SurveyPageProps> {
                     <PageTitle title="Thanks" />
                     <HeroPage
                         title="Thank you for sending feedback."
+                        body={
+                            <TweetFeedback
+                                score={this.props.location.state.score}
+                                feedback={this.props.location.state.feedback}
+                            />
+                        }
                         cta={<FeedbackText headerText="Anything else?" />}
                     />
                 </div>

--- a/web/src/marketing/SurveyPage.tsx
+++ b/web/src/marketing/SurveyPage.tsx
@@ -184,7 +184,7 @@ export interface TweetFeedbackProps {
     feedback: string
 }
 
-const SCORE_TO_TWEET = 8
+const SCORE_TO_TWEET = 9
 class TweetFeedback extends React.Component<TweetFeedbackProps> {
     private getMessage(): string {
         return `After using @srcgraph: ${encodeURIComponent(this.props.feedback)}`

--- a/web/src/marketing/SurveyPage.tsx
+++ b/web/src/marketing/SurveyPage.tsx
@@ -190,10 +190,20 @@ const TweetFeedback: React.FunctionComponent<TweetFeedbackProps> = ({ feedback, 
         const url = new URL('https://twitter.com/intent/tweet')
         url.searchParams.set('text', `After using @srcgraph: ${feedback}`)
         return (
-            <a className="btn btn-primary mt-3" href={url.href} target="_blank" rel="noreferrer noopener">
-                <TwitterIcon className="icon-inline mr-2" />
-                Tweet feedback
-            </a>
+            <>
+                <p className="mt-2">
+                    One more favor, could you share your feedback on Twitter? We'd really appreciate it!
+                </p>
+                <a
+                    className="d-inline-block mt-2 btn btn-primary"
+                    href={url.href}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    <TwitterIcon className="icon-inline mr-2" />
+                    Tweet feedback
+                </a>
+            </>
         )
     }
     return null
@@ -210,7 +220,7 @@ export class SurveyPage extends React.Component<SurveyPageProps> {
                 <div className="survey-page">
                     <PageTitle title="Thanks" />
                     <HeroPage
-                        title="Thank you for sending feedback."
+                        title="Thanks for the feedback!"
                         body={
                             <TweetFeedback
                                 score={this.props.location.state.score}


### PR DESCRIPTION
We want to make it easier for developers who love and would recommend Sourcegraph to their colleagues to share that feedback with the development community.

If the score is 9 or above, then a **Tweet feedback** button is shown.

<img width="763" alt="Screen Shot 2020-04-11 at 8 20 47 AM" src="https://user-images.githubusercontent.com/133014/79026890-8fd78600-7bcd-11ea-85f8-3d8dfc3a399e.png">
