### PR TITLE
observability: searcher: correct query for "unindexed search request errors"

### DIFF
--- a/observability/searcher.go
+++ b/observability/searcher.go
@@ -13,7 +13,7 @@ func Searcher() *Container {
 						{
 							Name:            "unindexed_search_request_errors",
 							Description:     "unindexed search request errors every 5m by code",
-							Query:           `sum by (code)(rate(searcher_service_request_total{code!="200",code!="canceled"}[5m]))`,
+							Query:           `sum by (code)(increase(searcher_service_request_total{code!="200",code!="canceled"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("{{code}}"),


### PR DESCRIPTION
Prior to https://github.com/sourcegraph/sourcegraph/pull/9672 this panel showed errors "over 5m" (e.g. 1 per second over 5 minutes) which is more difficult to understand than "every 5m" (e.g. 5 per 5 minutes), so in that PR it was changed however the query was incorrectly not updated to reflect this.