### PR TITLE
Fix modelType value in bundle-manager requests

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/definitions.go
+++ b/cmd/precise-code-intel-api-server/internal/api/definitions.go
@@ -41,7 +41,7 @@ func (api *codeIntelAPI) definitionsRaw(ctx context.Context, dump db.Dump, bundl
 	for _, monikers := range rangeMonikers {
 		for _, moniker := range monikers {
 			if moniker.Kind == "import" {
-				locations, _, err := lookupMoniker(api.db, api.bundleManagerClient, dump.ID, pathInBundle, "definitions", moniker, 0, 0)
+				locations, _, err := lookupMoniker(api.db, api.bundleManagerClient, dump.ID, pathInBundle, "definition", moniker, 0, 0)
 				if err != nil {
 					return nil, err
 				}
@@ -53,7 +53,7 @@ func (api *codeIntelAPI) definitionsRaw(ctx context.Context, dump db.Dump, bundl
 				// table of our own database in case there was a definition that wasn't properly
 				// attached to a result set but did have the correct monikers attached.
 
-				locations, _, err := bundleClient.MonikerResults(context.Background(), "definitions", moniker.Scheme, moniker.Identifier, 0, 0)
+				locations, _, err := bundleClient.MonikerResults(context.Background(), "definition", moniker.Scheme, moniker.Identifier, 0, 0)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/precise-code-intel-api-server/internal/api/definitions_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/definitions_test.go
@@ -60,7 +60,7 @@ func TestDefinitionViaSameDumpMoniker(t *testing.T) {
 	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{42: mockBundleClient})
 	setMockBundleClientDefinitions(t, mockBundleClient, "main.go", 10, 50, nil)
 	setMockBundleClientMonikersByPosition(t, mockBundleClient, "main.go", 10, 50, [][]bundles.MonikerData{{testMoniker2}})
-	setMockBundleClientMonikerResults(t, mockBundleClient, "definitions", "gomod", "pad", 0, 0, []bundles.Location{
+	setMockBundleClientMonikerResults(t, mockBundleClient, "definition", "gomod", "pad", 0, 0, []bundles.Location{
 		{DumpID: 42, Path: "foo.go", Range: testRange1},
 		{DumpID: 42, Path: "bar.go", Range: testRange2},
 		{DumpID: 42, Path: "baz.go", Range: testRange3},
@@ -94,7 +94,7 @@ func TestDefinitionViaRemoteDumpMoniker(t *testing.T) {
 	setMockBundleClientMonikersByPosition(t, mockBundleClient1, "main.go", 10, 50, [][]bundles.MonikerData{{testMoniker1}})
 	setMockBundleClientPackageInformation(t, mockBundleClient1, "main.go", "1234", testPackageInformation)
 	setMockDBGetPackage(t, mockDB, "gomod", "leftpad", "0.1.0", testDump2, true)
-	setMockBundleClientMonikerResults(t, mockBundleClient2, "definitions", "gomod", "pad", 0, 0, []bundles.Location{
+	setMockBundleClientMonikerResults(t, mockBundleClient2, "definition", "gomod", "pad", 0, 0, []bundles.Location{
 		{DumpID: 50, Path: "foo.go", Range: testRange1},
 		{DumpID: 50, Path: "bar.go", Range: testRange2},
 		{DumpID: 50, Path: "baz.go", Range: testRange3},

--- a/cmd/precise-code-intel-api-server/internal/api/hover_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/hover_test.go
@@ -61,7 +61,7 @@ func TestHoverRemoteDefinitionHoverText(t *testing.T) {
 	setMockBundleClientMonikersByPosition(t, mockBundleClient1, "main.go", 10, 50, [][]bundles.MonikerData{{testMoniker1}})
 	setMockBundleClientPackageInformation(t, mockBundleClient1, "main.go", "1234", testPackageInformation)
 	setMockDBGetPackage(t, mockDB, "gomod", "leftpad", "0.1.0", testDump2, true)
-	setMockBundleClientMonikerResults(t, mockBundleClient2, "definitions", "gomod", "pad", 0, 0, []bundles.Location{
+	setMockBundleClientMonikerResults(t, mockBundleClient2, "definition", "gomod", "pad", 0, 0, []bundles.Location{
 		{DumpID: 50, Path: "foo.go", Range: testRange1},
 		{DumpID: 50, Path: "bar.go", Range: testRange2},
 		{DumpID: 50, Path: "baz.go", Range: testRange3},

--- a/cmd/precise-code-intel-api-server/internal/api/monikers_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/monikers_test.go
@@ -19,7 +19,7 @@ func TestLookupMoniker(t *testing.T) {
 	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{42: mockBundleClient1, 50: mockBundleClient2})
 	setMockBundleClientPackageInformation(t, mockBundleClient1, "sub2/main.go", "1234", testPackageInformation)
 	setMockDBGetPackage(t, mockDB, "gomod", "leftpad", "0.1.0", testDump2, true)
-	setMockBundleClientMonikerResults(t, mockBundleClient2, "definitions", "gomod", "pad", 10, 5, []bundles.Location{
+	setMockBundleClientMonikerResults(t, mockBundleClient2, "definition", "gomod", "pad", 10, 5, []bundles.Location{
 		{DumpID: 42, Path: "foo.go", Range: testRange1},
 		{DumpID: 42, Path: "bar.go", Range: testRange2},
 		{DumpID: 42, Path: "baz.go", Range: testRange3},
@@ -27,7 +27,7 @@ func TestLookupMoniker(t *testing.T) {
 		{DumpID: 42, Path: "baz.go", Range: testRange5},
 	}, 15)
 
-	locations, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "sub2/main.go", "definitions", testMoniker2, 10, 5)
+	locations, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "sub2/main.go", "definition", testMoniker2, 10, 5)
 	if err != nil {
 		t.Fatalf("unexpected error querying moniker: %s", err)
 	}
@@ -51,7 +51,7 @@ func TestLookupMonikerNoPackageInformationID(t *testing.T) {
 	mockDB := dbmocks.NewMockDB()
 	mockBundleManagerClient := bundlemocks.NewMockBundleManagerClient()
 
-	_, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "sub/main.go", "definitions", testMoniker3, 10, 5)
+	_, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "sub/main.go", "definition", testMoniker3, 10, 5)
 	if err != nil {
 		t.Fatalf("unexpected error querying moniker: %s", err)
 	}
@@ -69,7 +69,7 @@ func TestLookupMonikerNoPackage(t *testing.T) {
 	setMockBundleClientPackageInformation(t, mockBundleClient, "main.go", "1234", testPackageInformation)
 	setMockDBGetPackage(t, mockDB, "gomod", "leftpad", "0.1.0", db.Dump{}, false)
 
-	_, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "main.go", "definitions", testMoniker1, 10, 5)
+	_, totalCount, err := lookupMoniker(mockDB, mockBundleManagerClient, 42, "main.go", "definition", testMoniker1, 10, 5)
 	if err != nil {
 		t.Fatalf("unexpected error querying moniker: %s", err)
 	}

--- a/internal/codeintel/bundles/client/bundle_client_test.go
+++ b/internal/codeintel/bundles/client/bundle_client_test.go
@@ -210,7 +210,7 @@ func TestMonikersByPosition(t *testing.T) {
 func TestMonikerResults(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(t, r, "GET", "/dbs/42/monikerResults", map[string]string{
-			"modelType":  "definitions",
+			"modelType":  "definition",
 			"scheme":     "gomod",
 			"identifier": "leftpad",
 			"take":       "25",
@@ -233,7 +233,7 @@ func TestMonikerResults(t *testing.T) {
 	}
 
 	client := &bundleClientImpl{bundleManagerURL: ts.URL, bundleID: 42}
-	locations, count, err := client.MonikerResults(context.Background(), "definitions", "gomod", "leftpad", 0, 25)
+	locations, count, err := client.MonikerResults(context.Background(), "definition", "gomod", "leftpad", 0, 25)
 	if err != nil {
 		t.Fatalf("unexpected error querying moniker results: %s", err)
 	}


### PR DESCRIPTION
The bundle manager expects the `modelType` query value to be `definition` or `reference`, but was plural at some callsites. Update this to be consistent across services.