### PR TITLE
Fix CI failure on master

### DIFF
--- a/docker-images/jaeger-agent/Dockerfile
+++ b/docker-images/jaeger-agent/Dockerfile
@@ -4,6 +4,7 @@ ARG JAEGER_VERSION
 FROM jaegertracing/jaeger-agent:${JAEGER_VERSION} as base
 
 FROM alpine:3.11.5@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221
+# hadolint ignore=DL3018
 RUN apk --no-cache add bash curl
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker-images/jaeger-agent/build.sh
+++ b/docker-images/jaeger-agent/build.sh
@@ -10,8 +10,8 @@ IMAGE=${IMAGE:-sourcegraph/jaeger-agent}
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"
 
 docker build --no-cache -t ${IMAGE} . \
-       --progress=plain \
-       --build-arg JAEGER_VERSION \
-       --build-arg COMMIT_SHA \
-       --build-arg DATE \
-       --build-arg VERSION
+  --progress=plain \
+  --build-arg JAEGER_VERSION \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -7,10 +7,11 @@ FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 
 FROM alpine:3.11.5@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221
 RUN apk update
-RUN apk add bash curl
+# hadolint ignore=DL3018
+RUN apk --no-cache add bash curl
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=base /go/bin/all-in-one-linux  /go/bin/all-in-one-linux
+COPY --from=base /go/bin/all-in-one-linux /go/bin/all-in-one-linux
 COPY --from=base /etc/jaeger/sampling_strategies.json /etc/jaeger/sampling_strategies.json
 
 RUN adduser -S -u 10001 jaeger

--- a/docker-images/jaeger-all-in-one/build.sh
+++ b/docker-images/jaeger-all-in-one/build.sh
@@ -10,8 +10,8 @@ IMAGE=${IMAGE:-sourcegraph/jaeger-all-in-one}
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"
 
 docker build --no-cache -t ${IMAGE} . \
-       --progress=plain \
-       --build-arg JAEGER_VERSION \
-       --build-arg COMMIT_SHA \
-       --build-arg DATE \
-       --build-arg VERSION
+  --progress=plain \
+  --build-arg JAEGER_VERSION \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION


### PR DESCRIPTION
Fixes CI on master.

This was introduced in https://buildkite.com/sourcegraph/sourcegraph/builds/61262 because PRs that only update Dockerfiles and shell scripts apparently don't run all the lint checks, but a minimal pipeline that only runs docsite checks