### PR TITLE
tracking-issue: Use latest image for team/distribution

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -43,7 +43,7 @@ jobs:
   distribution:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://sourcegraph/tracking-issue:prs
+      - uses: docker://sourcegraph/tracking-issue:latest
         with:
           args: -milestone 3.15 -labels team/distribution -update
         env:


### PR DESCRIPTION
#9711 is merged and the Docker image is pushed to Docker hub, so we can go back to latest.