### PR TITLE
job-runner MVP (heavily WIP still)

### DIFF
--- a/cmd/job-runner/Dockerfile
+++ b/cmd/job-runner/Dockerfile
@@ -1,0 +1,15 @@
+FROM sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+EXPOSE 3190
+USER sourcegraph
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/job-runner"]
+COPY job-runner /usr/local/bin/

--- a/cmd/job-runner/build.sh
+++ b/cmd/job-runner/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# We want to build multiple go binaries, so we use a custom build step on CI.
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
+set -ex
+
+OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+cleanup() {
+  rm -rf "$OUTPUT"
+}
+trap cleanup EXIT
+
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
+
+pkg="github.com/sourcegraph/sourcegraph/cmd/job-runner"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+
+docker build -f cmd/job-runner/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/cmd/job-runner/main.go
+++ b/cmd/job-runner/main.go
@@ -1,0 +1,74 @@
+// Command job-runner runs arbitrary/third-party jobs in a containerized (but)
+// not entirely sandboxed) fashion.
+//
+// Note: job-runner does not import the standard Sourcegraph debugserver or tracing
+// packages, as this service is intended to be as isolated as possible for hightened
+// security and they depend on the frontend internal API.
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sourcegraph/sourcegraph/cmd/job-runner/runner"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+)
+
+const port = "3190"
+
+func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+	log.SetFlags(0)
+
+	service := &runner.Service{
+		JobFinish: func() {
+			log.Fatal("job finished: exiting to restart ephemeral container (this is normal)")
+		},
+		Log: log15.Root(),
+	}
+
+	host := ""
+	if env.InsecureDev {
+		host = "127.0.0.1"
+	}
+	addr := net.JoinHostPort(host, port)
+
+	// We rely on the liveness probe not responding in the event a job has gone
+	// rogue and consumed all available container resources.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+		return
+	})
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/", ot.Middleware(service))
+	server := &http.Server{Addr: addr, Handler: mux}
+	go shutdownOnSIGINT(server)
+
+	log15.Info("job-runner: waiting for a job on", "addr", server.Addr)
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}
+
+func shutdownOnSIGINT(s *http.Server) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := s.Shutdown(ctx)
+	if err != nil {
+		log.Fatal("graceful server shutdown failed, will exit:", err)
+	}
+}

--- a/cmd/job-runner/protocol/protocol.go
+++ b/cmd/job-runner/protocol/protocol.go
@@ -1,0 +1,17 @@
+package protocol
+
+// Request is a request made to the job-runner service.
+type Request struct {
+	// TODO: the commands we would run
+	// TODO: a way to pass build context (repository)
+	// TODO: a way to pass timeout (or just have the remote end hangup?)
+}
+
+// Response is one of many responses the job-runner service streams back to the
+// requestor. It does this by keeping the HTTP connection open and sending back
+// newline-delimited JSON responses with this type (see https://ndjson.org).
+type Response struct {
+	// TODO: stderr/stdout logs
+	// TODO: exit code of process
+	// TODO: a way to signal job timeout
+}

--- a/cmd/job-runner/runner/service.go
+++ b/cmd/job-runner/runner/service.go
@@ -1,0 +1,24 @@
+// Package runner implements the job runner service.
+package runner
+
+import (
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+)
+
+// Service is the job runner service. It is an http.Handler.
+type Service struct {
+	// JobFinish is invoked when a job is finished, and should be used to cleanup.
+	JobFinish func()
+
+	// Logger where non-job related logs (e.g. "job starting") will go.
+	Log log15.Logger
+}
+
+// ServeHTTP handles HTTP requests to run jobs.
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: handle job execution requests by (a) decoding into protocol.Request type and (b) streaming back protocol.Response ndjson responses.
+	// TODO: run the command, capture output, stream back via protocol.Response
+	// TODO: If timeout is hit, send final response and exit immediately?
+}

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -21,6 +21,7 @@ docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
 precise-code-intel-api-server: yarn --cwd cmd/precise-code-intel run run:api-server
 precise-code-intel-bundle-manager: yarn --cwd cmd/precise-code-intel run run:bundle-manager
 precise-code-intel-worker: yarn --cwd cmd/precise-code-intel run run:worker
+job-runner: ./dev/job-runner.sh
 prometheus: ./dev/prometheus.sh
 grafana: ./dev/grafana.sh
 postgres_exporter: ./dev/postgres_exporter.sh

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -8,6 +8,7 @@ generate_dashboards=false
 generate_monitoring=false
 generate_schema=false
 generate_ctags_image=false
+rebuild_job_runner=false
 cmdlist=()
 all_cmds=false
 failed=false
