### PR TITLE
search: robust keyword scanning

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -167,7 +167,7 @@ func (p *parser) match(keyword keyword) bool {
 	if err != nil {
 		return false
 	}
-	return strings.ToLower(v) == string(keyword)
+	return strings.EqualFold(v, string(keyword))
 }
 
 // expect returns the result of match, and advances the position if it succeeds.


### PR DESCRIPTION
This PR:

- fixes a bug where we don't always ensure spaces before/after a keyword that requires it (currently `and` and `or`)

I'm introducing a helper function to do lookahead and lookbehind for keywords. The lookbehind is avoidable, but a more involved change, so I will address this later (filed in #9812). 

- the fix also makes keyword scanning more robust, so that queries like `or or or` also works
- fixes a bug where parsing would fail if the query only contained whitespace


