### PR TITLE
observability: do not average histogram quantiles

### DIFF
--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -13,7 +13,7 @@ func Frontend() *Container {
 						{
 							Name:            "99th_percentile_search_request_duration",
 							Description:     "99th percentile search request duration over 5m",
-							Query:           `avg(histogram_quantile(0.99, rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 3},
@@ -22,7 +22,7 @@ func Frontend() *Container {
 						{
 							Name:            "90th_percentile_search_request_duration",
 							Description:     "90th percentile search request duration over 5m",
-							Query:           `avg(histogram_quantile(0.90, rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
+							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 3},


### PR DESCRIPTION
I don't know what I was thinking when I wrote these, but averaging histogram quantiles is
non-sensical. See the end of https://prometheus.io/docs/practices/histograms/#quantiles

In other words, this is the correct aggregation which _actually_ produces a proper Nth percentile.