### PR TITLE
Add PatchSet.DiffStat field and use that instead of computing it client side

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -313,6 +313,7 @@ type PatchSetResolver interface {
 	Patches(ctx context.Context, args *graphqlutil.ConnectionArgs) PatchConnectionResolver
 
 	PreviewURL() string
+	DiffStat(ctx context.Context) (*DiffStat, error)
 }
 
 type PreviewFileDiff interface {

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -211,6 +211,7 @@ type CampaignResolver interface {
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
 	Changesets(ctx context.Context, args *ListChangesetsArgs) (ExternalChangesetsConnectionResolver, error)
+	OpenChangesets(ctx context.Context) (ExternalChangesetsConnectionResolver, error)
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
 	RepositoryDiffs(ctx context.Context, args *graphqlutil.ConnectionArgs) (RepositoryComparisonConnectionResolver, error)
 	PatchSet(ctx context.Context) (PatchSetResolver, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -591,9 +591,8 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ExternalChangesetConnection!
 
-
     # All the changesets in this campaign whose state is ChangesetState.OPEN.
-    openChangesets: ExternalChangesetConnection
+    openChangesets: ExternalChangesetConnection!
 
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -493,6 +493,9 @@ type PatchSet implements Node {
 
     # The URL where the PatchSet can be previewed and a campaign can be created from it.
     previewURL: String!
+
+    # The diff stat for all the patches in the patch set.
+    diffStat: DiffStat!
 }
 
 # A paginated list of repository diffs committed to git.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -591,6 +591,10 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ExternalChangesetConnection!
 
+
+    # All the changesets in this campaign whose state is ChangesetState.OPEN.
+    openChangesets: ExternalChangesetConnection
+
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(
         # Only include changeset counts up to this point in time (inclusive).

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -500,6 +500,9 @@ type PatchSet implements Node {
 
     # The URL where the PatchSet can be previewed and a campaign can be created from it.
     previewURL: String!
+
+    # The diff stat for all the patches in the patch set.
+    diffStat: DiffStat!
 }
 
 # A paginated list of repository diffs committed to git.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -598,9 +598,8 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ExternalChangesetConnection!
 
-
     # All the changesets in this campaign whose state is ChangesetState.OPEN.
-    openChangesets: ExternalChangesetConnection
+    openChangesets: ExternalChangesetConnection!
 
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -598,6 +598,10 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ExternalChangesetConnection!
 
+
+    # All the changesets in this campaign whose state is ChangesetState.OPEN.
+    openChangesets: ExternalChangesetConnection
+
     # The changeset counts over time, in 1 day intervals backwards from the point in time given in 'to'.
     changesetCountsOverTime(
         # Only include changeset counts up to this point in time (inclusive).

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -103,6 +103,7 @@ type Campaign struct {
 	}
 	Patches                 PatchConnection
 	Changesets              ChangesetConnection
+	OpenChangesets          ChangesetConnection
 	ChangesetCountsOverTime []ChangesetCounts
 	DiffStat                DiffStat
 }

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -67,6 +67,7 @@ type PatchSet struct {
 	ID         string
 	Patches    PatchConnection
 	PreviewURL string
+	DiffStat   DiffStat
 }
 
 type User struct {

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -172,6 +172,18 @@ func (r *campaignResolver) Changesets(
 	}, nil
 }
 
+func (r *campaignResolver) OpenChangesets(ctx context.Context) (graphqlbackend.ExternalChangesetsConnectionResolver, error) {
+	state := campaigns.ChangesetStateOpen
+	return &changesetsConnectionResolver{
+		store: r.store,
+		opts: ee.ListChangesetsOpts{
+			CampaignID:    r.Campaign.ID,
+			ExternalState: &state,
+			Limit:         -1,
+		},
+	}, nil
+}
+
 func (r *campaignResolver) Patches(
 	ctx context.Context,
 	args *graphqlutil.ConnectionArgs,

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1033,12 +1033,17 @@ func TestPatchSetResolver(t *testing.T) {
         node(id: %q) {
           ... on PatchSet {
             id
+            diffStat {
+              added
+              deleted
+              changed
+            }
             patches(first: %d) {
               nodes {
                 repository {
                   name
                 }
-				diff {
+                diff {
                   fileDiffs {
                     rawDiff
                     diffStat {
@@ -1070,7 +1075,7 @@ func TestPatchSetResolver(t *testing.T) {
                       }
                     }
                   }
-				}
+                }
               }
             }
           }
@@ -1080,6 +1085,10 @@ func TestPatchSetResolver(t *testing.T) {
 
 	if have, want := len(response.Node.Patches.Nodes), len(jobs); have != want {
 		t.Fatalf("have %d patches, want %d", have, want)
+	}
+
+	if have, want := response.Node.DiffStat.Changed, 4; have != want {
+		t.Fatalf("wrong PatchSet.DiffStat.Changed %d, want=%d", have, want)
 	}
 
 	for i, patch := range response.Node.Patches.Nodes {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1003,9 +1003,9 @@ func TestPatchSetResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var jobs []*campaigns.Patch
+	var patches []*campaigns.Patch
 	for _, repo := range rs {
-		job := &campaigns.Patch{
+		patch := &campaigns.Patch{
 			PatchSetID: patchSet.ID,
 			RepoID:     repo.ID,
 			Rev:        testingRev,
@@ -1013,11 +1013,11 @@ func TestPatchSetResolver(t *testing.T) {
 			Diff:       testDiff,
 		}
 
-		err := store.CreatePatch(ctx, job)
+		err := store.CreatePatch(ctx, patch)
 		if err != nil {
 			t.Fatal(err)
 		}
-		jobs = append(jobs, job)
+		patches = append(patches, patch)
 	}
 
 	sr := &Resolver{store: store}
@@ -1081,13 +1081,14 @@ func TestPatchSetResolver(t *testing.T) {
           }
         }
       }
-	`, marshalPatchSetID(patchSet.ID), len(jobs)))
+	`, marshalPatchSetID(patchSet.ID), len(patches)))
 
-	if have, want := len(response.Node.Patches.Nodes), len(jobs); have != want {
+	if have, want := len(response.Node.Patches.Nodes), len(patches); have != want {
 		t.Fatalf("have %d patches, want %d", have, want)
 	}
 
-	if have, want := response.Node.DiffStat.Changed, 4; have != want {
+	// Each patch has testDiff as diff, each with 2 lines changed
+	if have, want := response.Node.DiffStat.Changed, len(patches)*2; have != want {
 		t.Fatalf("wrong PatchSet.DiffStat.Changed %d, want=%d", have, want)
 	}
 

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1408,6 +1408,9 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 	        }
 	        totalCount
 	      }
+	      openChangesets {
+	        totalCount
+	      }
 	      diffStat {
 	        added
 	        deleted
@@ -1429,8 +1432,11 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 		t.Fatalf("campaign.Patches.TotalCount is not zero: %d", campaign.Patches.TotalCount)
 	}
 
+	if campaign.OpenChangesets.TotalCount != 1 {
+		t.Fatalf("campaign.OpenChangesets.TotalCount is not 1: %d", campaign.OpenChangesets.TotalCount)
+	}
 	if campaign.Changesets.TotalCount != 1 {
-		t.Fatalf("campaign.Patches.TotalCount is not zero: %d", campaign.Patches.TotalCount)
+		t.Fatalf("campaign.Changesets.TotalCount is not 1: %d", campaign.Changesets.TotalCount)
 	}
 
 	if campaign.DiffStat.Changed != 2 {

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow'
 import { CampaignActionsBar } from './CampaignActionsBar'
-import { BackgroundProcessState, ChangesetState } from '../../../../../shared/src/graphql/schema'
+import { BackgroundProcessState } from '../../../../../shared/src/graphql/schema'
 
 const PROPS = {
     name: 'Super campaign',
@@ -35,7 +35,7 @@ describe('CampaignActionsBar', () => {
                     mode="viewing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -55,7 +55,7 @@ describe('CampaignActionsBar', () => {
                     mode="viewing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -75,7 +75,7 @@ describe('CampaignActionsBar', () => {
                     mode="viewing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: new Date().toISOString(),
                         name: 'Super campaign',
                         status: {
@@ -95,7 +95,7 @@ describe('CampaignActionsBar', () => {
                     mode="editing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -115,7 +115,7 @@ describe('CampaignActionsBar', () => {
                     mode="editing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -135,7 +135,7 @@ describe('CampaignActionsBar', () => {
                     mode="saving"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -155,7 +155,7 @@ describe('CampaignActionsBar', () => {
                     mode="deleting"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -175,7 +175,7 @@ describe('CampaignActionsBar', () => {
                     mode="closing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 0, nodes: [] },
+                        openChangesets: { totalCount: 0 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -195,7 +195,7 @@ describe('CampaignActionsBar', () => {
                     mode="viewing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: { totalCount: 1, nodes: [{ state: ChangesetState.OPEN }] },
+                        openChangesets: { totalCount: 1 },
                         closedAt: null,
                         name: 'Super campaign',
                         status: {
@@ -215,13 +215,8 @@ describe('CampaignActionsBar', () => {
                     mode="viewing"
                     previewingPatchSet={false}
                     campaign={{
-                        changesets: {
-                            totalCount: 3,
-                            nodes: [
-                                { state: ChangesetState.CLOSED },
-                                { state: ChangesetState.DELETED },
-                                { state: ChangesetState.MERGED },
-                            ],
+                        openChangesets: {
+                            totalCount: 0,
                         },
                         closedAt: null,
                         name: 'Super campaign',

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -5,13 +5,13 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { CloseDeleteCampaignPrompt } from './form/CloseDeleteCampaignPrompt'
 import { CampaignUIMode } from './CampaignDetails'
-import { Campaign } from './backend'
 
 interface Props {
     mode: CampaignUIMode
     previewingPatchSet: boolean
 
-    campaign?: Pick<Campaign, 'name' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt' | 'openChangesets'> & {
+    campaign?: Pick<GQL.ICampaign, 'name' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt'> & {
+        openChangesets: Pick<GQL.ICampaign['openChangesets'], 'totalCount'>
         status: Pick<GQL.ICampaign['status'], 'state'>
     }
 

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -5,15 +5,13 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { CloseDeleteCampaignPrompt } from './form/CloseDeleteCampaignPrompt'
 import { CampaignUIMode } from './CampaignDetails'
+import { Campaign } from './backend'
 
 interface Props {
     mode: CampaignUIMode
     previewingPatchSet: boolean
 
-    campaign?: Pick<GQL.ICampaign, 'name' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt'> & {
-        changesets: Pick<GQL.ICampaign['changesets'], 'totalCount'> & {
-            nodes: Pick<GQL.IExternalChangeset, 'state'>[]
-        }
+    campaign?: Pick<Campaign, 'name' | 'closedAt' | 'viewerCanAdminister' | 'publishedAt' | 'openChangesets'> & {
         status: Pick<GQL.ICampaign['status'], 'state'>
     }
 
@@ -40,8 +38,7 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({
     const campaignProcessing = campaign ? campaign.status.state === GQL.BackgroundProcessState.PROCESSING : false
     const actionsDisabled = mode === 'deleting' || mode === 'closing' || mode === 'publishing' || campaignProcessing
 
-    const openChangesetsCount =
-        campaign?.changesets.nodes.filter(changeset => changeset.state === GQL.ChangesetState.OPEN).length ?? 0
+    const openChangesetsCount = campaign?.openChangesets.totalCount ?? 0
 
     let stateBadge: JSX.Element
 

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -61,6 +61,11 @@ describe('CampaignDetails', () => {
                     of({
                         __typename: 'PatchSet' as const,
                         id: 'c',
+                        diffStat: {
+                            added: 0,
+                            changed: 18,
+                            deleted: 999,
+                        },
                         patches: { nodes: [] as GQL.IPatch[], totalCount: 2 },
                     })
                 }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -95,8 +95,9 @@ describe('CampaignDetails', () => {
                     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     author: { username: 'alice' } as GQL.IUser,
                     patchSet: { id: 'p' },
-                    changesets: { nodes: [] as GQL.IExternalChangeset[], totalCount: 2 },
-                    patches: { nodes: [] as GQL.IPatch[], totalCount: 2 },
+                    changesets: { totalCount: 2 },
+                    openChangesets: { totalCount: 0 },
+                    patches: { totalCount: 2 },
                     changesetCountsOverTime: [] as GQL.IChangesetCounts[],
                     viewerCanAdminister,
                     branch: 'awesome-branch',

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -71,6 +71,7 @@ interface Campaign
 }
 
 interface PatchSet extends Pick<GQL.IPatchSet, '__typename' | 'id'> {
+    diffStat: Pick<GQL.IPatchSet['diffStat'], 'added' | 'deleted' | 'changed'>
     patches: Pick<GQL.IPatchSet['patches'], 'nodes' | 'totalCount'>
 }
 

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -17,7 +17,6 @@ import {
     closeCampaign,
     publishCampaign,
     fetchPatchSetById,
-    Campaign as BackendCampaign,
 } from './backend'
 import { useError, useObservable } from '../../../../../shared/src/util/useObservable'
 import { asError } from '../../../../../shared/src/util/errors'
@@ -50,7 +49,7 @@ export type CampaignUIMode = 'viewing' | 'editing' | 'saving' | 'deleting' | 'cl
 
 interface Campaign
     extends Pick<
-        BackendCampaign,
+        GQL.ICampaign,
         | '__typename'
         | 'id'
         | 'name'
@@ -63,10 +62,10 @@ interface Campaign
         | 'closedAt'
         | 'viewerCanAdminister'
         | 'branch'
-        | 'openChangesets'
     > {
     patchSet: Pick<GQL.IPatchSet, 'id'> | null
     changesets: Pick<GQL.ICampaign['changesets'], 'totalCount'>
+    openChangesets: Pick<GQL.ICampaign['openChangesets'], 'totalCount'>
     patches: Pick<GQL.ICampaign['patches'], 'totalCount'>
     status: Pick<GQL.ICampaign['status'], 'completedCount' | 'pendingCount' | 'errors' | 'state'>
     diffStat: Pick<GQL.ICampaign['diffStat'], 'added' | 'deleted' | 'changed'>

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -17,6 +17,7 @@ import {
     closeCampaign,
     publishCampaign,
     fetchPatchSetById,
+    Campaign as BackendCampaign,
 } from './backend'
 import { useError, useObservable } from '../../../../../shared/src/util/useObservable'
 import { asError } from '../../../../../shared/src/util/errors'
@@ -49,7 +50,7 @@ export type CampaignUIMode = 'viewing' | 'editing' | 'saving' | 'deleting' | 'cl
 
 interface Campaign
     extends Pick<
-        GQL.ICampaign,
+        BackendCampaign,
         | '__typename'
         | 'id'
         | 'name'
@@ -62,17 +63,18 @@ interface Campaign
         | 'closedAt'
         | 'viewerCanAdminister'
         | 'branch'
+        | 'openChangesets'
     > {
     patchSet: Pick<GQL.IPatchSet, 'id'> | null
-    changesets: Pick<GQL.ICampaign['changesets'], 'nodes' | 'totalCount'>
-    patches: Pick<GQL.ICampaign['patches'], 'nodes' | 'totalCount'>
+    changesets: Pick<GQL.ICampaign['changesets'], 'totalCount'>
+    patches: Pick<GQL.ICampaign['patches'], 'totalCount'>
     status: Pick<GQL.ICampaign['status'], 'completedCount' | 'pendingCount' | 'errors' | 'state'>
     diffStat: Pick<GQL.ICampaign['diffStat'], 'added' | 'deleted' | 'changed'>
 }
 
 interface PatchSet extends Pick<GQL.IPatchSet, '__typename' | 'id'> {
     diffStat: Pick<GQL.IPatchSet['diffStat'], 'added' | 'deleted' | 'changed'>
-    patches: Pick<GQL.IPatchSet['patches'], 'nodes' | 'totalCount'>
+    patches: Pick<GQL.IPatchSet['patches'], 'totalCount'>
 }
 
 interface Props extends ThemeProps, ExtensionsControllerProps, PlatformContextProps, TelemetryProps {

--- a/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
@@ -41,20 +41,10 @@ describe('CampaignDiffStat', () => {
                 <CampaignDiffStat
                     patchSet={{
                         __typename: 'PatchSet' as const,
-                        patches: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 888,
-                                                changed: 777,
-                                                deleted: 999,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
+                        diffStat: {
+                            added: 888,
+                            changed: 777,
+                            deleted: 999,
                         },
                     }}
                     className="abc"
@@ -67,20 +57,10 @@ describe('CampaignDiffStat', () => {
                 <CampaignDiffStat
                     patchSet={{
                         __typename: 'PatchSet' as const,
-                        patches: {
-                            nodes: [
-                                {
-                                    diff: {
-                                        fileDiffs: {
-                                            diffStat: {
-                                                added: 0,
-                                                changed: 0,
-                                                deleted: 0,
-                                            },
-                                        },
-                                    },
-                                },
-                            ],
+                        diffStat: {
+                            added: 0,
+                            changed: 0,
+                            deleted: 0,
                         },
                     }}
                     className="abc"

--- a/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDiffStat.test.tsx
@@ -8,7 +8,6 @@ describe('CampaignDiffStat', () => {
             createRenderer().render(
                 <CampaignDiffStat
                     campaign={{
-                        __typename: 'Campaign' as const,
                         diffStat: {
                             added: 888,
                             deleted: 777,
@@ -24,7 +23,6 @@ describe('CampaignDiffStat', () => {
             createRenderer().render(
                 <CampaignDiffStat
                     campaign={{
-                        __typename: 'Campaign' as const,
                         diffStat: {
                             added: 0,
                             deleted: 0,
@@ -40,7 +38,6 @@ describe('CampaignDiffStat', () => {
             createRenderer().render(
                 <CampaignDiffStat
                     patchSet={{
-                        __typename: 'PatchSet' as const,
                         diffStat: {
                             added: 888,
                             changed: 777,
@@ -56,7 +53,6 @@ describe('CampaignDiffStat', () => {
             createRenderer().render(
                 <CampaignDiffStat
                     patchSet={{
-                        __typename: 'PatchSet' as const,
                         diffStat: {
                             added: 0,
                             changed: 0,

--- a/web/src/enterprise/campaigns/detail/CampaignDiffStat.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDiffStat.tsx
@@ -3,11 +3,11 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { DiffStat } from '../../../components/diff/DiffStat'
 
 export interface CampaignDiffstatProps {
-    campaign?: Pick<GQL.ICampaign, '__typename'> & {
-        diffStat: { added: number; changed: number; deleted: number }
+    campaign?: {
+        diffStat: Pick<GQL.IDiffStat, 'added' | 'changed' | 'deleted'>
     }
-    patchSet?: Pick<GQL.IPatchSet, '__typename'> & {
-        diffStat: { added: number; changed: number; deleted: number }
+    patchSet?: {
+        diffStat: Pick<GQL.IDiffStat, 'added' | 'changed' | 'deleted'>
     }
 
     className?: string

--- a/web/src/enterprise/campaigns/detail/CampaignDiffStat.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDiffStat.tsx
@@ -2,44 +2,25 @@ import React, { useMemo } from 'react'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { DiffStat } from '../../../components/diff/DiffStat'
 
-interface NodesWithDiffStat {
-    nodes: {
-        diff: {
-            fileDiffs: { diffStat: { added: number; changed: number; deleted: number } }
-        } | null
-    }[]
-}
-
 export interface CampaignDiffstatProps {
     campaign?: Pick<GQL.ICampaign, '__typename'> & {
         diffStat: { added: number; changed: number; deleted: number }
     }
     patchSet?: Pick<GQL.IPatchSet, '__typename'> & {
-        patches: NodesWithDiffStat
+        diffStat: { added: number; changed: number; deleted: number }
     }
 
     className?: string
 }
 
-const sumDiffStat = (nodes: NodesWithDiffStat['nodes'], field: 'added' | 'changed' | 'deleted'): number =>
-    nodes.reduce((prev, next) => prev + (next.diff ? next.diff.fileDiffs.diffStat[field] : 0), 0)
-
 /**
  * Total diff stat of a campaign or patchset, including all changesets and patches
  */
 export const CampaignDiffStat: React.FunctionComponent<CampaignDiffstatProps> = ({ campaign, patchSet, className }) => {
-    const { added, changed, deleted } = useMemo(() => {
-        if (campaign) {
-            return campaign.diffStat
-        }
-        const nodesWithDiffStat = patchSet!.patches.nodes
-        const patchsetDiffStat = {
-            added: sumDiffStat(nodesWithDiffStat, 'added'),
-            deleted: sumDiffStat(nodesWithDiffStat, 'deleted'),
-            changed: sumDiffStat(nodesWithDiffStat, 'changed'),
-        }
-        return patchsetDiffStat
-    }, [campaign, patchSet])
+    const { added, changed, deleted } = useMemo(() => (campaign ? campaign.diffStat : patchSet!.diffStat), [
+        campaign,
+        patchSet,
+    ])
 
     if (added + changed + deleted === 0) {
         return <></>

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
@@ -3,7 +3,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { ErrorMessage } from '../../../components/alerts'
 import SyncIcon from 'mdi-react/SyncIcon'
 import { pluralize } from '../../../../../shared/src/util/strings'
-import { retryCampaign, Campaign } from './backend'
+import { retryCampaign } from './backend'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import ErrorIcon from 'mdi-react/ErrorIcon'
@@ -18,7 +18,7 @@ export interface CampaignStatusProps {
     /** Called when the "Publish campaign" button is clicked. */
     onPublish: () => void
     /** Called when the "Retry failed jobs" button is clicked. */
-    afterRetry: (updatedCampaign: Campaign) => void
+    afterRetry: (updatedCampaign: GQL.ICampaign) => void
     history: H.History
 }
 

--- a/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatus.tsx
@@ -3,7 +3,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { ErrorMessage } from '../../../components/alerts'
 import SyncIcon from 'mdi-react/SyncIcon'
 import { pluralize } from '../../../../../shared/src/util/strings'
-import { retryCampaign } from './backend'
+import { retryCampaign, Campaign } from './backend'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import ErrorIcon from 'mdi-react/ErrorIcon'
@@ -18,7 +18,7 @@ export interface CampaignStatusProps {
     /** Called when the "Publish campaign" button is clicked. */
     onPublish: () => void
     /** Called when the "Retry failed jobs" button is clicked. */
-    afterRetry: (updatedCampaign: GQL.ICampaign) => void
+    afterRetry: (updatedCampaign: Campaign) => void
     history: H.History
 }
 

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -171,6 +171,52 @@ Array [
      
     Patches
      
+    <div
+      className="ml-2 mb-0"
+    >
+      <div
+        className="diff-stat "
+        data-tooltip="18 changes, 999 deletions"
+      >
+        <span
+          className="diff-stat__total font-weight-bold"
+        >
+          <span
+            className="diff-stat__text-added mr-1"
+          >
+            +
+            0
+          </span>
+          <span
+            className="diff-stat__text-changed mr-1"
+          >
+            •
+            18
+          </span>
+          <span
+            className="diff-stat__text-deleted mr-1"
+          >
+            −
+            999
+          </span>
+        </span>
+        <div
+          className="diff-stat__square diff-stat__changed"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+        <div
+          className="diff-stat__square diff-stat__deleted"
+        />
+      </div>
+    </div>
   </h3>,
   <PatchSetPatches
     campaignUpdates={
@@ -239,6 +285,11 @@ Array [
     patchSet={
       Object {
         "__typename": "PatchSet",
+        "diffStat": Object {
+          "added": 0,
+          "changed": 18,
+          "deleted": 999,
+        },
         "id": "c",
         "patches": Object {
           "nodes": Array [],

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -507,7 +507,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -521,11 +520,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",
@@ -615,7 +616,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -629,11 +629,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",
@@ -886,7 +888,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -900,11 +901,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",
@@ -994,7 +997,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -1008,11 +1010,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",
@@ -1355,7 +1359,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -1369,11 +1372,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",
@@ -1463,7 +1468,6 @@ Array [
         "branch": "awesome-branch",
         "changesetCountsOverTime": Array [],
         "changesets": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "closedAt": null,
@@ -1477,11 +1481,13 @@ Array [
         },
         "id": "c",
         "name": "n",
+        "openChangesets": Object {
+          "totalCount": 0,
+        },
         "patchSet": Object {
           "id": "p",
         },
         "patches": Object {
-          "nodes": Array [],
           "totalCount": 2,
         },
         "publishedAt": "2020-01-01",

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -82,19 +82,14 @@ const patchSetFragment = gql`
     fragment PatchSetFields on PatchSet {
         __typename
         id
+        diffStat {
+            ...DiffStatFields
+        }
         patches(first: 10000) {
             totalCount
             nodes {
                 id
                 __typename
-                diff {
-                    fileDiffs {
-                        totalCount
-                        diffStat {
-                            ...DiffStatFields
-                        }
-                    }
-                }
             }
         }
     }

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -15,18 +15,9 @@ import {
     IPatchSet,
     IPatchesOnCampaignArguments,
     IPatchConnection,
-    IExternalChangesetConnection,
 } from '../../../../../shared/src/graphql/schema'
 import { DiffStatFields, FileDiffHunkRangeFields, PreviewFileDiffFields, FileDiffFields } from '../../../backend/diff'
 import { Connection, FilteredConnectionQueryArgs } from '../../../components/FilteredConnection'
-
-export type CampaignType = 'comby' | 'credentials' | 'regexSearchReplace'
-
-export type Campaign = ICampaign & { openChangesets: Pick<IExternalChangesetConnection, 'totalCount'> }
-
-function augmentOpenChangesets(campaign: ICampaign): Campaign {
-    return campaign as Campaign
-}
 
 const campaignFragment = gql`
     fragment CampaignFields on Campaign {
@@ -52,7 +43,7 @@ const campaignFragment = gql`
         changesets {
             totalCount
         }
-        openChangesets: changesets(state: OPEN) {
+        openChangesets {
             totalCount
         }
         patches {
@@ -94,7 +85,7 @@ const patchSetFragment = gql`
     ${DiffStatFields}
 `
 
-export async function updateCampaign(update: IUpdateCampaignInput): Promise<Campaign> {
+export async function updateCampaign(update: IUpdateCampaignInput): Promise<ICampaign> {
     const result = await mutateGraphQL(
         gql`
             mutation UpdateCampaign($update: UpdateCampaignInput!) {
@@ -106,10 +97,10 @@ export async function updateCampaign(update: IUpdateCampaignInput): Promise<Camp
         `,
         { update }
     ).toPromise()
-    return augmentOpenChangesets(dataOrThrowErrors(result).updateCampaign)
+    return dataOrThrowErrors(result).updateCampaign
 }
 
-export async function createCampaign(input: ICreateCampaignInput): Promise<Campaign> {
+export async function createCampaign(input: ICreateCampaignInput): Promise<ICampaign> {
     const result = await mutateGraphQL(
         gql`
             mutation CreateCampaign($input: CreateCampaignInput!) {
@@ -121,10 +112,10 @@ export async function createCampaign(input: ICreateCampaignInput): Promise<Campa
         `,
         { input }
     ).toPromise()
-    return augmentOpenChangesets(dataOrThrowErrors(result).createCampaign)
+    return dataOrThrowErrors(result).createCampaign
 }
 
-export async function retryCampaign(campaignID: ID): Promise<Campaign> {
+export async function retryCampaign(campaignID: ID): Promise<ICampaign> {
     const result = await mutateGraphQL(
         gql`
             mutation RetryCampaign($campaign: ID!) {
@@ -137,7 +128,7 @@ export async function retryCampaign(campaignID: ID): Promise<Campaign> {
         `,
         { campaign: campaignID }
     ).toPromise()
-    return augmentOpenChangesets(dataOrThrowErrors(result).retryCampaign)
+    return dataOrThrowErrors(result).retryCampaign
 }
 
 export async function closeCampaign(campaign: ID, closeChangesets = false): Promise<void> {
@@ -168,7 +159,7 @@ export async function deleteCampaign(campaign: ID, closeChangesets = false): Pro
     dataOrThrowErrors(result)
 }
 
-export const fetchCampaignById = (campaign: ID): Observable<Campaign | null> =>
+export const fetchCampaignById = (campaign: ID): Observable<ICampaign | null> =>
     queryGraphQL(
         gql`
             query CampaignByID($campaign: ID!) {
@@ -191,7 +182,7 @@ export const fetchCampaignById = (campaign: ID): Observable<Campaign | null> =>
             if (node.__typename !== 'Campaign') {
                 throw new Error(`The given ID is a ${node.__typename}, not a Campaign`)
             }
-            return augmentOpenChangesets(node)
+            return node
         })
     )
 
@@ -405,7 +396,7 @@ export const queryPatchesFromPatchSet = (
         })
     )
 
-export async function publishCampaign(campaign: ID): Promise<Campaign> {
+export async function publishCampaign(campaign: ID): Promise<ICampaign> {
     const result = await mutateGraphQL(
         gql`
             mutation PublishCampaign($campaign: ID!) {
@@ -417,7 +408,7 @@ export async function publishCampaign(campaign: ID): Promise<Campaign> {
         `,
         { campaign }
     ).toPromise()
-    return augmentOpenChangesets(dataOrThrowErrors(result).publishCampaign)
+    return dataOrThrowErrors(result).publishCampaign
 }
 
 export async function publishChangeset(patch: ID): Promise<IEmptyResponse> {


### PR DESCRIPTION
This is part 2/2 to fix #7092 and introdues the `diffStat` property on `PatchSet`.

Just like in #10170 this here includes no caching. For now I want to hold off on adding caching until I have a clear idea of how to invalidate said caches. I don't think it's a high priority right now. Will also document this in #7092.

@eseliger Can you take a closer look at the removal of the nested `patches { nodes { diffStat { ... } } }` in the query? I'm not sure how to find out whether that's used anywhere else or not (we do display single diffstats, but I'm nor 100% sure whether we need _that_ query for it)