### PR TITLE
authz: use smaller interface to mock GitHub client in tests

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/github/client.go
+++ b/enterprise/cmd/frontend/internal/authz/github/client.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+)
+
+// client defines the set of GitHub API client methods used by the authz provider.
+//
+// NOTE: All methods are sorted in alphabetical order.
+type client interface {
+	GetRepositoryByNodeID(ctx context.Context, token, id string) (*github.Repository, error)
+	GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error)
+	ListAffiliatedRepositories(ctx context.Context, page int) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error)
+	ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
+	WithToken(token string) client
+}
+
+var _ client = (*clientAdapter)(nil)
+
+// clientAdapter is an adapter for GitHub API client.
+type clientAdapter struct {
+	*github.Client
+}
+
+func (c *clientAdapter) WithToken(token string) client {
+	return &clientAdapter{Client: c.Client.WithToken(token)}
+}
+
+var _ client = (*mockClient)(nil)
+
+type mockClient struct {
+	MockGetRepositoryByNodeID          func(ctx context.Context, token, id string) (*github.Repository, error)
+	MockGetRepositoriesByNodeIDFromAPI func(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error)
+	MockListAffiliatedRepositories     func(ctx context.Context, page int) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error)
+	MockListRepositoryCollaborators    func(ctx context.Context, owner, repo string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
+	MockWithToken                      func(token string) client
+}
+
+func (m *mockClient) GetRepositoryByNodeID(ctx context.Context, token, id string) (*github.Repository, error) {
+	return m.MockGetRepositoryByNodeID(ctx, token, id)
+}
+
+func (m *mockClient) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error) {
+	return m.MockGetRepositoriesByNodeIDFromAPI(ctx, token, nodeIDs)
+}
+
+func (m *mockClient) ListAffiliatedRepositories(ctx context.Context, page int) ([]*github.Repository, bool, int, error) {
+	return m.MockListAffiliatedRepositories(ctx, page)
+}
+
+func (m *mockClient) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) ([]*github.Collaborator, bool, error) {
+	return m.MockListRepositoryCollaborators(ctx, owner, repo, page)
+}
+
+func (m *mockClient) WithToken(token string) client {
+	return m.MockWithToken(token)
+}

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -19,7 +19,7 @@ import (
 
 // Provider implements authz.Provider for GitHub repository permissions.
 type Provider struct {
-	client   *github.Client
+	client   client
 	codeHost *extsvc.CodeHost
 	cacheTTL time.Duration
 	cache    cache
@@ -27,7 +27,7 @@ type Provider struct {
 
 func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, mockCache cache) *Provider {
 	apiURL, _ := github.APIRoot(githubURL)
-	client := github.NewClient(apiURL, baseToken, nil)
+	client := &clientAdapter{Client: github.NewClient(apiURL, baseToken, nil)}
 
 	p := &Provider{
 		codeHost: extsvc.NewCodeHost(githubURL, github.ServiceType),

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -476,16 +476,10 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 	return repos, nil
 }
 
-var MockListAffiliatedRepositories func(ctx context.Context, token string, page int) ([]*Repository, bool, int, error)
-
 // ListAffiliatedRepositories lists GitHub repositories affiliated with the client
 // token. page is the page of results to return. Pages are 1-indexed (so the
 // first call should be for page 1).
 func (c *Client) ListAffiliatedRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
-	if MockListAffiliatedRepositories != nil {
-		return MockListAffiliatedRepositories(ctx, c.defaultToken, page)
-	}
-
 	path := fmt.Sprintf("user/repos?sort=created&page=%d&per_page=100", page)
 	repos, err = c.listRepositories(ctx, path)
 	if err == nil {

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -86,16 +86,11 @@ type Collaborator struct {
 	DatabaseID int64  `json:"id"`
 }
 
-var MockListRepositoryCollaborators func(ctx context.Context, owner, repo string, page int) ([]*Collaborator, bool, error)
 
 // ListRepositoryCollaborators lists all GitHub users that has access to the repository.
 // The page is the page of results to return, and is 1-indexed (so the first call should
 // be for page 1).
 func (c *Client) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
-	if MockListRepositoryCollaborators != nil {
-		return MockListRepositoryCollaborators(ctx, owner, repo, page)
-	}
-
 	path := fmt.Sprintf("/repos/%s/%s/collaborators?&page=%d&per_page=100", owner, repo, page)
 	err := c.requestGet(ctx, "", path, &users)
 	if err != nil {

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -86,7 +86,6 @@ type Collaborator struct {
 	DatabaseID int64  `json:"id"`
 }
 
-
 // ListRepositoryCollaborators lists all GitHub users that has access to the repository.
 // The page is the page of results to return, and is 1-indexed (so the first call should
 // be for page 1).


### PR DESCRIPTION
This is another effort to help remove global mocks for using GitHub API client, based on discussions in https://github.com/sourcegraph/sourcegraph/pull/9655, which defines a smaller interface and a client adapter/wrapper to be used in code, and a mock client in tests.

Special thanks to @keegancsmith :)