### PR TITLE
search: hoist or-expressions heuristic

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -33,7 +33,7 @@ func LowercaseFieldNames(nodes []Node) []Node {
 // repo:foo a or b or repo:bar c => (repo:foo a) or (b) or (repo:bar c)
 func HoistOr(nodes []Node) ([]Node, error) {
 	if len(nodes) != 1 {
-		return nil, fmt.Errorf("heuristic requires one top-level")
+		return nil, fmt.Errorf("heuristic requires one top-level expression")
 	}
 
 	expression, ok := nodes[0].(Operator)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -9,4 +11,53 @@ func LowercaseFieldNames(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool) Node {
 		return Parameter{Field: strings.ToLower(field), Value: value, Negated: negated}
 	})
+}
+
+// HoistOr is a heuristic that rewrites simple but possibly ambiguous queries
+// containing or-expressions. It changes certain expressions in a way that some
+// consider to be more natural. For example, the following query without
+// parentheses is interpreted as follows in the grammar:
+//
+// repo:foo a or b and c => (repo:foo a) or ((b) and (c))
+//
+// This function rewrites the above expression as follows:
+//
+// repo:foo a or b and c => repo:foo (a or b and c)
+//
+// Any number of field:value parameters may occur before and after the pattern
+// expression separated by or-operators, and these are hoisted out. The pattern
+// expression must be contiguous. If not, we want to preserve the default
+// interpretation, which corresponds more naturally to groupings with field
+// parameters, i.e.,
+//
+// repo:foo a or b or repo:bar c => (repo:foo a) or (b) or (repo:bar c)
+func HoistOr(nodes []Node) ([]Node, error) {
+	if len(nodes) != 1 {
+		return nil, fmt.Errorf("heuristic requires top-level or-expression")
+	}
+
+	expression, ok := nodes[0].(Operator)
+	if !ok || expression.Kind == And || expression.Kind == Concat {
+		return nil, fmt.Errorf("heuristic requires top-level or-expression")
+	}
+
+	n := len(expression.Operands)
+	var pattern []Node
+	var scopeParameters []Node
+	for i, node := range expression.Operands {
+		if i == 0 || i == n-1 {
+			scopePart, patternPart, err := PartitionSearchPattern([]Node{node})
+			if err != nil || patternPart == nil {
+				return nil, errors.New("could not partition first or last expression")
+			}
+			pattern = append(pattern, patternPart)
+			scopeParameters = append(scopeParameters, scopePart...)
+			continue
+		}
+		if !isPatternExpression([]Node{node}) {
+			return nil, errors.New("inner expression is not a pure pattern expression")
+		}
+		pattern = append(pattern, node)
+	}
+	return append(scopeParameters, newOperator(pattern, Or)...), nil
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -33,11 +33,11 @@ func LowercaseFieldNames(nodes []Node) []Node {
 // repo:foo a or b or repo:bar c => (repo:foo a) or (b) or (repo:bar c)
 func HoistOr(nodes []Node) ([]Node, error) {
 	if len(nodes) != 1 {
-		return nil, fmt.Errorf("heuristic requires top-level or-expression")
+		return nil, fmt.Errorf("heuristic requires one top-level")
 	}
 
 	expression, ok := nodes[0].(Operator)
-	if !ok || expression.Kind == And || expression.Kind == Concat {
+	if !ok || expression.Kind != Or {
 		return nil, fmt.Errorf("heuristic requires top-level or-expression")
 	}
 
@@ -55,7 +55,7 @@ func HoistOr(nodes []Node) ([]Node, error) {
 			continue
 		}
 		if !isPatternExpression([]Node{node}) {
-			return nil, errors.New("inner expression is not a pure pattern expression")
+			return nil, fmt.Errorf("inner expression %s is not a pure pattern expression", node.String())
 		}
 		pattern = append(pattern, node)
 	}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -77,7 +77,7 @@ func Test_HoistOr(t *testing.T) {
 		},
 		{
 			input:      "repo:foo a or repo:foobar b or c file:bar",
-			wantErrMsg: "inner expression is not a pure pattern expression",
+			wantErrMsg: `inner expression (and "repo:foobar" "b") is not a pure pattern expression`,
 		},
 	}
 	for _, c := range cases {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -24,3 +24,76 @@ func Test_LowercaseFieldNames(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func Test_HoistOr(t *testing.T) {
+	cases := []struct {
+		input      string
+		want       string
+		wantErrMsg string
+	}{
+		{
+			input: `repo:foo a or b`,
+			want:  `"repo:foo" (or "a" "b")`,
+		},
+		{
+			input: `repo:foo a or b file:bar`,
+			want:  `"repo:foo" "file:bar" (or "a" "b")`,
+		},
+		{
+			input: `repo:foo a or b or c file:bar`,
+			want:  `"repo:foo" "file:bar" (or "a" "b" "c")`,
+		},
+		{
+			input: `repo:foo a and b or c and d or e file:bar`,
+			want:  `"repo:foo" "file:bar" (or (and "a" "b") (and "c" "d") "e")`,
+		},
+		// This next pattern is valid for the heuristic, even though the ordering of the
+		// patterns 'a' and 'c' in the first and last position are not ordered next to the
+		// 'or' keyword. This because no ordering is assumed for patterns vs. field:value
+		// parameters in the grammar. To preserve relative ordering and check this would
+		// impose significant complexity to PartitionParameters function during parsing, and
+		// the PartitionSearchPattern helper function that the heurstic relies on. So: we
+		// accept this heuristic behavior here.
+		{
+			input: `a repo:foo or b or file:bar c`,
+			want:  `"repo:foo" "file:bar" (or "a" "b" "c")`,
+		},
+		// Errors.
+		{
+			input:      "repo:foo or a",
+			wantErrMsg: "could not partition first or last expression",
+		},
+		{
+			input:      "a or repo:foo",
+			wantErrMsg: "could not partition first or last expression",
+		},
+		{
+			input:      "repo:foo or repo:bar",
+			wantErrMsg: "could not partition first or last expression",
+		},
+		{
+			input:      "a b",
+			wantErrMsg: "heuristic requires top-level or-expression",
+		},
+		{
+			input:      "repo:foo a or repo:foobar b or c file:bar",
+			wantErrMsg: "inner expression is not a pure pattern expression",
+		},
+	}
+	for _, c := range cases {
+		t.Run("hoist or", func(t *testing.T) {
+			query, _ := ParseAndOr(c.input)
+			hoistedQuery, err := HoistOr(query)
+			if err != nil {
+				if diff := cmp.Diff(c.wantErrMsg, err.Error()); diff != "" {
+					t.Error(diff)
+				}
+				return
+			}
+			got := prettyPrint(hoistedQuery)
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -157,6 +157,10 @@ func Test_PartitionSearchPattern(t *testing.T) {
 			want:  `"x"`,
 		},
 		{
+			input: "file:foo",
+			want:  `"file:foo"`,
+		},
+		{
 			input: "x y",
 			want:  `(concat "x" "y")`,
 		},
@@ -223,7 +227,10 @@ func Test_PartitionSearchPattern(t *testing.T) {
 				}
 				return
 			}
-			result := append(scopeParameters, pattern)
+			result := scopeParameters
+			if pattern != nil {
+				result = append(scopeParameters, pattern)
+			}
 			var resultStr []string
 			for _, node := range result {
 				resultStr = append(resultStr, node.String())


### PR DESCRIPTION
This PR introduces a transformer to convert ambiguous queries like

`repo:foo a or b` to `repo:foo (a or b)` instead of the grammar spec `(repo:foo a) or b`. You may be familiar with the related [slack thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1585160931014700). 

In addition to arguments that this feels more natural to some (perhaps majority), what's far more important is the human view of visual consistency that this imposes (as opposed to grammatical consistency). Here's why: we will currently parse

`repo:foo a and b` as `(repo:foo a) and b`

but because we treat whitespace between _certain_ expressions implicitly as `and`, the interpretation here is rather:

`repo:foo a and b` == `repo:foo and a and b` == `(repo:foo a) and b` == `repo:foo (a and b)`, so there is no ambiguity (rather, it is the case that syntactically `(repo:foo a) and b` is kind of bogus, but we don't enforce that yet and just overlook it). Hence, as a user, you may experience:

`repo:foo a and b` => "hey this works"
`repo:foo a or b` => "?? why do I get an error?"

So, the above `or`-expression will be rewritten in simple cases, see comment description of heuristic. 

This PR does not _apply_ the heuristic anywhere. The decision to apply it rests in other logic, that comes in follow up PR: #9761