### PR TITLE
Redirect trees to blobs and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)
-- Tree pages now redirect to blob pages if the path is not a tree and vice versa ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
-- Files and directories that are not found now return a 404 status code ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
 - Tree pages now redirect to blob pages if the path is not a tree and vice versa. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 - Files and directories that are not found now return a 404 status code. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)
+- Tree pages now redirect to blob pages if the path is not a tree and vice versa ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
+- Files and directories that are not found now return a 404 status code ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Sourcegraph are documented in this file.
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)
 - Tree pages now redirect to blob pages if the path is not a tree and vice versa ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
 - Files and directories that are not found now return a 404 status code ([#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)).
+- Tree pages now redirect to blob pages if the path is not a tree and vice versa. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
+- Files and directories that are not found now return a 404 status code. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 
 ### Fixed
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -259,7 +259,7 @@ func serveSignIn(w http.ResponseWriter, r *http.Request) error {
 
 // redirectTreeOrBlob redirects a blob page to a tree page if the file is actually a directory,
 // or a tree page to a blob page if the directory is actually a file.
-func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w http.ResponseWriter) (requestHandled bool, err error) {
+func redirectTreeOrBlob(routeName string, common *Common, w http.ResponseWriter, r *http.Request) (requestHandled bool, err error) {
 	path := mux.Vars(r)["Path"]
 	if path == "/" || path == "" {
 		if routeName != routeRepo {
@@ -308,7 +308,7 @@ func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
 			return nil // request was handled
 		}
 
-		handled, err := redirectTreeOrBlob(routeTree, common, r, w)
+		handled, err := redirectTreeOrBlob(routeTree, common, w, r)
 		if handled {
 			return nil
 		}
@@ -331,7 +331,7 @@ func serveRepoOrBlob(routeName string, title func(c *Common, r *http.Request) st
 			return nil // request was handled
 		}
 
-		handled, err := redirectTreeOrBlob(routeName, common, r, w)
+		handled, err := redirectTreeOrBlob(routeName, common, w, r)
 		if handled {
 			return nil
 		}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 type InjectedHTML struct {
@@ -256,6 +257,75 @@ func serveSignIn(w http.ResponseWriter, r *http.Request) error {
 	return renderTemplate(w, "app.html", common)
 }
 
+// redirectTreeOrBlob redirects a blob page to a tree page if the file is actually a directory,
+// or a tree page to a blob page if the directory is actually a file.
+func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w http.ResponseWriter) (requestHandled bool, err error) {
+	path := mux.Vars(r)["Path"]
+	if path == "/" || path == "" {
+		if routeName != routeRepo {
+			// Redirect to repo route
+			target := "/" + string(common.Repo.Name)
+			if common.Rev != "" {
+				target += common.Rev
+			}
+			http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+			return true, nil
+		}
+		return false, nil
+	}
+	cachedRepo, err := backend.CachedGitRepo(r.Context(), common.Repo)
+	if err != nil {
+		return false, err
+	}
+	stat, err := git.Stat(r.Context(), *cachedRepo, common.CommitID, path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			serveError(w, r, err, http.StatusNotFound)
+			return true, nil
+		}
+		return false, err
+	}
+	expectedDir := (routeName == routeTree)
+	if stat.Mode().IsDir() != expectedDir {
+		target := "/" + string(common.Repo.Name)
+		if common.Rev != "" {
+			target += common.Rev
+		}
+		target += "/-/"
+		if expectedDir {
+			target += "blob"
+		} else {
+			target += "tree"
+		}
+		target += path
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+		return true, nil
+	}
+	return false, nil
+}
+
+// serveTree serves the tree (directory) pages
+func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		common, err := newCommon(w, r, "", serveError)
+		if err != nil {
+			return err
+		}
+		if common == nil {
+			return nil // request was handled
+		}
+		handled, err := redirectTreeOrBlob(routeTree, common, r, w)
+		if handled {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		common.Title = title(common, r)
+		return renderTemplate(w, "app.html", common)
+	}
+}
+
 func serveRepoOrBlob(routeName string, title func(c *Common, r *http.Request) string) handlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		common, err := newCommon(w, r, "", serveError)
@@ -265,6 +335,15 @@ func serveRepoOrBlob(routeName string, title func(c *Common, r *http.Request) st
 		if common == nil {
 			return nil // request was handled
 		}
+
+		handled, err := redirectTreeOrBlob(routeName, common, r, w)
+		if handled {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
 		common.Title = title(common, r)
 
 		q := r.URL.Query()

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -285,7 +285,7 @@ func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w htt
 		}
 		return false, err
 	}
-	expectedDir := (routeName == routeTree)
+	expectedDir := routeName == routeTree
 	if stat.Mode().IsDir() != expectedDir {
 		target := "/" + string(common.Repo.Name) + common.Rev + "/-/"
 		if expectedDir {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -300,7 +300,7 @@ func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w htt
 	return false, nil
 }
 
-// serveTree serves the tree (directory) pages
+// serveTree serves the tree (directory) pages.
 func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		common, err := newCommon(w, r, "", serveError)

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -287,11 +287,7 @@ func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w htt
 	}
 	expectedDir := (routeName == routeTree)
 	if stat.Mode().IsDir() != expectedDir {
-		target := "/" + string(common.Repo.Name)
-		if common.Rev != "" {
-			target += common.Rev
-		}
-		target += "/-/"
+		target := "/" + string(common.Repo.Name) + common.Rev + "/-/"
 		if expectedDir {
 			target += "blob"
 		} else {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -264,10 +264,7 @@ func redirectTreeOrBlob(routeName string, common *Common, r *http.Request, w htt
 	if path == "/" || path == "" {
 		if routeName != routeRepo {
 			// Redirect to repo route
-			target := "/" + string(common.Repo.Name)
-			if common.Rev != "" {
-				target += common.Rev
-			}
+			target := "/" + string(common.Repo.Name) + common.Rev
 			http.Redirect(w, r, target, http.StatusTemporaryRedirect)
 			return true, nil
 		}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -310,6 +310,7 @@ func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
 		if common == nil {
 			return nil // request was handled
 		}
+
 		handled, err := redirectTreeOrBlob(routeTree, common, r, w)
 		if handled {
 			return nil

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -318,6 +318,7 @@ func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
 		if err != nil {
 			return err
 		}
+
 		common.Title = title(common, r)
 		return renderTemplate(w, "app.html", common)
 	}

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -275,7 +275,7 @@ func initRouter() {
 	}))
 
 	// tree
-	router.Get(routeTree).Handler(handler(serveBasicPage(func(c *Common, r *http.Request) string {
+	router.Get(routeTree).Handler(handler(serveTree(func(c *Common, r *http.Request) string {
 		// e.g. "src - gorilla/mux - Sourcegraph"
 		dirName := path.Base(mux.Vars(r)["Path"])
 		return brandNameSubtitle(dirName, repoShortName(c.Repo.Name))

--- a/shared/src/panel/views/FileLocations.tsx
+++ b/shared/src/panel/views/FileLocations.tsx
@@ -14,7 +14,7 @@ import { VirtualList } from '../../components/VirtualList'
 import { SettingsCascadeProps } from '../../settings/settings'
 import { asError, ErrorLike, isErrorLike } from '../../util/errors'
 import { property, isDefined } from '../../util/types'
-import { parseRepoURI, toPrettyBlobURL } from '../../util/url'
+import { parseRepoURI, toPrettyBlobURL, toRepoURL } from '../../util/url'
 
 export const FileLocationsError: React.FunctionComponent<{ error: ErrorLike }> = ({ error }) => (
     <div className="file-locations__error alert alert-danger m-2">
@@ -181,7 +181,7 @@ function refsToFileMatch(uri: string, refs: Badged<Location>[]): IFileMatch {
             // This is the only usage of toRepoURL, and it is arguably simpler than getting the value from the
             // GraphQL API. We will be removing these old-style git: URIs eventually, so it's not worth fixing this
             // deprecated usage.
-            url: toRepoURL(p.repoName),
+            url: toRepoURL(p),
         },
         limitHit: false,
         lineMatches: refs.filter(property('range', isDefined)).map(
@@ -194,13 +194,4 @@ function refsToFileMatch(uri: string, refs: Badged<Location>[]): IFileMatch {
             })
         ),
     }
-}
-
-/**
- * Returns the URL path for the given repository name.
- *
- * @deprecated Obtain the repository's URL from the GraphQL Repository.url field instead.
- */
-function toRepoURL(repoName: string): string {
-    return `/${repoName}`
 }

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -466,16 +466,25 @@ function parseLineOrPosition(
 }
 
 /** Encodes a repository at a revspec for use in a URL. */
-export function encodeRepoRev(repo: string, rev?: string): string {
-    return rev ? `${repo}@${escapeRevspecForURL(rev)}` : repo
+export function encodeRepoRev({ repoName, rev }: RepoSpec & Partial<RevSpec>): string {
+    return rev ? `${repoName}@${escapeRevspecForURL(rev)}` : repoName
 }
 
 export function toPrettyBlobURL(
     target: RepoFile & Partial<UIPositionSpec> & Partial<ViewStateSpec> & Partial<UIRangeSpec> & Partial<RenderModeSpec>
 ): string {
-    return `/${encodeRepoRev(target.repoName, target.rev)}/-/blob/${target.filePath}${toRenderModeQuery(
-        target
-    )}${toPositionOrRangeHash(target)}${toViewStateHashComponent(target.viewState)}`
+    return `/${encodeRepoRev({ repoName: target.repoName, rev: target.rev })}/-/blob/${
+        target.filePath
+    }${toRenderModeQuery(target)}${toPositionOrRangeHash(target)}${toViewStateHashComponent(target.viewState)}`
+}
+
+/**
+ * Returns the URL path for the given repository name.
+ *
+ * @deprecated Obtain the repository's URL from the GraphQL Repository.url field instead.
+ */
+export function toRepoURL(target: RepoSpec & Partial<RevSpec>): string {
+    return '/' + encodeRepoRev(target)
 }
 
 /**

--- a/web/src/repo/blob/GoToRawAction.tsx
+++ b/web/src/repo/blob/GoToRawAction.tsx
@@ -13,7 +13,7 @@ interface Props {
  */
 export class GoToRawAction extends React.PureComponent<Props> {
     public render(): JSX.Element {
-        const to = `/${encodeRepoRev(this.props.repoName, this.props.rev)}/-/raw/${this.props.filePath}`
+        const to = `/${encodeRepoRev(this.props)}/-/raw/${this.props.filePath}`
         return (
             <a href={to} className="nav-link" data-tooltip="Raw (download file)" download={true}>
                 <FileDownloadIcon className="icon-inline" />

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -86,7 +86,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
 const hideRepoRevContent = localStorage.getItem('hideRepoRevContent')
 
 export const repoRevContainerRoutes: readonly RepoRevContainerRoute[] = [
-    ...['', '/-/:objectType(blob|tree)/:filePath+'].map(routePath => ({
+    ...['', '/-/:objectType(blob|tree)/:filePath*'].map(routePath => ({
         path: routePath,
         exact: routePath === '',
         render: ({
@@ -103,12 +103,17 @@ export const repoRevContainerRoutes: readonly RepoRevContainerRoute[] = [
                 objectType: 'blob' | 'tree' | undefined
                 filePath: string | undefined
             }>) => {
-            const objectType: 'blob' | 'tree' = match.params.objectType || 'tree'
-
             // The decoding depends on the pinned `history` version.
             // See https://github.com/sourcegraph/sourcegraph/issues/4408
             // and https://github.com/ReactTraining/history/issues/505
             const filePath = decodeURIComponent(match.params.filePath || '') // empty string is root
+
+            // Redirect tree and blob routes pointing to the root to the repo page
+            if (match.params.objectType && filePath.replace(/\/+$/g, '') === '') {
+                return <Redirect to={`/${repoName}`} />
+            }
+
+            const objectType: 'blob' | 'tree' = match.params.objectType || 'tree'
 
             const mode = getModeFromPath(filePath)
 

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { getModeFromPath } from '../../../shared/src/languages'
-import { isLegacyFragment, parseHash } from '../../../shared/src/util/url'
+import { isLegacyFragment, parseHash, toRepoURL } from '../../../shared/src/util/url'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
 import { RepoContainerRoute } from './RepoContainer'
@@ -110,7 +110,7 @@ export const repoRevContainerRoutes: readonly RepoRevContainerRoute[] = [
 
             // Redirect tree and blob routes pointing to the root to the repo page
             if (match.params.objectType && filePath.replace(/\/+$/g, '') === '') {
-                return <Redirect to={`/${repoName}`} />
+                return <Redirect to={toRepoURL({ repoName, rev: context.rev })} />
             }
 
             const objectType: 'blob' | 'tree' = match.params.objectType || 'tree'

--- a/web/src/util/url.test.ts
+++ b/web/src/util/url.test.ts
@@ -11,16 +11,14 @@ function assertDeepStrictEqual(actual: unknown, expected: unknown): void {
     expect(actual).toEqual(expected)
 }
 
-const ctx = {
-    repoName: 'github.com/gorilla/mux',
-    rev: '',
-    commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
-    filePath: 'mux.go',
-}
-
 describe('toTreeURL', () => {
     test('formats url', () => {
-        expect(toTreeURL(ctx)).toBe('/github.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7/-/tree/mux.go')
+        const target = {
+            repoName: 'github.com/gorilla/mux',
+            rev: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
+            filePath: 'mux.go',
+        }
+        expect(toTreeURL(target)).toBe('/github.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7/-/tree/mux.go')
     })
 
     // other cases are gratuitous given tests for other URL functions

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -9,9 +9,8 @@ import {
     toPositionHashComponent,
 } from '../../../shared/src/util/url'
 
-export function toTreeURL(ctx: RepoFile): string {
-    const rev = ctx.commitID || ctx.rev || ''
-    return `/${encodeRepoRev(ctx.repoName, rev)}/-/tree/${ctx.filePath}`
+export function toTreeURL(target: RepoFile): string {
+    return `/${encodeRepoRev(target)}/-/tree/${target.filePath}`
 }
 
 /**
@@ -50,10 +49,10 @@ function formatLineOrPositionOrRange(lpr: LineOrPositionOrRange): string {
  */
 export function replaceRevisionInURL(href: string, newRev: string): string {
     const parsed = parseBrowserRepoURL(href)
-    const repoRev = `/${encodeRepoRev(parsed.repoName, parsed.rev)}`
+    const repoRev = `/${encodeRepoRev(parsed)}`
 
     const u = new URL(href, window.location.href)
-    u.pathname = `/${encodeRepoRev(parsed.repoName, newRev)}${u.pathname.slice(repoRev.length)}`
+    u.pathname = `/${encodeRepoRev({ ...parsed, rev: newRev })}${u.pathname.slice(repoRev.length)}`
     return `${u.pathname}${u.search}${u.hash}`
 }
 


### PR DESCRIPTION
Extensions in code insights want to link to file paths and directories to support drilling into the details. Given how our URLs are structured, they currently need to know whether the file path is a directory or file to construct the URL. This information is not always available, and would require making a lot of API requests to determine eagerly.

We can be helpful by instead just redirecting a tree to a blob and vice versa if the file/directory turned out to be a directory/file. This also makes us return a proper 404 on not found files.
Redirect is implemented both in the client and the backend (to support internal and external links).

Please give extra care to my Go code 😄 