### PR TITLE
Jaeger in single Docker container

### DIFF
--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -4,6 +4,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -eux
 
+# Fail early if env vars are not set
+[ ! -z "$VERSION" ]
+[ ! -z "$IMAGE" ]
+
 export OUTPUT=$(mktemp -d -t sgserver_XXXXXXX)
 cleanup() {
     rm -rf "$OUTPUT"
@@ -83,6 +87,9 @@ cp dev/prometheus/linux/prometheus_targets.yml "$OUTPUT/sg_prometheus_add_ons"
 echo "--- grafana config"
 cp -r docker-images/grafana/config "$OUTPUT/sg_config_grafana"
 cp -r dev/grafana/linux "$OUTPUT/sg_config_grafana/provisioning/datasources"
+
+echo "--- jaeger-all-in-one binary"
+cmd/server/jaeger.sh
 
 echo "--- docker build"
 docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/cmd/server/jaeger.sh
+++ b/cmd/server/jaeger.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+[ ! -z "$OUTPUT" ]
+
+version=1.17.1
+suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
+target="${OUTPUT}/usr/local/bin/jaeger"
+url="https://github.com/jaegertracing/jaeger/releases/download/v${version}/jaeger-${suffix}.tar.gz"
+
+mkdir -p $(dirname $target)
+curl -sS -L -f "${url}" | tar -xz --to-stdout "jaeger-${suffix}/jaeger-all-in-one" > "${target}.tmp"
+mv "${target}.tmp" "${target}"
+
+chmod +x "${target}"

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -146,7 +146,7 @@ func Main() {
 		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
 		`prometheus: prometheus --config.file=/sg_config_prometheus/prometheus.yml --web.enable-admin-api --storage.tsdb.path=/var/opt/sourcegraph/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`,
 		`grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`,
-		`jaeger: jaeger`,
+		`jaeger: jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph/jaeger.log 2>&1`,
 		postgresExporterLine,
 	}
 	procfile = append(procfile, ProcfileAdditions...)

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -146,6 +146,7 @@ func Main() {
 		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
 		`prometheus: prometheus --config.file=/sg_config_prometheus/prometheus.yml --web.enable-admin-api --storage.tsdb.path=/var/opt/sourcegraph/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`,
 		`grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`,
+		`jaeger: jaeger`,
 		postgresExporterLine,
 	}
 	procfile = append(procfile, ProcfileAdditions...)


### PR DESCRIPTION
<!--
Pre-PR TODO
- [x] Mute Jaeger logging unless environment variable set (look at what's done for Prometheus and Grafana)
-->

Add Jaeger to the single Docker image.

#### Post-merge TODO
- [ ] Update docs.sourcegraph.com to document Jaeger use, including exposing port 16686