### PR TITLE
docs: Fix rendering of code blocks in list items

### DIFF
--- a/doc/admin/auth/saml/generic.md
+++ b/doc/admin/auth/saml/generic.md
@@ -29,23 +29,22 @@ Ensure the following values are set for the application configuration in the ide
 ## 2. Add a SAML auth provider to Sourcegraph site configuration
 
 1. In Sourcegraph [site config](../../config/site_config.md), ensure `externalURL` is set to a value (with no trailing slash) consistent with the URL you used in the previous section in the identity provider configuration.
-
 1. Add an item to `auth.providers` with `type` "saml" and *either* `identityProviderMetadataURL` or `identityProviderMetadata` set. The former is preferred, but not all identity providers support it (it is sometimes called "App Federation Metadata URL" or just "SAML metadata URL"). Here are some examples of what your site config might look like:
 
 Example 1:
 
-   ```json
-   {
-    // ...
-    "externalURL": "https://sourcegraph.example.com",
-    "auth.providers": [
-      {
-        "type": "saml",
-        "identityProviderMetadataURL": "https://example.com/saml-metadata"
-      }
-    ]
-   }
-   ```
+```json
+{
+  // ...
+  "externalURL": "https://sourcegraph.example.com",
+  "auth.providers": [
+    {
+      "type": "saml",
+      "identityProviderMetadataURL": "https://example.com/saml-metadata"
+    }
+  ]
+}
+```
 
 Example 2:
 

--- a/doc/admin/external_database.md
+++ b/doc/admin/external_database.md
@@ -28,7 +28,7 @@ Add the following to your `docker run` command:
 
 1. Add/modify the following environment variables to all of the `sourcegraph-frontend-*` services and the `sourcegraph-frontend-internal` service in ` [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.14.2/docker-compose/docker-compose.yaml): 
 
-    ```yaml
+    ```
     sourcegraph-frontend-0:
       # ...
       environment:
@@ -41,11 +41,11 @@ Add the following to your `docker run` command:
       # ...
     ```
 
