### PR TITLE
gitserver: internal git clone

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -126,9 +127,14 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 	m.Get(apirouter.ExternalURL).Handler(trace.TraceRoute(handler(serveExternalURL)))
 	m.Get(apirouter.CanSendEmail).Handler(trace.TraceRoute(handler(serveCanSendEmail)))
 	m.Get(apirouter.SendEmail).Handler(trace.TraceRoute(handler(serveSendEmail)))
+	m.Get(apirouter.GitExec).Handler(trace.TraceRoute(handler(serveGitExec)))
 	m.Get(apirouter.GitResolveRevision).Handler(trace.TraceRoute(handler(serveGitResolveRevision)))
 	m.Get(apirouter.GitTar).Handler(trace.TraceRoute(handler(serveGitTar)))
-	m.Get(apirouter.GitExec).Handler(trace.TraceRoute(handler(serveGitExec)))
+	gitService := &gitServiceHandler{
+		GitServer: gitserver.DefaultClient,
+	}
+	m.Get(apirouter.GitInfoRefs).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveInfoRefs)))
+	m.Get(apirouter.GitUploadPack).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveGitUploadPack)))
 	m.Get(apirouter.Telemetry).Handler(trace.TraceRoute(telemetryHandler))
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
 	m.Get(apirouter.Configuration).Handler(trace.TraceRoute(handler(serveConfiguration)))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -131,7 +131,7 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 	m.Get(apirouter.GitResolveRevision).Handler(trace.TraceRoute(handler(serveGitResolveRevision)))
 	m.Get(apirouter.GitTar).Handler(trace.TraceRoute(handler(serveGitTar)))
 	gitService := &gitServiceHandler{
-		GitServer: gitserver.DefaultClient,
+		Gitserver: gitserver.DefaultClient,
 	}
 	m.Get(apirouter.GitInfoRefs).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveInfoRefs)))
 	m.Get(apirouter.GitUploadPack).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveGitUploadPack)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -581,7 +581,7 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 // gitServiceHandler are handlers which proxy git clone requests to the
 // gitserver for the repo.
 type gitServiceHandler struct {
-	GitServer interface {
+	Gitserver interface {
 		AddrForRepo(context.Context, api.RepoName) string
 	}
 }
@@ -599,7 +599,7 @@ func (s *gitServiceHandler) redirectToGitServer(w http.ResponseWriter, r *http.R
 
 	u := &url.URL{
 		Scheme:   "http",
-		Host:     s.GitServer.AddrForRepo(r.Context(), api.RepoName(repo)),
+		Host:     s.Gitserver.AddrForRepo(r.Context(), api.RepoName(repo)),
 		Path:     path.Join("/git", repo, gitPath),
 		RawQuery: r.URL.RawQuery,
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -574,6 +576,35 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 
 	gitserver.DefaultReverseProxy.ServeHTTP(repo.Name, "POST", "exec", director, w, r)
 	return nil
+}
+
+// gitServiceHandler are handlers which proxy git clone requests to the
+// gitserver for the repo.
+type gitServiceHandler struct {
+	GitServer interface {
+		AddrForRepo(context.Context, api.RepoName) string
+	}
+}
+
+func (s *gitServiceHandler) serveInfoRefs(w http.ResponseWriter, r *http.Request) {
+	s.redirectToGitServer(w, r, "/info/refs")
+}
+
+func (s *gitServiceHandler) serveGitUploadPack(w http.ResponseWriter, r *http.Request) {
+	s.redirectToGitServer(w, r, "/git-upload-pack")
+}
+
+func (s *gitServiceHandler) redirectToGitServer(w http.ResponseWriter, r *http.Request, gitPath string) {
+	repo := mux.Vars(r)["RepoName"]
+
+	u := &url.URL{
+		Scheme:   "http",
+		Host:     s.GitServer.AddrForRepo(r.Context(), api.RepoName(repo)),
+		Path:     path.Join("/git", repo, gitPath),
+		RawQuery: r.URL.RawQuery,
+	}
+
+	http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
 }
 
 func handlePing(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -12,11 +12,52 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
+
+func TestGitServiceHandlers(t *testing.T) {
+	m := apirouter.NewInternal(mux.NewRouter())
+
+	gitService := &gitServiceHandler{
+		GitServer: mockAddrForRepo{},
+	}
+	m.Get(apirouter.GitInfoRefs).Handler(http.HandlerFunc(gitService.serveInfoRefs))
+	m.Get(apirouter.GitUploadPack).Handler(http.HandlerFunc(gitService.serveGitUploadPack))
+
+	cases := map[string]string{
+		"/git/foo/bar/info/refs?service=git-upload-pack": "http://foo.bar.gitserver/git/foo/bar/info/refs?service=git-upload-pack",
+		"/git/foo/bar/git-upload-pack":                   "http://foo.bar.gitserver/git/foo/bar/git-upload-pack",
+	}
+
+	for target, want := range cases {
+		req := httptest.NewRequest("GET", target, nil)
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusTemporaryRedirect {
+			body, _ := ioutil.ReadAll(resp.Body)
+			t.Errorf("expected redirect for %q, got status %d. Body: %s", target, resp.StatusCode, body)
+			continue
+		}
+
+		got := resp.Header.Get("Location")
+		if got != want {
+			t.Errorf("mismatched location for %q:\ngot:  %s\nwant: %s", target, got, want)
+		}
+	}
+}
+
+type mockAddrForRepo struct{}
+
+func (mockAddrForRepo) AddrForRepo(_ context.Context, name api.RepoName) string {
+	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver"
+}
 
 func TestReposList(t *testing.T) {
 	defaultRepos := []string{"github.com/popular/foo", "github.com/popular/bar"}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -24,7 +24,7 @@ func TestGitServiceHandlers(t *testing.T) {
 	m := apirouter.NewInternal(mux.NewRouter())
 
 	gitService := &gitServiceHandler{
-		GitServer: mockAddrForRepo{},
+		Gitserver: mockAddrForRepo{},
 	}
 	m.Get(apirouter.GitInfoRefs).Handler(http.HandlerFunc(gitService.serveInfoRefs))
 	m.Get(apirouter.GitUploadPack).Handler(http.HandlerFunc(gitService.serveGitUploadPack))

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -35,9 +35,11 @@ const (
 	CanSendEmail           = "internal.can-send-email"
 	SendEmail              = "internal.send-email"
 	Extension              = "internal.extension"
+	GitExec                = "internal.git.exec"
+	GitInfoRefs            = "internal.git.info-refs"
 	GitResolveRevision     = "internal.git.resolve-revision"
 	GitTar                 = "internal.git.tar"
-	GitExec                = "internal.git.exec"
+	GitUploadPack          = "internal.git.upload-pack"
 	PhabricatorRepoCreate  = "internal.phabricator.repo.create"
 	ReposGetByName         = "internal.repos.get-by-name"
 	ReposInventoryUncached = "internal.repos.inventory-uncached"
@@ -102,8 +104,10 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/send-email").Methods("POST").Name(SendEmail)
 	base.Path("/extension").Methods("POST").Name(Extension)
 	base.Path("/git/{RepoID:[0-9]+}/exec").Methods("POST").Name(GitExec)
+	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
 	base.Path("/git/{RepoName:.*}/resolve-revision/{Spec}").Methods("GET").Name(GitResolveRevision)
 	base.Path("/git/{RepoName:.*}/tar/{Commit}").Methods("GET").Name(GitTar)
+	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
 	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
 	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)
 	base.Path("/external-services/list").Methods("POST").Name(ExternalServicesList)

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -419,7 +419,7 @@ func (f *fakeDiskSizer) DiskSizeBytes(mountPoint string) (uint64, error) {
 
 func tmpDir(t *testing.T) string {
 	t.Helper()
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := ioutil.TempDir("", filepath.Base(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var uploadPackArgs = []string{
+	// Partial clones/fetches
+	"-c", "uploadpack.allowFilter=true",
+
+	// Can fetch any object. Used in case of race between a resolve ref and a
+	// fetch of a commit. Safe to do, since this is only used internally.
+	"-c", "uploadpack.allowAnySHA1InWant=true",
+
+	"upload-pack",
+
+	"--stateless-rpc", "--strict",
+}
+
+// handleGitService is a smart Git HTTP transfer protocol as documented at
+// https://www.git-scm.com/docs/http-protocol.
+//
+// This allows users to clone any git repo. We only support the smart
+// protocol. We aim to support modern git features such as protocol v2 to
+// minimize traffic.
+type gitServiceHandler struct {
+	// Dir is a funcion which takes a repository name and returns an absolute
+	// path to the GIT_DIR for it.
+	Dir func(string) string
+}
+
+func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only support clones and fetches (git upload-pack). /info/refs sets the
+	// service field.
+	if svcQ := r.URL.Query().Get("service"); svcQ != "" && svcQ != "git-upload-pack" {
+		http.Error(w, "only support service git-upload-pack", http.StatusBadRequest)
+		return
+	}
+
+	var repo, svc string
+	for _, suffix := range []string{"/info/refs", "/git-upload-pack"} {
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			svc = suffix
+			repo = strings.TrimSuffix(r.URL.Path, suffix)
+			repo = strings.TrimPrefix(repo, "/")
+			break
+		}
+	}
+
+	dir := s.Dir(repo)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		http.Error(w, "repository not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, "failed to stat repo: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	start := time.Now()
+	metricServiceRunning.WithLabelValues(svc).Inc()
+	defer func() {
+		metricServiceRunning.WithLabelValues(svc).Dec()
+		metricServiceDuration.WithLabelValues(svc).Observe(time.Since(start).Seconds())
+		if traceLogs {
+			log15.Debug("TRACE gitserver git service", "svc", svc, "repo", repo, "protocol", r.Header.Get("Git-Protocol"), "duration", time.Since(start))
+		}
+	}()
+
+	args := append([]string{}, uploadPackArgs...)
+	switch svc {
+	case "/info/refs":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.Write(packetWrite("# service=git-upload-pack\n"))
+		w.Write([]byte("0000"))
+		args = append(args, "--advertise-refs")
+	case "/git-upload-pack":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+	default:
+		http.Error(w, "unexpected subpath (want /info/refs or /git-upload-pack) ", http.StatusInternalServerError)
+		return
+	}
+	args = append(args, dir)
+
+	body := r.Body
+	defer body.Close()
+
+	env := os.Environ()
+	if protocol := r.Header.Get("Git-Protocol"); protocol != "" {
+		env = append(env, "GIT_PROTOCOL="+protocol)
+	}
+
+	cmd := exec.CommandContext(r.Context(), "git", args...)
+	cmd.Env = env
+	cmd.Stdout = w
+	cmd.Stdin = body
+	if err := cmd.Run(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func packetWrite(str string) []byte {
+	s := strconv.FormatInt(int64(len(str)+4), 16)
+	if len(s)%4 != 0 {
+		s = strings.Repeat("0", 4-len(s)%4) + s
+	}
+	return []byte(s + str)
+}
+
+var (
+	metricServiceDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_gitserver_service_duration_seconds",
+		Help:    "A histogram of latencies for the git service (upload-pack for internal clones) endpoint.",
+		Buckets: prometheus.ExponentialBuckets(.1, 5, 5), // 100ms -> 62s
+	}, []string{"type"})
+
+	metricServiceRunning = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "src_gitserver_service_running",
+		Help: "A histogram of latencies for the git service (upload-pack for internal clones) endpoint.",
+	}, []string{"type"})
+)

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -117,13 +117,13 @@ func packetWrite(str string) []byte {
 
 var (
 	metricServiceDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_gitserver_service_duration_seconds",
+		Name:    "src_gitserver_gitservice_duration_seconds",
 		Help:    "A histogram of latencies for the git service (upload-pack for internal clones) endpoint.",
 		Buckets: prometheus.ExponentialBuckets(.1, 5, 5), // 100ms -> 62s
 	}, []string{"type"})
 
 	metricServiceRunning = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_gitserver_service_running",
+		Name: "src_gitserver_gitservice_running",
 		Help: "A histogram of latencies for the git service (upload-pack for internal clones) endpoint.",
 	}, []string{"type"})
 )

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -26,7 +26,7 @@ var uploadPackArgs = []string{
 	"--stateless-rpc", "--strict",
 }
 
-// handleGitService is a smart Git HTTP transfer protocol as documented at
+// gitServiceHandler is a smart Git HTTP transfer protocol as documented at
 // https://www.git-scm.com/docs/http-protocol.
 //
 // This allows users to clone any git repo. We only support the smart

--- a/cmd/gitserver/server/gitservice_test.go
+++ b/cmd/gitserver/server/gitservice_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGitServiceHandler(t *testing.T) {
+	root := tmpDir(t)
+	repo := filepath.Join(root, "testrepo")
+
+	// Setup a repo with a commit so we can add bad refs
+	runCmd(t, root, "git", "init", repo)
+	runCmd(t, repo, "sh", "-c", "echo hello world > hello.txt")
+	runCmd(t, repo, "git", "add", "hello.txt")
+	runCmd(t, repo, "git", "commit", "-m", "hello")
+
+	ts := httptest.NewServer(&gitServiceHandler{
+		Dir: func(s string) string {
+			return filepath.Join(root, s, ".git")
+		},
+	})
+	defer ts.Close()
+
+	t.Run("404", func(t *testing.T) {
+		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
+		c.Dir = tmpDir(t)
+		b, err := c.CombinedOutput()
+		if !bytes.Contains(b, []byte("repository not found")) {
+			t.Fatal("expected clone to fail with repository not found", string(b), err)
+		}
+	})
+
+	cloneURL := ts.URL + "/testrepo"
+
+	t.Run("clonev1", func(t *testing.T) {
+		runCmd(t, tmpDir(t), "git", "-c", "protocol.version=1", "clone", cloneURL)
+	})
+
+	cloneV2 := []struct {
+		Name string
+		Args []string
+	}{{
+		"clonev2",
+		[]string{},
+	}, {
+		"shallow",
+		[]string{"--depth=1"},
+	}}
+
+	for _, tc := range cloneV2 {
+		t.Run(tc.Name, func(t *testing.T) {
+			args := []string{"-c", "protocol.version=2", "clone"}
+			args = append(args, tc.Args...)
+			args = append(args, cloneURL)
+
+			c := exec.Command("git", args...)
+			c.Dir = tmpDir(t)
+			c.Env = []string{
+				"GIT_TRACE_PACKET=1",
+			}
+			b, err := c.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command failed: %s\nOutput: %s", err, b)
+			}
+
+			// This is the same test done by git's tests for checking if the
+			// server is using protocol v2.
+			if !bytes.Contains(b, []byte("git< version 2")) {
+				t.Fatalf("protocol v2 not used by server. Output:\n%s", b)
+			}
+		})
+	}
+}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -238,6 +238,11 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+
+	mux.Handle("/git/", http.StripPrefix("/git", &gitServiceHandler{
+		Dir: func(d string) string { return string(s.dir(api.RepoName(d))) },
+	}))
+
 	return mux
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -336,7 +336,7 @@ func runCmd(t *testing.T, dir string, cmd string, arg ...string) string {
 	}
 	b, err := c.CombinedOutput()
 	if err != nil {
-		t.Fatalf("%s %s failed: %s", cmd, strings.Join(arg, " "), err)
+		t.Fatalf("%s %s failed: %s\nOutput: %s", cmd, strings.Join(arg, " "), err, b)
 	}
 	return string(b)
 }


### PR DESCRIPTION
We currently use git archives in most of our stack. However, we would like to index multiple branches at once in Zoekt. It is more convenient to pass Zoekt a repository in this case, rather than fetching multiple archives and merging them.

We ensure our smart handler is git protocol v2 capable and capable of shallow clones. The latter will initially be used, but we will likely experiment with more v2 features since it allows things such as skipping large objects/etc.

We previously had a handler for this in our codebase. The main differences to that implementation are:

- We don't proxy via the frontend, we now redirect directly to the responsible gitserver.
- We support protocol v2.
- We make gitserver responsible for all git service communication, rather than having business logic in the frontend internal handler.

Test Plan: unit and manually cloning via the dev server

```shell
git clone http://localhost:3090/.internal/git/github.com/gorilla/mux
```

Part of https://github.com/sourcegraph/sourcegraph/issues/6728