### PR TITLE
File tree improvements

### DIFF
--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -124,7 +124,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                         className="file-match-children__item-code-wrapper e2e-file-match-children-item-wrapper"
                     >
                         <Link
-                            to={`${props.result.file.url}?action${toPositionOrRangeHash({ position })}`}
+                            to={`${props.result.file.url}?subtree${toPositionOrRangeHash({ position })}`}
                             className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
                             onClick={props.onSelect}
                         >

--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -124,7 +124,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                         className="file-match-children__item-code-wrapper e2e-file-match-children-item-wrapper"
                     >
                         <Link
-                            to={`${props.result.file.url}?subtree${toPositionOrRangeHash({ position })}`}
+                            to={`${props.result.file.url}?subtree=true${toPositionOrRangeHash({ position })}`}
                             className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
                             onClick={props.onSelect}
                         >

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -43,7 +43,7 @@ export const RepoFileLink: React.FunctionComponent<Props> = ({
     return (
         <>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-            <Link to={`${fileURL}?action`}>
+            <Link to={`${fileURL}?subtree`}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>
             </Link>

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -43,7 +43,7 @@ export const RepoFileLink: React.FunctionComponent<Props> = ({
     return (
         <>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-            <Link to={`${fileURL}?subtree`}>
+            <Link to={`${fileURL}?subtree=true`}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>
             </Link>

--- a/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -10,7 +10,7 @@ Array [
   " ›",
   " ",
   <a
-    href="https://example.com/file?action"
+    href="https://example.com/file?subtree"
   >
     my/
     <strong>

--- a/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -10,7 +10,7 @@ Array [
   " ›",
   " ",
   <a
-    href="https://example.com/file?subtree"
+    href="https://example.com/file?subtree=true"
   >
     my/
     <strong>

--- a/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined?subtree"
+                  href="/github.com/foo/bar/-/blob/undefined?subtree=true"
                 >
                   <strong>
                     
@@ -70,7 +70,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined?subtree#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?subtree=true#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -234,7 +234,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/file1.txt?subtree"
+                  href="/github.com/foo/bar/-/blob/file1.txt?subtree=true"
                 >
                   <strong>
                     file1.txt
@@ -266,7 +266,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/file1.txt?subtree#L2:1"
+                href="/github.com/foo/bar/-/blob/file1.txt?subtree=true#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -386,7 +386,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined?subtree"
+                  href="/github.com/foo/bar/-/blob/undefined?subtree=true"
                 >
                   <strong>
                     
@@ -418,7 +418,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined?subtree#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?subtree=true#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor

--- a/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined?action"
+                  href="/github.com/foo/bar/-/blob/undefined?subtree"
                 >
                   <strong>
                     
@@ -70,7 +70,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined?action#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?subtree#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -234,7 +234,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/file1.txt?action"
+                  href="/github.com/foo/bar/-/blob/file1.txt?subtree"
                 >
                   <strong>
                     file1.txt
@@ -266,7 +266,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/file1.txt?action#L2:1"
+                href="/github.com/foo/bar/-/blob/file1.txt?subtree#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor
@@ -386,7 +386,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                  ›
                  
                 <a
-                  href="/github.com/foo/bar/-/blob/undefined?action"
+                  href="/github.com/foo/bar/-/blob/undefined?subtree"
                 >
                   <strong>
                     
@@ -418,7 +418,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
             >
               <a
                 className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
-                href="/github.com/foo/bar/-/blob/undefined?action#L2:1"
+                href="/github.com/foo/bar/-/blob/undefined?subtree#L2:1"
                 onClick={[Function]}
               >
                 <VisibilitySensor

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -6,7 +6,6 @@ import { isEmpty } from 'lodash'
 import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
 import { replaceRange } from './strings'
 import { discreteValueAliases } from '../search/parser/filters'
-import { URLToFileContext } from '../platform/context'
 
 export interface RepoSpec {
     /**
@@ -420,11 +419,11 @@ function parseLineOrPositionOrRange(lineChar: string): LineOrPositionOrRange {
     return lpr
 }
 
-function toRenderModeAndActionQuery(ctx: Partial<RenderModeSpec>, isWebUrl?: boolean): string {
+function toRenderModeQuery(ctx: Partial<RenderModeSpec>): string {
     if (ctx.renderMode === 'code') {
-        return isWebUrl ? '?action&view=code' : '?view=code'
+        return '?view=code'
     }
-    return isWebUrl ? '?action' : ''
+    return ''
 }
 
 /**
@@ -472,16 +471,10 @@ export function encodeRepoRev(repo: string, rev?: string): string {
 }
 
 export function toPrettyBlobURL(
-    target: RepoFile &
-        Partial<UIPositionSpec> &
-        Partial<ViewStateSpec> &
-        Partial<UIRangeSpec> &
-        Partial<RenderModeSpec>,
-    context?: Partial<URLToFileContext>
+    target: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
 ): string {
-    return `/${encodeRepoRev(target.repoName, target.rev)}/-/blob/${target.filePath}${toRenderModeAndActionQuery(
-        target,
-        context?.isWebURL
+    return `/${encodeRepoRev(target.repoName, target.rev)}/-/blob/${target.filePath}${toRenderModeQuery(
+        target
     )}${toPositionOrRangeHash(target)}${toViewStateHashComponent(target.viewState)}`
 }
 

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -80,7 +80,9 @@ export function createPlatformContext(): PlatformContext {
 function toPrettyWebBlobURL(
     ctx: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
 ): string {
-    return toPrettyBlobURL(ctx, { isWebURL: true })
+    const urlSearchParams = new URLSearchParams(toPrettyBlobURL(ctx))
+    urlSearchParams.set('subtree', 'true')
+    return `${decodeURIComponent(urlSearchParams.toString())}`
 }
 
 const settingsCascadeFragment = gql`

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -80,9 +80,9 @@ export function createPlatformContext(): PlatformContext {
 function toPrettyWebBlobURL(
     ctx: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
 ): string {
-    const urlSearchParams = new URLSearchParams(toPrettyBlobURL(ctx))
-    urlSearchParams.set('subtree', 'true')
-    return `${decodeURIComponent(urlSearchParams.toString())}`
+    const url = new URL(toPrettyBlobURL(ctx), location.href)
+    url.searchParams.set('subtree', 'true')
+    return url.pathname + url.search + url.hash
 }
 
 const settingsCascadeFragment = gql`

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -96,7 +96,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                     type: NonFilterSuggestionType.dir,
                     value: '^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
-                    url: `${item.url}?suggestion`,
+                    url: `${item.url}?subtree`,
                     label: 'go to dir',
                 }
             }
@@ -105,7 +105,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                 value: formatRegExp(item.path),
                 displayValue: item.name,
                 description: descriptionParts.join(' — '),
-                url: `${item.url}?suggestion`,
+                url: `${item.url}?subtree`,
                 label: 'go to file',
             }
         }

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -105,7 +105,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                 value: formatRegExp(item.path),
                 displayValue: item.name,
                 description: descriptionParts.join(' — '),
-                url: `${item.url}?subtree`,
+                url: `${item.url}?subtree=true`,
                 label: 'go to file',
             }
         }

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -96,7 +96,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                     type: NonFilterSuggestionType.dir,
                     value: '^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
-                    url: `${item.url}?subtree`,
+                    url: `${item.url}?subtree=true`,
                     label: 'go to dir',
                 }
             }

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -267,7 +267,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     }
 
                     // Strip the ?subtree query param. Handle both when going from ancestor -> child and child -> ancestor.
-                    if (queryParams.has('subtree')) {
+                    if (queryParams.get('subtree') === 'true') {
                         queryParams.delete('subtree')
                         this.props.history.replace({
                             search: queryParams.toString(),

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -246,7 +246,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     // If we're updating due to a file/directory suggestion or code intel action,
                     // load the relevant partial tree and jump to the file.
                     // This case is only used when going from an ancestor to a child file/directory, or equal.
-                    if (queryParams.has('subtree') && dotPathAsUndefined(newParentPath)) {
+                    if (queryParams.get('subtree') === 'true' && dotPathAsUndefined(newParentPath)) {
                         this.setState({
                             parentPath: dotPathAsUndefined(newParentPath),
                             resolveTo: [newParentPath],

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -246,7 +246,11 @@ export class Tree extends React.PureComponent<Props, State> {
                     // If we're updating due to a file/directory suggestion or code intel action,
                     // load the relevant partial tree and jump to the file.
                     // This case is only used when going from an ancestor to a child file/directory, or equal.
-                    if (queryParams.get('subtree') === 'true' && dotPathAsUndefined(newParentPath)) {
+                    if (
+                        queryParams.get('subtree') === 'true' &&
+                        !queryParams.has('tab') &&
+                        dotPathAsUndefined(newParentPath)
+                    ) {
                         this.setState({
                             parentPath: dotPathAsUndefined(newParentPath),
                             resolveTo: [newParentPath],
@@ -267,7 +271,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     }
 
                     // Strip the ?subtree query param. Handle both when going from ancestor -> child and child -> ancestor.
-                    if (queryParams.get('subtree') === 'true') {
+                    if (queryParams.get('subtree') === 'true' && !queryParams.has('tab')) {
                         queryParams.delete('subtree')
                         this.props.history.replace({
                             search: queryParams.toString(),

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -243,14 +243,12 @@ export class Tree extends React.PureComponent<Props, State> {
                 .subscribe((props: Props) => {
                     const newParentPath = props.activePathIsDir ? props.activePath : dirname(props.activePath)
                     const queryParams = new URLSearchParams(this.props.history.location.search)
+                    const queryParamsHasSubtree = queryParams.get('subtree') === 'true'
+
                     // If we're updating due to a file/directory suggestion or code intel action,
                     // load the relevant partial tree and jump to the file.
                     // This case is only used when going from an ancestor to a child file/directory, or equal.
-                    if (
-                        queryParams.get('subtree') === 'true' &&
-                        !queryParams.has('tab') &&
-                        dotPathAsUndefined(newParentPath)
-                    ) {
+                    if (queryParamsHasSubtree && !queryParams.has('tab') && dotPathAsUndefined(newParentPath)) {
                         this.setState({
                             parentPath: dotPathAsUndefined(newParentPath),
                             resolveTo: [newParentPath],
@@ -271,8 +269,8 @@ export class Tree extends React.PureComponent<Props, State> {
                     }
 
                     // Strip the ?subtree query param. Handle both when going from ancestor -> child and child -> ancestor.
-                    if (queryParams.get('subtree') === 'true' && !queryParams.has('tab')) {
-                        queryParams.delete('subtree')
+                    queryParams.delete('subtree')
+                    if (queryParamsHasSubtree && !queryParams.has('tab')) {
                         this.props.history.replace({
                             search: queryParams.toString(),
                             hash: this.props.history.location.hash,

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -243,12 +243,10 @@ export class Tree extends React.PureComponent<Props, State> {
                 .subscribe((props: Props) => {
                     const newParentPath = props.activePathIsDir ? props.activePath : dirname(props.activePath)
                     const queryParams = new URLSearchParams(this.props.history.location.search)
-                    // If we're updating due to a file or directory suggestion, load the relevant partial tree and jump to the file.
+                    // If we're updating due to a file/directory suggestion or code intel action,
+                    // load the relevant partial tree and jump to the file.
                     // This case is only used when going from an ancestor to a child file/directory, or equal.
-                    if (
-                        (queryParams.has('suggestion') || queryParams.has('action')) &&
-                        dotPathAsUndefined(newParentPath)
-                    ) {
+                    if (queryParams.has('subtree') && dotPathAsUndefined(newParentPath)) {
                         this.setState({
                             parentPath: dotPathAsUndefined(newParentPath),
                             resolveTo: [newParentPath],
@@ -268,15 +266,9 @@ export class Tree extends React.PureComponent<Props, State> {
                         })
                     }
 
-                    // Strip the ?suggestion query param. Handle both when going from ancestor -> child and child -> ancestor.
-                    if (queryParams.has('suggestion')) {
-                        queryParams.delete('suggestion')
-                        this.props.history.replace({
-                            search: queryParams.toString(),
-                            hash: this.props.history.location.hash,
-                        })
-                    } else if (queryParams.has('action')) {
-                        queryParams.delete('action')
+                    // Strip the ?subtree query param. Handle both when going from ancestor -> child and child -> ancestor.
+                    if (queryParams.has('subtree')) {
+                        queryParams.delete('subtree')
                         this.props.history.replace({
                             search: queryParams.toString(),
                             hash: this.props.history.location.hash,


### PR DESCRIPTION
Addresses outstanding comments in https://github.com/sourcegraph/sourcegraph/pull/9842.

Also fixes a small unintended bug in #9842. When the go-to-def or find refs button is clicked, the `?subtree` param would be included in the URL, so when the references or definition panel appears, the file tree updates to only show the current directory, which is not what we want. So I check to make sure the `tab=` parameter is not present before updating the tree. cc @uwedeportivo I would like to get this cherry-picked into the release. 