### PR TITLE
Search: add repogroup autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Autocompletion for `repogroup` filters in search queries. [#10141](https://github.com/sourcegraph/sourcegraph/pull/10286)
+
 ### Changed
 
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -4,7 +4,8 @@ import { FILTERS, resolveFilter } from './filters'
 import { Sequence, toMonacoRange } from './parser'
 import { Omit } from 'utility-types'
 import { Observable } from 'rxjs'
-import { SearchSuggestion, IRepository, IFile, ISymbol, ILanguage, SymbolKind } from '../../graphql/schema'
+import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup, SymbolKind } from '../../graphql/schema'
+import { SearchSuggestion } from '../suggestions'
 import { isDefined } from '../../util/types'
 import { FilterType, isNegatableFilter } from '../interactive/util'
 import { first } from 'rxjs/operators'
@@ -121,6 +122,13 @@ const languageToCompletion = ({ name }: ILanguage): PartialCompletionItem | unde
           }
         : undefined
 
+const repoGroupToCompletion = ({ name }: IRepoGroup): PartialCompletionItem => ({
+    label: name,
+    kind: repositoryCompletionItemKind,
+    insertText: name,
+    filterText: name,
+})
+
 const suggestionToCompletionItem = (
     suggestion: SearchSuggestion,
     options: { isFilterValue: boolean }
@@ -134,6 +142,8 @@ const suggestionToCompletionItem = (
             return symbolToCompletion(suggestion)
         case 'Language':
             return languageToCompletion(suggestion)
+        case 'RepoGroup':
+            return repoGroupToCompletion(suggestion)
     }
 }
 

--- a/shared/src/search/parser/filters.ts
+++ b/shared/src/search/parser/filters.ts
@@ -1,5 +1,5 @@
 import { Filter } from './parser'
