### PR TITLE
Remove uncommitted transaction from ExecChangesetJob

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1345,18 +1345,10 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// TODO: We need a transaction here because ExecChangesetJob expects a
-	// wrapping tx. We can remove that assertion from ExecChangesetJob though
-	// and then remove the tx here.
-	tx, err := store.Transact(ctx)
+	err = ee.ExecChangesetJob(ctx, clock, store, gitClient, sourcer, c, job)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ee.ExecChangesetJob(ctx, clock, tx, gitClient, sourcer, c, job)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tx.Done(nil)
 
 	updatedJob, err := store.GetChangesetJob(ctx, ee.GetChangesetJobOpts{ID: job.ID})
 	if err != nil {


### PR DESCRIPTION
The code in `ExecChangesetJob` was just there to ensure that a
transaction was opened.

The problem is that it doesn't fully work:

1. If a transaction was already open, the code is a noop. Good.
2. If no transaction was opened, it opens one, but never commits it. Bad.

So instead of using half a solution, we remove the code that can lead to
problems and add comments to ensure the code is called inside a
transaction.