### PR TITLE
search: hoist parameters in simple and-expressions

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -776,7 +776,7 @@ func tryFallbackParser(in string) ([]Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	if hoistedNodes, err := HoistOr(nodes); err == nil {
+	if hoistedNodes, err := Hoist(nodes); err == nil {
 		return newOperator(hoistedNodes, And), nil
 	}
 	return newOperator(nodes, And), nil
@@ -807,7 +807,7 @@ func ParseAndOr(in string) ([]Node, error) {
 	}
 	if !parser.unambiguated {
 		// Hoist or expressions if this query is potential ambiguous.
-		if hoistedNodes, err := HoistOr(nodes); err == nil {
+		if hoistedNodes, err := Hoist(nodes); err == nil {
 			nodes = hoistedNodes
 		}
 	}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -333,6 +333,11 @@ func Test_Parse(t *testing.T) {
 			WantHeuristic: Diff(`(and "repo:foo" (concat "(a)" "(b)"))`),
 		},
 		{
+			Input:         "repo:foo main { and bar {",
+			WantGrammar:   Spec(`(and (and "repo:foo" (concat "main" "{")) (concat "bar" "{"))`),
+			WantHeuristic: Diff(`(and "repo:foo" (concat "main" "{") (concat "bar" "{"))`),
+		},
+		{
 			Input:         "a b (repo:foo c d)",
 			WantGrammar:   `(concat "a" "b" (and "repo:foo" (concat "c" "d")))`,
 			WantHeuristic: Same,

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -25,7 +25,7 @@ func Test_LowercaseFieldNames(t *testing.T) {
 	}
 }
 
-func Test_HoistOr(t *testing.T) {
+func Test_Hoist(t *testing.T) {
 	cases := []struct {
 		input      string
 		want       string
@@ -42,6 +42,14 @@ func Test_HoistOr(t *testing.T) {
 		{
 			input: `repo:foo a or b or c file:bar`,
 			want:  `"repo:foo" "file:bar" (or "a" "b" "c")`,
+		},
+		{
+			input: "repo:foo bar { and baz {",
+			want:  `"repo:foo" (and (concat "bar" "{") (concat "baz" "{"))`,
+		},
+		{
+			input: "repo:foo bar { and baz { and qux {",
+			want:  `"repo:foo" (and (concat "bar" "{") (concat "baz" "{") (concat "qux" "{"))`,
 		},
 		{
 			input: `repo:foo a and b or c and d or e file:bar`,
@@ -73,7 +81,7 @@ func Test_HoistOr(t *testing.T) {
 		},
 		{
 			input:      "a b",
-			wantErrMsg: "heuristic requires top-level or-expression",
+			wantErrMsg: "heuristic requires top-level and- or or-expression",
 		},
 		{
 			input:      "repo:foo a or repo:foobar b or c file:bar",
@@ -81,8 +89,8 @@ func Test_HoistOr(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		t.Run("hoist or", func(t *testing.T) {
-			// To test HoistOr, Use a simplified parse function that
+		t.Run("hoist", func(t *testing.T) {
+			// To test Hoist, Use a simplified parse function that
 			// does not perform the heuristic.
 			parse := func(in string) []Node {
 				parser := &parser{
@@ -93,7 +101,7 @@ func Test_HoistOr(t *testing.T) {
 				return newOperator(nodes, And)
 			}
 			query := parse(c.input)
-			hoistedQuery, err := HoistOr(query)
+			hoistedQuery, err := Hoist(query)
 			if err != nil {
 				if diff := cmp.Diff(c.wantErrMsg, err.Error()); diff != "" {
 					t.Error(diff)


### PR DESCRIPTION
In #9760 I thought it was sufficient to hoist parameters in `or` expressions and not `and`-expressions because simple `and`-expressions are already reduced due to their tighter grouping to filters. This is true for very simple `and` expressions that don't concatenate any patterns. But an `and` expression that concatenates patterns, like:

`repo:foo main bar and baz`, we interpret as `(repo:foo (concat (main bar))) and baz`

whereas it would be better to run the heuristic on this form as well, to get 

`(repo:foo (concat (main bar)) and  baz)`