### PR TITLE
Implement accurate intersection and union behavior for and/or queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -42,6 +42,14 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	return &a.proposedQueries
 }
 
+func alertForCappedAndExpression() *searchAlert {
+	return &searchAlert{
+		prometheusType: "exceed_and_expression_search_limit",
+		title:          "Too many files to search for and-expression",
+		description:    fmt.Sprintf("One and-expression in the query requires a lot of work! Try using the 'repo:' or 'file:' filters to narrow your search. We're working on improving this experience in https://github.com/sourcegraph/sourcegraph/issues/9824"),
+	}
+}
+
 // alertForQuery converts errors in the query to search alerts.
 func alertForQuery(queryString string, err error) *searchAlert {
 	switch e := err.(type) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -613,22 +613,22 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 }
 
 // union returns the union of two sets of search results and merges common search data.
-func union(left, right *SearchResultsResolver) (*SearchResultsResolver, error) {
+func union(left, right *SearchResultsResolver) *SearchResultsResolver {
 	if right == nil {
-		return left, nil
+		return left
 	}
 	if left == nil {
-		return right, nil
+		return right
 	}
 	if left.SearchResults != nil && right.SearchResults != nil {
 		left.SearchResults = append(left.SearchResults, right.SearchResults...)
 		// merge common search data.
 		left.searchResultsCommon.update(right.searchResultsCommon)
-		return left, nil
+		return left
 	} else if right.SearchResults != nil {
-		return right, nil
+		return right
 	}
-	return left, nil
+	return left
 }
 
 // intersect returns the intersection of two sets of search result content
@@ -663,46 +663,152 @@ func intersect(left, right *SearchResultsResolver) (*SearchResultsResolver, erro
 		merged = append(merged, ltmp)
 	}
 	left.SearchResults = merged
-	// merge common search data.
 	left.searchResultsCommon.update(right.searchResultsCommon)
 	// for intersect we want the newly computed intersection size.
 	left.searchResultsCommon.resultCount = int32(len(merged))
 	return left, nil
 }
 
-func (r *searchResolver) evaluateOperator(ctx context.Context, scopeParameters []query.Node, operator query.Operator) (*SearchResultsResolver, error) {
-	if len(operator.Operands) == 0 {
+// evaluateAnd performs set intersection on result sets. It collects results for
+// all expressions that are ANDed together by searching for each subexpression
+// and then intersects those results that are in the same repo/file path. To
+// collect N results for count:N, we need to opportunistically ask for more than
+// N results for each subexpression (since intersect can never yield more than N,
+// and likely yields fewer than N results). Thus, we perform a search of 2*N for
+// each expression, and if the intersection does not yield N results, and is not
+// exhaustive for every expression, we rerun the search by doubling count again.
+func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []query.Node, operands []query.Node) (*SearchResultsResolver, error) {
+	if len(operands) == 0 {
 		return nil, nil
 	}
-	var new *SearchResultsResolver
+
 	var err error
-	result, err := r.evaluatePatternExpression(ctx, scopeParameters, operator.Operands[0])
+	var result *SearchResultsResolver
+	var new *SearchResultsResolver
+
+	// The number of results we want. Note that for intersect, this number
+	// corresponds to documents, not line matches. By default, we ask for at
+	// least 5 documents to fill the result page.
+	want := 5
+
+	var countStr string
+	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+		countStr = value
+	})
+	if countStr != "" {
+		// Override the value of count, if specified.
+		want, _ = strconv.Atoi(countStr) // Invariant: count is validated.
+	} else {
+		scopeParameters = append(scopeParameters, query.Parameter{
+			Field: "count",
+			Value: strconv.FormatInt(int64(want), 10),
+		})
+	}
+
+	tryCount := want * 2        // Opportunistic approximation for the number of results to get for an intersection.
+	maxResultsForRetry := 20000 // When we retry, cap the max search results we request for each expression if search continues to not be exhaustive. Alert if exceeded.
+
+	var exhausted bool
+	for {
+		scopeParameters = query.MapParameter(scopeParameters, func(field, value string, negated bool) query.Node {
+			if field == "count" {
+				value := strconv.FormatInt(int64(tryCount), 10)
+				return query.Parameter{Field: field, Value: value, Negated: negated}
+			}
+			return query.Parameter{Field: field, Value: value, Negated: negated}
+		})
+
+		result, err = r.evaluatePatternExpression(ctx, scopeParameters, operands[0])
+		if err != nil {
+			return nil, err
+		}
+		exhausted = !result.limitHit
+		for _, term := range operands[1:] {
+			new, err = r.evaluatePatternExpression(ctx, scopeParameters, term)
+			if err != nil {
+				return nil, err
+			}
+			if new != nil {
+				exhausted = exhausted && !new.limitHit
+				result, err = intersect(result, new)
+			}
+		}
+		if exhausted {
+			break
+		}
+		if result.searchResultsCommon.resultCount >= int32(want) {
+			break
+		}
+		// If the result size set is not big enough, and we haven't
+		// exhausted search on all expressions, double the tryCount and search more..
+		tryCount = tryCount * 2
+		if tryCount > maxResultsForRetry {
+			// We've capped out what we're willing to do, throw alert.
+			return &SearchResultsResolver{alert: alertForCappedAndExpression()}, nil
+		}
+	}
+	result.limitHit = !exhausted
+	return result, nil
+}
+
+// evaluateOr performs set union on result sets. It collects results for all
+// expressions that are ORed together by searching for each subexpression. If
+// the maximum number of results are reached after evaluating a subexpression,
+// we shortcircuit and return results immediately.
+func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query.Node, operands []query.Node) (*SearchResultsResolver, error) {
+	if len(operands) == 0 {
+		return nil, nil
+	}
+
+	var countStr string
+	wantCount := defaultMaxSearchResults
+	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+		countStr = value
+	})
+	if countStr != "" {
+		wantCount, _ = strconv.Atoi(countStr) // Invariant: count is validated.
+	}
+
+	result, err := r.evaluatePatternExpression(ctx, scopeParameters, operands[0])
 	if err != nil {
 		return nil, err
 	}
