### PR TITLE
search: resolve aliases for and/or queries

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -833,5 +833,6 @@ func ProcessAndOr(in string) (QueryInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	query = SubstituteAliases(query)
 	return &AndOrQuery{Query: query}, nil
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -6,6 +6,27 @@ import (
 	"strings"
 )
 
+// SubstituteAliases substitutes field name aliases for their canonical names.
+func SubstituteAliases(nodes []Node) []Node {
+	aliases := map[string]string{
+		"r":        FieldRepo,
+		"g":        FieldRepoGroup,
+		"f":        FieldFile,
+		"l":        FieldLang,
+		"language": FieldLang,
+		"since":    FieldAfter,
+		"until":    FieldBefore,
+		"m":        FieldMessage,
+		"msg":      FieldMessage,
+	}
+	return MapParameter(nodes, func(field, value string, negated bool) Node {
+		if canonical, ok := aliases[field]; ok {
+			field = canonical
+		}
+		return Parameter{Field: field, Value: value, Negated: negated}
+	})
+}
+
 // LowercaseFieldNames performs strings.ToLower on every field name.
 func LowercaseFieldNames(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool) Node {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -15,6 +15,16 @@ func prettyPrint(nodes []Node) string {
 	return strings.Join(resultStr, " ")
 }
 
+func Test_SubstituteAliases(t *testing.T) {
+	input := "r:repo g:repogroup f:file"
+	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
+	query, _ := ParseAndOr(input)
+	got := prettyPrint(SubstituteAliases(query))
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func Test_LowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -112,7 +112,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 		want
 	}{
 		query: "r:a r:b -r:c",
-		field: "r",
+		field: "repo",
 		want: want{
 			values:        []string{"a", "b"},
 			negatedValues: []string{"c"},


### PR DESCRIPTION
As per #10054: Alias fields are validated, but not resolved in the interface after validation. This PR implements a transformer that resolves aliases to their canonical names.