### PR TITLE
Allow including SVG in MarkupContent

### DIFF
--- a/shared/src/util/markdown.test.ts
+++ b/shared/src/util/markdown.test.ts
@@ -1,8 +1,27 @@
 import { renderMarkdown } from './markdown'
 
 describe('renderMarkdown', () => {
-    test('plainText option', () => {
+    it('renders to plain text with plainText: true', () => {
         expect(renderMarkdown('A **b**', { plainText: true })).toBe('A b\n')
+    })
+    it('sanitizes script tags', () => {
+        expect(renderMarkdown('<script>evil();</script>')).toBe('')
+    })
+    it('sanitizes event handlers', () => {
+        expect(renderMarkdown('<svg><rect onclick="evil()"></rect></svg>')).toBe('<p><svg><rect></rect></svg></p>\n')
+    })
+    it('sanitizes non-SVG <object> tags', () => {
+        expect(renderMarkdown('<object data="something"></object>')).toBe('<p></p>\n')
+    })
+    it('allows SVG <object> tags', () => {
+        expect(renderMarkdown('<object data="something" type="image/svg+xml"></object>')).toBe(
+            '<p><object data="something" type="image/svg+xml"></object></p>\n'
+        )
+    })
+    it('allows <svg> tags', () => {
+        const input =
+            '<svg viewbox="10 10 10 10" width="100"><rect x="37.5" y="7.5" width="675.0" height="16.875" fill="#e05d44" stroke="white" stroke-width="1"><title>/</title></rect></svg>'
+        expect(renderMarkdown(input)).toBe(`<p>${input}</p>\n`)
     })
 
     describe('allowDataUriLinksAndDownloads option', () => {

--- a/shared/src/util/markdown.test.ts
+++ b/shared/src/util/markdown.test.ts
@@ -1,15 +1,19 @@
 import { renderMarkdown } from './markdown'
 
 describe('renderMarkdown', () => {
-    test('plainText option', () => expect(renderMarkdown('A **b**', { plainText: true })).toBe('A b\n'))
+    test('plainText option', () => {
+        expect(renderMarkdown('A **b**', { plainText: true })).toBe('A b\n')
+    })
 
     describe('allowDataUriLinksAndDownloads option', () => {
         const MARKDOWN_WITH_DOWNLOAD = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
-        test('default disabled', () =>
-            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD)).toBe('<p><a>D</a><br /><a>D2</a></p>\n'))
-        test('enabled', () =>
+        test('default disabled', () => {
+            expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD)).toBe('<p><a>D</a>\n<a>D2</a></p>\n')
+        })
+        test('enabled', () => {
             expect(renderMarkdown(MARKDOWN_WITH_DOWNLOAD, { allowDataUriLinksAndDownloads: true })).toBe(
-                '<p><a href="data:text/plain,foobar" download>D</a><br /><a href="data:text/plain,foobar">D2</a></p>\n'
-            ))
+                '<p><a href="data:text/plain,foobar" download>D</a>\n<a href="data:text/plain,foobar">D2</a></p>\n'
+            )
+        })
     })
 })

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -62,7 +62,7 @@ export const renderMarkdown = (
 ): string => {
     const rendered = marked(markdown, {
         gfm: true,
-        breaks: true,
+        breaks: false,
         sanitize: false,
         highlight: (code, language) => highlightCodeSafe(code, language),
     })
@@ -77,9 +77,23 @@ export const renderMarkdown = (
             // Allow highligh.js styles, e.g.
             // <span class="hljs-keyword">
             // <code class="language-javascript">
-            allowedTags: [...without(sanitize.defaults.allowedTags, 'iframe'), 'h1', 'h2', 'span', 'img'],
+            allowedTags: [
+                ...without(sanitize.defaults.allowedTags, 'iframe'),
+                'h1',
+                'h2',
+                'span',
+                'img',
+                'object',
+                'svg',
+                'rect',
+                'title',
+            ],
             allowedAttributes: {
                 ...sanitize.defaults.allowedAttributes,
+                a: [...sanitize.defaults.allowedAttributes.a, 'title'],
+                object: ['data', { name: 'type', values: ['image/svg+xml'] }, 'width'],
+                svg: ['width', 'height', 'viewbox', 'version'],
+                rect: ['x', 'y', 'width', 'height', 'fill', 'stroke', 'stroke-width'],
                 span: ['class'],
                 code: ['class'],
                 h1: ['id'],
@@ -91,7 +105,7 @@ export const renderMarkdown = (
             },
         }
         if (options.allowDataUriLinksAndDownloads) {
-            opt.allowedAttributes.a = [...sanitize.defaults.allowedAttributes.a, 'download']
+            opt.allowedAttributes.a = [...opt.allowedAttributes.a, 'download']
             opt.allowedSchemesByTag = {
                 ...opt.allowedSchemesByTag,
                 a: [...(opt.allowedSchemesByTag.a || opt.allowedSchemes), 'data'],

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -4,6 +4,7 @@ import { without } from 'lodash'
 // eslint-disable-next-line no-restricted-imports
 import marked from 'marked'
 import sanitize from 'sanitize-html'
+import { Overwrite } from 'utility-types'
 
 /**
  * Escapes HTML by replacing characters like `<` with their HTML escape sequences like `&lt;`
@@ -67,12 +68,14 @@ export const renderMarkdown = (
         highlight: (code, language) => highlightCodeSafe(code, language),
     })
 
-    let opt: sanitize.IDefaults
+    let opt: Overwrite<sanitize.IOptions, sanitize.IDefaults>
     if (options.plainText) {
         opt = { allowedAttributes: {}, allowedSchemes: [], allowedSchemesByTag: {}, allowedTags: [], selfClosing: [] }
     } else {
         opt = {
             ...sanitize.defaults,
+            // Ensure <object> must have type attribute set
+            exclusiveFilter: ({ tag, attribs }) => tag === 'object' && !attribs.type,
 
             // Allow highligh.js styles, e.g.
             // <span class="hljs-keyword">


### PR DESCRIPTION
This enables code insights with available graphs (e.g. CodeCov).
Any `<script>`, `onclick` etc will still be sanitized, we are using a whitelist of elements. This may need to be expanded in the future.

This also:
- Makes our markdown follow how GitHub renders markdown files, not markdown comments with regard to line breaks
- Allows HTML titles (tooltips)