### PR TITLE
Fix CI by upgrading git in Grafana Dockerfile

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 go build -o /go/bin/src-observability-generator
 RUN mkdir -p /generated/grafana
 RUN PROMETHEUS_DIR='' GRAFANA_DIR=/generated/grafana /go/bin/src-observability-generator
 
-RUN apk add --no-cache bash=5.0.11-r1 git=2.24.2-r0 openssh=8.1_p1-r0 build-base=0.5-r1
+RUN apk add --no-cache bash=5.0.11-r1 git=2.24.2-r1 openssh=8.1_p1-r0 build-base=0.5-r1
 
 WORKDIR /opt
 RUN git clone --branch v0.14.0 https://github.com/google/jsonnet.git


### PR DESCRIPTION
CI currently breaks because of:

    #15 [builder 6/11] RUN apk add --no-cache bash=5.0.11-r1 git=2.24.2-r0 opens...
    #15       digest: sha256:d6c31f8c1479b3ff92b7570f0d8298a792c6e3365e8a0c894dd16534b0fdc869
    #15         name: "[builder 6/11] RUN apk add --no-cache bash=5.0.11-r1 git=2.24.2-r0 openssh=8.1_p1-r0 build-base=0.5-r1"
    #15      started: 2020-04-20 10:19:02.164456511 +0000 UTC
    #15 0.659 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
    #15 0.776 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
    #15 0.886 ERROR: unsatisfiable constraints:
    #15    completed: 2020-04-20 10:19:03.136479497 +0000 UTC
    #15     duration: 972.022986ms
    #15        error: "executor failed running [/bin/sh -c apk add --no-cache bash=5.0.11-r1 git=2.24.2-r0 openssh=8.1_p1-r0 build-base=0.5-r1]: exit code: 1"
    #15 0.901   git-2.24.2-r1:
    #15 0.901     breaks: world[git=2.24.2-r0]

And in the Alpine packages git has been upgraded from 2.24.2-r0 to
2.24.2-r1: https://pkgs.alpinelinux.org/packages?name=git&branch=v3.11



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
