### PR TITLE
Fix search bar too tall in plaintext mode

### DIFF
--- a/web/src/search/input/MonacoQueryInput.scss
+++ b/web/src/search/input/MonacoQueryInput.scss
@@ -43,8 +43,6 @@
     &__toggle-container {
         padding-right: 0.35rem;
         padding-left: 0.35rem;
-        padding-top: 0.375rem;
-        padding-bottom: 0.375rem;
     }
 }
 


### PR DESCRIPTION
Fixes an issue with the smart search field being too tall:  https://sourcegraph.slack.com/archives/CMT39K56Z/p1587132156164100.

Was introduced in https://github.com/sourcegraph/sourcegraph/commit/4f7910861b709a7ee0ab671a1b0511f1a38ceff7. We didn't need the vertical padding to actually fix the issue.

cc @uwedeportivo this needs to be cherry-picked on to 3.15 as it's a regression.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
