### PR TITLE
Add a diffStat field on Campaign to return combined diffStat

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -218,6 +218,8 @@ type CampaignResolver interface {
 	ClosedAt() *DateTime
 	PublishedAt(ctx context.Context) (*DateTime, error)
 	Patches(ctx context.Context, args *graphqlutil.ConnectionArgs) PatchConnectionResolver
+
+	DiffStat(ctx context.Context) (*DiffStat, error)
 }
 
 type CampaignsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -218,7 +218,6 @@ type CampaignResolver interface {
 	ClosedAt() *DateTime
 	PublishedAt(ctx context.Context) (*DateTime, error)
 	Patches(ctx context.Context, args *graphqlutil.ConnectionArgs) PatchConnectionResolver
-
 	DiffStat(ctx context.Context) (*DiffStat, error)
 }
 

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -401,6 +401,12 @@ func (r *DiffStat) AddStat(s diff.Stat) {
 	r.deleted += s.Deleted
 }
 
+func (r *DiffStat) AddDiffStat(s *DiffStat) {
+	r.added += s.Added()
+	r.changed += s.Changed()
+	r.deleted += s.Deleted()
+}
+
 func (r *DiffStat) Added() int32   { return r.added }
 func (r *DiffStat) Changed() int32 { return r.changed }
 func (r *DiffStat) Deleted() int32 { return r.deleted }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -622,6 +622,9 @@ type Campaign implements Node {
     # Campaign.status increments with every Patch turned into an
     # ExternalChangeset.
     patches(first: Int): PatchConnection!
+
+    # The diff stat for all the patches and changesets in the Campaign.
+    diffStat: DiffStat!
 }
 
 # The counts of changesets in certain states at a specific point in time.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -629,6 +629,9 @@ type Campaign implements Node {
     # Campaign.status increments with every Patch turned into an
     # ExternalChangeset.
     patches(first: Int): PatchConnection!
+
+    # The diff stat for all the patches and changesets in the Campaign.
+    diffStat: DiffStat!
 }
 
 # The counts of changesets in certain states at a specific point in time.

--- a/enterprise/internal/campaigns/resolvers/patch_sets.go
+++ b/enterprise/internal/campaigns/resolvers/patch_sets.go
@@ -345,6 +345,7 @@ func (r *previewFileDiffConnectionResolver) DiffStat(ctx context.Context) (*grap
 	}
 	return stat, nil
 }
