### PR TITLE
Handle in-app links within markdown

### DIFF
--- a/shared/dev/jest-environment.js
+++ b/shared/dev/jest-environment.js
@@ -29,10 +29,16 @@ class JSDOMEnvironment {
       ...config.testEnvironmentOptions,
     })
     const global = (this.global = this.dom.window.document.defaultView)
+
+    // JSDOM does not have SVGAElement implemented. Use a quick and dirty polyfill.
+    // This does not implement href and target, which is impossible without mofifying JSDOM.
+    global.SVGAElement = class SVGAElement extends global.SVGGraphicsElement {}
+
     // jsdom doesn't support document.queryCommandSupported(), needed for monaco-editor.
     // https://github.com/testing-library/react-testing-library/issues/546
     // eslint-disable-next-line @typescript-eslint/unbound-method
     this.dom.window.document.queryCommandSupported = () => false
+
     if (!global) {
       throw new Error('JSDOM did not return a Window object')
     }

--- a/shared/src/components/Markdown.test.tsx
+++ b/shared/src/components/Markdown.test.tsx
@@ -1,10 +1,55 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import renderer from 'react-test-renderer'
 import { Markdown } from './Markdown'
+import { createMemoryHistory } from 'history'
+import { renderMarkdown } from '../util/markdown'
+import * as sinon from 'sinon'
 
 describe('Markdown', () => {
-    test('render', () => {
-        const component = renderer.create(<Markdown dangerousInnerHTML="hello" />)
+    it('renders', () => {
+        const history = createMemoryHistory()
+        const component = renderer.create(<Markdown history={history} dangerousInnerHTML="hello" />)
         expect(component.toJSON()).toMatchSnapshot()
+    })
+    it('handles clicks on links that stay inside the app', () => {
+        jsdom.reconfigure({ url: 'https://sourcegraph.test/some/where' })
+        const root = document.body.appendChild(document.createElement('div'))
+        const history = createMemoryHistory({ initialEntries: [] })
+        expect(history).toHaveLength(0)
+        ReactDOM.render(
+            <Markdown
+                history={history}
+                dangerousInnerHTML={renderMarkdown('[test](https://sourcegraph.test/else/where)')}
+            />,
+            root
+        )
+        const anchor = root.querySelector('a')
+        expect(anchor).toBeDefined()
+        const spy = sinon.spy((_event: MouseEvent) => undefined)
+        window.addEventListener('click', spy)
+        anchor!.click()
+        sinon.assert.calledOnce(spy)
+        expect(spy.args[0][0].defaultPrevented).toBe(true)
+        expect(history).toHaveLength(1)
+        expect(history.entries[0].pathname).toBe('/else/where')
+    })
+    it('ignores clicks on links that go outside the app', () => {
+        jsdom.reconfigure({ url: 'https://sourcegraph.test/some/where' })
+        const root = document.body.appendChild(document.createElement('div'))
+        const history = createMemoryHistory({ initialEntries: [] })
+        expect(history).toHaveLength(0)
+        ReactDOM.render(
+            <Markdown history={history} dangerousInnerHTML={renderMarkdown('[test](https://github.com/some/where)')} />,
+            root
+        )
+        const anchor = root.querySelector('a')
+        expect(anchor).toBeDefined()
+        const spy = sinon.spy((_event: MouseEvent) => undefined)
+        window.addEventListener('click', spy)
+        anchor!.click()
+        sinon.assert.calledOnce(spy)
+        expect(spy.args[0][0].defaultPrevented).toBe(false)
+        expect(history).toHaveLength(0)
     })
 })

--- a/shared/src/components/Markdown.tsx
+++ b/shared/src/components/Markdown.tsx
@@ -1,9 +1,12 @@
 import classNames from 'classnames'
-import * as React from 'react'
+import React, { useCallback } from 'react'
+import * as H from 'history'
+import { isInstanceOf, anyOf } from '../util/types'
 
 interface Props {
     wrapper?: 'div' | 'span'
     dangerousInnerHTML: string
+    history: H.History
     className?: string
     /** A function to attain a reference to the top-level div from a parent component. */
     refFn?: (ref: HTMLElement | null) => void
@@ -13,11 +16,42 @@ export const Markdown: React.FunctionComponent<Props> = ({
     wrapper: RootComponent = 'div',
     refFn,
     className,
+    history,
     dangerousInnerHTML,
-}: Props) => (
-    <RootComponent
-        ref={refFn}
-        className={classNames(className, 'markdown')}
-        dangerouslySetInnerHTML={{ __html: dangerousInnerHTML }}
-    />
-)
+}: Props) => {
+    // Links in markdown cannot use react-router's <Link>.
+    // Prevent hitting the backend (full page reloads) for links that stay inside the app.
+    const onClick = useCallback<React.MouseEventHandler<unknown>>(
+        event => {
+            // Do nothing if the link was requested to open in a new tab
+            if (event.ctrlKey || event.metaKey) {
+                return
+            }
+            // Check if click happened within an anchor inside the markdown
+            const anchor = event.nativeEvent
+                .composedPath()
+                .slice(0, event.nativeEvent.composedPath().indexOf(event.currentTarget))
+                .find(anyOf(isInstanceOf(HTMLAnchorElement), isInstanceOf(SVGAElement)))
+            if (!anchor) {
+                return
+            }
+            const href = typeof anchor.href === 'string' ? anchor.href : anchor.href.baseVal
+            // Check if URL is outside the app
+            if (!href.startsWith(window.location.origin)) {
+                return
+            }
+            // Handle navigation programmatically
+            event.preventDefault()
+            history.push(new URL(href).pathname)
+        },
+        [history]
+    )
+    return (
+        <RootComponent
+            onClick={onClick}
+            ref={refFn}
+            className={classNames(className, 'markdown')}
+            dangerouslySetInnerHTML={{ __html: dangerousInnerHTML }}
+        />
+    )
+}

--- a/shared/src/components/__snapshots__/Markdown.test.tsx.snap
+++ b/shared/src/components/__snapshots__/Markdown.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Markdown render 1`] = `
+exports[`Markdown renders 1`] = `
 <div
   className="markdown"
   dangerouslySetInnerHTML={
@@ -8,5 +8,6 @@ exports[`Markdown render 1`] = `
       "__html": "hello",
     }
   }
+  onClick={[Function]}
 />
 `;

--- a/shared/src/panel/views/PanelView.tsx
+++ b/shared/src/panel/views/PanelView.tsx
@@ -34,7 +34,10 @@ export class PanelView extends React.PureComponent<Props, State> {
             >
                 {this.props.panelView.content && (
                     <div className="px-2 pt-2">
-                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.panelView.content)} />
+                        <Markdown
+                            dangerousInnerHTML={renderMarkdown(this.props.panelView.content)}
+                            history={this.props.history}
+                        />
                     </div>
                 )}
                 {this.props.panelView.reactElement}

--- a/shared/src/util/types.ts
+++ b/shared/src/util/types.ts
@@ -57,3 +57,31 @@ export const property = <O extends object, K extends keyof O, T extends O[K]>(
  */
 export const isInstanceOf = <C extends new () => object>(of: C) => (val: unknown): val is InstanceType<C> =>
     val instanceof of
+
+/**
+ * Combines multiple type guards into one type guard that checks if the value passes any of the provided type guards.
+ */
+export function anyOf<T0, T1 extends T0, T2 extends Exclude<T0, T1>>(
+    t1: (value: T0) => value is T1,
+    t2: (value: Exclude<T0, T1>) => value is T2
+): (value: T0) => value is T1 | T2
+export function anyOf<T0, T1 extends T0, T2 extends Exclude<T0, T1>, T3 extends Exclude<T1, T2>>(
+    t1: (value: T0) => value is T1,
+    t2: (value: Exclude<T0, T1>) => value is T2,
+    t3: (value: Exclude<T1, T2>) => value is T3
+): (value: T0) => value is T1 | T2 | T3
+export function anyOf<
+    T0,
+    T1 extends T0,
+    T2 extends Exclude<T0, T1>,
+    T3 extends Exclude<T1, T2>,
+    T4 extends Exclude<T2, T3>
+>(
+    t1: (value: T0) => value is T1,
+    t2: (value: Exclude<T0, T1>) => value is T2,
+    t3: (value: Exclude<T1, T2>) => value is T3,
+    t4: (value: Exclude<T2, T3>) => value is T4
+): (value: T0) => value is T1 | T2 | T3 | T4
+export function anyOf(...typeGuards: any[]): any {
+    return (value: unknown) => typeGuards.some((guard: (value: unknown) => boolean) => guard(value))
+}

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -141,6 +141,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             <GlobalAlerts
                 isSiteAdmin={!!props.authenticatedUser && props.authenticatedUser.siteAdmin}
                 settingsCascade={props.settingsCascade}
+                history={props.history}
             />
             {!needsSiteInit && !isSiteInit && !!props.authenticatedUser && (
                 <IntegrationsToast history={props.history} />

--- a/web/src/api/APIConsole.tsx
+++ b/web/src/api/APIConsole.tsx
@@ -128,7 +128,11 @@ export class APIConsole extends React.PureComponent<Props, State> {
                         <LoadingSpinner className="icon-inline" /> Loading…
                     </span>
                 ) : isErrorLike(this.state.graphiqlOrError) ? (
-                    <ErrorAlert prefix="Error loading API console" error={this.state.graphiqlOrError} />
+                    <ErrorAlert
+                        prefix="Error loading API console"
+                        error={this.state.graphiqlOrError}
+                        history={this.props.history}
+                    />
                 ) : (
                     this.renderGraphiQL()
                 )}

--- a/web/src/auth/ResetPasswordPage.tsx
+++ b/web/src/auth/ResetPasswordPage.tsx
@@ -10,6 +10,7 @@ import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { PasswordInput } from './SignInSignUpCommon'
 import { ErrorAlert } from '../components/alerts'
+import * as H from 'history'
 
 interface ResetPasswordInitFormState {
     /** The user's email input value. */
@@ -22,11 +23,15 @@ interface ResetPasswordInitFormState {
     submitOrError: undefined | 'loading' | ErrorLike | null
 }
 
+interface ResetPasswordInitFormProps {
+    history: H.History
+}
+
 /**
  * A form where the user can initiate the reset-password flow. This is the 1st step in the
  * reset-password flow; ResetPasswordCodePage is the 2nd step.
  */
-class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFormState> {
+class ResetPasswordInitForm extends React.PureComponent<ResetPasswordInitFormProps, ResetPasswordInitFormState> {
     public state: ResetPasswordInitFormState = {
         email: '',
         submitOrError: undefined,
@@ -67,7 +72,7 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
                 </button>
                 {this.state.submitOrError === 'loading' && <LoadingSpinner className="icon-inline mt-2" />}
                 {isErrorLike(this.state.submitOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} history={this.props.history} />
                 )}
             </Form>
         )
@@ -112,6 +117,7 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
 interface ResetPasswordCodeFormProps {
     userID: number
     code: string
+    history: H.History
 }
 
 interface ResetPasswordCodeFormState {
@@ -163,7 +169,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
                 </button>
                 {this.state.submitOrError === 'loading' && <LoadingSpinner className="icon-inline mt-2" />}
                 {isErrorLike(this.state.submitOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} history={this.props.history} />
                 )}
             </Form>
         )
@@ -225,12 +231,12 @@ export class ResetPasswordPage extends React.PureComponent<ResetPasswordPageProp
                 const code = searchParams.get('code')
                 const userID = parseInt(searchParams.get('userID') || '', 10)
                 if (code && !isNaN(userID)) {
-                    body = <ResetPasswordCodeForm code={code} userID={userID} />
+                    body = <ResetPasswordCodeForm code={code} userID={userID} history={this.props.history} />
                 } else {
                     body = <div className="alert alert-danger">The password reset link you followed is invalid.</div>
                 }
             } else {
-                body = <ResetPasswordInitForm />
+                body = <ResetPasswordInitForm history={this.props.history} />
             }
         } else {
             body = (

--- a/web/src/auth/SignUpForm.tsx
+++ b/web/src/auth/SignUpForm.tsx
@@ -9,6 +9,7 @@ import { enterpriseTrial, signupTerms } from '../util/features'
 import { EmailInput, PasswordInput, UsernameInput } from './SignInSignUpCommon'
 import { ErrorAlert } from '../components/alerts'
 import classNames from 'classnames'
+import * as H from 'history'
 
 export interface SignUpArgs {
     email: string
@@ -24,6 +25,7 @@ interface SignUpFormProps {
     doSignUp: (args: SignUpArgs) => Promise<void>
 
     buttonLabel?: string
+    history: H.History
 }
 
 interface SignUpFormState {
@@ -55,7 +57,9 @@ export class SignUpForm extends React.Component<SignUpFormProps, SignUpFormState
                 className={classNames('signin-signup-form', 'e2e-signup-form', this.props.className)}
                 onSubmit={this.handleSubmit}
             >
-                {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
+                {this.state.error && (
+                    <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
+                )}
                 <div className="form-group">
                     <EmailInput
                         className="signin-signup-form__input"

--- a/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -43,7 +43,9 @@ export class UsernamePasswordSignInForm extends React.Component<Props, State> {
                 ) : (
                     <p className="text-muted">To create an account, contact the site admin.</p>
                 )}
-                {this.state.error && <ErrorAlert className="my-2" error={this.state.error} icon={false} />}
+                {this.state.error && (
+                    <ErrorAlert className="my-2" error={this.state.error} icon={false} history={this.props.history} />
+                )}
                 <div className="form-group">
                     <input
                         className="form-control signin-signup-form__input"

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -770,7 +770,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                     <div className="alert alert-danger filtered-connection__error">
                         {errors.map((error, i) => (
                             <React.Fragment key={i}>
-                                <ErrorMessage error={error} />
+                                <ErrorMessage error={error} history={this.props.history} />
                             </React.Fragment>
                         ))}
                     </div>

--- a/web/src/components/SearchResult.tsx
+++ b/web/src/components/SearchResult.tsx
@@ -6,6 +6,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { SearchResultMatch } from './SearchResultMatch'
 import { ThemeProps } from '../../../shared/src/theme'
+import * as H from 'history'
 
 export interface HighlightRange {
     /**
@@ -24,6 +25,7 @@ export interface HighlightRange {
 
 interface Props extends ThemeProps {
     result: GQL.GenericSearchResultInterface
+    history: H.History
 }
 
 export class SearchResult extends React.Component<Props> {
@@ -69,6 +71,7 @@ export class SearchResult extends React.Component<Props> {
                         item={match}
                         highlightRanges={highlightRanges}
                         isLightTheme={this.props.isLightTheme}
+                        history={this.props.history}
                     />
                 )
             })}

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -14,10 +14,12 @@ import { renderMarkdown } from '../discussions/backend'
 import { highlightCode } from '../search/backend'
 import { HighlightRange } from './SearchResult'
 import { ThemeProps } from '../../../shared/src/theme'
+import * as H from 'history'
 
 interface SearchResultMatchProps extends ThemeProps {
     item: GQL.ISearchResultMatch
     highlightRanges: HighlightRange[]
+    history: H.History
 }
 
 interface SearchResultMatchState {
@@ -173,6 +175,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                         refFn={this.setTableContainerElement}
                                         className="search-result-match__markdown search-result-match__code-excerpt"
                                         dangerousInnerHTML={this.state.HTML}
+                                        history={this.props.history}
                                     />
                                 </code>
                             ) : (
@@ -180,6 +183,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                     refFn={this.setTableContainerElement}
                                     className="search-result-match__markdown"
                                     dangerousInnerHTML={this.state.HTML}
+                                    history={this.props.history}
                                 />
                             )}
                         </Link>

--- a/web/src/components/__snapshots__/alerts.test.tsx.snap
+++ b/web/src/components/__snapshots__/alerts.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`ErrorAlert should add a prefix if given 1`] = `
         "__html": "An error happened",
       }
     }
+    onClick={[Function]}
   />
 </div>
 `;
@@ -37,6 +38,7 @@ exports[`ErrorAlert should omit the icon if icon={false} 1`] = `
         "__html": "An error happened",
       }
     }
+    onClick={[Function]}
   />
 </div>
 `;
@@ -60,6 +62,7 @@ exports[`ErrorAlert should render a Go multierror nicely 1`] = `
 </ul>",
       }
     }
+    onClick={[Function]}
   />
 </div>
 `;
@@ -80,6 +83,7 @@ exports[`ErrorAlert should render an Error object as an alert 1`] = `
         "__html": "An error happened",
       }
     }
