### PR TITLE
Set default references page size

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/references.go
+++ b/cmd/precise-code-intel-api-server/internal/api/references.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bloomfilter"
@@ -10,9 +11,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
 
+var ErrIllegalLimit = errors.New("limit must be positive")
+
 // References returns the list of source locations that reference the symbol at the given position.
 // This may include references from other dumps and repositories.
 func (api *codeIntelAPI) References(ctx context.Context, repositoryID int, commit string, limit int, cursor Cursor) ([]ResolvedLocation, Cursor, bool, error) {
+	if limit <= 0 {
+		return nil, Cursor{}, false, ErrIllegalLimit
+	}
+
 	rpr := &ReferencePageResolver{
 		db:                  api.db,
 		bundleManagerClient: api.bundleManagerClient,

--- a/cmd/precise-code-intel-api-server/internal/server/handler.go
+++ b/cmd/precise-code-intel-api-server/internal/server/handler.go
@@ -15,6 +15,7 @@ import (
 )
 
 const DefaultUploadPageSize = 50
+const DefaultReferencesPageSize = 100
 
 func (s *Server) handler() http.Handler {
 	mux := mux.NewRouter()
@@ -215,11 +216,17 @@ func (s *Server) handleReferences(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	limit := getQueryIntDefault(r, "limit", DefaultReferencesPageSize)
+	if limit <= 0 {
+		http.Error(w, "illegal limit", http.StatusBadRequest)
+		return
+	}
+
 	locations, newCursor, hasNewCursor, err := s.api.References(
 		r.Context(),
 		getQueryInt(r, "repositoryId"),
 		getQuery(r, "commit"),
-		getQueryInt(r, "limit"),
+		limit,
 		cursor,
 	)
 	if err != nil {

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -110,13 +110,23 @@ func (s *Server) handleMonikerResults(w http.ResponseWriter, r *http.Request) {
 			return nil, errors.New("illegal tableName supplied")
 		}
 
+		skip := getQueryInt(r, "skip")
+		if skip < 0 {
+			return nil, errors.New("illegal skip supplied")
+		}
+
+		take := getQueryIntDefault(r, "take", DefaultMonikerResultPageSize)
+		if take <= 0 {
+			return nil, errors.New("illegal take supplied")
+		}
+
 		locations, count, err := db.MonikerResults(
 			ctx,
 			tableName,
 			getQuery(r, "scheme"),
 			getQuery(r, "identifier"),
-			getQueryInt(r, "skip"),
-			getQueryIntDefault(r, "take", DefaultMonikerResultPageSize),
+			skip,
+			take,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Ensure there is a default limit for reference requests. Without this, we try to fetch a zero-size page and will return a cursor that will request another zero-size page indefinitely.