### PR TITLE
observability: separate search-based code intelligence from regular search metrics

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -473,7 +473,7 @@ var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "graphql",
 	Name:      "search_response",
 	Help:      "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
-}, []string{"status", "alert_type", "source"})
+}, []string{"status", "alert_type", "source", "name"})
 
 // logSearchLatency records search durations in the event database. This
 // function may only be called after a search result is performed, because it
@@ -607,7 +607,12 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 	default:
 		status = "unknown"
 	}
-	searchResponseCounter.WithLabelValues(status, alertType, string(trace.RequestSource(ctx))).Inc()
+	searchResponseCounter.WithLabelValues(
+		status,
+		alertType,
+		string(trace.RequestSource(ctx)),
+		trace.GraphQLRequestName(ctx),
+	).Inc()
 
 	return rr, err
 }

--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -73,8 +73,8 @@ func Frontend() *Container {
 				Rows: []Row{
 					{
 						{
-							Name:            "99th_percentile_search_request_duration",
-							Description:     "99th percentile successful search request duration over 5m",
+							Name:            "99th_percentile_search_codeintel_request_duration",
+							Description:     "99th percentile code-intel successful search request duration over 5m",
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
@@ -82,8 +82,8 @@ func Frontend() *Container {
 							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
 						},
 						{
-							Name:            "90th_percentile_search_request_duration",
-							Description:     "90th percentile successful search request duration over 5m",
+							Name:            "90th_percentile_search_codeintel_request_duration",
+							Description:     "90th percentile code-intel successful search request duration over 5m",
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
@@ -93,8 +93,8 @@ func Frontend() *Container {
 					},
 					{
 						{
-							Name:            "hard_timeout_search_responses",
-							Description:     "hard timeout search responses every 5m",
+							Name:            "hard_timeout_search_codeintel_responses",
+							Description:     "hard timeout search code-intel responses every 5m",
 							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="browser",name="CodeIntelSearch"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
@@ -102,8 +102,8 @@ func Frontend() *Container {
 							PanelOptions:    PanelOptions().LegendFormat("hard timeout"),
 						},
 						{
-							Name:            "hard_error_search_responses",
-							Description:     "hard error search responses every 5m",
+							Name:            "hard_error_search_codeintel_responses",
+							Description:     "hard error search code-intel responses every 5m",
 							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
@@ -111,16 +111,16 @@ func Frontend() *Container {
 							PanelOptions:    PanelOptions().LegendFormat("hard error"),
 						},
 						{
-							Name:            "partial_timeout_search_responses",
-							Description:     "partial timeout search responses every 5m",
+							Name:            "partial_timeout_search_codeintel_responses",
+							Description:     "partial timeout search code-intel responses every 5m",
 							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("partial timeout"),
 						},
 						{
-							Name:            "search_alert_user_suggestions",
-							Description:     "search alert user suggestions shown every 5m",
+							Name:            "search_codeintel_alert_user_suggestions",
+							Description:     "search code-intel alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",name="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 50},

--- a/observability/frontend.go
+++ b/observability/frontend.go
@@ -13,7 +13,7 @@ func Frontend() *Container {
 						{
 							Name:            "99th_percentile_search_request_duration",
 							Description:     "99th percentile successful search request duration over 5m",
-							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name!="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 20},
@@ -22,7 +22,7 @@ func Frontend() *Container {
 						{
 							Name:            "90th_percentile_search_request_duration",
 							Description:     "90th percentile successful search request duration over 5m",
-							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser"}[5m])))`,
+							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name!="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
 							Warning:         Alert{GreaterOrEqual: 15},
@@ -33,7 +33,7 @@ func Frontend() *Container {
 						{
 							Name:            "hard_timeout_search_responses",
 							Description:     "hard timeout search responses every 5m",
-							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="browser"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser"}[5m])))`,
+							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="browser",name!="CodeIntelSearch"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name!="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							Critical:        Alert{GreaterOrEqual: 20},
@@ -42,7 +42,7 @@ func Frontend() *Container {
 						{
 							Name:            "hard_error_search_responses",
 							Description:     "hard error search responses every 5m",
-							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser"}[5m]))`,
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name!="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							Critical:        Alert{GreaterOrEqual: 20},
@@ -51,7 +51,7 @@ func Frontend() *Container {
 						{
 							Name:            "partial_timeout_search_responses",
 							Description:     "partial timeout search responses every 5m",
-							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser"}[5m]))`,
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name!="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("partial timeout"),
@@ -59,7 +59,7 @@ func Frontend() *Container {
 						{
 							Name:            "search_alert_user_suggestions",
 							Description:     "search alert user suggestions shown every 5m",
-							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser"}[5m]))`,
+							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",name!="CodeIntelSearch"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 50},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}"),
@@ -68,7 +68,69 @@ func Frontend() *Container {
 				},
 			},
 			{
-				Title:  "Search API at a glance",
+				Title:  "Search-based code intelligence at a glance",
+				Hidden: true,
+				Rows: []Row{
+					{
+						{
+							Name:            "99th_percentile_search_request_duration",
+							Description:     "99th percentile successful search request duration over 5m",
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name="CodeIntelSearch"}[5m])))`,
+							DataMayNotExist: true,
+							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
+							Warning:         Alert{GreaterOrEqual: 20},
+							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
+						},
+						{
+							Name:            "90th_percentile_search_request_duration",
+							Description:     "90th percentile successful search request duration over 5m",
+							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name="CodeIntelSearch"}[5m])))`,
+							DataMayNotExist: true,
+							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
+							Warning:         Alert{GreaterOrEqual: 15},
+							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
+						},
+					},
+					{
+						{
+							Name:            "hard_timeout_search_responses",
+							Description:     "hard timeout search responses every 5m",
+							Query:           `sum(sum by (status)(increase(src_graphql_search_response{status="timeout",source="browser",name="CodeIntelSearch"}[5m]))) + sum(sum by (status, alert_type)(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name="CodeIntelSearch"}[5m])))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							Critical:        Alert{GreaterOrEqual: 20},
+							PanelOptions:    PanelOptions().LegendFormat("hard timeout"),
+						},
+						{
+							Name:            "hard_error_search_responses",
+							Description:     "hard error search responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name="CodeIntelSearch"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							Critical:        Alert{GreaterOrEqual: 20},
+							PanelOptions:    PanelOptions().LegendFormat("hard error"),
+						},
+						{
+							Name:            "partial_timeout_search_responses",
+							Description:     "partial timeout search responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name="CodeIntelSearch"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 5},
+							PanelOptions:    PanelOptions().LegendFormat("partial timeout"),
+						},
+						{
+							Name:            "search_alert_user_suggestions",
+							Description:     "search alert user suggestions shown every 5m",
+							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",name="CodeIntelSearch"}[5m]))`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 50},
+							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}"),
+						},
+					},
+				},
+			},
+			{
+				Title:  "Search API usage at a glance",
 				Hidden: true,
 				Rows: []Row{
 					{


### PR DESCRIPTION
Prior to this commit, "Search" and "Search API" were the only distinction in the frontend monitoring dashboard. However, I learned that search-based code intelligence may be the most massive player on Sourcegraph.com's search usage and currently there is no way to distinguish the two. This makes it so that the two are distinguished and the breakdown is as follows:

- "Search at a glance" (shown by default)
- "Search-based code intelligence" (hidden by default)
- "Search API usage" (hidden by default)

The actual browser extension change so that the request_type is changed from /.api/graphql?Search to /.api/graphql?CodeIntelSearch will be rolled out separately.

For now, the expandable panels are just a copy of the search at a glance panels (but just focused on search code intel requests only), in the future they will likely be tailored more towards search code intel in specific as e.g. a "syntax error" alert there would mean a major error in our code as compared to a regular user's search where it means they messed up.

![image](https://user-images.githubusercontent.com/3173176/79622765-705cc380-80cd-11ea-9dab-d06ee197298b.png)
