### PR TITLE
Fix default interval value (1d is illegal)

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/env.go
+++ b/cmd/precise-code-intel-bundle-manager/env.go
@@ -15,7 +15,7 @@ var (
 	rawResultChunkDataCacheSize = env.Get("PRECISE_CODE_INTEL_RESULT_CHUNK_CACHE_CAPACITY", "100", "Maximum number of decoded result chunks that can be held in memory at once.")
 	rawDesiredPercentFree       = env.Get("PRECISE_CODE_INTEL_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
 	rawJanitorInterval          = env.Get("PRECISE_CODE_INTEL_JANITOR_INTERVAL", "1m", "Interval between cleanup runs.")
-	rawMaxUnconvertedUploadAge  = env.Get("PRECISE_CODE_INTEL_MAX_UNCONVERTED_UPLOAD_AGE", "1d", "The maximum time an unconverted upload can sit on disk.")
+	rawMaxUnconvertedUploadAge  = env.Get("PRECISE_CODE_INTEL_MAX_UNCONVERTED_UPLOAD_AGE", "24h", "The maximum time an unconverted upload can sit on disk.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.


### PR DESCRIPTION
`1d` cannot be parsed as an interval, but `24h` can be.