### PR TITLE
observability: use more color-blind friendly threshold colors

### DIFF
--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -448,7 +448,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(255, 152, 48, 0.5)",
+						FillColor: "rgba(255, 83, 67, 0.6)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -460,7 +460,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(242, 73, 92, 0.5)",
+						FillColor: "rgba(224, 28, 47, 0.6)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -472,7 +472,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(255, 152, 48, 0.5)",
+						FillColor: "rgba(255, 83, 67, 0.6)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -484,7 +484,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(242, 73, 92, 0.5)",
+						FillColor: "rgba(224, 28, 47, 0.6)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}


### PR DESCRIPTION
In this I can't tell if the color is green or orange (I have a spectacularly bad version of deuteranopia):

![image](https://user-images.githubusercontent.com/3173176/79156959-9fe79500-7d88-11ea-9cd1-4045be832c77.png)

With the new orange color, I can identify it easily:

![image](https://user-images.githubusercontent.com/3173176/79158480-459c0380-7d8b-11ea-9665-a73d185261d0.png)

With the new red and orange colors both present, also much easier for me due to the higher contrast:

![image](https://user-images.githubusercontent.com/3173176/79158550-63696880-7d8b-11ea-9a95-00a9f0dd7227.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
