### PR TITLE
Smart search: match styling in intermediate input

### DIFF
--- a/web/src/global-styles/code.scss
+++ b/web/src/global-styles/code.scss
@@ -1,7 +1,8 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
 $code-font-size: 12px;
 
-code {
+code,
+.code {
     font-family: $code-font-family;
     font-size: 12px;
     line-height: 16px;

--- a/web/src/global-styles/code.scss
+++ b/web/src/global-styles/code.scss
@@ -4,7 +4,7 @@ $code-font-size: 12px;
 code,
 .code {
     font-family: $code-font-family;
-    font-size: 12px;
+    font-size: $code-font-size;
     line-height: 16px;
     white-space: pre;
 }

--- a/web/src/search/input/LazyMonacoQueryInput.scss
+++ b/web/src/search/input/LazyMonacoQueryInput.scss
@@ -2,9 +2,7 @@
 
 // Match Monaco styling for the intermediate input displayed while
 // lazy-loading the MonacoQueryInput, to avoid unstable UI.
-.lazy-query-input--intermediate-input {
+.lazy-monaco-query-input--intermediate-input {
     height: 100%;
-    font-family: Menlo, Monaco, 'Courier New', monospace;
     font-size: 12px;
-    letter-spacing: 0;
 }

--- a/web/src/search/input/LazyMonacoQueryInput.scss
+++ b/web/src/search/input/LazyMonacoQueryInput.scss
@@ -1,0 +1,10 @@
+@import './MonacoQueryInput';
+
+// Match Monaco styling for the intermediate input displayed while
+// lazy-loading the MonacoQueryInput, to avoid unstable UI.
+.lazy-query-input--intermediate-input {
+    height: 100%;
+    font-family: Menlo, Monaco, 'Courier New', monospace;
+    font-size: 12px;
+    letter-spacing: 0;
+}

--- a/web/src/search/input/LazyMonacoQueryInput.scss
+++ b/web/src/search/input/LazyMonacoQueryInput.scss
@@ -4,5 +4,5 @@
 // lazy-loading the MonacoQueryInput, to avoid unstable UI.
 .lazy-monaco-query-input--intermediate-input {
     height: 100%;
-    font-size: 12px;
+    font-size: $code-font-size;
 }

--- a/web/src/search/input/LazyMonacoQueryInput.test.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.test.tsx
@@ -1,0 +1,57 @@
+import renderer from 'react-test-renderer'
+import React from 'react'
+import { noop } from 'lodash'
+import { PlainQueryInput } from './LazyMonacoQueryInput'
+import { createMemoryHistory } from 'history'
+import { SearchPatternType } from '../../../../shared/src/graphql/schema'
+
+describe('PlainQueryInput', () => {
+    const history = createMemoryHistory()
+    test('empty', () =>
+        expect(
+            renderer
+                .create(
+                    <PlainQueryInput
+                        history={history}
+                        location={history.location}
+                        queryState={{
+                            query: '',
+                            cursorPosition: 0,
+                        }}
+                        patternType={SearchPatternType.regexp}
+                        setPatternType={noop}
+                        caseSensitive={true}
+                        setCaseSensitivity={noop}
+                        onChange={noop}
+                        onSubmit={noop}
+                        isLightTheme={false}
+                        settingsCascade={{ subjects: [], final: {} }}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+
+    test('with query', () =>
+        expect(
+            renderer
+                .create(
+                    <PlainQueryInput
+                        history={history}
+                        location={history.location}
+                        queryState={{
+                            query: 'repo:jsonrpc2 file:async.go asyncHandler',
+                            cursorPosition: 0,
+                        }}
+                        patternType={SearchPatternType.regexp}
+                        setPatternType={noop}
+                        caseSensitive={true}
+                        setCaseSensitivity={noop}
+                        onChange={noop}
+                        onSubmit={noop}
+                        isLightTheme={false}
+                        settingsCascade={{ subjects: [], final: {} }}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+})

--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -9,7 +9,7 @@ const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'Mona
  * A plain query input displayed during lazy-loading of the MonacoQueryInput.
  * It has no suggestions, but still allows to type in and submit queries.
  */
-const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
+export const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
     queryState,
     autoFocus,
     onChange,

--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -27,7 +27,7 @@ const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
             <input
                 type="text"
                 autoFocus={autoFocus}
-                className="form-control query-input2__input e2e-query-input"
+                className="form-control lazy-query-input--intermediate-input"
                 value={queryState.query}
                 onChange={onInputChange}
                 spellCheck={false}

--- a/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -27,7 +27,7 @@ const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
             <input
                 type="text"
                 autoFocus={autoFocus}
-                className="form-control lazy-query-input--intermediate-input"
+                className="form-control code lazy-monaco-query-input--intermediate-input"
                 value={queryState.query}
                 onChange={onInputChange}
                 spellCheck={false}

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -2,7 +2,7 @@
 @import '../QuickLinks';
 @import './SearchScopes';
 @import './QueryInput';
-@import './MonacoQueryInput';
+@import './LazyMonacoQueryInput';
 @import './InfoDropdown';
 @import './interactive/InteractiveModeInput';
 

--- a/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
+++ b/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlainQueryInput empty 1`] = `
+<div
+  className="query-input2 d-flex"
+>
+  <input
+    className="form-control code lazy-monaco-query-input--intermediate-input"
+    onChange={[Function]}
+    spellCheck={false}
+    type="text"
+    value=""
+  />
+  <div
+    className="query-input2__toggle-container"
+  >
+    <div
+      className="toggle-container"
+    >
+      <div
+        aria-checked={true}
+        aria-disabled={false}
+        aria-label="Case sensitivity toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-case-sensitivity-toggle toggle-container__toggle--active e2e-case-sensitivity-toggle--active"
+        data-tooltip="Disable case sensitivity"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M20.06,18C20,17.83 19.91,17.54 19.86,17.11C19.19,17.81 18.38,18.16 17.45,18.16C16.62,18.16 15.93,17.92 15.4,17.45C14.87,17 14.6,16.39 14.6,15.66C14.6,14.78 14.93,14.1 15.6,13.61C16.27,13.12 17.21,12.88 18.43,12.88H19.83V12.24C19.83,11.75 19.68,11.36 19.38,11.07C19.08,10.78 18.63,10.64 18.05,10.64C17.53,10.64 17.1,10.76 16.75,11C16.4,11.25 16.23,11.54 16.23,11.89H14.77C14.77,11.46 14.92,11.05 15.22,10.65C15.5,10.25 15.93,9.94 16.44,9.71C16.95,9.5 17.5,9.36 18.13,9.36C19.11,9.36 19.87,9.6 20.42,10.09C20.97,10.58 21.26,11.25 21.28,12.11V16C21.28,16.8 21.38,17.42 21.58,17.88V18H20.06M17.66,16.88C18.11,16.88 18.54,16.77 18.95,16.56C19.35,16.35 19.65,16.07 19.83,15.73V14.16H18.7C16.93,14.16 16.04,14.63 16.04,15.57C16.04,16 16.19,16.3 16.5,16.53C16.8,16.76 17.18,16.88 17.66,16.88M5.46,13.71H9.53L7.5,8.29L5.46,13.71M6.64,6H8.36L13.07,18H11.14L10.17,15.43H4.82L3.86,18H1.93L6.64,6Z"
+          />
+        </svg>
+      </div>
+      <div
+        aria-checked={true}
+        aria-label="Regular expression toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-regexp-toggle toggle-container__toggle--active e2e-regexp-toggle--active"
+        data-tooltip="Disable regular expression"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M16,16.92C15.67,16.97 15.34,17 15,17C14.66,17 14.33,16.97 14,16.92V13.41L11.5,15.89C11,15.5 10.5,15 10.11,14.5L12.59,12H9.08C9.03,11.67 9,11.34 9,11C9,10.66 9.03,10.33 9.08,10H12.59L10.11,7.5C10.3,7.25 10.5,7 10.76,6.76V6.76C11,6.5 11.25,6.3 11.5,6.11L14,8.59V5.08C14.33,5.03 14.66,5 15,5C15.34,5 15.67,5.03 16,5.08V8.59L18.5,6.11C19,6.5 19.5,7 19.89,7.5L17.41,10H20.92C20.97,10.33 21,10.66 21,11C21,11.34 20.97,11.67 20.92,12H17.41L19.89,14.5C19.7,14.75 19.5,15 19.24,15.24V15.24C19,15.5 18.75,15.7 18.5,15.89L16,13.41V16.92H16V16.92M5,19A2,2 0 0,1 7,17A2,2 0 0,1 9,19A2,2 0 0,1 7,21A2,2 0 0,1 5,19H5Z"
+          />
+        </svg>
+      </div>
+      <div
+        aria-checked={false}
+        aria-label="Structural search toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-structural-search-toggle e2e-structural-search-toggle--active"
+        data-tooltip="Enable structural search"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M15,4V6H18V18H15V20H20V4M4,4V20H9V18H6V6H9V4H4Z"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PlainQueryInput with query 1`] = `
+<div
+  className="query-input2 d-flex"
+>
+  <input
+    className="form-control code lazy-monaco-query-input--intermediate-input"
+    onChange={[Function]}
+    spellCheck={false}
+    type="text"
+    value="repo:jsonrpc2 file:async.go asyncHandler"
+  />
+  <div
+    className="query-input2__toggle-container"
+  >
+    <div
+      className="toggle-container"
+    >
+      <div
+        aria-checked={true}
+        aria-disabled={false}
+        aria-label="Case sensitivity toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-case-sensitivity-toggle toggle-container__toggle--active e2e-case-sensitivity-toggle--active"
+        data-tooltip="Disable case sensitivity"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M20.06,18C20,17.83 19.91,17.54 19.86,17.11C19.19,17.81 18.38,18.16 17.45,18.16C16.62,18.16 15.93,17.92 15.4,17.45C14.87,17 14.6,16.39 14.6,15.66C14.6,14.78 14.93,14.1 15.6,13.61C16.27,13.12 17.21,12.88 18.43,12.88H19.83V12.24C19.83,11.75 19.68,11.36 19.38,11.07C19.08,10.78 18.63,10.64 18.05,10.64C17.53,10.64 17.1,10.76 16.75,11C16.4,11.25 16.23,11.54 16.23,11.89H14.77C14.77,11.46 14.92,11.05 15.22,10.65C15.5,10.25 15.93,9.94 16.44,9.71C16.95,9.5 17.5,9.36 18.13,9.36C19.11,9.36 19.87,9.6 20.42,10.09C20.97,10.58 21.26,11.25 21.28,12.11V16C21.28,16.8 21.38,17.42 21.58,17.88V18H20.06M17.66,16.88C18.11,16.88 18.54,16.77 18.95,16.56C19.35,16.35 19.65,16.07 19.83,15.73V14.16H18.7C16.93,14.16 16.04,14.63 16.04,15.57C16.04,16 16.19,16.3 16.5,16.53C16.8,16.76 17.18,16.88 17.66,16.88M5.46,13.71H9.53L7.5,8.29L5.46,13.71M6.64,6H8.36L13.07,18H11.14L10.17,15.43H4.82L3.86,18H1.93L6.64,6Z"
+          />
+        </svg>
+      </div>
+      <div
+        aria-checked={true}
+        aria-label="Regular expression toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-regexp-toggle toggle-container__toggle--active e2e-regexp-toggle--active"
+        data-tooltip="Disable regular expression"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M16,16.92C15.67,16.97 15.34,17 15,17C14.66,17 14.33,16.97 14,16.92V13.41L11.5,15.89C11,15.5 10.5,15 10.11,14.5L12.59,12H9.08C9.03,11.67 9,11.34 9,11C9,10.66 9.03,10.33 9.08,10H12.59L10.11,7.5C10.3,7.25 10.5,7 10.76,6.76V6.76C11,6.5 11.25,6.3 11.5,6.11L14,8.59V5.08C14.33,5.03 14.66,5 15,5C15.34,5 15.67,5.03 16,5.08V8.59L18.5,6.11C19,6.5 19.5,7 19.89,7.5L17.41,10H20.92C20.97,10.33 21,10.66 21,11C21,11.34 20.97,11.67 20.92,12H17.41L19.89,14.5C19.7,14.75 19.5,15 19.24,15.24V15.24C19,15.5 18.75,15.7 18.5,15.89L16,13.41V16.92H16V16.92M5,19A2,2 0 0,1 7,17A2,2 0 0,1 9,19A2,2 0 0,1 7,21A2,2 0 0,1 5,19H5Z"
+          />
+        </svg>
+      </div>
+      <div
+        aria-checked={false}
+        aria-label="Structural search toggle"
+        className="btn btn-icon icon-inline toggle-container__toggle e2e-regexp-toggle e2e-structural-search-toggle e2e-structural-search-toggle--active"
+        data-tooltip="Enable structural search"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <svg
+          className="mdi-icon "
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M15,4V6H18V18H15V20H20V4M4,4V20H9V18H6V6H9V4H4Z"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Fixes #9499

Avoids unstable UI effect by matching Monaco styling in the intermediate query input used for progressive enhancement while lazy-loading the Monaco query input.

Gif:

<details>
    <img src="https://user-images.githubusercontent.com/1741180/79744455-a33dcc00-8306-11ea-86b4-cbba94f9a425.gif">
</details>

