### PR TITLE
Fix codecov config

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -4,7 +4,7 @@ coverage:
     project: off
     patch:
       default:
-        threshold: 5%
+        target: 5%
 comment:
   require_changes: yes
   layout: 'diff, flags, files'


### PR DESCRIPTION
The intent was to enforce non-zero unit tests for each diff. Target is the right config to use, not threshold.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
