### PR TITLE
Update parseDirectoryChildren test cases

### DIFF
--- a/internal/codeintel/gitserver/directory_children.go
+++ b/internal/codeintel/gitserver/directory_children.go
@@ -3,6 +3,7 @@ package gitserver
 import (
 	"bytes"
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -31,7 +32,7 @@ func DirectoryChildren(db db.DB, repositoryID int, commit string, dirnames []str
 }
 
 // cleanDirectoriesForLsTree sanitizes the input dirnames to a git ls-tree command. There are a
-// few pecularities handled here:
+// few peculiarities handled here:
 //
 //   1. The root of the tree must be indicated with `.`, and
 //   2. In order for git ls-tree to return a directory's contents, the name must end in a slash.
@@ -56,25 +57,34 @@ func cleanDirectoriesForLsTree(dirnames []string) []string {
 // under that directory.
 func parseDirectoryChildren(dirnames []string, paths []string) map[string][]string {
 	childrenMap := map[string][]string{}
-	for _, dir := range dirnames {
-		if dir == "" {
-			var children []string
-			for _, path := range paths {
-				if !strings.Contains(path, "/") {
-					children = append(children, path)
+
+	// Ensure each directory has an entry, even if it has no children
+	// listed in the gitserver output.
+	for _, dirname := range dirnames {
+		childrenMap[dirname] = nil
+	}
+
+	// Order directory names by length (biggest first) so that we assign
+	// paths to the most specific enclosing directory in the following loop.
+	sort.Slice(dirnames, func(i, j int) bool {
+		return len(dirnames[i]) > len(dirnames[j])
+	})
+
+	for _, path := range paths {
+		if strings.Contains(path, "/") {
+			for _, dirname := range dirnames {
+				if strings.HasPrefix(path, dirname) {
+					childrenMap[dirname] = append(childrenMap[dirname], path)
+					break
 				}
 			}
-
-			childrenMap[dir] = children
 		} else {
-			var children []string
-			for _, path := range paths {
-				if strings.HasPrefix(path, dir) {
-					children = append(children, path)
-				}
+			// No need to loop here. If we have a root input directory it
+			// will necessarily be the last element due to the previous
+			// sorting step.
+			if len(dirnames) > 0 && dirnames[len(dirnames)-1] == "" {
+				childrenMap[""] = append(childrenMap[""], path)
 			}
-
-			childrenMap[dir] = children
 		}
 	}
 

--- a/internal/codeintel/gitserver/directory_children.go
+++ b/internal/codeintel/gitserver/directory_children.go
@@ -54,7 +54,8 @@ func cleanDirectoriesForLsTree(dirnames []string) []string {
 
 // parseDirectoryChildren converts the flat list of files from git ls-tree into a map. The keys of the
 // resulting map are the input (unsanitized) dirnames, and the value of that key are the files nested
-// under that directory.
+// under that directory. If dirnames contains a directory that encloses another, then the paths will
+// be placed into the key sharing the longest path prefix.
 func parseDirectoryChildren(dirnames []string, paths []string) map[string][]string {
 	childrenMap := map[string][]string{}
 

--- a/internal/codeintel/gitserver/directory_children_test.go
+++ b/internal/codeintel/gitserver/directory_children_test.go
@@ -48,6 +48,26 @@ func TestParseDirectoryChildrenNonRoot(t *testing.T) {
 	}
 }
 
+func TestParseDirectoryChildrenDifferentDepths(t *testing.T) {
+	dirnames := []string{"cmd/", "protocol/", "cmd/protocol/"}
+	paths := []string{
+		"cmd/lsif-go",
+		"protocol/protocol.go",
+		"protocol/writer.go",
+		"cmd/protocol/main.go",
+	}
+
+	expected := map[string][]string{
+		"cmd/":          {"cmd/lsif-go"},
+		"protocol/":     {"protocol/protocol.go", "protocol/writer.go"},
+		"cmd/protocol/": {"cmd/protocol/main.go"},
+	}
+
+	if diff := cmp.Diff(expected, parseDirectoryChildren(dirnames, paths)); diff != "" {
+		t.Errorf("unexpected directory children result (-want +got):\n%s", diff)
+	}
+}
+
 func TestCleanDirectoriesForLsTree(t *testing.T) {
 	args := []string{"", "foo", "bar/", "baz"}
 	actual := cleanDirectoriesForLsTree(args)


### PR DESCRIPTION
There was a possible bug in `parseDirectoryChildren` that would miscategorize paths to the wrong parent when the input has properly nested directory names. Test case written by @unknwon.