### PR TITLE
web: add experimental paginated search frontend

### DIFF
--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -35,6 +35,12 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "paginatedSearch": {
+          "description": "Enables paginated search in the web UI (may be slower for some search queries).",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -36,7 +36,9 @@ export function search(
     query: string,
     version: string,
     patternType: GQL.SearchPatternType,
-    { extensionsController }: ExtensionsControllerProps<'services'>
+    { extensionsController }: ExtensionsControllerProps<'services'>,
+    after?: string,
+    first?: number
 ): Observable<GQL.ISearchResults | ErrorLike> {
     /**
      * Emits whenever a search is executed, and whenever an extension registers a query transformer.
@@ -50,8 +52,8 @@ export function search(
                 : ''
             return queryGraphQL(
                 gql`
-                    query Search($query: String!, $version: SearchVersion!, $patternType: SearchPatternType!) {
-                        search(query: $query, version: $version, patternType: $patternType) {
+                    query Search($query: String!, $version: SearchVersion!, $patternType: SearchPatternType!, $after: String, $first: Int) {
+                        search(query: $query, version: $version, patternType: $patternType, after: $after, first: $first) {
                             results {
                                 __typename
                                 limitHit
@@ -138,11 +140,15 @@ export function search(
                                     }
                                 }
                                 elapsedMilliseconds
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
                             }
                         }
                     }
                 `,
-                { query, version, patternType }
+                { query, version, patternType, after, first }
             ).pipe(
                 map(({ data, errors }) => {
                     if (!data || !data.search || !data.search.results) {

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -22,6 +22,16 @@ export function parseSearchURLQuery(query: string): string | undefined {
 }
 
 /**
+ * Parses the page out of the URL search params (the 'p' parameter).
+ *
+ * @param query the URL query parameters
+ */
+export function parseSearchURLPage2(query: string): string | undefined {
+    const searchParams = new URLSearchParams(query)
+    return searchParams.get('p') || undefined
+}
+
+/**
  * Parses the pattern type out of the URL search params (the 'patternType' parameter). If the 'pattern' parameter
  * is not present, or it is an invalid value, it returns undefined.
  */


### PR DESCRIPTION
### This PR

Adds an `"experimentalFeatures": { "paginatedSearch": true }` option to global/org/user settings. When true, it enables an experimental frontend which uses the paginated search API instead of the traditional search API.

The UI here simply queries results using the paginated API, and when the bottom of the virtual list is hit a loading indicator is displayed and more results are loaded (no "Show more" button).

### Caveats

This will not be enabled by-default for the foreseeable future, because:

1) The paginated search API _currently_ does not handle non-text result types (diff,commit,symbol,etc).
2) Most significant, the paginated search API is not optimized heavily yet and on e.g. sourcegraph.com in specific is extremely slow.
3) The paginated search API makes a tradeoff for stable-ordered search results instead of fastest-first results, and we do not want to accept that tradeoff on customer instances by default.

### Broader experiment

With caveats above noted, I would like to land this in order for me to perform broader experiments. This in particular is part of a broader experiment I am making in which I think the following might be a good idea on Sourcegraph.com specifically:

1. Paginated search on-by-default
2. A very large cluster of *unindexed* searchers (e.g. a few hundred or maybe even thousand, exact number TBD)
3. Ability for customers to easily declare "search in my org's 1-20k repos by default"

The theory here is that we could support a large number of enterprise customers with a large cluster of unindexed searchers without having to scale _linearly_ using indexed search, reducing costs for us and customers while still providing a very nice nearly instant search across hundreds or thousands of repositories. This would be possible on Sourcegraph.com only due to the economies of scale savings effect we could have (unindexed searchers shared across all customers effectively).
