### PR TITLE
search: introduce query mapper and lowercase transformer

### DIFF
--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -1,14 +1,20 @@
 package query
 
+// The Mapper interface allows to replace nodes for each respective part of the
+// query grammar. It is a visitor that will replace the visited node by the
+// returned value.
 type Mapper interface {
 	MapNodes(v Mapper, node []Node) []Node
 	MapOperator(v Mapper, kind operatorKind, operands []Node) []Node
 	MapParameter(v Mapper, field, value string, negated bool) Node
 }
 
+// The BaseMapper is a mapper that recursively visits each node in a query and
+// maps it to itself. A BaseMapper's methods may be overrided by embedding it a
+// custom mapper's definitoin. See ParameterMapper for an example.
 type BaseMapper struct{}
 
-func (_ *BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
+func (*BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
 	mapped := []Node{}
 	for _, node := range nodes {
 		switch v := node.(type) {
@@ -22,26 +28,32 @@ func (_ *BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
 }
 
 // Base mapper for Operators. Reduces operands if changed.
-func (_ *BaseMapper) MapOperator(visitor Mapper, kind operatorKind, operands []Node) []Node {
+func (*BaseMapper) MapOperator(visitor Mapper, kind operatorKind, operands []Node) []Node {
 	return newOperator(visitor.MapNodes(visitor, operands), kind)
 }
 
 // Base mapper for Parameters. It is the identity function.
-func (_ *BaseMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
+func (*BaseMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
 	return Parameter{Field: field, Value: value, Negated: negated}
 }
 
+// ParameterMapper is a helper mapper that only maps parameters in a query. It
+// takes as state a callback that will call and map each visited parameter by
+// the return value.
 type ParameterMapper struct {
 	callback func(field, value string, negated bool) Node
 	BaseMapper
 }
 
+// MapParameter implements ParameterMapper by overriding the BaseMapper's value
+// to substitute a node as determined by the callback.
 func (s *ParameterMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
 	return s.callback(field, value, negated)
 }
 
-// MapParameter calls callback on all parameter nodes. callback supplies the
-// node's field, value, and whether the value is negated.
+// MapParameter calls callback on all parameter nodes, substituting them for
+// callback's return value. callback supplies the node's field, value, and
+// whether the value is negated.
 func MapParameter(nodes []Node, callback func(field, value string, negated bool) Node) []Node {
 	visitor := &ParameterMapper{callback: callback}
 	return visitor.MapNodes(visitor, nodes)

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -1,0 +1,48 @@
+package query
+
+type Mapper interface {
+	MapNodes(v Mapper, node []Node) []Node
+	MapOperator(v Mapper, kind operatorKind, operands []Node) []Node
+	MapParameter(v Mapper, field, value string, negated bool) Node
+}
+
+type BaseMapper struct{}
+
+func (_ *BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
+	mapped := []Node{}
+	for _, node := range nodes {
+		switch v := node.(type) {
+		case Parameter:
+			mapped = append(mapped, visitor.MapParameter(visitor, v.Field, v.Value, v.Negated))
+		case Operator:
+			mapped = append(mapped, visitor.MapOperator(visitor, v.Kind, v.Operands)...)
+		}
+	}
+	return mapped
+}
+
+// Base mapper for Operators. Reduces operands if changed.
+func (_ *BaseMapper) MapOperator(visitor Mapper, kind operatorKind, operands []Node) []Node {
+	return newOperator(visitor.MapNodes(visitor, operands), kind)
+}
+
+// Base mapper for Parameters. It is the identity function.
+func (_ *BaseMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
+	return Parameter{Field: field, Value: value, Negated: negated}
+}
+
+type ParameterMapper struct {
+	callback func(field, value string, negated bool) Node
+	BaseMapper
+}
+
+func (s *ParameterMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
+	return s.callback(field, value, negated)
+}
+
+// MapParameter calls callback on all parameter nodes. callback supplies the
+// node's field, value, and whether the value is negated.
+func MapParameter(nodes []Node, callback func(field, value string, negated bool) Node) []Node {
+	visitor := &ParameterMapper{callback: callback}
+	return visitor.MapNodes(visitor, nodes)
+}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -1,0 +1,12 @@
+package query
+
+import (
+	"strings"
+)
+
+// LowercaseFieldNames performs strings.ToLower on every field name.
+func LowercaseFieldNames(nodes []Node) []Node {
+	return MapParameter(nodes, func(field, value string, negated bool) Node {
+		return Parameter{Field: strings.ToLower(field), Value: value, Negated: negated}
+	})
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -22,6 +22,5 @@ func Test_LowercaseFieldNames(t *testing.T) {
 	got := prettyPrint(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
-
 	}
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -1,0 +1,27 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func prettyPrint(nodes []Node) string {
+	var resultStr []string
+	for _, node := range nodes {
+		resultStr = append(resultStr, node.String())
+	}
+	return strings.Join(resultStr, " ")
+}
+
+func Test_LowercaseFieldNames(t *testing.T) {
+	input := "rEpO:foo PATTERN"
+	want := `(and "repo:foo" "PATTERN")`
+	query, _ := parseAndOr(input)
+	got := prettyPrint(LowercaseFieldNames(query))
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatal(diff)
+
+	}
+}


### PR DESCRIPTION
Some visitor frameworks include a convenience mapper interface to transform trees. This is the initial mapper interface for and/or queries. The first use is a transformer that converts fields to lowercase, which is [a pass that we currently do](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@133f9631a97f991328048f455f69b62cb38a9c16/-/blob/internal/search/query/searchquery.go#L111-114) when validating current queries.

This is prep work for more and/or query validation in follow up PR #9757 