### PR TITLE
observability: do not over-count firing alerts due to number of service replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to Sourcegraph are documented in this file.
 - observability: Git Server dashboard: there is now a panel to show concurrent command executions to match the defined alerts. [#9354](https://github.com/sourcegraph/sourcegraph/issues/9354)
 - observability: Git Server dashboard: adjusted the critical disk space alert to 15% so it can now fire. [#9351](https://github.com/sourcegraph/sourcegraph/issues/9351)
 - observability: Git Server dashboard: the 'echo command duration test' panel now properly displays units in seconds. [#7628](https://github.com/sourcegraph/sourcegraph/issues/7628)
+- observability: Dashboard panels showing firing alerts no longer over-count firing alerts due to the number of service replicas. [#9353](https://github.com/sourcegraph/sourcegraph/issues/9353)
 - The Phabricator integration no longer makes duplicate requests to Phabricator's API on diff views. [#8849](https://github.com/sourcegraph/sourcegraph/issues/8849)
 - Changesets on repositories that aren't available on the instance anymore are now hidden instead of failing. [#9656](https://github.com/sourcegraph/sourcegraph/pull/9656)
 

--- a/docker-images/grafana/home.json
+++ b/docker-images/grafana/home.json
@@ -75,7 +75,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (service_name)(alert_count{level=\"critical\"})",
+          "expr": "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"critical\"}))",
+          "interval": "",
           "legendFormat": "{{service_name}}",
           "refId": "A"
         }
@@ -163,7 +164,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (service_name)(alert_count{level=\"warning\"})",
+          "expr": "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"warning\"}))",
+          "interval": "",
           "legendFormat": "{{service_name}}",
           "refId": "A"
         }
@@ -272,12 +274,9 @@
         {
           "expr": "count(sum(alert_count{name!=\"\"}) by (level,description))",
           "instant": true,
+          "interval": "",
           "legendFormat": "",
           "refId": "A"
-        },
-        {
-          "expr": "",
-          "refId": "B"
         }
       ],
       "thresholds": "",
@@ -382,9 +381,10 @@
       ],
       "targets": [
         {
-          "expr": "label_replace(sum(alert_count{name!=\"\"}) by (level,description), \"_01_level\", \"$1\", \"level\", \"(.*)\")",
+          "expr": "label_replace(sum by (level,description)(max by (level,service_name,name,description)(alert_count{name!=\"\"})), \"_01_level\", \"$1\", \"level\", \"(.*)\")",
           "format": "table",
           "instant": true,
+          "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
@@ -456,6 +456,8 @@
         {
           "expr": "count(sum(alert_count{name!=\"\"}) by (service_name))",
           "instant": true,
+          "interval": "",
+          "legendFormat": "",
           "refId": "A"
         }
       ],

--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -448,7 +448,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(255, 83, 67, 0.6)",
+						FillColor: "rgba(255, 73, 53, 0.8)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -460,7 +460,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(224, 28, 47, 0.6)",
+						FillColor: "rgba(255, 17, 36, 0.8)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -472,7 +472,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(255, 83, 67, 0.6)",
+						FillColor: "rgba(255, 73, 53, 0.8)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
@@ -484,7 +484,7 @@ func (c *Container) dashboard() *sdk.Board {
 						ColorMode: "custom",
 						Fill:      true,
 						Line:      true,
-						FillColor: "rgba(224, 28, 47, 0.6)",
+						FillColor: "rgba(255, 17, 36, 0.8)",
 						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}

--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -356,7 +356,7 @@ func (c *Container) dashboard() *sdk.Board {
 		},
 	}
 	alertsDefined.AddTarget(&sdk.Target{
-		Expr:    fmt.Sprintf(`label_replace(sum(alert_count{service_name="%s",name!="",level=~"$alert_level"}) by (level,description), "_01_level", "$1", "level", "(.*)")`, c.Name),
+		Expr:    fmt.Sprintf(`label_replace(sum(max by (level,service_name,name,description)(alert_count{service_name="%s",name!="",level=~"$alert_level"})) by (level,description), "_01_level", "$1", "level", "(.*)")`, c.Name),
 		Format:  "table",
 		Instant: true,
 	})
@@ -390,7 +390,7 @@ func (c *Container) dashboard() *sdk.Board {
 		},
 	}
 	alertsFiring.AddTarget(&sdk.Target{
-		Expr:         fmt.Sprintf(`sum by (service_name,level,name)(alert_count{service_name="%s",name!="",level=~"$alert_level"} >= 1)`, c.Name),
+		Expr:         fmt.Sprintf(`sum by (service_name,level,name)(max by (level,service_name,name,description)(alert_count{service_name="%s",name!="",level=~"$alert_level"}) >= 1)`, c.Name),
 		LegendFormat: "{{level}}: {{name}}",
 	})
 	board.Panels = append(board.Panels, alertsFiring)


### PR DESCRIPTION
See individual commit messages for details.

Fixes #9353
