### PR TITLE
Add additional methods to bundle manager client

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/mocks/mock_bundle_manager_client.go
+++ b/cmd/precise-code-intel-api-server/internal/mocks/mock_bundle_manager_client.go
@@ -17,6 +17,12 @@ type MockBundleManagerClient struct {
 	// BundleClientFunc is an instance of a mock function object controlling
 	// the behavior of the method BundleClient.
 	BundleClientFunc *BundleManagerClientBundleClientFunc
+	// GetUploadFunc is an instance of a mock function object controlling
+	// the behavior of the method GetUpload.
+	GetUploadFunc *BundleManagerClientGetUploadFunc
+	// SendDBFunc is an instance of a mock function object controlling the
+	// behavior of the method SendDB.
+	SendDBFunc *BundleManagerClientSendDBFunc
 	// SendUploadFunc is an instance of a mock function object controlling
 	// the behavior of the method SendUpload.
 	SendUploadFunc *BundleManagerClientSendUploadFunc
@@ -29,6 +35,16 @@ func NewMockBundleManagerClient() *MockBundleManagerClient {
 	return &MockBundleManagerClient{
 		BundleClientFunc: &BundleManagerClientBundleClientFunc{
 			defaultHook: func(int) client.BundleClient {
+				return nil
+			},
+		},
+		GetUploadFunc: &BundleManagerClientGetUploadFunc{
+			defaultHook: func(context.Context, int, string) (string, error) {
+				return "", nil
+			},
+		},
+		SendDBFunc: &BundleManagerClientSendDBFunc{
+			defaultHook: func(context.Context, int, io.Reader) error {
 				return nil
 			},
 		},
@@ -47,6 +63,12 @@ func NewMockBundleManagerClientFrom(i client.BundleManagerClient) *MockBundleMan
 	return &MockBundleManagerClient{
 		BundleClientFunc: &BundleManagerClientBundleClientFunc{
 			defaultHook: i.BundleClient,
+		},
+		GetUploadFunc: &BundleManagerClientGetUploadFunc{
+			defaultHook: i.GetUpload,
+		},
+		SendDBFunc: &BundleManagerClientSendDBFunc{
+			defaultHook: i.SendDB,
 		},
 		SendUploadFunc: &BundleManagerClientSendUploadFunc{
 			defaultHook: i.SendUpload,
@@ -157,6 +179,228 @@ func (c BundleManagerClientBundleClientFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c BundleManagerClientBundleClientFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// BundleManagerClientGetUploadFunc describes the behavior when the
+// GetUpload method of the parent MockBundleManagerClient instance is
+// invoked.
+type BundleManagerClientGetUploadFunc struct {
+	defaultHook func(context.Context, int, string) (string, error)
+	hooks       []func(context.Context, int, string) (string, error)
+	history     []BundleManagerClientGetUploadFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUpload delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockBundleManagerClient) GetUpload(v0 context.Context, v1 int, v2 string) (string, error) {
+	r0, r1 := m.GetUploadFunc.nextHook()(v0, v1, v2)
+	m.GetUploadFunc.appendCall(BundleManagerClientGetUploadFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetUpload method of
+// the parent MockBundleManagerClient instance is invoked and the hook queue
+// is empty.
+func (f *BundleManagerClientGetUploadFunc) SetDefaultHook(hook func(context.Context, int, string) (string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUpload method of the parent MockBundleManagerClient instance inovkes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *BundleManagerClientGetUploadFunc) PushHook(hook func(context.Context, int, string) (string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *BundleManagerClientGetUploadFunc) SetDefaultReturn(r0 string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *BundleManagerClientGetUploadFunc) PushReturn(r0 string, r1 error) {
+	f.PushHook(func(context.Context, int, string) (string, error) {
+		return r0, r1
+	})
+}
+
+func (f *BundleManagerClientGetUploadFunc) nextHook() func(context.Context, int, string) (string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BundleManagerClientGetUploadFunc) appendCall(r0 BundleManagerClientGetUploadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of BundleManagerClientGetUploadFuncCall
+// objects describing the invocations of this function.
+func (f *BundleManagerClientGetUploadFunc) History() []BundleManagerClientGetUploadFuncCall {
+	f.mutex.Lock()
+	history := make([]BundleManagerClientGetUploadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BundleManagerClientGetUploadFuncCall is an object that describes an
+// invocation of method GetUpload on an instance of MockBundleManagerClient.
+type BundleManagerClientGetUploadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BundleManagerClientGetUploadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BundleManagerClientGetUploadFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// BundleManagerClientSendDBFunc describes the behavior when the SendDB
+// method of the parent MockBundleManagerClient instance is invoked.
+type BundleManagerClientSendDBFunc struct {
+	defaultHook func(context.Context, int, io.Reader) error
+	hooks       []func(context.Context, int, io.Reader) error
+	history     []BundleManagerClientSendDBFuncCall
+	mutex       sync.Mutex
+}
+
+// SendDB delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockBundleManagerClient) SendDB(v0 context.Context, v1 int, v2 io.Reader) error {
+	r0 := m.SendDBFunc.nextHook()(v0, v1, v2)
+	m.SendDBFunc.appendCall(BundleManagerClientSendDBFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the SendDB method of the
+// parent MockBundleManagerClient instance is invoked and the hook queue is
+// empty.
+func (f *BundleManagerClientSendDBFunc) SetDefaultHook(hook func(context.Context, int, io.Reader) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SendDB method of the parent MockBundleManagerClient instance inovkes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *BundleManagerClientSendDBFunc) PushHook(hook func(context.Context, int, io.Reader) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *BundleManagerClientSendDBFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, io.Reader) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *BundleManagerClientSendDBFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, io.Reader) error {
+		return r0
+	})
+}
+
+func (f *BundleManagerClientSendDBFunc) nextHook() func(context.Context, int, io.Reader) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BundleManagerClientSendDBFunc) appendCall(r0 BundleManagerClientSendDBFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of BundleManagerClientSendDBFuncCall objects
+// describing the invocations of this function.
+func (f *BundleManagerClientSendDBFunc) History() []BundleManagerClientSendDBFuncCall {
+	f.mutex.Lock()
+	history := make([]BundleManagerClientSendDBFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BundleManagerClientSendDBFuncCall is an object that describes an
+// invocation of method SendDB on an instance of MockBundleManagerClient.
+type BundleManagerClientSendDBFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 io.Reader
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BundleManagerClientSendDBFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BundleManagerClientSendDBFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/codeintel/bundles/client/bundle_manager_client.go
+++ b/internal/codeintel/bundles/client/bundle_manager_client.go
@@ -6,6 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
 )
 
 // BundleManagerClient is the interface to the precise-code-intel-bundle-manager service.
@@ -15,6 +19,13 @@ type BundleManagerClient interface {
 
 	// SendUpload transfers a raw LSIF upload to the bundle manager to be stored on disk.
 	SendUpload(ctx context.Context, bundleID int, r io.Reader) error
+
+	// GetUploads retrieves a raw LSIF upload from disk. The file is written to a file in the
+	// given directory with a random filename. The generated filename is returned on success.
+	GetUpload(ctx context.Context, bundleID int, dir string) (string, error)
+
+	// SendDB transfers a converted databse to the bundle manager to be stored on disk.
+	SendDB(ctx context.Context, bundleID int, r io.Reader) error
 }
 
 type bundleManagerClientImpl struct {
@@ -37,25 +48,80 @@ func (c *bundleManagerClientImpl) BundleClient(bundleID int) BundleClient {
 
 // SendUpload transfers a raw LSIF upload to the bundle manager to be stored on disk.
 func (c *bundleManagerClientImpl) SendUpload(ctx context.Context, bundleID int, r io.Reader) error {
-	url, err := url.Parse(fmt.Sprintf("%s/uploads/%d", c.bundleManagerURL, bundleID))
+	body, err := c.request(ctx, "POST", fmt.Sprintf("uploads/%d", bundleID), r)
 	if err != nil {
 		return err
 	}
+	body.Close()
+	return nil
+}
 
-	req, err := http.NewRequest("POST", url.String(), r)
+// GetUploads retrieves a raw LSIF upload from disk. The file is written to a file in the
+// given directory with a random filename. The generated filename is returned on success.
+func (c *bundleManagerClientImpl) GetUpload(ctx context.Context, bundleID int, dir string) (_ string, err error) {
+	body, err := c.request(ctx, "GET", fmt.Sprintf("uploads/%d", bundleID), nil)
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	f, err := openRandomFile(dir)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	if _, err := io.Copy(f, body); err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+// SendDB transfers a converted databse to the bundle manager to be stored on disk.
+func (c *bundleManagerClientImpl) SendDB(ctx context.Context, bundleID int, r io.Reader) error {
+	body, err := c.request(ctx, "POST", fmt.Sprintf("dbs/%d", bundleID), r)
 	if err != nil {
 		return err
+	}
+	body.Close()
+	return nil
+}
+
+func (c *bundleManagerClientImpl) request(ctx context.Context, method, path string, body io.Reader) (io.ReadCloser, error) {
+	url, err := url.Parse(fmt.Sprintf("%s/%s", c.bundleManagerURL, path))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, url.String(), body)
+	if err != nil {
+		return nil, err
 	}
 
 	// TODO - use context
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 
-	return nil
+	return resp.Body, nil
+}
+
+func openRandomFile(dir string) (*os.File, error) {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Create(filepath.Join(dir, uuid.String()))
 }

--- a/internal/codeintel/bundles/client/bundle_manager_client_test.go
+++ b/internal/codeintel/bundles/client/bundle_manager_client_test.go
@@ -3,9 +3,12 @@ package client
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -45,5 +48,98 @@ func TestSendUploadBadResponse(t *testing.T) {
 	err := client.SendUpload(context.Background(), 42, bytes.NewReader([]byte("payload\n")))
 	if err == nil {
 		t.Fatalf("unexpected nil error sending upload")
+	}
+}
+
+func TestGetUpload(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("unexpected method. want=%s have=%s", "POST", r.Method)
+		}
+		if r.URL.Path != "/uploads/42" {
+			t.Errorf("unexpected method. want=%s have=%s", "/uploads/42", r.URL.Path)
+		}
+
+		for i := 0; i < 1000; i++ {
+			if _, err := w.Write([]byte(fmt.Sprintf("payload %d\n", i))); err != nil {
+				t.Fatalf("unexpected error writing to client: %s", err)
+			}
+		}
+	}))
+	defer ts.Close()
+
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp directory: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	path, err := client.GetUpload(context.Background(), 42, tempDir)
+	if err != nil {
+		t.Fatalf("unexpected error sending db: %s", err)
+	}
+
+	if !strings.HasPrefix(path, tempDir) {
+		t.Errorf("unexpected path location, want child of %s, got=%s", tempDir, path)
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error reading file: %s", err)
+	}
+
+	if lines := strings.Split(strings.TrimSpace(string(contents)), "\n"); len(lines) != 1000 {
+		t.Errorf("unexpected payload size. want=%d have=%d", 1000, len(lines))
+	}
+}
+
+func TestGetUploadBadResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	_, err := client.GetUpload(context.Background(), 42, "")
+	if err == nil {
+		t.Fatalf("unexpected nil error sending db")
+	}
+}
+
+func TestSendDB(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("unexpected method. want=%s have=%s", "POST", r.Method)
+		}
+		if r.URL.Path != "/dbs/42" {
+			t.Errorf("unexpected method. want=%s have=%s", "/dbs/42", r.URL.Path)
+		}
+
+		if content, err := ioutil.ReadAll(r.Body); err != nil {
+			t.Fatalf("unexpected error reading payload: %s", err)
+		} else if diff := cmp.Diff([]byte("payload\n"), content); diff != "" {
+			t.Errorf("unexpected request payload (-want +got):\n%s", diff)
+		}
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	err := client.SendDB(context.Background(), 42, bytes.NewReader([]byte("payload\n")))
+	if err != nil {
+		t.Fatalf("unexpected error sending db: %s", err)
+	}
+}
+
+func TestSendDBBadResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	err := client.SendDB(context.Background(), 42, bytes.NewReader([]byte("payload\n")))
+	if err == nil {
+		t.Fatalf("unexpected nil error sending db")
 	}
 }


### PR DESCRIPTION
Add `SendDB` and `GetUpload` to bundle manager client. These will be used by the worker to upload processed dbs and pull down the raw input, respectively.

This partially implements https://github.com/sourcegraph/sourcegraph/issues/9965.