### PR TITLE
observability: do not cut off panels at the bottom of home dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to Sourcegraph are documented in this file.
 - observability: Symbols dashboard: metrics are now aggregated instead of per-instance, for improved visibility. [#9730](https://github.com/sourcegraph/sourcegraph/issues/9730)
 - observability: The "resolve_revision_duration_slow" alert is no longer flaky / non-deterministic. [#9751](https://github.com/sourcegraph/sourcegraph/issues/9751)
 - observability: Firing alerts are now correctly sorted at the top of dashboards by default. [#9766](https://github.com/sourcegraph/sourcegraph/issues/9766)
+- observability: Panels at the bottom of the home dashboard no longer appear clipped / cut off. [#9768](https://github.com/sourcegraph/sourcegraph/issues/9768)
 - The Phabricator integration no longer makes duplicate requests to Phabricator's API on diff views. [#8849](https://github.com/sourcegraph/sourcegraph/issues/8849)
 - Changesets on repositories that aren't available on the instance anymore are now hidden instead of failing. [#9656](https://github.com/sourcegraph/sourcegraph/pull/9656)
 

--- a/docker-images/grafana/home.json
+++ b/docker-images/grafana/home.json
@@ -302,7 +302,7 @@
       "description": "",
       "fontSize": "100%",
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 19,
         "x": 5,
         "y": 16
@@ -410,7 +410,7 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 5,
         "x": 0,
         "y": 19

--- a/docker-images/grafana/home.json
+++ b/docker-images/grafana/home.json
@@ -29,7 +29,6 @@
       },
       "id": 9,
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -49,6 +48,7 @@
         "x": 0,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -136,6 +136,7 @@
         "x": 0,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -246,7 +247,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "pluginVersion": "6.4.4",
       "postfix": "",
       "postfixFontSize": "50%",
@@ -309,7 +309,6 @@
       },
       "id": 11,
       "links": [],
-      "options": {},
       "pageSize": null,
       "pluginVersion": "6.4.4",
       "showHeader": true,
@@ -320,6 +319,7 @@
       "styles": [
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -332,6 +332,7 @@
         },
         {
           "alias": "firing?",
+          "align": "auto",
           "colorMode": "row",
           "colors": ["rgba(50, 172, 45, 0.97)", "rgba(237, 129, 40, 0.89)", "rgba(245, 54, 54, 0.9)"],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -354,6 +355,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -366,6 +368,7 @@
         },
         {
           "alias": "level",
+          "align": "auto",
           "colorMode": null,
           "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -429,7 +432,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -473,7 +475,7 @@
       "valueName": "avg"
     }
   ],
-  "schemaVersion": 20,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -489,5 +491,8 @@
   "timezone": "utc",
   "title": "Overview",
   "uid": "overview",
+  "variables": {
+    "list": []
+  },
   "version": 1
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3173176/79078771-64cd5f00-7cbf-11ea-9b0c-54c33b4b4d41.png)

After:

![image](https://user-images.githubusercontent.com/3173176/79079142-28e7c900-7cc2-11ea-8b58-9b81f565c0d5.png)

Fixes #9768