+    onClick={[Function]}
   />
 </div>
 `;

--- a/web/src/components/alerts.test.tsx
+++ b/web/src/components/alerts.test.tsx
@@ -1,23 +1,40 @@
 import renderer from 'react-test-renderer'
 import { ErrorAlert } from './alerts'
 import React from 'react'
+import { createMemoryHistory } from 'history'
 
 jest.mock('mdi-react/AlertCircleIcon', () => 'AlertCircleIcon')
 
 describe('ErrorAlert', () => {
     it('should render an Error object as an alert', () => {
-        expect(renderer.create(<ErrorAlert error={new Error('an error happened')} />).toJSON()).toMatchSnapshot()
+        expect(
+            renderer
+                .create(<ErrorAlert error={new Error('an error happened')} history={createMemoryHistory()} />)
+                .toJSON()
+        ).toMatchSnapshot()
     })
 
     it('should add a prefix if given', () => {
         expect(
-            renderer.create(<ErrorAlert error={new Error('an error happened')} prefix="An error happened" />).toJSON()
+            renderer
+                .create(
+                    <ErrorAlert
+                        error={new Error('an error happened')}
+                        prefix="An error happened"
+                        history={createMemoryHistory()}
+                    />
+                )
+                .toJSON()
         ).toMatchSnapshot()
     })
 
     it('should omit the icon if icon={false}', () => {
         expect(
-            renderer.create(<ErrorAlert error={new Error('an error happened')} icon={false} />).toJSON()
+            renderer
+                .create(
+                    <ErrorAlert error={new Error('an error happened')} icon={false} history={createMemoryHistory()} />
+                )
+                .toJSON()
         ).toMatchSnapshot()
     })
 
@@ -31,6 +48,7 @@ describe('ErrorAlert', () => {
                                 '- Additional property asdasd is not allowed\n- projectQuery.0: String length must be greater than or equal to 1\n'
                             )
                         }
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()

--- a/web/src/components/alerts.tsx
+++ b/web/src/components/alerts.tsx
@@ -5,6 +5,7 @@ import { upperFirst } from 'lodash'
 import { Markdown } from '../../../shared/src/components/Markdown'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import classNames from 'classnames'
+import * as H from 'history'
 
 const renderError = (error: unknown): string =>
     renderMarkdown(upperFirst((asError(error).message || 'Unknown Error').replace(/\t/g, '')))
@@ -12,8 +13,8 @@ const renderError = (error: unknown): string =>
         .replace(/^<p>/, '')
         .replace(/<\/p>$/, '')
 
-export const ErrorMessage: React.FunctionComponent<{ error: unknown }> = ({ error }) => (
-    <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} />
+export const ErrorMessage: React.FunctionComponent<{ error: unknown; history: H.History }> = ({ error, history }) => (
+    <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} history={history} />
 )
 
 /**
@@ -43,12 +44,13 @@ export const ErrorAlert: React.FunctionComponent<{
 
     className?: string
     style?: React.CSSProperties
-}> = ({ error, className, icon = true, prefix, ...rest }) => {
+    history: H.History
+}> = ({ error, className, icon = true, prefix, history, ...rest }) => {
     prefix = prefix?.trim().replace(/:+$/, '')
     return (
         <div className={classNames('alert', 'alert-danger', className)} {...rest}>
             {icon && <AlertCircleIcon className="icon icon-inline" />} {prefix && <strong>{prefix}:</strong>}{' '}
-            <ErrorMessage error={error} />
+            <ErrorMessage error={error} history={history} />
         </div>
     )
 }

--- a/web/src/discussions/DiscussionsComment.tsx
+++ b/web/src/discussions/DiscussionsComment.tsx
@@ -40,6 +40,7 @@ interface Props extends ExtensionsControllerProps {
      * button clicks.
      */
     onDelete?: (comment: GQL.IDiscussionComment) => Observable<void>
+    history: H.History
 }
 
 interface State {
@@ -147,7 +148,7 @@ export class DiscussionsComment extends React.PureComponent<Props> {
                         setElementTooltip={setElementTooltip}
                         linkPreviewContentClass={LINK_PREVIEW_CLASS}
                     >
-                        {props => <Markdown {...props} />}
+                        {props => <Markdown {...props} history={this.props.history} />}
                     </WithLinkPreviews>
                 </div>
             </div>

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.test.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { AddChangesetForm } from './AddChangesetForm'
+import { createMemoryHistory } from 'history'
 
 describe('AddChangesetForm', () => {
     test('renders the form', () => {
         expect(
-            renderer.create(<AddChangesetForm campaignID="123" onAdd={() => undefined} />).toJSON()
+            renderer
+                .create(<AddChangesetForm campaignID="123" onAdd={() => undefined} history={createMemoryHistory()} />)
+                .toJSON()
         ).toMatchSnapshot()
     })
 })

--- a/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
+++ b/web/src/enterprise/campaigns/detail/AddChangesetForm.tsx
@@ -7,6 +7,7 @@ import { RepoNotFoundError } from '../../../../../shared/src/backend/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 async function addChangeset({
     campaignID,
@@ -63,9 +64,10 @@ async function addChangeset({
 /**
  * Simple, temporary form to add changesets.
  */
-export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: () => void }> = ({
+export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: () => void; history: H.History }> = ({
     campaignID,
     onAdd,
+    history,
 }) => {
     const [error, setError] = useState<Error>()
     const [repoName, setRepoName] = useState('')
@@ -135,7 +137,7 @@ export const AddChangesetForm: React.FunctionComponent<{ campaignID: ID; onAdd: 
                     {isLoading && <LoadingSpinner className="ml-2 icon-inline" />}
                 </button>
             </Form>
-            {error && <ErrorAlert error={error} className="mt-2" />}
+            {error && <ErrorAlert error={error} className="mt-2" history={history} />}
         </>
     )
 }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -404,9 +404,9 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                 onDelete={onDelete}
                 formID={campaignFormID}
             />
-            {alertError && <ErrorAlert error={alertError} />}
+            {alertError && <ErrorAlert error={alertError} history={history} />}
             {campaign && !patchSet && !['saving', 'editing'].includes(mode) && (
-                <CampaignStatus campaign={campaign} onPublish={onPublish} afterRetry={afterRetry} />
+                <CampaignStatus campaign={campaign} onPublish={onPublish} afterRetry={afterRetry} history={history} />
             )}
             <Form id={campaignFormID} onSubmit={onSubmit} onReset={onCancel} className="e2e-campaign-form">
                 {['saving', 'editing'].includes(mode) && (
@@ -549,6 +549,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                 <div className="card-body">
                                     <Markdown
                                         dangerousInnerHTML={renderMarkdown(campaign.description || '_No description_')}
+                                        history={history}
                                     />
                                 </div>
                             </div>
@@ -570,7 +571,11 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                                             Add a changeset to get started.
                                         </div>
                                     )}
-                                    <AddChangesetForm campaignID={campaign.id} onAdd={onAddChangeset} />
+                                    <AddChangesetForm
+                                        campaignID={campaign.id}
+                                        onAdd={onAddChangeset}
+                                        history={history}
+                                    />
                                 </>
                             )}
                         </>

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.story.tsx
@@ -4,6 +4,7 @@ import { CampaignStatus } from './CampaignStatus'
 import { BackgroundProcessState } from '../../../../../shared/src/graphql/schema'
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
+import { createMemoryHistory } from 'history'
 import webStyles from '../../../SourcegraphWebApp.scss'
 
 const { add } = storiesOf('CampaignStatus', module).addDecorator(story => (
@@ -40,5 +41,6 @@ add('Errored', () => (
         }}
         onPublish={action('Publish')}
         afterRetry={action('Retry')}
+        history={createMemoryHistory()}
     />
 ))

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.test.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { CampaignStatus } from './CampaignStatus'
 import { createRenderer } from 'react-test-renderer/shallow'
+import { createMemoryHistory } from 'history'
 
 const PROPS = {
     afterRetry: () => undefined,
+    history: createMemoryHistory(),
 }
 
 const CAMPAIGN: Pick<GQL.ICampaign, 'id' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt'> & {

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
@@ -7,6 +7,7 @@ import { retryCampaign } from './backend'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import ErrorIcon from 'mdi-react/ErrorIcon'
+import * as H from 'history'
 
 export interface CampaignStatusProps {
     campaign: Pick<GQL.ICampaign, 'id' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt'> & {
@@ -18,6 +19,7 @@ export interface CampaignStatusProps {
     onPublish: () => void
     /** Called when the "Retry failed jobs" button is clicked. */
     afterRetry: (updatedCampaign: GQL.ICampaign) => void
+    history: H.History
 }
 
 type CampaignState = 'closed' | 'errored' | 'processing' | 'completed'
@@ -25,7 +27,12 @@ type CampaignState = 'closed' | 'errored' | 'processing' | 'completed'
 /**
  * The status of a campaign's jobs, plus its closed state and errors.
  */
-export const CampaignStatus: React.FunctionComponent<CampaignStatusProps> = ({ campaign, onPublish, afterRetry }) => {
+export const CampaignStatus: React.FunctionComponent<CampaignStatusProps> = ({
+    campaign,
+    onPublish,
+    afterRetry,
+    history,
+}) => {
     const { status } = campaign
 
     const progress = (status.completedCount / (status.pendingCount + status.completedCount)) * 100
@@ -47,7 +54,7 @@ export const CampaignStatus: React.FunctionComponent<CampaignStatusProps> = ({ c
             {status.errors.map((error, i) => (
                 <li className="mb-2" key={i}>
                     <p className="mb-0">
-                        <ErrorMessage error={error} />
+                        <ErrorMessage error={error} history={history} />
                     </p>
                 </li>
             ))}

--- a/web/src/enterprise/campaigns/detail/CampaignUpdateSelection.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignUpdateSelection.tsx
@@ -45,6 +45,7 @@ export const CampaignUpdateSelection: React.FunctionComponent<Props> = ({ histor
                 nodeComponent={CampaignNode}
                 nodeComponentProps={{
                     selection: { buttonLabel: 'Preview', enabled: true, onSelect: selectCampaign },
+                    history,
                 }}
                 queryConnection={queryConnection}
                 useURLQuery={false}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -691,6 +691,7 @@ Array [
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
   </div>,
@@ -1101,6 +1102,7 @@ Array [
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
   </div>,

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignStatus.test.tsx.snap
@@ -23,6 +23,38 @@ exports[`CampaignStatus viewerCanAdminister: false campaign errored 1`] = `
             >
               <ErrorMessage
                 error="a"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -34,6 +66,38 @@ exports[`CampaignStatus viewerCanAdminister: false campaign errored 1`] = `
             >
               <ErrorMessage
                 error="b"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -91,6 +155,38 @@ exports[`CampaignStatus viewerCanAdminister: false campaign processing 1`] = `
             >
               <ErrorMessage
                 error="a"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -102,6 +198,38 @@ exports[`CampaignStatus viewerCanAdminister: false campaign processing 1`] = `
             >
               <ErrorMessage
                 error="b"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -187,6 +315,38 @@ exports[`CampaignStatus viewerCanAdminister: true campaign errored 1`] = `
             >
               <ErrorMessage
                 error="a"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -198,6 +358,38 @@ exports[`CampaignStatus viewerCanAdminister: true campaign errored 1`] = `
             >
               <ErrorMessage
                 error="b"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -263,6 +455,38 @@ exports[`CampaignStatus viewerCanAdminister: true campaign processing 1`] = `
             >
               <ErrorMessage
                 error="a"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>
