### PR TITLE
src-expose: ignore .git files (submodules)

### DIFF
--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -174,7 +174,7 @@ func configureRepos(logger *log.Logger, root string) []string {
 		// A directory which also is a repository (have .git folder inside it)
 		// will contain nil error. If it does, proceed to configure.
 		gitdir := filepath.Join(path, ".git")
-		if _, err := os.Stat(gitdir); os.IsNotExist(err) {
+		if fi, err := os.Stat(gitdir); err != nil || !fi.IsDir() {
 			return nil
 		}
 

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -154,6 +154,27 @@ func gitInitRepos(t *testing.T, names ...string) string {
 	return root
 }
 
+func TestIgnoreGitSubmodules(t *testing.T) {
+	root, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(root) })
+
+	if err := os.MkdirAll(filepath.Join(root, "dir"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(root, "dir", ".git"), []byte("ignore me please"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := configureRepos(testLogger(t), root)
+	if len(repos) != 0 {
+		t.Fatalf("expected no repos, got %v", repos)
+	}
+}
+
 func testLogger(t *testing.T) *log.Logger {
 	return log.New(testWriter{t}, "testLogger ", log.LstdFlags)
 }


### PR DESCRIPTION
.git can exist as a file (eg for submodules). Currently we would spam logs
about failing to configure those repos. This was benign but looked like
src-expose was broken. Instead we only treat ".git" directories as special.

Fixes https://github.com/sourcegraph/sourcegraph/issues/10140