-	if result == nil {
-		return nil, nil
+	if result.searchResultsCommon.resultCount > int32(wantCount) {
+		result.SearchResults = result.SearchResults[:wantCount]
+		result.searchResultsCommon.resultCount = int32(wantCount)
+		return result, nil
 	}
-	for _, term := range operator.Operands[1:] {
+	var new *SearchResultsResolver
+	for _, term := range operands[1:] {
 		new, err = r.evaluatePatternExpression(ctx, scopeParameters, term)
 		if err != nil {
 			return nil, err
 		}
-		if new == nil && operator.Kind == query.And {
-			// Shortcircuit: intersecting with empty new results is empty.
-			return nil, nil
-		}
 		if new != nil {
-			switch operator.Kind {
-			case query.And:
-				result, err = intersect(result, new)
-			case query.Or:
-				result, err = union(result, new)
-			}
-			if err != nil {
-				return nil, err
+			result = union(result, new)
+			if result.searchResultsCommon.resultCount > int32(wantCount) {
+				result.SearchResults = result.SearchResults[:wantCount]
+				result.searchResultsCommon.resultCount = int32(wantCount)
+				return result, nil
 			}
 		}
+	}
+	return result, nil
+}
+
+func (r *searchResolver) evaluateOperator(ctx context.Context, scopeParameters []query.Node, operator query.Operator) (*SearchResultsResolver, error) {
+	if len(operator.Operands) == 0 {
+		return nil, nil
+	}
+	var result *SearchResultsResolver
+	var err error
+	if operator.Kind == query.And {
+		result, err = r.evaluateAnd(ctx, scopeParameters, operator.Operands)
+	} else {
+		result, err = r.evaluateOr(ctx, scopeParameters, operator.Operands)
+	}
+	if err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
@@ -69,50 +68,35 @@ func (q OrdinaryQuery) IsCaseSensitive() bool {
 
 // AndOrQuery satisfies the interface for QueryInfo close to that of OrdinaryQuery.
 func (q AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
-	found := false
 	VisitField(q.Query, field, func(visitedValue string, negated bool) {
-		found = true
 		if negated {
 			negatedValues = append(negatedValues, visitedValue)
 		} else {
 			values = append(values, visitedValue)
 		}
 	})
-	if !found {
-		panic("no such field: " + field)
-	}
 	return values, negatedValues
 }
 
 func (q AndOrQuery) StringValues(field string) (values, negatedValues []string) {
-	found := false
 	VisitField(q.Query, field, func(visitedValue string, negated bool) {
-		found = true
 		if negated {
 			negatedValues = append(negatedValues, visitedValue)
 		} else {
 			values = append(values, visitedValue)
 		}
 	})
-	if !found {
-		panic("no such field: " + field)
-	}
 	return values, negatedValues
 }
 
 func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
-	found := false
 	VisitField(q.Query, field, func(visitedValue string, negated bool) {
-		found = true
 		if negated {
 			negatedValue = visitedValue
 		} else {
 			value = visitedValue
 		}
 	})
-	if !found {
-		panic("no such field: " + field)
-	}
 	return value, negatedValue
 }
 
@@ -145,7 +129,6 @@ func (q AndOrQuery) ParseTree() syntax.ParseTree {
 		}
 		tree = append(tree, expr)
 	})
-	log15.Info("Query", "ParseTree", tree)
 	return tree
 }
 

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -119,15 +119,6 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 			t.Error(diff)
 		}
 	})
-	t.Run("for unrecognized field", func(t *testing.T) {
-		query, err := ProcessAndOr("")
-		if err != nil {
-			t.Fatal(err)
-		}
-		checkPanic(t, "no such field: z", func() {
-			query.RegexpPatterns("z")
-		})
-	})
 }
 
 func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {


### PR DESCRIPTION
We need to evaluate `and` vs. `or` queries quite differently due to the semantics. This function splits up the logic in `evaluateOperator`  to `evaluateAnd` and `evaluateOr`. 

The task for getting an accurate number of results for something like `count:100` in an `and`-query is quite complex. Please see in line comments.

I'm still testing this manually. Putting this up for review now because I've converged on the implementation.