@@ -274,6 +498,38 @@ exports[`CampaignStatus viewerCanAdminister: true campaign processing 1`] = `
             >
               <ErrorMessage
                 error="b"
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "key": undefined,
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "key": undefined,
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
               />
             </p>
           </li>

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignUpdateSelection.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignUpdateSelection.test.tsx.snap
@@ -64,6 +64,36 @@ exports[`CampaignUpdateSelection renders with URL param 1`] = `
     nodeComponent={[Function]}
     nodeComponentProps={
       Object {
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": undefined,
+              "pathname": "/campaigns/update",
+              "search": "?patchSet=123",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": undefined,
+            "pathname": "/campaigns/update",
+            "search": "?patchSet=123",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
         "selection": Object {
           "buttonLabel": "Preview",
           "enabled": true,

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../../../../../shared/src/components/Link'
 import { RouteComponentProps } from 'react-router'
 import { FilteredConnection, FilteredConnectionFilter } from '../../../../components/FilteredConnection'
 import { IUser, CampaignState } from '../../../../../../shared/src/graphql/schema'
-import { CampaignNode, CampaignNodeCampaign } from '../../list/CampaignNode'
+import { CampaignNode, CampaignNodeCampaign, CampaignNodeProps } from '../../list/CampaignNode'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
 import { Observable } from 'rxjs'
 
@@ -79,9 +79,10 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
             </div>
 
             {typeof totalCount === 'number' && totalCount > 0 && (
-                <FilteredConnection<CampaignNodeCampaign>
+                <FilteredConnection<CampaignNodeCampaign, Omit<CampaignNodeProps, 'node'>>
                     {...props}
                     nodeComponent={CampaignNode}
+                    nodeComponentProps={{ history: props.history }}
                     queryConnection={queryCampaigns}
                     hideSearch={true}
                     filters={FILTERS}

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -207,6 +207,40 @@ Array [
       }
     }
     nodeComponent={[Function]}
+    nodeComponentProps={
+      Object {
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": undefined,
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": undefined,
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+      }
+    }
     noun="campaign"
     pluralNoun="campaigns"
     queryConnection={[Function]}
@@ -455,6 +489,40 @@ Array [
       }
     }
     nodeComponent={[Function]}
+    nodeComponentProps={
+      Object {
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": undefined,
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": undefined,
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+      }
+    }
     noun="campaign"
     pluralNoun="campaigns"
     queryConnection={[Function]}

--- a/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import { CampaignNode } from './CampaignNode'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { parseISO } from 'date-fns'
+import { createMemoryHistory } from 'history'
 
 jest.mock('../icons', () => ({ CampaignsIcon: 'CampaignsIcon' }))
 
@@ -25,7 +26,11 @@ describe('CampaignNode', () => {
 
     test('open campaign', () => {
         expect(
-            renderer.create(<CampaignNode node={node} now={parseISO('2019-01-01T23:15:01Z')} />).toJSON()
+            renderer
+                .create(
+                    <CampaignNode node={node} now={parseISO('2019-01-01T23:15:01Z')} history={createMemoryHistory()} />
+                )
+                .toJSON()
         ).toMatchSnapshot()
     })
     test('closed campaign', () => {
@@ -35,6 +40,7 @@ describe('CampaignNode', () => {
                     <CampaignNode
                         node={{ ...node, closedAt: '2019-12-04T23:19:01Z' }}
                         now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()
@@ -43,7 +49,13 @@ describe('CampaignNode', () => {
     test('open draft campaign', () => {
         expect(
             renderer
-                .create(<CampaignNode node={{ ...node, publishedAt: null }} now={parseISO('2019-01-01T23:15:01Z')} />)
+                .create(
+                    <CampaignNode
+                        node={{ ...node, publishedAt: null }}
+                        now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
+                    />
+                )
                 .toJSON()
         ).toMatchSnapshot()
     })
@@ -54,6 +66,7 @@ describe('CampaignNode', () => {
                     <CampaignNode
                         node={{ ...node, publishedAt: null, closedAt: '2019-12-04T23:19:01Z' }}
                         now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()
@@ -70,6 +83,7 @@ describe('CampaignNode', () => {
                             description: '',
                         }}
                         now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()
@@ -87,6 +101,7 @@ describe('CampaignNode', () => {
                             onSelect: () => undefined,
                         }}
                         now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()
@@ -104,6 +119,7 @@ describe('CampaignNode', () => {
                             },
                         }}
                         now={parseISO('2019-01-01T23:15:01Z')}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()

--- a/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -9,6 +9,7 @@ import { changesetStateIcons, changesetStatusColorClasses } from '../detail/chan
 import formatDistance from 'date-fns/formatDistance'
 import parseISO from 'date-fns/parseISO'
 import { DraftBadge } from '../DraftBadge'
+import * as H from 'history'
 
 export type CampaignNodeCampaign = Pick<
     GQL.ICampaign,
@@ -30,12 +31,18 @@ export interface CampaignNodeProps {
     }
     /** Used for testing purposes. Sets the current date */
     now?: Date
+    history: H.History
 }
 
 /**
  * An item in the list of campaigns.
  */
-export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node, selection, now = new Date() }) => {
+export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({
+    node,
+    selection,
+    history,
+    now = new Date(),
+}) => {
     const campaignIconClass = node.closedAt ? 'text-danger' : 'text-success'
     const OpenChangesetIcon = changesetStateIcons[GQL.ChangesetState.OPEN]
     const MergedChangesetIcon = changesetStateIcons[GQL.ChangesetState.MERGED]
@@ -63,6 +70,7 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node,
                         dangerousInnerHTML={
                             node.description ? renderMarkdown(node.description, { plainText: true }) : 'No description'
                         }
+                        history={history}
                     />
                 </div>
                 <div data-tooltip="Open changesets">

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -46,6 +46,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -139,6 +140,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -221,6 +223,7 @@ exports[`CampaignNode campaign without description 1`] = `
             "__html": "No description",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -307,6 +310,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -398,6 +402,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -484,6 +489,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div
@@ -575,6 +581,7 @@ and renders in markdown
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <div

--- a/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
+++ b/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
@@ -3,6 +3,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import renderer, { act } from 'react-test-renderer'
 import { ProductPlanFormControl } from './ProductPlanFormControl'
 import { of } from 'rxjs'
+import { createMemoryHistory } from 'history'
 
 jest.mock('./ProductPlanPrice', () => ({
     ProductPlanPrice: 'ProductPlanPrice',
@@ -44,6 +45,7 @@ describe('ProductPlanFormControl', () => {
                         },
                     ])
                 }
+                history={createMemoryHistory()}
             />
         )
         act(() => undefined)

--- a/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
+++ b/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
@@ -10,6 +10,7 @@ import { ProductPlanPrice } from './ProductPlanPrice'
 import { ProductPlanTiered } from './ProductPlanTiered'
 import { ErrorAlert } from '../../../components/alerts'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 interface Props {
     /** The selected plan's billing ID. */
@@ -20,6 +21,7 @@ interface Props {
 
     disabled?: boolean
     className?: string
+    history: H.History
 
     /** For mocking in tests only. */
     _queryProductPlans?: typeof queryProductPlans
@@ -35,6 +37,7 @@ export const ProductPlanFormControl: React.FunctionComponent<Props> = ({
     onChange,
     disabled,
     className = '',
+    history,
     _queryProductPlans = queryProductPlans,
 }) => {
     /**
@@ -72,7 +75,7 @@ export const ProductPlanFormControl: React.FunctionComponent<Props> = ({
             {plans === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(plans) ? (
-                <ErrorAlert error={plans.message} />
+                <ErrorAlert error={plans.message} history={history} />
             ) : (
                 <>
                     <div className="list-group">

--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
@@ -9,8 +9,11 @@ import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../
 import { queryGraphQL } from '../../../backend/graphql'
 import { ExtensionsExploreSectionExtensionCard } from './ExtensionsExploreSectionExtensionCard'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
-interface Props {}
+interface Props {
+    history: H.History
+}
 
 const LOADING = 'loading' as const
 
@@ -66,7 +69,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
             <div className="card">
                 <h3 className="card-header">Top Sourcegraph extensions</h3>
                 {isErrorLike(extensionsOrError) ? (
-                    <ErrorAlert error={extensionsOrError} />
+                    <ErrorAlert error={extensionsOrError} history={this.props.history} />
                 ) : extensionsOrError.length === 0 ? (
                     <p>No extensions are available.</p>
                 ) : (

--- a/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -8,6 +8,7 @@ import {
     RegistryPublisher,
 } from '../../../extensions/extension/extension'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 export const RegistryPublisherFormGroup: React.FunctionComponent<{
     className?: string
@@ -20,11 +21,12 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
 
     disabled?: boolean
     onChange?: React.FormEventHandler<HTMLSelectElement>
-}> = ({ className = '', value, publishersOrError, disabled, onChange }) => (
+    history: H.History
+}> = ({ className = '', value, publishersOrError, disabled, onChange, history }) => (
     <div className={`form-group ${className}`}>
         <label htmlFor="extension-registry-create-extension-page__publisher">Publisher</label>
         {isErrorLike(publishersOrError) ? (
-            <ErrorAlert error={publishersOrError} />
+            <ErrorAlert error={publishersOrError} history={history} />
         ) : (
             <select
                 id="extension-registry-create-extension-page__publisher"

--- a/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -19,6 +19,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { RegistryExtensionDeleteButton } from './RegistryExtensionDeleteButton'
 import { RegistryExtensionNameFormGroup, RegistryPublisherFormGroup } from './RegistryExtensionForm'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 function updateExtension(
     args: Pick<
@@ -56,6 +57,7 @@ function updateExtension(
 
 interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
+    history: H.History
 }
 
 interface State {
@@ -152,6 +154,7 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                             value={publisher.id}
                             publishersOrError={[publisher]}
                             disabled={true}
+                            history={this.props.history}
                         />
                         <RegistryExtensionNameFormGroup
                             className="registry-extension-manage-page__input"
@@ -181,7 +184,9 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                             )}
                         </button>
                     </Form>
-                    {isErrorLike(this.state.updateOrError) && <ErrorAlert error={this.state.updateOrError} />}
+                    {isErrorLike(this.state.updateOrError) && (
+                        <ErrorAlert error={this.state.updateOrError} history={this.props.history} />
+                    )}
                     <div className="card mt-5 registry-extension-manage-page__other-actions">
                         <div className="card-header">Other actions</div>
                         <div className="card-body">

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -175,7 +175,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(({ e
                                             <LoadingSpinner className="icon-inline" />
                                         </div>
                                     ) : isErrorLike(bundleOrError) ? (
-                                        <ErrorAlert error={bundleOrError} />
+                                        <ErrorAlert error={bundleOrError} history={history} />
                                     ) : (
                                         <DynamicallyImportedMonacoSettingsEditor
                                             id="registry-extension-new-release-page__bundle"
@@ -212,7 +212,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(({ e
                                     </span>
                                 ))}
                         </div>
-                        {isErrorLike(updateOrError) && <ErrorAlert error={updateOrError} />}
+                        {isErrorLike(updateOrError) && <ErrorAlert error={updateOrError} history={history} />}
                     </Form>
                 </>
             ) : (

--- a/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -19,6 +19,7 @@ import { RegistryExtensionNameFormGroup, RegistryPublisherFormGroup } from '../e
 import { queryViewerRegistryPublishers } from './backend'
 import { RegistryAreaPageProps } from './RegistryArea'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 function createExtension(publisher: GQL.ID, name: string): Observable<GQL.IExtensionRegistryCreateExtensionResult> {
     return mutateGraphQL(
@@ -53,6 +54,7 @@ function createExtension(publisher: GQL.ID, name: string): Observable<GQL.IExten
 
 interface Props extends RegistryAreaPageProps, RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
+    history: H.History
 }
 
 interface State {
@@ -155,6 +157,7 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                                 publishersOrError={this.state.publishersOrError}
                                 onChange={this.onPublisherChange}
                                 disabled={this.state.creationOrError === 'loading'}
+                                history={this.props.history}
                             />
                             <RegistryExtensionNameFormGroup
                                 value={this.state.name}
@@ -195,7 +198,11 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             </button>
                         </Form>
                         {isErrorLike(this.state.creationOrError) && (
-                            <ErrorAlert className="mt-3" error={this.state.creationOrError} />
+                            <ErrorAlert
+                                className="mt-3"
+                                error={this.state.creationOrError}
+                                history={this.props.history}
+                            />
                         )}
                     </ModalPage>
                 </>

--- a/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsCodeIntelligencePage.tsx
@@ -15,8 +15,15 @@ import DeleteIcon from 'mdi-react/DeleteIcon'
 import { ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
 import { Subject } from 'rxjs'
+import * as H from 'history'
 
-const LsifUploadNode: FunctionComponent<{ node: GQL.ILSIFUpload; onDelete: () => void }> = ({ node, onDelete }) => {
+export interface LsifUploadNodeProps {
+    node: GQL.ILSIFUpload
+    onDelete: () => void
+    history: H.History
+}
+
+const LsifUploadNode: FunctionComponent<LsifUploadNodeProps> = ({ node, onDelete, history }) => {
     const [deletionOrError, setDeletionOrError] = useState<'loading' | 'deleted' | ErrorLike>()
 
     const deleteUpload = async (): Promise<void> => {
@@ -40,7 +47,7 @@ const LsifUploadNode: FunctionComponent<{ node: GQL.ILSIFUpload; onDelete: () =>
     }
 
     return deletionOrError && isErrorLike(deletionOrError) ? (
-        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} />
+        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} history={history} />
     ) : (
         <div className="w-100 list-group-item py-2 align-items-center lsif-data__main">
             <div className="lsif-data__meta">
@@ -159,13 +166,13 @@ export const RepoSettingsCodeIntelligencePage: FunctionComponent<Props> = ({ rep
                 intelligence for historic and branch commits.
             </p>
 
-            <FilteredConnection<GQL.ILSIFUpload, { onDelete: () => void }>
+            <FilteredConnection<GQL.ILSIFUpload, Omit<LsifUploadNodeProps, 'node'>>
                 className="list-group list-group-flush mt-3"
                 noun="upload"
                 pluralNoun="uploads"
                 queryConnection={queryUploads}
                 nodeComponent={LsifUploadNode}
-                nodeComponentProps={{ onDelete: onDeleteCallback }}
+                nodeComponentProps={{ onDelete: onDeleteCallback, history: props.history }}
                 updates={onDeleteSubject}
                 history={props.history}
                 location={props.location}

--- a/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsLsifUploadPage.tsx
@@ -16,6 +16,7 @@ import { Timestamp } from '../../../components/time/Timestamp'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import { SchedulerLike, timer } from 'rxjs'
+import * as H from 'history'
 
 const REFRESH_INTERVAL_MS = 5000
 
@@ -24,6 +25,7 @@ interface Props extends RouteComponentProps<{ id: string }> {
 
     /** Scheduler for the refresh timer */
     scheduler?: SchedulerLike
+    history: H.History
 }
 
 const terminalStates = [GQL.LSIFUploadState.COMPLETED, GQL.LSIFUploadState.ERRORED]
@@ -41,6 +43,7 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
     match: {
         params: { id },
     },
+    history,
 }) => {
     useEffect(() => eventLogger.logViewEvent('RepoSettingsLsifUpload'))
 
@@ -84,12 +87,12 @@ export const RepoSettingsLsifUploadPage: FunctionComponent<Props> = ({
     return deletionOrError === 'deleted' ? (
         <Redirect to=".." />
     ) : isErrorLike(deletionOrError) ? (
-        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} />
+        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} history={history} />
     ) : (
         <div className="site-admin-lsif-upload-page w-100">
             <PageTitle title="LSIF uploads - Admin" />
             {isErrorLike(uploadOrError) ? (
-                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} />
+                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} history={history} />
             ) : !uploadOrError ? (
                 <LoadingSpinner className="icon-inline" />
             ) : (

--- a/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
@@ -18,11 +18,6 @@ import {
 
 interface Props extends RouteComponentProps<{}> {}
 
-class FilteredExternalAccountConnection extends FilteredConnection<
-    GQL.IExternalAccount,
-    Pick<ExternalAccountNodeProps, 'onDidUpdate' | 'showUser'>
-> {}
-
 interface FilterParams {
     user?: GQL.ID
     serviceType?: string
@@ -46,9 +41,10 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<ExternalAccountNodeProps, 'onDidUpdate' | 'showUser'> = {
+        const nodeProps: Omit<ExternalAccountNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateExternalAccount,
             showUser: true,
+            history: this.props.history,
         }
 
         return (
@@ -64,7 +60,7 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
                     An external account (on an <Link to="/site-admin/auth/providers">authentication provider</Link>) is
                     linked to a Sourcegraph user when it's used to sign into Sourcegraph.
                 </p>
-                <FilteredExternalAccountConnection
+                <FilteredConnection<GQL.IExternalAccount, Omit<ExternalAccountNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="external user account"
                     pluralNoun="external user accounts"

--- a/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -15,6 +15,7 @@ interface Props extends RouteComponentProps<{ id: string }> {}
  * A page displaying metadata about an LSIF upload.
  */
 export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
+    history,
     match: {
         params: { id },
     },
@@ -31,9 +32,13 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
             {!uploadOrError ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(uploadOrError) ? (
-                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} />
+                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} history={history} />
             ) : !uploadOrError.projectRoot ? (
-                <ErrorAlert prefix="Error loading LSIF upload" error={{ message: 'Cannot resolve project root' }} />
+                <ErrorAlert
+                    prefix="Error loading LSIF upload"
+                    error={{ message: 'Cannot resolve project root' }}
+                    history={history}
+                />
             ) : (
                 <Redirect
                     to={`${uploadOrError.projectRoot.commit.repository.url}/-/settings/code-intelligence/lsif-uploads/${id}`}

--- a/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -16,10 +16,12 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { deleteRegistryExtensionWithConfirmation } from '../extensions/registry/backend'
 import { RegistryExtensionSourceBadge } from '../extensions/registry/RegistryExtensionSourceBadge'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 interface RegistryExtensionNodeSiteAdminProps {
     node: GQL.IRegistryExtension
     onDidUpdate: () => void
+    history: H.History
 }
 
 interface RegistryExtensionNodeSiteAdminState {
@@ -121,7 +123,7 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                     </div>
                 </div>
                 {isErrorLike(this.state.deletionOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.deletionOrError} history={this.props.history} />
                 )}
             </li>
         )
@@ -162,8 +164,9 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<RegistryExtensionNodeSiteAdminProps, 'onDidUpdate'> = {
+        const nodeProps: Omit<RegistryExtensionNodeSiteAdminProps, 'node'> = {
             onDidUpdate: this.onDidUpdateRegistryExtension,
+            history: this.props.history,
         }
 
         return (
@@ -184,7 +187,7 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
                     Extensions add features to Sourcegraph and other connected tools (such as editors, code hosts, and
                     code review tools).
                 </p>
-                <FilteredConnection<GQL.IRegistryExtension, Pick<RegistryExtensionNodeSiteAdminProps, 'onDidUpdate'>>
+                <FilteredConnection<GQL.IRegistryExtension, Omit<RegistryExtensionNodeSiteAdminProps, 'node'>>
                     className="list-group list-group-flush registry-extensions-list"
                     listComponent="ul"
                     noun="extension"

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { SiteAdminGenerateProductLicenseForSubscriptionForm } from './SiteAdminGenerateProductLicenseForSubscriptionForm'
+import { createMemoryHistory } from 'history'
 
 describe('SiteAdminGenerateProductLicenseForSubscriptionForm', () => {
     test('renders', () => {
@@ -10,6 +11,7 @@ describe('SiteAdminGenerateProductLicenseForSubscriptionForm', () => {
                     <SiteAdminGenerateProductLicenseForSubscriptionForm
                         subscriptionID="s"
                         onGenerate={() => undefined}
+                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -11,10 +11,12 @@ import { Form } from '../../../../components/Form'
 import { ExpirationDate } from '../../../productSubscription/ExpirationDate'
 import { ErrorAlert } from '../../../../components/alerts'
 import { useEventObservable } from '../../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 interface Props {
     subscriptionID: GQL.ID
     onGenerate: () => void
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -51,6 +53,7 @@ const DURATION_LINKS = [
 export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionComponent<Props> = ({
     subscriptionID,
     onGenerate,
+    history,
 }) => {
     const [formData, setFormData] = useState<FormData>(EMPTY_FORM_DATA)
 
@@ -222,7 +225,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                     </button>
                 </Form>
             )}
-            {isErrorLike(creation) && <ErrorAlert className="mt-3" error={creation} />}
+            {isErrorLike(creation) && <ErrorAlert className="mt-3" error={creation} history={history} />}
         </div>
     )
 }

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -28,6 +28,7 @@ import {
 import { SiteAdminProductSubscriptionBillingLink } from './SiteAdminProductSubscriptionBillingLink'
 import { ErrorAlert } from '../../../../components/alerts'
 import { useEventObservable, useObservable } from '../../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 interface Props extends RouteComponentProps<{ subscriptionUUID: string }> {
     /** For mocking in tests only. */
@@ -35,6 +36,7 @@ interface Props extends RouteComponentProps<{ subscriptionUUID: string }> {
 
     /** For mocking in tests only. */
     _queryProductLicenses?: typeof queryProductLicenses
+    history: H.History
 }
 
 class FilteredSiteAdminProductLicenseConnection extends FilteredConnection<
@@ -135,7 +137,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} />
+                <ErrorAlert className="my-2" error={productSubscription} history={history} />
             ) : (
                 <>
                     <h2>Product subscription {productSubscription.name}</h2>
@@ -148,7 +150,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
                         >
                             Archive
                         </button>
-                        {isErrorLike(archival) && <ErrorAlert className="mt-2" error={archival} />}
+                        {isErrorLike(archival) && <ErrorAlert className="mt-2" error={archival} history={history} />}
                     </div>
                     <div className="card mt-3">
                         <div className="card-header">Details</div>
@@ -216,6 +218,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
                                 <SiteAdminGenerateProductLicenseForSubscriptionForm
                                     subscriptionID={productSubscription.id}
                                     onGenerate={onLicenseUpdate}
+                                    history={history}
                                 />
                             </div>
                         )}

--- a/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -15,6 +15,7 @@ import { TrueUpStatusSummary } from '../../productSubscription/TrueUpStatusSumma
 import { ErrorAlert } from '../../../components/alerts'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 const queryProductLicenseInfo = (): Observable<GQL.IProductSubscriptionStatus> =>
     queryGraphQL(gql`
@@ -48,12 +49,13 @@ interface Props {
      *
      */
     showTrueUpStatus?: boolean
+    history: H.History
 }
 
 /**
  * A component displaying information about and the status of the product subscription.
  */
-export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ className, showTrueUpStatus }) => {
+export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ className, showTrueUpStatus, history }) => {
     /** The product subscription status, or an error, or undefined while loading. */
     const statusOrError = useObservable(
         useMemo(() => queryProductLicenseInfo().pipe(catchError((err): [ErrorLike] => [asError(err)])), [])
@@ -66,7 +68,7 @@ export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ clas
         )
     }
     if (isErrorLike(statusOrError)) {
-        return <ErrorAlert error={statusOrError} prefix="Error checking product license" />
+        return <ErrorAlert error={statusOrError} prefix="Error checking product license" history={history} />
     }
 
     const {

--- a/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
@@ -7,13 +7,13 @@ import { RouteComponentProps } from 'react-router'
 /**
  * Displays the product subscription information from the license key in site configuration.
  */
-export const SiteAdminProductSubscriptionPage: React.FunctionComponent<RouteComponentProps> = () => {
+export const SiteAdminProductSubscriptionPage: React.FunctionComponent<RouteComponentProps> = props => {
     useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscription'), [])
 
     return (
         <div className="site-admin-product-subscription-page">
             <PageTitle title="Sourcegraph product subscription" />
-            <ProductSubscriptionStatus showTrueUpStatus={true} />
+            <ProductSubscriptionStatus {...props} showTrueUpStatus={true} />
         </div>
     )
 }

--- a/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.test.tsx
+++ b/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
 import { ProductSubscriptionForm } from './ProductSubscriptionForm'
+import { createMemoryHistory } from 'history'
+import { Router } from 'react-router'
 
 jest.mock('../../dotcom/billing/StripeWrapper', () => ({
     StripeWrapper: ({
@@ -29,10 +30,11 @@ jest.mock('./NewProductSubscriptionPaymentSection', () => ({
 
 describe('ProductSubscriptionForm', () => {
     test('new subscription for anonymous viewer (no account)', () => {
+        const history = createMemoryHistory()
         expect(
             renderer
                 .create(
-                    <MemoryRouter>
+                    <Router history={history}>
                         <ProductSubscriptionForm
                             accountID={null}
                             subscriptionID={null}
@@ -40,18 +42,20 @@ describe('ProductSubscriptionForm', () => {
                             submissionState={undefined}
                             primaryButtonText="Submit"
                             isLightTheme={false}
+                            history={history}
                         />
-                    </MemoryRouter>
+                    </Router>
                 )
                 .toJSON()
         ).toMatchSnapshot()
     })
 
     test('new subscription for existing account', () => {
+        const history = createMemoryHistory()
         expect(
             renderer
                 .create(
-                    <MemoryRouter>
+                    <Router history={history}>
                         <ProductSubscriptionForm
                             accountID="a"
                             subscriptionID={null}
@@ -59,18 +63,20 @@ describe('ProductSubscriptionForm', () => {
                             submissionState={undefined}
                             primaryButtonText="Submit"
                             isLightTheme={false}
+                            history={history}
                         />
-                    </MemoryRouter>
+                    </Router>
                 )
                 .toJSON()
         ).toMatchSnapshot()
     })
 
     test('edit existing subscription', () => {
+        const history = createMemoryHistory()
         expect(
             renderer
                 .create(
-                    <MemoryRouter>
+                    <Router history={history}>
                         <ProductSubscriptionForm
                             accountID="a"
                             subscriptionID="s"
@@ -79,8 +85,9 @@ describe('ProductSubscriptionForm', () => {
                             submissionState={undefined}
                             primaryButtonText="Submit"
                             isLightTheme={false}
+                            history={history}
                         />
-                    </MemoryRouter>
+                    </Router>
                 )
                 .toJSON()
         ).toMatchSnapshot()

--- a/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -17,6 +17,7 @@ import { productSubscriptionInputForLocationHash } from './UserSubscriptionsNewP
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { ErrorAlert } from '../../../components/alerts'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 /**
  * The form data that is submitted by the ProductSubscriptionForm component.
@@ -62,6 +63,8 @@ interface Props extends ThemeProps {
 
     /** A fragment to render below the form's primary button. */
     afterPrimaryButton?: React.ReactFragment
+
+    history: H.History
 }
 
 const DEFAULT_USER_COUNT = 1
@@ -79,6 +82,7 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
     afterPrimaryButton,
     isLightTheme,
     stripe,
+    history,
 }) => {
     if (!stripe) {
         throw new Error('billing service is not available')
@@ -184,7 +188,7 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                     <div className="col-md-6">
                         <ProductSubscriptionUserCountFormControl value={userCount} onChange={setUserCount} />
                         <h4 className="mt-2 mb-0">Plan</h4>
-                        <ProductPlanFormControl value={billingPlanID} onChange={setBillingPlanID} />
+                        <ProductPlanFormControl value={billingPlanID} onChange={setBillingPlanID} history={history} />
                     </div>
                     <div className="col-md-6 mt-3 mt-md-0">
                         <h3 className="mt-2 mb-0">Billing</h3>
@@ -238,8 +242,8 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                     </div>
                 </div>
             </Form>
-            {isErrorLike(paymentToken) && <ErrorAlert className="mt-3" error={paymentToken} />}
-            {isErrorLike(submissionState) && <ErrorAlert className="mt-3" error={submissionState} />}
+            {isErrorLike(paymentToken) && <ErrorAlert className="mt-3" error={paymentToken} history={history} />}
+            {isErrorLike(submissionState) && <ErrorAlert className="mt-3" error={submissionState} history={history} />}
         </div>
     )
 }

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -15,12 +15,14 @@ import { ProductSubscriptionForm, ProductSubscriptionFormData } from './ProductS
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { ErrorAlert } from '../../../components/alerts'
 import { useEventObservable, useObservable } from '../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 interface Props extends RouteComponentProps<{ subscriptionUUID: string }>, ThemeProps {
     user: Pick<GQL.IUser, 'id'>
 
     /** For mocking in tests only. */
     _queryProductSubscription?: typeof queryProductSubscription
+    history: H.History
 }
 
 type ProductSubscription = Pick<GQL.IProductSubscription, 'id' | 'name' | 'invoiceItem' | 'url'>
@@ -97,7 +99,7 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} />
+                <ErrorAlert className="my-2" error={productSubscription} history={history} />
             ) : (
                 <>
                     <Link to={productSubscription.url} className="btn btn-link btn-sm mb-3">
@@ -124,6 +126,7 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
                                 An upgraded license key will be available immediately after payment.
                             </small>
                         }
+                        history={history}
                     />
                 </>
             )}

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
@@ -1,4 +1,4 @@
-import H from 'history'
+import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import React, { useEffect, useCallback } from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -23,6 +23,7 @@ interface Props extends RouteComponentProps<{}>, ThemeProps {
      * authenticated user and this page is accessed at /subscriptions/new.
      */
     user: GQL.IUser | null
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -97,6 +98,7 @@ export const UserSubscriptionsNewProductSubscriptionPage: React.FunctionComponen
                         </Link>
                     </small>
                 }
+                history={history}
             />
         </div>
     )

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
@@ -4,6 +4,7 @@ import renderer, { act } from 'react-test-renderer'
 import { UserSubscriptionsProductSubscriptionPage } from './UserSubscriptionsProductSubscriptionPage'
 import { of } from 'rxjs'
 import { MemoryRouter } from 'react-router'
+import { createMemoryHistory } from 'history'
 
 jest.mock('./BackToAllSubscriptionsLink', () => ({
     BackToAllSubscriptionsLink: 'BackToAllSubscriptionsLink',
@@ -37,6 +38,7 @@ describe('UserSubscriptionsProductSubscriptionPage', () => {
                             __typename: 'ProductSubscription',
                         } as GQL.IProductSubscription)
                     }
+                    history={createMemoryHistory()}
                 />
             </MemoryRouter>
         )

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -19,12 +19,14 @@ import { ProductSubscriptionHistory } from './ProductSubscriptionHistory'
 import { UserProductSubscriptionStatus } from './UserProductSubscriptionStatus'
 import { ErrorAlert } from '../../../components/alerts'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 interface Props extends Pick<RouteComponentProps<{ subscriptionUUID: string }>, 'match'> {
     user: Pick<GQL.IUser, 'settingsURL'>
 
     /** For mocking in tests only. */
     _queryProductSubscription?: typeof queryProductSubscription
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -38,6 +40,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<P
         params: { subscriptionUUID },
     },
     _queryProductSubscription = queryProductSubscription,
+    history,
 }) => {
     useEffect(() => eventLogger.logViewEvent('UserSubscriptionsProductSubscription'), [])
 
@@ -74,7 +77,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<P
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} />
+                <ErrorAlert className="my-2" error={productSubscription} history={history} />
             ) : (
                 <>
                     <h2>Subscription {productSubscription.name}</h2>

--- a/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -25,6 +25,38 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
           Plan
         </h4>
         <ProductPlanFormControl
+          history={
+            Object {
+              "action": "POP",
+              "block": [Function],
+              "canGo": [Function],
+              "createHref": [Function],
+              "entries": Array [
+                Object {
+                  "hash": "",
+                  "key": undefined,
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+              ],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "index": 0,
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "key": undefined,
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
           onChange={[Function]}
           value="p"
         />
@@ -109,6 +141,38 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
           Plan
         </h4>
         <ProductPlanFormControl
+          history={
+            Object {
+              "action": "POP",
+              "block": [Function],
+              "canGo": [Function],
+              "createHref": [Function],
+              "entries": Array [
+                Object {
+                  "hash": "",
+                  "key": undefined,
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+              ],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "index": 0,
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "key": undefined,
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
           onChange={[Function]}
           value={null}
         />
@@ -212,6 +276,38 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
           Plan
         </h4>
         <ProductPlanFormControl
+          history={
+            Object {
+              "action": "POP",
+              "block": [Function],
+              "canGo": [Function],
+              "createHref": [Function],
+              "entries": Array [
+                Object {
+                  "hash": "",
+                  "key": undefined,
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+              ],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "index": 0,
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "key": undefined,
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
           onChange={[Function]}
           value={null}
         />

--- a/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
+++ b/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
@@ -27,6 +27,38 @@ exports[`UserSubscriptionsEditProductSubscriptionPage renders 1`] = `
         An upgraded license key will be available immediately after payment.
       </small>
     }
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "key": undefined,
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "key": undefined,
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
     initialValue={
       Object {
         "billingPlanID": "bp",

--- a/web/src/enterprise/user/settings/ExternalAccountNode.tsx
+++ b/web/src/enterprise/user/settings/ExternalAccountNode.tsx
@@ -9,6 +9,7 @@ import { mutateGraphQL } from '../../../backend/graphql'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { userURL } from '../../../user'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 export const externalAccountFragment = gql`
     fragment ExternalAccountFields on ExternalAccount {
@@ -53,6 +54,7 @@ export interface ExternalAccountNodeProps {
     showUser: boolean
 
     onDidUpdate: () => void
+    history: H.History
 }
 
 interface ExternalAccountNodeState {
@@ -153,7 +155,11 @@ export class ExternalAccountNode extends React.PureComponent<ExternalAccountNode
                             Delete
                         </button>
                         {isErrorLike(this.state.deletionOrError) && (
-                            <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
+                            <ErrorAlert
+                                className="mt-2"
+                                error={this.state.deletionOrError}
+                                history={this.props.history}
+                            />
                         )}
                     </div>
                 </div>

--- a/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
+++ b/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
@@ -15,11 +15,6 @@ interface Props extends RouteComponentProps<{}> {
     user: GQL.IUser
 }
 
-class FilteredExternalAccountConnection extends FilteredConnection<
-    GQL.IExternalAccount,
-    Pick<ExternalAccountNodeProps, 'onDidUpdate' | 'showUser'>
-> {}
-
 /**
  * Displays the external accounts (from authentication providers) associated with the user's account.
  */
@@ -36,16 +31,17 @@ export class UserSettingsExternalAccountsPage extends React.Component<Props> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<ExternalAccountNodeProps, 'onDidUpdate' | 'showUser'> = {
+        const nodeProps: Omit<ExternalAccountNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateExternalAccount,
             showUser: false,
+            history: this.props.history,
         }
 
         return (
             <div className="user-settings-external-accounts-page">
                 <PageTitle title="External accounts" />
                 <h2>External accounts</h2>
-                <FilteredExternalAccountConnection
+                <FilteredConnection<GQL.IExternalAccount, Omit<ExternalAccountNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="external account"
                     pluralNoun="external accounts"

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -204,11 +204,15 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                 {this.state.data.resultOrError === LOADING ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.data.resultOrError) ? (
-                    <ErrorAlert error={this.state.data.resultOrError} />
+                    <ErrorAlert error={this.state.data.resultOrError} history={this.props.history} />
                 ) : (
                     <>
                         {this.state.data.resultOrError.error && (
-                            <ErrorAlert className="mb-2" error={this.state.data.resultOrError.error} />
+                            <ErrorAlert
+                                className="mb-2"
+                                error={this.state.data.resultOrError.error}
+                                history={this.props.history}
+                            />
                         )}
                         {this.state.data.resultOrError.extensions.length === 0 ? (
                             this.state.data.query ? (

--- a/web/src/extensions/explore/ExtensionViewsExploreSection.tsx
+++ b/web/src/extensions/explore/ExtensionViewsExploreSection.tsx
@@ -52,7 +52,7 @@ export class ExtensionViewsExploreSection extends React.PureComponent<Props, Sta
                     <div key={i} className="mt-5">
                         <h2>{view.title}</h2>
                         <div onClick={createLinkClickHandler(this.props.history)}>
-                            <Markdown dangerousInnerHTML={renderMarkdown(view.content)} />
+                            <Markdown dangerousInnerHTML={renderMarkdown(view.content)} history={this.props.history} />
                         </div>
                     </div>
                 ))}

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -167,7 +167,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.extensionOrError} />}
+                    subtitle={<ErrorMessage error={this.state.extensionOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -10,8 +10,11 @@ import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorAlert } from '../../components/alerts'
 import { hasProperty } from '../../../../shared/src/util/types'
+import * as H from 'history'
 
-interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {}
+interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {
+    history: H.History
+}
 
 interface ContributionGroup {
     title: string
@@ -20,8 +23,9 @@ interface ContributionGroup {
     rows: (React.ReactFragment | null)[][]
 }
 
-const ContributionsTable: React.FunctionComponent<{ contributionGroups: ContributionGroup[] }> = ({
+const ContributionsTable: React.FunctionComponent<{ contributionGroups: ContributionGroup[]; history: H.History }> = ({
     contributionGroups,
+    history,
 }) => (
     <div>
         {contributionGroups.length === 0 && (
@@ -34,7 +38,7 @@ const ContributionsTable: React.FunctionComponent<{ contributionGroups: Contribu
                         <h3>
                             {group.title} ({group.rows.length})
                         </h3>
-                        {group.error && <ErrorAlert className="mt-1" error={group.error} />}
+                        {group.error && <ErrorAlert className="mt-1" error={group.error} history={history} />}
                         <table className="table mb-5">
                             <thead>
                                 <tr>
@@ -155,9 +159,16 @@ export class RegistryExtensionContributionsPage extends React.PureComponent<Prop
                     {this.props.extension.manifest === null ? (
                         <ExtensionNoManifestAlert extension={this.props.extension} />
                     ) : isErrorLike(this.props.extension.manifest) ? (
-                        <ErrorAlert error={this.props.extension.manifest} prefix="Error parsing extension manifest" />
+                        <ErrorAlert
+                            error={this.props.extension.manifest}
+                            prefix="Error parsing extension manifest"
+                            history={this.props.history}
+                        />
                     ) : (
-                        <ContributionsTable contributionGroups={toContributionsGroups(this.props.extension.manifest)} />
+                        <ContributionsTable
+                            contributionGroups={toContributionsGroups(this.props.extension.manifest)}
+                            history={this.props.history}
+                        />
                     )}
                 </div>
             </div>

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -1,9 +1,10 @@
 import { noop } from 'lodash'
 import React from 'react'
-import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
 import { RegistryExtensionOverviewPage } from './RegistryExtensionOverviewPage'
 import { PageTitle } from '../../components/PageTitle'
+import { createMemoryHistory } from 'history'
+import { Router } from 'react-router'
 
 jest.mock('mdi-react/GithubCircleIcon', () => 'GithubCircleIcon')
 
@@ -11,11 +12,12 @@ describe('RegistryExtensionOverviewPage', () => {
     afterEach(() => {
         PageTitle.titleSet = false
     })
-    test('renders', () =>
+    test('renders', () => {
+        const history = createMemoryHistory()
         expect(
             renderer
                 .create(
-                    <MemoryRouter>
+                    <Router history={history}>
                         <RegistryExtensionOverviewPage
                             eventLogger={{ logViewEvent: noop }}
                             extension={{
@@ -33,16 +35,19 @@ describe('RegistryExtensionOverviewPage', () => {
                                     },
                                 },
                             }}
+                            history={history}
                         />
-                    </MemoryRouter>
+                    </Router>
                 )
                 .toJSON()
-        ).toMatchSnapshot())
+        ).toMatchSnapshot()
+    })
 
     describe('categories', () => {
         test('filters out unrecognized categories', () => {
+            const history = createMemoryHistory()
             const x = renderer.create(
-                <MemoryRouter>
+                <Router history={history}>
                     <RegistryExtensionOverviewPage
                         eventLogger={{ logViewEvent: noop }}
                         extension={{
@@ -54,8 +59,9 @@ describe('RegistryExtensionOverviewPage', () => {
                                 categories: ['Programming languages', 'invalid', 'Other'],
                             },
                         }}
+                        history={createMemoryHistory()}
                     />
-                </MemoryRouter>
+                </Router>
             ).root
             expect(
                 toText(

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -14,9 +14,11 @@ import { EventLogger } from '../../tracking/eventLogger'
 import { extensionIDPrefix, extensionsQuery, urlToExtensionsQuery, validCategories } from './extension'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionREADME } from './RegistryExtensionREADME'
+import * as H from 'history'
 
 interface Props extends Pick<ExtensionAreaRouteContext, 'extension'> {
     eventLogger: Pick<EventLogger, 'logViewEvent'>
+    history: H.History
 }
 
 /** A page that displays overview information about a registry extension. */
@@ -57,7 +59,7 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
             <div className="registry-extension-overview-page d-flex flex-wrap">
                 <PageTitle title={this.props.extension.id} />
                 <div className="registry-extension-overview-page__readme mr-3">
-                    <ExtensionREADME extension={this.props.extension} />
+                    <ExtensionREADME extension={this.props.extension} history={this.props.history} />
                 </div>
                 <aside className="registry-extension-overview-page__sidebar">
                     {categories && (

--- a/web/src/extensions/extension/RegistryExtensionREADME.tsx
+++ b/web/src/extensions/extension/RegistryExtensionREADME.tsx
@@ -5,6 +5,7 @@ import { ConfiguredRegistryExtension } from '../../../../shared/src/extensions/e
 import { isErrorLike } from '../../../../shared/src/util/errors'
 import { renderMarkdown } from '../../../../shared/src/util/markdown'
 import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
+import * as H from 'history'
 
 const PublishNewManifestAlert: React.FunctionComponent<{
     extension: ConfiguredRegistryExtension
@@ -27,7 +28,8 @@ const PublishNewManifestAlert: React.FunctionComponent<{
 
 export const ExtensionREADME: React.FunctionComponent<{
     extension: ConfiguredRegistryExtension
-}> = ({ extension }) => {
+    history: H.History
+}> = ({ extension, history }) => {
     if (!extension.rawManifest) {
         return <ExtensionNoManifestAlert extension={extension} />
     }
@@ -59,7 +61,7 @@ export const ExtensionREADME: React.FunctionComponent<{
 
     try {
         const html = renderMarkdown(manifest.readme)
-        return <Markdown dangerousInnerHTML={html} />
+        return <Markdown dangerousInnerHTML={html} history={history} />
     } catch (err) {
         return (
             <PublishNewManifestAlert

--- a/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
 ",
         }
       }
+      onClick={[Function]}
     />
   </div>
   <aside

--- a/web/src/global/GlobalAlert.tsx
+++ b/web/src/global/GlobalAlert.tsx
@@ -6,19 +6,21 @@ import { Markdown } from '../../../shared/src/components/Markdown'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { DismissibleAlert } from '../components/DismissibleAlert'
+import * as H from 'history'
 
 /**
  * A global alert that is shown at the top of the viewport.
  */
-export const GlobalAlert: React.FunctionComponent<{ alert: GQL.IAlert; className: string }> = ({
+export const GlobalAlert: React.FunctionComponent<{ alert: GQL.IAlert; className: string; history: H.History }> = ({
     alert,
+    history,
     className: commonClassName,
 }) => {
     const Icon = alertIconForType(alert.type)
     const content = (
         <>
             <Icon className="icon-inline mr-2 flex-shrink-0" />
-            <Markdown dangerousInnerHTML={renderMarkdown(alert.message)} />
+            <Markdown dangerousInnerHTML={renderMarkdown(alert.message)} history={history} />
         </>
     )
     const className = `${commonClassName} alert alert-${alertClassForType(alert.type)} d-flex`

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -16,6 +16,7 @@ import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfig
 import { UpdateAvailableAlert } from '../site/UpdateAvailableAlert'
 import { GlobalAlert } from './GlobalAlert'
 import { Notices } from './Notices'
+import * as H from 'history'
 
 // This module is not in @types/semver yet. We can't use the top-level semver module because it uses
 // dynamic requires, which Webpack complains about.
@@ -25,6 +26,7 @@ import { Notices } from './Notices'
 import semverParse from 'semver/functions/parse'
 
 interface Props extends SettingsCascadeProps {
+    history: H.History
     isSiteAdmin: boolean
 }
 
@@ -82,7 +84,12 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                         {/* Only show if the user has already added repositories; if not yet, the user wouldn't experience any Docker for Mac perf issues anyway. */}
                         {window.context.likelyDockerOnMac && <DockerForMacAlert className="global-alerts__alert" />}
                         {this.state.siteFlags.alerts.map((alert, i) => (
-                            <GlobalAlert key={i} alert={alert} className="global-alerts__alert" />
+                            <GlobalAlert
+                                key={i}
+                                alert={alert}
+                                className="global-alerts__alert"
+                                history={this.props.history}
+                            />
                         ))}
                         {this.state.siteFlags.productSubscription.license &&
                             (() => {
@@ -108,13 +115,14 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                             partialStorageKey={`motd.${m}`}
                             className="alert alert-info global-alerts__alert"
                         >
-                            <Markdown dangerousInnerHTML={renderMarkdown(m)} />
+                            <Markdown dangerousInnerHTML={renderMarkdown(m)} history={this.props.history} />
                         </DismissibleAlert>
                     ))}
                 <Notices
                     alertClassName="global-alerts__alert"
                     location="top"
                     settingsCascade={this.props.settingsCascade}
+                    history={this.props.history}
                 />
             </div>
         )

--- a/web/src/global/Notices.test.tsx
+++ b/web/src/global/Notices.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { Notices } from './Notices'
+import * as H from 'history'
 
 describe('Notices', () => {
     test('shows notices for location', () =>
@@ -19,6 +20,7 @@ describe('Notices', () => {
                                 ],
                             },
                         }}
+                        history={H.createMemoryHistory()}
                     />
                 )
                 .toJSON()
@@ -27,7 +29,13 @@ describe('Notices', () => {
     test('no notices', () =>
         expect(
             renderer
-                .create(<Notices location="home" settingsCascade={{ subjects: [], final: { notices: null } }} />)
+                .create(
+                    <Notices
+                        location="home"
+                        history={H.createMemoryHistory()}
+                        settingsCascade={{ subjects: [], final: { notices: null } }}
+                    />
+                )
                 .toJSON()
         ).toMatchSnapshot())
 })

--- a/web/src/global/Notices.tsx
+++ b/web/src/global/Notices.tsx
@@ -4,9 +4,14 @@ import { isSettingsValid, SettingsCascadeProps } from '../../../shared/src/setti
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { DismissibleAlert } from '../components/DismissibleAlert'
 import { Notice, Settings } from '../schema/settings.schema'
+import * as H from 'history'
 
-const NoticeAlert: React.FunctionComponent<{ notice: Notice; className?: string }> = ({ notice, className = '' }) => {
-    const content = <Markdown dangerousInnerHTML={renderMarkdown(notice.message)} />
+const NoticeAlert: React.FunctionComponent<{ notice: Notice; className?: string; history: H.History }> = ({
+    notice,
+    history,
+    className = '',
+}) => {
+    const content = <Markdown history={history} dangerousInnerHTML={renderMarkdown(notice.message)} />
     const baseClassName = notice.location === 'top' ? 'alert-info' : 'bg-transparent border'
     return notice.dismissible ? (
         <DismissibleAlert className={`${baseClassName} ${className}`} partialStorageKey={`notice.${notice.message}`}>
@@ -18,6 +23,7 @@ const NoticeAlert: React.FunctionComponent<{ notice: Notice; className?: string 
 }
 
 interface Props extends SettingsCascadeProps {
+    history: H.History
     className?: string
 
     /** Apply this class name to each notice (alongside .alert). */
@@ -35,6 +41,7 @@ export const Notices: React.FunctionComponent<Props> = ({
     alertClassName,
     settingsCascade,
     location,
+    history,
 }) => {
     if (
         !isSettingsValid<Settings>(settingsCascade) ||
@@ -50,7 +57,7 @@ export const Notices: React.FunctionComponent<Props> = ({
     return (
         <div className={`notices ${className}`}>
             {notices.map((notice, i) => (
-                <NoticeAlert key={i} className={alertClassName} notice={notice} />
+                <NoticeAlert key={i} className={alertClassName} notice={notice} history={history} />
             ))}
         </div>
     )

--- a/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Notices shows notices for location 1`] = `
 ",
         }
       }
+      onClick={[Function]}
     />
   </div>
   <div
@@ -33,6 +34,7 @@ exports[`Notices shows notices for location 1`] = `
 ",
           }
         }
+        onClick={[Function]}
       />
     </div>
     <button

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -111,6 +111,7 @@ export class NavLinks extends React.PureComponent<Props> {
                             <StatusMessagesNavItem
                                 fetchMessages={fetchAllStatusMessages}
                                 isSiteAdmin={this.props.authenticatedUser.siteAdmin}
+                                history={this.props.history}
                             />
                         </li>
                     )}

--- a/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import { of, Observable } from 'rxjs'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
+import { createMemoryHistory } from 'history'
 
 jest.mock('mdi-react/CloudAlertIcon', () => 'CloudAlertIcon')
 jest.mock('mdi-react/CloudCheckIcon', () => 'CloudCheckIcon')
@@ -12,7 +13,15 @@ describe('StatusMessagesNavItem', () => {
     test('no messages', () => {
         const fetchMessages = (): Observable<GQL.StatusMessage[]> => of([])
         expect(
-            renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={false} />).toJSON()
+            renderer
+                .create(
+                    <StatusMessagesNavItem
+                        fetchMessages={fetchMessages}
+                        isSiteAdmin={false}
+                        history={createMemoryHistory()}
+                    />
+                )
+                .toJSON()
         ).toMatchSnapshot()
     })
 
@@ -25,13 +34,29 @@ describe('StatusMessagesNavItem', () => {
         const fetchMessages = (): Observable<GQL.StatusMessage[]> => of([message])
         test('as non-site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={false} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={false}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
 
         test('as site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={true} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={true}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
     })
@@ -55,13 +80,29 @@ describe('StatusMessagesNavItem', () => {
         const fetchMessages = () => of([message])
         test('as non-site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={false} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={false}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
 
         test('as site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={true} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={true}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
     })
@@ -75,13 +116,29 @@ describe('StatusMessagesNavItem', () => {
         const fetchMessages = () => of([message])
         test('as non-site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={false} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={false}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
 
         test('as site admin', () => {
             expect(
-                renderer.create(<StatusMessagesNavItem fetchMessages={fetchMessages} isSiteAdmin={true} />).toJSON()
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={true}
+                            history={createMemoryHistory()}
+                        />
+                    )
+                    .toJSON()
             ).toMatchSnapshot()
         })
     })

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -12,6 +12,7 @@ import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors
 import { queryGraphQL } from '../backend/graphql'
 import classNames from 'classnames'
 import { ErrorAlert } from '../components/alerts'
+import * as H from 'history'
 
 export function fetchAllStatusMessages(): Observable<GQL.StatusMessage[]> {
     return queryGraphQL(
@@ -93,6 +94,7 @@ const StatusMessagesNavItemEntry: React.FunctionComponent<StatusMessageEntryProp
 interface Props {
     fetchMessages: () => Observable<GQL.StatusMessage[]>
     isSiteAdmin: boolean
+    history: H.History
 }
 
 interface State {
@@ -234,6 +236,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                                 className="status-messages-nav-item__entry"
                                 prefix="Failed to load status messages"
                                 error={this.state.messagesOrError}
+                                history={this.props.history}
                             />
                         ) : this.state.messagesOrError.length > 0 ? (
                             this.state.messagesOrError.map((m, i) => this.renderMessage(m, i))

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -21,6 +21,7 @@ import { OrgInvitationPage } from './OrgInvitationPage'
 import { PatternTypeProps } from '../../search'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorMessage } from '../../components/alerts'
+import * as H from 'history'
 
 function queryOrganization(args: { name: string }): Observable<GQL.IOrg> {
     return queryGraphQL(
@@ -81,6 +82,7 @@ interface Props
      * The currently authenticated user.
      */
     authenticatedUser: GQL.IUser | null
+    history: H.History
 }
 
 interface State {
@@ -169,7 +171,7 @@ export class OrgArea extends React.Component<Props> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.orgOrError} />}
+                    subtitle={<ErrorMessage error={this.state.orgOrError} history={this.props.history} />}
                 />
             )
         }
@@ -188,7 +190,13 @@ export class OrgArea extends React.Component<Props> {
 
         if (this.props.location.pathname === `${this.props.match.url}/invitation`) {
             // The OrgInvitationPage is displayed without the OrgHeader because it is modal-like.
-            return <OrgInvitationPage {...context} onDidRespondToInvitation={this.onDidRespondToInvitation} />
+            return (
+                <OrgInvitationPage
+                    {...context}
+                    onDidRespondToInvitation={this.onDidRespondToInvitation}
+                    history={this.props.history}
+                />
+            )
         }
 
         return (

--- a/web/src/org/area/OrgInvitationPage.tsx
+++ b/web/src/org/area/OrgInvitationPage.tsx
@@ -18,12 +18,14 @@ import { userURL } from '../../user'
 import { OrgAvatar } from '../OrgAvatar'
 import { OrgAreaPageProps } from './OrgArea'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 interface Props extends OrgAreaPageProps {
     authenticatedUser: GQL.IUser
 
     /** Called when the viewer responds to the invitation. */
     onDidRespondToInvitation: () => void
+    history: H.History
 }
 
 interface State {
@@ -157,7 +159,11 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     </button>
                                 </div>
                                 {isErrorLike(this.state.submissionOrError) && (
-                                    <ErrorAlert className="my-2" error={this.state.submissionOrError} />
+                                    <ErrorAlert
+                                        className="my-2"
+                                        error={this.state.submissionOrError}
+                                        history={this.props.history}
+                                    />
                                 )}
                                 {this.state.submissionOrError === 'loading' && (
                                     <LoadingSpinner className="icon-inline" />

--- a/web/src/org/area/OrgMembersPage.tsx
+++ b/web/src/org/area/OrgMembersPage.tsx
@@ -15,6 +15,7 @@ import { removeUserFromOrganization } from '../backend'
 import { InviteForm } from '../invite/InviteForm'
 import { OrgAreaPageProps } from './OrgArea'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 interface UserNodeProps {
     /** The user to display in this list item. */
@@ -28,6 +29,7 @@ interface UserNodeProps {
 
     /** Called when the user is updated by an action in this list item. */
     onDidUpdate?: () => void
+    history: H.History
 }
 
 interface UserNodeState {
@@ -112,7 +114,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                     </div>
                 </div>
                 {isErrorLike(this.state.removalOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.removalOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.removalOrError} history={this.props.history} />
                 )}
             </li>
         )
@@ -121,7 +123,9 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     private remove = (): void => this.removes.next()
 }
 
-interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {}
+interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
+    history: H.History
+}
 
 interface State {
     /**
@@ -170,10 +174,11 @@ export class OrgMembersPage extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<UserNodeProps, 'org' | 'authenticatedUser' | 'onDidUpdate'> = {
+        const nodeProps: Omit<UserNodeProps, 'node'> = {
             org: { ...this.props.org, viewerCanAdminister: this.state.viewerCanAdminister },
             authenticatedUser: this.props.authenticatedUser,
             onDidUpdate: this.onDidUpdateUser,
+            history: this.props.history,
         }
 
         return (
@@ -185,9 +190,10 @@ export class OrgMembersPage extends React.PureComponent<Props, State> {
                         authenticatedUser={this.props.authenticatedUser}
                         onOrganizationUpdate={this.props.onOrganizationUpdate}
                         onDidUpdateOrganizationMembers={this.onDidUpdateOrganizationMembers}
+                        history={this.props.history}
                     />
                 )}
-                <FilteredConnection<GQL.IUser, Pick<UserNodeProps, 'org' | 'authenticatedUser' | 'onDidUpdate'>>
+                <FilteredConnection<GQL.IUser, Omit<UserNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="member"
                     pluralNoun="members"

--- a/web/src/org/invite/InviteForm.tsx
+++ b/web/src/org/invite/InviteForm.tsx
@@ -15,6 +15,7 @@ import { DismissibleAlert } from '../../components/DismissibleAlert'
 import { Form } from '../../components/Form'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 function inviteUserToOrganization(
     username: string,
@@ -103,6 +104,7 @@ interface Props {
     onDidUpdateOrganizationMembers: () => void
 
     onOrganizationUpdate: () => void
+    history: H.History
 }
 
 interface SubmittedInvite extends Pick<GQL.IInviteUserToOrganizationResult, 'sentInvitationEmail' | 'invitationURL'> {
@@ -331,7 +333,9 @@ export class InviteForm extends React.PureComponent<Props, State> {
                         />
                         /* eslint-enable react/jsx-no-bind */
                     ))}
-                {this.state.error && <ErrorAlert className="invite-form__alert" error={this.state.error} />}
+                {this.state.error && (
+                    <ErrorAlert className="invite-form__alert" error={this.state.error} history={this.props.history} />
+                )}
             </div>
         )
     }

--- a/web/src/org/new/NewOrganizationPage.tsx
+++ b/web/src/org/new/NewOrganizationPage.tsx
@@ -89,7 +89,9 @@ export class NewOrganizationPage extends React.Component<Props, State> {
                         <Link to="/help/user/organizations">Sourcegraph documentation</Link> for information about
                         configuring organizations.
                     </p>
-                    {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
+                    {this.state.error && (
+                        <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
+                    )}
                     <div className="form-group">
                         <label htmlFor="new-org-page__form-name">Organization name</label>
                         <input

--- a/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -10,8 +10,11 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { OrgAreaPageProps } from '../../area/OrgArea'
 import { updateOrganization } from '../../backend'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
-interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {}
+interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
+    history: H.History
+}
 
 interface State {
     displayName: string
@@ -119,7 +122,7 @@ export class OrgSettingsProfilePage extends React.PureComponent<Props, State> {
                     >
                         <small>Updated!</small>
                     </div>
-                    {this.state.error && <ErrorAlert error={this.state.error} />}
+                    {this.state.error && <ErrorAlert error={this.state.error} history={this.props.history} />}
                 </Form>
             </div>
         )

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -38,6 +38,7 @@ import { RepoSettingsSideBarItem } from './settings/RepoSettingsSidebar'
 import { ErrorMessage } from '../components/alerts'
 import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
+import * as H from 'history'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -89,6 +90,7 @@ interface RepoContainerProps
     repoSettingsSidebarItems: readonly RepoSettingsSideBarItem[]
     authenticatedUser: GQL.IUser | null
     onNavbarQueryChange: (state: QueryState) => void
+    history: H.History
 }
 
 interface RepoRevContainerState extends ParsedRepoRev {
@@ -284,7 +286,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.repoOrError} />}
+                    subtitle={<ErrorMessage error={this.state.repoOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -37,6 +37,7 @@ import { PatternTypeProps, CaseSensitivityProps } from '../search'
 import { RepoSettingsAreaRoute } from './settings/RepoSettingsArea'
 import { RepoSettingsSideBarItem } from './settings/RepoSettingsSidebar'
 import { ErrorMessage } from '../components/alerts'
+import * as H from 'history'
 
 /** Props passed to sub-routes of {@link RepoRevContainer}. */
 export interface RepoRevContainerContext
@@ -91,6 +92,7 @@ interface RepoRevContainerProps
 
     /** Called when the resolvedRevOrError state in this component's parent should be updated. */
     onResolvedRevOrError: (v: ResolvedRev | ErrorLike | undefined) => void
+    history: H.History
 }
 
 interface RepoRevContainerState {}
@@ -206,7 +208,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.props.resolvedRevOrError} />}
+                    subtitle={<ErrorMessage error={this.props.resolvedRevOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/repo/RepositoryGitDataContainer.tsx
+++ b/web/src/repo/RepositoryGitDataContainer.tsx
@@ -15,6 +15,7 @@ import { HeroPage } from '../components/HeroPage'
 import { resolveRev } from './backend'
 import { DirectImportRepoAlert } from './DirectImportRepoAlert'
 import { ErrorMessage } from '../components/alerts'
+import * as H from 'history'
 
 export const RepositoryCloningInProgressPage: React.FunctionComponent<{ repoName: string; progress?: string }> = ({
     repoName,
@@ -40,6 +41,7 @@ interface Props {
 
     /** The fragment to render if the repository's Git data is accessible. */
     children: React.ReactNode
+    history: H.History
 }
 
 interface State {
@@ -133,7 +135,7 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.gitDataPresentOrError} />}
+                    subtitle={<ErrorMessage error={this.state.gitDataPresentOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -252,7 +252,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                     <LoadingSpinner className="icon-inline tree-page__entries-loader" /> Loading files and directories
                 </div>
             ) : isErrorLike(treeOrError) ? (
-                <ErrorAlert error={treeOrError} />
+                <ErrorAlert error={treeOrError} history={props.history} />
             ) : (
                 <>
                     {treeOrError.isRoot ? (

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -269,7 +269,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                     <HeroPage
                         icon={AlertCircleIcon}
                         title="Error"
-                        subtitle={<ErrorMessage error={this.state.blobOrError} />}
+                        subtitle={<ErrorMessage error={this.state.blobOrError} history={this.props.history} />}
                     />
                 </>
             )
@@ -298,7 +298,11 @@ export class BlobPage extends React.PureComponent<Props, State> {
                     />
                 )}
                 {this.state.blobOrError.richHTML && renderMode === 'rendered' && (
-                    <RenderedFile dangerousInnerHTML={this.state.blobOrError.richHTML} location={this.props.location} />
+                    <RenderedFile
+                        dangerousInnerHTML={this.state.blobOrError.richHTML}
+                        location={this.props.location}
+                        history={this.props.history}
+                    />
                 )}
                 {!this.state.blobOrError.richHTML && this.state.blobOrError.highlight.aborted && (
                     <div className="blob-page__aborted">

--- a/web/src/repo/blob/RenderedFile.tsx
+++ b/web/src/repo/blob/RenderedFile.tsx
@@ -10,17 +10,18 @@ interface Props {
     dangerousInnerHTML: string
 
     location: H.Location
+    history: H.History
 }
 
 /**
  * Displays a file whose contents are rendered to HTML, such as a Markdown file.
  */
-export const RenderedFile: React.FunctionComponent<Props> = ({ dangerousInnerHTML, location }) => {
+export const RenderedFile: React.FunctionComponent<Props> = ({ dangerousInnerHTML, location, history }) => {
     useScrollToLocationHash(location)
     return (
         <div className="rendered-file">
             <div className="rendered-file__container">
-                <Markdown dangerousInnerHTML={dangerousInnerHTML} />
+                <Markdown dangerousInnerHTML={dangerousInnerHTML} history={history} />
             </div>
         </div>
     )

--- a/web/src/repo/blob/discussions/DiscussionsInput.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsInput.tsx
@@ -312,7 +312,9 @@ export class DiscussionsInput extends React.PureComponent<Props, State> {
                     </div>
                     <div key="preview" className="discussions-input__preview">
                         {previewLoading && <LoadingSpinner className="icon-inline" />}
-                        {!previewLoading && previewHTML && <Markdown dangerousInnerHTML={previewHTML} />}
+                        {!previewLoading && previewHTML && (
+                            <Markdown dangerousInnerHTML={previewHTML} history={this.props.history} />
+                        )}
                     </div>
                 </TabsWithLocalStorageViewStatePersistence>
                 <div className="discussions-input__row">
@@ -324,7 +326,9 @@ export class DiscussionsInput extends React.PureComponent<Props, State> {
                         {this.props.submitLabel}
                     </button>
                 </div>
-                {error && <ErrorAlert className="discussions-input__error" error={error} />}
+                {error && (
+                    <ErrorAlert className="discussions-input__error" error={error} history={this.props.history} />
+                )}
             </Form>
         )
     }

--- a/web/src/repo/blob/discussions/DiscussionsThread.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsThread.tsx
@@ -102,7 +102,12 @@ export class DiscussionsThread extends React.PureComponent<Props, State> {
                 <DiscussionsNavbar {...this.props} threadTitle={thread ? thread.title : undefined} />
                 {loading && <LoadingSpinner className="icon-inline" />}
                 {error && (
-                    <ErrorAlert className="discussions-thread__error" prefix="Error loading thread" error={error} />
+                    <ErrorAlert
+                        className="discussions-thread__error"
+                        prefix="Error loading thread"
+                        error={error}
+                        history={this.props.history}
+                    />
                 )}
                 {thread && (
                     <div className="discussions-thread__comments">

--- a/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -14,6 +14,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { gitRefFragment, GitRefNode } from '../GitRef'
 import { RepositoryBranchesAreaPageProps } from './RepositoryBranchesArea'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 interface Data {
     defaultBranch: GQL.IGitRef | null
@@ -67,7 +68,9 @@ const queryGitBranches = memoizeObservable(
     args => `${args.repo}:${args.first}`
 )
 
-interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}> {}
+interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}> {
+    history: H.History
+}
 
 interface State {
     /** The page content, undefined while loading, or an error. */
@@ -120,7 +123,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                 {this.state.dataOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.dataOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.dataOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.dataOrError} history={this.props.history} />
                 ) : (
                     <div className="repository-branches-page__cards">
                         {this.state.dataOrError.defaultBranch && (

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -204,7 +204,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 {this.state.commitOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.commitOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.commitOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.commitOrError} history={this.props.history} />
                 ) : (
                     <>
                         <div className="card repository-commit-page__card">

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -35,6 +35,7 @@ import { RepositoryCompareHeader } from './RepositoryCompareHeader'
 import { RepositoryCompareOverviewPage } from './RepositoryCompareOverviewPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorMessage } from '../../components/alerts'
+import * as H from 'history'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -52,6 +53,7 @@ interface RepositoryCompareAreaProps
         ExtensionsControllerProps,
         ThemeProps {
     repo: GQL.IRepository
+    history: H.History
 }
 
 interface State extends HoverState<HoverContext, HoverMerged, ActionItemAction> {
@@ -157,7 +159,11 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
     public render(): JSX.Element | null {
         if (this.state.error) {
             return (
-                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={this.state.error} />} />
+                <HeroPage
+                    icon={AlertCircleIcon}
+                    title="Error"
+                    subtitle={<ErrorMessage error={this.state.error} history={this.props.history} />}
+                />
             )
         }
 

--- a/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -20,6 +20,7 @@ import { RepositoryCompareCommitsPage } from './RepositoryCompareCommitsPage'
 import { RepositoryCompareDiffPage } from './RepositoryCompareDiffPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 function queryRepositoryComparison(args: {
     repo: GQL.ID
@@ -86,6 +87,7 @@ interface Props
     /** The head of the comparison. */
     head: { repoName: string; repoID: GQL.ID; rev?: string | null }
     hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemAction>
+    history: H.History
 }
 
 interface State {
@@ -151,7 +153,7 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                 ) : this.state.rangeOrError === undefined ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.rangeOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.rangeOrError} />
+                    <ErrorAlert className="mt-2" error={this.state.rangeOrError} history={this.props.history} />
                 ) : (
                     <>
                         <RepositoryCompareCommitsPage {...this.props} />

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -12,8 +12,13 @@ import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { PatternTypeProps } from '../../search'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 const LOADING = 'loading' as const
+
+interface Props extends Omit<PatternTypeProps, 'setPatternType'> {
+    history: H.History
+}
 
 interface State {
     /** The repositories, loading, or an error. */
@@ -23,7 +28,7 @@ interface State {
 /**
  * An explore section that shows a few repositories and a link to all.
  */
-export class RepositoriesExploreSection extends React.PureComponent<Omit<PatternTypeProps, 'setPatternType'>, State> {
+export class RepositoriesExploreSection extends React.PureComponent<Props, State> {
     private static QUERY_REPOSITORIES_ARGS: { first: number } & Pick<GQL.IRepositoriesOnQueryArguments, 'names'> = {
         // Show sample repositories on Sourcegraph.com.
         names: window.context.sourcegraphDotComMode
@@ -78,7 +83,7 @@ export class RepositoriesExploreSection extends React.PureComponent<Omit<Pattern
                 <h3 className="card-header">Repositories</h3>
                 <div className="list-group list-group-flush">
                     {isErrorLike(repositoriesOrError) ? (
-                        <ErrorAlert error={repositoriesOrError} />
+                        <ErrorAlert error={repositoriesOrError} history={this.props.history} />
                     ) : repositoriesOrError.length === 0 ? (
                         <p>No repositories.</p>
                     ) : (

--- a/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -10,6 +10,7 @@ import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
 import { ErrorMessage } from '../../components/alerts'
+import * as H from 'history'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -23,6 +24,7 @@ interface Props
     extends RouteComponentProps<{}>,
         Pick<RepoContainerContext, 'repo' | 'routePrefix' | 'repoHeaderContributionsLifecycleProps'> {
     repo: GQL.IRepository
+    history: H.History
 }
 
 interface State {
@@ -54,7 +56,11 @@ export class RepositoryReleasesArea extends React.Component<Props> {
     public render(): JSX.Element | null {
         if (this.state.error) {
             return (
-                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={this.state.error} />} />
+                <HeroPage
+                    icon={AlertCircleIcon}
+                    title="Error"
+                    subtitle={<ErrorMessage error={this.state.error} history={this.props.history} />}
+                />
             )
         }
 

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -35,7 +35,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/commit/:revspec+',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepositoryCommitPage {...context} />
             </RepositoryGitDataContainer>
         ),
@@ -43,7 +43,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/branches',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepositoryBranchesArea {...context} />
             </RepositoryGitDataContainer>
         ),
@@ -51,7 +51,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/tags',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepositoryReleasesArea {...context} />
             </RepositoryGitDataContainer>
         ),
@@ -59,7 +59,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/compare/:spec*',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepositoryCompareArea {...context} />
             </RepositoryGitDataContainer>
         ),
@@ -67,7 +67,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/stats',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepositoryStatsArea {...context} />
             </RepositoryGitDataContainer>
         ),
@@ -75,7 +75,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/settings',
         render: context => (
-            <RepositoryGitDataContainer repoName={context.repo.name}>
+            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
                 <RepoSettingsArea {...context} />
             </RepositoryGitDataContainer>
         ),

--- a/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/web/src/repo/settings/RepoSettingsArea.tsx
@@ -14,6 +14,7 @@ import { RepoSettingsSidebar, RepoSettingsSideBarItems } from './RepoSettingsSid
 import { RouteDescriptor } from '../../util/contributions'
 import { ErrorMessage } from '../../components/alerts'
 import { asError } from '../../../../shared/src/util/errors'
+import * as H from 'history'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -36,6 +37,7 @@ interface Props extends RouteComponentProps<{}>, RepoHeaderContributionsLifecycl
     repo: GQL.IRepository
     authenticatedUser: GQL.IUser | null
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    history: H.History
 }
 
 interface State {
@@ -80,7 +82,11 @@ export class RepoSettingsArea extends React.Component<Props> {
     public render(): JSX.Element | null {
         if (this.state.error) {
             return (
-                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={this.state.error} />} />
+                <HeroPage
+                    icon={AlertCircleIcon}
+                    title="Error"
+                    subtitle={<ErrorMessage error={this.state.error} history={this.props.history} />}
+                />
             )
         }
 

--- a/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -16,6 +16,7 @@ import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 /**
  * Fetches a repository's text search index information.
@@ -114,6 +115,7 @@ const TextSearchIndexedRef: React.FunctionComponent<{
 
 interface Props extends RouteComponentProps<{}> {
     repo: GQL.IRepository
+    history: H.History
 }
 
 interface State {
@@ -159,7 +161,11 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                 <h2>Indexing</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.error && (
-                    <ErrorAlert prefix="Error getting repository index status" error={this.state.error} />
+                    <ErrorAlert
+                        prefix="Error getting repository index status"
+                        error={this.state.error}
+                        history={this.props.history}
+                    />
                 )}
                 {!this.state.error &&
                     !this.state.loading &&

--- a/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -17,12 +17,14 @@ import { fetchRepository } from './backend'
 import { ActionContainer, BaseActionContainer } from './components/ActionContainer'
 import { ErrorAlert } from '../../components/alerts'
 import { asError } from '../../../../shared/src/util/errors'
+import * as H from 'history'
 
 interface UpdateMirrorRepositoryActionContainerProps {
     repo: GQL.IRepository
     onDidUpdateRepository: () => void
     disabled: boolean
     disabledReason: string | undefined
+    history: H.History
 }
 
 class UpdateMirrorRepositoryActionContainer extends React.PureComponent<UpdateMirrorRepositoryActionContainerProps> {
@@ -112,6 +114,7 @@ class UpdateMirrorRepositoryActionContainer extends React.PureComponent<UpdateMi
                 flashText="Added to queue"
                 info={info}
                 run={this.updateMirrorRepository}
+                history={this.props.history}
             />
         )
     }
@@ -125,6 +128,7 @@ class UpdateMirrorRepositoryActionContainer extends React.PureComponent<UpdateMi
 interface CheckMirrorRepositoryConnectionActionContainerProps {
     repo: GQL.IRepository
     onDidUpdateReachability: (reachable: boolean | undefined) => void
+    history: H.History
 }
 
 interface CheckMirrorRepositoryConnectionActionContainerState {
@@ -199,7 +203,11 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                 details={
                     <>
                         {this.state.errorDescription && (
-                            <ErrorAlert className="action-container__alert" error={this.state.errorDescription} />
+                            <ErrorAlert
+                                className="action-container__alert"
+                                error={this.state.errorDescription}
+                                history={this.props.history}
+                            />
                         )}
                         {this.state.loading && (
                             <div className="alert alert-primary action-container__alert">
@@ -233,6 +241,7 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
 interface Props extends RouteComponentProps<{}> {
     repo: GQL.IRepository
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    history: H.History
 }
 
 interface State {
@@ -287,7 +296,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Mirror settings" />
                 <h2>Mirroring and cloning</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} />}
+                {this.state.error && <ErrorAlert error={this.state.error} history={this.props.history} />}
                 <div className="form-group">
                     <label>
                         Remote repository URL{' '}
@@ -314,10 +323,12 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
                     disabledReason={
                         typeof this.state.reachable === 'boolean' && !this.state.reachable ? 'Not reachable' : undefined
                     }
+                    history={this.props.history}
                 />
                 <CheckMirrorRepositoryConnectionActionContainer
                     repo={this.state.repo}
                     onDidUpdateReachability={this.onDidUpdateReachability}
+                    history={this.props.history}
                 />
                 {typeof this.state.reachable === 'boolean' && !this.state.reachable && (
                     <div className="alert alert-info repo-settings-mirror-page__troubleshooting">

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -12,10 +12,12 @@ import { fetchRepository } from './backend'
 import { ErrorAlert } from '../../components/alerts'
 import { defaultExternalServices } from '../../site-admin/externalServices'
 import { asError } from '../../../../shared/src/util/errors'
+import * as H from 'history'
 
 interface Props extends RouteComponentProps<{}> {
     repo: GQL.IRepository
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    history: H.History
 }
 
 interface State {
@@ -66,7 +68,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Repository settings" />
                 <h2>Settings</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} />}
+                {this.state.error && <ErrorAlert error={this.state.error} history={this.props.history} />}
                 {services.length > 0 && (
                     <div className="mb-4">
                         {services.map(service => (

--- a/web/src/repo/settings/components/ActionContainer.tsx
+++ b/web/src/repo/settings/components/ActionContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { ErrorAlert } from '../../../components/alerts'
 import { asError } from '../../../../../shared/src/util/errors'
+import * as H from 'history'
 
 export const BaseActionContainer: React.FunctionComponent<{
     title: React.ReactFragment
@@ -33,6 +34,7 @@ interface Props {
     flashText?: string
 
     run: () => Promise<void>
+    history: H.History
 }
 
 interface State {
@@ -94,7 +96,7 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                 details={
                     <>
                         {this.state.error ? (
-                            <ErrorAlert className="mb-0 mt-3" error={this.state.error} />
+                            <ErrorAlert className="mb-0 mt-3" error={this.state.error} history={this.props.history} />
                         ) : (
                             this.props.info
                         )}

--- a/web/src/savedSearches/SavedSearchForm.tsx
+++ b/web/src/savedSearches/SavedSearchForm.tsx
@@ -170,7 +170,7 @@ export class SavedSearchForm extends React.Component<Props, State> {
                         {this.props.submitLabel}
                     </button>
                     {this.props.error && !this.props.loading && (
-                        <ErrorAlert className="mb-3" error={this.props.error} />
+                        <ErrorAlert className="mb-3" error={this.props.error} history={this.props.history} />
                     )}
                 </Form>
             </div>

--- a/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/web/src/savedSearches/SavedSearchListPage.tsx
@@ -14,6 +14,7 @@ import { NamespaceProps } from '../namespaces'
 import { deleteSavedSearch, fetchSavedSearches } from '../search/backend'
 import { PatternTypeProps } from '../search'
 import { ErrorAlert } from '../components/alerts'
+import * as H from 'history'
 
 interface NodeProps extends RouteComponentProps, Omit<PatternTypeProps, 'setPatternType'> {
     savedSearch: GQL.ISavedSearch
@@ -102,7 +103,9 @@ interface State {
     savedSearchesOrError?: GQL.ISavedSearch[] | ErrorLike
 }
 
-interface Props extends RouteComponentProps<{}>, NamespaceProps, Omit<PatternTypeProps, 'setPatternType'> {}
+interface Props extends RouteComponentProps<{}>, NamespaceProps, Omit<PatternTypeProps, 'setPatternType'> {
+    history: H.History
+}
 
 export class SavedSearchListPage extends React.Component<Props, State> {
     public subscriptions = new Subscription()
@@ -147,7 +150,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                     </div>
                 </div>
                 {this.state.savedSearchesOrError && isErrorLike(this.state.savedSearchesOrError) && (
-                    <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} />
+                    <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} history={this.props.history} />
                 )}
                 <div className="list-group list-group-flush">
                     {this.state.savedSearchesOrError &&

--- a/web/src/search/ScopePage.tsx
+++ b/web/src/search/ScopePage.tsx
@@ -23,6 +23,7 @@ import { asError, isErrorLike } from '../../../shared/src/util/errors'
 import { useObservable } from '../../../shared/src/util/useObservable'
 import { Markdown } from '../../../shared/src/components/Markdown'
 import { pluralize } from '../../../shared/src/util/strings'
+import * as H from 'history'
 
 const ScopeNotFound: React.FunctionComponent = () => (
     <HeroPage
@@ -45,6 +46,7 @@ interface Props
         CaseSensitivityProps {
     authenticatedUser: GQL.IUser | null
     onNavbarQueryChange: (queryState: QueryState) => void
+    history: H.History
 }
 
 /**
@@ -107,7 +109,9 @@ export const ScopePage: React.FunctionComponent<Props> = ({ settingsCascade, onN
             <PageTitle title={searchScope.name} />
             <header>
                 <h1>{searchScope.name}</h1>
-                {searchScope.description && <Markdown dangerousInnerHTML={renderMarkdown(searchScope.description)} />}
+                {searchScope.description && (
+                    <Markdown dangerousInnerHTML={renderMarkdown(searchScope.description)} history={props.history} />
+                )}
             </header>
             <section className="mb-5">
                 <Form className="d-flex" onSubmit={onSubmit}>
@@ -131,7 +135,7 @@ export const ScopePage: React.FunctionComponent<Props> = ({ settingsCascade, onN
             </section>
 
             {isErrorLike(scopeRepositories) ? (
-                <ErrorAlert error={scopeRepositories} />
+                <ErrorAlert error={scopeRepositories} history={props.history} />
             ) : (
                 scopeRepositories &&
                 (scopeRepositories.length > 0 ? (

--- a/web/src/search/__snapshots__/ScopePage.test.tsx.snap
+++ b/web/src/search/__snapshots__/ScopePage.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`ScopePage renders 1`] = `
 ",
         }
       }
+      onClick={[Function]}
     />
   </header>
   <section

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -151,6 +151,7 @@ export class SearchPage extends React.Component<Props, State> {
                                         className="my-3"
                                         location="home"
                                         settingsCascade={this.props.settingsCascade}
+                                        history={this.props.history}
                                     />
                                 </Form>
                             </>

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -345,6 +345,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                             className="m-2"
                             data-testid="search-results-list-error"
                             error={this.props.resultsOrError}
+                            history={this.props.history}
                         />
                     ) : (
                         (() => {
@@ -520,7 +521,14 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     />
                 )
         }
-        return <SearchResult key={result.url} result={result} isLightTheme={this.props.isLightTheme} />
+        return (
+            <SearchResult
+                key={result.url}
+                result={result}
+                isLightTheme={this.props.isLightTheme}
+                history={this.props.history}
+            />
+        )
     }
 
     /** onBottomHit increments the amount of results to be shown when we have scrolled to the bottom of the list. */

--- a/web/src/settings/SettingsArea.tsx
+++ b/web/src/settings/SettingsArea.tsx
@@ -18,6 +18,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { mergeSettingsSchemas } from './configuration'
 import { SettingsPage } from './SettingsPage'
 import { ErrorMessage } from '../components/alerts'
+import * as H from 'history'
 
 const NotFoundPage: React.FunctionComponent = () => <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 
@@ -49,6 +50,7 @@ export interface SettingsAreaPageProps extends SettingsAreaPageCommonProps {
 interface Props extends SettingsAreaPageCommonProps, RouteComponentProps<{}> {
     className?: string
     extraHeader?: JSX.Element
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -120,7 +122,7 @@ export class SettingsArea extends React.Component<Props, State> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.dataOrError} />}
+                    subtitle={<ErrorMessage error={this.state.dataOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/settings/tokens/AccessTokenNode.tsx
+++ b/web/src/settings/tokens/AccessTokenNode.tsx
@@ -6,11 +6,11 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { mutateGraphQL } from '../../backend/graphql'
-import { FilteredConnection } from '../../components/FilteredConnection'
 import { Timestamp } from '../../components/time/Timestamp'
 import { userURL } from '../../user'
 import { AccessTokenCreatedAlert } from './AccessTokenCreatedAlert'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 export const accessTokenFragment = gql`
     fragment AccessTokenFields on AccessToken {
@@ -60,6 +60,7 @@ export interface AccessTokenNodeProps {
     newToken?: GQL.ICreateAccessTokenResult
 
     onDidUpdate: () => void
+    history: H.History
 }
 
 interface AccessTokenNodeState {
@@ -159,7 +160,11 @@ export class AccessTokenNode extends React.PureComponent<AccessTokenNodeProps, A
                             Delete
                         </button>
                         {isErrorLike(this.state.deletionOrError) && (
-                            <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
+                            <ErrorAlert
+                                className="mt-2"
+                                error={this.state.deletionOrError}
+                                history={this.props.history}
+                            />
                         )}
                     </div>
                 </div>
@@ -176,8 +181,3 @@ export class AccessTokenNode extends React.PureComponent<AccessTokenNodeProps, A
 
     private deleteAccessToken = (): void => this.deletes.next()
 }
-
-export class FilteredAccessTokenConnection extends FilteredConnection<
-    GQL.IAccessToken,
-    Pick<AccessTokenNodeProps, 'onDidUpdate'>
-> {}

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -113,7 +113,10 @@ export class SiteAdminAddExternalServicePage extends React.Component<Props, Stat
                         </div>
                         <div className="alert alert-warning">
                             <h4>Warning</h4>
-                            <Markdown dangerousInnerHTML={renderMarkdown(createdExternalService.warning)} />
+                            <Markdown
+                                dangerousInnerHTML={renderMarkdown(createdExternalService.warning)}
+                                history={this.props.history}
+                            />
                         </div>
                     </div>
                 ) : (

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -18,6 +18,7 @@ import { userURL } from '../user'
 import { setUserEmailVerified } from '../user/settings/backend'
 import { deleteUser, fetchAllUsers, randomizeUserPassword, setUserIsSiteAdmin } from './backend'
 import { ErrorAlert } from '../components/alerts'
+import * as H from 'history'
 
 interface UserNodeProps {
     /**
@@ -34,6 +35,7 @@ interface UserNodeProps {
      * Called when the user is updated by an action in this list item.
      */
     onDidUpdate?: () => void
+    history: H.History
 }
 
 interface UserNodeState {
@@ -165,7 +167,9 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         )}
                     </div>
                 </div>
-                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
+                {this.state.errorDescription && (
+                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
+                )}
                 {this.state.resetPasswordURL && (
                     <div className="alert alert-success mt-2">
                         <p>
@@ -273,17 +277,13 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
 
 interface Props extends RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
+    history: H.History
 }
 
 interface State {
     users?: GQL.IUser[]
     totalCount?: number
 }
-
-class FilteredUserConnection extends FilteredConnection<
-    GQL.IUser,
-    Pick<UserNodeProps, 'authenticatedUser' | 'onDidUpdate'>
-> {}
 
 /**
  * A page displaying the users on this site.
@@ -303,9 +303,10 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<UserNodeProps, 'authenticatedUser' | 'onDidUpdate'> = {
+        const nodeProps: Omit<UserNodeProps, 'node'> = {
             authenticatedUser: this.props.authenticatedUser,
             onDidUpdate: this.onDidUpdateUser,
+            history: this.props.history,
         }
 
         return (
@@ -319,7 +320,7 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
                         </Link>
                     </div>
                 </div>
-                <FilteredUserConnection
+                <FilteredConnection<GQL.IUser, Omit<UserNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="user"
                     pluralNoun="users"

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -14,6 +14,7 @@ import { fetchSite, reloadSite, updateSiteConfiguration } from './backend'
 import { ErrorAlert } from '../components/alerts'
 import * as jsonc from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
+import * as H from 'history'
 
 const defaultFormattingOptions: jsonc.FormattingOptions = {
     eol: '\n',
@@ -192,6 +193,7 @@ const quickConfigureActions: {
 
 interface Props extends RouteComponentProps<{}> {
     isLightTheme: boolean
+    history: H.History
 }
 
 interface State {
@@ -309,7 +311,12 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         const alerts: JSX.Element[] = []
         if (this.state.error) {
             alerts.push(
-                <ErrorAlert key="error" className="site-admin-configuration-page__alert" error={this.state.error} />
+                <ErrorAlert
+                    key="error"
+                    className="site-admin-configuration-page__alert"
+                    error={this.state.error}
+                    history={this.props.history}
+                />
             )
         }
         if (this.state.reloadStartedAt) {

--- a/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -12,8 +12,11 @@ import { eventLogger } from '../tracking/eventLogger'
 import { createUser } from './backend'
 import { ErrorAlert } from '../components/alerts'
 import { asError } from '../../../shared/src/util/errors'
+import * as H from 'history'
 
-interface Props extends RouteComponentProps<{}> {}
+interface Props extends RouteComponentProps<{}> {
+    history: H.History
+}
 
 interface State {
     errorDescription?: string
@@ -153,7 +156,11 @@ export class SiteAdminCreateUserPage extends React.Component<Props, State> {
                             </small>
                         </div>
                         {this.state.errorDescription && (
-                            <ErrorAlert className="my-2" error={this.state.errorDescription} />
+                            <ErrorAlert
+                                className="my-2"
+                                error={this.state.errorDescription}
+                                history={this.props.history}
+                            />
                         )}
                         <button className="btn btn-primary" disabled={this.state.loading} type="submit">
                             {window.context.resetPasswordEnabled

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -29,11 +29,11 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
     public render(): JSX.Element | null {
         return (
             <Form className="external-service-form" onSubmit={this.props.onSubmit}>
-                {this.props.error && <ErrorAlert error={this.props.error} />}
+                {this.props.error && <ErrorAlert error={this.props.error} history={this.props.history} />}
                 {this.props.warning && (
                     <div className="alert alert-warning">
                         <h4>Warning</h4>
-                        <ErrorMessage error={this.props.warning} />
+                        <ErrorMessage error={this.props.warning} history={this.props.history} />
                     </div>
                 )}
                 {this.props.hideDisplayNameField || (

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -15,9 +15,11 @@ import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
 import { ErrorAlert } from '../components/alerts'
 import { defaultExternalServices, codeHostExternalServices } from './externalServices'
 import { hasProperty } from '../../../shared/src/util/types'
+import * as H from 'history'
 
 interface Props extends RouteComponentProps<{ id: GQL.ID }> {
     isLightTheme: boolean
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -136,7 +138,11 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 <h2>Update synced repositories</h2>
                 {this.state.externalServiceOrError === LOADING && <LoadingSpinner className="icon-inline" />}
                 {isErrorLike(this.state.externalServiceOrError) && (
-                    <ErrorAlert className="mb-3" error={this.state.externalServiceOrError} />
+                    <ErrorAlert
+                        className="mb-3"
+                        error={this.state.externalServiceOrError}
+                        history={this.props.history}
+                    />
                 )}
                 {externalServiceCategory && (
                     <div className="mb-3">

--- a/web/src/site-admin/SiteAdminExternalServicesPage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicesPage.tsx
@@ -17,6 +17,7 @@ import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { ErrorAlert } from '../components/alerts'
 import { useEventObservable } from '../../../shared/src/util/useObservable'
+import * as H from 'history'
 
 async function deleteExternalService(externalService: GQL.ID): Promise<void> {
     const result = await mutateGraphQL(
@@ -35,9 +36,10 @@ async function deleteExternalService(externalService: GQL.ID): Promise<void> {
 interface ExternalServiceNodeProps {
     node: GQL.IExternalService
     onDidUpdate: () => void
+    history: H.History
 }
 
-const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodeProps> = ({ node, onDidUpdate }) => {
+const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodeProps> = ({ node, onDidUpdate, history }) => {
     const [nextDeleteClick, deletedOrError] = useEventObservable(
         useCallback(
             (clicks: Observable<React.MouseEvent>) =>
@@ -82,12 +84,14 @@ const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodeProps> = (
                     </button>
                 </div>
             </div>
-            {isErrorLike(deletedOrError) && <ErrorAlert className="mt-2" error={deletedOrError} />}
+            {isErrorLike(deletedOrError) && <ErrorAlert className="mt-2" error={deletedOrError} history={history} />}
         </li>
     )
 }
 
-interface Props extends RouteComponentProps<{}>, ActivationProps {}
+interface Props extends RouteComponentProps<{}>, ActivationProps {
+    history: H.History
+}
 
 interface State {
     noExternalServices?: boolean
@@ -152,8 +156,9 @@ export class SiteAdminExternalServicesPage extends React.PureComponent<Props, St
         )
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<ExternalServiceNodeProps, 'onDidUpdate'> = {
+        const nodeProps: Omit<ExternalServiceNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateExternalServices,
+            history: this.props.history,
         }
 
         if (this.state.noExternalServices) {
@@ -172,7 +177,7 @@ export class SiteAdminExternalServicesPage extends React.PureComponent<Props, St
                     </Link>
                 </div>
                 <p className="mt-2">Manage code host connections to sync repositories.</p>
-                <FilteredConnection<GQL.IExternalService, Pick<ExternalServiceNodeProps, 'onDidUpdate'>>
+                <FilteredConnection<GQL.IExternalService, Omit<ExternalServiceNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="external service"
                     pluralNoun="external services"

--- a/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -15,6 +15,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { deleteOrganization, fetchAllOrganizations } from './backend'
 import { ErrorAlert } from '../components/alerts'
 import { asError } from '../../../shared/src/util/errors'
+import * as H from 'history'
 
 interface OrgNodeProps {
     /**
@@ -26,6 +27,7 @@ interface OrgNodeProps {
      * Called when the org is updated by an action in this list item.
      */
     onDidUpdate?: () => void
+    history: H.History
 }
 
 interface OrgNodeState {
@@ -81,7 +83,9 @@ class OrgNode extends React.PureComponent<OrgNodeProps, OrgNodeState> {
                         </button>
                     </div>
                 </div>
-                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
+                {this.state.errorDescription && (
+                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
+                )}
             </li>
         )
     }
@@ -110,14 +114,14 @@ class OrgNode extends React.PureComponent<OrgNodeProps, OrgNodeState> {
     }
 }
 
-interface Props extends RouteComponentProps<{}> {}
+interface Props extends RouteComponentProps<{}> {
+    history: H.History
+}
 
 interface State {
     orgs?: GQL.IOrg[]
     totalCount?: number
 }
-
-class FilteredOrgConnection extends FilteredConnection<GQL.IOrg, Pick<OrgNodeProps, 'onDidUpdate'>> {}
 
 /**
  * A page displaying the orgs on this site.
@@ -137,8 +141,9 @@ export class SiteAdminOrgsPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<OrgNodeProps, 'onDidUpdate'> = {
+        const nodeProps: Omit<OrgNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateOrg,
+            history: this.props.history,
         }
 
         return (
@@ -155,7 +160,7 @@ export class SiteAdminOrgsPage extends React.Component<Props, State> {
                     <Link to="/help/user/organizations">Sourcegraph documentation</Link> for information about
                     configuring organizations.
                 </p>
-                <FilteredOrgConnection
+                <FilteredConnection<GQL.IOrg, Omit<OrgNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="organization"
                     pluralNoun="organizations"

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -19,10 +19,12 @@ import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchAllRepositoriesAndPollIfEmptyOrAnyCloning } from './backend'
 import { ErrorAlert } from '../components/alerts'
+import * as H from 'history'
 
 interface RepositoryNodeProps extends ActivationProps {
     node: GQL.IRepository
     onDidUpdate?: () => void
+    history: H.History
 }
 
 interface RepositoryNodeState {
@@ -73,18 +75,15 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
                         }{' '}
                     </div>
                 </div>
-                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
+                {this.state.errorDescription && (
+                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
+                )}
             </li>
         )
     }
 }
 
 interface Props extends RouteComponentProps<{}>, ActivationProps {}
-
-class FilteredRepositoryConnection extends FilteredConnection<
-    GQL.IRepository,
-    Pick<RepositoryNodeProps, 'onDidUpdate'>
-> {}
 
 /**
  * A page displaying the repositories on this site.
@@ -142,9 +141,10 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<RepositoryNodeProps, 'onDidUpdate' | 'activation'> = {
+        const nodeProps: Omit<RepositoryNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateRepository,
             activation: this.props.activation,
+            history: this.props.history,
         }
 
         return (
@@ -155,7 +155,7 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
                     Repositories are synced from connected{' '}
                     <Link to="/site-admin/external-services">code host connections</Link>.
                 </p>
-                <FilteredRepositoryConnection
+                <FilteredConnection<GQL.IRepository, Omit<RepositoryNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="repository"
                     pluralNoun="repositories"

--- a/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -8,14 +8,10 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { createAggregateError } from '../../../shared/src/util/errors'
 import { queryGraphQL } from '../backend/graphql'
 import { PageTitle } from '../components/PageTitle'
-import {
-    accessTokenFragment,
-    AccessTokenNode,
-    AccessTokenNodeProps,
-    FilteredAccessTokenConnection,
-} from '../settings/tokens/AccessTokenNode'
+import { accessTokenFragment, AccessTokenNode, AccessTokenNodeProps } from '../settings/tokens/AccessTokenNode'
 import { eventLogger } from '../tracking/eventLogger'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
+import { FilteredConnection } from '../components/FilteredConnection'
 
 interface Props extends RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser
@@ -36,9 +32,10 @@ export class SiteAdminTokensPage extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<AccessTokenNodeProps, 'showSubject' | 'onDidUpdate'> = {
+        const nodeProps: Omit<AccessTokenNodeProps, 'node'> = {
             showSubject: true,
             onDidUpdate: this.onDidUpdateAccessToken,
+            history: this.props.history,
         }
 
         const accessTokensEnabled = window.context.accessTokensAllow !== 'none'
@@ -56,7 +53,7 @@ export class SiteAdminTokensPage extends React.PureComponent<Props, State> {
                     </LinkOrSpan>
                 </div>
                 <p>Tokens may be used to access the Sourcegraph API with the full privileges of the token's creator.</p>
-                <FilteredAccessTokenConnection
+                <FilteredConnection<GQL.IAccessToken, Omit<AccessTokenNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="access token"
                     pluralNoun="access tokens"

--- a/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -91,6 +91,7 @@ export class SiteAdminUpdatesPage extends React.Component<Props, State> {
                                 className="site-admin-updates-page__alert"
                                 prefix="Error checking for updates"
                                 error={this.state.updateCheck.errorMessage}
+                                history={this.props.history}
                             />
                         )}
                     </div>

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -234,7 +234,9 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
             <div className="site-admin-usage-statistics-page">
                 <PageTitle title="Usage statistics - Admin" />
                 <h2>Usage statistics</h2>
-                {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
+                {this.state.error && (
+                    <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
+                )}
                 {this.state.stats && (
                     <>
                         <RadioButtons

--- a/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { SiteInitPage } from './SiteInitPage'
 import { MemoryRouter, Redirect } from 'react-router'
+import { createMemoryHistory } from 'history'
 
 describe('SiteInitPage', () => {
     const origContext = window.context
@@ -15,7 +16,12 @@ describe('SiteInitPage', () => {
     test('site already initialized', () => {
         const component = renderer.create(
             <MemoryRouter>
-                <SiteInitPage isLightTheme={true} needsSiteInit={false} authenticatedUser={null} />
+                <SiteInitPage
+                    isLightTheme={true}
+                    needsSiteInit={false}
+                    authenticatedUser={null}
+                    history={createMemoryHistory()}
+                />
             </MemoryRouter>
         )
         const redirect = component.root.findByType(Redirect)
@@ -27,13 +33,27 @@ describe('SiteInitPage', () => {
         expect(
             renderer
                 .create(
-                    <SiteInitPage isLightTheme={true} needsSiteInit={true} authenticatedUser={{ username: 'alice' }} />
+                    <SiteInitPage
+                        isLightTheme={true}
+                        needsSiteInit={true}
+                        authenticatedUser={{ username: 'alice' }}
+                        history={createMemoryHistory()}
+                    />
                 )
                 .toJSON()
         ).toMatchSnapshot())
 
     test('normal', () =>
         expect(
-            renderer.create(<SiteInitPage isLightTheme={true} needsSiteInit={true} authenticatedUser={null} />).toJSON()
+            renderer
+                .create(
+                    <SiteInitPage
+                        isLightTheme={true}
+                        needsSiteInit={true}
+                        authenticatedUser={null}
+                        history={createMemoryHistory()}
+                    />
+                )
+                .toJSON()
         ).toMatchSnapshot())
 })

--- a/web/src/site-admin/init/SiteInitPage.tsx
+++ b/web/src/site-admin/init/SiteInitPage.tsx
@@ -5,6 +5,7 @@ import { SignUpArgs, SignUpForm } from '../../auth/SignUpForm'
 import { submitTrialRequest } from '../../marketing/backend'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { ThemeProps } from '../../../../shared/src/theme'
+import * as H from 'history'
 
 const initSite = async (args: SignUpArgs): Promise<void> => {
     const resp = await fetch('/-/site-init', {
@@ -35,6 +36,7 @@ interface Props extends ThemeProps {
      * `window.context.needsSiteInit` is used.
      */
     needsSiteInit?: typeof window.context.needsSiteInit
+    history: H.History
 }
 
 /**
@@ -45,6 +47,7 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
     authenticatedUser,
     isLightTheme,
     needsSiteInit = window.context.needsSiteInit,
+    history,
 }) => {
     if (!needsSiteInit) {
         return <Redirect to="/search" />
@@ -71,6 +74,7 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
                                 className="w-100"
                                 buttonLabel="Create admin account & continue"
                                 doSignUp={initSite}
+                                history={history}
                             />
                         </>
                     )}

--- a/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import H from 'history'
+import * as H from 'history'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useEffect, useMemo } from 'react'
 import { Observable, of } from 'rxjs'
@@ -204,7 +204,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                         {info.users > 1 &&
                             stats !== undefined &&
                             (isErrorLike(stats) ? (
-                                <ErrorAlert className="mb-3" error={stats} />
+                                <ErrorAlert className="mb-3" error={stats} history={history} />
                             ) : (
                                 <Collapsible
                                     title={

--- a/web/src/snippets/SnippetsPage.tsx
+++ b/web/src/snippets/SnippetsPage.tsx
@@ -27,7 +27,7 @@ interface Props extends ExtensionsControllerProps {
  * to allow experimentation with extensions that listen for changes in documents and display
  * Markdown-formatted text.
  */
-export const SnippetsPage: React.FunctionComponent<Props> = ({ location, extensionsController, ...props }) => {
+export const SnippetsPage: React.FunctionComponent<Props> = ({ location, history, extensionsController }) => {
     const [textArea, setTextArea] = useState<HTMLTextAreaElement | null>(null)
     const textAreaRef = createRef<HTMLTextAreaElement>()
     useLayoutEffect(() => setTextArea(textAreaRef.current), [textAreaRef])
@@ -128,14 +128,14 @@ export const SnippetsPage: React.FunctionComponent<Props> = ({ location, extensi
                 allPanelViews.map((view, i) => (
                     <div key={i} className="mt-3 card">
                         <h3 className="card-header">{view.title}</h3>
-                        <div className="card-body" onClick={createLinkClickHandler(props.history)}>
+                        <div className="card-body" onClick={createLinkClickHandler(history)}>
                             <WithLinkPreviews
                                 dangerousInnerHTML={renderMarkdown(view.content)}
                                 extensionsController={extensionsController}
                                 setElementTooltip={setElementTooltip}
                                 linkPreviewContentClass={LINK_PREVIEW_CLASS}
                             >
-                                {props => <Markdown {...props} />}
+                                {props => <Markdown {...props} history={history} />}
                             </WithLinkPreviews>
                         </div>
                     </div>

--- a/web/src/tree/TreeLayer.tsx
+++ b/web/src/tree/TreeLayer.tsx
@@ -276,6 +276,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                                     style={treePadding(this.props.depth, true)}
                                                     error={treeOrError}
                                                     prefix="Error loading file tree"
+                                                    history={this.props.history}
                                                 />
                                             ) : (
                                                 treeOrError && (

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -161,6 +161,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                         className="tree__row tree__row-alert"
                         prefix="Error loading tree"
                         error={treeOrError}
+                        history={this.props.history}
                     />
                 ) : (
                     <table className="tree-layer" tabIndex={0}>

--- a/web/src/usageStatistics/explore/SiteUsageExploreSection.tsx
+++ b/web/src/usageStatistics/explore/SiteUsageExploreSection.tsx
@@ -7,9 +7,11 @@ import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/err
 import { BarChart } from '../../components/d3/BarChart'
 import { fetchSiteUsageStatistics } from '../../site-admin/backend'
 import { ErrorAlert } from '../../components/alerts'
+import * as H from 'history'
 
 interface Props {
     isLightTheme: boolean
+    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -44,7 +46,7 @@ export class SiteUsageExploreSection extends React.PureComponent<Props, State> {
             <div className="site-usage-explore-section">
                 <h2>Site usage</h2>
                 {isErrorLike(this.state.siteUsageStatisticsOrError) ? (
-                    <ErrorAlert error={this.state.siteUsageStatisticsOrError} />
+                    <ErrorAlert error={this.state.siteUsageStatisticsOrError} history={this.props.history} />
                 ) : this.state.siteUsageStatisticsOrError === LOADING ? (
                     <p>Loading...</p>
                 ) : (

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -193,7 +193,7 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.userOrError} />}
+                    subtitle={<ErrorMessage error={this.state.userOrError} history={this.props.history} />}
                 />
             )
         }

--- a/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -199,7 +199,11 @@ export class UserSettingsCreateAccessTokenPage extends React.PureComponent<Props
                     </Link>
                 </Form>
                 {isErrorLike(this.state.creationOrError) && (
-                    <ErrorAlert className="invite-form__alert" error={this.state.creationOrError} />
+                    <ErrorAlert
+                        className="invite-form__alert"
+                        error={this.state.creationOrError}
+                        history={this.props.history}
+                    />
                 )}
             </div>
         )

--- a/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -9,14 +9,11 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { createAggregateError } from '../../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../../backend/graphql'
 import { PageTitle } from '../../../components/PageTitle'
-import {
-    accessTokenFragment,
-    AccessTokenNode,
-    AccessTokenNodeProps,
-    FilteredAccessTokenConnection,
-} from '../../../settings/tokens/AccessTokenNode'
+import { accessTokenFragment, AccessTokenNode, AccessTokenNodeProps } from '../../../settings/tokens/AccessTokenNode'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserAreaRouteContext } from '../../area/UserArea'
+import { FilteredConnection } from '../../../components/FilteredConnection'
+import * as H from 'history'
 
 interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {
     /**
@@ -30,6 +27,7 @@ interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {
      * from all state (and not displayed to the user anymore).
      */
     onDidPresentNewToken: () => void
+    history: H.History
 }
 
 interface State {}
@@ -59,9 +57,10 @@ export class UserSettingsTokensPage extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<AccessTokenNodeProps, 'onDidUpdate' | 'newToken'> = {
+        const nodeProps: Omit<AccessTokenNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateAccessToken,
             newToken: this.props.newToken,
+            history: this.props.history,
         }
 
         return (
@@ -74,7 +73,7 @@ export class UserSettingsTokensPage extends React.PureComponent<Props, State> {
                     </Link>
                 </div>
                 <p>Access tokens may be used to access the Sourcegraph API.</p>
-                <FilteredAccessTokenConnection
+                <FilteredConnection<GQL.IAccessToken, Omit<AccessTokenNodeProps, 'node'>>
                     listClassName="list-group list-group-flush"
                     noun="access token"
                     pluralNoun="access tokens"

--- a/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -11,10 +11,12 @@ import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { updatePassword } from '../backend'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 interface Props extends RouteComponentProps<{}> {
     user: GQL.IUser
     authenticatedUser: GQL.IUser
+    history: H.History
 }
 
 interface State {
@@ -97,7 +99,9 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                     </div>
                 ) : (
                     <>
-                        {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
+                        {this.state.error && (
+                            <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
+                        )}
                         {this.state.saved && <div className="alert alert-success mb-3">Password changed!</div>}
                         <Form onSubmit={this.handleSubmit}>
                             {/* Include a username field as a hint for password managers to update the saved password. */}

--- a/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -8,6 +8,7 @@ import { mutateGraphQL } from '../../../backend/graphql'
 import { Form } from '../../../components/Form'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 interface Props {
     /** The GraphQL ID of the user with whom the new emails are associated. */
@@ -17,6 +18,7 @@ interface Props {
     onDidAdd: () => void
 
     className?: string
+    history: H.History
 }
 
 interface State {
@@ -85,7 +87,9 @@ export class AddUserEmailForm extends React.PureComponent<Props, State> {
                         {loading ? 'Adding...' : 'Add'}
                     </button>
                 </Form>
-                {this.state.error && <ErrorAlert className="mt-2" error={this.state.error} />}
+                {this.state.error && (
+                    <ErrorAlert className="mt-2" error={this.state.error} history={this.props.history} />
+                )}
             </div>
         )
     }

--- a/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -16,12 +16,14 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { setUserEmailVerified } from '../backend'
 import { AddUserEmailForm } from './AddUserEmailForm'
 import { ErrorAlert } from '../../../components/alerts'
+import * as H from 'history'
 
 interface UserEmailNodeProps {
     node: GQL.IUserEmail
     user: GQL.IUser
 
     onDidUpdate: () => void
+    history: H.History
 }
 
 interface UserEmailNodeState {
@@ -73,7 +75,9 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
                         )}
                     </div>
                 </div>
-                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
+                {this.state.errorDescription && (
+                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
+                )}
             </li>
         )
     }
@@ -147,6 +151,7 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
 
 interface Props extends RouteComponentProps<{}> {
     user: GQL.IUser
+    history: H.History
 }
 
 interface State {
@@ -176,9 +181,10 @@ export class UserSettingsEmailsPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<UserEmailNodeProps, 'user' | 'onDidUpdate'> = {
+        const nodeProps: Omit<UserEmailNodeProps, 'node'> = {
             user: this.props.user,
             onDidUpdate: this.onDidUpdateUserEmail,
+            history: this.props.history,
         }
 
         return (
@@ -191,7 +197,7 @@ export class UserSettingsEmailsPage extends React.Component<Props, State> {
                         manually verified by a site admin.
                     </div>
                 )}
-                <FilteredConnection<GQL.IUserEmail, Pick<UserEmailNodeProps, 'user' | 'onDidUpdate'>>
+                <FilteredConnection<GQL.IUserEmail, Omit<UserEmailNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"
                     noun="email address"
                     pluralNoun="email addresses"
@@ -204,7 +210,12 @@ export class UserSettingsEmailsPage extends React.Component<Props, State> {
                     history={this.props.history}
                     location={this.props.location}
                 />
-                <AddUserEmailForm className="mt-4" user={this.props.user.id} onDidAdd={this.onDidUpdateUserEmail} />
+                <AddUserEmailForm
+                    className="mt-4"
+                    user={this.props.user.id}
+                    onDidAdd={this.onDidUpdateUserEmail}
+                    history={this.props.history}
+                />
             </div>
         )
     }

--- a/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -177,8 +177,10 @@ export class UserSettingsProfilePage extends React.Component<Props, State> {
                         </div>
                     )}
 
-                {isErrorLike(this.state.userOrError) && <ErrorAlert error={this.state.userOrError.message} />}
-                {this.state.error && <ErrorAlert error={this.state.error.message} />}
+                {isErrorLike(this.state.userOrError) && (
+                    <ErrorAlert error={this.state.userOrError.message} history={this.props.history} />
+                )}
+                {this.state.error && <ErrorAlert error={this.state.error.message} history={this.props.history} />}
                 {this.state.userOrError && !isErrorLike(this.state.userOrError) && (
                     <Form className="user-settings-profile-page__form" onSubmit={this.handleSubmit}>
                         <div className="form-group">

--- a/web/src/views/ViewContent.tsx
+++ b/web/src/views/ViewContent.tsx
@@ -28,7 +28,7 @@ export const ViewContent: React.FunctionComponent<ViewContentProps> = ({ viewCon
             isMarkupContent(content) ? (
                 <section key={i} className="mt-3">
                     {content.kind === MarkupKind.Markdown || !content.kind ? (
-                        <Markdown dangerousInnerHTML={renderMarkdown(content.value)} />
+                        <Markdown dangerousInnerHTML={renderMarkdown(content.value)} history={props.history} />
                     ) : (
                         content.value
                     )}

--- a/web/src/views/__snapshots__/ViewPage.test.tsx.snap
+++ b/web/src/views/__snapshots__/ViewPage.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`ViewPage renders view 1`] = `
 ",
         }
       }
+      onClick={[Function]}
     />
   </section>
   <section
@@ -34,6 +35,7 @@ exports[`ViewPage renders view 1`] = `
 ",
         }
       }
+      onClick={[Function]}
     />
   </section>
   <QueryInputInViewContent


### PR DESCRIPTION
Prevents full-page reloads when a link is clicked inside markdown, which makes a jarring UX. Code insights need to link to other pages of the app (e.g. directories, files, or search results).

Example (note the full page reload):

![2020-04-24 15 02 51](https://user-images.githubusercontent.com/10532611/80313905-55393480-87ee-11ea-81fe-8e2dfc74eb83.gif)

The interesting part of this PR is the change in Markdown.tsx. The majority of this PR is adding the `history` prop to most components that were missing it, which I did with `ts-morph`. I'd be happy to add ts-morph as a tool in a separate PR.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
