### PR TITLE
all: fix errcheck warnings

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -79,8 +79,8 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch svc {
 	case "/info/refs":
 		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-		w.Write(packetWrite("# service=git-upload-pack\n"))
-		w.Write([]byte("0000"))
+		_, _ = w.Write(packetWrite("# service=git-upload-pack\n"))
+		_, _ = w.Write([]byte("0000"))
 		args = append(args, "--advertise-refs")
 	case "/git-upload-pack":
 		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")

--- a/enterprise/internal/campaigns/testing.go
+++ b/enterprise/internal/campaigns/testing.go
@@ -44,7 +44,9 @@ func (s FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Chang
 		return s.ChangesetExists, fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.WantBaseRef, c.BaseRef)
 	}
 
-	c.SetMetadata(s.FakeMetadata)
+	if err := c.SetMetadata(s.FakeMetadata); err != nil {
+		return s.ChangesetExists, err
+	}
 
 	return s.ChangesetExists, s.Err
 }
@@ -58,8 +60,7 @@ func (s FakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Chang
 		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.WantBaseRef, c.BaseRef)
 	}
 
-	c.SetMetadata(s.FakeMetadata)
-	return nil
+	return c.SetMetadata(s.FakeMetadata)
 }
 
 var fakeNotImplemented = errors.New("not implement in FakeChangesetSource")

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -100,7 +100,9 @@ func TestExecChangesetJob(t *testing.T) {
 				}
 				// This sets ExternalID, which we need to trigger the
 				// AlreadyExistsError.
-				ch.SetMetadata(meta)
+				if err := ch.SetMetadata(meta); err != nil {
+					t.Fatal(err)
+				}
 				// Now we can remove metadata.
 				ch.Metadata = nil
 

--- a/internal/rcache/mutex.go
+++ b/internal/rcache/mutex.go
@@ -53,7 +53,7 @@ func TryAcquireMutex(ctx context.Context, name string) (context.Context, func(),
 			select {
 			case <-ctx.Done():
 				// TODO handle error
-				mu.Unlock()
+				_, _ = mu.Unlock()
 				ticker.Stop()
 				close(unlockedC)
 				return


### PR DESCRIPTION
We stopped running golanglint-ci due to resource use. So ran it and it found
these errcheck warnings. In some cases I just explicitly opted out of the
errcheck.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
