### PR TITLE
Unify campaigns teams into singular ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,7 @@
 /cmd/frontend/graphqlbackend/campaigns.go @sourcegraph/campaigns
 /enterprise/internal/campaigns @sourcegraph/campaigns
 /internal/campaigns @sourcegraph/campaigns
-/web/**/campaigns/** @sourcegraph/campaigns @eseliger
+/web/**/campaigns/** @sourcegraph/campaigns
 
 # Auth
 /cmd/frontend/auth/ @beyang @unknwon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,10 +100,10 @@
 /internal/eventlogger @dadlerj
 
 # Campaigns
-/cmd/frontend/graphqlbackend/campaigns.go @sourcegraph/campaigns-core
-/enterprise/internal/campaigns @sourcegraph/campaigns-core
-/internal/campaigns @sourcegraph/campaigns-core
-/web/**/campaigns/** @sourcegraph/campaigns-web @mrnugget @sourcegraph/web
+/cmd/frontend/graphqlbackend/campaigns.go @sourcegraph/campaigns
+/enterprise/internal/campaigns @sourcegraph/campaigns
+/internal/campaigns @sourcegraph/campaigns
+/web/**/campaigns/** @sourcegraph/campaigns @eseliger
 
 # Auth
 /cmd/frontend/auth/ @beyang @unknwon


### PR DESCRIPTION
With campaigns becoming it's own team, we decided that we should flat-out the hierarchy here. 