### PR TITLE
search: validate count value

### DIFF
--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -152,8 +152,15 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 	}
 
 	isNumber := func() error {
-		if _, err := strconv.Atoi(value); err != nil {
-			return fmt.Errorf("field %s has value %s, %s is not a number", field, value, value)
+		count, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			if err.(*strconv.NumError).Err == strconv.ErrRange {
+				return fmt.Errorf("field %s has a value that is out of range, try making it smaller", field)
+			}
+			return fmt.Errorf("field %s has value %[2]s, %[2]s is not a number", field, value)
+		}
+		if count <= 0 {
+			return fmt.Errorf("field %s requires a positive number", field)
 		}
 		return nil
 	}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -151,6 +151,13 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		return nil
 	}
 
+	isNumber := func() error {
+		if _, err := strconv.Atoi(value); err != nil {
+			return fmt.Errorf("field %s has value %s, %s is not a number", field, value, value)
+		}
+		return nil
+	}
+
 	isLanguage := func() error {
 		_, ok := enry.GetLanguageByAlias(value)
 		if !ok {
@@ -218,9 +225,11 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldMessage, "m", "msg":
 		return satisfies(isValidRegexp)
 	case
-		FieldIndex,
-		FieldCount:
+		FieldIndex:
 		return satisfies(isSingular, isNotNegated)
+	case
+		FieldCount:
+		return satisfies(isSingular, isNumber, isNotNegated)
 	case
 		FieldStable:
 		return satisfies(isSingular, isBoolean, isNotNegated)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -41,6 +41,14 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: "count:sedonuts",
 			want:  "field count has value sedonuts, sedonuts is not a number",
 		},
+		{
+			input: "count:10000000000000000",
+			want:  "field count has a value that is out of range, try making it smaller",
+		},
+		{
+			input: "count:-1",
+			want:  "field count requires a positive number",
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -37,6 +37,10 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: "mr:potato",
 			want:  `unrecognized field "mr"`,
 		},
+		{
+			input: "count:sedonuts",
+			want:  "field count has value sedonuts, sedonuts is not a number",
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {


### PR DESCRIPTION
Validate that that `count:X` is a number, for `X`. We don't do this in the query code, and I presume we take the default value of 30 when it's garbage. This fix is only for and/or queries because I need this validation for a search. It'd be an annoying/fragmented fix in the current query code.