### PR TITLE
auth: ensure the redirect URL always starts with a single slash

### DIFF
--- a/cmd/frontend/auth/redirect.go
+++ b/cmd/frontend/auth/redirect.go
@@ -15,6 +15,9 @@ func SafeRedirectURL(urlStr string) string {
 		return "/"
 	}
 
+	// Make sure u.Path always starts with a single slash.
+	u.Path = "/" + strings.TrimLeft(u.Path, "/")
+
 	// Only take certain known-safe fields.
 	u = &url.URL{Path: u.Path, RawQuery: u.RawQuery}
 	return u.String()

--- a/cmd/frontend/auth/redirect.go
+++ b/cmd/frontend/auth/redirect.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/url"
+	"path"
 	"strings"
 )
 

--- a/cmd/frontend/auth/redirect.go
+++ b/cmd/frontend/auth/redirect.go
@@ -16,7 +16,7 @@ func SafeRedirectURL(urlStr string) string {
 	}
 
 	// Make sure u.Path always starts with a single slash.
-	u.Path = "/" + strings.TrimLeft(u.Path, "/")
+	u.Path = path.Clean(u.Path)
 
 	// Only take certain known-safe fields.
 	u = &url.URL{Path: u.Path, RawQuery: u.RawQuery}

--- a/cmd/frontend/auth/redirect_test.go
+++ b/cmd/frontend/auth/redirect_test.go
@@ -4,15 +4,16 @@ import "testing"
 
 func TestSafeRedirectURL(t *testing.T) {
 	tests := map[string]string{
-		"":               "/",
-		"/":              "/",
-		"a@b.com:c":      "/",
-		"a@b.com/c":      "/",
-		"//a":            "/",
-		"http://a.com/b": "/b",
-		"//a.com/b":      "/b",
-		"//a@b.com/c":    "/c",
-		"/a?b":           "/a?b",
+		"":                   "/",
+		"/":                  "/",
+		"a@b.com:c":          "/",
+		"a@b.com/c":          "/",
+		"//a":                "/",
+		"http://a.com/b":     "/b",
+		"//a.com/b":          "/b",
+		"//a@b.com/c":        "/c",
+		"/a?b":               "/a?b",
+		"//foo//example.com": "/example.com",
 	}
 	for input, want := range tests {
 		got := SafeRedirectURL(input)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/security-issues/issues/63