### PR TITLE
enterprise/dev/ci: build republished images

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -25,7 +25,13 @@ var allDockerImages = []string{
 
 	// Images under docker-images/
 	"grafana",
+	"indexed-searcher",
+	"postgres-11.4",
 	"prometheus",
+	"redis-cache",
+	"redis-store",
+	"search-indexer",
+	"syntax-highlighter",
 }
 
 // Verifies the docs formatting and builds the `docsite` command.


### PR DESCRIPTION
Corrects a mistake in https://github.com/sourcegraph/sourcegraph/pull/9847
