### PR TITLE
Fix double-encoded path inside lsif reference cursor

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/server/handler.go
+++ b/cmd/precise-code-intel-api-server/internal/server/handler.go
@@ -200,7 +200,7 @@ func (s *Server) handleReferences(w http.ResponseWriter, r *http.Request) {
 		getQueryInt(r, "line"),
 		getQueryInt(r, "character"),
 		getQueryInt(r, "uploadId"),
-		getQuery(r, "rawCursor"),
+		getQuery(r, "cursor"),
 		s.db,
 		s.bundleManagerClient,
 	)

--- a/internal/codeintel/lsifserver/client/request.go
+++ b/internal/codeintel/lsifserver/client/request.go
@@ -135,13 +135,7 @@ func buildURL(baseURL, path string, cursor *string, query queryValues) (string, 
 	build := url.Parse
 	if len(path) > 0 && path[0] == '/' {
 		build = func(path string) (*url.URL, error) {
-			u, err := url.Parse(baseURL)
-			if err != nil {
-				return nil, err
-			}
-
-			u.Path = path
-			return u, nil
+			return url.Parse(baseURL + path)
 		}
 	}
 


### PR DESCRIPTION
Fix issue with cursor encoding after translating services to Go.