### PR TITLE
observability: relax search latency alerts to match real world

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -132,7 +132,7 @@ const (
 	SourceBrowser SourceType = "browser"
 
 	// SourceOther indicates the request likely came from a non-browser HTTP client.
-	SourceOther SourceType = ""
+	SourceOther SourceType = "other"
 )
 
 // WithRequestSource sets the request source type in the context.

--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -16,7 +16,7 @@ func Frontend() *Container {
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 3},
+							Warning:         Alert{GreaterOrEqual: 20},
 							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
 						},
 						{
@@ -25,7 +25,7 @@ func Frontend() *Container {
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 3},
+							Warning:         Alert{GreaterOrEqual: 15},
 							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
 						},
 					},
@@ -78,7 +78,7 @@ func Frontend() *Container {
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 3},
+							Warning:         Alert{GreaterOrEqual: 50},
 							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
 						},
 						{
@@ -87,7 +87,7 @@ func Frontend() *Container {
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 3},
+							Warning:         Alert{GreaterOrEqual: 40},
 							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
 						},
 					},


### PR DESCRIPTION
This PR relaxes the search P99/P90 latency alerts to more accurately
reflect well-behaving instances of Sourcegraph.

Based on 30d average and max value on three real instances:

sourcegraph.com: avg(P99=30s P90=4s) max(P99=30s P90=5s)
k8s.sgdev.org: avg(P99=11s P90=7s) max(P99=35s P90=30s)
customer: avg(P99=15s P90=10s) max(P99=35s P90=35s)

Max values are assumed to mostly be attributable to heavy API requests, avg appears to be more generally correct browser user experience. sourcegraph.com also assumed to be an outlier, so not used.

Thus, the alerts we configure here are relaxed to:

- Browser: P99>20s P90>15s
- API: P99>50s P90>40s

Fixes #9894