### PR TITLE
github: refactor API client to only associate with one token

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/github/client.go
+++ b/enterprise/cmd/frontend/internal/authz/github/client.go
@@ -10,8 +10,8 @@ import (
 //
 // NOTE: All methods are sorted in alphabetical order.
 type client interface {
-	GetRepositoryByNodeID(ctx context.Context, token, id string) (*github.Repository, error)
-	GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error)
+	GetRepositoryByNodeID(ctx context.Context, id string) (*github.Repository, error)
+	GetRepositoriesByNodeIDFromAPI(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error)
 	ListAffiliatedRepositories(ctx context.Context, page int) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error)
 	ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
 	WithToken(token string) client
@@ -31,19 +31,19 @@ func (c *clientAdapter) WithToken(token string) client {
 var _ client = (*mockClient)(nil)
 
 type mockClient struct {
-	MockGetRepositoryByNodeID          func(ctx context.Context, token, id string) (*github.Repository, error)
-	MockGetRepositoriesByNodeIDFromAPI func(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error)
+	MockGetRepositoryByNodeID          func(ctx context.Context, id string) (*github.Repository, error)
+	MockGetRepositoriesByNodeIDFromAPI func(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error)
 	MockListAffiliatedRepositories     func(ctx context.Context, page int) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error)
 	MockListRepositoryCollaborators    func(ctx context.Context, owner, repo string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
 	MockWithToken                      func(token string) client
 }
 
-func (m *mockClient) GetRepositoryByNodeID(ctx context.Context, token, id string) (*github.Repository, error) {
-	return m.MockGetRepositoryByNodeID(ctx, token, id)
+func (m *mockClient) GetRepositoryByNodeID(ctx context.Context, id string) (*github.Repository, error) {
+	return m.MockGetRepositoryByNodeID(ctx, id)
 }
 
-func (m *mockClient) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error) {
-	return m.MockGetRepositoriesByNodeIDFromAPI(ctx, token, nodeIDs)
+func (m *mockClient) GetRepositoriesByNodeIDFromAPI(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error) {
+	return m.MockGetRepositoriesByNodeIDFromAPI(ctx, nodeIDs)
 }
 
 func (m *mockClient) ListAffiliatedRepositories(ctx context.Context, page int) ([]*github.Repository, bool, int, error) {

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -205,7 +205,7 @@ func (p *Provider) getCachedPublicRepos(ctx context.Context, repos []*types.Repo
 func (p *Provider) fetchPublicRepos(ctx context.Context, repos []*types.Repo) (map[string]bool, error) {
 	isPublic := make(map[string]bool)
 	for _, repo := range repos {
-		ghRepo, err := p.client.GetRepositoryByNodeID(ctx, "", repo.ExternalRepo.ID)
+		ghRepo, err := p.client.GetRepositoryByNodeID(ctx, repo.ExternalRepo.ID)
 		if err == github.ErrNotFound {
 			// Note: we could set `isPublic[repo.ExternalRepoSpec.ID] = false` here, but
 			// purposefully don't cache if a repo is private in case it later becomes public.
@@ -328,6 +328,7 @@ func (p *Provider) fetchUserRepos(ctx context.Context, userAccount *extsvc.Accou
 	if err != nil {
 		return nil, nil, err
 	}
+	client := p.client.WithToken(tok.AccessToken)
 
 	// Batch fetch repos from API
 	ghRepos := make(map[string]*github.Repository)
@@ -336,7 +337,7 @@ func (p *Provider) fetchUserRepos(ctx context.Context, userAccount *extsvc.Accou
 		if j > len(repoIDs) {
 			j = len(repoIDs)
 		}
-		ghReposBatch, err := p.client.GetRepositoriesByNodeIDFromAPI(ctx, tok.AccessToken, repoIDs[i:j])
+		ghReposBatch, err := client.GetRepositoriesByNodeIDFromAPI(ctx, repoIDs[i:j])
 		if err != nil {
 			return nil, nil, err
 		}

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -35,8 +35,9 @@ func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, m
 		cache:    mockCache,
 		cacheTTL: cacheTTL,
 	}
+
 	// Note: this will use the same underlying Redis instance and key namespace for every instance
-	// of Provider.  This is by design, so that different instances, even in different processes,
+	// of Provider. This is by design, so that different instances, even in different processes,
 	// will share cache entries.
 	if p.cache == nil {
 		p.cache = rcache.NewWithTTL(fmt.Sprintf("githubAuthz:%s", githubURL.String()), int(math.Ceil(cacheTTL.Seconds())))

--- a/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
@@ -2,12 +2,10 @@ package github
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -16,23 +14,25 @@ import (
 // TestProvider_RepoPerms_cacheTTL tests that cache entries are invalidated after the cache TTL
 // changes.
 func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
-	githubMock := newMockGitHub([]*github.Repository{
-		{ID: "u0/r0", IsPrivate: true},
-		{ID: "u1/r1", IsPrivate: true},
-		{ID: "u1/public"},
-	}, map[string][]string{
-		"t0": {"u0/r0"},
-		"t1": {"u1/r1"},
-	})
-	github.GetRepositoryByNodeIDMock = githubMock.GetRepositoryByNodeID
-	defer func() { github.GetRepositoryByNodeIDMock = nil }()
-	github.GetRepositoriesByNodeIDFromAPIMock = githubMock.GetRepositoriesByNodeIDFromAPI
-	defer func() { github.GetRepositoriesByNodeIDFromAPIMock = nil }()
+	cacheMisses := 0
+	mockClient := &mockClient{
+		MockGetRepositoriesByNodeIDFromAPI: func(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error) {
+			cacheMisses++
+			return map[string]*github.Repository{
+				"u1/public": {},
+				"u0/r0":     {},
+			}, nil
+		},
+	}
+	mockClient.MockWithToken = func(token string) client {
+		return mockClient
+	}
 
-	provider := NewProvider(mustURL(t, "https://github.com"), "base-token", 3*time.Hour, make(authz.MockCache))
+	p := NewProvider(mustURL(t, "https://github.com"), "base-token", 3*time.Hour, make(authz.MockCache))
+	p.client = mockClient
+
 	ctx := context.Background()
 
-	githubMock.getRepositoriesByNodeIDCount = 0
 	userAccount := ua("u0", "t0")
 	repos := []*types.Repo{
 		rp("r0", "u0/r0", "https://github.com/"),
@@ -45,50 +45,44 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 		{Repo: repos[2], Perms: authz.Read},
 	}
 	{
-		gotPerms, gotErr := provider.RepoPerms(ctx, userAccount, repos)
-		if gotErr != nil {
-			t.Fatal(gotErr)
+		perms, err := p.RepoPerms(ctx, userAccount, repos)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(gotPerms, wantPerms) {
-			dmp := diffmatchpatch.New()
-			t.Errorf("wantPerms != gotPerms:\n%s",
-				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
+		if diff := cmp.Diff(wantPerms, perms); diff != "" {
+			t.Fatal(diff)
 		}
-		if want, got := 1, githubMock.getRepositoriesByNodeIDCount; want != got {
-			t.Errorf("expected %d cache misses, but got %d", want, got)
+		if cacheMisses != 1 {
+			t.Errorf("expected 1 cache misses, but got %d", cacheMisses)
 		}
-		githubMock.getRepositoriesByNodeIDCount = 0
+		cacheMisses = 0
 	}
 	{
-		gotPerms, gotErr := provider.RepoPerms(ctx, userAccount, repos)
+		perms, gotErr := p.RepoPerms(ctx, userAccount, repos)
 		if gotErr != nil {
 			t.Fatal(gotErr)
 		}
-		if !reflect.DeepEqual(gotPerms, wantPerms) {
-			dmp := diffmatchpatch.New()
-			t.Errorf("wantPerms != gotPerms:\n%s",
-				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
+		if diff := cmp.Diff(wantPerms, perms); diff != "" {
+			t.Fatal(diff)
 		}
-		if want, got := 0, githubMock.getRepositoriesByNodeIDCount; want != got {
-			t.Errorf("expected %d cache misses, but got %d", want, got)
+		if cacheMisses != 0 {
+			t.Errorf("expected 0 cache misses, but got %d", cacheMisses)
 		}
-		githubMock.getRepositoriesByNodeIDCount = 0
+		cacheMisses = 0
 	}
 
-	provider.cacheTTL = 1 * time.Hour // lower cache TTL
+	p.cacheTTL = 1 * time.Hour // lower cache TTL
 	{
-		gotPerms, gotErr := provider.RepoPerms(ctx, userAccount, repos)
+		perms, gotErr := p.RepoPerms(ctx, userAccount, repos)
 		if gotErr != nil {
 			t.Fatal(gotErr)
 		}
-		if !reflect.DeepEqual(gotPerms, wantPerms) {
-			dmp := diffmatchpatch.New()
-			t.Errorf("wantPerms != gotPerms:\n%s",
-				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
+		if diff := cmp.Diff(wantPerms, perms); diff != "" {
+			t.Fatal(diff)
 		}
-		if want, got := 1, githubMock.getRepositoriesByNodeIDCount; want != got {
-			t.Errorf("expected %d cache misses, but got %d", want, got)
+		if cacheMisses != 1 {
+			t.Errorf("expected 1 cache misses, but got %d", cacheMisses)
 		}
-		githubMock.getRepositoriesByNodeIDCount = 0
+		cacheMisses = 0
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -5,14 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -20,71 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"golang.org/x/oauth2"
 )
-
-type Provider_RepoPerms_Test struct {
-	description string
-	githubURL   *url.URL
-	cacheTTL    time.Duration
-	calls       []Provider_RepoPerms_call
-}
-
-type Provider_RepoPerms_call struct {
-	description string
-	userAccount *extsvc.Account
-	repos       []*types.Repo
-	wantPerms   []authz.RepoPerms
-	wantErr     error
-}
-
-func (p *Provider_RepoPerms_Test) run(t *testing.T) {
-	githubMock := newMockGitHub([]*github.Repository{
-		{ID: "u0/private", IsPrivate: true},
-		{ID: "u0/public"},
-		{ID: "u1/private", IsPrivate: true},
-		{ID: "u1/public"},
-		{ID: "u99/private", IsPrivate: true},
-		{ID: "u99/public"},
-	}, map[string][]string{
-		"t0": {"u0/private", "u0/public"},
-		"t1": {"u1/private", "u1/public"},
-	})
-	github.GetRepositoryByNodeIDMock = githubMock.GetRepositoryByNodeID
-	defer func() { github.GetRepositoryByNodeIDMock = nil }()
-	github.GetRepositoriesByNodeIDFromAPIMock = githubMock.GetRepositoriesByNodeIDFromAPI
-	defer func() { github.GetRepositoriesByNodeIDFromAPIMock = nil }()
-
-	provider := NewProvider(p.githubURL, "base-token", p.cacheTTL, make(authz.MockCache))
-	for j := 0; j < 2; j++ { // run twice for cache coherency
-		for _, c := range p.calls {
-			t.Run(fmt.Sprintf("%s: run %d", c.description, j), func(t *testing.T) {
-				c := c
-				ctx := context.Background()
-				githubMock.getRepositoryByNodeIDCount = 0
-
-				gotPerms, gotErr := provider.RepoPerms(ctx, c.userAccount, c.repos)
-				if gotErr != c.wantErr {
-					t.Errorf("expected err %v, got err %v", c.wantErr, gotErr)
-				}
-
-				for _, perms := range [][]authz.RepoPerms{gotPerms, c.wantPerms} {
-					sort.Slice(perms, func(i, j int) bool {
-						return perms[i].Repo.Name <= perms[j].Repo.Name
-					})
-				}
-
-				if !reflect.DeepEqual(gotPerms, c.wantPerms) {
-					dmp := diffmatchpatch.New()
-					t.Errorf("expected perms did not equal actual, diff:\n%s",
-						dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(c.wantPerms), spew.Sdump(gotPerms), false)))
-				}
-
-				if j == 1 && githubMock.getRepositoryByNodeIDCount > 0 {
-					t.Errorf("expected entries to be fully cached")
-				}
-			})
-		}
-	}
-}
 
 func TestProvider_RepoPerms(t *testing.T) {
 	repos := map[string]*types.Repo{
@@ -97,12 +29,26 @@ func TestProvider_RepoPerms(t *testing.T) {
 		"r00": rp("r00", "404", "https://github.com/"),
 	}
 
-	tests := []Provider_RepoPerms_Test{
+	type call struct {
+		description string
+		userAccount *extsvc.Account
+		repos       []*types.Repo
+		mockRepos   map[string]*github.Repository
+		wantPerms   []authz.RepoPerms
+		wantErr     error
+	}
+
+	tests := []struct {
+		description string
+		githubURL   *url.URL
+		cacheTTL    time.Duration
+		calls       []call
+	}{
 		{
 			description: "common_case",
 			githubURL:   mustURL(t, "https://github.com"),
 			cacheTTL:    3 * time.Hour,
-			calls: []Provider_RepoPerms_call{
+			calls: []call{
 				{
 					description: "t0_repos",
 					userAccount: ua("u0", "t0"),
@@ -113,6 +59,12 @@ func TestProvider_RepoPerms(t *testing.T) {
 						repos["r3"],
 						repos["r4"],
 						repos["r5"],
+					},
+					mockRepos: map[string]*github.Repository{
+						"u0/private": {ID: "u0/private", IsPrivate: true},
+						"u0/public":  {ID: "u0/public"},
+						"u1/public":  {ID: "u1/public"},
+						"u99/public": {ID: "u99/public"},
 					},
 					wantPerms: []authz.RepoPerms{
 						{Repo: repos["r0"], Perms: authz.Read},
@@ -134,6 +86,12 @@ func TestProvider_RepoPerms(t *testing.T) {
 						repos["r4"],
 						repos["r5"],
 					},
+					mockRepos: map[string]*github.Repository{
+						"u0/public":  {ID: "u0/public"},
+						"u1/private": {ID: "u1/private", IsPrivate: true},
+						"u1/public":  {ID: "u1/public"},
+						"u99/public": {ID: "u99/public"},
+					},
 					wantPerms: []authz.RepoPerms{
 						{Repo: repos["r0"], Perms: authz.None},
 						{Repo: repos["r1"], Perms: authz.Read},
@@ -154,6 +112,11 @@ func TestProvider_RepoPerms(t *testing.T) {
 						repos["r4"],
 						repos["r5"],
 					},
+					mockRepos: map[string]*github.Repository{
+						"u0/public":  {ID: "u0/public"},
+						"u1/public":  {ID: "u1/public"},
+						"u99/public": {ID: "u99/public"},
+					},
 					wantPerms: []authz.RepoPerms{
 						{Repo: repos["r0"], Perms: authz.None},
 						{Repo: repos["r1"], Perms: authz.Read},
@@ -173,6 +136,14 @@ func TestProvider_RepoPerms(t *testing.T) {
 						repos["r3"],
 						repos["r4"],
 						repos["r5"],
+					},
+					mockRepos: map[string]*github.Repository{
+						"u0/private":  {ID: "u0/private", IsPrivate: true},
+						"u0/public":   {ID: "u0/public"},
+						"u1/private":  {ID: "u1/private", IsPrivate: true},
+						"u1/public":   {ID: "u1/public"},
+						"u99/private": {ID: "u99/private", IsPrivate: true},
+						"u99/public":  {ID: "u99/public"},
 					},
 					wantPerms: []authz.RepoPerms{
 						{Repo: repos["r1"], Perms: authz.Read},
@@ -204,30 +175,77 @@ func TestProvider_RepoPerms(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.description, test.run)
+		t.Run(test.description, func(t *testing.T) {
+			mockClient := &mockClient{}
+			mockClient.MockWithToken = func(token string) client {
+				return mockClient
+			}
+
+			p := NewProvider(test.githubURL, "base-token", test.cacheTTL, make(authz.MockCache))
+			p.client = mockClient
+
+			for j := 0; j < 2; j++ { // run twice for cache coherency
+				for _, c := range test.calls {
+					t.Run(fmt.Sprintf("%s: run %d", c.description, j), func(t *testing.T) {
+						c := c
+
+						called := 0
+						mockClient.MockGetRepositoriesByNodeIDFromAPI = func(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error) {
+							called++
+							return c.mockRepos, nil
+						}
+						mockClient.MockGetRepositoryByNodeID = func(ctx context.Context, id string) (*github.Repository, error) {
+							called++
+							r, ok := c.mockRepos[id]
+							if !ok {
+								return nil, github.ErrNotFound
+							}
+							return r, nil
+						}
+
+						perms, err := p.RepoPerms(context.Background(), c.userAccount, c.repos)
+						if diff := cmp.Diff(c.wantErr, err); diff != "" {
+							t.Fatal(diff)
+						}
+
+						for _, ps := range [][]authz.RepoPerms{perms, c.wantPerms} {
+							sort.Slice(ps, func(i, j int) bool {
+								return ps[i].Repo.Name <= ps[j].Repo.Name
+							})
+						}
+						if diff := cmp.Diff(c.wantPerms, perms); diff != "" {
+							t.Fatal(diff)
+						}
+
+						if j == 1 && called > 0 {
+							t.Fatal("expected entries to be fully cached")
+						}
+					})
+				}
+			}
+		})
 	}
 }
 
 func Test_fetchUserRepos(t *testing.T) {
-	githubMock := newMockGitHub([]*github.Repository{
-		{ID: "u0/private", IsPrivate: true},
-		{ID: "u0/public"},
-		{ID: "u1/private", IsPrivate: true},
-		{ID: "u1/public"},
-		{ID: "u99/private", IsPrivate: true},
-		{ID: "u99/public"},
-	}, map[string][]string{
-		"t0": {"u0/private", "u0/public"},
-		"t1": {"u1/private", "u1/public"},
-	})
-	github.GetRepositoriesByNodeIDFromAPIMock = githubMock.GetRepositoriesByNodeIDFromAPI
-	defer func() { github.GetRepositoriesByNodeIDFromAPIMock = nil }()
-	oldMaxNodeIDs := github.MaxNodeIDs
-	github.MaxNodeIDs = 2
-	defer func() { github.MaxNodeIDs = oldMaxNodeIDs }()
+	mockClient := &mockClient{
+		MockGetRepositoriesByNodeIDFromAPI: func(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error) {
+			return map[string]*github.Repository{
+				"u0/private": {ID: "u0/private", IsPrivate: true},
+				"u0/public":  {ID: "u0/public"},
+				"u1/public":  {ID: "u1/public"},
+				"u99/public": {ID: "u99/public"},
+			}, nil
+		},
+	}
+	mockClient.MockWithToken = func(token string) client {
+		return mockClient
+	}
 
-	provider := NewProvider(mustURL(t, "https://github.com"), "base-token", 0, make(authz.MockCache))
-	canAccess, isPublic, err := provider.fetchUserRepos(context.Background(), ua("u0", "t0"), []string{
+	p := NewProvider(mustURL(t, "https://github.com"), "base-token", 0, make(authz.MockCache))
+	p.client = mockClient
+
+	canAccess, isPublic, err := p.fetchUserRepos(context.Background(), ua("u0", "t0"), []string{
 		"u0/private",
 		"u0/public",
 		"u1/private",
@@ -254,11 +272,11 @@ func Test_fetchUserRepos(t *testing.T) {
 		"u99/public": true,
 	}
 
-	if !reflect.DeepEqual(canAccess, wantCanAccess) {
-		t.Errorf("canAccess %+v != wantCanAccess %+v", canAccess, wantCanAccess)
+	if diff := cmp.Diff(wantCanAccess, canAccess); diff != "" {
+		t.Fatal(diff)
 	}
-	if !reflect.DeepEqual(isPublic, wantIsPublic) {
-		t.Errorf("isPublic %+v != wantIsPublic %+v", isPublic, wantIsPublic)
+	if diff := cmp.Diff(wantIsPublic, isPublic); diff != "" {
+		t.Fatal(diff)
 	}
 }
 
@@ -288,89 +306,6 @@ func rp(name, ghid, serviceID string) *types.Repo {
 			ServiceID:   serviceID,
 		},
 	}
-}
-
-type mockGitHub struct {
-	// Repos is a map from repo ID to repository
-	Repos map[string]*github.Repository
-
-	// TokenRepos is a map from auth token to list of repo IDs that are explicitly readable with that token
-	TokenRepos map[string]map[string]struct{}
-
-	// PublicRepos is the set of repo IDs corresponding to public repos
-	PublicRepos map[string]struct{}
-
-	// getRepositoryByNodeIDCount tracks the number of times GetRepositoryByNodeID is called
-	getRepositoryByNodeIDCount int
-
-	// getRepositoriesByNodeIDCount tracks the number of times GetRepositoriesByNodeIDFromAPI is called
-	getRepositoriesByNodeIDCount int
-}
-
-func newMockGitHub(repos []*github.Repository, tokenRepos map[string][]string) *mockGitHub {
-	rp := make(map[string]*github.Repository)
-	for _, r := range repos {
-		rp[r.ID] = r
-	}
-	tr := make(map[string]map[string]struct{})
-	for t, rps := range tokenRepos {
-		tr[t] = make(map[string]struct{})
-		for _, r := range rps {
-			tr[t][r] = struct{}{}
-		}
-	}
-	pr := make(map[string]struct{})
-	for _, r := range repos {
-		if !r.IsPrivate {
-			pr[r.ID] = struct{}{}
-		}
-	}
-	return &mockGitHub{
-		Repos:       rp,
-		TokenRepos:  tr,
-		PublicRepos: pr,
-	}
-}
-
-func (m *mockGitHub) GetRepositoryByNodeID(ctx context.Context, token, id string) (repo *github.Repository, err error) {
-	m.getRepositoryByNodeIDCount++
-	if _, isPublic := m.PublicRepos[id]; isPublic {
-		r, ok := m.Repos[id]
-		if !ok {
-			return nil, github.ErrNotFound
-		}
-		return r, nil
-	}
-
-	if token == "" {
-		return nil, github.ErrNotFound
-	}
-
-	tr := m.TokenRepos[token]
-	if tr == nil {
-		return nil, github.ErrNotFound
-	}
-	if _, explicit := tr[id]; !explicit {
-		return nil, github.ErrNotFound
-	}
-	r, ok := m.Repos[id]
-	if !ok {
-		return nil, github.ErrNotFound
-	}
-	return r, nil
-}
-
-func (m *mockGitHub) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error) {
-	m.getRepositoriesByNodeIDCount++
-
-	repos := make(map[string]*github.Repository)
-	for rid := range m.PublicRepos {
-		repos[rid] = m.Repos[rid]
-	}
-	for rid := range m.TokenRepos[token] {
-		repos[rid] = m.Repos[rid]
-	}
-	return repos, nil
 }
 
 func TestProvider_FetchUserPerms(t *testing.T) {

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -54,8 +54,10 @@ type Client struct {
 	// githubDotCom is true if this client connects to github.com.
 	githubDotCom bool
 
-	// token is the personal access token used to authenticate requests.
-	// May be empty, in which case the default behavior is to make unauthenticated requests.
+	// token is the personal access token used to authenticate requests. May be empty, in which case
+	// the default behavior is to make unauthenticated requests.
+	// 🚨 SECURITY: Should not be changed after client creation to prevent unauthorized access to the
+	// repository cache. Use `WithToken` to create a new client with a different token instead.
 	token string
 
 	// httpClient is the HTTP client used to make requests to the GitHub API.

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
@@ -70,36 +71,39 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestNewRepoCache_GitHubDotCom(t *testing.T) {
-	url, _ := url.Parse("https://www.github.com")
-	token := "asdf"
+func Test_newRepoCache(t *testing.T) {
+	cmpOpts := cmp.AllowUnexported(rcache.Cache{})
+	t.Run("GitHub.com", func(t *testing.T) {
+		url, _ := url.Parse("https://www.github.com")
+		token := "asdf"
 
-	// github.com caches should:
-	// (1) use githubProxyURL for the prefix hash rather than the given url
-	// (2) have a TTL of 10 minutes
-	key := sha256.Sum256([]byte(token + ":" + githubProxyURL.String()))
-	prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
-	got := NewRepoCache(url, token, "", 0)
-	want := rcache.NewWithTTL(prefix, 600)
-	if *got != *want {
-		t.Errorf("TestNewRepoCache_GitHubDotCom: got %#v, want %#v", *got, *want)
-	}
-}
+		// github.com caches should:
+		// (1) use githubProxyURL for the prefix hash rather than the given url
+		// (2) have a TTL of 10 minutes
+		key := sha256.Sum256([]byte(token + ":" + githubProxyURL.String()))
+		prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
+		got := newRepoCache(url, token)
+		want := rcache.NewWithTTL(prefix, 600)
+		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 
-func TestNewRepoCache_GitHubEnterprise(t *testing.T) {
-	url, _ := url.Parse("https://www.sourcegraph.com")
-	token := "asdf"
+	t.Run("GitHub Enterprise", func(t *testing.T) {
+		url, _ := url.Parse("https://www.sourcegraph.com")
+		token := "asdf"
 
-	// GitHub Enterprise caches should:
-	// (1) use the given URL for the prefix hash
-	// (2) have a TTL of 30 seconds
-	key := sha256.Sum256([]byte(token + ":" + url.String()))
-	prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
-	got := NewRepoCache(url, token, "", 0)
-	want := rcache.NewWithTTL(prefix, 30)
-	if *got != *want {
-		t.Errorf("TestNewRepoCache_GitHubEnterprise: got %#v, want %#v", *got, *want)
-	}
+		// GitHub Enterprise caches should:
+		// (1) use the given URL for the prefix hash
+		// (2) have a TTL of 30 seconds
+		key := sha256.Sum256([]byte(token + ":" + url.String()))
+		prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
+		got := newRepoCache(url, token)
+		want := rcache.NewWithTTL(prefix, 30)
+		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }
 
 var updateRegex = flag.String("update", "", "Update testdata of tests matching the given regex")

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -118,8 +118,8 @@ func TestClient_WithToken(t *testing.T) {
 	}
 
 	old := &Client{
-		apiURL:       uri,
-		defaultToken: "old_token",
+		apiURL: uri,
+		token:  "old_token",
 	}
 
 	newToken := "new_token"
@@ -128,8 +128,8 @@ func TestClient_WithToken(t *testing.T) {
 		t.Fatal("both clients have the same address")
 	}
 
-	if new.defaultToken != newToken {
-		t.Fatalf("defaultToken: want %q but got %q", newToken, new.defaultToken)
+	if new.token != newToken {
+		t.Fatalf("token: want %q but got %q", newToken, new.token)
 	}
 }
 

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -482,7 +482,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInp
 	}
 
 	input := map[string]interface{}{"input": in}
-	err := c.requestGraphQL(ctx, "", q.String(), input, &result)
+	err := c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
 		if gqlErrs, ok := err.(graphqlErrors); ok && len(gqlErrs) == 1 {
 			e := gqlErrs[0]
@@ -534,7 +534,7 @@ func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInp
 	}
 
 	input := map[string]interface{}{"input": in}
-	err := c.requestGraphQL(ctx, "", q.String(), input, &result)
+	err := c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
 		if gqlErrs, ok := err.(graphqlErrors); ok && len(gqlErrs) == 1 {
 			e := gqlErrs[0]
@@ -576,7 +576,7 @@ func (c *Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error {
 	input := map[string]interface{}{"input": struct {
 		ID string `json:"pullRequestId"`
 	}{ID: pr.ID}}
-	err := c.requestGraphQL(ctx, "", q.String(), input, &result)
+	err := c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
 		return err
 	}
@@ -658,7 +658,7 @@ func (c *Client) loadPullRequests(ctx context.Context, prs ...*PullRequest) erro
 		TimelineItems struct{ Nodes []TimelineItem }
 	}
 
-	err := c.requestGraphQL(ctx, "", q.String(), nil, &results)
+	err := c.requestGraphQL(ctx, q.String(), nil, &results)
 	if err != nil {
 		return err
 	}
@@ -700,7 +700,7 @@ func (c *Client) GetOpenPullRequestByRefs(ctx context.Context, owner, name, base
 		}
 	}
 
-	err := c.requestGraphQL(ctx, "", q.String(), nil, &results)
+	err := c.requestGraphQL(ctx, q.String(), nil, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -103,9 +103,6 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 	}, false)
 }
 
-// GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
-var GetRepositoryByNodeIDMock func(ctx context.Context, id string) (*Repository, error)
-
 // GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID using the specified user token.
 func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Repository, error) {
 	return c.getRepositoryByNodeID(ctx, id, false)
@@ -119,10 +116,6 @@ func (c *Client) GetRepositoryByNodeIDNoCache(ctx context.Context, id string) (*
 }
 
 func (c *Client) getRepositoryByNodeID(ctx context.Context, id string, nocache bool) (*Repository, error) {
-	if GetRepositoryByNodeIDMock != nil {
-		return GetRepositoryByNodeIDMock(ctx, id)
-	}
-
 	key := nodeIDCacheKey(id)
 
 	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
@@ -335,19 +328,12 @@ query Repository($id: ID!) {
 // GitHub GraphQL API.
 var MaxNodeIDs = 100
 
-// GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
-var GetRepositoriesByNodeIDFromAPIMock func(ctx context.Context, nodeIDs []string) (map[string]*Repository, error)
-
 // GetRepositoriesByNodeIDFromAPI fetches the specified repositories (nodeIDs) and returns a map
 // from node ID to repository metadata. If a repository is not found, it will not be present in the
 // return map. The caller should respect the max nodeID count limit of the GitHub API, which at the
 // time of writing, is 100 (if the caller does not respect this match, this method will return an
 // error). This method does not cache.
 func (c *Client) GetRepositoriesByNodeIDFromAPI(ctx context.Context, nodeIDs []string) (map[string]*Repository, error) {
-	if GetRepositoriesByNodeIDFromAPIMock != nil {
-		return GetRepositoriesByNodeIDFromAPIMock(ctx, nodeIDs)
-	}
-
 	var result struct {
 		Nodes []*Repository
 	}

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -93,7 +93,7 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 	}
 
 	key := ownerNameCacheKey(owner, name)
-	return c.cachedGetRepository(ctx, "", key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
+	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
 		keys = append(keys, key)
 		repo, err = c.getRepositoryFromAPI(ctx, owner, name)
 		if repo != nil {
@@ -104,31 +104,31 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 }
 
 // GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
-var GetRepositoryByNodeIDMock func(ctx context.Context, token, id string) (*Repository, error)
+var GetRepositoryByNodeIDMock func(ctx context.Context, id string) (*Repository, error)
 
 // GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID using the specified user token.
-func (c *Client) GetRepositoryByNodeID(ctx context.Context, token, id string) (*Repository, error) {
-	return c.getRepositoryByNodeID(ctx, token, id, false)
+func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Repository, error) {
+	return c.getRepositoryByNodeID(ctx, id, false)
 }
 
 // HACK: allows us to bypass the GitHub client cache (used for fetching repositories to determine
 // permissions). TODO(beyang): merge this into a unified GetRepositoryByNodeID with a clean
 // interface.
-func (c *Client) GetRepositoryByNodeIDNoCache(ctx context.Context, token, id string) (*Repository, error) {
-	return c.getRepositoryByNodeID(ctx, token, id, true)
+func (c *Client) GetRepositoryByNodeIDNoCache(ctx context.Context, id string) (*Repository, error) {
+	return c.getRepositoryByNodeID(ctx, id, true)
 }
 
-func (c *Client) getRepositoryByNodeID(ctx context.Context, token, id string, nocache bool) (*Repository, error) {
+func (c *Client) getRepositoryByNodeID(ctx context.Context, id string, nocache bool) (*Repository, error) {
 	if GetRepositoryByNodeIDMock != nil {
-		return GetRepositoryByNodeIDMock(ctx, token, id)
+		return GetRepositoryByNodeIDMock(ctx, id)
 	}
 
 	key := nodeIDCacheKey(id)
 
 	// 🚨 SECURITY: must forward token here to ensure caching by token
-	return c.cachedGetRepository(ctx, token, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
+	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
 		keys = append(keys, key)
-		repo, err = c.getRepositoryByNodeIDFromAPI(ctx, token, id)
+		repo, err = c.getRepositoryByNodeIDFromAPI(ctx, id)
 		if repo != nil {
 			keys = append(keys, nameWithOwnerCacheKey(repo.NameWithOwner)) // also cache under "owner/name"
 		}
@@ -137,10 +137,10 @@ func (c *Client) getRepositoryByNodeID(ctx context.Context, token, id string, no
 }
 
 // cachedGetRepository caches the getRepositoryFromAPI call.
-func (c *Client) cachedGetRepository(ctx context.Context, token, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error), nocache bool) (*Repository, error) {
+func (c *Client) cachedGetRepository(ctx context.Context, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error), nocache bool) (*Repository, error) {
 	// 🚨 SECURITY: must forward token here to ensure caching by token
 	if !nocache {
-		if cached := c.getRepositoryFromCache(ctx, token, key); cached != nil {
+		if cached := c.getRepositoryFromCache(ctx, key); cached != nil {
 			reposGitHubCacheCounter.WithLabelValues("hit").Inc()
 			if cached.NotFound {
 				return nil, ErrNotFound
@@ -154,7 +154,7 @@ func (c *Client) cachedGetRepository(ctx context.Context, token, key string, get
 		// Before we do anything, ensure we cache NotFound responses.
 		// Do this if client is unauthed or authed, it's okay since we're only caching not found responses here.
 		// 🚨 SECURITY: must forward token here to ensure caching by token
-		c.addRepositoryToCache(token, keys, &cachedRepo{NotFound: true})
+		c.addRepositoryToCache(keys, &cachedRepo{NotFound: true})
 		reposGitHubCacheCounter.WithLabelValues("notfound").Inc()
 	}
 	if err != nil {
@@ -163,7 +163,7 @@ func (c *Client) cachedGetRepository(ctx context.Context, token, key string, get
 	}
 
 	// 🚨 SECURITY: must forward token here to ensure caching by token
-	c.addRepositoryToCache(token, keys, &cachedRepo{Repository: *repo})
+	c.addRepositoryToCache(keys, &cachedRepo{Repository: *repo})
 	reposGitHubCacheCounter.WithLabelValues("miss").Inc()
 
 	return repo, nil
@@ -189,9 +189,9 @@ type cachedRepo struct {
 
 // getRepositoryFromCache attempts to get a response from the redis cache.
 // It returns nil error for cache-hit condition and non-nil error for cache-miss.
-func (c *Client) getRepositoryFromCache(ctx context.Context, token, key string) *cachedRepo {
+func (c *Client) getRepositoryFromCache(ctx context.Context, key string) *cachedRepo {
 	// 🚨 SECURITY: must forward token here to ensure caching by token
-	b, ok := c.cache(token).Get(strings.ToLower(key))
+	b, ok := c.repoCache.Get(strings.ToLower(key))
 	if !ok {
 		return nil
 	}
@@ -204,35 +204,26 @@ func (c *Client) getRepositoryFromCache(ctx context.Context, token, key string) 
 	return &cached
 }
 
-func firstNonEmpty(strs ...string) string {
-	for _, s := range strs {
-		if s != "" {
-			return s
-		}
-	}
-	return ""
-}
-
 // addRepositoryToCache will cache the value for repo. The caller can provide multiple cache keys
 // for the multiple ways that this repository can be retrieved (e.g., both "owner/name" and the
 // GraphQL node ID).
-func (c *Client) addRepositoryToCache(token string, keys []string, repo *cachedRepo) {
+func (c *Client) addRepositoryToCache(keys []string, repo *cachedRepo) {
 	b, err := json.Marshal(repo)
 	if err != nil {
 		return
 	}
 	for _, key := range keys {
-		c.cache(token).Set(strings.ToLower(key), b)
+		c.repoCache.Set(strings.ToLower(key), b)
 	}
 }
 
 // addRepositoriesToCache will cache repositories that exist
 // under relevant cache keys.
-func (c *Client) addRepositoriesToCache(token string, repos []*Repository) {
+func (c *Client) addRepositoriesToCache(repos []*Repository) {
 	for _, repo := range repos {
 		keys := []string{nameWithOwnerCacheKey(repo.NameWithOwner), nodeIDCacheKey(repo.ID)} // cache under multiple
 		// 🚨 SECURITY: must forward token here to ensure caching by token
-		c.addRepositoryToCache(token, keys, &cachedRepo{Repository: *repo})
+		c.addRepositoryToCache(keys, &cachedRepo{Repository: *repo})
 	}
 }
 
@@ -261,7 +252,7 @@ func (c *Client) getRepositoryFromAPI(ctx context.Context, owner, name string) (
 	// example) a server with autoAddRepos and no GitHub connection configured when someone visits
 	// http://[sourcegraph-hostname]/github.com/foo/bar.
 	var result restRepository
-	if err := c.requestGet(ctx, "", fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
+	if err := c.requestGet(ctx, fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
 		if HTTPErrorCode(err) == http.StatusNotFound {
 			return nil, ErrNotFound
 		}
@@ -316,11 +307,11 @@ func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) (
 
 // getRepositoryByNodeIDFromAPI attempts to fetch a repository by GraphQL node ID from the GitHub
 // API without use of the redis cache.
-func (c *Client) getRepositoryByNodeIDFromAPI(ctx context.Context, token, id string) (*Repository, error) {
+func (c *Client) getRepositoryByNodeIDFromAPI(ctx context.Context, id string) (*Repository, error) {
 	var result struct {
 		Node *Repository `json:"node"`
 	}
-	if err := c.requestGraphQL(ctx, token, `
+	if err := c.requestGraphQL(ctx, `
 query Repository($id: ID!) {
 	node(id: $id) {
 		... on Repository {
@@ -351,22 +342,22 @@ query Repository($id: ID!) {
 var MaxNodeIDs = 100
 
 // GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
-var GetRepositoriesByNodeIDFromAPIMock func(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error)
+var GetRepositoriesByNodeIDFromAPIMock func(ctx context.Context, nodeIDs []string) (map[string]*Repository, error)
 
 // GetRepositoriesByNodeIDFromAPI fetches the specified repositories (nodeIDs) and returns a map
 // from node ID to repository metadata. If a repository is not found, it will not be present in the
 // return map. The caller should respect the max nodeID count limit of the GitHub API, which at the
 // time of writing, is 100 (if the caller does not respect this match, this method will return an
 // error). This method does not cache.
-func (c *Client) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error) {
+func (c *Client) GetRepositoriesByNodeIDFromAPI(ctx context.Context, nodeIDs []string) (map[string]*Repository, error) {
 	if GetRepositoriesByNodeIDFromAPIMock != nil {
-		return GetRepositoriesByNodeIDFromAPIMock(ctx, token, nodeIDs)
+		return GetRepositoriesByNodeIDFromAPIMock(ctx, nodeIDs)
 	}
 
 	var result struct {
 		Nodes []*Repository
 	}
-	err := c.requestGraphQL(ctx, token, `
+	err := c.requestGraphQL(ctx, `
 query Repositories($ids: [ID!]!) {
 	nodes(ids: $ids) {
 		... on Repository {
@@ -424,7 +415,7 @@ func (c *Client) GetReposByNameWithOwner(ctx context.Context, namesWithOwners ..
 	}
 
 	var result map[string]*Repository
-	err = c.requestGraphQL(ctx, "", query, map[string]interface{}{}, &result)
+	err = c.requestGraphQL(ctx, query, map[string]interface{}{}, &result)
 	if err != nil {
 		if gqlErrs, ok := err.(graphqlErrors); ok {
 			for _, err2 := range gqlErrs {
@@ -472,7 +463,7 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 	if err != nil {
 		return nil, err
 	}
-	c.addRepositoriesToCache("", repos)
+	c.addRepositoriesToCache(repos)
 	return repos, nil
 }
 
@@ -484,7 +475,7 @@ func (c *Client) ListAffiliatedRepositories(ctx context.Context, page int) (repo
 	repos, err = c.listRepositories(ctx, path)
 	if err == nil {
 		// 🚨 SECURITY: must forward token here to ensure caching by token
-		c.addRepositoriesToCache("", repos)
+		c.addRepositoriesToCache(repos)
 	}
 
 	return repos, len(repos) > 0, 1, err
@@ -528,7 +519,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 	}
 	path := "search/repositories?" + urlValues.Encode()
 	var response restSearchResponse
-	if err := c.requestGet(ctx, "", path, &response); err != nil {
+	if err := c.requestGet(ctx, path, &response); err != nil {
 		return RepositoryListPage{}, err
 	}
 	if response.IncompleteResults {
@@ -538,7 +529,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 	for _, restRepo := range response.Items {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
-	c.addRepositoriesToCache("", repos)
+	c.addRepositoriesToCache(repos)
 
 	return RepositoryListPage{
 		TotalCount:  response.TotalCount,
@@ -559,7 +550,7 @@ func (c *Client) ListTopicsOnRepository(ctx context.Context, ownerAndName string
 	}
 
 	var result restTopicsResponse
-	if err := c.requestGet(ctx, "", fmt.Sprintf("/repos/%s/%s/topics", owner, name), &result); err != nil {
+	if err := c.requestGet(ctx, fmt.Sprintf("/repos/%s/%s/topics", owner, name), &result); err != nil {
 		if HTTPErrorCode(err) == http.StatusNotFound {
 			return nil, ErrNotFound
 		}

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
@@ -76,14 +75,9 @@ func newTestClient(t *testing.T, cli httpcli.Doer) *Client {
 
 func newTestClientWithToken(t *testing.T, token string, cli httpcli.Doer) *Client {
 	rcache.SetupForTest(t)
-	c := &Client{
-		apiURL:     &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		token:      token,
-		httpClient: cli,
-		RateLimit:  &ratelimit.Monitor{},
-	}
-	c.repoCache = NewRepoCache(c.apiURL, token, "__test__gh_repo", 1000)
-	return c
+
+	apiURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/"}
+	return NewClient(apiURL, token, cli)
 }
 
 // TestClient_GetRepository tests the behavior of GetRepository.

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -70,15 +71,19 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 }
 
 func newTestClient(t *testing.T, cli httpcli.Doer) *Client {
+	return newTestClientWithToken(t, "", cli)
+}
+
+func newTestClientWithToken(t *testing.T, token string, cli httpcli.Doer) *Client {
 	rcache.SetupForTest(t)
-	return &Client{
-		apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		httpClient:      cli,
-		RateLimit:       &ratelimit.Monitor{},
-		repoCache:       map[string]*rcache.Cache{},
-		repoCachePrefix: "__test__gh_repo",
-		repoCacheTTL:    1000,
+	c := &Client{
+		apiURL:     &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		token:      token,
+		httpClient: cli,
+		RateLimit:  &ratelimit.Monitor{},
 	}
+	c.repoCache = NewRepoCache(c.apiURL, token, "__test__gh_repo", 1000)
+	return c
 }
 
 // TestClient_GetRepository tests the behavior of GetRepository.
@@ -255,7 +260,7 @@ func TestClient_GetRepositoriesByNodeFromAPI(t *testing.T) {
 			responseBody: test.responseBody,
 		}
 		c := newTestClient(t, &mock)
-		gotRepos, err := c.GetRepositoriesByNodeIDFromAPI(context.Background(), "", test.nodeIDs)
+		gotRepos, err := c.GetRepositoriesByNodeIDFromAPI(context.Background(), test.nodeIDs)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,7 +316,7 @@ func TestClient_GetRepositoryByNodeID(t *testing.T) {
 		IsFork:        true,
 	}
 
-	repo, err := c.GetRepositoryByNodeID(context.Background(), "", "i")
+	repo, err := c.GetRepositoryByNodeID(context.Background(), "i")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +331,7 @@ func TestClient_GetRepositoryByNodeID(t *testing.T) {
 	}
 
 	// Test that repo is cached (and therefore NOT fetched) from client on second request.
-	repo, err = c.GetRepositoryByNodeID(context.Background(), "", "i")
+	repo, err = c.GetRepositoryByNodeID(context.Background(), "i")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +360,7 @@ func TestClient_GetRepositoryByNodeID_nonexistent(t *testing.T) {
 	}
 	c := newTestClient(t, &mock)
 
-	repo, err := c.GetRepositoryByNodeID(context.Background(), "", "i")
+	repo, err := c.GetRepositoryByNodeID(context.Background(), "i")
 	if !IsNotFound(err) {
 		t.Errorf("got err == %v, want IsNotFound(err) == true", err)
 	}
@@ -526,61 +531,77 @@ func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {
 
 // 🚨 SECURITY: test that cache entries are keyed by auth token
 func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
-	c := newTestClient(t, newMockHTTPResponseBody(`{ "data": { "node": { "id": "i0" } } }`, http.StatusOK))
+	c0 := newTestClient(t, nil)
+	c1 := newTestClientWithToken(t, "tok1", nil)
+	c2 := newTestClientWithToken(t, "tok2", nil)
 
-	got, err := c.GetRepositoryByNodeID(context.Background(), "tok0", "id0")
+	// Get "id0" and cache the result for c1
+	c1.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id0-tok1" } } }`, http.StatusOK)
+	got, err := c1.GetRepositoryByNodeID(context.Background(), "id0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := (&Repository{ID: "i0"}); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	expRepo := &Repository{ID: "id0-tok1"}
+	if diff := cmp.Diff(expRepo, got); diff != "" {
+		t.Fatal(diff)
 	}
 
-	c.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "SHOULD NOT BE SEEN" } } }`, http.StatusOK)
-	got, err = c.GetRepositoryByNodeID(context.Background(), "tok0", "id0")
+	// Verify c1 gets the "id0" from cache in subsequent calls
+	c1.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "SHOULD NOT BE SEEN" } } }`, http.StatusOK)
+	got, err = c1.GetRepositoryByNodeID(context.Background(), "id0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := (&Repository{ID: "i0"}); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	expRepo = &Repository{ID: "id0-tok1"}
+	if diff := cmp.Diff(expRepo, got); diff != "" {
+		t.Fatal(diff)
 	}
 
-	c.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "i0-tok1" } } }`, http.StatusOK)
-	got, err = c.GetRepositoryByNodeID(context.Background(), "tok1", "id0")
+	// c2 should not get "id0" from cache
+	c2.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id0-tok2" } } }`, http.StatusOK)
+	got, err = c2.GetRepositoryByNodeID(context.Background(), "id0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := (&Repository{ID: "i0-tok1"}); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	expRepo = &Repository{ID: "id0-tok2"}
+	if diff := cmp.Diff(expRepo, got); diff != "" {
+		t.Fatal(diff)
 	}
 
-	c.httpClient = newMockHTTPResponseBody(`{}`, http.StatusNotFound)
-	_, err = c.GetRepositoryByNodeID(context.Background(), "tok0", "id1")
+	// Let c1 cache "id1" as not found
+	c1.httpClient = newMockHTTPResponseBody(`{}`, http.StatusNotFound)
+	_, err = c1.GetRepositoryByNodeID(context.Background(), "id1")
 	if err != ErrNotFound {
-		t.Errorf("expected err %v, but got %v", ErrNotFound, err)
+		t.Fatalf("want err %v, but got %v", ErrNotFound, err)
 	}
 
-	// "not found" should be cached
-	c.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1" } } }`, http.StatusOK)
-	_, err = c.GetRepositoryByNodeID(context.Background(), "tok0", "id1")
+	// Verify c1 sees "id1" as "not found" from cache in subsequent calls
+	c1.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1-tok1" } } }`, http.StatusOK)
+	_, err = c1.GetRepositoryByNodeID(context.Background(), "id1")
 	if err != ErrNotFound {
-		t.Errorf("expected err %v, but got %v", ErrNotFound, err)
+		t.Fatalf("want err %v, but got %v", ErrNotFound, err)
 	}
-	// "not found" not cached with different auth token
-	got, err = c.GetRepositoryByNodeID(context.Background(), "tok1", "id1")
+
+	// c2 should get "id1" as usual
+	c2.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1-tok2" } } }`, http.StatusOK)
+	got, err = c2.GetRepositoryByNodeID(context.Background(), "id1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := (&Repository{ID: "id1"}); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	expRepo = &Repository{ID: "id1-tok2"}
+	if diff := cmp.Diff(expRepo, got); diff != "" {
+		t.Fatal(diff)
 	}
-	// "not found" not cached with no auth token
-	got, err = c.GetRepositoryByNodeID(context.Background(), "", "id1")
+
+	// For sanity, c0 (unauthenticated) should get "id1" as usual
+	c0.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1" } } }`, http.StatusOK)
+	got, err = c0.GetRepositoryByNodeID(context.Background(), "id1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := (&Repository{ID: "id1"}); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	expRepo = &Repository{ID: "id1"}
+	if diff := cmp.Diff(expRepo, got); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -52,7 +52,7 @@ func (c *Client) GetAuthenticatedUserEmails(ctx context.Context) ([]*UserEmail, 
 	}
 
 	var emails []*UserEmail
-	err := c.requestGet(ctx, "", "/user/emails?per_page=100", &emails)
+	err := c.requestGet(ctx, "/user/emails?per_page=100", &emails)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (c *Client) GetAuthenticatedUserOrgs(ctx context.Context) ([]*Org, error) {
 	}
 
 	var orgs []*Org
-	err := c.requestGet(ctx, "", "/user/orgs?per_page=100", &orgs)
+	err := c.requestGet(ctx, "/user/orgs?per_page=100", &orgs)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ type Collaborator struct {
 // be for page 1).
 func (c *Client) ListRepositoryCollaborators(ctx context.Context, owner, repo string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
 	path := fmt.Sprintf("/repos/%s/%s/collaborators?&page=%d&per_page=100", owner, repo, page)
-	err := c.requestGet(ctx, "", path, &users)
+	err := c.requestGet(ctx, path, &users)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
This is pure refactoring and should not change any functionality, it simplifies the design of the GitHub client to only associate with exactly one token.

## Why?

1. With the introduction of `WithToken` method, it is not necessary to pass around the `token` argument anymore.
2. Simplifies the management of repository cache, instead of holding a map of caches for different tokens, just one cache object that is associated with the token. Much easier to reason.

---

~~**NOTE**: I'll fix failing tests that require a bit more effort once get approval for the core change.~~