### PR TITLE
monitoring: distinguish between browser and API requests

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -473,7 +473,7 @@ var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "graphql",
 	Name:      "search_response",
 	Help:      "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
-}, []string{"status", "alert_type"})
+}, []string{"status", "alert_type", "source"})
 
 // logSearchLatency records search durations in the event database. This
 // function may only be called after a search result is performed, because it
@@ -607,7 +607,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 	default:
 		status = "unknown"
 	}
-	searchResponseCounter.WithLabelValues(status, alertType).Inc()
+	searchResponseCounter.WithLabelValues(status, alertType, string(trace.RequestSource(ctx))).Inc()
 
 	return rr, err
 }

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -33,6 +33,7 @@ const (
 	requestErrorCauseKey
 	graphQLRequestNameKey
 	originKey
+	sourceKey
 )
 
 // trackOrigin specifies a URL value. When an incoming request has the request header "Origin" set
@@ -121,6 +122,31 @@ func RequestOrigin(ctx context.Context) string {
 // WithRequestOrigin sets the request origin in the context.
 func WithRequestOrigin(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, originKey, name)
+}
+
+// SourceType indicates the type of source that likely created the request.
+type SourceType string
+
+const (
+	// SourceBrowser indicates the request likely came from a web browser.
+	SourceBrowser SourceType = "browser"
+
+	// SourceOther indicates the request likely came from a non-browser HTTP client.
+	SourceOther SourceType = ""
+)
+
+// WithRequestSource sets the request source type in the context.
+func WithRequestSource(ctx context.Context, source SourceType) context.Context {
+	return context.WithValue(ctx, sourceKey, source)
+}
+
+// RequestSource returns the request source constant for a request context.
+func RequestSource(ctx context.Context) SourceType {
+	v := ctx.Value(sourceKey)
+	if v == nil {
+		return SourceOther
+	}
+	return v.(SourceType)
 }
 
 // Middleware captures and exports metrics to Prometheus, etc.

--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -13,7 +13,7 @@ func Frontend() *Container {
 						{
 							Name:            "99th_percentile_search_request_duration",
 							Description:     "99th percentile successful search request duration over 5m",
-							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 3},
@@ -22,7 +22,7 @@ func Frontend() *Container {
 						{
 							Name:            "90th_percentile_search_request_duration",
 							Description:     "90th percentile successful search request duration over 5m",
-							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false"}[5m])))`,
+							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 3},
@@ -33,7 +33,7 @@ func Frontend() *Container {
 						{
 							Name:            "hard_timeout_search_responses",
 							Description:     "hard timeout search responses every 5m",
-							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out"}[5m])))`,
+							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="browser"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser"}[5m])))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							Critical:        Alert{GreaterOrEqual: 20},
@@ -42,7 +42,7 @@ func Frontend() *Container {
 						{
 							Name:            "hard_error_search_responses",
 							Description:     "hard error search responses every 5m",
-							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error"}[5m]))`,
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							Critical:        Alert{GreaterOrEqual: 20},
@@ -51,7 +51,7 @@ func Frontend() *Container {
 						{
 							Name:            "partial_timeout_search_responses",
 							Description:     "partial timeout search responses every 5m",
-							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout"}[5m]))`,
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("partial timeout"),
@@ -59,7 +59,69 @@ func Frontend() *Container {
 						{
 							Name:            "search_alert_user_suggestions",
 							Description:     "search alert user suggestions shown every 5m",
-							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out"}[5m]))`,
+							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 50},
+							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}"),
+						},
+					},
+				},
+			},
+			{
+				Title: "Search API at a glance",
+				Hidden: true,
+				Rows: []Row{
+					{
+						{
+							Name:            "99th_percentile_search_api_request_duration",
+							Description:     "99th percentile successful search API request duration over 5m",
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
+							DataMayNotExist: true,
+							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
+							Warning:         Alert{GreaterOrEqual: 3},
+							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
+						},
+						{
+							Name:            "90th_percentile_search_api_request_duration",
+							Description:     "90th percentile successful search API request duration over 5m",
+							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
+							DataMayNotExist: true,
+							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
+							Warning:         Alert{GreaterOrEqual: 3},
+							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
+						},
+					},
+					{
+						{
+							Name:            "hard_timeout_search_api_responses",
+							Description:     "hard timeout search API responses every 5m",
+							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="other"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="other"}[5m])))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							Critical:        Alert{GreaterOrEqual: 20},
+							PanelOptions:    PanelOptions().LegendFormat("hard timeout"),
+						},
+						{
+							Name:            "hard_error_search_api_responses",
+							Description:     "hard error search API responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							Critical:        Alert{GreaterOrEqual: 20},
+							PanelOptions:    PanelOptions().LegendFormat("hard error"),
+						},
+						{
+							Name:            "partial_timeout_search_api_responses",
+							Description:     "partial timeout search API responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							PanelOptions:    PanelOptions().LegendFormat("partial timeout"),
+						},
+						{
+							Name:            "search_api_alert_user_suggestions",
+							Description:     "search API alert user suggestions shown every 5m",
+							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="other"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 50},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}"),

--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -68,7 +68,7 @@ func Frontend() *Container {
 				},
 			},
 			{
-				Title: "Search API at a glance",
+				Title:  "Search API at a glance",
 				Hidden: true,
 				Rows: []Row{
 					{


### PR DESCRIPTION
Browser requests are most often real users, while non-browser user agants are most often API consumers which have different requirements (slower response times are acceptable, they are often querying the entire `count:999999` result set, etc.)

This change distinguishes between the two in GraphQL Promethees metrics by adding a `source="browser"` and `source="other"` field that is based on user agent sniffing.

In the frontend dashboard, the `Search at a glance` section now only shows user requests and there is an additional expandable `Search API at a glance` section.

Fixes #9358