### PR TITLE
build Grafana and Prometheus images on CI

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -24,6 +24,13 @@ RUN ./build.sh
 
 FROM grafana/grafana:6.7.1@sha256:1ff3999e0fc08a3909e9a3ecdf6e74b4789db9b67c8297c44fdee1e167b9375f as production
 
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
 LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+rm -rf observability
+cp -R ../../observability .
+
+docker build -t ${IMAGE:-sourcegraph/grafana} . \
+    --progress=plain \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/docker-images/grafana/pre-build.sh
+++ b/docker-images/grafana/pre-build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-
-rm -rf observability
-cp -R ../../observability .

--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -17,6 +17,13 @@ FROM prom/prometheus:v2.16.0@sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d549868
 # hadolint ignore=DL3007
 FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:0c38f63cbe19e40123668a48c36466ef72b195e723cbfcbe01e9657a5f14cec6
 
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
 LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/

--- a/docker-images/prometheus/build.sh
+++ b/docker-images/prometheus/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+rm -rf observability
+cp -R ../../observability .
+
+docker build -t ${IMAGE:-sourcegraph/prometheus} . \
+    --progress=plain \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/docker-images/prometheus/pre-build.sh
+++ b/docker-images/prometheus/pre-build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-
-rm -rf observability
-cp -R ../../observability .

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -66,7 +66,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]
 		pipelineOperations = []func(*bk.Pipeline){
-			addCanidateDockerImage(c, app),
+			addCandidateDockerImage(c, app),
 			wait,
 			addFinalDockerImage(c, app, false),
 		}


### PR DESCRIPTION
This PR begins building the `docker-images/grafana` and `docker-images/prometheus` on CI.

They are published using the same versioning as Sourcegraph, per https://github.com/sourcegraph/sourcegraph/issues/9251

In specific, it is worth noting:

> grafana and prometheus DO have version conflicts with traditional Sourcegraph versioning, but their version numbers started at 10.x.x so luckily we won't have any conflicts until years from now (at which point it seems fine to delete said old images).

Once merged, these images will auto-update and deploy nicely like all of our other images.