### PR TITLE
config: prevent usage of non-root external url in the site configuration

### DIFF
--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -51,7 +51,7 @@ func validateCustom(cfg Unified) (problems Problems) {
 		}
 	}
 
-	// prevent usage of non-root externalURLs until we add their support
+	// Prevent usage of non-root externalURLs until we add their support:
 	// https://github.com/sourcegraph/sourcegraph/issues/7884
 	if cfg.ExternalURL != "" {
 		eURL, err := url.Parse(cfg.ExternalURL)

--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -47,6 +48,17 @@ func validateCustom(cfg Unified) (problems Problems) {
 		}
 		if hasSMTPAuth && (cfg.EmailSmtp.Username == "" && cfg.EmailSmtp.Password == "") {
 			invalid(NewSiteProblem(`must set email.smtp username and password for email.smtp authentication`))
+		}
+	}
+
+	// prevent usage of non-root externalURLs until we add their support
+	// https://github.com/sourcegraph/sourcegraph/issues/7884
+	if cfg.ExternalURL != "" {
+		eURL, err := url.Parse(cfg.ExternalURL)
+		if err != nil {
+			invalid(NewSiteProblem(`externalURL must be a valid URL`))
+		} else if eURL.Path != "/" && eURL.Path != "" {
+			invalid(NewSiteProblem(`externalURL must not be a non-root URL`))
 		}
 	}
 

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -41,6 +41,16 @@ func TestValidateCustom(t *testing.T) {
 			rawSite:     "{}",
 			wantErr:     "tagged union type must have a",
 		},
+		"valid externalURL": {
+			rawSite: `{"externalURL":"http://example.com"}`,
+		},
+		"valid externalURL ending with slash": {
+			rawSite: `{"externalURL":"http://example.com/"}`,
+		},
+		"non-root externalURL": {
+			rawSite:     `{"externalURL":"http://example.com/sourcegraph"}`,
+			wantProblem: "externalURL must not be a non-root URL",
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -987,7 +987,7 @@ type SiteConfiguration struct {
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: Configures Sourcegraph extensions.
 	Extensions *Extensions `json:"extensions,omitempty"`
-	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root urls are allowed.
+	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
 	ExternalURL string `json:"externalURL,omitempty"`
 	// GitCloneURLToRepositoryName description: JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -987,7 +987,7 @@ type SiteConfiguration struct {
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: Configures Sourcegraph extensions.
 	Extensions *Extensions `json:"extensions,omitempty"`
-	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`.
+	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root urls are allowed.
 	ExternalURL string `json:"externalURL,omitempty"`
 	// GitCloneURLToRepositoryName description: JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -564,7 +564,7 @@
       "group": "Misc."
     },
     "externalURL": {
-      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root urls are allowed.",
+      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -564,7 +564,7 @@
       "group": "Misc."
     },
     "externalURL": {
-      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`.",
+      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root urls are allowed.",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -569,7 +569,7 @@ const SiteSchemaJSON = `{
       "group": "Misc."
     },
     "externalURL": {
-      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called ` + "`" + `appURL` + "`" + `. Only root urls are allowed.",
+      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called ` + "`" + `appURL` + "`" + `. Only root URLs are allowed.",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -569,7 +569,7 @@ const SiteSchemaJSON = `{
       "group": "Misc."
     },
     "externalURL": {
-      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called ` + "`" + `appURL` + "`" + `.",
+      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called ` + "`" + `appURL` + "`" + `. Only root urls are allowed.",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },


### PR DESCRIPTION
This PR adds a custom validation preventing users from using non-root externalURL in the site configuration.

Fixes #7884 