### PR TITLE
Remove unused code in TestService

### DIFF
--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -722,7 +722,6 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 			var (
 				campaign    *campaigns.Campaign
 				oldPatches  []*campaigns.Patch
-				newPatches  []*campaigns.Patch
 				patchesByID map[int64]*campaigns.Patch
 
 				changesetStateByPatchID map[int64]campaigns.ChangesetState
@@ -829,7 +828,6 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				newPatches = append(newPatches, j)
 				patchesByID[j.ID] = j
 			}
 


### PR DESCRIPTION
This was called out by `staticcheck` as a useless `append`. Turns out that the whole thing is not needed. Thanks @keegancsmith!