### PR TITLE
gitserver: remove findMountPoint

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -587,38 +587,6 @@ func makeFakeRepo(d string, sizeBytes int) error {
 	return nil
 }
 
-func Test_findMountPoint(t *testing.T) {
-	type args struct {
-		d string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "mount point of root is root",
-			args:    args{d: "/"},
-			want:    "/",
-			wantErr: false,
-		},
-		// What else can we portably count on?
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := findMountPoint(tt.args.d)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("findMountPoint() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("findMountPoint() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMaybeCorruptStderrRe(t *testing.T) {
 	bad := []string{
 		"error: packfile .git/objects/pack/pack-a.pack does not match index",


### PR DESCRIPTION
This function is unnecessary. Statfs works on any file, you don't need to pass
in the mountpoint. Additionally the mountpoint can change while a process is
running, but we will want to continue monitoring the disk for ReposDir.
