### PR TITLE
dev start script: redirect verbose jaeger logs into separate file

### DIFF
--- a/dev/jaeger.sh
+++ b/dev/jaeger.sh
@@ -4,6 +4,9 @@ set -euf -o pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
 
+JAEGER_DISK="${HOME}/.sourcegraph-dev/data/jaeger"
+
+mkdir -p ${JAEGER_DISK}/logs
 mkdir -p .bin
 
 version=1.17.1
@@ -21,4 +24,4 @@ chmod +x "${target}"
 
 popd > /dev/null
 
-exec "${target}" --log-level "${JAEGER_LOG_LEVEL:-info}" "$@"
+exec "${target}" --log-level "${JAEGER_LOG_LEVEL:-info}" "$@" >> ${JAEGER_DISK}/logs/jaeger.log 2>&1


### PR DESCRIPTION
makes procfile output more readable