### PR TITLE
extsvc: add extra check on repo name to prevent 500

### DIFF
--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -62,6 +62,13 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 // code hosts' URL hostname component.
 func CodeHostOf(name api.RepoName, codehosts ...*CodeHost) *CodeHost {
 	for _, c := range codehosts {
+
+		// Check if repo name is missing path/namespace by checking if the repo name
+		// is exactly the code host.
+		// https://github.com/sourcegraph/sourcegraph/issues/9274
+		if strings.EqualFold(string(name), c.BaseURL.Hostname()) {
+			return nil
+		}
 		if strings.HasPrefix(strings.ToLower(string(name)), c.BaseURL.Hostname()) {
 			return c
 		}

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -32,6 +32,11 @@ func TestCodeHostOf(t *testing.T) {
 		repo:      "GITHUB.COM/foo/bar",
 		codehosts: PublicCodeHosts,
 		want:      GitHubDotCom,
+	}, {
+		name:      "missing-path",
+		repo:      "github.com",
+		codehosts: PublicCodeHosts,
+		want:      nil,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			have := CodeHostOf(tc.repo, tc.codehosts...)


### PR DESCRIPTION
After looking at this bug, I discovered [a branch of code responsible for deciding on redirects](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/backend/repos.go#L74) which calls `func CodeHostsOf(name api.RepoName, codehosts ...*CodeHost)`. 

This func checks if the repo name is prefixed with the code host, and returns the matched code host or nil. If it returns nil, the handler will return a 404 - not found. 

We do not want to redirect in cases where the function is passed 'github.com'  vs its successful counterpart - 'github.com/namespace/repo', so I added a small string assertion without parsing the name as a url and checking path existence.

Ref #9274