### PR TITLE
Extract disksizer from cmd/gitserver

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -410,16 +410,16 @@ func Test_howManyBytesToFree(t *testing.T) {
 }
 
 type fakeDiskSizer struct {
-	bytesFree uint64
 	diskSize  uint64
+	bytesFree uint64
 }
 
-func (f *fakeDiskSizer) BytesFreeOnDisk(mountPoint string) (uint64, error) {
-	return f.bytesFree, nil
+func (f *fakeDiskSizer) MountPoint() string {
+	return ""
 }
 
-func (f *fakeDiskSizer) DiskSizeBytes(mountPoint string) (uint64, error) {
-	return f.diskSize, nil
+func (f *fakeDiskSizer) Size() (uint64, uint64, error) {
+	return f.diskSize, f.bytesFree, nil
 }
 
 func tmpDir(t *testing.T) (string, func()) {
@@ -585,38 +585,6 @@ func makeFakeRepo(d string, sizeBytes int) error {
 		return errors.Wrapf(err, "writing to space_eater file")
 	}
 	return nil
-}
-
-func Test_findMountPoint(t *testing.T) {
-	type args struct {
-		d string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "mount point of root is root",
-			args:    args{d: "/"},
-			want:    "/",
-			wantErr: false,
-		},
-		// What else can we portably count on?
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := findMountPoint(tt.args.d)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("findMountPoint() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("findMountPoint() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }
 
 func TestMaybeCorruptStderrRe(t *testing.T) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/diskutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -114,7 +115,7 @@ type Server struct {
 	DesiredPercentFree int
 
 	// DiskSizer tells how much disk is free and how large the disk is.
-	DiskSizer DiskSizer
+	DiskSizer diskutil.DiskSizer
 
 	// skipCloneForTests is set by tests to avoid clones.
 	skipCloneForTests bool

--- a/internal/diskutil/mount.go
+++ b/internal/diskutil/mount.go
@@ -1,0 +1,69 @@
+package diskutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// findMountPoint searches upwards starting from the directory d to find the mount point.
+func findMountPoint(d string) (string, error) {
+	d, err := filepath.Abs(d)
+	if err != nil {
+		return "", errors.Wrapf(err, "getting absolute version of %s", d)
+	}
+
+	for {
+		m, err := isMount(d)
+		if err != nil {
+			return "", errors.Wrapf(err, "finding out if %s is a mount point", d)
+		}
+		if m {
+			return d, nil
+		}
+
+		parent := filepath.Dir(d)
+		if parent == d {
+			return parent, nil
+		}
+		d = parent
+	}
+}
+
+// isMount tells whether the directory d is a mount point.
+func isMount(d string) (bool, error) {
+	ddev, err := device(d)
+	if err != nil {
+		return false, errors.Wrapf(err, "getting device id for %s", d)
+	}
+
+	parent := filepath.Dir(d)
+	if parent == d {
+		// root of filesystem
+		return true, nil
+	}
+
+	pdev, err := device(parent)
+	if err != nil {
+		return false, errors.Wrapf(err, "getting device id for %s", parent)
+	}
+
+	// root of device
+	return pdev != ddev, nil
+}
+
+// device gets the device id of a file f.
+func device(f string) (int64, error) {
+	fi, err := os.Stat(f)
+	if err != nil {
+		return 0, errors.Wrapf(err, "running stat on %s", f)
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("failed to get stat details for %s", f)
+	}
+	return int64(stat.Dev), nil
+}

--- a/internal/diskutil/mount_test.go
+++ b/internal/diskutil/mount_test.go
@@ -1,0 +1,37 @@
+package diskutil
+
+import (
+	"testing"
+)
+
+func Test_findMountPoint(t *testing.T) {
+	type args struct {
+		d string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "mount point of root is root",
+			args:    args{d: "/"},
+			want:    "/",
+			wantErr: false,
+		},
+		// What else can we portably count on?
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findMountPoint(tt.args.d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findMountPoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("findMountPoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/diskutil/sizer.go
+++ b/internal/diskutil/sizer.go
@@ -1,0 +1,46 @@
+package diskutil
+
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// DiskSizer gets information about disk size and free space.
+type DiskSizer interface {
+	// MountPoint returns the root of the device.
+	MountPoint() string
+
+	// Size returns the total and available size of a disk in bytes.
+	Size() (diskSizeBytes uint64, freeBytes uint64, err error)
+}
+
+type statDiskSizer struct {
+	mountPoint string
+}
+
+// NewDiskSizer creates a DiskSizer for the mount point containing
+// directory d.
+func NewDiskSizer(d string) (DiskSizer, error) {
+	mountPoint, err := findMountPoint(d)
+	if err != nil {
+		return nil, err
+	}
+
+	return statDiskSizer{
+		mountPoint: mountPoint,
+	}, nil
+}
+
+func (s statDiskSizer) MountPoint() string {
+	return s.mountPoint
+}
+
+func (s statDiskSizer) Size() (uint64, uint64, error) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(s.mountPoint, &fs); err != nil {
+		return 0, 0, errors.Wrap(err, "statting")
+	}
+
+	return fs.Blocks * uint64(fs.Bsize), fs.Bavail * uint64(fs.Bsize), nil
+}


### PR DESCRIPTION
Move `findMountPoint` and `DiskSizer` from the cmd/gitserver package into an internal package so it can be used by the (upcoming) precise-code-intel-bundle-manager process (which is being rewritten in Go, tracked in https://github.com/sourcegraph/sourcegraph/issues/9964).