### PR TITLE
Extract sqlite setup from cmd/symbols

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /internal/txemail @slimsag
 /internal/src-cli @efritz
 /internal/linkheader @efritz
+/internal/sqliteutil @efritz
 /renovate.json @felixfbecker
 /.stylelintrc.json @felixfbecker
 /.stylelintignore @felixfbecker

--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -2,23 +2,18 @@ package symbols
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"regexp/syntax"
 	"strings"
 	"time"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/inconshreveable/log15"
 	"github.com/jmoiron/sqlx"
 	"github.com/keegancsmith/sqlf"
-	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
@@ -28,18 +23,6 @@ import (
 
 // maxFileSize is the limit on file size in bytes. Only files smaller than this are processed.
 const maxFileSize = 1 << 19 // 512KB
-
-var libSqlite3Pcre = env.Get("LIBSQLITE3_PCRE", "", "path to the libsqlite3-pcre library")
-
-// MustRegisterSqlite3WithPcre registers a sqlite3 driver with PCRE support and
-// panics if it can't.
-func MustRegisterSqlite3WithPcre() {
-	if libSqlite3Pcre == "" {
-		env.PrintHelp()
-		log.Fatal("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set")
-	}
-	sql.Register("sqlite3_with_pcre", &sqlite3.SQLiteDriver{Extensions: []string{libSqlite3Pcre}})
-}
 
 func (s *Service) handleSearch(w http.ResponseWriter, r *http.Request) {
 	var args protocol.SearchArgs

--- a/cmd/symbols/internal/symbols/search_test.go
+++ b/cmd/symbols/internal/symbols/search_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/pkg/ctags"
+	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func BenchmarkSearch(b *testing.B) {
-	MustRegisterSqlite3WithPcre()
+	sqliteutil.MustRegisterSqlite3WithPcre()
 	ctagsCommand := ctags.GetCommand()
 
 	log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))

--- a/cmd/symbols/internal/symbols/service_test.go
+++ b/cmd/symbols/internal/symbols/service_test.go
@@ -4,41 +4,24 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
-	"os/exec"
-	"path"
 	"reflect"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/pkg/ctags"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	symbolsclient "github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
 
 func init() {
-	if libSqlite3Pcre == "" {
-		repositoryRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-		if err != nil {
-			panic("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set and you're not in the git repository, which is where the library is expected to be.")
-		}
-		if runtime.GOOS == "darwin" {
-			libSqlite3Pcre = path.Join(strings.TrimSpace(string(repositoryRoot)), "libsqlite3-pcre.dylib")
-		} else {
-			libSqlite3Pcre = path.Join(strings.TrimSpace(string(repositoryRoot)), "libsqlite3-pcre.so")
-		}
-		if _, err := os.Stat(libSqlite3Pcre); os.IsNotExist(err) {
-			panic(fmt.Errorf("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set and %s doesn't exist at the root of the repository - try building it with `./dev/build-libsqlite3pcre.sh`", libSqlite3Pcre))
-		}
-	}
+	sqliteutil.SetLocalLibpath()
 }
 
 func TestIsLiteralEquality(t *testing.T) {
@@ -74,7 +57,7 @@ func TestIsLiteralEquality(t *testing.T) {
 }
 
 func TestService(t *testing.T) {
-	MustRegisterSqlite3WithPcre()
+	sqliteutil.MustRegisterSqlite3WithPcre()
 
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -42,7 +43,7 @@ func main() {
 	log.SetFlags(0)
 	tracer.Init()
 
-	symbols.MustRegisterSqlite3WithPcre()
+	sqliteutil.MustRegisterSqlite3WithPcre()
 
 	go debugserver.Start()
 

--- a/internal/sqliteutil/register.go
+++ b/internal/sqliteutil/register.go
@@ -1,0 +1,49 @@
+package sqliteutil
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var libSqlite3Pcre = env.Get("LIBSQLITE3_PCRE", "", "path to the libsqlite3-pcre library")
+
+// MustRegisterSqlite3WithPcre registers a sqlite3 driver with PCRE support and
+// panics if it can't.
+func MustRegisterSqlite3WithPcre() {
+	if libSqlite3Pcre == "" {
+		env.PrintHelp()
+		log.Fatal("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set")
+	}
+	sql.Register("sqlite3_with_pcre", &sqlite3.SQLiteDriver{Extensions: []string{libSqlite3Pcre}})
+}
+
+// SetLocalLibpath sets the path to the LIBSQLITE3_PCRE shared library. This should
+// be called only in test environments. Production environments must require that
+// the envvar be set explicitly.
+func SetLocalLibpath() {
+	if libSqlite3Pcre != "" {
+		return
+	}
+
+	repositoryRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		panic("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set and you're not in the git repository, which is where the library is expected to be.")
+	}
+	if runtime.GOOS == "darwin" {
+		libSqlite3Pcre = path.Join(strings.TrimSpace(string(repositoryRoot)), "libsqlite3-pcre.dylib")
+	} else {
+		libSqlite3Pcre = path.Join(strings.TrimSpace(string(repositoryRoot)), "libsqlite3-pcre.so")
+	}
+	if _, err := os.Stat(libSqlite3Pcre); os.IsNotExist(err) {
+		panic(fmt.Errorf("can't find the libsqlite3-pcre library because LIBSQLITE3_PCRE was not set and %s doesn't exist at the root of the repository - try building it with `./dev/build-libsqlite3pcre.sh`", libSqlite3Pcre))
+	}
+}


### PR DESCRIPTION
Move the libsqlite path setup/test code from the cmd/symbols package into an internal package so it can be used by the (upcoming) precise-code-intel-bundle-manager process (which is being rewritten in Go, tracked in https://github.com/sourcegraph/sourcegraph/issues/9964).