### PR TITLE
Add ts-morph scaffold for TS codemods

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,12 +39,22 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "TS-Morph",
+      "program": "${workspaceFolder}/dev/ts-morph/out/main.js",
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "internalConsole",
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Gulp",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
       "args": ["webpack"],
       "env": {
-        "TS_NODE_COMPILER_OPTIONS": '{"module":"commonjs"}',
+        // prettier-ignore
+        "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"commonjs\"}"
       },
       "internalConsoleOptions": "openOnSessionStart",
     },

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -17,6 +17,7 @@ DIRS=(
   packages/sourcegraph-extension-api
   packages/@sourcegraph/extension-api-types
   dev/release
+  dev/ts-morph
 )
 
 run_command() {

--- a/dev/ts-morph/.eslintrc.js
+++ b/dev/ts-morph/.eslintrc.js
@@ -1,0 +1,9 @@
+const baseConfig = require('../../.eslintrc')
+module.exports = {
+  extends: '../../.eslintrc.js',
+  parserOptions: {
+    ...baseConfig.parserOptions,
+    project: [__dirname + '/tsconfig.json'],
+  },
+  overrides: baseConfig.overrides,
+}

--- a/dev/ts-morph/add-history-prop.ts
+++ b/dev/ts-morph/add-history-prop.ts
@@ -1,0 +1,160 @@
+import {
+    Diagnostic,
+    Node,
+    SyntaxKind,
+    ImportDeclaration,
+    VariableDeclaration,
+    ts,
+    BindingElement,
+    StructureKind,
+    SourceFile,
+} from 'ts-morph'
+import { anyOf } from '../../shared/src/util/types'
+
+/**
+ * Code mod to add a missing history prop to JSX and props interfaces,
+ * given a diagnostic "Property 'history' is missing in ...".
+ * Adds the needed imports and works for test files too.
+ */
+export function addMissingHistoryProp(diagnostic: Diagnostic, sourceFile: SourceFile): void {
+    console.log(sourceFile.getFilePath())
+    const diagnosticNode = sourceFile.getDescendantAtPos(diagnostic.getStart()!)
+    if (!diagnosticNode) {
+        throw new Error('Node of diagnostic not found')
+    }
+
+    /** The component JSX expression */
+    const jsxNode = diagnosticNode.getFirstAncestorOrThrow(
+        anyOf(Node.isJsxSelfClosingElement, Node.isJsxOpeningElement)
+    )
+
+    /** The expression we will pass to the history Prop */
+    let initializer: string
+
+    if (sourceFile?.getBaseName().endsWith('.test.tsx')) {
+        // Test files
+        // Add import { createMemoryHistory } from 'history' if not exists
+        let importDecl = sourceFile.getImportDeclaration(decl => decl.getModuleSpecifierValue() === 'history')
+        if (!importDecl) {
+            importDecl = sourceFile.addImportDeclaration({
+                namedImports: ['createMemoryHistory'],
+                moduleSpecifier: 'history',
+            })
+        }
+        const namedBindings = importDecl.getImportClauseOrThrow().getNamedBindingsOrThrow()
+        if (
+            Node.isNamedImports(namedBindings) &&
+            !namedBindings
+                .getChildrenOfKind(SyntaxKind.ImportSpecifier)
+                .some(spec => spec.getText() === 'createMemoryHistory')
+        ) {
+            importDecl.addNamedImport('createMemoryHistory')
+        }
+        const namespace = Node.isNamespaceImport(namedBindings) ? namedBindings.getName() : null
+        initializer = namespace ? `{${namespace}.createMemoryHistory()}` : '{createMemoryHistory()}'
+    } else {
+        // Application code
+        // Add import * as H from 'history' if not exists
+        let importDecl = sourceFile.getImportDeclaration(decl => decl.getModuleSpecifierValue() === 'history')
+        if (!importDecl) {
+            importDecl = sourceFile.addImportDeclaration({
+                namespaceImport: 'H',
+                moduleSpecifier: 'history',
+            })
+        }
+        const defaultImport = importDecl.getImportClauseOrThrow().getDefaultImport()
+        if (defaultImport) {
+            // history should not be imported with a default import
+            importDecl = importDecl.replaceWithText("import * as H from 'history'") as ImportDeclaration
+        }
+        const namedBindings = importDecl.getImportClauseOrThrow().getNamedBindingsOrThrow()
+        if (
+            Node.isNamedImports(namedBindings) &&
+            !namedBindings.getChildrenOfKind(SyntaxKind.ImportSpecifier).some(spec => spec.getText() === 'History')
+        ) {
+            importDecl.addNamedImport('History')
+        }
+        const namespace = Node.isNamespaceImport(namedBindings) ? namedBindings.getName() : null
+        const classDecl = jsxNode.getFirstAncestor(anyOf(Node.isClassDeclaration, Node.isClassExpression))
+        if (classDecl) {
+            // React class component
+            initializer = '{this.props.history}'
+            // Add history prop to Props interface
+            const [propsTypeArg] = classDecl.getExtendsOrThrow().getTypeArguments()
+            // Get interface reference or inline type declaration
+            const propsSymbol = Node.isTypeReferenceNode(propsTypeArg)
+                ? propsTypeArg.getFirstChildByKindOrThrow(SyntaxKind.Identifier).getSymbolOrThrow()
+                : propsTypeArg.getSymbolOrThrow()
+            if (!propsSymbol.getMember('history')) {
+                const propsDecl = propsSymbol.getDeclarations()[0]
+                if (Node.isInterfaceDeclaration(propsDecl) || Node.isTypeLiteralNode(propsDecl)) {
+                    propsDecl.addProperty({
+                        name: 'history',
+                        type: namespace ? `${namespace}.History` : 'History',
+                    })
+                } else {
+                    throw new Error('Props type is neither interface nor type literal')
+                }
+            }
+        } else {
+            // Function component
+            const functionDecl = jsxNode.getFirstAncestorOrThrow((node: Node): node is VariableDeclaration => {
+                const isVarDecl = Node.isVariableDeclaration(node)
+                try {
+                    const isFuncComp = node.getType().getSymbol()?.getName() === 'FunctionComponent'
+                    return isVarDecl && isFuncComp
+                } catch {
+                    return false
+                }
+            })
+            const propsSymbol = functionDecl.getType().getTypeArguments()[0].getSymbolOrThrow()
+            if (!propsSymbol.getMember('history')) {
+                const propsDecl = propsSymbol.getDeclarations()[0]
+                if (Node.isInterfaceDeclaration(propsDecl) || Node.isTypeLiteralNode(propsDecl)) {
+                    propsDecl.addProperty({
+                        name: 'history',
+                        type: namespace ? `${namespace}.History` : 'History',
+                    })
+                } else {
+                    // Edge cases like intersection types etc must be fixed manually
+                    throw new Error('Props type is neither interface nor type literal')
+                }
+            }
+            const paramNode = functionDecl.getFirstDescendantByKindOrThrow(SyntaxKind.Parameter)
+            const paramName = paramNode.getNameNode()
+            if (Node.isObjectBindingPattern(paramName)) {
+                const restSpread = paramName.getFirstChild(
+                    (node): node is BindingElement => Node.isBindingElement(node) && !!node.getDotDotDotToken()
+                )
+                if (restSpread) {
+                    // Reference rest spread
+                    initializer = `{${restSpread.getName()}.history}`
+                } else {
+                    if (!paramName.getElements().some(element => element.getName() === 'history')) {
+                        // Add to destructured props
+                        // ts-morph currently has no nice API for this so we use the low-level TS API
+                        // https://github.com/dsherret/ts-morph/issues/775
+                        paramName.transform(traversal => {
+                            if (ts.isObjectBindingPattern(traversal.currentNode)) {
+                                return ts.updateObjectBindingPattern(traversal.currentNode, [
+                                    ...traversal.currentNode.elements,
+                                    ts.createBindingElement(undefined, undefined, 'history'),
+                                ])
+                            }
+                            return traversal.currentNode
+                        })
+                    }
+                    initializer = '{history}'
+                }
+            } else {
+                initializer = '{' + paramName.getText() + '.history}'
+            }
+        }
+    }
+
+    jsxNode.addAttribute({
+        kind: StructureKind.JsxAttribute,
+        name: 'history',
+        initializer,
+    })
+}

--- a/dev/ts-morph/main.ts
+++ b/dev/ts-morph/main.ts
@@ -1,0 +1,60 @@
+// This is a basic setup to do codemods on our TypeScript code.
+// For example, this can be used to make a large refactor that requires passing a new prop through a lot of components.
+// We can go through all type errors TypeScript reports and add the missing prop to JSX and interfaces.
+// The script may need to be run multiple times to fix new type errors, and some cases may need to be updated manually.
+// Overall, this can be much faster for those large refactors than making every change by hand.
+// This script can be run in the VS Code debugger by selecting "TS-Morph".
+// Learn more about how to use ts-morph in the documentation: https://ts-morph.com/manipulation/
+// To understand the AST for a given file, paste it into https://ts-ast-viewer.com/
+// The code committed here is just as an example that can be modified locally.
+// Code mods don't have to be committed to the repo (unless they could be useful as a reference too).
+
+import { Project, QuoteKind } from 'ts-morph'
+import { formatSourceFile } from './prettier-ts-morph'
+import { addMissingHistoryProp } from './add-history-prop'
+import * as path from 'path'
+
+async function main(): Promise<void> {
+    const repoRoot = path.resolve(__dirname, '..', '..')
+
+    const project = new Project({
+        tsConfigFilePath: path.resolve(repoRoot, 'tsconfig.json'),
+        manipulationSettings: {
+            quoteKind: QuoteKind.Single,
+            useTrailingCommas: true,
+        },
+    })
+    // project.enableLogging(true)
+    project.addSourceFilesFromTsConfig(path.resolve(repoRoot, 'web/tsconfig.json'))
+    project.addSourceFilesFromTsConfig(path.resolve(repoRoot, 'shared/tsconfig.json'))
+    project.addSourceFilesAtPaths([
+        path.resolve(repoRoot, 'web/src/**/*.d.ts'),
+        path.resolve(repoRoot, 'shared/src/**/*.d.ts'),
+        path.resolve(repoRoot, 'browser/src/**/*.d.ts'),
+    ])
+
+    console.log('Getting diagnostics')
+    const diagnostics = project
+        .getPreEmitDiagnostics()
+        // Some declaration files are not found by ts-morph for some reason, ignore
+        .filter(d => !/(declaration|type definition) file/i.test(project.formatDiagnosticsWithColorAndContext([d])))
+
+    for (const diagnostic of diagnostics.filter(d =>
+        /property 'history' is missing/i.test(project.formatDiagnosticsWithColorAndContext([d]))
+    )) {
+        try {
+            let sourceFile = diagnostic.getSourceFile()
+            if (!sourceFile) {
+                continue
+            }
+            addMissingHistoryProp(diagnostic, sourceFile)
+            sourceFile = await formatSourceFile(sourceFile)
+            await sourceFile.save()
+        } catch (err) {
+            console.error(err)
+        }
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+main()

--- a/dev/ts-morph/prettier-ts-morph.ts
+++ b/dev/ts-morph/prettier-ts-morph.ts
@@ -1,0 +1,18 @@
+import * as prettier from 'prettier'
+import { SourceFile } from 'ts-morph'
+
+/**
+ * Formats the given source file with Prettier.
+ */
+export async function formatSourceFile(sourceFile: SourceFile): Promise<SourceFile> {
+    const config = await prettier.resolveConfig(sourceFile.getFilePath())
+    if (!config) {
+        throw new Error(`Prettier config not found for file ${sourceFile.getFilePath() as string}`)
+    }
+    return sourceFile.replaceWithText(
+        prettier.format(sourceFile.getFullText(), {
+            ...config,
+            filepath: sourceFile.getFilePath(),
+        })
+    ) as SourceFile
+}

--- a/dev/ts-morph/tsconfig.json
+++ b/dev/ts-morph/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../../shared" }],
+  "compilerOptions": {
+    "module": "commonjs",
+    "baseUrl": ".",
+    "rootDir": ".",
+    "outDir": "out",
+    "noEmit": false,
+  },
+  "include": ["./**/*"],
+}

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "thread-loader": "^2.1.3",
     "to-string-loader": "^1.1.6",
     "ts-graphql-plugin": "^1.12.0",
+    "ts-morph": "^7.1.0",
     "ts-node": "^8.10.1",
     "typescript": "^3.9.2",
     "utc-version": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,6 +1145,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@dsherret/to-absolute-glob@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1f6475dc8bd974cea07a2daf3864b317b1dd332c"
+  integrity sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=
+  dependencies:
+    is-absolute "^1.0.0"
+    is-negated-glob "^1.0.0"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -2757,6 +2765,18 @@
     "@babel/runtime" "^7.9.6"
     "@testing-library/dom" "^7.2.2"
     "@types/testing-library__react" "^10.0.1"
+
+"@ts-morph/common@~0.5.0":
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/@ts-morph/common/-/common-0.5.0.tgz#d6ba5d162a8d6bf5c0870ffe2083a1f513d2193d"
+  integrity sha512-/nIPpBgAJULjFnPlreL3gm4XJK9wiE3TGkBh02qXe80naG+AvegvCZX34abU3MArJRPeTfQL8vJxcx8HBMVBiQ==
+  dependencies:
+    "@dsherret/to-absolute-glob" "^2.0.2"
+    fast-glob "^3.2.2"
+    fs-extra "^9.0.0"
+    is-negated-glob "^1.0.0"
+    multimatch "^4.0.0"
+    typescript "~3.9.2"
 
 "@types/anymatch@*":
   version "1.3.0"
@@ -4728,6 +4748,11 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob-lite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
@@ -6481,6 +6506,11 @@ coa@~2.0.1:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
+
+code-block-writer@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz#54fc410ebef2af836d9c2314ac40af7d7b37eee9"
+  integrity sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA==
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -9170,16 +9200,17 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
-  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
+fast-glob@^3.1.1, fast-glob@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
+  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
     glob-parent "^5.1.0"
     merge2 "^1.3.0"
     micromatch "^4.0.2"
+    picomatch "^2.2.1"
 
 fast-json-parse@^1.0.0:
   version "1.0.3"
@@ -9716,13 +9747,23 @@ fs-extra@^7.0.0:
     universalify "^0.1.0"
 
 fs-extra@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
-  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
 
 fs-extra@~4.0.2:
   version "4.0.3"
@@ -10398,7 +10439,7 @@ graceful-fs@4.1.15:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -12870,6 +12911,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -14424,7 +14474,7 @@ multimap@^1.1.0:
   resolved "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
   integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
 
-multimatch@4.0.0:
+multimatch@4.0.0, multimatch@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
   integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
@@ -16025,10 +16075,10 @@ performance-now@^2.1.0:
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5:
-  version "2.0.7"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
-  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -20611,6 +20661,15 @@ ts-key-enum@^2.0.0, ts-key-enum@^2.0.2:
   resolved "https://registry.npmjs.org/ts-key-enum/-/ts-key-enum-2.0.2.tgz#76ce5a889eb194801796924721d7983b407233df"
   integrity sha512-9S3QMUVixqX7hRRdeWTSDyz/EzO5Gf5iWkub0EYCnqDtDa4r11WKSOO2xLyMrGUq9Ltz+3jfk7uU0H4bTtBqbw==
 
+ts-morph@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/ts-morph/-/ts-morph-7.1.0.tgz#cba07079a2dd92a7db2830d66f486764bc32a2ae"
+  integrity sha512-BXlOdqTnCH5xQQRBHXfrE69/XTdVVEOoQZwZKdUpvbCrTMInilbUZjv9J8TdhekV/gloq2NqMgeQhIzdPZCiDA==
+  dependencies:
+    "@dsherret/to-absolute-glob" "^2.0.2"
+    "@ts-morph/common" "~0.5.0"
+    code-block-writer "^10.1.0"
+
 ts-node@^8.10.1:
   version "8.10.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
@@ -20735,10 +20794,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.2:
-  version "3.9.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
-  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+typescript@^3.9.2, typescript@~3.9.2:
+  version "3.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"
@@ -20975,6 +21034,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I used this for the change in #10198 

`ts-morph` is a wrapper around the TS compiler by @dsherret that makes it easy to work with for codemods. You have full access to type errors, type resolution, symbols, autofixes and of course the AST (type-safe with autocompletion etc).

It took a while to set up and figure out, but after that I think it can save a ton of time. By adding this to the repo I want to eliminate this first-time setup cost so it can save everyone working on the web codebase a lot of time going forward when big refactors are required.