### PR TITLE
search: record whether a value was quoted

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -692,7 +692,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 	want := 5
 
 	var countStr string
-	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _, _ bool) {
 		countStr = value
 	})
 	if countStr != "" {
@@ -761,7 +761,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 
 	var countStr string
 	wantCount := defaultMaxSearchResults
-	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _, _ bool) {
 		countStr = value
 	})
 	if countStr != "" {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -35,6 +35,7 @@ type Parameter struct {
 	Field   string `json:"field"`   // The repo part in repo:sourcegraph.
 	Value   string `json:"value"`   // The sourcegraph part in repo:sourcegraph.
 	Negated bool   `json:"negated"` // True if the - prefix exists, as in -repo:sourcegraph.
+	Quoted  bool   `json:"quoted"`  // True if the parsed value was quoted
 }
 
 type operatorKind int
@@ -402,6 +403,10 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	if !p.heuristic.parensAsPatterns || p.heuristic.allowDanglingParens {
 		return Parameter{Field: "", Value: ""}, false
 	}
+	if value, ok := p.TryParseDelimiter(); ok {
+		return Parameter{Field: "", Value: value}, true
+	}
+
 	start := p.pos
 	pieces, advance, ok := ScanSearchPatternHeuristic(p.buf[p.pos:])
 	end := start + advance
@@ -486,13 +491,9 @@ func ScanValue(buf []byte, allowDanglingParens bool) (string, int) {
 	return string(result), count
 }
 
-// ParseValue parses a value at the current position. A value may belong to a
-// parameter like repo:<value> or the <value> may be a search pattern. Values
-// may be quoted. ParseValue cannot fail: it will first try to scan well-formed
-// delimiters, like quoted strings. If that fails, it will accept unbalanced
-// strings as patterns. Uses of value can then be validated along other concerns
-// for different search types (literal, regexp, etc.).
-func (p *parser) ParseValue() string {
+// TryParseDelimiter tries to parse a delimited, returning whether it succeeded,
+// and the interpreted (i.e., unquoted) value if it succeeds.
+func (p *parser) TryParseDelimiter() (string, bool) {
 	delimited := func(delimiter rune) (string, error) {
 		value, advance, err := ScanDelimited(p.buf[p.pos:], delimiter)
 		if err != nil {
@@ -508,17 +509,28 @@ func (p *parser) ParseValue() string {
 		if p.match(DQUOTE) {
 			return delimited('"')
 		}
-		if p.match(SLASH) {
-			return delimited('/')
-		}
 		return "", errors.New("failed to scan delimiter")
 	}
 	if value, err := tryScanDelimiter(); err == nil {
-		return value
+		return value, true
+	}
+	return "", false
+}
+
+// ParseValue parses a value at the current position and whether it was quoted.
+// A value may belong to a parameter like repo:<value> or the <value> may be a
+// search pattern. Values may be quoted. ParseValue cannot fail: it will first
+// try to scan well-formed delimiters, like quoted strings. If that fails, it
+// will accept unbalanced strings as patterns. Uses of value can then be
+// validated along other concerns for different search types (literal, regexp,
+// etc.).
+func (p *parser) ParseValue() (string, bool) {
+	if value, ok := p.TryParseDelimiter(); ok {
+		return value, true
 	}
 	value, advance := ScanValue(p.buf[p.pos:], p.heuristic.allowDanglingParens)
 	p.pos += advance
-	return value
+	return value, false
 }
 
 // ParseParameter returns a leaf node usable by _any_ kind of search (e.g.,
@@ -535,19 +547,19 @@ func (p *parser) ParseValue() string {
 func (p *parser) ParseParameter() Parameter {
 	field, advance := ScanField(p.buf[p.pos:])
 	p.pos += advance
-	value := p.ParseValue()
+	value, quoted := p.ParseValue()
 	negated := len(field) > 0 && field[0] == '-'
 	if negated {
 		field = field[1:]
 	}
-	return Parameter{Field: field, Value: value, Negated: negated}
+	return Parameter{Field: field, Value: value, Negated: negated, Quoted: quoted}
 }
 
 // containsPattern returns true if any descendent of nodes is a search pattern
 // (i.e., a parameter where the field is the empty string).
 func containsPattern(node Node) bool {
 	var result bool
-	VisitField([]Node{node}, "", func(_ string, _ bool) {
+	VisitField([]Node{node}, "", func(_ string, _, _ bool) {
 		result = true
 	})
 	return result

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -35,7 +35,7 @@ type Parameter struct {
 	Field   string `json:"field"`   // The repo part in repo:sourcegraph.
 	Value   string `json:"value"`   // The sourcegraph part in repo:sourcegraph.
 	Negated bool   `json:"negated"` // True if the - prefix exists, as in -repo:sourcegraph.
-	Quoted  bool   `json:"quoted"`  // True if the parsed value was quoted
+	Quoted  bool   `json:"quoted"`  // True if the parsed value was quoted.
 }
 
 type operatorKind int

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -21,7 +21,7 @@ func (e *UnsupportedError) Error() string {
 // a search pattern.
 func isPatternExpression(nodes []Node) bool {
 	result := true
-	VisitParameter(nodes, func(field, _ string, _ bool) {
+	VisitParameter(nodes, func(field, _ string, _, _ bool) {
 		if field != "" && field != "content" {
 			result = false
 		}
@@ -270,7 +270,7 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 func validate(nodes []Node) error {
 	var err error
 	seen := map[string]struct{}{}
-	VisitParameter(nodes, func(field, value string, negated bool) {
+	VisitParameter(nodes, func(field, value string, negated, _ bool) {
 		if err != nil {
 			return
 		}

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -31,10 +31,10 @@ func VisitOperator(nodes []Node, f func(kind operatorKind, operands []Node)) {
 
 // VisitParameter calls f on all parameter nodes. f supplies the node's field,
 // value, and whether the value is negated.
-func VisitParameter(nodes []Node, f func(field, value string, negated bool)) {
+func VisitParameter(nodes []Node, f func(field, value string, negated, quoted bool)) {
 	visitor := func(node Node) {
 		if v, ok := node.(Parameter); ok {
-			f(v.Field, v.Value, v.Negated)
+			f(v.Field, v.Value, v.Negated, v.Quoted)
 		}
 	}
 	Visit(nodes, visitor)
@@ -42,10 +42,10 @@ func VisitParameter(nodes []Node, f func(field, value string, negated bool)) {
 
 // VisitField calls f on all parameter nodes whose field matches the field
 // argument. f supplies the node's value and whether the value is negated.
-func VisitField(nodes []Node, field string, f func(value string, negated bool)) {
-	visitor := func(visitedField, value string, negated bool) {
+func VisitField(nodes []Node, field string, f func(value string, negated, quoted bool)) {
+	visitor := func(visitedField, value string, negated, quoted bool) {
 		if field == visitedField {
-			f(value, negated)
+			f(value, negated, quoted)
 		}
 	}
 	VisitParameter(nodes, visitor)


### PR DESCRIPTION
The one search mode where we care whether a value is quoted is regexp mode. In this mode, quoted values are interpreted literally. The and/or parser interprets quoted values, but throws away whether it was quoted, and as yet, parameters are untyped. This means that later on, when using the value in regexp mode, we have no idea whether it was quoted or not.

This PR:
- adds a `Quoted` field to to `Parameter` to indicate that it was quoted
- makes the heuristic search pattern parser (the one that is OK with values like `main(`,) also first try to parse strings starting with quotes as well-formed delimiter values (before, it would just consume things without caring, which is indeed what we want, except when delimited values are available first.)
- updates visitor interface
- updates tests to reflect these decisions

Adding `Quoted` is not the desired end goal for the Parameter types. It currently pollutes the visitor interface a bit. I will be turning parameter values into better structures with type members later.

Needed up the stack for #9846