### PR TITLE
refactor: rename internal API `getView(s) -> getPanelView(s)`

### DIFF
--- a/shared/src/api/client/api/views.ts
+++ b/shared/src/api/client/api/views.ts
@@ -6,7 +6,7 @@ import { PanelView } from 'sourcegraph'
 import { ContributableViewContainer } from '../../protocol'
 import { EditorService, getActiveCodeEditorPosition } from '../services/editorService'
 import { TextDocumentLocationProviderIDRegistry } from '../services/location'
-import { PanelViewWithComponent, ViewProviderRegistry } from '../services/view'
+import { PanelViewWithComponent, PanelViewProviderRegistry } from '../services/panelViews'
 import { Location } from '@sourcegraph/extension-api-types'
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 
@@ -27,7 +27,7 @@ export class ClientViews implements ClientViewsAPI {
     public readonly [proxyValueSymbol] = true
 
     constructor(
-        private viewRegistry: ViewProviderRegistry,
+        private panelViewRegistry: PanelViewProviderRegistry,
         private textDocumentLocations: TextDocumentLocationProviderIDRegistry,
         private editorService: EditorService
     ) {}
@@ -36,7 +36,7 @@ export class ClientViews implements ClientViewsAPI {
         // TODO(sqs): This will probably hang forever if an extension neglects to set any of the fields on a
         // PanelView because this subject will never emit.
         const panelView = new ReplaySubject<PanelViewData>(1)
-        const registryUnsubscribable = this.viewRegistry.registerProvider(
+        const registryUnsubscribable = this.panelViewRegistry.registerProvider(
             { ...provider, container: ContributableViewContainer.Panel },
             combineLatest([
                 panelView.pipe(

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -117,7 +117,7 @@ export async function createExtensionHostClientConnection(
         }
     )
 
-    const clientViews = new ClientViews(services.views, services.textDocumentLocations, services.editor)
+    const clientViews = new ClientViews(services.panelViews, services.textDocumentLocations, services.editor)
 
     const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration)
     subscription.add(clientCodeEditor)

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -14,7 +14,7 @@ import { createModelService } from './services/modelService'
 import { NotificationsService } from './services/notifications'
 import { QueryTransformerRegistry } from './services/queryTransformer'
 import { createSettingsService } from './services/settings'
-import { ViewProviderRegistry } from './services/view'
+import { PanelViewProviderRegistry } from './services/panelViews'
 import { createWorkspaceService } from './services/workspaceService'
 
 /**
@@ -49,6 +49,6 @@ export class Services {
     public readonly textDocumentHover = new TextDocumentHoverProviderRegistry()
     public readonly textDocumentDecoration = new TextDocumentDecorationProviderRegistry()
     public readonly queryTransformer = new QueryTransformerRegistry()
-    public readonly views = new ViewProviderRegistry()
+    public readonly panelViews = new PanelViewProviderRegistry()
     public readonly completionItems = new CompletionItemProviderRegistry()
 }

--- a/shared/src/api/client/services/panelViews.test.ts
+++ b/shared/src/api/client/services/panelViews.test.ts
@@ -2,17 +2,17 @@ import { Observable, of, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ContributableViewContainer } from '../../protocol'
 import { Entry } from './registry'
-import { getView, getViews, PanelViewWithComponent, ViewProviderRegistrationOptions } from './view'
+import { getPanelView, getPanelViews, PanelViewWithComponent, PanelViewProviderRegistrationOptions } from './panelViews'
 
 const FIXTURE_CONTAINER = ContributableViewContainer.Panel
 
-const FIXTURE_ENTRY_1: Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>> = {
+const FIXTURE_ENTRY_1: Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>> = {
     registrationOptions: { container: FIXTURE_CONTAINER, id: '1' },
     provider: of<PanelViewWithComponent>({ title: 't1', content: 'c1', priority: 0 }),
 }
 const FIXTURE_RESULT_1 = { container: FIXTURE_CONTAINER, id: '1', title: 't1', content: 'c1', priority: 0 }
 
-const FIXTURE_ENTRY_2: Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>> = {
+const FIXTURE_ENTRY_2: Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>> = {
     registrationOptions: { container: FIXTURE_CONTAINER, id: '2' },
     provider: of<PanelViewWithComponent>({ title: 't2', content: 'c2', priority: 0 }),
 }
@@ -20,15 +20,18 @@ const FIXTURE_RESULT_2 = { container: FIXTURE_CONTAINER, id: '2', title: 't2', c
 
 const scheduler = (): TestScheduler => new TestScheduler((a, b) => expect(a).toEqual(b))
 
-describe('getView', () => {
+describe('getPanelView', () => {
     describe('0 providers', () => {
         test('returns null', () =>
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
-                    getView(
-                        cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
-                            a: [],
-                        }),
+                    getPanelView(
+                        cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>(
+                            '-a-|',
+                            {
+                                a: [],
+                            }
+                        ),
                         '1'
                     )
                 ).toBe('-a-|', {
@@ -40,8 +43,8 @@ describe('getView', () => {
     test('returns result from provider', () =>
         scheduler().run(({ cold, expectObservable }) =>
             expectObservable(
-                getView(
-                    cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
+                getPanelView(
+                    cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
                         a: [FIXTURE_ENTRY_1],
                     }),
                     '1'
@@ -55,11 +58,14 @@ describe('getView', () => {
         test('returns stream of results', () =>
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
-                    getView(
-                        cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-b-|', {
-                            a: [FIXTURE_ENTRY_1],
-                            b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
-                        }),
+                    getPanelView(
+                        cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>(
+                            '-a-b-|',
+                            {
+                                a: [FIXTURE_ENTRY_1],
+                                b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
+                            }
+                        ),
                         '2'
                     )
                 ).toBe('-a-b-|', {
@@ -70,15 +76,18 @@ describe('getView', () => {
     })
 })
 
-describe('getViews', () => {
+describe('getPanelViews', () => {
     describe('0 providers', () => {
         test('returns null', () =>
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
-                    getViews(
-                        cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
-                            a: [],
-                        }),
+                    getPanelViews(
+                        cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>(
+                            '-a-|',
+                            {
+                                a: [],
+                            }
+                        ),
                         FIXTURE_CONTAINER
                     )
                 ).toBe('-a-|', {
@@ -90,8 +99,8 @@ describe('getViews', () => {
     test('returns result from provider', () =>
         scheduler().run(({ cold, expectObservable }) =>
             expectObservable(
-                getViews(
-                    cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
+                getPanelViews(
+                    cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
                         a: [FIXTURE_ENTRY_1],
                     }),
                     FIXTURE_CONTAINER
@@ -104,8 +113,8 @@ describe('getViews', () => {
     test('continues if provider has error', () =>
         scheduler().run(({ cold, expectObservable }) =>
             expectObservable(
-                getViews(
-                    cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
+                getPanelViews(
+                    cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-|', {
                         a: [
                             {
                                 registrationOptions: { container: FIXTURE_CONTAINER, id: 'err' },
@@ -126,11 +135,14 @@ describe('getViews', () => {
         test('returns stream of results', () =>
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
-                    getViews(
-                        cold<Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>('-a-b-|', {
-                            a: [FIXTURE_ENTRY_1],
-                            b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
-                        }),
+                    getPanelViews(
+                        cold<Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent>>[]>(
+                            '-a-b-|',
+                            {
+                                a: [FIXTURE_ENTRY_1],
+                                b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
+                            }
+                        ),
                         FIXTURE_CONTAINER
                     )
                 ).toBe('-a-b-|', {

--- a/shared/src/api/integration-test/views.test.ts
+++ b/shared/src/api/integration-test/views.test.ts
@@ -13,8 +13,8 @@ describe('Views (integration)', () => {
             panelView.priority = 3
             await extensionAPI.internal.sync()
 
-            const values = await services.views
-                .getViews(ContributableViewContainer.Panel)
+            const values = await services.panelViews
+                .getPanelViews(ContributableViewContainer.Panel)
                 .pipe(first(v => v.length > 0))
                 .toPromise()
             assertToJSON(values, [
@@ -42,8 +42,8 @@ describe('Views (integration)', () => {
             panelView.priority = 3
             panelView.component = { locationProvider: LOCATION_PROVIDER_ID }
 
-            const values = await services.views
-                .getViews(ContributableViewContainer.Panel)
+            const values = await services.panelViews
+                .getPanelViews(ContributableViewContainer.Panel)
                 .pipe(first(v => v.length > 0))
                 .toPromise()
             assertToJSON(

--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -3,7 +3,7 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import * as React from 'react'
 import { Observable, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { PanelViewWithComponent, ViewProviderRegistrationOptions } from '../api/client/services/view'
+import { PanelViewWithComponent, PanelViewProviderRegistrationOptions } from '../api/client/services/panelViews'
 import { ContributableMenu, ContributableViewContainer } from '../api/protocol/contribution'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { ActionsNavItems } from '../actions/ActionsNavItems'
@@ -33,7 +33,7 @@ interface Props
 
 interface State {
     /** Panel views contributed by extensions. */
-    panelViews?: (PanelViewWithComponent & Pick<ViewProviderRegistrationOptions, 'id'>)[] | null
+    panelViews?: (PanelViewWithComponent & Pick<PanelViewProviderRegistrationOptions, 'id'>)[] | null
 }
 
 /**
@@ -70,8 +70,8 @@ export class Panel extends React.PureComponent<Props, State> {
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.extensionsController.services.views
-                .getViews(ContributableViewContainer.Panel)
+            this.props.extensionsController.services.panelViews
+                .getPanelViews(ContributableViewContainer.Panel)
                 .pipe(map(panelViews => ({ panelViews })))
                 .subscribe(stateUpdate => this.setState(stateUpdate))
         )

--- a/shared/src/panel/views/PanelView.tsx
+++ b/shared/src/panel/views/PanelView.tsx
@@ -1,7 +1,7 @@
 import H from 'history'
 import React from 'react'
 import { Observable } from 'rxjs'
-import { PanelViewWithComponent, ViewProviderRegistrationOptions } from '../../api/client/services/view'
+import { PanelViewWithComponent, PanelViewProviderRegistrationOptions } from '../../api/client/services/panelViews'
 import { FetchFileCtx } from '../../components/CodeExcerpt'
 import { Markdown } from '../../components/Markdown'
 import { ExtensionsControllerProps } from '../../extensions/controller'
@@ -12,7 +12,7 @@ import { EmptyPanelView } from './EmptyPanelView'
 import { HierarchicalLocationsView } from './HierarchicalLocationsView'
 
 interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
-    panelView: PanelViewWithComponent & Pick<ViewProviderRegistrationOptions, 'id'>
+    panelView: PanelViewWithComponent & Pick<PanelViewProviderRegistrationOptions, 'id'>
     repoName?: string
     history: H.History
     location: H.Location

--- a/web/src/extensions/explore/ExtensionViewsExploreSection.tsx
+++ b/web/src/extensions/explore/ExtensionViewsExploreSection.tsx
@@ -2,7 +2,7 @@ import H from 'history'
 import React from 'react'
 import { Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { PanelViewWithComponent } from '../../../../shared/src/api/client/services/view'
+import { PanelViewWithComponent } from '../../../../shared/src/api/client/services/panelViews'
 import { ContributableViewContainer } from '../../../../shared/src/api/protocol'
 import { Markdown } from '../../../../shared/src/components/Markdown'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
@@ -30,8 +30,8 @@ export class ExtensionViewsExploreSection extends React.PureComponent<Props, Sta
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.extensionsController.services.views
-                .getViews(ContributableViewContainer.Panel)
+            this.props.extensionsController.services.panelViews
+                .getPanelViews(ContributableViewContainer.Panel)
                 .pipe(map(views => ({ views })))
                 .subscribe(stateUpdate => this.setState(stateUpdate))
         )

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -8,9 +8,9 @@ import { TextDocumentLocationProviderRegistry } from '../../../../../shared/src/
 import { Entry } from '../../../../../shared/src/api/client/services/registry'
 import {
     PanelViewWithComponent,
-    ProvideViewSignature,
-    ViewProviderRegistrationOptions,
-} from '../../../../../shared/src/api/client/services/view'
+    ProvidePanelViewSignature,
+    PanelViewProviderRegistrationOptions,
+} from '../../../../../shared/src/api/client/services/panelViews'
 import { ContributableViewContainer, TextDocumentPositionParams } from '../../../../../shared/src/api/protocol'
 import { ActivationProps } from '../../../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
@@ -93,7 +93,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             priority: number,
             registry: TextDocumentLocationProviderRegistry<P>,
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
-        ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
+        ): Entry<PanelViewProviderRegistrationOptions, ProvidePanelViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
             provider: from(this.props.extensionsController.services.editor.activeEditorUpdates).pipe(
                 map(activeEditor =>
@@ -140,7 +140,7 @@ export class BlobPanel extends React.PureComponent<Props> {
         })
 
         this.subscriptions.add(
-            this.props.extensionsController.services.views.registerProviders(
+            this.props.extensionsController.services.panelViews.registerProviders(
                 [
                     entryForViewProviderRegistration(
                         'def',
@@ -211,7 +211,8 @@ export class BlobPanel extends React.PureComponent<Props> {
                         ),
                     },
                 ].filter(
-                    (v): v is Entry<ViewProviderRegistrationOptions, Observable<PanelViewWithComponent | null>> => !!v
+                    (v): v is Entry<PanelViewProviderRegistrationOptions, Observable<PanelViewWithComponent | null>> =>
+                        !!v
                 )
             )
         )

--- a/web/src/snippets/SnippetsPage.tsx
+++ b/web/src/snippets/SnippetsPage.tsx
@@ -4,7 +4,7 @@ import React, { createRef, useEffect, useLayoutEffect, useState } from 'react'
 import { map } from 'rxjs/operators'
 import { EditorId, observeEditorAndModel } from '../../../shared/src/api/client/services/editorService'
 import { TextModel } from '../../../shared/src/api/client/services/modelService'
-import { PanelViewWithComponent } from '../../../shared/src/api/client/services/view'
+import { PanelViewWithComponent } from '../../../shared/src/api/client/services/panelViews'
 import { SNIPPET_URI_SCHEME } from '../../../shared/src/api/client/types/textDocument'
 import { ContributableViewContainer } from '../../../shared/src/api/protocol'
 import { EditorTextField } from '../../../shared/src/components/editorTextField/EditorTextField'
@@ -70,11 +70,11 @@ export const SnippetsPage: React.FunctionComponent<Props> = ({ location, extensi
 
     const [panelViews, setPanelViews] = useState<PanelViewWithComponent[] | null>(null)
     useEffect(() => {
-        const subscription = extensionsController.services.views
-            .getViews(ContributableViewContainer.Panel)
+        const subscription = extensionsController.services.panelViews
+            .getPanelViews(ContributableViewContainer.Panel)
             .subscribe(views => setPanelViews(views))
         return () => subscription.unsubscribe()
-    }, [extensionsController.services.views])
+    }, [extensionsController.services.panelViews])
 
     // Add Markdown panel for Markdown snippets.
     const [modelText, setModelText] = useState<string | null>(null)


### PR DESCRIPTION
These internal APIs are only for panel views (created with `sourcegraph.app.createPanelView` in the extension API). Renaming them from "view" to "panel view" makes it so we can introduce a more general "view" extensibility point in the future.