### PR TITLE
avoid webpack hot reload problem with reach-ui Popover component

### DIFF
--- a/shared/src/components/activation/ActivationDropdown.scss
+++ b/shared/src/components/activation/ActivationDropdown.scss
@@ -20,10 +20,6 @@
     border: none;
     color: var(--link-color);
 
-    &--hidden {
-        display: none;
-    }
-
     &__progress-bar-container {
         display: inline-block;
         width: 1rem;

--- a/shared/src/components/activation/ActivationDropdown.tsx
+++ b/shared/src/components/activation/ActivationDropdown.tsx
@@ -65,12 +65,16 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
         this.subscriptions.unsubscribe()
     }
 
-    public render(): JSX.Element {
+    public render(): JSX.Element | null {
         const show =
             this.props.alwaysShow ||
             this.state.displayEvenIfFullyCompleted ||
             this.state.animate ||
             (this.props.activation.completed !== undefined && percentageDone(this.props.activation.completed) < 100)
+        if (!show) {
+            return null
+        }
+
         const confettiConfig = {
             spread: 68,
             startVelocity: 12,
@@ -87,8 +91,7 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
                         <MenuButton
                             className={classNames(
                                 'activation-dropdown-button activation-dropdown-button__animated-button bg-transparent align-items-center e2e-activation-nav-item-toggle',
-                                { animate: this.state.animate },
-                                { 'activation-dropdown-button--hidden': !show }
+                                { animate: this.state.animate }
                             )}
                         >
                             <div className="activation-dropdown-button__confetti">


### PR DESCRIPTION
The reach-ui Popover component uses React portals in a way that breaks Webpack hot reloading. This results in the following error after changing a file (necessitating a browser hard reload, which slows down the dev cycle):

```
(ActivationDropdown, in Portal (created by Popover)) TypeError: Cannot read property 'ownerDocument' of null

Stack trace:
at eval (webpack-internal:///1570:42:43)
in Portal (created by Popover)
in Popover (created by MenuPopover)
in MenuPopover (created by Menu)
in DescendantProvider (created by Menu)
in Menu (created by ActivationDropdown)
in ActivationDropdown (created by NavLinks)
in li (created by NavLinks)
in ul (created by NavLinks)
in NavLinks (created by GlobalNavbar)
in div (created by GlobalNavbar)
in GlobalNavbar (created by Layout)
in div (created by Layout)
in Layout (created by WithActivation)
in WithActivation (created by Context.Consumer)
in Route (created by ColdSourcegraphWebApp)
in Router (created by BrowserRouter)
in BrowserRouter (created by ColdSourcegraphWebApp)
in ShortcutProvider (created by ColdSourcegraphWebApp)
in ErrorBoundary (created by ColdSourcegraphWebApp)
in ColdSourcegraphWebApp (created by HotExportedColdSourcegraphWebApp)
in AppContainer (created by HotExportedColdSourcegraphWebApp)
in HotExportedColdSourcegraphWebApp
```

This commit does not fix it, but it does make it occur much less often: only when the activation menu button is shown.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->