### PR TITLE
debugproxies: use IP address instead of host for endpoints

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -38,7 +38,7 @@ func addDebugHandlers(r *mux.Router) {
 		for _, s := range debugserver.Services {
 			peps = append(peps, debugproxies.Endpoint{
 				Service: s.Name,
-				Host:    s.Host,
+				Addr:    s.Host,
 			})
 		}
 		rph.Populate(peps)

--- a/cmd/frontend/internal/app/debugproxies/handler.go
+++ b/cmd/frontend/internal/app/debugproxies/handler.go
@@ -109,17 +109,20 @@ func (rph *ReverseProxyHandler) Populate(peps []Endpoint) {
 
 // Creates a display name from an endpoint suited for using in a URL link.
 func displayNameFromEndpoint(ep Endpoint) string {
-	colonIdx := strings.Index(ep.Addr, ":")
-	strippedHost := ep.Addr
-	if colonIdx != -1 {
-		strippedHost = strippedHost[:colonIdx]
+	host := ep.Hostname
+	if host == "" {
+		host = ep.Addr
+		if idx := strings.Index(host, ":"); idx != -1 {
+			host = host[:idx]
+		}
 	}
+
 	// Stateful Services have unique pod names. Lets use them to avoid stutter
 	// in the name (gitserver-gitserver-0 becomes gitserver-0).
-	if strings.HasPrefix(strippedHost, ep.Service) {
-		return strippedHost
+	if strings.HasPrefix(host, ep.Service) {
+		return host
 	}
-	return fmt.Sprintf("%s-%s", ep.Service, strippedHost)
+	return fmt.Sprintf("%s-%s", ep.Service, host)
 }
 
 // reverseProxyFromHost creates a reverse proxy from specified host with the path prefix that will be stripped from

--- a/cmd/frontend/internal/app/debugproxies/handler.go
+++ b/cmd/frontend/internal/app/debugproxies/handler.go
@@ -97,8 +97,8 @@ func (rph *ReverseProxyHandler) Populate(peps []Endpoint) {
 	for _, ep := range peps {
 		displayName := displayNameFromEndpoint(ep)
 		rps[displayName] = &proxyEndpoint{
-			reverseProxy: reverseProxyFromHost(ep.Host, displayName),
-			host:         ep.Host,
+			reverseProxy: reverseProxyFromHost(ep.Addr, displayName),
+			host:         ep.Addr,
 		}
 	}
 
@@ -109,8 +109,8 @@ func (rph *ReverseProxyHandler) Populate(peps []Endpoint) {
 
 // Creates a display name from an endpoint suited for using in a URL link.
 func displayNameFromEndpoint(ep Endpoint) string {
-	colonIdx := strings.Index(ep.Host, ":")
-	strippedHost := ep.Host
+	colonIdx := strings.Index(ep.Addr, ":")
+	strippedHost := ep.Addr
 	if colonIdx != -1 {
 		strippedHost = strippedHost[:colonIdx]
 	}

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -100,29 +100,31 @@ func TestIndexLinks(t *testing.T) {
 
 func TestDisplayNameFromEndpoint(t *testing.T) {
 	cases := []struct {
-		Service, Host string
-		Want          string
+		Service, Addr, Hostname string
+		Want                    string
 	}{{
-		Service: "gitserver",
-		Host:    "gitserver-0:2323",
-		Want:    "gitserver-0",
+		Service:  "gitserver",
+		Addr:     "192.168.10.0:2323",
+		Hostname: "gitserver-0",
+		Want:     "gitserver-0",
 	}, {
 		Service: "searcher",
-		Host:    "192.168.10.3:2323",
+		Addr:    "192.168.10.3:2323",
 		Want:    "searcher-192.168.10.3",
 	}, {
 		Service: "no-port",
-		Host:    "192.168.10.1",
+		Addr:    "192.168.10.1",
 		Want:    "no-port-192.168.10.1",
 	}}
 
 	for _, c := range cases {
 		got := displayNameFromEndpoint(Endpoint{
-			Service: c.Service,
-			Addr:    c.Host,
+			Service:  c.Service,
+			Addr:     c.Addr,
+			Hostname: c.Hostname,
 		})
 		if got != c.Want {
-			t.Errorf("displayNameFromEndpoint(%q, %q) mismatch (-want +got):\n%s", c.Service, c.Host, cmp.Diff(c.Want, got))
+			t.Errorf("displayNameFromEndpoint(%q, %q) mismatch (-want +got):\n%s", c.Service, c.Addr, cmp.Diff(c.Want, got))
 		}
 	}
 }

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -30,7 +30,7 @@ func TestReverseProxyRequestPaths(t *testing.T) {
 		return
 	}
 
-	ep := Endpoint{Service: "gitserver", Host: proxiedURL.Host}
+	ep := Endpoint{Service: "gitserver", Addr: proxiedURL.Host}
 	displayName := displayNameFromEndpoint(ep)
 	rph.Populate([]Endpoint{ep})
 
@@ -70,7 +70,7 @@ func TestIndexLinks(t *testing.T) {
 		return
 	}
 
-	ep := Endpoint{Service: "gitserver", Host: proxiedURL.Host}
+	ep := Endpoint{Service: "gitserver", Addr: proxiedURL.Host}
 	displayName := displayNameFromEndpoint(ep)
 	rph.Populate([]Endpoint{ep})
 
@@ -119,7 +119,7 @@ func TestDisplayNameFromEndpoint(t *testing.T) {
 	for _, c := range cases {
 		got := displayNameFromEndpoint(Endpoint{
 			Service: c.Service,
-			Host:    c.Host,
+			Addr:    c.Host,
 		})
 		if got != c.Want {
 			t.Errorf("displayNameFromEndpoint(%q, %q) mismatch (-want +got):\n%s", c.Service, c.Host, cmp.Diff(c.Want, got))

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -18,6 +18,9 @@ type Endpoint struct {
 	Service string
 	// Addr:port, so hostname part of a URL (ip address ok)
 	Addr string
+	// Hostname of the endpoint, if set. Only use this for display purposes,
+	// it doesn't include the port nor is it gaurenteed to be resolvable.
+	Hostname string
 }
 
 // ScanConsumer is the callback to consume scan results.
@@ -171,11 +174,16 @@ func (cs *clusterScanner) scanCluster() {
 
 			for _, addr := range subset.Addresses {
 				for _, port := range ports {
-					host := addrToHost(addr, port)
-					if host != "" {
+					addrStr := fromStrPtr(addr.Ip)
+					if addrStr == "" {
+						addrStr = fromStrPtr(addr.Hostname)
+					}
+
+					if addrStr != "" {
 						scanResults = append(scanResults, Endpoint{
-							Service: svcName,
-							Addr:    host,
+							Service:  svcName,
+							Addr:     fmt.Sprintf("%s:%d", addrStr, port),
+							Hostname: fromStrPtr(addr.Hostname),
 						})
 					}
 				}
@@ -186,12 +194,10 @@ func (cs *clusterScanner) scanCluster() {
 	cs.consume(scanResults)
 }
 
-// addrToHost converts a scanned k8s endpoint address structure into a string that is the host:port part of a URL.
-func addrToHost(addr *corev1.EndpointAddress, port int) string {
-	if addr.Hostname != nil && *addr.Hostname != "" {
-		return fmt.Sprintf("%s:%d", *addr.Hostname, port)
-	} else if addr.Ip != nil {
-		return fmt.Sprintf("%s:%d", *addr.Ip, port)
+// fromStrPtr returns *s. If s is nil the empty string is returned.
+func fromStrPtr(s *string) string {
+	if s == nil {
+		return ""
 	}
-	return ""
+	return *s
 }

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -16,8 +16,8 @@ import (
 type Endpoint struct {
 	// Service to which the endpoint belongs
 	Service string
-	// Host:port, so hostname part of a URL (ip address ok)
-	Host string
+	// Addr:port, so hostname part of a URL (ip address ok)
+	Addr string
 }
 
 // ScanConsumer is the callback to consume scan results.
@@ -175,7 +175,7 @@ func (cs *clusterScanner) scanCluster() {
 					if host != "" {
 						scanResults = append(scanResults, Endpoint{
 							Service: svcName,
-							Host:    host,
+							Addr:    host,
 						})
 					}
 				}

--- a/cmd/frontend/internal/app/debugproxies/scanner_test.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner_test.go
@@ -162,8 +162,9 @@ func TestClusterScan(t *testing.T) {
 	cs.scanCluster()
 
 	want := []Endpoint{{
-		Service: "gitserver",
-		Addr:    "gitserver-0:2323",
+		Service:  "gitserver",
+		Addr:     "192.168.10.0:2323",
+		Hostname: "gitserver-0",
 	}, {
 		Service: "searcher",
 		Addr:    "192.168.10.3:2323",

--- a/cmd/frontend/internal/app/debugproxies/scanner_test.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner_test.go
@@ -163,13 +163,13 @@ func TestClusterScan(t *testing.T) {
 
 	want := []Endpoint{{
 		Service: "gitserver",
-		Host:    "gitserver-0:2323",
+		Addr:    "gitserver-0:2323",
 	}, {
 		Service: "searcher",
-		Host:    "192.168.10.3:2323",
+		Addr:    "192.168.10.3:2323",
 	}, {
 		Service: "no-prom-port",
-		Host:    "192.168.10.2:2324",
+		Addr:    "192.168.10.2:2324",
 	}}
 
 	if !cmp.Equal(want, eps) {


### PR DESCRIPTION
This was a regression introduced by https://github.com/sourcegraph/sourcegraph/pull/9950

The hostname we get from the endpoint is something like `gitserver-0`. However, this isn't resolvable and requires the service name (so `gitserver-0.gitserver`). Instead of depending on that, we can rely on the IP like we used to. We still keep the behaviour of the better display name though by storing Hostname if we have it.