### PR TITLE
release publish: fix version occurrence not caught by previous sed

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -315,6 +315,7 @@ Key dates:
                     commitMessage: `Update latest release to ${parsedVersion.version}`,
                     bashEditCommands: [
                         `find . -type f -name '*.md' ! -name 'CHANGELOG.md' -exec ${sed} -i -E 's/sourcegraph\\/server:[0-9]+\\.[0-9]+\\.[0-9]+/sourcegraph\\/server:${parsedVersion.version}/g' {} +`,
+                        `${sed} -i -E 's/version \`[0-9]+\\.[0-9]+\\.[0-9]+\`/version \`${parsedVersion.version}\`/g' doc/index.md`,
                         parsedVersion.patch === 0
                             ? `comby -in-place '{{$previousReleaseRevspec := ":[1]"}} {{$previousReleaseVersion := ":[2]"}} {{$currentReleaseRevspec := ":[3]"}} {{$currentReleaseVersion := ":[4]"}}' '{{$previousReleaseRevspec := ":[3]"}} {{$previousReleaseVersion := ":[4]"}} {{$currentReleaseRevspec := "v${parsedVersion.version}"}} {{$currentReleaseVersion := "${parsedVersion.major}.${parsedVersion.minor}"}}' doc/_resources/templates/document.html`
                             : `comby -in-place 'currentReleaseRevspec := ":[1]"' 'currentReleaseRevspec := "v${parsedVersion.version}"' doc/_resources/templates/document.html`,


### PR DESCRIPTION
fixes remaining version string occurrence in doc when creating publishing release PR

related to https://github.com/sourcegraph/sourcegraph/pull/10059