### PR TITLE
dev/watchman: merge file change events while running handle changed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@
 /dev/src-expose @keegancsmith
 /dev/drop-test-databases.sh @efritz
 /dev/squash_migrations.sh @efritz
+/dev/watchmanwrapper @keegancsmith
 /.storybook @felixfbecker
 /CONTRIBUTING.md @beyang @nicksnyder @slimsag
 /SECURITY.md @beyang @nicksnyder


### PR DESCRIPTION
Watchman only sends file change events once the FS is settled. However, it
isn't aware of our handleChanged process, so if a dev is still saving files
while the compiler is running the events would queue up. This would lead to
our watchman wrapper running handle changed several times. We now dedup the
watch events while the compilation is running before calling it again.