### PR TITLE
conf: add CONFIGURATION_MODE empty

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -51,6 +51,8 @@ func getMode() configurationMode {
 		return modeServer
 	case "client":
 		return modeClient
+	case "dummy":
+		return modeTest
 	default:
 		// Detect 'go test' and default to test mode in that case.
 		p, err := os.Executable()

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -40,7 +40,7 @@ const (
 	modeClient
 
 	// The user of pkg/conf is a test case.
-	modeTest
+	modeEmpty
 )
 
 func getMode() configurationMode {
@@ -52,12 +52,12 @@ func getMode() configurationMode {
 	case "client":
 		return modeClient
 	case "dummy":
-		return modeTest
+		return modeEmpty
 	default:
 		// Detect 'go test' and default to test mode in that case.
 		p, err := os.Executable()
 		if err == nil && strings.Contains(strings.ToLower(p), "test") {
-			return modeTest
+			return modeEmpty
 		}
 
 		// Otherwise we default to client mode, so that most services need not
@@ -78,7 +78,7 @@ func initDefaultClient() *client {
 
 	// Don't kickoff the background updaters for the client/server
 	// when running test cases.
-	if mode == modeTest {
+	if mode == modeEmpty {
 		close(configurationServerFrontendOnlyInitialized)
 
 		// Seed the client store with a dummy configuration for test cases.
@@ -146,7 +146,7 @@ func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.R
 func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	mode := getMode()
 
-	if mode == modeTest {
+	if mode == modeEmpty {
 		return nil
 	}
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -39,7 +39,8 @@ const (
 	// The user of pkg/conf only reads the configuration file.
 	modeClient
 
-	// The user of pkg/conf is a test case.
+	// The user of pkg/conf is a test case or explicitly opted to have no
+	// configuration.
 	modeEmpty
 )
 
@@ -51,10 +52,10 @@ func getMode() configurationMode {
 		return modeServer
 	case "client":
 		return modeClient
-	case "dummy":
+	case "empty":
 		return modeEmpty
 	default:
-		// Detect 'go test' and default to test mode in that case.
+		// Detect 'go test' and default to empty mode in that case.
 		p, err := os.Executable()
 		if err == nil && strings.Contains(strings.ToLower(p), "test") {
 			return modeEmpty
@@ -77,11 +78,11 @@ func initDefaultClient() *client {
 	mode := getMode()
 
 	// Don't kickoff the background updaters for the client/server
-	// when running test cases.
+	// when in empty mode.
 	if mode == modeEmpty {
 		close(configurationServerFrontendOnlyInitialized)
 
-		// Seed the client store with a dummy configuration for test cases.
+		// Seed the client store with an empty configuration.
 		_, err := clientStore.MaybeUpdate(conftypes.RawUnified{
 			Critical:           "{}",
 			Site:               "{}",


### PR DESCRIPTION
This is to allow services to be run in isolation without the need to start up
all services. For example to run gitserver you can do

```sh
env SRC_REPOS_DIR=$HOME/.sourcegraph/repos CONFIGURATION_MODE=empty go run ./cmd/gitserver
```

When using "empty" mode we create an empty configuration like we do for running
tests.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
