### PR TITLE
docker-images/postgres-11.4: fix image version regression in 3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+## 3.15.1 (not released)
+
+### Fixed
+
+- An issue where `sourcegraph/postgres-11.4:3.15.0` was incorrectly an older version of the image incompatible with non-root Kubernetes deployments. `sourcegraph/postgres-11.4:3.15.1` now matches the same image version found in Sourcegraph 3.14.3 (`20-04-07_56b20163`).
+
 ## 3.15.0
 
 ### Added

--- a/docker-images/postgres-11.4/build.sh
+++ b/docker-images/postgres-11.4/build.sh
@@ -7,5 +7,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297
-docker tag index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297 "$IMAGE"
+docker pull index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+docker tag index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad "$IMAGE"


### PR DESCRIPTION
https://github.com/sourcegraph/deploy-sourcegraph/commit/ccd87ad566b5d62a3e2117509c01c5c5eae9d860#diff-1c41402b2ef772fe0d34e24f1e0d091aR38 changed the image version from `20-04-07_56b20163` to `insiders`, unfortunately this regressed the image version back to an older one from 2019 `19-11-14_b084311b` -- luckily, nothing much changed in this image during that timeframe except support for most notably non-root Kubernetes environments.

This fixes the regression. Also confirmed that all of the following 'rebranded' images are correct:

- redis-store
- redis-cache
- syntax-highlighter
- indexed-searcher
- search-indexer

I did not manually verify jaeger, grafana, or prometheus since those are built in CI / not rebranded images so they should definitely be OK.