### PR TITLE
docs: Make ordered lists look fancy

### DIFF
--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -481,7 +481,6 @@ a:hover {
     counter-reset:li;
     list-style:none;
     position:relative;
-    padding-bottom:10px;
     padding-left:0
 }
 
@@ -489,6 +488,14 @@ a:hover {
     padding: 8px 0 8px 42px;
     position: relative;
     margin-bottom: 5px;
+}
+
+.markdown-body ol>li p:first-child {
+    margin-top: 0px;
+}
+
+.markdown-body ol>li p:last-child {
+    margin-bottom: 0px;
 }
 
 .markdown-body ol>li:before {

--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -476,6 +476,37 @@ a:hover {
 .markdown-body li + li {
     margin-top: 0.25em;
 }
+
+.markdown-body ol {
+    counter-reset:li;
+    list-style:none;
+    position:relative;
+    padding-bottom:10px;
+    padding-left:0
+}
+
+.markdown-body ol>li {
+    padding: 8px 0 8px 42px;
+    position: relative;
+    margin-bottom: 5px;
+}
+
+.markdown-body ol>li:before {
+    content:counter(li);
+    counter-increment:li;
+    position:absolute;
+    top: 2px;
+    left:0;
+    height:100%;
+    width: 24px;
+    padding:0 10px 0 0;
+    color:#999;
+    font-size: 16px;
+    font-weight:bold;
+    line-height:35px;
+    text-align:right
+}
+
 .markdown-body dl {
     padding: 0;
 }

--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -477,28 +477,28 @@ a:hover {
     margin-top: 0.25em;
 }
 
-.markdown-body ol {
+.markdown-body > ol {
     counter-reset:li;
     list-style:none;
     position:relative;
     padding-left:0
 }
 
-.markdown-body ol>li {
+.markdown-body > ol > li {
     padding: 8px 0 8px 42px;
     position: relative;
     margin-bottom: 5px;
 }
 
-.markdown-body ol>li p:first-child {
+.markdown-body > ol > li p:first-child {
     margin-top: 0px;
 }
 
-.markdown-body ol>li p:last-child {
+.markdown-body > ol > li p:last-child {
     margin-bottom: 0px;
 }
 
-.markdown-body ol>li:before {
+.markdown-body > ol > li:before {
     content:counter(li);
     counter-increment:li;
     position:absolute;


### PR DESCRIPTION
### Preview

<img width="1864" alt="Screen Shot 2020-04-22 at 15 24 27" src="https://user-images.githubusercontent.com/1185253/79987699-0c137880-84ae-11ea-9d66-820abef5bde5.png">

<img width="1909" alt="Screen Shot 2020-04-22 at 15 22 38" src="https://user-images.githubusercontent.com/1185253/79987627-f56d2180-84ad-11ea-8289-e8f29adcf44a.png">

The second picture also includes some changes to the Markdown to render the code as blocks.

Note that this only works with top-level ordered lists:

<img width="1694" alt="Screen Shot 2020-04-22 at 15 34 06" src="https://user-images.githubusercontent.com/1185253/79988397-e63aa380-84ae-11ea-889d-54660129fb8c.png">
