### PR TITLE
tracking-issue: Implement simplified workflow

### DIFF
--- a/internal/cmd/tracking-issue/main_test.go
+++ b/internal/cmd/tracking-issue/main_test.go
@@ -19,20 +19,23 @@ var (
 	update        = flag.Bool("update", false, "update testdata golden")
 )
 
-func TestGenerate(t *testing.T) {
-	milestone := "3.13"
-	issues, prs := getIssuesAndPullRequestsFixtures(t, "sourcegraph", milestone, []string{"team/core-services"})
-	got := generate(workloads(issues, prs, milestone))
+func TestIntegration(t *testing.T) {
+	ti := &TrackingIssue{
+		Issue: &Issue{
+			Number:    7719,
+			Milestone: "3.13",
+			Labels:    []string{"tracking", "team/core-services"},
+		},
+	}
+
+	loadTrackingIssueFixtures(t, "sourcegraph", ti)
+
+	got := ti.Workloads().Markdown()
 	path := filepath.Join("testdata", "issue.md")
 	testutil.AssertGolden(t, path, *update, got)
 }
 
-func getIssuesAndPullRequestsFixtures(t testing.TB, org, milestone string, labels []string) ([]*Issue, []*PullRequest) {
-	type fixtures struct {
-		Issues       []*Issue
-		PullRequests []*PullRequest
-	}
-
+func loadTrackingIssueFixtures(t testing.TB, org string, issue *TrackingIssue) {
 	path := filepath.Join("testdata", "fixtures.json")
 
 	if *updateFixture {
@@ -43,20 +46,20 @@ func getIssuesAndPullRequestsFixtures(t testing.TB, org, milestone string, label
 				&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 			))),
 		)
-		issues, prs, err := listIssuesAndPullRequests(ctx, cli, org, milestone, labels)
+		err := loadTrackingIssues(ctx, cli, org, []*TrackingIssue{issue})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		for _, issue := range issues {
+		for _, issue := range issue.Issues {
 			issue.Redact()
 		}
 
-		for _, pr := range prs {
+		for _, pr := range issue.PRs {
 			pr.Redact()
 		}
 
-		testutil.AssertGolden(t, path, true, fixtures{issues, prs})
+		testutil.AssertGolden(t, path, true, issue)
 	}
 
 	f, err := os.Open(path)
@@ -65,10 +68,7 @@ func getIssuesAndPullRequestsFixtures(t testing.TB, org, milestone string, label
 	}
 	defer f.Close()
 
-	var v fixtures
-	if err := json.NewDecoder(f).Decode(&v); err != nil {
+	if err := json.NewDecoder(f).Decode(issue); err != nil {
 		t.Fatal(err)
 	}
-
-	return v.Issues, v.PullRequests
 }

--- a/internal/cmd/tracking-issue/testdata/fixtures.json
+++ b/internal/cmd/tracking-issue/testdata/fixtures.json
@@ -1,4 +1,22 @@
 {
+  "ID": "",
+  "Title": "",
+  "Body": "",
+  "Number": 7719,
+  "URL": "",
+  "State": "",
+  "Repository": "",
+  "Private": false,
+  "Labels": [
+   "tracking",
+   "team/core-services"
+  ],
+  "Assignees": null,
+  "Milestone": "3.13",
+  "Author": "",
+  "CreatedAt": "0001-01-01T00:00:00Z",
+  "UpdatedAt": "0001-01-01T00:00:00Z",
+  "ClosedAt": "0001-01-01T00:00:00Z",
   "Issues": [
    {
     "ID": "MDU6SXNzdWU1NjQxNzA3NzY=",
@@ -20,8 +38,7 @@
     "Author": "ryanslade",
     "CreatedAt": "2020-02-12T18:01:28Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-20T07:20:17Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-20T07:20:17Z"
    },
    {
     "ID": "MDU6SXNzdWU1NjI3MzAxMDU=",
@@ -45,8 +62,7 @@
     "Author": "rvantonder",
     "CreatedAt": "2020-02-10T18:00:38Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-21T19:05:54Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-21T19:05:54Z"
    },
    {
     "ID": "MDU6SXNzdWU1NjEzMjk5NjM=",
@@ -69,8 +85,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-02-06T23:26:18Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-10T14:38:19Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-10T14:38:19Z"
    },
    {
     "ID": "MDU6SXNzdWU1NjA0NzMzMDQ=",
@@ -93,8 +108,7 @@
     "Author": "kpsource",
     "CreatedAt": "2020-02-05T16:08:54Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-07T06:39:03Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-07T06:39:03Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTgzNTA5OTA=",
@@ -118,8 +132,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-31T20:17:42Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-06T16:14:09Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-06T16:14:09Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTY5NTUxMTk=",
@@ -143,8 +156,7 @@
     "Author": "attfarhan",
     "CreatedAt": "2020-01-29T15:56:34Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-13T14:57:55Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-13T14:57:55Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTY3ODc5OTg=",
@@ -167,8 +179,7 @@
     "Author": "unknwon",
     "CreatedAt": "2020-01-29T11:02:17Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-18T11:17:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-18T11:17:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTU4OTI2NjE=",
@@ -189,8 +200,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-27T23:20:47Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-06T06:09:28Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-06T06:09:28Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTU4OTA2MDQ=",
@@ -209,8 +219,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-27T23:15:32Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-03T16:28:39Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-03T16:28:39Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTU4Mzk0MjQ=",
@@ -232,8 +241,7 @@
     "Author": "beyang",
     "CreatedAt": "2020-01-27T21:19:52Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-17T17:53:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-17T17:53:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTQ3NTQ0NTA=",
@@ -257,8 +265,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-24T14:05:06Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-20T10:51:36Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-20T10:51:36Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTQ1NTE2MzY=",
@@ -283,8 +290,7 @@
     "Author": "christinaforney",
     "CreatedAt": "2020-01-24T05:26:37Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-24T12:43:46Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-24T12:43:46Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTQ1NDE3MTA=",
@@ -307,8 +313,7 @@
     "Author": "sqs",
     "CreatedAt": "2020-01-24T04:45:32Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-24T11:33:43Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-24T11:33:43Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTQzNTQyMzM=",
@@ -332,8 +337,7 @@
     "Author": "dadlerj",
     "CreatedAt": "2020-01-23T19:20:46Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-28T11:37:57Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-28T11:37:57Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTQwMjYwMzM=",
@@ -358,8 +362,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-23T09:05:56Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-23T10:36:22Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-23T10:36:22Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTI5NjYwMDg=",
@@ -381,8 +384,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-21T15:53:26Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-24T11:08:45Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-24T11:08:45Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTI3OTEyMTU=",
@@ -407,8 +409,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-21T10:38:58Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-03T13:23:43Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-03T13:23:43Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTI3Nzc1NzQ=",
@@ -432,8 +433,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-21T10:15:38Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-23T10:41:05Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-23T10:41:05Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTI3MjEyNjI=",
@@ -457,8 +457,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-21T09:18:29Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-21T13:37:58Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-21T13:37:58Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTE2ODk2OTc=",
@@ -481,8 +480,7 @@
     "Author": "unknwon",
     "CreatedAt": "2020-01-18T00:16:46Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-24T10:25:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-24T10:25:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTE2NDcwNjk=",
@@ -503,8 +501,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-01-17T21:47:07Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T22:39:18Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T22:39:18Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTE0NDI0Njg=",
@@ -530,8 +527,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-17T14:21:07Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-26T05:56:48Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-26T05:56:48Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTEyODI1NTY=",
@@ -556,8 +552,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-17T08:47:56Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-28T19:13:10Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-28T19:13:10Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTA2NjU1MjY=",
@@ -583,8 +578,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-16T09:00:13Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-27T18:14:48Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-27T18:14:48Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTA2NTk0NzY=",
@@ -607,8 +601,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-16T08:47:49Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-24T13:49:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-24T13:49:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTA0MzI1Njc=",
@@ -632,8 +625,7 @@
     "Author": "ryanslade",
     "CreatedAt": "2020-01-15T21:13:46Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-22T10:40:07Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-22T10:40:07Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTAxOTM0MzU=",
@@ -658,8 +650,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-15T13:41:41Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-28T13:58:49Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-28T13:58:49Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTAwMTU4NjM=",
@@ -683,8 +674,7 @@
     "Author": "unknwon",
     "CreatedAt": "2020-01-15T07:35:30Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-27T17:06:41Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-27T17:06:41Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDk1ODkzMDY=",
@@ -709,8 +699,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-14T14:04:28Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-26T05:56:49Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-26T05:56:49Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDk1MjA4MjM=",
@@ -733,8 +722,7 @@
     "Author": "tsenart",
     "CreatedAt": "2020-01-14T11:59:17Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-21T18:22:32Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-21T18:22:32Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDk0MjEwMDg=",
@@ -758,8 +746,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-14T08:54:57Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-11T18:23:36Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-11T18:23:36Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDkyNTc5NjQ=",
@@ -783,8 +770,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-14T00:18:11Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-17T11:49:14Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-17T11:49:14Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDkyNTAwMDQ=",
@@ -806,8 +792,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-01-13T23:53:01Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-06T07:06:15Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-06T07:06:15Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDkwNTUyNDk=",
@@ -832,8 +817,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-13T16:50:21Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-13T13:18:04Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-13T13:18:04Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDgzNTQ5NzE=",
@@ -857,8 +841,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-01-11T00:47:30Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T19:03:06Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T19:03:06Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDcyNDcyMTQ=",
@@ -884,8 +867,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-09T04:49:11Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-05T04:58:37Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-05T04:58:37Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDcxNzAxNjg=",
@@ -910,8 +892,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-08T23:56:57Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T10:53:41Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T10:53:41Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY4NDUzNzU=",
@@ -936,8 +917,7 @@
     "Author": "ryanslade",
     "CreatedAt": "2020-01-08T13:01:00Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T15:46:40Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T15:46:40Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY4NDA2MzQ=",
@@ -961,8 +941,7 @@
     "Author": "ryanslade",
     "CreatedAt": "2020-01-08T12:50:24Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-05T12:33:29Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-05T12:33:29Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY0NzQ0MDQ=",
@@ -987,8 +966,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-01-07T19:50:05Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T09:27:46Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T09:27:46Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY0NTkyNDc=",
@@ -1012,8 +990,7 @@
     "Author": "slimsag",
     "CreatedAt": "2020-01-07T19:16:41Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-22T13:04:42Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-22T13:04:42Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDAwOTg3MDI=",
@@ -1036,8 +1013,7 @@
     "Author": "unknwon",
     "CreatedAt": "2019-12-19T06:04:18Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-27T17:58:02Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-27T17:58:02Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDAwNjQ3MzQ=",
@@ -1062,8 +1038,7 @@
     "Author": "rvantonder",
     "CreatedAt": "2019-12-19T04:14:51Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-19T20:24:43Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-19T20:24:43Z"
    },
    {
     "ID": "MDU6SXNzdWU1MzQyMDY3ODk=",
@@ -1088,8 +1063,7 @@
     "Author": "eseliger",
     "CreatedAt": "2019-12-06T19:00:07Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-18T08:17:59Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-18T08:17:59Z"
    },
    {
     "ID": "MDU6SXNzdWU1MjQ2MzgxMzQ=",
@@ -1116,8 +1090,7 @@
     "Author": "slimsag",
     "CreatedAt": "2019-11-18T21:45:44Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-17T17:46:06Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-17T17:46:06Z"
    },
    {
     "ID": "MDU6SXNzdWU1MTk1Mzc2NTk=",
@@ -1144,8 +1117,7 @@
     "Author": "felixfbecker",
     "CreatedAt": "2019-11-07T21:59:55Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-05T04:57:19Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-05T04:57:19Z"
    },
    {
     "ID": "MDU6SXNzdWU1MTkzMzQyMTk=",
@@ -1170,8 +1142,7 @@
     "Author": "attfarhan",
     "CreatedAt": "2019-11-07T15:22:55Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-13T17:57:34Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-13T17:57:34Z"
    },
    {
     "ID": "MDU6SXNzdWU1MTkzMjg1OTU=",
@@ -1195,8 +1166,7 @@
     "Author": "attfarhan",
     "CreatedAt": "2019-11-07T15:14:07Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-12T07:15:21Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-12T07:15:21Z"
    },
    {
     "ID": "MDU6SXNzdWU0ODQxNTk2MDQ=",
@@ -1222,8 +1192,7 @@
     "Author": "dadlerj",
     "CreatedAt": "2019-08-22T19:01:10Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-11T17:35:09Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-11T17:35:09Z"
    },
    {
     "ID": "MDU6SXNzdWU0Nzc5ODcxMTY=",
@@ -1247,8 +1216,7 @@
     "Author": "felixfbecker",
     "CreatedAt": "2019-08-07T15:08:02Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-04T17:40:39Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-04T17:40:39Z"
    },
    {
     "ID": "MDU6SXNzdWU0NDMyOTI5NTY=",
@@ -1271,8 +1239,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2019-05-13T09:23:27Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-20T09:32:44Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-20T09:32:44Z"
    },
    {
     "ID": "MDU6SXNzdWU0Mzk0NDEyNTk=",
@@ -1296,8 +1263,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2019-05-02T06:20:56Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T07:56:26Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T07:56:26Z"
    },
    {
     "ID": "MDU6SXNzdWU0MzQ0NzUwMzI=",
@@ -1321,8 +1287,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2019-04-17T20:37:08Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-03T12:18:44Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-03T12:18:44Z"
    },
    {
     "ID": "MDU6SXNzdWU0MzA2MjUwMzc=",
@@ -1345,8 +1310,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2019-04-08T19:43:25Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T12:44:45Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T12:44:45Z"
    },
    {
     "ID": "MDU6SXNzdWU0MjM5NTk1NzA=",
@@ -1370,8 +1334,7 @@
     "Author": "ijsnow",
     "CreatedAt": "2019-03-21T21:55:53Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-31T13:40:56Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-31T13:40:56Z"
    },
    {
     "ID": "MDU6SXNzdWUzMjA5MTQ2NTM=",
@@ -1396,8 +1359,7 @@
     "Author": "sfllaw",
     "CreatedAt": "2018-05-07T18:51:53Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-29T14:37:04Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-29T14:37:04Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTMwMjc0MzQ=",
@@ -1424,8 +1386,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-21T17:36:59Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTMwMDE4NjQ=",
@@ -1449,8 +1410,7 @@
     "Author": "dadlerj",
     "CreatedAt": "2020-01-21T16:50:57Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTIwMzgxMjc=",
@@ -1463,20 +1423,19 @@
     "Private": false,
     "Labels": [
      "bug",
-     "estimate/0.5d",
+     "estimate/2d",
      "planned/3.13",
      "planned/3.14",
      "team/core-services"
     ],
     "Assignees": [
-     "tsenart"
+     "asdine"
     ],
-    "Milestone": "Backlog",
+    "Milestone": "3.16",
     "Author": "sqs",
     "CreatedAt": "2020-01-20T02:52:50Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTEwMDgwODg=",
@@ -1500,8 +1459,7 @@
     "Author": "unknwon",
     "CreatedAt": "2020-01-16T19:28:51Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-28T14:48:37Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-28T14:48:37Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTA5MTczMjU=",
@@ -1525,13 +1483,12 @@
     "Author": "kzh",
     "CreatedAt": "2020-01-16T16:27:23Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-26T12:24:45Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-26T12:24:45Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTA5MTM4NDg=",
     "Title": "search: Support AND / OR / NOT predicate language in search queries",
-    "Body": "This the umbrella issue for reaching feature parity with OpenGrok. This is an OKR of the Core Services team in Q1 2020.\r\n\r\nProgress:\r\n\r\n- [x] Design for and/or queries is tracked in #8346 \r\n- [ ] Implement predicates support for searching file content #8567\r\n  - [x] Parser additions #8633 #8802 #8784  #8809 \r\n  - [x] Refactors for existing search #8566 #8565 #8564\r\n- [ ] Add checking and/or query usage to pings #9177\r\n- [ ] Wish: extend search support to non-content searches (i.e., repo, filepath, commit, ... searches)\r\n\r\n---\r\n\r\nRelated documents: [RFC 94](https://docs.google.com/document/d/1nYv_p1138eHsN7WOw0s3x69Y0HK2L8x7VP-nFKQGal8/edit?ts=5e2845ae#heading=h.trqab8y0kufp)\r\nRelated issues: #7154,  #4774, #1005,#8397, #636",
+    "Body": "This the umbrella issue for reaching feature parity with OpenGrok. This is an OKR of the Core Services team in Q1 2020.\r\n\r\nProgress:\r\n\r\n- [x] Design for and/or queries is tracked in #8346 \r\n- [x] Implement predicates support for searching file content #8567\r\n  - [x] Parser additions #8633 #8802 #8784  #8809 \r\n  - [x] Refactors for existing search #8566 #8565 #8564\r\n  - [x] Heuristics to make search usable and robust #9762 #9816 \r\n  - [x] Basic query validation #9817 #9172 #9754 \r\n\r\n---\r\n\r\nQ2:\r\n- [ ] Checking and/or query usage to pings #9177\r\n- [ ] Refine query validation #9971 \r\n- [ ] Add `NOT` as syntactic sugar #9976\r\n- [ ] Explore search support to non-content searches (i.e., repo, filepath, commit, ... searches) #9974 \r\n\r\n---\r\n\r\nRelated documents: [RFC 94](https://docs.google.com/document/d/1nYv_p1138eHsN7WOw0s3x69Y0HK2L8x7VP-nFKQGal8/edit?ts=5e2845ae#heading=h.trqab8y0kufp)\r\nRelated issues: #7154,  #4774, #1005,#8397, #636",
     "Number": 7823,
     "URL": "https://github.com/sourcegraph/sourcegraph/issues/7823",
     "State": "OPEN",
@@ -1551,8 +1508,7 @@
     "Author": "tsenart",
     "CreatedAt": "2020-01-16T16:21:31Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NTAxODczNDU=",
@@ -1576,8 +1532,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-15T13:30:42Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDk1NzI0ODY=",
@@ -1602,8 +1557,7 @@
     "Author": "mrnugget",
     "CreatedAt": "2020-01-14T13:36:35Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-01-30T09:28:48Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-01-30T09:28:48Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDc4ODA3NDg=",
@@ -1629,8 +1583,7 @@
     "Author": "sqs",
     "CreatedAt": "2020-01-10T05:53:50Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY4NDQ2NDI=",
@@ -1648,15 +1601,12 @@
      "roadmap",
      "team/core-services"
     ],
-    "Assignees": [
-     "ryanslade"
-    ],
+    "Assignees": [],
     "Milestone": "Backlog",
     "Author": "ryanslade",
     "CreatedAt": "2020-01-08T12:59:25Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY4Mzk4Njk=",
@@ -1674,15 +1624,12 @@
      "roadmap",
      "team/core-services"
     ],
-    "Assignees": [
-     "ryanslade"
-    ],
+    "Assignees": [],
     "Milestone": "Backlog",
     "Author": "ryanslade",
     "CreatedAt": "2020-01-08T12:48:46Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY3ODU3MzA=",
@@ -1709,8 +1656,7 @@
     "Author": "tsenart",
     "CreatedAt": "2020-01-08T10:52:39Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-25T08:21:34Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-25T08:21:34Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDY1MTE1MjY=",
@@ -1731,8 +1677,7 @@
     "Author": "nicksnyder",
     "CreatedAt": "2020-01-07T21:15:48Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-02-20T11:19:13Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-02-20T11:19:13Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDU2MDc0NTE=",
@@ -1756,8 +1701,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2020-01-06T08:36:44Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-03-17T10:03:03Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-03-17T10:03:03Z"
    },
    {
     "ID": "MDU6SXNzdWU1NDE4MjEyMTI=",
@@ -1765,7 +1709,7 @@
     "Body": "I've been following the quick-start + GitLab instructions for getting the new integration working within GitLab.\r\n\r\nI got a must be logged into sourcegraph error in GitLab and even though I was logged in, I thought perhaps it needs the OAuth authentication setup - so I followed the instructions for configuring that and logged in.\r\n\r\nThe GitLab sign-in doesn't work - \"The redirect URI included is not valid.\" though I'm pretty sure I followed the instructions - not sure if it's not happy about the port or the http sourcegraph (it's https).\r\n\r\nNow every request to login (with the regular account I was previously using) is failing with \"Forbidden - CSRF token invalid\".\r\n\r\nI've cleared cookies, session, tried new browsers, etc. - same issue.\r\n\r\nI see a graphQL log \r\n![image](https://user-images.githubusercontent.com/692676/71368847-09902900-2577-11ea-9fc3-85a406a6707d.png)\r\n\r\nahead of each of the login attempt - not sure if that's \"using up\" the CSRF token.\r\n\r\nI can't access the site configuration because I can't login so I can't undo the GitLab OAuth setup either.\r\n",
     "Number": 7368,
     "URL": "https://github.com/sourcegraph/sourcegraph/issues/7368",
-    "State": "OPEN",
+    "State": "CLOSED",
     "Repository": "sourcegraph/sourcegraph",
     "Private": false,
     "Labels": [
@@ -1783,8 +1727,7 @@
     "Author": "philjones",
     "CreatedAt": "2019-12-23T16:28:24Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-04-14T21:12:53Z"
    },
    {
     "ID": "MDU6SXNzdWU1MzE2MTM5NjU=",
@@ -1810,8 +1753,7 @@
     "Author": "slimsag",
     "CreatedAt": "2019-12-02T23:48:21Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1Mjg5NjYzNjE=",
@@ -1837,8 +1779,7 @@
     "Author": "beyang",
     "CreatedAt": "2019-11-26T20:53:40Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1MjY3ODg2NzM=",
@@ -1861,12 +1802,11 @@
     "Assignees": [
      "rvantonder"
     ],
-    "Milestone": "3.15",
+    "Milestone": "Backlog",
     "Author": "kzh",
     "CreatedAt": "2019-11-21T19:13:21Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU1MTY1NDk4NDA=",
@@ -1892,8 +1832,7 @@
     "Author": "tsenart",
     "CreatedAt": "2019-11-02T09:40:33Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-03-02T14:48:49Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-03-02T14:48:49Z"
    },
    {
     "ID": "MDU6SXNzdWU0NTk2NzU2MDI=",
@@ -1914,12 +1853,11 @@
     "Assignees": [
      "keegancsmith"
     ],
-    "Milestone": "3.15",
+    "Milestone": "Backlog",
     "Author": "Antoine98",
     "CreatedAt": "2019-06-24T03:57:38Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU0NDI4MDg4NTk=",
@@ -1941,12 +1879,11 @@
     "Assignees": [
      "keegancsmith"
     ],
-    "Milestone": "3.15",
+    "Milestone": "Backlog",
     "Author": "tsenart",
     "CreatedAt": "2019-05-10T16:54:30Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWU0NDIyNDg4MDk=",
@@ -1972,8 +1909,7 @@
     "Author": "keegancsmith",
     "CreatedAt": "2019-05-09T13:52:19Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "2020-04-09T06:52:14Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-04-09T06:52:14Z"
    },
    {
     "ID": "MDU6SXNzdWUzODQ0NDcwMTM=",
@@ -1998,8 +1934,7 @@
     "Author": "beyang",
     "CreatedAt": "2018-11-26T18:02:28Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "0001-01-01T00:00:00Z"
    },
    {
     "ID": "MDU6SXNzdWUzNzY5Nzk3MzA=",
@@ -2007,7 +1942,7 @@
     "Body": "Some sites put an HTTPS or SSH proxy in front of their code host to reduce load. Some sites also use a service like AWS CodeCommit to do the same. In these cases, the repos still should be treated as being repos on the original code host, not the proxy site.\r\n\r\nFor example, I have a GitHub repo github.com/foo/bar. I want Sourcegraph to clone it using the URL https://cloneproxy.example.com/foo/bar.git. But I still want the \"Go to GitHub repository\" button, etc., to take me to https://github.com/foo/bar.\r\n\r\n- Document workaround of using `ssh_config` or `gitconfig`'s `insteadOf`\r\n- Support this as a first-class feature (not scheduled yet)\r\n\r\nThe actual code work is not prioritized, this is just a docs change.",
     "Number": 658,
     "URL": "https://github.com/sourcegraph/sourcegraph/issues/658",
-    "State": "OPEN",
+    "State": "CLOSED",
     "Repository": "sourcegraph/sourcegraph",
     "Private": false,
     "Labels": [
@@ -2025,11 +1960,10 @@
     "Author": "sqs",
     "CreatedAt": "2018-11-02T21:54:23Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
-    "ClosedAt": "0001-01-01T00:00:00Z",
-    "Deprioritised": false
+    "ClosedAt": "2020-04-14T07:42:00Z"
    }
   ],
-  "PullRequests": [
+  "PRs": [
    {
     "ID": "MDExOlB1bGxSZXF1ZXN0Mzc2OTc5OTIw",
     "Title": "Support build status event webhook",
@@ -2048,7 +1982,7 @@
     "CreatedAt": "2020-02-19T05:57:56Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
     "ClosedAt": "2020-02-20T07:20:17Z",
-    "BeganAt": "2020-02-19T10:54:56Z"
+    "BeganAt": "2020-02-19T05:55:05Z"
    },
    {
     "ID": "MDExOlB1bGxSZXF1ZXN0MzY3NDczMTUw",
@@ -2069,7 +2003,7 @@
     "CreatedAt": "2020-01-27T12:49:52Z",
     "UpdatedAt": "0001-01-01T00:00:00Z",
     "ClosedAt": "2020-01-27T13:40:45Z",
-    "BeganAt": "2020-01-27T12:47:53Z"
+    "BeganAt": "2020-01-27T10:58:08Z"
    }
   ]
  }

--- a/internal/cmd/tracking-issue/testdata/issue.md
+++ b/internal/cmd/tracking-issue/testdata/issue.md
@@ -1,4 +1,13 @@
 
+@Unassigned
+
+- [ ] ~a8n/core: Extend GraphQL API to include participant users involved in the campaign~ [#7552](https://github.com/sourcegraph/sourcegraph/issues/7552) __1d__ 🛠️
+- [ ] ~a8n/core: Expose comments of all changesets in campaign in GraphQL API~ [#7548](https://github.com/sourcegraph/sourcegraph/issues/7548) __2d__ 🛠️
+
+@asdine
+
+- [ ] ~Reject invalid externalURL with non-/ path~ [#7884](https://github.com/sourcegraph/sourcegraph/issues/7884) __2d__ 🐛
+
 @keegancsmith: __8.00d__
 
 - [x] e2e: log all e2e failures into central location for triage [#8026](https://github.com/sourcegraph/sourcegraph/issues/8026) __1d__ 
@@ -16,7 +25,7 @@
 - [ ] ~Gitlab OAuth certificate signed by unknown authority~ [#4652](https://github.com/sourcegraph/sourcegraph/issues/4652) __0.5d__ 🐛👩
 - [ ] ~Support SSH key credentials directly in external service configs~ [#3924](https://github.com/sourcegraph/sourcegraph/issues/3924) __2d__ 👩
 - [x] ~docs: Ensure new arch for repo-updater is reflected in dev docs~ [#3911](https://github.com/sourcegraph/sourcegraph/issues/3911) __0.5d__ 🧶
-- [ ] ~docs: Document using an alternate clone URL for repos~ [#658](https://github.com/sourcegraph/sourcegraph/issues/658) __0.5d__ 🧶
+- [x] ~docs: Document using an alternate clone URL for repos~ [#658](https://github.com/sourcegraph/sourcegraph/issues/658) __0.5d__ 🧶
 
 @kzh: __6.50d__
 
@@ -27,7 +36,7 @@
 - [x] a8n/core: Extend CreateCampaignInput to accept Branch and persist it [#7687](https://github.com/sourcegraph/sourcegraph/issues/7687) __2d__ 🛠️
 - [x] Password-reset link not rendered for non-admin users [#7520](https://github.com/sourcegraph/sourcegraph/issues/7520) __0.5d__ 🐛
 - [x] Error fetching commit author info from GraphQL API [#5335](https://github.com/sourcegraph/sourcegraph/issues/5335) __1d__ [👩](https://app.hubspot.com/contacts/2762526/company/814799425)🐛
-- [x] ~Simplify Bitbucket Server plugin interaction with Sourcegraph~ [#7824](https://github.com/sourcegraph/sourcegraph/issues/7824) __3d__ 
+- [x] Simplify Bitbucket Server plugin interaction with Sourcegraph [#7824](https://github.com/sourcegraph/sourcegraph/issues/7824) __3d__ 
 
 @mrnugget: __10.00d__
 
@@ -48,7 +57,7 @@
 - [x] Enforce warnings for unsupported parameters and filters in structural search [#7293](https://github.com/sourcegraph/sourcegraph/issues/7293) __1d__ 🧶
 - [x] Backend returns invalid filter chip with space "lang:ignore list" [#6498](https://github.com/sourcegraph/sourcegraph/issues/6498) __2d__ [👩](https://app.hubspot.com/contacts/2762526/company/419771425)🐛
 - [x] Impossible to search for colons in literal search [#6490](https://github.com/sourcegraph/sourcegraph/issues/6490) __2d__ 🐛
-- [ ] ~search: Support AND / OR / NOT predicate language in search queries~ [#7823](https://github.com/sourcegraph/sourcegraph/issues/7823) 👩🛠️
+- [ ] search: Support AND / OR / NOT predicate language in search queries [#7823](https://github.com/sourcegraph/sourcegraph/issues/7823) 👩🛠️
 - [ ] ~search filter `archived`/`fork` "yes/no/only" values are confusing~ [#7003](https://github.com/sourcegraph/sourcegraph/issues/7003) __4d__ [👩](https://app.hubspot.com/contacts/2762526/company/1749284052)🛠️
 - [ ] ~Address repohascommitafter search filter performance bottleneck~ [#6745](https://github.com/sourcegraph/sourcegraph/issues/6745) __1d__ 👩🕵️
 
@@ -63,8 +72,6 @@
 - [x] a8n/core: GraphQL API for an extended campaign list view [#7553](https://github.com/sourcegraph/sourcegraph/issues/7553) __2d__ 🛠️
 - [x] a8n/core: Expose labels of all changesets in campaign in GraphQL API [#7549](https://github.com/sourcegraph/sourcegraph/issues/7549) __1d__ 
 - [x] a8n/core: Expose CI status on changesets [#7093](https://github.com/sourcegraph/sourcegraph/issues/7093) __2d__ 🛠️
-- [ ] ~a8n/core: Extend GraphQL API to include participant users involved in the campaign~ [#7552](https://github.com/sourcegraph/sourcegraph/issues/7552) __1d__ 🛠️
-- [ ] ~a8n/core: Expose comments of all changesets in campaign in GraphQL API~ [#7548](https://github.com/sourcegraph/sourcegraph/issues/7548) __2d__ 🛠️
 - [x] ~Diagnose and fix slow /.api/registry/extensions endpoint~ [#7544](https://github.com/sourcegraph/sourcegraph/issues/7544) __1d__ 🧶
 - [x] ~campaigns: Heuristic syncing of Changesets and ChangesetEvents~ [#6388](https://github.com/sourcegraph/sourcegraph/issues/6388) __4d__ 🧶
 
@@ -75,7 +82,6 @@
 - [x] Prevent upgrading more than one minor version at a time [#7702](https://github.com/sourcegraph/sourcegraph/issues/7702) __1d__ 🐛
 - [x] Redis AOF file grows unbounded due to frequent container restarts [#3300](https://github.com/sourcegraph/sourcegraph/issues/3300) __2d__ 
 - [x] redis: Log spam warning when redis is loading the dataset in memory [#2904](https://github.com/sourcegraph/sourcegraph/issues/2904) 🐛👩
-- [ ] ~Reject invalid externalURL with non-/ path~ [#7884](https://github.com/sourcegraph/sourcegraph/issues/7884) __0.5d__ 🐛
 
 @unknwon: __16.00d__
 
@@ -98,6 +104,6 @@
 - [x] postgresql: (Auto)tune DB pool sizes based on max_connections [#3473](https://github.com/sourcegraph/sourcegraph/issues/3473) __3d__ [👩](https://app.hubspot.com/contacts/2762526/company/419771425)
 - [ ] ~Make new pricing tiers reflected in feature access~ [#7927](https://github.com/sourcegraph/sourcegraph/issues/7927) __1d__ 🐛
 - [x] ~RFC 40: Add Prometheus metrics~ [#7827](https://github.com/sourcegraph/sourcegraph/issues/7827) __1d__ 🛠️
-- [x] ~sourcegraph/security-issues~ [#53](https://github.com/sourcegraph/security-issues/issues/53) 
-- [ ] ~Forbidden - CSRF token invalid~ [#7368](https://github.com/sourcegraph/sourcegraph/issues/7368) __2d__ 🐛
+- [x] sourcegraph/security-issues [#53](https://github.com/sourcegraph/security-issues/issues/53) 
+- [x] ~Forbidden - CSRF token invalid~ [#7368](https://github.com/sourcegraph/sourcegraph/issues/7368) __2d__ 🐛
 - [ ] ~Auth: explicit session invalidation~ [#1126](https://github.com/sourcegraph/sourcegraph/issues/1126) __2d__ 🔒


### PR DESCRIPTION
This PR changes the tracking-issue tool to simplify how we create tracking issues and have them be automatically updated.

Before, changing which tracking issues are automatically updated required a change and pull request to the "Tracking Issue Syncer" GitHub Action definition. This needed to happen on every milestone change, for instance.

With this change, the tool instead finds all open tracking issues in the sourcegraph repo that have the **tracking** label, searches for all their issues and PRs (that have the rest of the labels in the tracking issue), and updates them automatically when there are modifications.

Additionally, this change set also makes it possible for tracking issues to be created for any other label, even if the tracking issue isn't bound to a milestone. This allows us to have tracking issues for things like RFCs, OKRs, etc. cc @nicksnyder 

All of this will be documented properly in https://github.com/sourcegraph/about/pull/786.