### PR TITLE
use sentence case in doc sidebar

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -306,7 +306,7 @@
                             </svg>
                     </div>
                     <li class="content-nav-no-hover">
-                        <a class="content-nav-section-header" href="/api">API Documentation</a>
+                        <a class="content-nav-section-header" href="/api">API documentation</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/api/graphql">GraphQL API</a></li>
                             <li class="content-nav-no-hover">


### PR DESCRIPTION
["Use 'Sentence case'", from the style guide.](https://about.sourcegraph.com/handbook/communication/style_guide#general)