### PR TITLE
search: avoid nil deref for stable: on alert

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -567,7 +567,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 			// paginatedResults should be ensuring that result is
 			// non-nil, but the possibility that this changes at a
 			// later stage is too scary to entertain.
-			return &SearchResultsResolver{}, nil
+			panic("stable search: paginated search returned nil results")
 		}
 		if result.cursor == nil {
 			// Perhaps an alert was raised.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -560,7 +560,20 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 	// If the request specifies stable:truthy, use pagination to return a stable ordering.
 	if r.query.BoolValue("stable") {
 		result, err := r.paginatedResults(ctx)
-		if err == nil && !result.cursor.Finished {
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			// paginatedResults should be ensuring that result is
+			// non-nil, but the possibility that this changes at a
+			// later stage is too scary to entertain.
+			return &SearchResultsResolver{}, nil
+		}
+		if result.cursor == nil {
+			// Perhaps an alert was raised.
+			return result, err
+		}
+		if !result.cursor.Finished {
 			// For stable result queries limitHit = true implies
 			// there is a next cursor, and more results may exist.
 			result.searchResultsCommon.limitHit = true

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -564,9 +564,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 			return nil, err
 		}
 		if result == nil {
-			// paginatedResults should be ensuring that result is
-			// non-nil, but the possibility that this changes at a
-			// later stage is too scary to entertain.
+			// Panic if paginatedResults does not ensure a non-nil search result.
 			panic("stable search: paginated search returned nil results")
 		}
 		if result.cursor == nil {


### PR DESCRIPTION
Specifying `stable:` for a query that may raise an alert instead of returning results can result in a nil deref. See comments. No test: this is a defensive change. I may add one later.

Context: I triggered this by running a query with `stable:` that should have thrown a 'repo limit' alert, but instead I got a nil deref.