### PR TITLE
tracking-issue: GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.yml
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.yml
@@ -1,0 +1,35 @@
+---
+name: Tracking issue
+about: An issue to capture planned and on-going work of a team's milestone.
+title: '$TEAM: $MILESTONE Tracking issue'
+labels: 'tracking'
+assignees: ''
+
+---
+
+### Status
+
+This tracking issue is being prepared.
+
+### Availability
+
+Period is from **$START_DATE** to **$END_DATE**. Please write the days you won't be working and the number of working days for the period.
+
+- Teammate A: 15d
+- Teammate B: 12d
+- Teammate ...
+
+### Workload
+
+<!-- BEGIN WORK -->
+<!-- END WORK -->
+
+#### Legend
+
+- 👩 Customer issue
+- 🐛 Bug
+- 🧶 Technical debt
+- 🛠️ [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.5nwl5fv52ess)
+- 🕵️ [Spike](https://en.wikipedia.org/wiki/Spike_(software_development))
+- 🔒 Security issue
+- :shipit: Pull Request

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -102,8 +102,8 @@ func trackingIssue(org, milestone string, issues []*Issue) (*Issue, error) {
 
 func patchIssueBody(issue *Issue, work string) (body string, err error) {
 	const (
-		openingMarker = "<!-- BEGIN PLANNED WORK -->"
-		closingMarker = "<!-- END PLANNED WORK -->"
+		openingMarker = "<!-- BEGIN WORK -->"
+		closingMarker = "<!-- END WORK -->"
 	)
 	return patch(issue.Body, work, openingMarker, closingMarker)
 }


### PR DESCRIPTION
As part of revamping the documentation of Tracking issues, I'm creating this tracking issue template to make it easy to create a new tracking issue on each milestone.