@@ -32,6 +33,9 @@ for i; do
     cmd/precise-code-intel/*)
       # noop (uses tsc-watch).
       exit
+      ;;
+    cmd/job-runner/*)
+      rebuild_job_runner=true
       ;;
     cmd/*)
       cmd=${i#cmd/}
@@ -64,6 +68,11 @@ elif [ ${#cmdlist[@]} -gt 0 ]; then
   if ! mapfile -t rebuilt < <(./dev/go-install.sh -v "${cmdlist[@]}"); then
     failed=true
   fi
+fi
+
+if [ $rebuild_job_runner ]; then
+  WATCH_TRIGGER=true ./dev/job-runner.sh
+  echo "Rebuilt job-runner"
 fi
 
 if [ ${#rebuilt[@]} -gt 0 ]; then

--- a/dev/job-runner.sh
+++ b/dev/job-runner.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Description: Runs the ephemeral job-runner container.
+
+set -euf -o pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+
+function finish() {
+  echo 'trapped CTRL-C: stopping docker job-runner container'
+  docker rm -f job-runner
+}
+[ -n "${WATCH_TRIGGER-}" ] || trap finish EXIT
+
+# Stop the previously running container, if present.
+docker inspect job-runner >/dev/null 2>&1 && docker rm -f job-runner
+
+# Build the image
+rm -rf .bin/job-runner-tmp && mkdir -p .bin/job-runner-tmp && OUTPUT=.bin/job-runner-tmp IMAGE="sourcegraph/job-runner:dev" ./cmd/job-runner/build.sh
+
+# Run the container
+docker run \
+  --name=job-runner \
+  --cpus=1 \
+  --memory=4g \
+  --restart=always \
+  -p 0.0.0.0:3190:3190 \
+  sourcegraph/job-runner:dev &
+
+[ -n "${WATCH_TRIGGER-}" ] || sleep 99999999

--- a/dev/prometheus/all/prometheus_targets.yml
+++ b/dev/prometheus/all/prometheus_targets.yml
@@ -50,6 +50,11 @@
     # precise-code-intel-worker
     - host.docker.internal:3188
 - labels:
+    job: job-runner
+  targets:
+    # job-runner
+    - host.docker.internal:3190
+- labels:
     job: postgres_exporter
   targets:
     # postgres exporter

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -51,6 +51,7 @@ export QUERY_RUNNER_URL=http://localhost:3183
 export SYMBOLS_URL=http://localhost:3184
 export PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186
 export PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
+export JOB_RUNNER_URL=http://localhost:3190
 export SRC_SYNTECT_SERVER=http://localhost:9238
 export SRC_FRONTEND_INTERNAL=localhost:3090
 export SRC_PROF_HTTP=


### PR DESCRIPTION
The goal here is to implement an MVP of the job runner [proposed in RFC 152](https://docs.google.com/document/d/1HfNyZ8fHJnQ94B20dZUVyd3Fmtj7aUygTQ11CrRDqm8/edit#) that could be agnostic/independent of campaigns while serving campaigns as its first use case. The actual scope of this in practice is still being defined, but I view it as "the supporting infrastructure for running campaign jobs" while campaigns would itself provide the actual web UI for viewing things, API and UI for creating campaigns, etc. It is not intended to conflict with https://github.com/sourcegraph/sourcegraph/pull/8574 but rather to be the "backend" for that change to run in customer environments and on sourcegraph.com.

Eventually, I see this type of approach and https://github.com/sourcegraph/sourcegraph/pull/8574 converging into a single thing where campaigns behind the scenes uses this approach and exposes logs, all interaction with it, etc. through its own interface (so no change in the way users interact with it, this would be an implementation detail of how campaigns runs server-side and other parts of Sourcegraph could later reuse this same infrastructure/logic).

Notable mentions:

- [x] The Docker image is automatically built and ran as part of dev/start.sh
- [x] Changes to cmd/job-runner/*.go automatically rebuild the Docker image and re-run it, so you get live code reloading just like our other services.
- [x] Prometheus scrapes it for metrics in dev.
- [x] Health check handles rogue jobs
- [ ] It exposes Prometheus metrics we can monitor (what would these be? at least CPU/memory/IO I guess) and a Grafana dashboard exists for it
- [x] Basic protocol (`cmd/job-runner/protocol`) idea is defined
- [ ] Protocol is implemented
- [ ] There is a format for writing the commands we run defined (jsonc? yaml? bash script? a combination?) that fits in well with campaign actions (since it would need to use it)
- [ ] There is a good way to send build context to the job runner, i.e. repository contents
- [ ] There is a src command which provides a nice local-dev experience (100% local execution using the same job-runner service / docker image)
- [ ] You can actually send it a job and get the results back, e.g. via `curl` or a `src` command.
- [ ] Campaigns makes use of it.
- [ ] Docker Compose out-of-the-box deployment:
    - [ ] Prometheus scraping
    - [ ] As isolated network as possible, while still allowing outbound downloads
- [ ] Kubernetes out-of-the-box deployment:
    - [ ] Prometheus scraping
    - [ ] As isolated network as possible, while still allowing outbound downloads
- [ ] Optional secure deployment:
    - With out-of-the-box deployment on sourcegraph.com, only us (site admins) can run jobs we trust / have vetted.
    - With out-of-the-box deployment on Docker Compose / Kubernetes, only site admins can run jobs by default but an option allows all users to be trusted to submit jobs (they are trusted to not be malicious).
    - With optional secure deployment, we would have proper sandboxing (effectively the same codepath, just more infrastructure wrapping it) which allows arbitrary users to run arbitrary jobs. Both for sourcegraph.com and customers who want better security guarantees and are willing to pay the cost of setup.
