### PR TITLE
Smart search: improve keyboard accessibility

### DIFF
--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -213,6 +213,18 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
     }
 
     private onEditorCreated = (editor: Monaco.editor.IStandaloneCodeEditor): void => {
+        // Accessibility: allow tab usage to move focus to
+        // next previous focusable element (and not to insert the tab character).
+        // - Cannot be set through IEditorOptions
+        // - Cannot be called synchronously (otherwise risks being overridden by Monaco defaults)
+        this.subscriptions.add(
+            toUnsubscribable(
+                editor.onDidFocusEditorText(() => {
+                    editor.createContextKey('editorTabMovesFocus', true)
+                })
+            )
+        )
+
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(


### PR DESCRIPTION
Allow using tab to move focus.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/79857222-bd8ead00-83cd-11ea-8cc2-d710773ed5ac.gif"/>
</details>

Previously this just inserted a tab character.

<details>
    <img src="https://user-images.githubusercontent.com/1741180/79857212-bb2c5300-83cd-11ea-91c2-b79752493385.gif"/>
</details>