### PR TITLE
Fix insertText for file/repo suggestions

### DIFF
--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -1,4 +1,5 @@
-import { getCompletionItems } from './completion'
+import * as Monaco from 'monaco-editor'
+import { getCompletionItems, repositoryCompletionItemKind } from './completion'
 import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
 import { NEVER, of } from 'rxjs'
 import { SearchSuggestion } from '../../graphql/schema'
@@ -292,7 +293,37 @@ describe('getCompletionItems()', () => {
                         },
                     ] as SearchSuggestion[])
                 )
-            )?.suggestions.map(({ label }) => label)
-        ).toStrictEqual(['connect.go'])
+            )?.suggestions.map(({ label, insertText }) => ({ label, insertText }))
+        ).toStrictEqual([{ label: 'connect.go', insertText: '^connect\\.go$' }])
+    })
+
+    test('inserts valid filters when selecting a file or repository suggestion', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    (parseSearchQuery('jsonrpc') as ParseSuccess<Sequence>).token,
+                    { column: 8 },
+                    of([
+                        {
+                            __typename: 'File',
+                            path: 'jsonrpc2.go',
+                            name: 'jsonrpc2.go',
+                            repository: {
+                                name: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        },
+                        {
+                            __typename: 'Repository',
+                            name: 'github.com/sourcegraph/jsonrpc2.go',
+                        },
+                    ] as SearchSuggestion[])
+                )
+            )?.suggestions
+                .filter(
+                    ({ kind }) =>
+                        kind === Monaco.languages.CompletionItemKind.File || kind === repositoryCompletionItemKind
+                )
+                .map(({ insertText }) => insertText)
+        ).toStrictEqual(['file:^jsonrpc2\\.go$ ', 'repo:^github\\.com/sourcegraph/jsonrpc2\\.go$ '])
     })
 })

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -15,7 +15,7 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Customcolor
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
 const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] = Object.keys(FILTERS)
-    .flatMap((label) => {
+    .flatMap(label => {
         const filterType = label as FilterType
         const completionItem: Omit<Monaco.languages.CompletionItem, 'range' | 'detail'> = {
             label,
@@ -206,9 +206,9 @@ export async function getCompletionItems(
             suggestions: [
                 ...staticSuggestions,
                 ...(await dynamicSuggestions.pipe(first()).toPromise())
-                    .map((suggestion) => suggestionToCompletionItem(suggestion, { isFilterValue: false }))
+                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: false }))
                     .filter(isDefined)
-                    .map((completionItem) => ({
+                    .map(completionItem => ({
                         ...completionItem,
                         range: toMonacoRange(range),
                         // Set a sortText so that dynamic suggestions
@@ -231,7 +231,7 @@ export async function getCompletionItems(
         if (resolvedFilter.definition.suggestions) {
             if (resolvedFilter.definition.suggestions instanceof Array) {
                 return {
-                    suggestions: resolvedFilter.definition.suggestions.map((label) => ({
+                    suggestions: resolvedFilter.definition.suggestions.map(label => ({
                         label,
                         kind: Monaco.languages.CompletionItemKind.Text,
                         insertText: label,
@@ -245,9 +245,9 @@ export async function getCompletionItems(
             return {
                 suggestions: suggestions
                     .filter(({ __typename }) => __typename === resolvedFilter.definition.suggestions)
-                    .map((suggestion) => suggestionToCompletionItem(suggestion, { isFilterValue: true }))
+                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: true }))
                     .filter(isDefined)
-                    .map((partialCompletionItem) => ({
+                    .map(partialCompletionItem => ({
                         ...partialCompletionItem,
                         range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
                     })),


### PR DESCRIPTION
Addresses #8749

When selecting a file/repo from suggestions, we now insert a well-formed filter, unless we're already typing a filter value.
