### PR TITLE
extsvc: relax GitLab repo exclude validation

### DIFF
--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -841,7 +841,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   "GITLAB",
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
-			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+			assert: includes(`exclude.0.name: Does not match pattern '^[\w.-]+(/[\w.-]+)+$'`),
 		},
 		{
 			kind:   "GITLAB",
@@ -859,6 +859,34 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"projectQuery": ["none"],
 				"exclude": [
 					{"name": "foo/bar", "id": 1234}
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind: "GITLAB",
+			desc: "subgroup paths are valid for exclude",
+			config: `
+			{
+				"url": "https://gitlab.corp.com",
+				"token": "very-secret-token",
+				"projectQuery": ["none"],
+				"exclude": [
+					{"name": "foo/bar/baz", "id": 1234}
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind: "GITLAB",
+			desc: "paths containing . in the first part of the path are valid for exclude",
+			config: `
+			{
+				"url": "https://gitlab.corp.com",
+				"token": "very-secret-token",
+				"projectQuery": ["none"],
+				"exclude": [
+					{"name": "foo.bar/baz", "id": 1234}
 				]
 			}`,
 			assert: equals(`<nil>`),
@@ -885,7 +913,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   "GITLAB",
 			desc:   "invalid projects item name",
 			config: `{"projects": [{"name": "bar"}]}`,
-			assert: includes(`projects.0.name: Does not match pattern '^[\w-]+(/[\w.-]+)+$'`),
+			assert: includes(`projects.0.name: Does not match pattern '^[\w.-]+(/[\w.-]+)+$'`),
 		},
 		{
 			kind:   "GITLAB",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -72,7 +72,7 @@
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to mirror.",
             "type": "string",
-            "pattern": "^[\\w-]+(/[\\w.-]+)+$"
+            "pattern": "^[\\w.-]+(/[\\w.-]+)+$"
           },
           "id": {
             "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to mirror.",
@@ -97,7 +97,7 @@
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^[\\w.-]+(/[\\w.-]+)+$"
           },
           "id": {
             "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to exclude from mirroring.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -77,7 +77,7 @@ const GitLabSchemaJSON = `{
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to mirror.",
             "type": "string",
-            "pattern": "^[\\w-]+(/[\\w.-]+)+$"
+            "pattern": "^[\\w.-]+(/[\\w.-]+)+$"
           },
           "id": {
             "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to mirror.",
@@ -102,7 +102,7 @@ const GitLabSchemaJSON = `{
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^[\\w.-]+(/[\\w.-]+)+$"
           },
           "id": {
             "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to exclude from mirroring.",


### PR DESCRIPTION
Addresses #10096. This only does validation--It'd be great if someone familiar with this code (maybe @tsenart?) can confirm that the underlying code will actually honor/process the additional exclude patterns that this validation now supports (i.e., when excluding [subgroups](https://docs.gitlab.com/ee/user/group/subgroups/)).
