### PR TITLE
search: handle regexp quoting in and/or queries

### DIFF
--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -159,8 +159,12 @@ func valueToTypedValue(field, value string, quoted bool) []*types.Value {
 	switch field {
 	case
 		FieldDefault:
-		// Treat as string for sipmplicity. The type could be regexp or
-		// string depending on quotes or search kind.
+		if quoted {
+			return []*types.Value{{String: &value}}
+		}
+		if regexp, err := regexp.Compile(value); err == nil {
+			return []*types.Value{{Regexp: regexp}}
+		}
 		return []*types.Value{{String: &value}}
 
 	case

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -1,0 +1,39 @@
+package query
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
+)
+
+func Test_valueToTypedValue(t *testing.T) {
+	value := ".*"
+	t.Run("is quoted is string", func(t *testing.T) {
+		inputQuoted := true
+		got := valueToTypedValue("", value, inputQuoted)
+		want := types.Value{String: &value}
+		if *got[0].String != *want.String {
+			t.Errorf("got %v, want %v", *got[0].String, *want.String)
+		}
+	})
+	t.Run("is not quoted is regex", func(t *testing.T) {
+		inputQuoted := false
+		got := valueToTypedValue("", value, inputQuoted)
+		regexValue, _ := regexp.Compile(value)
+		want := types.Value{Regexp: regexValue}
+		if got[0].Regexp.String() != want.Regexp.String() {
+			t.Errorf("got %v, want %v", got[0].Regexp, want.Regexp)
+		}
+	})
+
+	value = ".*("
+	t.Run("uncompilable regex is string", func(t *testing.T) {
+		inputQuoted := false
+		got := valueToTypedValue("", value, inputQuoted)
+		want := types.Value{String: &value}
+		if *got[0].String != *want.String {
+			t.Errorf("got %v, want %v", *got[0].String, *want.String)
+		}
+	})
+}


### PR DESCRIPTION
Stacked on #9844. This (finally) enables a regexp search that gives the same essential functionality as our existing mode, but now with and/or queries. For the unfamliar, the place where this matters (where the values are discriminated and used) is [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c3bff3e6a96b4d26be18432e2f12f76bbcf163e1/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1069-1115).