### PR TITLE
repo-updater: implement errorcode interface for errors

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -12,24 +12,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-)
-
-var (
-	// ErrNotFound is when a repository is not found.
-	ErrNotFound = errors.New("repository not found")
-
-	// ErrUnauthorized is when an authorization error occurred.
-	ErrUnauthorized = errors.New("not authorized")
-
-	// ErrTemporarilyUnavailable is when the repository was reported as being temporarily
-	// unavailable.
-	ErrTemporarilyUnavailable = errors.New("repository temporarily unavailable")
 )
 
 // CachedGitRepo returns a handle to the Git repository that does not know the remote URL. If
@@ -65,7 +54,7 @@ func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
 		return gitserver.Repo{Name: repo.Name}, err
 	}
 	if result.Repo == nil {
-		return gitserver.Repo{Name: repo.Name}, ErrNotFound
+		return gitserver.Repo{Name: repo.Name}, &repoupdater.ErrNotFound{Repo: repo.Name, IsNotFound: true}
 	}
 	return gitserver.Repo{Name: result.Repo.Name, URL: result.Repo.VCS.URL}, nil
 }
@@ -214,18 +203,17 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {
-	err = errors.Cause(err)
-	return err == ErrNotFound || err == ErrUnauthorized || err == ErrTemporarilyUnavailable
+	return errcode.IsNotFound(err) || errcode.IsUnauthorized(err) || errcode.IsTemporary(err)
 }
 
 func maybeLogRepoUpdaterError(repo *types.Repo, err error) {
 	var msg string
-	switch c := errors.Cause(err); c {
-	case ErrNotFound:
+	switch {
+	case errcode.IsNotFound(err):
 		msg = "Repository host reported a repository as not found. If this repository was deleted on its origin, the site admin must explicitly delete it on Sourcegraph."
-	case ErrUnauthorized:
+	case errcode.IsUnauthorized(err):
 		msg = "Repository host rejected as unauthorized an attempt to retrieve a repository's metadata. Check the repository host credentials in site configuration."
-	case ErrTemporarilyUnavailable:
+	case errcode.IsTemporary(err):
 		msg = "Repository host was temporarily unavailable while retrieving repository information."
 	}
 	if msg != "" {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -166,12 +166,12 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				serveError(w, r, err, http.StatusNotFound)
 				return nil, nil
 			}
-			if errcode.IsNotFound(err) || errors.Cause(err) == repoupdater.ErrNotFound {
+			if errcode.IsNotFound(err) {
 				// Repo does not exist.
 				serveError(w, r, err, http.StatusNotFound)
 				return nil, nil
 			}
-			if errors.Cause(err) == repoupdater.ErrUnauthorized {
+			if errcode.IsUnauthorized(err) {
 				// Not authorized to access repository.
 				serveError(w, r, err, http.StatusUnauthorized)
 				return nil, nil

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,13 +99,13 @@ func TestNewCommon_repo_error(t *testing.T) {
 		code: 404,
 	}, {
 		name: "repoupdater-not-found",
-		err:  repoupdater.ErrNotFound,
-		want: repoupdater.ErrNotFound.Error(),
+		err:  &repoupdater.ErrNotFound{Repo: "repo-404", IsNotFound: true},
+		want: fmt.Sprintf("repository not found (name=%s notfound=%v)", "repo-404", true),
 		code: 404,
 	}, {
 		name: "repoupdater-unauthorized",
-		err:  repoupdater.ErrUnauthorized,
-		want: repoupdater.ErrUnauthorized.Error(),
+		err:  &repoupdater.ErrUnauthorized{Repo: "repo-unauth", NoAuthz: true},
+		want: fmt.Sprintf("not authorized (name=%s noauthz=%v)", "repo-unauth", true),
 		code: 401,
 	}, {
 		name: "github.com/sourcegraphtest/Always500Test",

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -860,7 +860,7 @@ func TestRepoLookup(t *testing.T) {
 				Repo: api.RepoName("github.com/a/b"),
 			},
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
-			err:    "repository not found",
+			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("github.com/a/b"), true),
 		},
 		{
 			name: "found - GitHub",
@@ -971,7 +971,7 @@ func TestRepoLookup(t *testing.T) {
 				err: github.ErrNotFound,
 			},
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
-			err:    "repository not found",
+			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("github.com/foo/bar"), true),
 			assert: repos.Assert.ReposEqual(),
 		},
 		{
@@ -983,7 +983,7 @@ func TestRepoLookup(t *testing.T) {
 				err: &github.APIError{Code: http.StatusUnauthorized},
 			},
 			result: &protocol.RepoLookupResult{ErrorUnauthorized: true},
-			err:    "not authorized",
+			err:    fmt.Sprintf("not authorized (name=%s noauthz=%v)", api.RepoName("github.com/foo/bar"), true),
 			assert: repos.Assert.ReposEqual(),
 		},
 		{
@@ -995,7 +995,7 @@ func TestRepoLookup(t *testing.T) {
 				err: &github.APIError{Message: "API rate limit exceeded"},
 			},
 			result: &protocol.RepoLookupResult{ErrorTemporarilyUnavailable: true},
-			err:    "repository temporarily unavailable",
+			err:    fmt.Sprintf("repository temporarily unavailable (name=%s istemporary=%v)", api.RepoName("github.com/foo/bar"), true),
 			assert: repos.Assert.ReposEqual(),
 		},
 		{
@@ -1061,7 +1061,7 @@ func TestRepoLookup(t *testing.T) {
 				repo: githubRepository,
 			},
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
-			err:    "repository not found",
+			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("git-codecommit.us-west-1.amazonaws.com/stripe-go"), true),
 		},
 	}
 

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -109,18 +109,18 @@ func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		switch {
 		case result.ErrorNotFound:
 			err = &ErrNotFound{
-				repo:     args.Repo,
-				notFound: true,
+				Repo:       args.Repo,
+				IsNotFound: true,
 			}
 		case result.ErrorUnauthorized:
 			err = &ErrUnauthorized{
-				repo:    args.Repo,
-				noAuthz: true,
+				Repo:    args.Repo,
+				NoAuthz: true,
 			}
 		case result.ErrorTemporarilyUnavailable:
 			err = &ErrTemporary{
-				repo:        args.Repo,
-				isTemporary: true,
+				Repo:        args.Repo,
+				IsTemporary: true,
 			}
 		}
 	}

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -25,18 +25,6 @@ var repoupdaterURL = env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "re
 
 var requestMeter = metrics.NewRequestMeter("repoupdater", "Total number of requests sent to repoupdater.")
 
