### PR TITLE
campaigns: Include service ID in bitbucket webhook

### DIFF
--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -878,12 +878,6 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *repo
 		return nil, nil, &httpError{http.StatusInternalServerError, err}
 	}
 
-	args := repos.StoreListExternalServicesArgs{Kinds: []string{"BITBUCKETSERVER"}}
-	es, err := h.Repos.ListExternalServices(r.Context(), args)
-	if err != nil {
-		return nil, nil, &httpError{http.StatusInternalServerError, err}
-	}
-
 	sig := r.Header.Get("X-Hub-Signature")
 
 	rawID := r.FormValue(externalServiceIDParam)
@@ -894,6 +888,15 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *repo
 		if err != nil {
 			return nil, nil, &httpError{http.StatusBadRequest, errors.Wrap(err, "invalid external service id")}
 		}
+	}
+
+	args := repos.StoreListExternalServicesArgs{Kinds: []string{"BITBUCKETSERVER"}}
+	if externalServiceID != 0 {
+		args.IDs = append(args.IDs, externalServiceID)
+	}
+	es, err := h.Repos.ListExternalServices(r.Context(), args)
+	if err != nil {
+		return nil, nil, &httpError{http.StatusInternalServerError, err}
 	}
 
 	var extSvc *repos.ExternalService

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -800,6 +800,7 @@ func (h *BitbucketServerWebhook) syncWebhook(id int64, con *schema.BitbucketServ
 
 	secret := con.WebhookSecret()
 	oldSecret, ok := h.secrets[id]
+
 	if ok && oldSecret == secret {
 		// Nothing has changed since our last check
 		return nil

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -794,12 +794,12 @@ const externalServiceIDParam = "externalServiceID"
 
 // syncWebook ensures that the webhook has been configured correctly on Bitbucket. If no secret has been set, we delete
 // the exising webhook config.
-func (h *BitbucketServerWebhook) syncWebhook(id int64, con *schema.BitbucketServerConnection, externalURL string) error {
+func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schema.BitbucketServerConnection, externalURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	secret := con.WebhookSecret()
-	oldSecret, ok := h.secrets[id]
+	oldSecret, ok := h.secrets[externalServiceID]
 
 	if ok && oldSecret == secret {
 		// Nothing has changed since our last check
@@ -819,12 +819,12 @@ func (h *BitbucketServerWebhook) syncWebhook(id int64, con *schema.BitbucketServ
 		if err != nil {
 			return errors.Wrap(err, "deleting webhook")
 		}
-		h.secrets[id] = secret
+		h.secrets[externalServiceID] = secret
 		return nil
 	}
 
 	// Secret has changed to a non blank value, upsert
-	endpoint := fmt.Sprintf("%s/.api/bitbucket-server-webhooks?%s=%d", externalURL, externalServiceIDParam, id)
+	endpoint := fmt.Sprintf("%s/.api/bitbucket-server-webhooks?%s=%d", externalURL, externalServiceIDParam, externalServiceID)
 	wh := bbs.Webhook{
 		Name:     h.Name,
 		Scope:    "global",
@@ -837,7 +837,7 @@ func (h *BitbucketServerWebhook) syncWebhook(id int64, con *schema.BitbucketServ
 	if err != nil {
 		return errors.Wrap(err, "upserting webhook")
 	}
-	h.secrets[id] = secret
+	h.secrets[externalServiceID] = secret
 	return nil
 }
 


### PR DESCRIPTION
This allows us to map incoming bitbucket webhooks with the correct external service.

Part of: https://github.com/sourcegraph/sourcegraph/issues/9008