-import { SearchSuggestion } from '../../graphql/schema'
+import { SearchSuggestion } from '../suggestions'
 import {
     FilterType,
     isNegatedFilter,
@@ -121,6 +121,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.repogroup]: {
         description: 'group-name (include results from the named group)',
         singular: true,
+        suggestions: 'RepoGroup',
     },
     [FilterType.repohascommitafter]: {
         description: '"string specifying time frame" (filter out stale repositories without recent commits)',

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -6,7 +6,8 @@ import { getMonacoTokens } from './tokens'
 import { getDiagnostics } from './diagnostics'
 import { getCompletionItems } from './completion'
 import { getHoverResult } from './hover'
-import { SearchSuggestion, SearchPatternType } from '../../graphql/schema'
+import { SearchPatternType } from '../../graphql/schema'
+import { SearchSuggestion } from '../suggestions'
 
 interface SearchFieldProviders {
     tokens: Monaco.languages.TokensProvider

--- a/shared/src/search/suggestions/index.ts
+++ b/shared/src/search/suggestions/index.ts
@@ -1,0 +1,3 @@
+import { IRepoGroup, SearchSuggestion as DynamicSearchSuggestion } from '../../graphql/schema'
+
+export type SearchSuggestion = DynamicSearchSuggestion | IRepoGroup

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -7,7 +7,7 @@ import { QueryState } from '../helpers'
 import { getProviders } from '../../../../shared/src/search/parser/providers'
 import { Subscription, Observable, Subject, Unsubscribable } from 'rxjs'
 import { fetchSuggestions } from '../backend'
-import { toArray, map, distinctUntilChanged, publishReplay, refCount, filter } from 'rxjs/operators'
+import { map, distinctUntilChanged, publishReplay, refCount, filter } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { CaseSensitivityProps, PatternTypeProps } from '..'
@@ -53,9 +53,7 @@ function addSouregraphSearchCodeIntelligence(
     monaco.languages.register({ id: SOURCEGRAPH_SEARCH })
 
     // Register providers
-    const providers = getProviders(searchQueries, patternTypes, (query: string) =>
-        fetchSuggestions(query).pipe(toArray())
-    )
+    const providers = getProviders(searchQueries, patternTypes, fetchSuggestions)
     subscriptions.add(toUnsubscribable(monaco.languages.setTokensProvider(SOURCEGRAPH_SEARCH, providers.tokens)))
     subscriptions.add(toUnsubscribable(monaco.languages.registerHoverProvider(SOURCEGRAPH_SEARCH, providers.hover)))
     subscriptions.add(

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -10,7 +10,6 @@ import {
     takeUntil,
     switchMap,
     map,
-    toArray,
     catchError,
     delay,
     share,
@@ -204,22 +203,27 @@ export class QueryInput extends React.Component<Props, State> {
                                 : queryForFuzzySearch
 
                             const fuzzySearchSuggestions = fetchSuggestions(fullQuery).pipe(
-                                map(createSuggestion),
-                                filter(isDefined),
-                                map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true })),
-                                filter(suggestion => {
-                                    // Only show fuzzy-suggestions that are relevant to the typed filter
-                                    if (filterAndValueBeforeCursor?.resolvedFilterType) {
-                                        switch (filterAndValueBeforeCursor.resolvedFilterType) {
-                                            case FilterType.repohasfile:
-                                                return suggestion.type === FilterType.file
-                                            default:
-                                                return suggestion.type === filterAndValueBeforeCursor.resolvedFilterType
-                                        }
-                                    }
-                                    return true
-                                }),
-                                toArray(),
+                                map((suggestions): Suggestion[] =>
+                                    suggestions
+                                        .map(createSuggestion)
+                                        .filter(isDefined)
+                                        .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
+                                        .filter(suggestion => {
+                                            // Only show fuzzy-suggestions that are relevant to the typed filter
+                                            if (filterAndValueBeforeCursor?.resolvedFilterType) {
+                                                switch (filterAndValueBeforeCursor.resolvedFilterType) {
+                                                    case FilterType.repohasfile:
+                                                        return suggestion.type === FilterType.file
+                                                    default:
+                                                        return (
+                                                            suggestion.type ===
+                                                            filterAndValueBeforeCursor.resolvedFilterType
+                                                        )
+                                                }
+                                            }
+                                            return suggestion.type !== FilterType.repogroup
+                                        })
+                                ),
                                 map(suggestions => ({
                                     suggestions: {
                                         cursorPosition: queryState.cursorPosition,

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -9,6 +9,7 @@ import { SymbolIcon } from '../../../../shared/src/symbols/SymbolIcon'
 import { SuggestionType, NonFilterSuggestionType } from '../../../../shared/src/search/suggestions/util'
 import { escapeRegExp } from 'lodash'
 import { FilterType } from '../../../../shared/src/search/interactive/util'
+import { SearchSuggestion } from '../../../../shared/src/search/suggestions'
 
 export const filterAliases: Record<string, FilterSuggestionTypes | undefined> = {
     r: FilterType.repo,
@@ -71,7 +72,7 @@ interface SuggestionIconProps {
  */
 const formatRegExp = (value: string): string => '^' + escapeRegExp(value) + '$'
 
-export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undefined {
+export function createSuggestion(item: SearchSuggestion): Suggestion | undefined {
     switch (item.__typename) {
         case 'Repository': {
             return {
@@ -121,6 +122,11 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | undef
                 label: 'go to definition',
             }
         }
+        case 'RepoGroup':
+            return {
+                type: FilterType.repogroup,
+                value: item.name,
+            }
         default:
             return undefined
     }
@@ -131,6 +137,7 @@ const SuggestionIcon: React.FunctionComponent<SuggestionIconProps> = ({ suggesti
         case NonFilterSuggestionType.filters:
             return <FilterIcon {...props} />
         case FilterType.repo:
+        case FilterType.repogroup:
             return <SourceRepositoryIcon {...props} />
         case FilterType.file:
             return <FileIcon {...props} />

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -8,8 +8,6 @@ import {
     distinctUntilChanged,
     switchMap,
     map,
-    filter,
-    toArray,
     catchError,
     debounceTime,
     takeUntil,
@@ -190,22 +188,27 @@ export class FilterInput extends React.Component<Props, State> {
 
                         fullQuery = formatInteractiveQueryForFuzzySearch(fullQuery, filterType, inputValue)
                         const suggestions = fetchSuggestions(fullQuery).pipe(
-                            map(createSuggestion),
-                            filter(isDefined),
-                            map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true })),
-                            filter(suggestion => {
-                                // Only show fuzzy-suggestions that are relevant to the typed filter
-                                if (filterAndValueBeforeCursor?.resolvedFilterType) {
-                                    switch (filterAndValueBeforeCursor.resolvedFilterType) {
-                                        case FilterType.repohasfile:
-                                            return suggestion.type === FilterType.file
-                                        default:
-                                            return suggestion.type === filterAndValueBeforeCursor.resolvedFilterType
-                                    }
-                                }
-                                return true
-                            }),
-                            toArray(),
+                            map((suggestions): Suggestion[] =>
+                                suggestions
+                                    .map(createSuggestion)
+                                    .filter(isDefined)
+                                    .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
+                                    .filter(suggestion => {
+                                        // Only show fuzzy-suggestions that are relevant to the typed filter
+                                        if (filterAndValueBeforeCursor?.resolvedFilterType) {
+                                            switch (filterAndValueBeforeCursor.resolvedFilterType) {
+                                                case FilterType.repohasfile:
+                                                    return suggestion.type === FilterType.file
+                                                default:
+                                                    return (
+                                                        suggestion.type ===
+                                                        filterAndValueBeforeCursor.resolvedFilterType
+                                                    )
+                                            }
+                                        }
+                                        return true
+                                    })
+                            ),
                             map(suggestions => ({
                                 suggestions: {
                                     values: suggestions,


### PR DESCRIPTION
Fixes #10141 

Adds repogroup autocompletion in all search contexts:

![Screen Shot 2020-04-30 at 12 14 39 PM](https://user-images.githubusercontent.com/1741180/80699447-40092200-8adc-11ea-8c25-ad2a16fb0c8c.png)
![Screen Shot 2020-04-30 at 12 15 04 PM](https://user-images.githubusercontent.com/1741180/80699455-43041280-8adc-11ea-9597-c2ae33714afc.png)
![Screen Shot 2020-04-30 at 12 11 28 PM](https://user-images.githubusercontent.com/1741180/80699133-c709ca80-8adb-11ea-8564-d3e3021b3fd6.png)