### PR TITLE
enforce published user limit when no license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Sourcegraph are documented in this file.
   - `Campaign.changesetPlans` has been renamed to `campaign.changesetPlan`.
   - `createCampaignPlanFromPatches` mutation has been renamed to `createPatchSetFromPatches`.
 - Removed the scoped search field on tree pages. When browsing code, the global search query will now get scoped to the current tree or file. [#9225](https://github.com/sourcegraph/sourcegraph/pull/9225)
+- Instances without a license key that exceed the published user limit will now display a notice to all users.
 
 ### Fixed
 

--- a/enterprise/cmd/frontend/internal/licensing/user_count.go
+++ b/enterprise/cmd/frontend/internal/licensing/user_count.go
@@ -154,11 +154,10 @@ func StartMaxUserCount(s UsersStore) {
 	}
 }
 
-// NoLicenseMaximumAllowedUserCount is the maximum number of user accounts that may exist on Sourcegraph Core
-// (i.e., when running without a license). Exceeding this number of user accounts requires a
-// license.
-const NoLicenseMaximumAllowedUserCount int32 = 20
+// NoLicenseMaximumAllowedUserCount is the maximum number of user accounts that may exist when
+// running without a license. Exceeding this number of user accounts requires a license.
+const NoLicenseMaximumAllowedUserCount int32 = 10
 
 // NoLicenseWarningUserCount is the number of user accounts when all users are shown a warning (when running
 // without a license).
-const NoLicenseWarningUserCount int32 = 20
+const NoLicenseWarningUserCount int32 = 10


### PR DESCRIPTION
The [pricing page](https://about.sourcegraph.com/pricing/) states the limit is 10 users. Previously, we had an unpublished "grace period" that allowed up to 20 users. This change makes it so the published limit (10 users) is actually enforced.

If an instance is currently in the "grace period" (i.e., it has between 11-20 user accounts), then it will not be able to create new user accounts. If a new user signs up (over 10 users) or a site admin tries to create a new user account (over 10 users), an error will be displayed:

> Unable to create user account: a Sourcegraph subscription is required to exceed %d users (this instance now has %d users). Contact Sourcegraph to learn more at https://about.sourcegraph.com/contact/sales.

(The `%d` are filled in by the actual numbers.)

Also, all users will see the following notice at the top of each page:

> This Sourcegraph instance has reached the limit for free users, and an admin must purchase a license or contact Sourcegraph for a free trial.

Previously, e.g., an instance with 15 user accounts could create more user accounts (up to 20) despite being over the limit. An instance with over 10 user accounts is not immediately disabled or locked out as a result of this change (doing so would be very bad).

This affects some trials and prospects. See https://docs.google.com/spreadsheets/d/1C7ih9-w6Y21TPFfM79RFnrHXioyQxn5k2Uh3metPFbw/edit#gid=0 for a list.