### PR TITLE
search: achieve validation parity with existing queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -88,7 +88,7 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 
 	var queryInfo query.QueryInfo
 	if conf.AndOrQueryEnabled() {
-		queryInfo, err = query.ParseAndOr(args.Query)
+		queryInfo, err = query.ProcessAndOr(args.Query)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
 		}
@@ -817,10 +817,11 @@ func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver,
 	var queryInfo query.QueryInfo
 	var err error
 	if conf.AndOrQueryEnabled() {
-		queryInfo, err = query.ParseAndOr(plainQuery)
+		andOrQuery, err := query.ParseAndOr(plainQuery)
 		if err != nil {
 			return nil, err
 		}
+		queryInfo = &query.AndOrQuery{Query: andOrQuery}
 	} else {
 		queryInfo, err = query.ParseAndCheck(queryString)
 		if err != nil {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -595,8 +595,8 @@ func (p *parser) parseOr() ([]Node, error) {
 	return newOperator(append(left, right...), Or), nil
 }
 
-// parseAndOr a raw input string into a parse tree comprising Nodes.
-func parseAndOr(in string) ([]Node, error) {
+// ParseAndOr a raw input string into a parse tree comprising Nodes.
+func ParseAndOr(in string) ([]Node, error) {
 	if in == "" {
 		return nil, nil
 	}
@@ -611,8 +611,14 @@ func parseAndOr(in string) ([]Node, error) {
 	return newOperator(nodes, And), nil
 }
 
-func ParseAndOr(in string) (QueryInfo, error) {
-	query, err := parseAndOr(in)
+// ProcessAndOr query parses and validates an and/or query for a given search type.
+func ProcessAndOr(in string) (QueryInfo, error) {
+	query, err := ParseAndOr(in)
+	if err != nil {
+		return nil, err
+	}
+	query = LowercaseFieldNames(query)
+	err = validate(query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -424,7 +424,7 @@ func Test_Parse(t *testing.T) {
 			var err error
 			result, err = parseAndOrGrammar(tt.Input) // Parse without heuristic.
 			check(result, err, string(tt.WantGrammar))
-			result, err = parseAndOr(tt.Input)
+			result, err = ParseAndOr(tt.Input)
 			if tt.WantHeuristic == Same {
 				check(result, err, string(tt.WantGrammar))
 			} else {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -18,7 +18,7 @@ func prettyPrint(nodes []Node) string {
 func Test_LowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
-	query, _ := parseAndOr(input)
+	query, _ := ParseAndOr(input)
 	got := prettyPrint(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -5,7 +5,147 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
+
+func TestAndOrQuery_Validation(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "case:yes case:no",
+			want:  `field "case" may not be used more than once`,
+		},
+		{
+			input: "repo:[",
+			want:  "error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			input: "-index:yes",
+			want:  `field "index" does not support negation`,
+		},
+		{
+			input: "lang:c lang:go lang:stephenhas9cats",
+			want:  `unknown language: "stephenhas9cats"`,
+		},
+		{
+			input: "stable:???",
+			want:  `invalid boolean "???"`,
+		},
+		{
+			input: "mr:potato",
+			want:  `unrecognized field "mr"`,
+		},
+	}
+	for _, c := range cases {
+		t.Run("validate and/or query", func(t *testing.T) {
+			_, err := ProcessAndOr(c.input)
+			if err == nil {
+				t.Fatal("expected test to fail")
+			}
+			if diff := cmp.Diff(c.want, err.Error()); diff != "" {
+				t.Fatal(diff)
+			}
+
+		})
+
+	}
+}
+
+func TestAndOrQuery_IsCaseSensitive(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "yes",
+			input: "case:yes",
+			want:  true,
+		},
+		{
+			name:  "no (explicit)",
+			input: "case:no",
+			want:  false,
+		},
+		{
+			name:  "no (default)",
+			input: "case:no",
+			want:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			query, err := ProcessAndOr(c.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := query.IsCaseSensitive()
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestAndOrQuery_RegexpPatterns(t *testing.T) {
+	type want struct {
+		values        []string
+		negatedValues []string
+	}
+	c := struct {
+		query string
+		field string
+		want
+	}{
+		query: "r:a r:b -r:c",
+		field: "r",
+		want: want{
+			values:        []string{"a", "b"},
+			negatedValues: []string{"c"},
+		},
+	}
+	t.Run("for regexp field", func(t *testing.T) {
+		query, err := ProcessAndOr(c.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotValues, gotNegatedValues := query.RegexpPatterns(c.field)
+		if diff := cmp.Diff(c.want.values, gotValues); diff != "" {
+			t.Error(diff)
+		}
+		if diff := cmp.Diff(c.want.negatedValues, gotNegatedValues); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("for unrecognized field", func(t *testing.T) {
+		query, err := ProcessAndOr("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		checkPanic(t, "no such field: z", func() {
+			query.RegexpPatterns("z")
+		})
+	})
+}
+
+func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {
+	query, err := ProcessAndOr("repoHasFile:foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values, _ := query.RegexpPatterns(FieldRepoHasFile)
+	if len(values) != 1 || values[0] != "foo" {
+		t.Errorf("unexpected values: want {\"foo\"}, got %v", values)
+	}
+
+	fields := types.Fields(query.Fields())
+	if got, want := fields.String(), `repohasfile~"foo"`; got != want {
+		t.Errorf("unexpected parsed query:\ngot:  %s\nwant: %s", got, want)
+	}
+}
 
 func Test_PartitionSearchPattern(t *testing.T) {
 	cases := []struct {
@@ -76,8 +216,7 @@ func Test_PartitionSearchPattern(t *testing.T) {
 	for _, tt := range cases {
 		t.Run("partition search pattern", func(t *testing.T) {
 			q, _ := ParseAndOr(tt.input)
-			andOrQuery, _ := q.(*AndOrQuery)
-			scopeParameters, pattern, err := PartitionSearchPattern(andOrQuery.Query)
+			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
 				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {
 					t.Fatal(diff)


### PR DESCRIPTION
Stacked on #9752. This PR validates and/or queries in essentially the same way as our existing query logic. The main addition is function `validateField`, which does basically all the work of our existing `searchquery.go` [definition constraints](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a1e17db/-/blob/internal/search/query/searchquery.go#L52-164) and check logic in `check.go`. The rest of the PR is basically just set up.

I have migrated validation tests from `search_query.go` where it makes sense, and added my own additional ones. See linked issue for further description.