### PR TITLE
Allow disabling the verbose logging of GraphQL requests

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -82,15 +82,15 @@ func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, oper
 	lvl("serving GraphQL request", "name", requestName, "user", currentUserName, "source", requestSource)
 	if !disableLog && requestName == "unknown" {
 		log.Printf(`logging complete query for unnamed GraphQL request above name=%s user=%s source=%s:
-	QUERY
-	-----
-	%s
+QUERY
+-----
+%s
 
-	VARIABLES
-	---------
-	%v
+VARIABLES
+---------
+%v
 
-	`, requestName, currentUserName, requestSource, queryString, variables)
+`, requestName, currentUserName, requestSource, queryString, variables)
 	}
 	return ctx, func(err []*gqlerrors.QueryError) {
 		if finish != nil {
@@ -100,7 +100,7 @@ func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, oper
 		if v := conf.Get().ObservabilityLogSlowGraphQLRequests; v != 0 && d.Milliseconds() > int64(v) {
 			encodedVariables, _ := json.Marshal(variables)
 			log15.Warn("slow GraphQL request", "time", d, "name", requestName, "user", currentUserName, "source", requestSource, "error", err, "variables", string(encodedVariables))
-			if !disableLog && requestName == "unknown" {
+			if requestName == "unknown" {
 				log.Printf(`logging complete query for slow GraphQL request above time=%v name=%s user=%s source=%s error=%v:
 QUERY
 -----

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1313,7 +1313,9 @@ func exec(
 		return r.Errors
 	}
 
-	if testing.Verbose() {
+	_, disableLog := os.LookupEnv("NO_GRAPHQL_LOG")
+
+	if testing.Verbose() && !disableLog {
 		t.Logf("\n---- GraphQL Query ----\n%s\n\nVars: %s\n---- GraphQL Result ----\n%s\n -----------", query, toJSON(t, in), r.Data)
 	}
 


### PR DESCRIPTION
Cherry-picked out of my current working branch.

I need this to make sense of any errors that happen while I'm testing. With the logging enabled running `go test -v ./enterprise/internal/campaigns/resolvers/...` is so verbose that you cannot see anything.