### PR TITLE
authz: set dummy provider to unblock GraphQL in OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- GraphQL APIs are blocking forever in OSS version. [#3487](https://github.com/sourcegraph/sourcegraph/issues/3487)
+- In the OSS version of Sourcegraph, authorization providers are properly initialized and GraphQL APIs are no longer blocked. [#3487](https://github.com/sourcegraph/sourcegraph/issues/3487)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- GraphQL APIs are blocking forever in OSS version. [#3487](https://github.com/sourcegraph/sourcegraph/issues/3487)
+
 ### Removed
 
 ## 3.15.1

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assets"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 )
@@ -9,5 +10,9 @@ import (
 // function for details.
 
 func main() {
+	// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
+	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
+	authz.SetProviders(true, []authz.Provider{})
+
 	shared.Main(nil, nil)
 }


### PR DESCRIPTION
For some reason GitHub doesn't allow me to directly make changes to #8646 so making up a new PR.

Fixes #3847