### PR TITLE
Fix detection of docs-only commits

### DIFF
--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -135,7 +135,7 @@ func isDocsOnly() bool {
 		panic(err)
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if !strings.HasPrefix(line, "doc") && line != "CHANGELOG.md" {
+		if !strings.HasPrefix(line, "doc/") && line != "CHANGELOG.md" {
 			return false
 		}
 	}


### PR DESCRIPTION
Before, this would false-positive on changes to `docker-images/` like #9906