### PR TITLE
Add GraphQL to highlightable languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "graphiql": "^0.17.5",
     "he": "^1.2.0",
     "highlight.js": "^9.18.1",
+    "highlightjs-graphql": "^1.0.1",
     "is-absolute-url": "^3.0.3",
     "lodash": "^4.17.15",
     "marked": "^0.8.2",

--- a/shared/src/highlight/contributions.ts
+++ b/shared/src/highlight/contributions.ts
@@ -1,4 +1,5 @@
 import { registerLanguage } from 'highlight.js/lib/highlight'
+import { definer as graphQLLanguage } from 'highlightjs-graphql'
 
 let registered = false
 
@@ -46,6 +47,7 @@ export function registerHighlightContributions(): void {
     registerLanguage('dart', require('highlight.js/lib/languages/dart'))
     registerLanguage('perl', require('highlight.js/lib/languages/perl'))
     registerLanguage('scala', require('highlight.js/lib/languages/scala'))
+    registerLanguage('graphql', graphQLLanguage)
     /* eslint-enable @typescript-eslint/no-require-imports */
     /* eslint-enable @typescript-eslint/no-var-requires */
 }

--- a/shared/src/types/highlightjs-graphql/index.d.ts
+++ b/shared/src/types/highlightjs-graphql/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'highlightjs-graphql' {
+    import { HLJSStatic, IModeBase } from 'highlight.js'
+
+    function hljsDefineGraphQL(hljs: typeof import('highlight.js')): void
+    namespace hljsDefineGraphQL {
+        export const definer: (hljs?: HLJSStatic) => IModeBase
+    }
+
+    export = hljsDefineGraphQL
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10452,6 +10452,11 @@ highlight.js@~9.13.0:
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
 
+highlightjs-graphql@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz#e6e3a69585348a14492386260bb2c0c54c6a2e7b"
+  integrity sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA==
+
 history@4.5.1, history@^4.9.0:
   version "4.5.1"
   resolved "https://registry.npmjs.org/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"


### PR DESCRIPTION
Fixes code intel hovers on GQL files not being highlighted.

cc @sourcegraph/code-intel 