### PR TITLE
regression e2e: test fixes 3.15

### DIFF
--- a/web/src/regression/core.test.ts
+++ b/web/src/regression/core.test.ts
@@ -263,7 +263,8 @@ describe('Core functionality regression test suite', () => {
         }
 
         const { subjectID, settingsID, contents: oldContents } = await getGlobalSettings(gqlClient)
-        if (parse(oldContents).quicklinks) {
+        const parsedOldContents = parse(oldContents)
+        if (parsedOldContents && parsedOldContents.quicklinks) {
             throw new Error('Global setting quicklinks already exists, aborting test')
         }
         const newContents = applyEdits(

--- a/web/src/regression/core.test.ts
+++ b/web/src/regression/core.test.ts
@@ -264,7 +264,7 @@ describe('Core functionality regression test suite', () => {
 
         const { subjectID, settingsID, contents: oldContents } = await getGlobalSettings(gqlClient)
         const parsedOldContents = parse(oldContents)
-        if (parsedOldContents && parsedOldContents.quicklinks) {
+        if (parsedOldContents?.quicklinks) {
             throw new Error('Global setting quicklinks already exists, aborting test')
         }
         const newContents = applyEdits(

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -688,7 +688,9 @@ describe('Search regression test suite', () => {
             await driver.page.click('.e2e-query-input')
             await driver.page.keyboard.type('error')
             await driver.page.keyboard.press('Enter')
-            await driver.assertWindowLocation('/search?q=error+repo:%22auth0/go-jwt-middleware%24%22&patternType=literal')
+            await driver.assertWindowLocation(
+                '/search?q=error+repo:%22auth0/go-jwt-middleware%24%22&patternType=literal'
+            )
             await driver.page.waitForSelector('.e2e-search-result')
             await driver.page.waitForFunction(() => {
                 const results = document.querySelectorAll('.e2e-file-match-children-item-wrapper')

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -269,7 +269,7 @@ describe('Search regression test suite', () => {
                 config.sourcegraphBaseUrl +
                     '/search?q=String+repo:%5Egithub.com/adjust/go-wrk%24+&patternType=regexp&case=yes'
             )
-            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length === 2)
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length === 3)
         })
         test('Global text search, fork:only, few results', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=fork:only+router')
@@ -677,7 +677,7 @@ describe('Search regression test suite', () => {
             await driver.page.waitForSelector('.filter-input')
             await driver.page.keyboard.type('auth0/go-jwt-middleware$')
             await driver.page.keyboard.press('Enter')
-            await driver.assertWindowLocation('/search?q=repo:auth0/go-jwt-middleware%24&patternType=literal')
+            await driver.assertWindowLocation('/search?q=repo:%22auth0/go-jwt-middleware%24%22&patternType=literal')
             await driver.page.waitForSelector('.e2e-search-result')
             await driver.page.waitForFunction(() => {
                 const results = document.querySelectorAll('.e2e-search-result')
@@ -688,7 +688,7 @@ describe('Search regression test suite', () => {
             await driver.page.click('.e2e-query-input')
             await driver.page.keyboard.type('error')
             await driver.page.keyboard.press('Enter')
-            await driver.assertWindowLocation('/search?q=error+repo:auth0/go-jwt-middleware%24&patternType=literal')
+            await driver.assertWindowLocation('/search?q=error+repo:%22auth0/go-jwt-middleware%24%22&patternType=literal')
             await driver.page.waitForSelector('.e2e-search-result')
             await driver.page.waitForFunction(() => {
                 const results = document.querySelectorAll('.e2e-file-match-children-item-wrapper')
@@ -702,7 +702,7 @@ describe('Search regression test suite', () => {
             await driver.page.keyboard.type('README')
             await driver.page.keyboard.press('Enter')
             await driver.assertWindowLocation(
-                '/search?q=error+repo:auth0/go-jwt-middleware%24+file:README&patternType=literal'
+                '/search?q=error+repo:%22auth0/go-jwt-middleware%24%22+file:%22README%22&patternType=literal'
             )
             await driver.page.waitForSelector('.e2e-search-result')
             await driver.page.waitForFunction(() => {
@@ -719,7 +719,7 @@ describe('Search regression test suite', () => {
             await driver.page.keyboard.type('markdown')
             await driver.page.keyboard.press('Enter')
             await driver.assertWindowLocation(
-                '/search?q=error+repo:auth0/go-jwt-middleware%24+file:README+lang:markdown&patternType=literal'
+                '/search?q=error+repo:%22auth0/go-jwt-middleware%24%22+file:%22README%22+lang:%22markdown%22&patternType=literal'
             )
             await driver.page.waitForSelector('.e2e-search-result')
             await driver.page.waitForFunction(() => {
@@ -785,10 +785,11 @@ describe('Search regression test suite', () => {
 
         test('Querying from a repository tree page produces correct query and filter values', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/github.com/auth0/go-jwt-middleware')
-            await driver.page.waitForSelector('.tree-page__section-search  .query-input2 .e2e-query-input')
-            await driver.page.click('.tree-page__section-search  .query-input2 .e2e-query-input')
+            await driver.page.waitForSelector('.query-input2 .e2e-query-input')
+            await driver.page.click('.query-input2 .e2e-query-input')
             await driver.page.keyboard.type('test')
             await driver.page.keyboard.press('Enter')
+            // TODO(uwedeportivo): the query string flips between "test" before or after the repo clause
             await driver.assertWindowLocation(
                 '/search?q=repo:%5Egithub%5C.com/auth0/go-jwt-middleware%24+test&patternType=literal'
             )
@@ -877,7 +878,7 @@ describe('Search regression test suite', () => {
             await driver.page.keyboard.press('Enter')
             await driver.page.keyboard.press('Enter')
             await driver.assertWindowLocation(
-                '/search?q=repo:%5Egithub%5C.com/auth0/go-jwt-middleware%24&patternType=literal'
+                '/search?q=repo:%22%5Egithub%5C%5C.com/auth0/go-jwt-middleware%24%22&patternType=literal'
             )
         })
 
@@ -889,7 +890,7 @@ describe('Search regression test suite', () => {
             await driver.page.keyboard.press('Backspace')
             await driver.page.keyboard.press('Enter')
             await driver.assertWindowLocation(
-                '/search?q=repo:%5Egithub%5C.com/auth0/go-jwt-middlewar&patternType=literal'
+                '/search?q=repo:%22%5Egithub%5C%5C.com/auth0/go-jwt-middlewar%22&patternType=literal'
             )
         })
         test('Adding and editing finite filters', async () => {
@@ -901,14 +902,14 @@ describe('Search regression test suite', () => {
             await driver.page.waitForSelector('.e2e-filter-input-radio-button-no')
             await driver.page.click('.e2e-filter-input-radio-button-no')
             await driver.page.click('.e2e-confirm-filter-button')
-            await driver.assertWindowLocation('/search?q=test+fork:no&patternType=literal')
+            await driver.assertWindowLocation('/search?q=test+fork:%22no%22&patternType=literal')
             await driver.page.waitForSelector('.filter-input')
             await driver.page.click('.filter-input')
             await driver.page.waitForSelector('.e2e-filter-input-finite-form')
             await driver.page.waitForSelector('.e2e-filter-input-radio-button-only')
             await driver.page.click('.e2e-filter-input-radio-button-only')
             await driver.page.click('.e2e-confirm-filter-button')
-            await driver.assertWindowLocation('/search?q=test+fork:only&patternType=literal')
+            await driver.assertWindowLocation('/search?q=test+fork:%22only%22&patternType=literal')
         })
     })
 })

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -741,9 +741,9 @@ describe('Search regression test suite', () => {
 
                     return (
                         textContents.length === 3 &&
-                        textContents.includes('repo:auth0/go-jwt-middleware$') &&
-                        textContents.includes('file:README') &&
-                        textContents.includes('lang:markdown')
+                        textContents.includes('repo:"auth0/go-jwt-middleware$"') &&
+                        textContents.includes('file:"README"') &&
+                        textContents.includes('lang:"markdown"')
                     )
                 })
             assert.strictEqual(await hasCorrectFilters(), true)


### PR DESCRIPTION
can you guys go over these test edits and look if they're correct. even with these edits i get 5 failures for

```
SLOWMO=10 KEEP_BROWSER=true yarn run test:regression:search
```

<img width="1015" alt="Screen Shot 2020-04-16 at 6 49 54 PM" src="https://user-images.githubusercontent.com/534011/79523497-2adbc000-8013-11ea-9eae-55c32d587afe.png">

run the instance like so:

```
IMAGE=sourcegraph/server:3.15.0-rc.3 ./dev/run-server-image.sh
```

and make yourself a .envrc before you run the tests as described here:
( you need at least a sourcegraph sudo token, a github token etc, change the sourcegraph base url to your setup)

Follow [README.md](https://github.com/sourcegraph/sourcegraph/blob/master/web/src/regression/README.md) to set up your e2e environment. 
        Run the tests from the `web` directory. A more complete set of env vars can be found in this
        [1password](https://team-sourcegraph.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/gm5dfflq6sfclmotneuayfdj5q) entry.