### PR TITLE
Fix browser extension e2e tests

### DIFF
--- a/browser/src/e2e/github.test.ts
+++ b/browser/src/e2e/github.test.ts
@@ -54,7 +54,7 @@ describe('Sourcegraph browser extension on github.com', function () {
             token: 'host',
             lineId: 'diff-9ef8a22c4ce5141c30a501c542fb1adeR247',
             goToDefinitionURL:
-                'https://github.com/gorilla/mux/blob/e73f183699f8ab7d54609771e1fa0ab7ffddc21b/regexp.go#L233:2',
+                'https://sourcegraph.com/github.com/gorilla/mux@e73f183699f8ab7d54609771e1fa0ab7ffddc21b/-/blob/regexp.go#L247:24&tab=def',
         },
     }
 
@@ -100,7 +100,7 @@ describe('Sourcegraph browser extension on github.com', function () {
                         // Check go-to-definition jumps to the right place
                         await retry(async () => {
                             const href = await driver.page.evaluate(
-                                () => document.querySelector<HTMLLinkElement>('.e2e-tooltip-go-to-definition')?.href
+                                () => document.querySelector<HTMLAnchorElement>('.e2e-tooltip-go-to-definition')?.href
                             )
                             assert.strictEqual(href, goToDefinitionURL)
                         })
@@ -108,7 +108,9 @@ describe('Sourcegraph browser extension on github.com', function () {
                             driver.page.waitForNavigation(),
                             driver.page.click('.e2e-tooltip-go-to-definition'),
                         ])
-                        assert.strictEqual(await driver.page.evaluate(() => location.href), goToDefinitionURL)
+                        await retry(async () => {
+                            assert.strictEqual(await driver.page.evaluate(() => location.href), goToDefinitionURL)
+                        })
                     })
                 }
             })

--- a/browser/src/e2e/shared.ts
+++ b/browser/src/e2e/shared.ts
@@ -1,5 +1,7 @@
 import expect from 'expect'
 import { Driver } from '../../../shared/src/e2e/driver'
+import { retry } from '../../../shared/src/e2e/e2e-test-utils'
+import assert from 'assert'
 
 /**
  * Defines e2e tests for a single-file page of a code host.
@@ -59,14 +61,15 @@ export function testSingleFilePage({
             const [token] = await line.$x('//span[text()="CallOption"]')
             await token.hover()
             await getDriver().page.waitForSelector('.e2e-tooltip-go-to-definition')
-            await Promise.all([
-                getDriver().page.waitForNavigation(),
-                getDriver().page.click('.e2e-tooltip-go-to-definition'),
-            ])
-            expect(await getDriver().page.evaluate(() => location.href)).toBe(
-                goToDefinitionURL ||
-                    `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go#L5:6`
-            )
+            await retry(async () => {
+                assert.strictEqual(
+                    await getDriver().page.evaluate(
+                        () => document.querySelector<HTMLAnchorElement>('.e2e-tooltip-go-to-definition')?.href
+                    ),
+                    goToDefinitionURL ||
+                        `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go#L5:6`
+                )
+            })
         })
     })
 }


### PR DESCRIPTION
This was broken because language servers were disabled on sourcegraph.com, and we now have a less precise multi-definition result from basic code intel. This updates the URLs to that.