+
 func (r *previewFileDiffConnectionResolver) RawDiff(ctx context.Context) (string, error) {
 	fileDiffs, err := r.compute(ctx)
 	if err != nil {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -104,7 +104,7 @@ func (r *Resolver) PatchByID(ctx context.Context, id graphql.ID) (graphqlbackend
 		return nil, err
 	}
 
-	job, err := r.store.GetPatch(ctx, ee.GetPatchOpts{ID: patchID})
+	patch, err := r.store.GetPatch(ctx, ee.GetPatchOpts{ID: patchID})
 	if err != nil {
 		if err == ee.ErrNoResults {
 			return nil, nil
@@ -112,7 +112,7 @@ func (r *Resolver) PatchByID(ctx context.Context, id graphql.ID) (graphqlbackend
 		return nil, err
 	}
 
-	return &patchResolver{store: r.store, job: job}, nil
+	return &patchResolver{store: r.store, patch: patch}, nil
 }
 
 func (r *Resolver) PatchSetByID(ctx context.Context, id graphql.ID) (graphqlbackend.PatchSetResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -570,6 +570,7 @@ func TestCampaigns(t *testing.T) {
 		Namespace               UserOrg
 		Changesets              ChangesetConnection
 		ChangesetCountsOverTime []ChangesetCounts
+		DiffStat                DiffStat
 	}
 
 	var addChangesetsResult struct{ Campaign CampaignWithChangesets }
@@ -625,6 +626,11 @@ func TestCampaigns(t *testing.T) {
 				openApproved
 				openChangesRequested
 				openPending
+			}
+			diffStat {
+				added
+				changed
+				deleted
 			}
 		}
 		mutation() {
@@ -687,6 +693,14 @@ func TestCampaigns(t *testing.T) {
 			if have, want := c.Total, int32(1); have != want {
 				t.Errorf("wrong changeset counts total %d, have=%d", want, have)
 			}
+		}
+	}
+
+	{
+		have := addChangesetsResult.Campaign.DiffStat
+		want := DiffStat{Added: 0, Changed: 0, Deleted: 0}
+		if have != want {
+			t.Errorf("wrong campaign combined diffstat. want=%v, have=%v", want, have)
 		}
 	}
 

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 
-	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -1530,7 +1529,7 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	gitClient := &dummyGitserverClient{response: headRef, responseErr: nil}
+	gitClient := &ee.FakeGitserverClient{Response: headRef, ResponseErr: nil}
 
 	sourcer := repos.NewFakeSourcer(nil, ee.FakeChangesetSource{
 		Svc:          ext,
@@ -1823,14 +1822,4 @@ func newGitHubTestRepo(name string, externalID int) *repos.Repo {
 			},
 		},
 	}
-}
-
-// This is copied from campaigns/service_test.go
-type dummyGitserverClient struct {
-	response    string
-	responseErr error
-}
-
-func (d *dummyGitserverClient) CreateCommitFromPatch(ctx context.Context, req gitprotocol.CreateCommitFromPatchRequest) (string, error) {
-	return d.response, d.responseErr
 }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,12 +34,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+
+	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -698,6 +704,8 @@ func TestCampaigns(t *testing.T) {
 
 	{
 		have := addChangesetsResult.Campaign.DiffStat
+		// Expected DiffStat is zeros, because we don't return diffstats for
+		// closed changesets
 		want := DiffStat{Added: 0, Changed: 0, Deleted: 0}
 		if have != want {
 			t.Errorf("wrong campaign combined diffstat. want=%v, have=%v", want, have)
@@ -745,16 +753,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 		return now.UTC().Truncate(time.Microsecond)
 	}
 
-	u, err := db.Users.Create(ctx, db.NewUser{
-		Email:                 "thorsten@sourcegraph.com",
-		Username:              "thorsten",
-		DisplayName:           "thorsten",
-		Password:              "1234",
-		EmailVerificationCode: "foobar",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	u := createTestUser(ctx, t)
 
 	repoStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	githubExtSvc := &repos.ExternalService{
@@ -767,7 +766,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 		}),
 	}
 
-	err = repoStore.UpsertExternalServices(ctx, githubExtSvc)
+	err := repoStore.UpsertExternalServices(ctx, githubExtSvc)
 	if err != nil {
 		t.Fatal(t)
 	}
@@ -956,8 +955,9 @@ type FileDiffs struct {
 }
 
 type Patch struct {
-	Repository struct{ Name, URL string }
-	Diff       struct {
+	PublicationEnqueued bool
+	Repository          struct{ Name, URL string }
+	Diff                struct {
 		FileDiffs FileDiffs
 	}
 }
@@ -1026,20 +1026,7 @@ func TestCreatePatchSetFromPatchesResolver(t *testing.T) {
 		defer func() { backend.Mocks.Repos.GetCommit = nil }()
 
 		reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
-		repo := &repos.Repo{
-			Name: "github.com/sourcegraph/sourcegraph",
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "external-id",
-				ServiceType: "github",
-				ServiceID:   "https://github.com/",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:github:4": {
-					ID:       "extsvc:github:4",
-					CloneURL: "https://secrettoken@github.com/sourcegraph/sourcegraph",
-				},
-			},
-		}
+		repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
 		if err := reposStore.UpsertRepos(ctx, repo); err != nil {
 			t.Fatal(err)
 		}
@@ -1161,22 +1148,7 @@ func TestPatchSetResolver(t *testing.T) {
 
 	var rs []*repos.Repo
 	for i := 0; i < 3; i++ {
-		repo := &repos.Repo{
-			Name:        fmt.Sprintf("github.com/sourcegraph/sourcegraph-%d", i),
-			URI:         fmt.Sprintf("github.com/sourcegraph/sourcegraph-%d", i),
-			Description: "Code search and navigation tool",
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          fmt.Sprintf("external-id-%d", i),
-				ServiceType: "github",
-				ServiceID:   "https://github.com/",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:github:4": {
-					ID:       "extsvc:github:4",
-					CloneURL: "https://secrettoken@github.com/sourcegraph/sourcegraph",
-				},
-			},
-		}
+		repo := newGitHubTestRepo(fmt.Sprintf("github.com/sourcegraph/sourcegraph-%d", i), i)
 		err := reposStore.UpsertRepos(ctx, repo)
 		if err != nil {
 			t.Fatal(err)
@@ -1293,6 +1265,382 @@ func TestPatchSetResolver(t *testing.T) {
 		if !reflect.DeepEqual(haveFileDiffs, wantFileDiffs) {
 			t.Fatal(cmp.Diff(haveFileDiffs, wantFileDiffs))
 		}
+	}
+}
+
+func TestCreateCampaignWithPatchSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	dbtesting.SetupGlobalTestDB(t)
+	rcache.SetupForTest(t)
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	user := createTestUser(ctx, t)
+	act := actor.FromUser(user.ID)
+	ctx = actor.WithActor(ctx, act)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+
+	testBaseRevision := api.CommitID("24f7ca7c1190835519e261d7eefa09df55ceea4f")
+	testBaseRef := "refs/heads/master"
+
+	// gitserver Mocks
+	backend.Mocks.Repos.ResolveRev = func(_ context.Context, _ *types.Repo, _ string) (api.CommitID, error) {
+		return testBaseRevision, nil
+	}
+	defer func() { backend.Mocks.Repos.ResolveRev = nil }()
+
+	backend.Mocks.Repos.GetCommit = func(_ context.Context, _ *types.Repo, _ api.CommitID) (*git.Commit, error) {
+		return &git.Commit{ID: testBaseRevision}, nil
+	}
+	defer func() { backend.Mocks.Repos.GetCommit = nil }()
+
+	// repo & external service setup
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+	ext := &repos.ExternalService{
+		Kind:        github.ServiceType,
+		DisplayName: "GitHub",
+		Config: marshalJSON(t, &schema.GitHubConnection{
+			Url:   "https://github.com",
+			Token: "SECRETTOKEN",
+		}),
+	}
+
+	if err := reposStore.UpsertExternalServices(ctx, ext); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
+	repo.Sources = map[string]*repos.SourceInfo{ext.URN(): {ID: ext.URN()}}
+
+	if err := reposStore.UpsertRepos(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup schema resolver
+	store := ee.NewStoreWithClock(dbconn.Global, clock)
+	sr := &Resolver{store: store}
+	s, err := graphqlbackend.NewSchema(sr, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start test
+	var createPatchSetResponse struct{ CreatePatchSetFromPatches PatchSet }
+	mustExec(ctx, t, s, nil, &createPatchSetResponse, fmt.Sprintf(`
+		mutation {
+			createPatchSetFromPatches(patches: [{repository: %q, baseRevision: %q, baseRef: %q, patch: %q}]) {
+				... on PatchSet {
+					id
+					previewURL
+				}
+			}
+		}
+	`, graphqlbackend.MarshalRepositoryID(api.RepoID(repo.ID)), testBaseRevision, testBaseRef, testDiff))
+
+	patchSetID := createPatchSetResponse.CreatePatchSetFromPatches.ID
+
+	type Changeset struct {
+		ID          string
+		Title       string
+		Body        string
+		State       string
+		ExternalURL struct {
+			URL         string
+			ServiceType string
+		}
+		ReviewState string
+		CheckState  string
+		Diff        struct {
+			FileDiffs FileDiffs
+		}
+	}
+
+	type Campaign struct {
+		ID     string
+		Name   string
+		Branch string
+		Status struct {
+			State string
+		}
+		Description string
+		Patches     struct {
+			Nodes      []Patch
+			TotalCount int
+		}
+		Changesets struct {
+			Nodes      []Changeset
+			TotalCount int
+		}
+		DiffStat DiffStat
+	}
+
+	var createCampaignResponse struct{ CreateCampaign Campaign }
+
+	input := map[string]interface{}{
+		"input": map[string]interface{}{
+			"namespace":   string(graphqlbackend.MarshalUserID(user.ID)),
+			"name":        "Campaign with PatchSet",
+			"description": "This campaign has a patchset",
+			"draft":       true,
+			"patchSet":    patchSetID,
+			"branch":      "my-cool-branch",
+		},
+	}
+
+	mustExec(ctx, t, s, input, &createCampaignResponse, `
+    fragment c on Campaign {
+      id
+      branch
+      status { state }
+      patches {
+        nodes {
+          publicationEnqueued
+          repository {
+            name
+          }
+          diff {
+            fileDiffs {
+              rawDiff
+              diffStat {
+                added
+                deleted
+                changed
+              }
+              nodes {
+                oldPath
+                newPath
+                hunks {
+                  body
+                  section
+                  newRange { startLine, lines }
+                  oldRange { startLine, lines }
+                  oldNoNewlineAt
+                }
+                stat {
+                  added
+                  deleted
+                  changed
+                }
+                oldFile {
+                  name
+                  externalURLs {
+                    serviceType
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      diffStat {
+        added
+        deleted
+        changed
+      }
+    }
+
+    mutation($input: CreateCampaignInput!) {
+      createCampaign(input: $input) { ...c }
+    }
+	`)
+
+	campaign := createCampaignResponse.CreateCampaign
+	if campaign.ID == "" {
+		log.Fatalf("Campaign does not have ID!")
+	}
+
+	if have, want := len(campaign.Patches.Nodes), 1; have != want {
+		log.Fatalf("wrong length of patches. want=%d, have=%d", want, have)
+	}
+
+	if campaign.DiffStat.Changed != 2 {
+		t.Fatalf("diffstat is wrong: %+v", campaign.DiffStat)
+	}
+
+	patch := campaign.Patches.Nodes[0]
+	if have, want := campaign.DiffStat, patch.Diff.FileDiffs.DiffStat; have != want {
+		t.Errorf("wrong campaign combined diffstat. want=%v, have=%v", want, have)
+	}
+
+	if patch.PublicationEnqueued {
+		t.Errorf("patch PublicationEnqueued is true, want false")
+	}
+
+	var publishCampaignResponse struct{ PublishCampaign Campaign }
+	mustExec(ctx, t, s, nil, &publishCampaignResponse, fmt.Sprintf(`
+      mutation {
+        publishCampaign(campaign: %q) {
+          id
+          status { state }
+          branch
+          patches {
+            nodes {
+              publicationEnqueued
+            }
+          }
+        }
+      }
+	`, campaign.ID))
+
+	publishedCampaign := publishCampaignResponse.PublishCampaign
+	if publishedCampaign.Status.State != "PROCESSING" {
+		t.Fatalf("campaign is not in state 'PROCESSING': %q", publishedCampaign.Status.State)
+	}
+	enqueuedPatch := publishedCampaign.Patches.Nodes[0]
+	if !enqueuedPatch.PublicationEnqueued {
+		t.Fatalf("patch is not enqueued for publication")
+	}
+
+	// Now we need to run the created ChangsetJob
+	changesetJobs, _, err := store.ListChangesetJobs(ctx, ee.ListChangesetJobsOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(changesetJobs) != 1 {
+		t.Fatalf("more than 1 changeset jobs created: %d", len(changesetJobs))
+	}
+
+	headRef := "refs/heads/" + campaign.Branch
+
+	fakePR := &github.PullRequest{
+		ID:          "FOOBARID",
+		Title:       campaign.Name,
+		Body:        campaign.Description,
+		HeadRefName: git.AbbreviateRef(headRef),
+		Number:      12345,
+		State:       "OPEN",
+		TimelineItems: []github.TimelineItem{
+			{Type: "PullRequestCommit", Item: &github.PullRequestCommit{
+				Commit: github.Commit{
+					OID:           "new-f00bar",
+					PushedDate:    now,
+					CommittedDate: now,
+				},
+			}},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	gitClient := &dummyGitserverClient{response: headRef, responseErr: nil}
+
+	sourcer := repos.NewFakeSourcer(nil, fakeChangesetSource{
+		svc:          ext,
+		wantHeadRef:  headRef,
+		wantBaseRef:  testBaseRef,
+		fakeMetadata: fakePR,
+	})
+
+	job := changesetJobs[0]
+
+	c, err := store.GetCampaign(ctx, ee.GetCampaignOpts{ID: job.CampaignID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: We need a transaction here because ExecChangesetJob expects a
+	// wrapping tx. We can remove that assertion from ExecChangesetJob though
+	// and then remove the tx here.
+	tx, err := store.Transact(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ee.ExecChangesetJob(ctx, clock, tx, gitClient, sourcer, c, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx.Done(nil)
+
+	updatedJob, err := store.GetChangesetJob(ctx, ee.GetChangesetJobOpts{ID: job.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedJob.ChangesetID == 0 {
+		t.Fatal("ChangesetJob.ChangesetID has not been updated")
+	}
+
+	// We need to setup these mocks because the GraphQL now needs to talk to
+	// gitserver to calculate the diff for a changeset.
+	git.Mocks.GetCommit = func(api.CommitID) (*git.Commit, error) {
+		return &git.Commit{ID: testBaseRevision}, nil
+	}
+	defer func() { git.Mocks.GetCommit = nil }()
+
+	git.Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+		if len(args) < 1 && args[0] != "diff" {
+			t.Fatalf("gitserver.ExecReader received wrong args: %v", args)
+		}
+		return ioutil.NopCloser(strings.NewReader(testDiff)), nil
+	}
+	defer func() { git.Mocks.ExecReader = nil }()
+
+	var queryCampaignResponse struct {
+		Node Campaign
+	}
+
+	mustExec(ctx, t, s, nil, &queryCampaignResponse, fmt.Sprintf(`
+	    fragment c on Campaign {
+	      id
+	      status { state }
+	      branch
+	      patches {
+	        totalCount
+	      }
+	      changesets {
+	        nodes {
+	          state
+	          diff {
+	            fileDiffs {
+	              diffStat {
+	                added
+	                deleted
+	                changed
+	              }
+	            }
+	          }
+	        }
+	        totalCount
+	      }
+	      diffStat {
+	        added
+	        deleted
+	        changed
+	      }
+	    }
+
+	    query {
+	      node(id: %q) { ...c }
+	    }
+	`, campaign.ID))
+
+	campaign = queryCampaignResponse.Node
+	if campaign.Status.State != "COMPLETED" {
+		t.Fatalf("campaign is not in state 'COMPLETED': %q", campaign.Status.State)
+	}
+
+	if campaign.Patches.TotalCount != 0 {
+		t.Fatalf("campaign.Patches.TotalCount is not zero: %d", campaign.Patches.TotalCount)
+	}
+
+	if campaign.Changesets.TotalCount != 1 {
+		t.Fatalf("campaign.Patches.TotalCount is not zero: %d", campaign.Patches.TotalCount)
+	}
+
+	if campaign.DiffStat.Changed != 2 {
+		t.Fatalf("diffstat is wrong: %+v", campaign.DiffStat)
+	}
+
+	changeset := campaign.Changesets.Nodes[0]
+	if have, want := campaign.DiffStat, changeset.Diff.FileDiffs.DiffStat; have != want {
+		t.Errorf("wrong campaign combined diffstat. want=%v, have=%v", want, have)
 	}
 }
 
@@ -1458,4 +1806,90 @@ func createTestUser(ctx context.Context, t *testing.T) *types.User {
 		t.Fatal(err)
 	}
 	return user
+}
+
+func newGitHubTestRepo(name string, externalID int) *repos.Repo {
+	return &repos.Repo{
+		Name: name,
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          fmt.Sprintf("external-id-%d", externalID),
+			ServiceType: "github",
+			ServiceID:   "https://github.com/",
+		},
+		Sources: map[string]*repos.SourceInfo{
+			"extsvc:github:4": {
+				ID:       "extsvc:github:4",
+				CloneURL: fmt.Sprintf("https://secrettoken@%s", name),
+			},
+		},
+	}
+}
+
+// This is copied from campaigns/workers_test.go. We should probably find a better place for this?
+type fakeChangesetSource struct {
+	svc *repos.ExternalService
+
+	wantHeadRef string
+	wantBaseRef string
+
+	fakeMetadata interface{}
+	exists       bool
+	err          error
+}
+
+func (s fakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
+	if s.err != nil {
+		return s.exists, s.err
+	}
+
+	if c.HeadRef != s.wantHeadRef {
+		return s.exists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.wantHeadRef, c.HeadRef)
+	}
+
+	if c.BaseRef != s.wantBaseRef {
+		return s.exists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
+	}
+
+	c.SetMetadata(s.fakeMetadata)
+
+	return s.exists, s.err
+}
+
+func (s fakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Changeset) error {
+	if s.err != nil {
+		return s.err
+	}
+
+	if c.BaseRef != s.wantBaseRef {
+		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
+	}
+
+	c.SetMetadata(s.fakeMetadata)
+	return nil
+}
+
+var fakeNotImplemented = errors.New("not implement in fakeChangesetSource")
+
+func (s fakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
+	results <- repos.SourceResult{Source: s, Err: fakeNotImplemented}
+}
+
+func (s fakeChangesetSource) ExternalServices() repos.ExternalServices {
+	return repos.ExternalServices{s.svc}
+}
+func (s fakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Changeset) error {
+	return fakeNotImplemented
+}
+func (s fakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
+	return fakeNotImplemented
+}
+
+// This is copied from campaigns/service_test.go
+type dummyGitserverClient struct {
+	response    string
+	responseErr error
+}
+
+func (d *dummyGitserverClient) CreateCommitFromPatch(ctx context.Context, req gitprotocol.CreateCommitFromPatchRequest) (string, error) {
+	return d.response, d.responseErr
 }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1532,11 +1532,11 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 
 	gitClient := &dummyGitserverClient{response: headRef, responseErr: nil}
 
-	sourcer := repos.NewFakeSourcer(nil, fakeChangesetSource{
-		svc:          ext,
-		wantHeadRef:  headRef,
-		wantBaseRef:  testBaseRef,
-		fakeMetadata: fakePR,
+	sourcer := repos.NewFakeSourcer(nil, ee.FakeChangesetSource{
+		Svc:          ext,
+		WantHeadRef:  headRef,
+		WantBaseRef:  testBaseRef,
+		FakeMetadata: fakePR,
 	})
 
 	job := changesetJobs[0]
@@ -1823,65 +1823,6 @@ func newGitHubTestRepo(name string, externalID int) *repos.Repo {
 			},
 		},
 	}
-}
-
-// This is copied from campaigns/workers_test.go. We should probably find a better place for this?
-type fakeChangesetSource struct {
-	svc *repos.ExternalService
-
-	wantHeadRef string
-	wantBaseRef string
-
-	fakeMetadata interface{}
-	exists       bool
-	err          error
-}
-
-func (s fakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
-	if s.err != nil {
-		return s.exists, s.err
-	}
-
-	if c.HeadRef != s.wantHeadRef {
-		return s.exists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.wantHeadRef, c.HeadRef)
-	}
-
-	if c.BaseRef != s.wantBaseRef {
-		return s.exists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
-	}
-
-	c.SetMetadata(s.fakeMetadata)
-
-	return s.exists, s.err
-}
-
-func (s fakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Changeset) error {
-	if s.err != nil {
-		return s.err
-	}
-
-	if c.BaseRef != s.wantBaseRef {
-		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
-	}
-
-	c.SetMetadata(s.fakeMetadata)
-	return nil
-}
-
-var fakeNotImplemented = errors.New("not implement in fakeChangesetSource")
-
-func (s fakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
-	results <- repos.SourceResult{Source: s, Err: fakeNotImplemented}
-}
-
-func (s fakeChangesetSource) ExternalServices() repos.ExternalServices {
-	return repos.ExternalServices{s.svc}
-}
-func (s fakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Changeset) error {
-	return fakeNotImplemented
-}
-func (s fakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
-	return fakeNotImplemented
 }
 
 // This is copied from campaigns/service_test.go

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
@@ -39,7 +38,7 @@ func TestService(t *testing.T) {
 		return now.UTC().Truncate(time.Microsecond)
 	}
 
-	gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
+	gitClient := &FakeGitserverClient{Response: "testresponse", ResponseErr: nil}
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	user := createTestUser(ctx, t)
@@ -467,7 +466,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 		return now.UTC().Truncate(time.Microsecond)
 	}
 
-	gitClient := &dummyGitserverClient{response: "testresponse", responseErr: nil}
+	gitClient := &FakeGitserverClient{Response: "testresponse", ResponseErr: nil}
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	user := createTestUser(ctx, t)
@@ -1170,13 +1169,4 @@ func testChangeset(repoID api.RepoID, campaign int64, changesetJob int64, state 
 		Metadata:            pr,
 		ExternalState:       state,
 	}
-}
-
-type dummyGitserverClient struct {
-	response    string
-	responseErr error
-}
-
-func (d *dummyGitserverClient) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
-	return d.response, d.responseErr
 }

--- a/enterprise/internal/campaigns/testing.go
+++ b/enterprise/internal/campaigns/testing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
 
 // FakeChangesetSource is a fake implementation of the repos.ChangesetSource
@@ -75,4 +76,15 @@ func (s FakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Ch
 }
 func (s FakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
 	return fakeNotImplemented
+}
+
+// FakeGitserverClient is a test implementation of the GitserverClient
+// interface required by ExecChangesetJob.
+type FakeGitserverClient struct {
+	Response    string
+	ResponseErr error
+}
+
+func (f *FakeGitserverClient) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
+	return f.Response, f.ResponseErr
 }

--- a/enterprise/internal/campaigns/testing.go
+++ b/enterprise/internal/campaigns/testing.go
@@ -1,0 +1,78 @@
+package campaigns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+)
+
+// FakeChangesetSource is a fake implementation of the repos.ChangesetSource
+// interface to be used in tests.
+type FakeChangesetSource struct {
+	Svc *repos.ExternalService
+
+	// The Changeset.HeadRef to be expected in CreateChangeset/UpdateChangeset calls.
+	WantHeadRef string
+	// The Changeset.BaseRef to be expected in CreateChangeset/UpdateChangeset calls.
+	WantBaseRef string
+
+	// The metadata the FakeChangesetSource should set on the created/updated
+	// Changeset with changeset.SetMetadata.
+	FakeMetadata interface{}
+
+	// Whether or not the changeset already ChangesetExists on the code host at the time
+	// when CreateChangeset is called.
+	ChangesetExists bool
+
+	// error to be returned from every method
+	Err error
+}
+
+func (s FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
+	if s.Err != nil {
+		return s.ChangesetExists, s.Err
+	}
+
+	if c.HeadRef != s.WantHeadRef {
+		return s.ChangesetExists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.WantHeadRef, c.HeadRef)
+	}
+
+	if c.BaseRef != s.WantBaseRef {
+		return s.ChangesetExists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.WantBaseRef, c.BaseRef)
+	}
+
+	c.SetMetadata(s.FakeMetadata)
+
+	return s.ChangesetExists, s.Err
+}
+
+func (s FakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Changeset) error {
+	if s.Err != nil {
+		return s.Err
+	}
+
+	if c.BaseRef != s.WantBaseRef {
+		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.WantBaseRef, c.BaseRef)
+	}
+
+	c.SetMetadata(s.FakeMetadata)
+	return nil
+}
+
+var fakeNotImplemented = errors.New("not implement in FakeChangesetSource")
+
+func (s FakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
+	results <- repos.SourceResult{Source: s, Err: fakeNotImplemented}
+}
+
+func (s FakeChangesetSource) ExternalServices() repos.ExternalServices {
+	return repos.ExternalServices{s.Svc}
+}
+func (s FakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Changeset) error {
+	return fakeNotImplemented
+}
+func (s FakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
+	return fakeNotImplemented
+}

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -3,13 +3,11 @@ package campaigns
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -113,13 +111,13 @@ func TestExecChangesetJob(t *testing.T) {
 
 			gitClient := &dummyGitserverClient{response: headRef, responseErr: nil}
 
-			sourcer := repos.NewFakeSourcer(nil, fakeChangesetSource{
-				svc:          extSvc,
-				err:          nil,
-				exists:       tc.existsOnCodehost,
-				wantHeadRef:  headRef,
-				wantBaseRef:  baseRef,
-				fakeMetadata: meta,
+			sourcer := repos.NewFakeSourcer(nil, FakeChangesetSource{
+				Svc:             extSvc,
+				Err:             nil,
+				ChangesetExists: tc.existsOnCodehost,
+				WantHeadRef:     headRef,
+				WantBaseRef:     baseRef,
+				FakeMetadata:    meta,
 			})
 
 			changesetJob := &cmpgn.ChangesetJob{CampaignID: campaign.ID, PatchID: patch.ID}
@@ -183,64 +181,6 @@ index d75b080..cf04b5b 100644
 -onto monto(int argc, char *argv[]) { printf("Nice."); }
 +int main(int argc, char *argv[]) { printf("Nice."); }
 `
-
-type fakeChangesetSource struct {
-	svc *repos.ExternalService
-
-	wantHeadRef string
-	wantBaseRef string
-
-	fakeMetadata interface{}
-	exists       bool
-	err          error
-}
-
-func (s fakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
-	if s.err != nil {
-		return s.exists, s.err
-	}
-
-	if c.HeadRef != s.wantHeadRef {
-		return s.exists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.wantHeadRef, c.HeadRef)
-	}
-
-	if c.BaseRef != s.wantBaseRef {
-		return s.exists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
-	}
-
-	c.SetMetadata(s.fakeMetadata)
-
-	return s.exists, s.err
-}
-
-func (s fakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Changeset) error {
-	if s.err != nil {
-		return s.err
-	}
-
-	if c.BaseRef != s.wantBaseRef {
-		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.wantBaseRef, c.BaseRef)
-	}
-
-	c.SetMetadata(s.fakeMetadata)
-	return nil
-}
-
-var fakeNotImplemented = errors.New("not implement in fakeChangesetSource")
-
-func (s fakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
-	results <- repos.SourceResult{Source: s, Err: fakeNotImplemented}
-}
-
-func (s fakeChangesetSource) ExternalServices() repos.ExternalServices {
-	return repos.ExternalServices{s.svc}
-}
-func (s fakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.Changeset) error {
-	return fakeNotImplemented
-}
-func (s fakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
-	return fakeNotImplemented
-}
 
 func createGitHubRepo(t *testing.T, ctx context.Context, now time.Time, s *Store) (*repos.Repo, *repos.ExternalService) {
 	t.Helper()

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -109,7 +109,7 @@ func TestExecChangesetJob(t *testing.T) {
 				}
 			}
 
-			gitClient := &dummyGitserverClient{response: headRef, responseErr: nil}
+			gitClient := &FakeGitserverClient{Response: headRef, ResponseErr: nil}
 
 			sourcer := repos.NewFakeSourcer(nil, FakeChangesetSource{
 				Svc:             extSvc,

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -58,6 +58,10 @@ func ExecSafe(ctx context.Context, repo gitserver.Repo, params []string) (stdout
 // ExecReader executes an arbitrary `git` command (`git [args...]`) and returns a reader connected
 // to its stdout.
 func ExecReader(ctx context.Context, repo gitserver.Repo, args []string) (io.ReadCloser, error) {
+	if Mocks.ExecReader != nil {
+		return Mocks.ExecReader(args)
+	}
+
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ExecReader")
 	span.SetTag("args", args)
 	defer span.Finish()

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -14,6 +14,7 @@ import (
 var Mocks, emptyMocks struct {
 	GetCommit        func(api.CommitID) (*Commit, error)
 	ExecSafe         func(params []string) (stdout, stderr []byte, exitCode int, err error)
+	ExecReader       func(args []string) (reader io.ReadCloser, err error)
 	RawLogDiffSearch func(opt RawLogDiffSearchOptions) ([]*LogCommitSearchResult, bool, error)
 	NewFileReader    func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile         func(commit api.CommitID, name string) ([]byte, error)

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -105,6 +105,12 @@ describe('CampaignDetails', () => {
                     updatedAt: '2020-01-01',
                     publishedAt: '2020-01-01',
                     closedAt: null,
+                    diffStat: {
+                        __typename: 'IDiffStat' as const,
+                        added: 5,
+                        changed: 3,
+                        deleted: 2,
+                    },
                 })
             }
             _noSubject={true}

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -66,6 +66,7 @@ interface Campaign
     changesets: Pick<GQL.ICampaign['changesets'], 'nodes' | 'totalCount'>
     patches: Pick<GQL.ICampaign['patches'], 'nodes' | 'totalCount'>
     status: Pick<GQL.ICampaign['status'], 'completedCount' | 'pendingCount' | 'errors' | 'state'>
+    diffStat: Pick<GQL.ICampaign['diffStat'], 'added' | 'deleted' | 'changed'>
 }
 
 interface PatchSet extends Pick<GQL.IPatchSet, '__typename' | 'id'> {

--- a/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
@@ -9,35 +9,10 @@ describe('CampaignDiffStat', () => {
                 <CampaignDiffStat
                     campaign={{
                         __typename: 'Campaign' as const,
-                        changesets: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 10,
-                                                changed: 10,
-                                                deleted: 10,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
-                        },
-                        patches: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 10,
-                                                changed: 10,
-                                                deleted: 10,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
+                        diffStat: {
+                            added: 888,
+                            deleted: 777,
+                            changed: 999,
                         },
                     }}
                     className="abc"
@@ -50,35 +25,10 @@ describe('CampaignDiffStat', () => {
                 <CampaignDiffStat
                     campaign={{
                         __typename: 'Campaign' as const,
-                        changesets: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 0,
-                                                changed: 0,
-                                                deleted: 0,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
-                        },
-                        patches: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 0,
-                                                changed: 0,
-                                                deleted: 0,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
+                        diffStat: {
+                            added: 0,
+                            deleted: 0,
+                            changed: 0,
                         },
                     }}
                     className="abc"
@@ -97,9 +47,9 @@ describe('CampaignDiffStat', () => {
                                     diff: {
                                         fileDiffs: {
                                             diffStat: {
-                                                added: 10,
-                                                changed: 10,
-                                                deleted: 10,
+                                                added: 888,
+                                                changed: 777,
+                                                deleted: 999,
                                             },
                                         },
                                     },

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -399,6 +399,52 @@ Array [
      
     Changesets
      
+    <div
+      className="ml-2 mb-0"
+    >
+      <div
+        className="diff-stat "
+        data-tooltip="5 additions, 3 changes, 2 deletions"
+      >
+        <span
+          className="diff-stat__total font-weight-bold"
+        >
+          <span
+            className="diff-stat__text-added mr-1"
+          >
+            +
+            5
+          </span>
+          <span
+            className="diff-stat__text-changed mr-1"
+          >
+            •
+            3
+          </span>
+          <span
+            className="diff-stat__text-deleted mr-1"
+          >
+            −
+            2
+          </span>
+        </span>
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__changed"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+      </div>
+    </div>
   </h3>,
   <CampaignPatches
     campaign={
@@ -416,6 +462,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {
@@ -518,6 +570,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {
@@ -720,6 +778,52 @@ Array [
      
     Changesets
      
+    <div
+      className="ml-2 mb-0"
+    >
+      <div
+        className="diff-stat "
+        data-tooltip="5 additions, 3 changes, 2 deletions"
+      >
+        <span
+          className="diff-stat__total font-weight-bold"
+        >
+          <span
+            className="diff-stat__text-added mr-1"
+          >
+            +
+            5
+          </span>
+          <span
+            className="diff-stat__text-changed mr-1"
+          >
+            •
+            3
+          </span>
+          <span
+            className="diff-stat__text-deleted mr-1"
+          >
+            −
+            2
+          </span>
+        </span>
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__changed"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+      </div>
+    </div>
   </h3>,
   <CampaignPatches
     campaign={
@@ -737,6 +841,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {
@@ -839,6 +949,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {
@@ -1131,6 +1247,52 @@ Array [
      
     Changesets
      
+    <div
+      className="ml-2 mb-0"
+    >
+      <div
+        className="diff-stat "
+        data-tooltip="5 additions, 3 changes, 2 deletions"
+      >
+        <span
+          className="diff-stat__total font-weight-bold"
+        >
+          <span
+            className="diff-stat__text-added mr-1"
+          >
+            +
+            5
+          </span>
+          <span
+            className="diff-stat__text-changed mr-1"
+          >
+            •
+            3
+          </span>
+          <span
+            className="diff-stat__text-deleted mr-1"
+          >
+            −
+            2
+          </span>
+        </span>
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__added"
+        />
+        <div
+          className="diff-stat__square diff-stat__changed"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+      </div>
+    </div>
   </h3>,
   <CampaignPatches
     campaign={
@@ -1148,6 +1310,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {
@@ -1250,6 +1418,12 @@ Array [
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
+        "diffStat": Object {
+          "__typename": "IDiffStat",
+          "added": 5,
+          "changed": 3,
+          "deleted": 2,
+        },
         "id": "c",
         "name": "n",
         "patchSet": Object {

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDiffStat.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDiffStat.test.tsx.snap
@@ -5,9 +5,9 @@ exports[`CampaignDiffStat for campaign 1`] = `
   className="abc"
 >
   <DiffStat
-    added={20}
-    changed={20}
-    deleted={20}
+    added={888}
+    changed={999}
+    deleted={777}
     expandedCounts={true}
   />
 </div>
@@ -18,9 +18,9 @@ exports[`CampaignDiffStat for patch set 1`] = `
   className="abc"
 >
   <DiffStat
-    added={10}
-    changed={10}
-    deleted={10}
+    added={888}
+    changed={777}
+    deleted={999}
     expandedCounts={true}
   />
 </div>

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -48,13 +48,6 @@ const campaignFragment = gql`
                 __typename
                 id
                 state
-                diff {
-                    fileDiffs {
-                        diffStat {
-                            ...DiffStatFields
-                        }
-                    }
-                }
             }
         }
         patches(first: 10000) {
@@ -62,14 +55,6 @@ const campaignFragment = gql`
             nodes {
                 id
                 __typename
-                diff {
-                    fileDiffs {
-                        totalCount
-                        diffStat {
-                            ...DiffStatFields
-                        }
-                    }
-                }
             }
         }
         patchSet {
@@ -84,6 +69,9 @@ const campaignFragment = gql`
             openChangesRequested
             openPending
             total
+        }
+        diffStat {
+            ...DiffStatFields
         }
     }
 


### PR DESCRIPTION
This is the first part of #10170, the second part would add `diffStat` on `PatchSet`.

Note that this does _not_ include any caching of sorts. I think that makes it easier to understand for now, because I'm still not sure when would be the best time to cache these diff stats and when to invalidate the cache. Also easier to review.

So for now this "only" adds a `diffStat` field on Campaign that loads all the data under the hood and computes the diff stat. Probably equally as inefficient as computing the combined diff stat on the client (maybe even more in-efficient, since we need to do 2 additional SQL queries?). But it enables the caching later on.

I also changed the web code to make use of this new field.

This also adds an _extensive_ integration-y test on the GraphQL level that not only tests the `diffStat` field but also the whole _create a campaign with a patch set and create a changeset on the code host_ flow. I was in the mood for writing tests.

What I also want to follow up on (maybe in this PR as commits that review doesn't need to wait for or in separate PRs):

- Remove the `TODO` related to the stray transaction in `ExecChangeset`
- Create a single `fakeChangesetSource` somewhere that can be shared between tests
- Clean up the type definitions and queries in the tests
