### PR TITLE
Remove unneeded gitserver dependency from campaigns.Service

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -258,7 +257,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	err = svc.CreateCampaign(ctx, campaign, draft)
 	if err != nil {
 		return nil, err
@@ -297,7 +296,7 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 		updateArgs.PatchSet = &patchSetID
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	campaign, detachedChangesets, err := svc.UpdateCampaign(ctx, updateArgs)
 	if err != nil {
 		return nil, err
@@ -333,7 +332,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	err = svc.DeleteCampaign(ctx, campaignID, args.CloseChangesets)
 	return &graphqlbackend.EmptyResponse{}, err
 }
@@ -577,7 +576,7 @@ func (r *Resolver) CreatePatchSetFromPatches(ctx context.Context, args graphqlba
 		}
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	patchSet, err := svc.CreatePatchSetFromPatches(ctx, patches, user.ID)
 	if err != nil {
 		return nil, err
@@ -603,7 +602,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 
 	campaign, err := svc.CloseCampaign(ctx, campaignID, args.CloseChangesets)
 	if err != nil {
@@ -630,7 +629,7 @@ func (r *Resolver) PublishCampaign(ctx context.Context, args *graphqlbackend.Pub
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	campaign, err := svc.PublishCampaign(ctx, campaignID)
 	if err != nil {
 		return nil, errors.Wrap(err, "publishing campaign")
@@ -656,7 +655,7 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 		return nil, err
 	}
 
-	svc := ee.NewService(r.store, gitserver.DefaultClient, r.httpFactory)
+	svc := ee.NewService(r.store, r.httpFactory)
 	err = svc.CreateChangesetJobForPatch(ctx, patchID)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -13,32 +13,26 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 // NewService returns a Service.
-func NewService(store *Store, git GitserverClient, cf *httpcli.Factory) *Service {
-	return NewServiceWithClock(store, git, cf, store.Clock())
+func NewService(store *Store, cf *httpcli.Factory) *Service {
+	return NewServiceWithClock(store, cf, store.Clock())
 }
 
 // NewServiceWithClock returns a Service the given clock used
 // to generate timestamps.
-func NewServiceWithClock(store *Store, git GitserverClient, cf *httpcli.Factory, clock func() time.Time) *Service {
-	svc := &Service{store: store, git: git, cf: cf, clock: clock}
+func NewServiceWithClock(store *Store, cf *httpcli.Factory, clock func() time.Time) *Service {
+	svc := &Service{store: store, cf: cf, clock: clock}
 
 	return svc
 }
 
-type GitserverClient interface {
-	CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error)
-}
-
 type Service struct {
 	store *Store
-	git   GitserverClient
 	cf    *httpcli.Factory
 
 	clock func() time.Time

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -38,7 +38,6 @@ func TestService(t *testing.T) {
 		return now.UTC().Truncate(time.Microsecond)
 	}
 
-	gitClient := &FakeGitserverClient{Response: "testresponse", ResponseErr: nil}
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	user := createTestUser(ctx, t)
@@ -57,7 +56,7 @@ func TestService(t *testing.T) {
 	}
 
 	t.Run("CreatePatchSetFromPatches", func(t *testing.T) {
-		svc := NewServiceWithClock(store, nil, nil, clock)
+		svc := NewServiceWithClock(store, nil, clock)
 
 		const patch = `diff f f
 --- f
@@ -112,7 +111,7 @@ func TestService(t *testing.T) {
 		}
 
 		campaign := testCampaign(user.ID, patchSet.ID)
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, cf, clock)
 
 		// Without Patches it should fail
 		err = svc.CreateCampaign(ctx, campaign, false)
@@ -170,7 +169,7 @@ func TestService(t *testing.T) {
 
 		campaign := testCampaign(user.ID, patchSet.ID)
 
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, cf, clock)
 		err = svc.CreateCampaign(ctx, campaign, true)
 		if err != nil {
 			t.Fatal(err)
@@ -208,7 +207,7 @@ func TestService(t *testing.T) {
 		}
 
 		campaign := testCampaign(user.ID, patchSet.ID)
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, cf, clock)
 
 		err = svc.CreateCampaign(ctx, campaign, false)
 		if err != nil {
@@ -241,7 +240,7 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, cf, clock)
 		err = svc.CreateChangesetJobForPatch(ctx, patch.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -336,7 +335,7 @@ func TestService(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				svc := NewServiceWithClock(store, gitClient, cf, clock)
+				svc := NewServiceWithClock(store, cf, clock)
 				campaign := testCampaign(user.ID, patchSet.ID)
 
 				if tc.closed {
@@ -400,7 +399,7 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("UpdateCampaignWithPatchSetAttachedToOtherCampaign", func(t *testing.T) {
-		svc := NewServiceWithClock(store, gitClient, cf, clock)
+		svc := NewServiceWithClock(store, cf, clock)
 
 		patchSet := &campaigns.PatchSet{UserID: user.ID}
 		err = store.CreatePatchSet(ctx, patchSet)
@@ -466,7 +465,6 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 		return now.UTC().Truncate(time.Microsecond)
 	}
 
-	gitClient := &FakeGitserverClient{Response: "testresponse", ResponseErr: nil}
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	user := createTestUser(ctx, t)
@@ -719,7 +717,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewStoreWithClock(dbconn.Global, clock)
-			svc := NewServiceWithClock(store, gitClient, cf, clock)
+			svc := NewServiceWithClock(store, cf, clock)
 
 			var (
 				campaign    *campaigns.Campaign

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -27,6 +27,10 @@ var maxWorkers = env.Get("CAMPAIGNS_MAX_WORKERS", "8", "maximum number of reposi
 
 const defaultWorkerCount = 8
 
+type GitserverClient interface {
+	CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error)
+}
+
 // RunWorkers should be executed in a background goroutine and is responsible
 // for finding pending ChangesetJobs and executing them.
 // ctx should be canceled to terminate the function.


### PR DESCRIPTION
I noticed this while working in another branch: we don't have a dependency on `GitserverClient` in `Service` anymore.
