### PR TITLE
search: introduce fallback parser for dangling parens

### DIFF
--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -85,7 +85,10 @@ func Test_HoistOr(t *testing.T) {
 			// To test HoistOr, Use a simplified parse function that
 			// does not perform the heuristic.
 			parse := func(in string) []Node {
-				parser := &parser{buf: []byte(in), heuristic: true}
+				parser := &parser{
+					buf:       []byte(in),
+					heuristic: heuristic{parensAsPatterns: true},
+				}
 				nodes, _ := parser.parseOr()
 				return newOperator(nodes, And)
 			}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -79,7 +79,10 @@ func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err 
 // pattern in the and/or grammar.
 func isPureSearchPattern(buf []byte) bool {
 	// Check if the balanced string we scanned is perhaps an and/or expression by parsing without the heuristic.
-	try := &parser{buf: buf, heuristic: false}
+	try := &parser{
+		buf:       buf,
+		heuristic: heuristic{parensAsPatterns: false},
+	}
 	result, err := try.parseOr()
 	if err != nil {
 		// This is not an and/or expression, but it is balanced. It


### PR DESCRIPTION
Stacked on #9761.

Introduces a fallback parser that may as well be called the honey badger parser because it just doesn't care. This parser is triggered after all other parses and heuristics fail. The parser doesn't give any significance to parentheses, so if they're dangling or partially balanced doesn't matter, it all just becomes a pattern. That means you can search things like

`main( or foo(` and it'll be interpreted as `"main(" or "foo("`

See tests for more examples.