### PR TITLE
Add variable-entry-size LRU cache implementation in internal/memcache

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /internal/txemail @slimsag
 /internal/src-cli @efritz
 /internal/linkheader @efritz
+/internal/memcache @efritz
 /renovate.json @felixfbecker
 /.stylelintrc.json @felixfbecker
 /.stylelintignore @felixfbecker

--- a/internal/memcache/cache.go
+++ b/internal/memcache/cache.go
@@ -1,0 +1,146 @@
+package memcache
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Cache is a generic in-memory LRU cache.
+type Cache interface {
+	// Size returns the current sum of all cache entry sizes.
+	Size() int
+
+	// GetOrCreate returns the value cached at the given key or creates a new
+	// value and adds it to the cache.
+	GetOrCreate(key interface{}, factory ValueFactory) (interface{}, error)
+}
+
+// ValueFactory constructs a value and returns its weight within the cache.
+type ValueFactory func() (interface{}, int, error)
+
+// EvictCallback is invoked when an entry is pushed from the cache.
+type EvictCallback func(key interface{}, value interface{})
+
+// cache implements the Cache interface. This implementation is based off of
+// github.com/hashicorp/golang-lru, but allows cache values to report their
+// own size instead of using the length of evictList as the sole heuristic.
+type cache struct {
+	size      int                           // sum of all cache entry sizes
+	maxSize   int                           // upper bound on the sum of all cache entry sizes
+	cacheMu   sync.Mutex                    // protcts evictList and items
+	evictList *list.List                    // list of cacheEntires ordered by recency
+	items     map[interface{}]*list.Element // map from key to the node in the evictList
+	onEvict   EvictCallback
+}
+
+type cacheEntry struct {
+	key   interface{}
+	value interface{}
+	size  int
+}
+
+// New creates a new cache bounded by maxSize.
+func New(maxSize int) (Cache, error) {
+	return NewWithEvict(maxSize, nil)
+}
+
+// NewWithEvict creates a new cache bounded by maxSize with the given eviction callback.
+func NewWithEvict(maxSize int, onEvict EvictCallback) (Cache, error) {
+	if maxSize <= 0 {
+		return nil, errors.New("must provide a positive size")
+	}
+
+	return &cache{
+		maxSize:   maxSize,
+		evictList: list.New(),
+		items:     map[interface{}]*list.Element{},
+		onEvict:   onEvict,
+	}, nil
+}
+
+// Size returns the current sum of all cache entry sizes.
+func (c *cache) Size() int {
+	return c.size
+}
+
+// GetOrCreate returns the value cached at the given key or creates a new value and adds it
+// to the cache. This method is goroutine-safe.
+func (c *cache) GetOrCreate(key interface{}, factory ValueFactory) (interface{}, error) {
+	value, exists := c.get(key)
+	if exists {
+		return value, nil
+	}
+
+	value, size, err := factory()
+	if err != nil {
+		return nil, err
+	}
+
+	if size <= 0 {
+		c.evict(key, value)
+		return nil, fmt.Errorf("must provide a positive cache entry size")
+	}
+
+	c.add(key, value, size)
+	return value, nil
+}
+
+// get returns the value stored at the given key.
+func (c *cache) get(key interface{}) (interface{}, bool) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+
+	entry, exists := c.items[key]
+	if !exists {
+		// cache miss
+		return nil, false
+	}
+
+	// cache hit, update recency data
+	kv := entry.Value.(*cacheEntry)
+	c.evictList.MoveToFront(entry)
+	return kv.value, true
+}
+
+// add inserts a key/value pair into the cache.
+func (c *cache) add(key, value interface{}, size int) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+
+	if entry, exists := c.items[key]; exists {
+		kv := entry.Value.(*cacheEntry)
+		oldValue, oldSize := kv.value, kv.size
+		kv.value, kv.size = value, size
+		c.size += (size - oldSize)
+		c.evictList.MoveToFront(entry)
+		c.evict(key, oldValue)
+		return
+	}
+
+	kv := &cacheEntry{key: key, value: value, size: size}
+	entry := c.evictList.PushFront(kv)
+	c.items[key] = entry
+	c.size += size
+
+	for c.size > c.maxSize {
+		// Get the least recently used cache entry. This value is
+		// guaranteed to exist as we can't empty the evictList without
+		// getting back to a zero size, which is strictly less than
+		// any valid value of the cache max size.
+		entry := c.evictList.Back()
+		kv := entry.Value.(*cacheEntry)
+		c.evictList.Remove(entry)
+		delete(c.items, kv.key)
+		c.size -= kv.size
+		c.evict(kv.key, kv.value)
+	}
+}
+
+// evict invokes the evict callback, if set, on key and value.
+func (c *cache) evict(key, value interface{}) {
+	if c.onEvict != nil {
+		c.onEvict(key, value)
+	}
+}

