### PR TITLE
Fix wrong instructions in campaigns CLI help

### DIFF
--- a/web/src/enterprise/campaigns/global/create/CampaignCLIHelp.tsx
+++ b/web/src/enterprise/campaigns/global/create/CampaignCLIHelp.tsx
@@ -107,7 +107,7 @@ export const CampaignCLIHelp: React.FunctionComponent<Props> = ({ className }) =
                     <pre className="alert alert-secondary ml-3">
                         <code
                             dangerouslySetInnerHTML={{
-                                __html: highlightCodeSafe('$ src cli exec -f action.json -create-patchset', 'bash'),
+                                __html: highlightCodeSafe('$ src action exec -f action.json -create-patchset', 'bash'),
                             }}
                         />
                     </pre>

--- a/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCLIHelp.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCLIHelp.test.tsx.snap
@@ -166,7 +166,7 @@ $ export SRC_ACCESS_TOKEN=&lt;YOUR TOKEN&gt;
           <code
             dangerouslySetInnerHTML={
               Object {
-                "__html": "$ src cli exec -f action.json -create-patchset",
+                "__html": "$ src action exec -f action.json -create-patchset",
               }
             }
           />


### PR DESCRIPTION
Just noticed this on `master`. Will cherry-pick into 3.15.
