### PR TITLE
graphql: add GitTree.rawZipArchiveURL for getting raw zip URL

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -108,6 +109,13 @@ func (r *GitTreeEntryResolver) IsDirectory() bool { return r.stat.Mode().IsDir()
 
 func (r *GitTreeEntryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
 	return externallink.FileOrDir(ctx, r.commit.repo.repo, r.commit.inputRevOrImmutableRev(), r.Path(), r.stat.Mode().IsDir())
+}
+
+func (r *GitTreeEntryResolver) RawZipArchiveURL() string {
+	return globals.ExternalURL().ResolveReference(&neturl.URL{
+		Path:     path.Join(r.Repository().URL(), "-/raw/", r.Path()),
+		RawQuery: "format=zip",
+	}).String()
 }
 
 func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -1,0 +1,22 @@
+package graphqlbackend
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+)
+
+func TestGitTreeEntry_RawZipArchiveURL(t *testing.T) {
+	got := (&GitTreeEntryResolver{
+		commit: &GitCommitResolver{
+			repo: &RepositoryResolver{
+				repo: &types.Repo{Name: "my/repo"},
+			},
+		},
+		stat: CreateFileInfo("a/b", true),
+	}).RawZipArchiveURL()
+	want := "http://example.com/my/repo/-/raw/a/b?format=zip"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2660,6 +2660,8 @@ type GitTree implements TreeEntry {
     canonicalURL: String!
     # The URLs to this tree on external services.
     externalURLs: [ExternalLink!]!
+    # The URL to this entry's raw contents as a Zip archive.
+    rawZipArchiveURL: String!
     # Submodule metadata if this tree points to a submodule
     submodule: Submodule
     # A list of directories in this tree.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2667,6 +2667,8 @@ type GitTree implements TreeEntry {
     canonicalURL: String!
     # The URLs to this tree on external services.
     externalURLs: [ExternalLink!]!
+    # The URL to this entry's raw contents as a Zip archive.
+    rawZipArchiveURL: String!
     # Submodule metadata if this tree points to a submodule
     submodule: Submodule
     # A list of directories in this tree.


### PR DESCRIPTION
Many of our extensions and API clients currently synthesize this URL manually. Allowing them to obtain the URL from the GraphQL API makes them more robust and makes it easier for other people to build things that benefit from Zip archives.