### PR TITLE
dev/go-install.sh: only delete tmpdir if it exists

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -71,7 +71,7 @@ fi
 # For the target commands, build into a temp directory for comparison, so that
 # we can update only those packages that change. Clean up the temp at exit.
 tmpdir="$(mktemp -d -t src-binaries.XXXXXXXX)"
-trap 'rm "$tmpdir"/*; rmdir "$tmpdir"' EXIT
+trap 'if [ -d "$tmpdir" ]; then rm "$tmpdir"/*; rmdir "$tmpdir"; fi;' EXIT
 export GOBIN="$tmpdir"
 
 TAGS='dev'

--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -71,7 +71,7 @@ fi
 # For the target commands, build into a temp directory for comparison, so that
 # we can update only those packages that change. Clean up the temp at exit.
 tmpdir="$(mktemp -d -t src-binaries.XXXXXXXX)"
-trap 'if [ -d "$tmpdir" ]; then rm "$tmpdir"/*; rmdir "$tmpdir"; fi;' EXIT
+trap 'rm -rf "$tmpdir"' EXIT
 export GOBIN="$tmpdir"
 
 TAGS='dev'


### PR DESCRIPTION
I've run into this multiple times:

    $ ./enterprise/dev/start.sh
    [...]
    12:50:41  watch | rm: /var/folders/86/23tk7bxn04vgj7slgj_qdj6m0000gn/T/src-binaries.XXXXXXXX.bcuIH78v/*: No such file or directory
    12:50:41  watch | Terminating watch

I don't know which condition can trigger it, but it doesn't seem wrong
to be safe here.
