### PR TITLE
docs: fix link to GitLab.com

### DIFF
--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -1,6 +1,6 @@
 # GitLab integration with Sourcegraph
 
-You can use Sourcegraph with [GitLab.com](https://github.com) and GitLab CE/EE.
+You can use Sourcegraph with [GitLab.com](https://gitlab.com) and GitLab CE/EE.
 
 Feature | Supported?
 ------- | ----------


### PR DESCRIPTION
Correction of link to GitLab;
Was pointing to GitHub.com > now points to GitLab.com;
The section of relevant html is:
````html
 <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/integration/gitlab.md">Edit this page on GitHub</a>

        </div>
        
        <section class="column large-7 large-push-3 medium-6 medium-push-4 small-12 docs-content-section">
             
            <div class="markdown-body"><h1 id="gitlab-integration-with-sourcegraph"><a name="gitlab-integration-with-sourcegraph" class="anchor" href="#gitlab-integration-with-sourcegraph" rel="nofollow" aria-hidden="true" title="#gitlab-integration-with-sourcegraph"></a>GitLab integration with Sourcegraph</h1>

<p>You can use Sourcegraph with <a href="https://gitlab.com">GitLab.com</a> and GitLab CE/EE.</p>

<table>
<thead>
<tr>
<th>Feature</th>
<th>Supported?</th>
</tr>
</thead>
````
Cheers!