### PR TITLE
search: friendlier alert for missing operands

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -76,7 +76,7 @@ func alertForQuery(queryString string, err error) *searchAlert {
 				proposedQueries: proposedQuotedQueries(queryString),
 			}
 		}
-	case *query.UnsupportedError:
+	case *query.UnsupportedError, *query.ExpectedOperand:
 		return &searchAlert{
 			prometheusType: "unsupported_and_or_query",
 			title:          "Unable To Process Query",

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -12,6 +12,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
+type ExpectedOperand struct {
+	Msg string
+}
+
+func (e *ExpectedOperand) Error() string {
+	return e.Msg
+}
+
 /*
 Parser implements a parser for the following grammar:
 
@@ -735,7 +743,7 @@ func (p *parser) parseAnd() ([]Node, error) {
 		return nil, err
 	}
 	if left == nil {
-		return nil, fmt.Errorf("expected operand at %d", p.pos)
+		return nil, &UnsupportedError{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
 	if !p.expect(AND) {
 		return left, nil
@@ -755,7 +763,7 @@ func (p *parser) parseOr() ([]Node, error) {
 		return nil, err
 	}
 	if left == nil {
-		return nil, fmt.Errorf("expected operand at %d", p.pos)
+		return nil, &UnsupportedError{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
 	if !p.expect(OR) {
 		return left, nil

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -412,6 +412,11 @@ func Test_Parse(t *testing.T) {
 			WantGrammar:   `(and "a" "OR")`,
 			WantHeuristic: Same,
 		},
+		{
+			Input:         "repo:foo or or or",
+			WantGrammar:   "expected operand at 12",
+			WantHeuristic: Same,
+		},
 		// Reduction.
 		{
 			Name:          "paren reduction with ands",

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -10,11 +10,11 @@ import (
 )
 
 type UnsupportedError struct {
-	UnsupportedMsg string
+	Msg string
 }
 
 func (e *UnsupportedError) Error() string {
-	return e.UnsupportedMsg
+	return e.Msg
 }
 
 // isPatternExpression returns true if every leaf node in a tree root at node is
@@ -51,7 +51,7 @@ func processTopLevel(nodes []Node) ([]Node, error) {
 		} else if term.Kind == Concat {
 			return nodes, nil
 		} else {
-			return nil, &UnsupportedError{UnsupportedMsg: "cannot evaluate: unable to partition pure search pattern"}
+			return nil, &UnsupportedError{Msg: "cannot evaluate: unable to partition pure search pattern"}
 		}
 	}
 	return nodes, nil
@@ -77,7 +77,7 @@ func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err 
 		} else if term, ok := node.(Parameter); ok {
 			parameters = append(parameters, term)
 		} else {
-			return nil, nil, &UnsupportedError{UnsupportedMsg: "cannot evaluate: unable to partition pure search pattern"}
+			return nil, nil, &UnsupportedError{Msg: "cannot evaluate: unable to partition pure search pattern"}
 		}
 	}
 	if len(patterns) > 1 {


### PR DESCRIPTION
Stacked on #9881.

A query like `repo:foo or or or` is ambiguous and no heuristics apply, so an error "Expected operand at <pos>" is shown. This PR replaces the debug message with the friendlier alert.

Side note: `repo:foo (or or or)`, implied by the alert suggestion, is fine. In future we could consider just running this query and showing the alert with it parenthesized, or add a heuristic that suggests this. See #9745 
