### PR TITLE
Drop GitHub ReviewRequestedEvents when reviewer has been deleted

### DIFF
--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -436,6 +436,19 @@ func (c *Changeset) Events() (events []*ChangesetEvent) {
 					ev.Metadata = c
 					events = append(events, &ev)
 				}
+
+			case *github.ReviewRequestedEvent:
+				// If the reviewer of a ReviewRequestedEvent has been deleted,
+				// the fields are blank and we cannot match the event to an
+				// entry in the database and/or reliably use it, so we drop it.
+				if e.ReviewerDeleted() {
+					continue
+				}
+				ev.Key = e.Key()
+				ev.Kind = ChangesetEventKindFor(e)
+				ev.Metadata = e
+				events = append(events, &ev)
+
 			default:
 				ev.Key = ti.Item.(Keyer).Key()
 				ev.Kind = ChangesetEventKindFor(ti.Item)

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -177,6 +177,45 @@ func TestChangesetEvents(t *testing.T) {
 				Metadata:    commit,
 			}},
 		})
+
+		reviewRequestedActorEvent := &github.ReviewRequestedEvent{
+			RequestedReviewer: github.Actor{Login: "the-great-tortellini"},
+			Actor:             actor,
+			CreatedAt:         now,
+		}
+		reviewRequestedTeamEvent := &github.ReviewRequestedEvent{
+			RequestedTeam: github.Team{Name: "the-belgian-waffles"},
+			Actor:         actor,
+			CreatedAt:     now,
+		}
+
+		cases = append(cases, testCase{"github-blank-review-requested",
+			Changeset{
+				ID: 23,
+				Metadata: &github.PullRequest{
+					TimelineItems: []github.TimelineItem{
+						{Type: "ReviewRequestedEvent", Item: reviewRequestedActorEvent},
+						{Type: "ReviewRequestedEvent", Item: reviewRequestedTeamEvent},
+						{Type: "ReviewRequestedEvent", Item: &github.ReviewRequestedEvent{
+							// Both Team and Reviewer are blank.
+							Actor:     actor,
+							CreatedAt: now,
+						}},
+					},
+				},
+			},
+			[]*ChangesetEvent{{
+				ChangesetID: 23,
+				Kind:        ChangesetEventKindGitHubReviewRequested,
+				Key:         reviewRequestedActorEvent.Key(),
+				Metadata:    reviewRequestedActorEvent,
+			}, {
+				ChangesetID: 23,
+				Kind:        ChangesetEventKindGitHubReviewRequested,
+				Key:         reviewRequestedTeamEvent.Key(),
+				Metadata:    reviewRequestedTeamEvent,
+			}},
+		})
 	}
 
 	{ // Bitbucket Server

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -350,6 +350,13 @@ func (e ReviewRequestedEvent) Key() string {
 	return fmt.Sprintf("%s:%s:%d", e.Actor.Login, requestedFrom, e.CreatedAt.UnixNano())
 }
 
+// ReviewerDeleted returns true if both RequestedReviewer and RequestedTeam are
+// blank, indicating that one or the other has been deleted.
+// We use it to drop the event.
+func (e ReviewRequestedEvent) ReviewerDeleted() bool {
+	return e.RequestedReviewer.Login == "" && e.RequestedTeam.Name == ""
+}
+
 // UnassignedEvent represents an 'unassigned' event on a pull request.
 type UnassignedEvent struct {
 	Actor     Actor


### PR DESCRIPTION
This is another follow-up to #10264. After fixing one of the symptoms of deleted reviewers in #10267 I decided to follow @ryanslade's suggestion and actually "remove" the events.

Now, actually removing the matching entry from the database is not possible with out current architecture, since it would require us to persist the GitHub-Node-ID of each event and then, on sync, map the now-with-deleted-reviewer event to the one in the database and then not only drop the new event but also delete the one in the DB.

I think we can tackle in the future, when we want to make sure that our "sync" is actually a full sync (i.e. deletes items in the DB that do not exist on the code host anymore).

For now, this lets me sleep better at night.
