### PR TITLE
Fix savepoint id generation (must start with a letter)

### DIFF
--- a/internal/codeintel/db/job_handle.go
+++ b/internal/codeintel/db/job_handle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -84,9 +85,10 @@ func (h *jobHandleImpl) Savepoint() error {
 		return err
 	}
 
-	savepointID := strings.ReplaceAll(id.String(), "-", "_")
+	savepointID := fmt.Sprintf("sp_%s", strings.ReplaceAll(id.String(), "-", "_"))
 	h.savepoints = append(h.savepoints, savepointID)
-	_, err = h.tw.exec(h.ctx, sqlf.Sprintf(`SAVEPOINT %s`, savepointID))
+	// Unfortunately, it's a syntax error to supply this as a param
+	_, err = h.tw.exec(h.ctx, sqlf.Sprintf("SAVEPOINT "+savepointID))
 	return err
 }
 
@@ -110,7 +112,7 @@ func (h *jobHandleImpl) RollbackToLastSavepoint() error {
 	}
 
 	// Perform rollback
-	_, err := h.tw.exec(h.ctx, sqlf.Sprintf(`ROLLBACK TO SAVEPOINT %s`, savepointID))
+	_, err := h.tw.exec(h.ctx, sqlf.Sprintf("ROLLBACK TO SAVEPOINT "+savepointID))
 	return err
 }
 

--- a/internal/codeintel/db/job_handle_test.go
+++ b/internal/codeintel/db/job_handle_test.go
@@ -1,0 +1,138 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestJobHandleUnmarkedClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := &dbImpl{db: dbconn.Global}
+
+	ctx := context.Background()
+	tw, err := db.beginTx(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error creating transaction: %s", err)
+	}
+
+	jobHandle := &jobHandleImpl{
+		ctx:      ctx,
+		id:       1,
+		tw:       tw,
+		txCloser: &txCloser{tw.tx},
+	}
+
+	if err := jobHandle.CloseTx(nil); err == nil {
+		t.Fatalf("unexpected nil error")
+	} else if err != ErrJobNotFinalized {
+		t.Errorf("unexpected error. want=%q have=%q", ErrJobNotFinalized, err)
+	}
+}
+
+func TestJobHandleRollbackNoSavepoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := &dbImpl{db: dbconn.Global}
+
+	ctx := context.Background()
+	tw, err := db.beginTx(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error creating transaction: %s", err)
+	}
+
+	jobHandle := &jobHandleImpl{
+		ctx:      ctx,
+		id:       1,
+		tw:       tw,
+		txCloser: &txCloser{tw.tx},
+	}
+
+	if err := jobHandle.RollbackToLastSavepoint(); err == nil {
+		t.Fatalf("unexpected nil error")
+	} else if err != ErrNoSavepoint {
+		t.Errorf("unexpected error. want=%q have=%q", ErrNoSavepoint, err)
+	}
+}
+
+func TestJobHandleSavepointRollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := &dbImpl{db: dbconn.Global}
+
+	ctx := context.Background()
+	tw, err := db.beginTx(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error creating transaction: %s", err)
+	}
+
+	jobHandle := &jobHandleImpl{
+		ctx:      ctx,
+		id:       1,
+		tw:       tw,
+		txCloser: &txCloser{tw.tx},
+	}
+
+	if err := jobHandle.Savepoint(); err != nil {
+		t.Fatalf("unexpected error creating savepoint: %s", err)
+	}
+	if err := jobHandle.MarkComplete(); err != nil {
+		t.Fatalf("unexpected error marking upload complete: %s", err)
+	}
+	if err := jobHandle.RollbackToLastSavepoint(); err != nil {
+		t.Fatalf("unexpected error rolling back to savepoint: %s", err)
+	}
+
+	if err := jobHandle.CloseTx(nil); err == nil {
+		t.Fatalf("unexpected nil error")
+	} else if err != ErrJobNotFinalized {
+		t.Errorf("unexpected error. want=%q have=%q", ErrJobNotFinalized, err)
+	}
+}
+
+func TestJobHandlePartialSavepointRollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := &dbImpl{db: dbconn.Global}
+
+	ctx := context.Background()
+	tw, err := db.beginTx(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error creating transaction: %s", err)
+	}
+
+	jobHandle := &jobHandleImpl{
+		ctx:      ctx,
+		id:       1,
+		tw:       tw,
+		txCloser: &txCloser{tw.tx},
+	}
+
+	if err := jobHandle.Savepoint(); err != nil {
+		t.Fatalf("unexpected error creating savepoint: %s", err)
+	}
+	if err := jobHandle.MarkComplete(); err != nil {
+		t.Fatalf("unexpected error marking upload complete: %s", err)
+	}
+	if err := jobHandle.Savepoint(); err != nil {
+		t.Fatalf("unexpected error creating savepoint: %s", err)
+	}
+	if err := jobHandle.RollbackToLastSavepoint(); err != nil {
+		t.Fatalf("unexpected error rolling back to savepoint: %s", err)
+	}
+
+	if err := jobHandle.CloseTx(nil); err != nil {
+		t.Fatalf("unexpected error closing transaction: %s", err)
+	}
+}


### PR DESCRIPTION
Fix query syntax issues with postgres savepoints and add additional test coverage.