### PR TITLE
doc: Add disclaimer about k8s namespaces

### DIFF
--- a/doc/admin/faq.md
+++ b/doc/admin/faq.md
@@ -42,6 +42,8 @@ NAME                     READY     STATUS    RESTARTS   AGE
 pgsql-76a4bfcd64-rt4cn   2/2       Running   0          19m
 ```
 
+Make sure you are operating under the correct namespace (i.e. add `-n prod` if your pod is under the `prod` namespace).
+
 Open a PostgreSQL interactive terminal:
 
 ```bash


### PR DESCRIPTION
This adds a line to make sure users select the right namespace when trying accessing the psql pod.

As I am a beginner in Kubernetes I'm not sure this is absolutely necessary to add this line though, perhaps it is obvious to any k8s user, please let me know if it's not.