--- a/internal/memcache/cache_test.go
+++ b/internal/memcache/cache_test.go
@@ -1,0 +1,177 @@
+package memcache
+
+import (
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLRU(t *testing.T) {
+	cache, err := New(64)
+	if err != nil {
+		t.Fatalf("unexpected error from New: %s", err)
+	}
+
+	numCacheMisses := 0
+	assertKeyValue := func(key interface{}) {
+		value, err := cache.GetOrCreate(key, func() (interface{}, int, error) {
+			numCacheMisses++
+			return key, 1, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error from GetOrCreate: %s", err)
+		}
+		if value != key {
+			t.Errorf("unexpected cached value: want=%d have=%d", key, value)
+		}
+	}
+
+	// Fresh values
+	for i := 0; i < 128; i++ {
+		assertKeyValue(i)
+	}
+	if numCacheMisses != 128 {
+		t.Errorf("unexpected number of cache misses: want=%d have=%d", 128, numCacheMisses)
+	}
+
+	// Cached values
+	for i := 64; i < 128; i++ {
+		assertKeyValue(i)
+	}
+	if numCacheMisses != 128 {
+		t.Errorf("unexpected number of cache misses: want=%d have=%d", 128, numCacheMisses)
+	}
+
+	// Evicted values
+	for i := 0; i < 64; i++ {
+		assertKeyValue(i)
+	}
+	if numCacheMisses != 192 {
+		t.Errorf("unexpected number of cache misses: want=%d have=%d", 192, numCacheMisses)
+	}
+}
+
+func TestEntrySize(t *testing.T) {
+	var evicted []interface{}
+	cache, err := NewWithEvict(50, func(key interface{}, value interface{}) {
+		evicted = append(evicted, key)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from New: %s", err)
+	}
+
+	numCacheMisses := 0
+	assertKeyValue := func(key interface{}, size int) {
+		value, err := cache.GetOrCreate(key, func() (interface{}, int, error) {
+			numCacheMisses++
+			return key, size, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error from GetOrCreate: %s", err)
+		}
+		if value != key {
+			t.Errorf("unexpected cached value: want=%d have=%d", key, value)
+		}
+	}
+
+	assertKeyValue("foo", 25)  // size = 25
+	assertKeyValue("bar", 25)  // size = 50
+	assertKeyValue("baz", 27)  // size = 77; evict "foo" and "bar"; size = 27
+	assertKeyValue("foo", 10)  // size = 37
+	assertKeyValue("bar", 10)  // size = 47
+	assertKeyValue("s01", 1)   // size = 48
+	assertKeyValue("s02", 1)   // size = 49
+	assertKeyValue("s03", 1)   // size = 50
+	assertKeyValue("s04", 1)   // size = 51; evict "baz"; size = 24
+	assertKeyValue("bonk", 26) // size = 50
+
+	if numCacheMisses != 10 {
+		t.Errorf("unexpected number of cache misses: want=%d have=%d", 10, numCacheMisses)
+	}
+
+	expected := []interface{}{"foo", "bar", "baz"}
+	if !reflect.DeepEqual(evicted, expected) {
+		t.Errorf("unexpected evictions: want=%s have=%s", expected, evicted)
+	}
+}
+
+func TestGetOrCreateConcurrentFactoryInvocations(t *testing.T) {
+	// This tests a race that can happen between acquiring the locks of
+	// cache.get and cache.add. We do not hold a singel lock as the factory
+	// function may be expensive and the lock would be too coarse, blocking
+	// all cache reads while the factory is in its critical section.
+	//
+	// This test ensures that two concurrent invocations of cache.GetOrCreate
+	// acquire the locks in this order:
+	//
+	//   1. [call A].get
+	//   2. [call B].get
+	//   3. [call A].add
+	//   4. [call B].add // evicts call A's value
+	//   5. [call C].get // gets call B's value
+
+	var evicted []interface{}
+	cache, err := NewWithEvict(50, func(key interface{}, value interface{}) {
+		evicted = append(evicted, value)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from New: %s", err)
+	}
+
+	numCacheMisses := uint64(0)
+	assertKeyValue := func(key, expectedValue interface{}, fu func() interface{}) {
+		value, err := cache.GetOrCreate(key, func() (interface{}, int, error) {
+			atomic.AddUint64(&numCacheMisses, 1)
+			return fu(), 1, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error from GetOrCreate: %s", err)
+		}
+		if value != expectedValue {
+			t.Errorf("unexpected cached value: want=%s have=%s", expectedValue, value)
+		}
+	}
+
+	tick := make(chan struct{})
+	defer close(tick)
+
+	assertKeyValueViaChannel := func(key, expectedValue interface{}, factoryValueCh <-chan interface{}) {
+		assertKeyValue(key, expectedValue, func() interface{} {
+			tick <- struct{}{}      // sync point 1
+			return <-factoryValueCh // blocked by main test
+		})
+
+		tick <- struct{}{} // sync point 2
+	}
+
+	// concurrent call A
+	val1 := make(chan interface{})
+	defer close(val1)
+	go assertKeyValueViaChannel("foo", "bar", val1) // gets own value
+
+	// concurrent call B
+	val2 := make(chan interface{})
+	defer close(val2)
+	go assertKeyValueViaChannel("foo", "baz", val2) // gets own value
+
+	<-tick        // wait for A (sync point 1)
+	<-tick        // wait for B (sync point 1)
+	val1 <- "bar" // release A
+	<-tick        // wait for A (sync point 2)
+	val2 <- "baz" // release B
+	<-tick        // wait for B (sync point 2)
+
+	// call C
+	assertKeyValue("foo", "baz", func() interface{} {
+		return "bonk"
+	})
+
+	if numCacheMisses != 2 {
+		t.Errorf("unexpected number of cache misses: want=%d have=%d", 2, numCacheMisses)
+	}
+
+	expected := []interface{}{"bar"}
+	if !reflect.DeepEqual(evicted, expected) {
+		t.Errorf("unexpected evictions: want=%s have=%s", expected, evicted)
+	}
+}


### PR DESCRIPTION
Add `internal/memcache`, a variation of github.com/hashicorp/golang-lru that allows cache values to report their size. This allows an in-memory cache to be gauged on its memory pressure rather than assuming that all cache values are equally weighted.

This will be necessary to store variable-length documents in the precise-code-intel-bundle-manager, which is being rewritten in Go (effort tracked in https://github.com/sourcegraph/sourcegraph/issues/9964).

This PR is being submitted separately to get more in-depth reviews on the cache implementation (which could be used easily in other parts of the code base) without getting overshadowed by larger changed in the porting effort.