### PR TITLE
tracking-issue: exclude tracking issue from tracking issue

### DIFF
--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -269,6 +269,11 @@ func (t *TrackingIssue) Workloads() Workloads {
 	}
 
 	for _, issue := range t.Issues {
+		// Exclude listing the tracking issue in the tracking issue.
+		if issue.URL == t.Issue.URL {
+			continue
+		}
+
 		w := workload(Assignee(issue.Assignees))
 
 		w.Issues = append(w.Issues, issue)


### PR DESCRIPTION
Currently all tracking issues are listing themselves in the list of tracked
work.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
