### PR TITLE
Caddy workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,10 @@ comment.txt
 
 .eslintcache
 storybook-static/
+
+# Certificates
+*.pem
+*.crt
+
+# Custom dev-specific nginx config
+/dev/*.nginx.conf

--- a/dev/caddy.sh
+++ b/dev/caddy.sh
@@ -29,9 +29,4 @@ chmod +x "${target}"
 
 popd >/dev/null
 
-if [ "${SOURCEGRAPH_HTTPS_PORT:-"3443"}" -lt 1000 ] && ! [ "$(id -u)" = 0 ] && hash authbind; then
-  # Support using authbind to bind to port 443 as non-root
-  exec authbind "${target}" "$@"
-else
   exec "${target}" "$@"
-fi

--- a/dev/caddy.sh
+++ b/dev/caddy.sh
@@ -4,6 +4,11 @@ set -euf -o pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
+if ! [ -z "${NO_CADDY:-}" ]; then
+  echo Not using Caddy because NO_CADDY is set. SSH support through Caddy will not work.
+  exit 0
+fi
+
 mkdir -p .bin
 
 version="2.0.0-rc.3"
@@ -29,4 +34,4 @@ chmod +x "${target}"
 
 popd >/dev/null
 
-  exec "${target}" "$@"
+exec "${target}" "$@"

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -34,4 +34,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+
+    # Allow dev-specific gitignored custom nginx config (e.g. custom.nginx.conf)
+    include ./*.nginx.conf;
 }

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -131,4 +131,10 @@ build_ts_pid="$!"
 
 printf >&2 "\nStarting all binaries...\n\n"
 export GOREMAN="goreman --set-ports=false --exit-on-error -f dev/Procfile"
-exec $GOREMAN start
+
+if ! [ "$(id -u)" = 0 ] && hash authbind; then
+  # Support using authbind to bind to port 443 as non-root
+  exec authbind --deep $GOREMAN start
+else
+  exec $GOREMAN start
+fi


### PR DESCRIPTION
This is an escape hatch for when Caddy doesn't work. I wasn't able to figure out yet why (more context in [this thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1586860609310400)), but without HTTPS support, my local dev environment is completely broken because sign-in fails in Chrome.

This allows to add custom gitignored nginx config that gets included. For reference, here is the `ssh.nginx.conf` I am using as a workaround:

```nginx
upstream dev {
    server localhost:3080 max_fails=0;
}

server {
    listen 443 ssl;
    server_name sourcegraph.test;

    ssl_certificate ./sourcegraph.test.pem;
    ssl_certificate_key ./sourcegraph.test-key.pem;
	
    # Webpack Dev server HMR
    location /sockjs-node/ {
        proxy_pass http://dev/sockjs-node/;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_read_timeout 60d;
    }

    location / {
        proxy_pass http://dev;
        proxy_set_header Host $http_host;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```

With certificates I created with `mkcert sourcegraph.test` in `dev/`.

The other commits are for allowing to disable Caddy with an env var, and making the authbind support work for all processes (including nginx), not just Caddy.