### PR TITLE
Fix yaml definition for prometheus

### DIFF
--- a/docker-images/prometheus/config/prometheus_pure_docker_or_compose.yml
+++ b/docker-images/prometheus/config/prometheus_pure_docker_or_compose.yml
@@ -30,13 +30,13 @@ scrape_configs:
 # control part of the precise code intel worker in Go to leverage application-level
 # concurrency control.
 
-- job_name: federate
-  honor_labels: true
-  metrics_path: /federate
-  params:
-    'match[]':
-      - '{__name__=~'lsif_.*'}'
+  - job_name: federate
+    honor_labels: true
+    metrics_path: /federate
+    params:
+      'match[]':
+        - "{__name__=~'lsif_.*'}"
 
-  static_configs:
-    - targets:
-      - precise-code-intel-worker:9090
+    static_configs:
+      - targets:
+        - precise-code-intel-worker:9090


### PR DESCRIPTION
The indentation was wrong. Found this while experimenting with prettier, which crashed on this file.