### PR TITLE
search: gate and/or query execution

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -87,7 +87,10 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	}
 
 	var queryInfo query.QueryInfo
-	if conf.AndOrQueryEnabled() {
+	if conf.AndOrQueryEnabled() && searchType != query.SearchTypeLiteral && query.ContainsAndOrKeyword(args.Query) {
+		// To process the input as an and/or query, the flag must be enabled, not be a
+		// literal search, and must contain either an 'and' or 'or' expression.
+		// Else, fallback to the older existing parser.
 		queryInfo, err = query.ProcessAndOr(args.Query)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -29,6 +29,14 @@ func isPatternExpression(nodes []Node) bool {
 	return result
 }
 
+// ContainsAndOrKeyword returns true if this query contains or- or and-
+// keywords. It is a temporary signal to determine whether we can fallback to
+// the older existing search functionality.
+func ContainsAndOrKeyword(input string) bool {
+	lower := strings.ToLower(input)
+	return strings.Contains(lower, " and ") || strings.Contains(lower, " or ")
+}
+
 // processTopLevel processes the top level of a query. It validates that we can
 // process the query with respect to and/or expressions on file content, but not
 // otherwise for nested parameters.

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -245,3 +245,15 @@ func Test_PartitionSearchPattern(t *testing.T) {
 		})
 	}
 }
+
+func Test_ContainsAndOrKeyword(t *testing.T) {
+	if !ContainsAndOrKeyword("foo OR bar") {
+		t.Errorf("Expected query to contain keyword")
+	}
+	if !ContainsAndOrKeyword("repo:foo AND bar") {
+		t.Errorf("Expected query to contain keyword")
+	}
+	if ContainsAndOrKeyword("repo:foo bar") {
+		t.Errorf("Did not expect query to contain keyword")
+	}
+}


### PR DESCRIPTION
Stacked on #9827. 

This PR:
- disables and/or queries in literal search mode (as planned in RFC 94)
- uses a cheap heuristic to fall back to the existing older parser if possible. It's not critical that this heuristic fires (it's OK if it's not 100% accurate). The intent is to help a gradual transition away from something that has been in use for longer than the new code.