### PR TITLE
search: apply hoist-or heuristic for likely ambiguous queries

### DIFF
--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -82,7 +82,14 @@ func Test_HoistOr(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("hoist or", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			// To test HoistOr, Use a simplified parse function that
+			// does not perform the heuristic.
+			parse := func(in string) []Node {
+				parser := &parser{buf: []byte(in), heuristic: true}
+				nodes, _ := parser.parseOr()
+				return newOperator(nodes, And)
+			}
+			query := parse(c.input)
 			hoistedQuery, err := HoistOr(query)
 			if err != nil {
 				if diff := cmp.Diff(c.wantErrMsg, err.Error()); diff != "" {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -198,7 +198,7 @@ func Test_PartitionSearchPattern(t *testing.T) {
 		},
 		{
 			input: "file:foo x or y",
-			want:  "cannot evaluate: unable to partition pure search pattern",
+			want:  `"file:foo" (or "x" "y")`,
 		},
 		{
 			input: "(file:foo x) or y",


### PR DESCRIPTION
Stacked on #9760.

Deciding whether to play the or-heuristic depends on detecting whether a query contains explicit parentheses. All explicit parentheses are discarded by the time we finish parsing, so detecting explicit parentheses (and importantly, those that refer to expression groups and not patterns) can only happen during parsing.

This PR adds a signal in the parser state to indicate an observation of explicit parentheses, which drives application of the heuristic.

Up the stack: #9762.