### PR TITLE
Implement UI component for next sync property

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -243,7 +243,7 @@ type ExternalChangesetResolver interface {
 	ExternalID() string
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
-	NextSync() DateTime
+	NextSync() *DateTime
 	Title() (string, error)
 	Body() (string, error)
 	State() campaigns.ChangesetState

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -748,8 +748,8 @@ type ExternalChangeset implements Node {
     # The date and time when the changeset was updated.
     updatedAt: DateTime!
 
-    # The date and time when the next changeset sync is scheduled
-    nextSync: DateTime!
+    # The date and time when the next changeset sync is scheduled. Can be null if not scheduled.
+    nextSync: DateTime
 
     # The title of the changeset
     title: String!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -755,8 +755,8 @@ type ExternalChangeset implements Node {
     # The date and time when the changeset was updated.
     updatedAt: DateTime!
 
-    # The date and time when the next changeset sync is scheduled
-    nextSync: DateTime!
+    # The date and time when the next changeset sync is scheduled. Can be null if not scheduled.
+    nextSync: DateTime
 
     # The title of the changeset
     title: String!

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -219,8 +219,11 @@ func (r *changesetResolver) UpdatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: r.Changeset.UpdatedAt}
 }
 
-func (r *changesetResolver) NextSync() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.nextSync}
+func (r *changesetResolver) NextSync() *graphqlbackend.DateTime {
+	if r.nextSync.IsZero() {
+		return nil
+	}
+	return &graphqlbackend.DateTime{Time: r.nextSync}
 }
 
 func (r *changesetResolver) Title() (string, error) {

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -296,6 +296,7 @@ export const queryChangesets = (
                                 externalID
                                 createdAt
                                 updatedAt
+                                nextSync
                                 diff {
                                     fileDiffs {
                                         diffStat {

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.test.tsx
@@ -4,11 +4,25 @@ import { ChangesetLastSynced } from './ChangesetLastSynced'
 import { subMinutes } from 'date-fns'
 
 describe('ChangesetLastSynced', () => {
-    test('renders', () => {
+    test('renders not scheduled', () => {
         const result = renderer.create(
             <ChangesetLastSynced
                 changeset={{
                     id: '123',
+                    nextSync: null,
+                    updatedAt: subMinutes(new Date('2020-03-01'), 10).toISOString(),
+                }}
+                _now={new Date('2020-03-01')}
+            />
+        )
+        expect(result.toJSON()).toMatchSnapshot()
+    })
+    test('renders scheduled', () => {
+        const result = renderer.create(
+            <ChangesetLastSynced
+                changeset={{
+                    id: '123',
+                    nextSync: new Date('2020-03-02').toISOString(),
                     updatedAt: subMinutes(new Date('2020-03-01'), 10).toISOString(),
                 }}
                 _now={new Date('2020-03-01')}

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
@@ -10,7 +10,7 @@ import ErrorIcon from 'mdi-react/ErrorIcon'
 import { isErrorLike } from '../../../../../../shared/src/util/errors'
 
 interface Props {
-    changeset: Pick<IExternalChangeset, 'id' | 'updatedAt'>
+    changeset: Pick<IExternalChangeset, 'id' | 'nextSync' | 'updatedAt'>
     campaignUpdates?: Pick<Observer<void>, 'next'>
 
     /** For testing purposes only */
@@ -43,6 +43,25 @@ export const ChangesetLastSynced: React.FunctionComponent<Props> = ({ changeset,
         }
     }
 
+    let tooltipText = ''
+    if (changeset.updatedAt === lastUpdatedAt) {
+        tooltipText = 'Currently refreshing'
+    } else {
+        // false positive
+        // eslint-disable-next-line no-sync
+        if (!changeset.nextSync) {
+            tooltipText = 'Not scheduled for syncing.'
+        } else {
+            tooltipText = `Next refresh in ${formatDistance(
+                // false positive
+                // eslint-disable-next-line no-sync
+                parseISO(changeset.nextSync),
+                _now ?? new Date()
+            )}.`
+        }
+        tooltipText += ' Click to prioritize refresh'
+    }
+
     const UpdateLoaderIcon =
         typeof lastUpdatedAt === 'string' && changeset.updatedAt === lastUpdatedAt ? LoadingSpinner : SyncIcon
 
@@ -52,11 +71,7 @@ export const ChangesetLastSynced: React.FunctionComponent<Props> = ({ changeset,
             {isErrorLike(lastUpdatedAt) && (
                 <ErrorIcon data-tooltip={lastUpdatedAt.message} className="ml-2 icon-inline small" />
             )}
-            <span
-                data-tooltip={
-                    changeset.updatedAt === lastUpdatedAt ? 'Currently refreshing' : 'Click to prioritize refresh'
-                }
-            >
+            <span data-tooltip={tooltipText}>
                 <UpdateLoaderIcon
                     className={classNames('icon-inline', typeof lastUpdatedAt !== 'string' && 'cursor-pointer')}
                     onClick={enqueueChangeset}

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetLastSynced.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetLastSynced.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChangesetLastSynced renders 1`] = `
+exports[`ChangesetLastSynced renders not scheduled 1`] = `
 <small
   className="text-muted ml-2"
 >
@@ -9,7 +9,34 @@ exports[`ChangesetLastSynced renders 1`] = `
    ago.
    
   <span
-    data-tooltip="Click to prioritize refresh"
+    data-tooltip="Not scheduled for syncing. Click to prioritize refresh"
+  >
+    <svg
+      className="mdi-icon icon-inline cursor-pointer"
+      fill="currentColor"
+      height={24}
+      onClick={[Function]}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M12,18A6,6 0 0,1 6,12C6,11 6.25,10.03 6.7,9.2L5.24,7.74C4.46,8.97 4,10.43 4,12A8,8 0 0,0 12,20V23L16,19L12,15M12,4V1L8,5L12,9V6A6,6 0 0,1 18,12C18,13 17.75,13.97 17.3,14.8L18.76,16.26C19.54,15.03 20,13.57 20,12A8,8 0 0,0 12,4Z"
+      />
+    </svg>
+  </span>
+</small>
+`;
+
+exports[`ChangesetLastSynced renders scheduled 1`] = `
+<small
+  className="text-muted ml-2"
+>
+  Last synced 
+  10 minutes
+   ago.
+   
+  <span
+    data-tooltip="Next refresh in 1 day. Click to prioritize refresh"
   >
     <svg
       className="mdi-icon icon-inline cursor-pointer"


### PR DESCRIPTION
Closed campaign: 
![image](https://user-images.githubusercontent.com/19534377/79358937-33b09100-7f42-11ea-9176-89f8ff02ceb5.png)

Open campaign:
![image](https://user-images.githubusercontent.com/19534377/79358992-4a56e800-7f42-11ea-8402-643ba00a92bf.png)

I also changed the resolver to return null on zero time, so the checking in the frontend is easier.