-var (
-	// ErrNotFound is when a repository is not found.
-	ErrNotFound = errors.New("repository not found")
-
-	// ErrUnauthorized is when an authorization error occurred.
-	ErrUnauthorized = errors.New("not authorized")
-
-	// ErrTemporarilyUnavailable is when the repository was reported as being temporarily
-	// unavailable.
-	ErrTemporarilyUnavailable = errors.New("repository temporarily unavailable")
-)
-
 // DefaultClient is the default Client. Unless overwritten, it is connected to the server specified by the
 // REPO_UPDATER_URL environment variable.
 var DefaultClient = &Client{
@@ -120,11 +108,20 @@ func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	if err == nil && result != nil {
 		switch {
 		case result.ErrorNotFound:
-			err = ErrNotFound
+			err = &ErrNotFound{
+				repo:     args.Repo,
+				notFound: true,
+			}
 		case result.ErrorUnauthorized:
-			err = ErrUnauthorized
+			err = &ErrUnauthorized{
+				repo:    args.Repo,
+				noAuthz: true,
+			}
 		case result.ErrorTemporarilyUnavailable:
-			err = ErrTemporarilyUnavailable
+			err = &ErrTemporary{
+				repo:        args.Repo,
+				isTemporary: true,
+			}
 		}
 	}
 	return result, err

--- a/internal/repoupdater/errors.go
+++ b/internal/repoupdater/errors.go
@@ -1,0 +1,54 @@
+package repoupdater
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+// ErrNotFound is an error that occurs when a repo doesn't exist.
+type ErrNotFound struct {
+	repo     api.RepoName
+	notFound bool
+}
+
+// ErrNotFound returns true if the repo does not exist.
+func (e *ErrNotFound) NotFound() bool {
+	return e.notFound
+}
+
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("repo not found (name=%s  notfound=%v) ", e.repo, e.notFound)
+}
+
+// ErrUnauthorized is an error that occurs when repo access is
+// unauthorized.
+type ErrUnauthorized struct {
+	repo    api.RepoName
+	noAuthz bool
+}
+
+// Unauthorized returns true if repo access is unauthorized.
+func (e *ErrUnauthorized) Unauthorized() bool {
+	return e.noAuthz
+}
+
+func (e *ErrUnauthorized) Error() string {
+	return fmt.Sprintf("repo access not authorized (name=%s  noauthz=%v) ", e.repo, e.noAuthz)
+}
+
+// ErrTemporary is an error that can be retried
+type ErrTemporary struct {
+	repo        api.RepoName
+	isTemporary bool
+}
+
+// ErrTemporary is when the repository was reported as being temporarily
+// unavailable.
+func (e *ErrTemporary) Temporary() bool {
+	return e.isTemporary
+}
+
+func (e *ErrTemporary) Error() string {
+	return fmt.Sprintf("repo temporary unavailable (name=%s  isTemporary=%v) ", e.repo, e.isTemporary)
+}

--- a/internal/repoupdater/errors.go
+++ b/internal/repoupdater/errors.go
@@ -18,7 +18,7 @@ func (e *ErrNotFound) NotFound() bool {
 }
 
 func (e *ErrNotFound) Error() string {
-	return fmt.Sprintf("repo Not found (name=%s  notfound=%v) ", e.Repo, e.IsNotFound)
+	return fmt.Sprintf("repository not found (name=%s notfound=%v)", e.Repo, e.IsNotFound)
 }
 
 // ErrUnauthorized is an error that occurs when repo access is