-    - See ["Environment variables in Compose"](https://docs.docker.com/compose/environment-variables/) for other ways to pass these environment variables to the relevant services (including from the command line, a `.env` file, etc.).
+    See ["Environment variables in Compose"](https://docs.docker.com/compose/environment-variables/) for other ways to pass these environment variables to the relevant services (including from the command line, a `.env` file, etc.).
 
 1. Comment out / remove the internal `pgsql` service in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/v3.14.2/docker-compose/docker-compose.yaml) since Sourcegraph is using the external one now.
 
-    ```yaml
+    ```
     # # Description: PostgreSQL database for various data.
     # #
     # # Disk: 128GB / persistent SSD

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -14,7 +14,7 @@ This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AW
 - Ensure the **Auto-assign Public IP** option is "Enable". This ensures your instance is accessible to the Internet.
 - Add the following user data (as text) in the **Advanced Details** section:
 
-   ```yaml
+   ```
    #cloud-config
    repo_update: true
    repo_upgrade: all

--- a/doc/admin/management_console.md
+++ b/doc/admin/management_console.md
@@ -82,13 +82,13 @@ Second, bcrypt your password on any machine:
 
     a. (**If you have Python 2**):
 
-    ```bash
+    ```
     PASSWORD='abc123' python -c "import bcrypt; import os; print(bcrypt.hashpw(os.environ['PASSWORD'], bcrypt.gensalt(15)))"
     ```
 
     b. (**If you have Python 3**): 
 
-    ```bash
+    ```
     PASSWORD='abc123' python -c "import bcrypt; import os; print(bcrypt.hashpw(os.environ['PASSWORD'].encode('utf-8'), bcrypt.gensalt(15)))"
     ```
 

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -51,19 +51,19 @@ The following are two recommendations for installing these dependencies:
 
     optionally via `brew`
 
-    ```bash
+    ```
     brew cask install docker
     ```
 
 3.  Install Go, Node Version Manager, PostgreSQL, Redis, Git, NGINX, golang-migrate, Comby, and SQLite tools with the following command:
 
-    ```bash
+    ```
     brew install go yarn redis postgresql git gnu-sed nginx golang-migrate comby sqlite pcre FiloSottile/musl-cross/musl-cross
     ```
 
 4.  Install the Node Version Manager (`nvm`) using:
 
-    ```bash
+    ```
     NVM_VERSION="$(curl https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name)"
     curl -L https://raw.githubusercontent.com/nvm-sh/nvm/"$NVM_VERSION"/install.sh -o install-nvm.sh
     sh install-nvm.sh
@@ -81,7 +81,7 @@ The following are two recommendations for installing these dependencies:
 5.  Install the current recommended version of Node JS by running the following
     from the working directory of a sourcegraph repository clone:
 
-    ```bash
+    ```
     nvm install
     nvm use --delete-prefix
     ```
@@ -95,7 +95,7 @@ The following are two recommendations for installing these dependencies:
 
 6.  Configure PostgreSQL and Redis to start automatically
 
-    ```bash
+    ```
     brew services start postgresql
     brew services start redis
     ```
@@ -105,7 +105,7 @@ The following are two recommendations for installing these dependencies:
 7.  Ensure `psql`, the PostgreSQL command line client, is on your `$PATH`.
     Homebrew does not put it there by default. Homebrew gives you the command to run to insert `psql` in your path in the "Caveats" section of `brew info postgresql`. Alternatively, you can use the command below. It might need to be adjusted depending on your Homebrew prefix (`/usr/local` below) and shell (bash below).
 
-    ```bash
+    ```
     hash psql || { echo 'export PATH="/usr/local/opt/postgresql/bin:$PATH"' >> ~/.bash_profile }
     source ~/.bash_profile
     ```
@@ -117,7 +117,7 @@ The following are two recommendations for installing these dependencies:
 
 1. Add package repositories:
 
-    ```bash
+    ```
     # Go
     sudo add-apt-repository ppa:longsleep/golang-backports
 
@@ -132,13 +132,13 @@ The following are two recommendations for installing these dependencies:
 
 2. Update repositories:
 
-    ```bash
+    ```
     sudo apt-get update
     ```
 
 3. Install dependencies:
 
-    ```bash
+    ```
     sudo apt install -y make git-all postgresql postgresql-contrib redis-server nginx libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io yarn
 
     # install golang-migrate (you must move the extracted binary into your $PATH)
@@ -156,7 +156,7 @@ The following are two recommendations for installing these dependencies:
 
 4. Configure startup services
 
-    ```bash
+    ```
     sudo systemctl enable postgresql
     sudo systemctl enable redis-server.service
     ```
@@ -165,7 +165,7 @@ The following are two recommendations for installing these dependencies:
 
     In this case you should not enable the `redis-server.service` from the previous step.
 
-    ```bash
+    ```
     dockerd # if docker isn't already running
     docker run -p 6379:6379 -v $REDIS_DATA_DIR redis
     # $REDIS_DATA_DIR should be an absolute path to a folder where you intend to store Redis data
@@ -230,25 +230,25 @@ You need a fresh Postgres database and a database user that has full ownership o
 
 1. Create a database for the current Unix user
 
-    ```bash
+    ```
     # For Linux users, first access the postgres user shell
     sudo su - postgres
     ```
 
-    ```bash
+    ```
     createdb
     ```
 
 2. Create the Sourcegraph user and password
 
-    ```bash
+    ```
     createuser --superuser sourcegraph
     psql -c "ALTER USER sourcegraph WITH PASSWORD 'sourcegraph';"
     ```
 
 3. Create the Sourcegraph database
 
-    ```bash
+    ```
     createdb --owner=sourcegraph --encoding=UTF8 --template=template0 sourcegraph
     ```
 
@@ -258,7 +258,7 @@ You need a fresh Postgres database and a database user that has full ownership o
 
     Add these, for example, in your `~/.bashrc`:
 
-    ```bash
+    ```
     export PGPORT=5432
     export PGHOST=localhost
     export PGUSER=sourcegraph

--- a/doc/dev/phabricator_gitolite.md
+++ b/doc/dev/phabricator_gitolite.md
@@ -151,23 +151,23 @@ will be `/opt/bitnami/phabricator`.
 
 3. Ensure `.arcconfig` has been added
 
-```json
-  {
-    "phabricator.uri" : "https://<your phabricator host>/"
-  }
-```
+    ```
+      {
+        "phabricator.uri" : "https://<your phabricator host>/"
+      }
+    ```
 
 4. Make some changes and push the diff to Phabricator's
 
     Use `arc` to create a new branch
 
-    ```shell
+    ```
     arc branch my-branch
     ```
 
     Make some changes, commit them, and upload the diff to Phabricator. DO NOT PUSH them to the git remote. If you push the changes to the git remote, we no longer are testing a critical feature of the Sourcegraph Phabricator integration, which is that it uses staging areas if configured or attempts to apply patchsets.
 
-    ```shell
+    ```
     git add . git commit -m "some changes" arc diff
     ```
 

--- a/doc/extensions/authoring/local_development.md
+++ b/doc/extensions/authoring/local_development.md
@@ -22,13 +22,13 @@ When you're done, clear the sideload URL from the extensions debug menu.
 1. Add `mkdirp` and `lnfs-cli` as dependencies (`npm install --save-dev mkdirp lnfs-cli`).
 2. Add the following npm script to your `package.json`:
 
-    ```json
+    ```
     "symlink-package": "mkdirp dist && lnfs ./package.json ./dist/package.json"
     ```
 
 3. Edit the `serve` npm script to run `symlink-package`:
 
-    ```json
+    ```
     "serve": "npm run symlink-package && parcel serve --no-hmr --out-file dist/your-extension.js src/your-extension.ts"
     ```
 

--- a/doc/user/campaigns/creating_campaign_from_patches.md
+++ b/doc/user/campaigns/creating_campaign_from_patches.md
@@ -5,10 +5,26 @@ A campaign can be created from a set of patches, one per repository. For each pa
 Here is the short version for how to create a patch set and turn that into changesets by creating a campaign:
 
 1. Create an action JSON file (e.g. `action.json`) that contains an action definition.
-1. _Optional_: See repositories the action would run over: `src actions scope-query -f action.json`
-1. Create a set of patches by executing the action over repositories: `src actions exec -f action.json > patches.json`
-1. Save the patches in Sourcegraph by creating a patch set: `src campaign patchset create-from-patches < patches.json`
-1. Create a campaign based on the patch set: `src campaigns create -branch=<branch-name> -patchset=<patchset-ID-returned-by-previous-command>`
+1. _Optional_: See repositories the action would run over:
+
+  ```
+  src actions scope-query -f action.json
+  ```
+1. Create a set of patches by executing the action over repositories:
+
+  ```
+  src actions exec -f action.json > patches.json
+  ```
+1. Save the patches in Sourcegraph by creating a patch set:
+
+  ```
+  src campaign patchset create-from-patches < patches.json
+  ```
+1. Create a campaign based on the patch set:
+
+  ```
+  src campaigns create -branch=<branch-name> -patchset=<patchset-ID-returned-by-previous-command>
+  ```
 
 Read on detailed steps and documentation and see "[Actions](./actions.md)" for more information about how to define and execute actions.
 


### PR DESCRIPTION
@unknwon and I found out that a bug (https://github.com/russross/blackfriday/issues/484) in our Markdown renderer, blackfriday, causes list items to be rendered incorrectly if they contain code blocks with a language.

The workaround is to remove the language from the code blocks. We lose syntax highlighting, but we gain readable lists.

Example:

<img width="1896" alt="Screen Shot 2020-04-22 at 16 09 55" src="https://user-images.githubusercontent.com/1185253/79992455-c9ed3580-84b3-11ea-8f85-8e3224f90a2a.png">