### PR TITLE
campaigns: Add WebhookURL to ExternalService

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -87,6 +87,7 @@ func (r *externalServiceResolver) CampaignWebhookURL() *string {
 		parsed, err := extsvc.ParseConfig(r.externalService.Kind, r.externalService.Config)
 		if err != nil {
 			log15.Error("parsing external service config", "err", err)
+			return
 		}
 		u := campaigns.WebhookURL(r.externalService.ID)
 		switch c := parsed.(type) {

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -92,10 +92,10 @@ func (r *externalServiceResolver) CampaignWebhookURL() *string {
 		u := campaigns.WebhookURL(r.externalService.ID)
 		switch c := parsed.(type) {
 		case *schema.BitbucketServerConnection:
-			if c.Webhooks != nil && c.Webhooks.Secret != "" {
+			if c.Webhooks != nil {
 				r.webhookURL = u
 			}
-			if c.Plugin != nil && c.Plugin.Webhooks != nil && c.Plugin.Webhooks.Secret != "" {
+			if c.Plugin != nil && c.Plugin.Webhooks != nil {
 				r.webhookURL = u
 			}
 		case *schema.GitHubConnection:

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -89,7 +90,7 @@ func (r *externalServiceResolver) WebhookURL() (*string, error) {
 			r.webhookErr = errors.Wrap(err, "parsing external service config")
 			return
 		}
-		u, err := extsvc.WebhookURL(r.externalService.Kind, r.externalService.ID)
+		u, err := extsvc.WebhookURL(r.externalService.Kind, r.externalService.ID, conf.ExternalURL())
 		if err != nil {
 			r.webhookErr = errors.Wrap(err, "creating webhook url")
 			return

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1553,7 +1553,7 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when webhooks have been configured for the external service.
+    # An optional URL that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1553,7 +1553,7 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when webhooks have been configured
+    # An optional url that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1553,6 +1553,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
+    # An optional url that will be populated when a campaign webhook has been configured
+    campaignWebhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1553,8 +1553,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when a campaign webhook has been configured
-    campaignWebhookURL: String
+    # An optional url that will be populated when webhooks have been configured
+    webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1560,7 +1560,7 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when webhooks have been configured for the external service.
+    # An optional URL that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1560,8 +1560,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when a campaign webhook has been configured
-    campaignWebhookURL: String
+    # An optional url that will be populated when webhooks have been configured
+    webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1560,6 +1560,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
+    # An optional url that will be populated when a campaign webhook has been configured
+    campaignWebhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1560,7 +1560,7 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
-    # An optional url that will be populated when webhooks have been configured
+    # An optional url that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -91,25 +92,7 @@ func (e *ExternalService) Update(n *ExternalService) (modified bool) {
 
 // Configuration returns the external service config.
 func (e ExternalService) Configuration() (cfg interface{}, _ error) {
-	switch strings.ToLower(e.Kind) {
-	case "awscodecommit":
-		cfg = &schema.AWSCodeCommitConnection{}
-	case "bitbucketserver":
-		cfg = &schema.BitbucketServerConnection{}
-	case "github":
-		cfg = &schema.GitHubConnection{}
-	case "gitlab":
-		cfg = &schema.GitLabConnection{}
-	case "gitolite":
-		cfg = &schema.GitoliteConnection{}
-	case "phabricator":
-		cfg = &schema.PhabricatorConnection{}
-	case "other":
-		cfg = &schema.OtherExternalServiceConnection{}
-	default:
-		return nil, fmt.Errorf("unknown external service kind %q", e.Kind)
-	}
-	return cfg, jsonc.Unmarshal(e.Config, cfg)
+	return extsvc.ParseConfig(e.Kind, e.Config)
 }
 
 // Exclude changes the configuration of an external service to exclude the given

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -253,7 +253,7 @@ func (h *GitHubWebhook) parseEvent(r *http.Request) (interface{}, *repos.Externa
 
 	sig := r.Header.Get("X-Hub-Signature")
 
-	rawID := r.FormValue(externalServiceIDParam)
+	rawID := r.FormValue(campaigns.ExternalServiceIDParam)
 	var externalServiceID int64
 	// Older hook URL's may not contain the external service
 	if rawID != "" {
@@ -804,8 +804,6 @@ func (h *BitbucketServerWebhook) SyncWebhooks(every time.Duration) {
 	}
 }
 
-const externalServiceIDParam = "externalServiceID"
-
 // syncWebhook ensures that the webhook has been configured correctly on Bitbucket. If no secret has been set, we delete
 // the existing webhook config.
 func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schema.BitbucketServerConnection, externalURL string) error {
@@ -838,7 +836,7 @@ func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schem
 	}
 
 	// Secret has changed to a non blank value, upsert
-	endpoint := fmt.Sprintf("%s/.api/bitbucket-server-webhooks?%s=%d", externalURL, externalServiceIDParam, externalServiceID)
+	endpoint := campaigns.WebhookURL(externalServiceID)
 	wh := bbs.Webhook{
 		Name:     h.Name,
 		Scope:    "global",
@@ -895,7 +893,7 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *repo
 
 	sig := r.Header.Get("X-Hub-Signature")
 
-	rawID := r.FormValue(externalServiceIDParam)
+	rawID := r.FormValue(campaigns.ExternalServiceIDParam)
 	var externalServiceID int64
 	// id could be blank temporarily if we haven't updated the hook url to include the param yet
 	if rawID != "" {

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -59,11 +59,11 @@ func (h Webhook) getRepoForPR(
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to load repository")
+		return nil, errors.Wrap(err, "failed to load repository")
 	}
 
 	if len(rs) != 1 {
-		return nil, fmt.Errorf("Fetched repositories have wrong length: %d", len(rs))
+		return nil, fmt.Errorf("fetched repositories have wrong length: %d", len(rs))
 	}
 
 	return rs[0], nil

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	bbs "github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -836,7 +837,7 @@ func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schem
 	}
 
 	// Secret has changed to a non blank value, upsert
-	endpoint, err := extsvc.WebhookURL("bitbucketserver", externalServiceID)
+	endpoint, err := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID)
 	if err != nil {
 		return errors.Wrap(err, "getting webhook URL")
 	}

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -792,8 +792,8 @@ func (h *BitbucketServerWebhook) SyncWebhooks(every time.Duration) {
 
 const externalServiceIDParam = "externalServiceID"
 
-// syncWebook ensures that the webhook has been configured correctly on Bitbucket. If no secret has been set, we delete
-// the exising webhook config.
+// syncWebhook ensures that the webhook has been configured correctly on Bitbucket. If no secret has been set, we delete
+// the existing webhook config.
 func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schema.BitbucketServerConnection, externalURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -837,7 +837,7 @@ func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schem
 	}
 
 	// Secret has changed to a non blank value, upsert
-	endpoint, err := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID)
+	endpoint, err := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID, conf.ExternalURL())
 	if err != nil {
 		return errors.Wrap(err, "getting webhook URL")
 	}

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -253,7 +253,7 @@ func (h *GitHubWebhook) parseEvent(r *http.Request) (interface{}, *repos.Externa
 
 	sig := r.Header.Get("X-Hub-Signature")
 
-	rawID := r.FormValue(extsvc.ExternalServiceIDParam)
+	rawID := r.FormValue(extsvc.IDParam)
 	var externalServiceID int64
 	// If a webhook was setup before we introduced the externalServiceID as part of the URL,
 	// the webhook requests may not contain the external service ID, so we need to fall back.
@@ -897,7 +897,7 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *repo
 
 	sig := r.Header.Get("X-Hub-Signature")
 
-	rawID := r.FormValue(extsvc.ExternalServiceIDParam)
+	rawID := r.FormValue(extsvc.IDParam)
 	var externalServiceID int64
 	// id could be blank temporarily if we haven't updated the hook url to include the param yet
 	if rawID != "" {

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -142,7 +143,11 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u := campaigns.WebhookURL(extSvc.ID)
+						u, err := extsvc.WebhookURL("github", extSvc.ID)
+						if err != nil {
+							t.Fatal(err)
+						}
+
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)
@@ -313,7 +318,10 @@ func testBitbucketWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u := campaigns.WebhookURL(extSvc.ID)
+						u, err := extsvc.WebhookURL("bitbucketserver", extSvc.ID)
+						if err != nil {
+							t.Fatal(err)
+						}
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -147,7 +147,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL(github.ServiceType, extSvc.ID)
+						u, err := extsvc.WebhookURL(github.ServiceType, extSvc.ID, "https://example.com/")
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -322,7 +322,7 @@ func testBitbucketWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL(bitbucketserver.ServiceType, extSvc.ID)
+						u, err := extsvc.WebhookURL(bitbucketserver.ServiceType, extSvc.ID, "https://example.com/")
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -143,7 +143,8 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						req, err := http.NewRequest("POST", "", bytes.NewReader(event.Data))
+						u := fmt.Sprintf("https://example.com/?%s=%d", externalServiceIDParam, extSvc.ID)
+						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -313,7 +314,7 @@ func testBitbucketWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u := fmt.Sprintf("http://example.com/?%s=%d", externalServiceIDParam, extSvc.ID)
+						u := fmt.Sprintf("https://example.com/?%s=%d", externalServiceIDParam, extSvc.ID)
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -143,7 +142,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u := fmt.Sprintf("https://example.com/?%s=%d", externalServiceIDParam, extSvc.ID)
+						u := campaigns.WebhookURL(extSvc.ID)
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)
@@ -314,7 +313,7 @@ func testBitbucketWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u := fmt.Sprintf("https://example.com/?%s=%d", externalServiceIDParam, extSvc.ID)
+						u := campaigns.WebhookURL(extSvc.ID)
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -19,6 +19,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -143,7 +147,7 @@ func testGitHubWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL("github", extSvc.ID)
+						u, err := extsvc.WebhookURL(github.ServiceType, extSvc.ID)
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -318,7 +322,7 @@ func testBitbucketWebhook(db *sql.DB) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL("bitbucketserver", extSvc.ID)
+						u, err := extsvc.WebhookURL(bitbucketserver.ServiceType, extSvc.ID)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1,18 +1,19 @@
 package campaigns
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 // SupportedExternalServices are the external service types currently supported
@@ -1269,4 +1270,13 @@ type ChangesetSyncData struct {
 
 func unixMilliToTime(ms int64) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
+}
+
+const ExternalServiceIDParam = "externalServiceID"
+
+func WebhookURL(externalServiceID int64) string {
+	host := conf.Cached(func() interface{} {
+		return conf.Get().ExternalURL
+	})().(string)
+	return fmt.Sprintf("https://%s/?%s=%d", host, ExternalServiceIDParam, externalServiceID)
 }

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1,7 +1,6 @@
 package campaigns
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -10,7 +9,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -1270,13 +1268,4 @@ type ChangesetSyncData struct {
 
 func unixMilliToTime(ms int64) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
-}
-
-const ExternalServiceIDParam = "externalServiceID"
-
-func WebhookURL(externalServiceID int64) string {
-	host := conf.Cached(func() interface{} {
-		return conf.Get().ExternalURL
-	})().(string)
-	return fmt.Sprintf("https://%s/?%s=%d", host, ExternalServiceIDParam, externalServiceID)
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -244,6 +244,10 @@ func CampaignsReadAccessEnabled() bool {
 	return false
 }
 
+func ExternalURL() string {
+	return Get().ExternalURL
+}
+
 func UsingExternalURL() bool {
 	url := Get().ExternalURL
 	return !(url == "" || strings.HasPrefix(url, "http://localhost") || strings.HasPrefix(url, "https://localhost") || strings.HasPrefix(url, "http://127.0.0.1") || strings.HasPrefix(url, "https://127.0.0.1")) // CI:LOCALHOST_OK

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -99,7 +99,7 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 	return cfg, jsonc.Unmarshal(config, cfg)
 }
 
-const ExternalServiceIDParam = "externalServiceID"
+const IDParam = "externalServiceID"
 
 func WebhookURL(kind string, externalServiceID int64) (string, error) {
 	host := conf.Cached(func() interface{} {
@@ -114,5 +114,5 @@ func WebhookURL(kind string, externalServiceID int64) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown external service kind: %q", kind)
 	}
-	return fmt.Sprintf("https://%s/%s?%s=%d", host, path, ExternalServiceIDParam, externalServiceID), nil
+	return fmt.Sprintf("https://%s/%s?%s=%d", host, path, IDParam, externalServiceID), nil
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -102,9 +102,6 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 const IDParam = "externalServiceID"
 
 func WebhookURL(kind string, externalServiceID int64) (string, error) {
-	host := conf.Cached(func() interface{} {
-		return conf.Get().ExternalURL
-	})().(string)
 	var path string
 	switch strings.ToLower(kind) {
 	case "github":
@@ -115,5 +112,5 @@ func WebhookURL(kind string, externalServiceID int64) (string, error) {
 		return "", fmt.Errorf("unknown external service kind: %q", kind)
 	}
 	// eg. https://example.com/.api/github-webhooks?externalServiceID=1
-	return fmt.Sprintf("%s/.api/%s?%s=%d", host, path, IDParam, externalServiceID), nil
+	return fmt.Sprintf("%s/.api/%s?%s=%d", conf.ExternalURL(), path, IDParam, externalServiceID), nil
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -112,7 +112,7 @@ func WebhookURL(kind string, externalServiceID int64) (string, error) {
 	case "bitbucketserver":
 		path = "bitbucket-server-webhooks"
 	default:
-		return "", fmt.Errorf("uknown external service kind: %q", kind)
+		return "", fmt.Errorf("unknown external service kind: %q", kind)
 	}
 	return fmt.Sprintf("https://%s/%s?%s=%d", host, path, ExternalServiceIDParam, externalServiceID), nil
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -114,5 +114,6 @@ func WebhookURL(kind string, externalServiceID int64) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown external service kind: %q", kind)
 	}
-	return fmt.Sprintf("https://%s/%s?%s=%d", host, path, IDParam, externalServiceID), nil
+	// eg. https://example.com/.api/github-webhooks?externalServiceID=1
+	return fmt.Sprintf("%s/.api/%s?%s=%d", host, path, IDParam, externalServiceID), nil
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -8,7 +8,6 @@ import (
 
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -101,7 +100,7 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 
 const IDParam = "externalServiceID"
 
-func WebhookURL(kind string, externalServiceID int64) (string, error) {
+func WebhookURL(kind string, externalServiceID int64, externalURL string) (string, error) {
 	var path string
 	switch strings.ToLower(kind) {
 	case "github":
@@ -112,5 +111,5 @@ func WebhookURL(kind string, externalServiceID int64) (string, error) {
 		return "", fmt.Errorf("unknown external service kind: %q", kind)
 	}
 	// eg. https://example.com/.api/github-webhooks?externalServiceID=1
-	return fmt.Sprintf("%s/.api/%s?%s=%d", conf.ExternalURL(), path, IDParam, externalServiceID), nil
+	return fmt.Sprintf("%s/.api/%s?%s=%d", externalURL, path, IDParam, externalServiceID), nil
 }

--- a/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -73,6 +73,7 @@ describe('StatusMessagesNavItem', () => {
                 config: '{}',
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString(),
+                webhookURL: null,
                 warning: '',
             },
         }


### PR DESCRIPTION
The CampaignWebhookURL optional string is now included on ExternalService in the API. This can be used from the frontend to show a URL that the admin should configure their webook to point at.

Additionally, we now check for this parameter when parsing both GitHub and BitbucketServer webhooks. 

Part of: https://github.com/sourcegraph/sourcegraph/issues/9008