@@ -34,7 +34,7 @@ func (e *ErrUnauthorized) Unauthorized() bool {
 }
 
 func (e *ErrUnauthorized) Error() string {
-	return fmt.Sprintf("repo access Not authorized (name=%s  noauthz=%v) ", e.Repo, e.NoAuthz)
+	return fmt.Sprintf("not authorized (name=%s noauthz=%v)", e.Repo, e.NoAuthz)
 }
 
 // ErrTemporary is an error that can be retried
@@ -50,5 +50,5 @@ func (e *ErrTemporary) Temporary() bool {
 }
 
 func (e *ErrTemporary) Error() string {
-	return fmt.Sprintf("repo temporary unavailable (name=%s  istemporary=%v) ", e.Repo, e.IsTemporary)
+	return fmt.Sprintf("repository temporarily unavailable (name=%s istemporary=%v)", e.Repo, e.IsTemporary)
 }

--- a/internal/repoupdater/errors.go
+++ b/internal/repoupdater/errors.go
@@ -6,49 +6,49 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-// ErrNotFound is an error that occurs when a repo doesn't exist.
+// ErrNotFound is an error that occurs when a Repo doesn't exist.
 type ErrNotFound struct {
-	repo     api.RepoName
-	notFound bool
+	Repo       api.RepoName
+	IsNotFound bool
 }
 
-// ErrNotFound returns true if the repo does not exist.
+// ErrNotFound returns true if the repo does Not exist.
 func (e *ErrNotFound) NotFound() bool {
-	return e.notFound
+	return e.IsNotFound
 }
 
 func (e *ErrNotFound) Error() string {
-	return fmt.Sprintf("repo not found (name=%s  notfound=%v) ", e.repo, e.notFound)
+	return fmt.Sprintf("repo Not found (name=%s  notfound=%v) ", e.Repo, e.IsNotFound)
 }
 
 // ErrUnauthorized is an error that occurs when repo access is
 // unauthorized.
 type ErrUnauthorized struct {
-	repo    api.RepoName
-	noAuthz bool
+	Repo    api.RepoName
+	NoAuthz bool
 }
 
 // Unauthorized returns true if repo access is unauthorized.
 func (e *ErrUnauthorized) Unauthorized() bool {
-	return e.noAuthz
+	return e.NoAuthz
 }
 
 func (e *ErrUnauthorized) Error() string {
-	return fmt.Sprintf("repo access not authorized (name=%s  noauthz=%v) ", e.repo, e.noAuthz)
+	return fmt.Sprintf("repo access Not authorized (name=%s  noauthz=%v) ", e.Repo, e.NoAuthz)
 }
 
 // ErrTemporary is an error that can be retried
 type ErrTemporary struct {
-	repo        api.RepoName
-	isTemporary bool
+	Repo        api.RepoName
+	IsTemporary bool
 }
 
 // ErrTemporary is when the repository was reported as being temporarily
 // unavailable.
 func (e *ErrTemporary) Temporary() bool {
-	return e.isTemporary
+	return e.IsTemporary
 }
 
 func (e *ErrTemporary) Error() string {
-	return fmt.Sprintf("repo temporary unavailable (name=%s  isTemporary=%v) ", e.repo, e.isTemporary)
+	return fmt.Sprintf("repo temporary unavailable (name=%s  istemporary=%v) ", e.Repo, e.IsTemporary)
 }


### PR DESCRIPTION
previous PR w/ discussion https://github.com/sourcegraph/sourcegraph/pull/10146

Summary: repoupdater's errors do no implement `NotFound(), Temporary(), && Unauthorized()`. One middleware layer (`errorutil.Handler`) relies on these error methods to be defined on the error to return the proper status code. This update adds these methods to repoupdater's error types, and may fix a handful of leaky 500s. 

[Here's a patch to demonstrate the current state returning 500s, vs the expected 404.](https://github.com/notjrbauer/sourcegraph/commit/aecec8f012ae84956c4a14d62db9964a016f8fae.patch)

Locations handler is used:
```
৸ ag errorutil.Handler
internal/app/app.go
38:     r.Get(router.RepoBadge).Handler(trace.TraceRoute(errorutil.Handler(serveRepoBadge)))
50:             r.Get(router.GoSymbolURL).Handler(trace.TraceRoute(errorutil.Handler(serveGoSymbolURL)))
65:     r.Get(router.GDDORefs).Handler(trace.TraceRoute(errorutil.Handler(serveGDDORefs)))
66:     r.Get(router.Editor).Handler(trace.TraceRoute(errorutil.Handler(serveEditor)))

internal/app/debugproxies/handler.go
38:     r.PathPrefix("/proxies").Handler(http.StripPrefix("/-/debug/proxies", adminOnly(errorutil.Handler(rph.serveReverseProxy))))
```

refs #9274 #10000