### PR TITLE
observability: do not mark dashboards as non-editable

### DIFF
--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -245,12 +245,6 @@ func (c *Container) dashboard() *sdk.Board {
 
 	board := sdk.NewBoard(c.Title)
 	board.Version = uint(rand.Uint32())
-
-	// Note: being able to test edits quickly to dashboards is useful, but without setting this expansion and
-	// unexpansion of rows counts as an "edit" and the site admin would be warned about an unsaved change that
-	// they cannot actually save when navigating away, so we set this when not in dev environments.
-	board.Editable = isDev
-
 	board.UID = c.Name
 	board.ID = 0
 	board.Timezone = "utc"


### PR DESCRIPTION
This prevents anyone from defining alerts on dashboard panels, so
we cannot use it, period.