### PR TITLE
Fix: search type tabs overlapped in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A potential security vulnerability with in the authentication workflow has been fixed. [#10167](https://github.com/sourcegraph/sourcegraph/pull/10167)
+- An issue that caused the search result type tabs to be overlapped in Safari.
 
 ### Removed
 

--- a/web/src/search/results/SearchResultTypeTabs.scss
+++ b/web/src/search/results/SearchResultTypeTabs.scss
@@ -1,6 +1,0 @@
-.search-result-type-tabs {
-    display: flex;
-    margin-top: 0.5rem;
-    justify-content: space-between;
-    align-items: flex-end;
-}

--- a/web/src/search/results/SearchResultTypeTabs.tsx
+++ b/web/src/search/results/SearchResultTypeTabs.tsx
@@ -13,7 +13,7 @@ interface Props
 }
 
 export const SearchResultTypeTabs: React.FunctionComponent<Props> = props => (
-    <div className="search-result-type-tabs e2e-search-result-type-tabs border-bottom">
+    <div className="mt-2 border-bottom e2e-search-result-type-tabs">
         <ul className="nav nav-tabs border-bottom-0">
             <SearchResultTabHeader {...props} type={null} />
             <SearchResultTabHeader {...props} type="diff" />

--- a/web/src/search/results/SearchResults.scss
+++ b/web/src/search/results/SearchResults.scss
@@ -2,4 +2,3 @@
 @import './SearchResultsList';
 @import '../FilterChip';
 @import './SearchResultsFilterBars';
-@import './SearchResultTypeTabs';


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/10147.

The styles removed here are no longer needed and caused overlap in Safari. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
