### PR TITLE
observability: add site configuration option to log slow GraphQL and search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to Sourcegraph are documented in this file.
   - The site configuration field, `useJaeger`, is deprecated in favor of `observability.tracing`.
   - Support for configuring Lightstep as a distributed tracer is deprecated and will be removed in a subsequent release. Instances that use Lightstep with Sourcegraph are encouraged to migrate to Jaeger (directions for running Jaeger alongside Sourcegraph are included in the installation instructions).
 
+- Added site configuration options `observability.logSlowGraphQLRequests` and `observability.logSlowSearches`, which can be used to identify GraphQL and search queries that take longer than a specified number of milliseconds.
 - [`sourcegraph/git-extras`](https://sourcegraph.com/extensions/sourcegraph/git-extras) is now enabled by default on new instances [#3501](https://github.com/sourcegraph/sourcegraph/issues/3501)
 - The Sourcegraph Docker image will now copy `/etc/sourcegraph/gitconfig` to `$HOME/.gitconfig`. This is a convenience similiar to what we provide for [repositories that need HTTP(S) or SSH authentication](https://docs.sourcegraph.com/admin/repo/auth). [#658](https://github.com/sourcegraph/sourcegraph/issues/658)
 - Permissions background syncing is now supported for GitHub via site configuration `"permissions.backgroundSync": {"enabled": true}`.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1021,6 +1021,10 @@ type SiteConfiguration struct {
 	LsifEnforceAuth bool `json:"lsifEnforceAuth,omitempty"`
 	// MaxReposToSearch description: The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
 	MaxReposToSearch int `json:"maxReposToSearch,omitempty"`
+	// ObservabilityLogSlowGraphQLRequests description: (debug) logs all GraphQL requests slower than the specified number of milliseconds.
+	ObservabilityLogSlowGraphQLRequests int `json:"observability.logSlowGraphQLRequests,omitempty"`
+	// ObservabilityLogSlowSearches description: (debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.
+	ObservabilityLogSlowSearches int `json:"observability.logSlowSearches,omitempty"`
 	// ObservabilityTracing description: Controls the settings for distributed tracing.
 	ObservabilityTracing *ObservabilityTracing `json:"observability.tracing,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -601,6 +601,18 @@
         }
       }
     },
+    "observability.logSlowSearches": {
+      "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
+      "type": "integer",
+      "group": "Debug",
+      "examples": [["10000"]]
+    },
+    "observability.logSlowGraphQLRequests": {
+      "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
+      "type": "integer",
+      "group": "Debug",
+      "examples": [["10000"]]
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -606,6 +606,18 @@ const SiteSchemaJSON = `{
         }
       }
     },
+    "observability.logSlowSearches": {
+      "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
+      "type": "integer",
+      "group": "Debug",
+      "examples": [["10000"]]
+    },
+    "observability.logSlowGraphQLRequests": {
+      "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
+      "type": "integer",
+      "group": "Debug",
+      "examples": [["10000"]]
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the ` + "`" + `<head>` + "`" + ` element on each page, for analytics scripts",
       "type": "string",


### PR DESCRIPTION
This is a very low-risk addition that adds two site configuraiton options to log
slow GraphQL and search queries. It is low-risk because it is only running if the
option is set in the site configuration.

We have seen twice in the past that these options would be very useful in debugging,
and right now one customer is asking how they would debug slow search queries and
this would help them.