### PR TITLE
debugproxies: Nicer display names for statefulset pods

### DIFF
--- a/cmd/frontend/internal/app/debugproxies/handler.go
+++ b/cmd/frontend/internal/app/debugproxies/handler.go
@@ -114,6 +114,11 @@ func displayNameFromEndpoint(ep Endpoint) string {
 	if colonIdx != -1 {
 		strippedHost = strippedHost[:colonIdx]
 	}
+	// Stateful Services have unique pod names. Lets use them to avoid stutter
+	// in the name (gitserver-gitserver-0 becomes gitserver-0).
+	if strings.HasPrefix(strippedHost, ep.Service) {
+		return strippedHost
+	}
 	return fmt.Sprintf("%s-%s", ep.Service, strippedHost)
 }
 

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
@@ -94,5 +95,34 @@ func TestIndexLinks(t *testing.T) {
 
 	if !strings.Contains(string(body), expectedContent) {
 		t.Errorf("expected %s, got %s", expectedContent, body)
+	}
+}
+
+func TestDisplayNameFromEndpoint(t *testing.T) {
+	cases := []struct {
+		Service, Host string
+		Want          string
+	}{{
+		Service: "gitserver",
+		Host:    "gitserver-0:2323",
+		Want:    "gitserver-0",
+	}, {
+		Service: "searcher",
+		Host:    "192.168.10.3:2323",
+		Want:    "searcher-192.168.10.3",
+	}, {
+		Service: "no-port",
+		Host:    "192.168.10.1",
+		Want:    "no-port-192.168.10.1",
+	}}
+
+	for _, c := range cases {
+		got := displayNameFromEndpoint(Endpoint{
+			Service: c.Service,
+			Host:    c.Host,
+		})
+		if got != c.Want {
+			t.Errorf("displayNameFromEndpoint(%q, %q) mismatch (-want +got):\n%s", c.Service, c.Host, cmp.Diff(c.Want, got))
+		}
 	}
 }

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -188,10 +188,10 @@ func (cs *clusterScanner) scanCluster() {
 
 // addrToHost converts a scanned k8s endpoint address structure into a string that is the host:port part of a URL.
 func addrToHost(addr *corev1.EndpointAddress, port int) string {
-	if addr.Ip != nil {
-		return fmt.Sprintf("%s:%d", *addr.Ip, port)
-	} else if addr.Hostname != nil && *addr.Hostname != "" {
+	if addr.Hostname != nil && *addr.Hostname != "" {
 		return fmt.Sprintf("%s:%d", *addr.Hostname, port)
+	} else if addr.Ip != nil {
+		return fmt.Sprintf("%s:%d", *addr.Ip, port)
 	}
 	return ""
 }

--- a/cmd/frontend/internal/app/debugproxies/scanner_test.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner_test.go
@@ -77,7 +77,15 @@ func TestClusterScan(t *testing.T) {
 	ktc.getResponses["gitserver"] = &corev1.Endpoints{
 		Subsets: []*corev1.EndpointSubset{{
 			Addresses: []*corev1.EndpointAddress{{
-				Ip: stringPtr("192.168.10.0"),
+				Hostname: stringPtr("gitserver-0"),
+				Ip:       stringPtr("192.168.10.0"),
+			}},
+		}},
+	}
+	ktc.getResponses["searcher"] = &corev1.Endpoints{
+		Subsets: []*corev1.EndpointSubset{{
+			Addresses: []*corev1.EndpointAddress{{
+				Ip: stringPtr("192.168.10.3"),
 			}},
 		}},
 	}
@@ -105,6 +113,16 @@ func TestClusterScan(t *testing.T) {
 				Metadata: &metav1.ObjectMeta{
 					Namespace: stringPtr("foospace"),
 					Name:      stringPtr("gitserver"),
+					Annotations: map[string]string{
+						"sourcegraph.prometheus/scrape": "true",
+						"prometheus.io/port":            "2323",
+					},
+				},
+			},
+			{
+				Metadata: &metav1.ObjectMeta{
+					Namespace: stringPtr("foospace"),
+					Name:      stringPtr("searcher"),
 					Annotations: map[string]string{
 						"sourcegraph.prometheus/scrape": "true",
 						"prometheus.io/port":            "2323",
@@ -145,7 +163,10 @@ func TestClusterScan(t *testing.T) {
 
 	want := []Endpoint{{
 		Service: "gitserver",
-		Host:    "192.168.10.0:2323",
+		Host:    "gitserver-0:2323",
+	}, {
+		Service: "searcher",
+		Host:    "192.168.10.3:2323",
 	}, {
 		Service: "no-prom-port",
 		Host:    "192.168.10.2:2324",


### PR DESCRIPTION
StatefulSet pods have unique hostnames, so we don't need to refer to them by the IP. This will give them nice and stable names via our site admin debug proxies page. The nice part of this is we can include sample links to pod `-0` in documentation and they should work for customers.