### PR TITLE
docker images: include jaeger in versioning

### DIFF
--- a/docker-images/jaeger-agent/build.sh
+++ b/docker-images/jaeger-agent/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+# This merely re-tags the image to match our official versioning scheme. The
+# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+#
+# TODO: Move the image to this directory so it is open-source and built in CI automatically.
+docker pull index.docker.io/sourcegraph/jaeger-agent:1.17.1@sha256:03ddce35d7bdbacdedc90369df84395e9aecfa51571ef661e5128ac1e95b8d5c
+docker tag index.docker.io/sourcegraph/jaeger-agent:1.17.1@sha256:03ddce35d7bdbacdedc90369df84395e9aecfa51571ef661e5128ac1e95b8d5c $IMAGE

--- a/docker-images/jaeger-all-in-one/build.sh
+++ b/docker-images/jaeger-all-in-one/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+# This merely re-tags the image to match our official versioning scheme. The
+# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+#
+# TODO: Move the image to this directory so it is open-source and built in CI automatically.
+docker pull index.docker.io/sourcegraph/jaeger-all-in-one:1.17.1@sha256:46bfa2ac08dd08181ab443ef966d664048a6c6ac725054bcc1fbfda5bd4040a3
+docker tag index.docker.io/sourcegraph/jaeger-all-in-one:1.17.1@sha256:46bfa2ac08dd08181ab443ef966d664048a6c6ac725054bcc1fbfda5bd4040a3 $IMAGE

--- a/docker-images/jaeger-collector/build.sh
+++ b/docker-images/jaeger-collector/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+# This merely re-tags the image to match our official versioning scheme. The
+# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+#
+# TODO: Move the image to this directory so it is open-source and built in CI automatically.
+docker pull index.docker.io/sourcegraph/jaeger-collector:latest@sha256:81dc49f8d8abcf0dd116e096027a19b54d3c0d441164a71b44585ee0ee1095dc
+docker tag index.docker.io/sourcegraph/jaeger-collector:latest@sha256:81dc49f8d8abcf0dd116e096027a19b54d3c0d441164a71b44585ee0ee1095dc $IMAGE

--- a/docker-images/jaeger-query/build.sh
+++ b/docker-images/jaeger-query/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+set -ex
+
+# This merely re-tags the image to match our official versioning scheme. The
+# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+#
+# TODO: Move the image to this directory so it is open-source and built in CI automatically.
+docker pull index.docker.io/sourcegraph/jaeger-query:latest@sha256:21a30fbaeed1290bd1fe9c93f67bd6c1d47b8d854ebc64808a6611a501991a58
+docker tag index.docker.io/sourcegraph/jaeger-query:latest@sha256:21a30fbaeed1290bd1fe9c93f67bd6c1d47b8d854ebc64808a6611a501991a58 $IMAGE


### PR DESCRIPTION
in same tact as rest of sourcegraph