### PR TITLE
fix name of "Global settings" page in site admin

### DIFF
--- a/web/src/site-admin/SiteAdminSettingsPage.tsx
+++ b/web/src/site-admin/SiteAdminSettingsPage.tsx
@@ -14,7 +14,7 @@ interface Props extends RouteComponentProps<{}>, PlatformContextProps, SettingsC
 
 export const SiteAdminSettingsPage: React.FunctionComponent<Props> = props => (
     <>
-        <PageTitle title="Site settings" />
+        <PageTitle title="Global settings" />
         <SettingsArea
             {...props}
             subject={props.site}


### PR DESCRIPTION
"Site settings" is not a thing.

