### PR TITLE
observability: correctly sort firing alerts to the tops of dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to Sourcegraph are documented in this file.
 - observability: Symbols dashboard: "Store fetch queue size" can no longer appear to go negative. [#9731](https://github.com/sourcegraph/sourcegraph/issues/9731)
 - observability: Symbols dashboard: metrics are now aggregated instead of per-instance, for improved visibility. [#9730](https://github.com/sourcegraph/sourcegraph/issues/9730)
 - observability: The "resolve_revision_duration_slow" alert is no longer flaky / non-deterministic. [#9751](https://github.com/sourcegraph/sourcegraph/issues/9751)
+- observability: Firing alerts are now correctly sorted at the top of dashboards by default. [#9766](https://github.com/sourcegraph/sourcegraph/issues/9766)
 - The Phabricator integration no longer makes duplicate requests to Phabricator's API on diff views. [#8849](https://github.com/sourcegraph/sourcegraph/issues/8849)
 - Changesets on repositories that aren't available on the instance anymore are now hidden instead of failing. [#9656](https://github.com/sourcegraph/sourcegraph/pull/9656)
 

--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -285,7 +285,7 @@ func (c *Container) dashboard() *sdk.Board {
 	alertsDefined := sdk.NewTable("Alerts defined")
 	setPanelSize(alertsDefined, 9, 5)
 	setPanelPos(alertsDefined, 0, 3)
-	alertsDefined.TablePanel.Sort = &sdk.Sort{Desc: true}
+	alertsDefined.TablePanel.Sort = &sdk.Sort{Desc: true, Col: 4}
 	alertsDefined.TablePanel.Styles = []sdk.ColumnStyle{
 		{
 			Pattern: "Time",


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3173176/79078566-0358c080-7cbe-11ea-9883-530385a35ab9.png)

After:

![image](https://user-images.githubusercontent.com/3173176/79078612-592d6880-7cbe-11ea-9080-0fb10b32c4e9.png)

Applies to all generated dashboards.

Fixes #9766