### PR TITLE
Don't log warning if codehost is unsupported in ChangesetSyncer/RateLimiter

### DIFF
--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -948,7 +948,10 @@ func NewRateLimiterRegistry(ctx context.Context, store Store) (*RateLimiterRegis
 	for _, svc := range svcs {
 		err = r.updateRateLimiter(svc)
 		if err != nil {
-			// Errors here are not fatal
+			if _, ok := err.(errRateLimitUnsupported); ok {
+				continue
+			}
+			// Errors here are not fatal, so we can log them
 			log15.Warn("Updating rate limiter", "kind", svc.Kind, "err", err)
 		}
 	}
@@ -1041,11 +1044,19 @@ func (r *RateLimiterRegistry) updateRateLimiter(svc *ExternalService) error {
 			}
 		}
 	default:
-		return fmt.Errorf("internal rate limiting not support for %s", svc.Kind)
+		return errRateLimitUnsupported{codehostKind: svc.Kind}
 	}
 
 	l := r.GetRateLimiter(svc.ID)
 	l.SetLimit(limit)
 
 	return nil
+}
+
+type errRateLimitUnsupported struct {
+	codehostKind string
+}
+
+func (e errRateLimitUnsupported) Error() string {
+	return fmt.Sprintf("internal rate limiting not support for %s", e.codehostKind)
 }

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -1058,5 +1058,5 @@ type errRateLimitUnsupported struct {
 }
 
 func (e errRateLimitUnsupported) Error() string {
-	return fmt.Sprintf("internal rate limiting not support for %s", e.codehostKind)
+	return fmt.Sprintf("internal rate limiting not supported for %s", e.codehostKind)
 }

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -82,7 +82,8 @@ func (s *SyncRegistry) Add(extServiceID int64) {
 	case "GITHUB", "BITBUCKETSERVER":
 	// Supported by campaigns
 	default:
-		log15.Warn("Syncer not started for unsupported code host", "kind", service.Kind)
+		log15.Debug("Syncer not started for unsupported code host", "kind", service.Kind)
+		return
 	}
 
 	s.mu.Lock()

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -82,7 +82,7 @@ func (s *SyncRegistry) Add(extServiceID int64) {
 	case "GITHUB", "BITBUCKETSERVER":
 	// Supported by campaigns
 	default:
-		log15.Debug("Syncer not started for unsupported code host", "kind", service.Kind)
+		log15.Debug("Campaigns syncer not started for unsupported code host", "kind", service.Kind)
 		return
 	}
 


### PR DESCRIPTION
(cc @ryanslade)

This fixes https://github.com/sourcegraph/sourcegraph/issues/9779 by not not logging a warning when a codehost is either

a) not supported as a ChangesetSyncer
b) not supported with a custom rate limiter

In addition to that I also changed the SyncRegistry according to this
comment (https://github.com/sourcegraph/sourcegraph/pull/9544/files#r402890686)
and not create syncers for unsupported code hosts.
