### PR TITLE
docs: Fix hidden headers after clicking on in-page link

### DIFF
--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -68,7 +68,7 @@ code {
         display: block;
         content: " ";
         margin-top: -84px;
-        height: 75px;
+        height: 114px;
         visibility: hidden;
     }
 }

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -4,9 +4,9 @@
     <title>{{block "title" .}}Home{{end}} - Sourcegraph docs</title>
     <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
     <link rel="stylesheet" href="{{asset "bootstrap.min.css"}}?4.3.1" />
-    <link rel="stylesheet" href="{{asset "layout.css"}}?16" />
-    <link rel="stylesheet" href="{{asset "search.css"}}?16" />
-    <link rel="stylesheet" href="{{asset "content.css"}}?16" />
+    <link rel="stylesheet" href="{{asset "layout.css"}}?17" />
+    <link rel="stylesheet" href="{{asset "search.css"}}?17" />
+    <link rel="stylesheet" href="{{asset "content.css"}}?17" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />
     {{block "head" .}}{{end}}
 </head>


### PR DESCRIPTION
Two commits:

- First commit fixes the issue
- Second commit is necessary to bust the CSS cache

### Before

![scrolling_before](https://user-images.githubusercontent.com/1185253/79220414-392fad80-7e54-11ea-986d-484555be0455.gif)

### After

![scrolling_after](https://user-images.githubusercontent.com/1185253/79220454-4ba9e700-7e54-11ea-9ad2-ca760330413f.gif)