### PR TITLE
Fix file tree not updating on code intel actions

### DIFF
--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -124,7 +124,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                         className="file-match-children__item-code-wrapper e2e-file-match-children-item-wrapper"
                     >
                         <Link
-                            to={`${props.result.file.url}${toPositionOrRangeHash({ position })}`}
+                            to={`${props.result.file.url}?action${toPositionOrRangeHash({ position })}`}
                             className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
                             onClick={props.onSelect}
                         >

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -43,7 +43,7 @@ export const RepoFileLink: React.FunctionComponent<Props> = ({
     return (
         <>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-            <Link to={fileURL}>
+            <Link to={`${fileURL}?action`}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>
             </Link>

--- a/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -10,7 +10,7 @@ Array [
   " ›",
   " ",
   <a
-    href="https://example.com/file"
+    href="https://example.com/file?action"
   >
     my/
     <strong>

--- a/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined"
+                  href="/github.com/foo/bar/-/blob/undefined?action"
                 >
                   <strong>
                     
@@ -70,7 +70,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?action#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -234,7 +234,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/file1.txt"
+                  href="/github.com/foo/bar/-/blob/file1.txt?action"
                 >
                   <strong>
                     file1.txt
@@ -266,7 +266,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/file1.txt#L2:1"
+                href="/github.com/foo/bar/-/blob/file1.txt?action#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -386,7 +386,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined"
+                  href="/github.com/foo/bar/-/blob/undefined?action"
                 >
                   <strong>
                     
@@ -418,7 +418,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?action#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -27,6 +27,8 @@ export interface URLToFileContext {
      * the part of the diff it was invoked on.
      */
     part: DiffPart | undefined
+
+    isWebURL?: boolean
 }
 
 /**

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -6,6 +6,7 @@ import { isEmpty } from 'lodash'
 import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
 import { replaceRange } from './strings'
 import { discreteValueAliases } from '../search/parser/filters'
+import { URLToFileContext } from '../platform/context'
 
 export interface RepoSpec {
     /**
@@ -85,7 +86,7 @@ export interface UIPositionSpec {
     position: UIPosition
 }
 
-interface UIRangeSpec {
+export interface UIRangeSpec {
     /**
      * A 1-indexed range in the blob
      */
@@ -116,7 +117,7 @@ export interface ViewStateSpec {
  */
 export type RenderMode = 'code' | 'rendered' | undefined
 
-interface RenderModeSpec {
+export interface RenderModeSpec {
     /**
      * How the file should be rendered.
      */
@@ -419,11 +420,11 @@ function parseLineOrPositionOrRange(lineChar: string): LineOrPositionOrRange {
     return lpr
 }
 
-function toRenderModeQuery(ctx: Partial<RenderModeSpec>): string {
+function toRenderModeAndActionQuery(ctx: Partial<RenderModeSpec>, isWebUrl?: boolean): string {
     if (ctx.renderMode === 'code') {
-        return '?view=code'
+        return isWebUrl ? '?action&view=code' : '?view=code'
     }
-    return ''
+    return isWebUrl ? '?action' : ''
 }
 
 /**
@@ -471,11 +472,17 @@ export function encodeRepoRev(repo: string, rev?: string): string {
 }
 
 export function toPrettyBlobURL(
-    ctx: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
+    target: RepoFile &
+        Partial<UIPositionSpec> &
+        Partial<ViewStateSpec> &
+        Partial<UIRangeSpec> &
+        Partial<RenderModeSpec>,
+    context?: Partial<URLToFileContext>
 ): string {
-    return `/${encodeRepoRev(ctx.repoName, ctx.rev)}/-/blob/${ctx.filePath}${toRenderModeQuery(
-        ctx
-    )}${toPositionOrRangeHash(ctx)}${toViewStateHashComponent(ctx.viewState)}`
+    return `/${encodeRepoRev(target.repoName, target.rev)}/-/blob/${target.filePath}${toRenderModeAndActionQuery(
+        target,
+        context?.isWebURL
+    )}${toPositionOrRangeHash(target)}${toViewStateHashComponent(target.viewState)}`
 }
 
 /**

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -8,7 +8,14 @@ import { mutateSettings, updateSettings } from '../../../shared/src/settings/edi
 import { gqlToCascade } from '../../../shared/src/settings/settings'
 import { createAggregateError, asError } from '../../../shared/src/util/errors'
 import { LocalStorageSubject } from '../../../shared/src/util/LocalStorageSubject'
-import { toPrettyBlobURL } from '../../../shared/src/util/url'
+import {
+    toPrettyBlobURL,
+    RepoFile,
+    UIPositionSpec,
+    ViewStateSpec,
+    RenderModeSpec,
+    UIRangeSpec,
+} from '../../../shared/src/util/url'
 import { queryGraphQL, requestGraphQL } from '../backend/graphql'
 import { Tooltip } from '../components/tooltip/Tooltip'
 import { eventLogger } from '../tracking/eventLogger'
@@ -60,7 +67,7 @@ export function createPlatformContext(): PlatformContext {
             ),
         forceUpdateTooltip: () => Tooltip.forceUpdate(),
         createExtensionHost: () => createExtensionHost({ wrapEndpoints: false }),
-        urlToFile: toPrettyBlobURL,
+        urlToFile: toPrettyWebBlobURL,
         getScriptURLForExtension: bundleURL => bundleURL,
         sourcegraphURL: window.context.externalURL,
         clientApplication: 'sourcegraph',
@@ -68,6 +75,12 @@ export function createPlatformContext(): PlatformContext {
         telemetryService: eventLogger,
     }
     return context
+}
+
+function toPrettyWebBlobURL(
+    ctx: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
+): string {
+    return toPrettyBlobURL(ctx, { isWebURL: true })
 }
 
 const settingsCascadeFragment = gql`

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -245,7 +245,10 @@ export class Tree extends React.PureComponent<Props, State> {
                     const queryParams = new URLSearchParams(this.props.history.location.search)
                     // If we're updating due to a file or directory suggestion, load the relevant partial tree and jump to the file.
                     // This case is only used when going from an ancestor to a child file/directory, or equal.
-                    if (queryParams.has('suggestion') && dotPathAsUndefined(newParentPath)) {
+                    if (
+                        (queryParams.has('suggestion') || queryParams.has('action')) &&
+                        dotPathAsUndefined(newParentPath)
+                    ) {
                         this.setState({
                             parentPath: dotPathAsUndefined(newParentPath),
                             resolveTo: [newParentPath],
@@ -268,7 +271,16 @@ export class Tree extends React.PureComponent<Props, State> {
                     // Strip the ?suggestion query param. Handle both when going from ancestor -> child and child -> ancestor.
                     if (queryParams.has('suggestion')) {
                         queryParams.delete('suggestion')
-                        this.props.history.replace({ search: queryParams.toString() })
+                        this.props.history.replace({
+                            search: queryParams.toString(),
+                            hash: this.props.history.location.hash,
+                        })
+                    } else if (queryParams.has('action')) {
+                        queryParams.delete('action')
+                        this.props.history.replace({
+                            search: queryParams.toString(),
+                            hash: this.props.history.location.hash,
+                        })
                     }
                 })
         )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/4710. The file tree wouldn't update on go-to-def or find refs if the new location was in a sub-folder of the current location, due to [this logic](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@fc0dfa5e9bc6dc83bab8e012f492804c87721202/-/blob/web/src/tree/Tree.tsx#L248-265). We didn't want to reset the tree to render _only_ the current directory if we were going into child folder because when users click into sub directories they should still see the directory they started in. However, we do want to do it for code intel actions/other navigation actions because we also don't want to have to open `X` number of directories in the file tree, causing `X` HTTP requests. 

Now, we add a `action` query parameter to the the file name in FileMatch, and the FileMatchChildren components. When `action` is seen in the URL, the tree will render only the current directory.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
