### PR TITLE
observability: remove line color dividing warning/critical thresholds

### DIFF
--- a/observability/src-observability-generator.go
+++ b/observability/src-observability-generator.go
@@ -447,9 +447,8 @@ func (c *Container) dashboard() *sdk.Board {
 						Op:        "gt",
 						ColorMode: "custom",
 						Fill:      true,
-						Line:      true,
+						Line:      false,
 						FillColor: "rgba(255, 73, 53, 0.8)",
-						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
 				if o.Critical.GreaterOrEqual != 0 {
@@ -459,9 +458,8 @@ func (c *Container) dashboard() *sdk.Board {
 						Op:        "gt",
 						ColorMode: "custom",
 						Fill:      true,
-						Line:      true,
+						Line:      false,
 						FillColor: "rgba(255, 17, 36, 0.8)",
-						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
 				if o.Warning.LessOrEqual != 0 {
@@ -471,9 +469,8 @@ func (c *Container) dashboard() *sdk.Board {
 						Op:        "lt",
 						ColorMode: "custom",
 						Fill:      true,
-						Line:      true,
+						Line:      false,
 						FillColor: "rgba(255, 73, 53, 0.8)",
-						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
 				if o.Critical.LessOrEqual != 0 {
@@ -483,9 +480,8 @@ func (c *Container) dashboard() *sdk.Board {
 						Op:        "lt",
 						ColorMode: "custom",
 						Fill:      true,
-						Line:      true,
+						Line:      false,
 						FillColor: "rgba(255, 17, 36, 0.8)",
-						LineColor: "rgba(31, 96, 196, 0.6)",
 					})
 				}
 


### PR DESCRIPTION
Consider the following screenshot and answer "what is the remaining disk space?" -- is it 15%, or is that just the divider between the "warning" and "critical" threshold colors?:

![image](https://user-images.githubusercontent.com/3173176/79172349-522f5480-7da9-11ea-8e4f-50426bceae0f.png)

If we remove the line dividing the colors, it becomes at least a bit more apparent (and you don't have to second-guess yourself):

![image](https://user-images.githubusercontent.com/3173176/79172472-a33f4880-7da9-11ea-923b-35f2930ef718.png)

Fixes #9830



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
