### PR TITLE
Move repoupdater observability definitions into internal package

### DIFF
--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -10,17 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-// ErrorLogger captures the method required for logging an error.
-type ErrorLogger interface {
-	Error(msg string, ctx ...interface{})
-}
-
 // ObservedSource returns a decorator that wraps a Source
 // with error logging, Prometheus metrics and tracing.
-func ObservedSource(l ErrorLogger, m SourceMetrics) func(Source) Source {
+func ObservedSource(l metrics.ErrorLogger, m SourceMetrics) func(Source) Source {
 	return func(s Source) Source {
 		return &observedSource{
 			Source:  s,
@@ -35,47 +31,19 @@ func ObservedSource(l ErrorLogger, m SourceMetrics) func(Source) Source {
 type observedSource struct {
 	Source
 	metrics SourceMetrics
-	log     ErrorLogger
-}
-
-// OperationMetrics contains three common metrics for any operation.
-type OperationMetrics struct {
-	Duration *prometheus.HistogramVec // How long did it take?
-	Count    *prometheus.CounterVec   // How many things were processed?
-	Errors   *prometheus.CounterVec   // How many errors occurred?
-}
-
-// Observe registers an observation of a single operation.
-func (m *OperationMetrics) Observe(secs, count float64, err *error, lvals ...string) {
-	if m == nil {
-		return
-	}
-
-	m.Duration.WithLabelValues(lvals...).Observe(secs)
-	m.Count.WithLabelValues(lvals...).Add(count)
-	if err != nil && *err != nil {
-		m.Errors.WithLabelValues(lvals...).Add(1)
-	}
-}
-
-// MustRegister registers all metrics in OperationMetrics in the given
-// prometheus.Registerer. It panics in case of failure.
-func (m *OperationMetrics) MustRegister(r prometheus.Registerer) {
-	r.MustRegister(m.Duration)
-	r.MustRegister(m.Count)
-	r.MustRegister(m.Errors)
+	log     metrics.ErrorLogger
 }
 
 // SourceMetrics encapsulates the Prometheus metrics of a Source.
 type SourceMetrics struct {
-	ListRepos *OperationMetrics
+	ListRepos *metrics.OperationMetrics
 }
 
 // NewSourceMetrics returns SourceMetrics that need to be registered
 // in a Prometheus registry.
 func NewSourceMetrics() SourceMetrics {
 	return SourceMetrics{
-		ListRepos: &OperationMetrics{
+		ListRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -108,7 +76,7 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.ListRepos.Observe(secs, count, &err)
-		log(o.log, "source.list-repos", &err)
+		metrics.Log(o.log, "source.list-repos", &err)
 	}(time.Now())
 
 	uncounted := make(chan SourceResult)
@@ -131,7 +99,7 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 // Prometheus metrics and tracing.
 func NewObservedStore(
 	s Store,
-	l ErrorLogger,
+	l metrics.ErrorLogger,
 	m StoreMetrics,
 	t trace.Tracer,
 ) *ObservedStore {
@@ -147,7 +115,7 @@ func NewObservedStore(
 // Prometheus metrics and tracing.
 type ObservedStore struct {
 	store   Store
-	log     ErrorLogger
+	log     metrics.ErrorLogger
 	metrics StoreMetrics
 	tracer  trace.Tracer
 	txtrace *trace.Trace
@@ -156,20 +124,36 @@ type ObservedStore struct {
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.
 type StoreMetrics struct {
-	Transact               *OperationMetrics
-	Done                   *OperationMetrics
-	UpsertRepos            *OperationMetrics
-	ListRepos              *OperationMetrics
-	UpsertExternalServices *OperationMetrics
-	ListExternalServices   *OperationMetrics
-	ListAllRepoNames       *OperationMetrics
+	Transact               *metrics.OperationMetrics
+	Done                   *metrics.OperationMetrics
+	UpsertRepos            *metrics.OperationMetrics
+	ListRepos              *metrics.OperationMetrics
+	UpsertExternalServices *metrics.OperationMetrics
+	ListExternalServices   *metrics.OperationMetrics
+	ListAllRepoNames       *metrics.OperationMetrics
+}
+
+// MustRegister registers all metrics in StoreMetrics in the given
+// prometheus.Registerer. It panics in case of failure.
+func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
+	for _, om := range []*metrics.OperationMetrics{
+		sm.Transact,
+		sm.Done,
+		sm.ListRepos,
+		sm.UpsertRepos,
+		sm.ListExternalServices,
+		sm.UpsertExternalServices,
+		sm.ListAllRepoNames,
+	} {
+		om.MustRegister(r)
+	}
 }
 
 // NewStoreMetrics returns StoreMetrics that need to be registered
 // in a Prometheus registry.
 func NewStoreMetrics() StoreMetrics {
 	return StoreMetrics{
-		Transact: &OperationMetrics{
+		Transact: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -189,7 +173,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when opening a transaction",
 			}, []string{}),
 		},
-		Done: &OperationMetrics{
+		Done: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -209,7 +193,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when closing a transaction",
 			}, []string{}),
 		},
-		UpsertRepos: &OperationMetrics{
+		UpsertRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -229,7 +213,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when upserting repos",
 			}, []string{}),
 		},
-		ListRepos: &OperationMetrics{
+		ListRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -249,7 +233,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when listing repos",
 			}, []string{}),
 		},
-		UpsertExternalServices: &OperationMetrics{
+		UpsertExternalServices: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "external_serviceupdater",
@@ -269,7 +253,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when upserting external_services",
 			}, []string{}),
 		},
-		ListExternalServices: &OperationMetrics{
+		ListExternalServices: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -289,7 +273,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when listing external_services",
 			}, []string{}),
 		},
-		ListAllRepoNames: &OperationMetrics{
+		ListAllRepoNames: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -320,7 +304,7 @@ func (o *ObservedStore) Transact(ctx context.Context) (s TxStore, err error) {
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.Transact.Observe(secs, 1, &err)
-		log(o.log, "store.transact", &err)
+		metrics.Log(o.log, "store.transact", &err)
 		if err != nil {
 			tr.SetError(err)
 			// Finish is called in Done in the non-error case
@@ -357,7 +341,7 @@ func (o *ObservedStore) Done(errs ...*error) {
 				done = true
 				tr.SetError(*err)
 				o.metrics.Done.Observe(secs, 1, err)
-				log(o.log, "store.done", err)
+				metrics.Log(o.log, "store.done", err)
 			}
 		}
 
@@ -384,7 +368,7 @@ func (o *ObservedStore) ListExternalServices(ctx context.Context, args StoreList
 		count := float64(len(es))
 
 		o.metrics.ListExternalServices.Observe(secs, count, &err)
-		log(o.log, "store.list-external-services", &err,
+		metrics.Log(o.log, "store.list-external-services", &err,
 			"args", fmt.Sprintf("%+v", args),
 			"count", len(es),
 		)
@@ -415,7 +399,7 @@ func (o *ObservedStore) UpsertExternalServices(ctx context.Context, svcs ...*Ext
 		count := float64(len(svcs))
 
 		o.metrics.UpsertExternalServices.Observe(secs, count, &err)
-		log(o.log, "store.upsert-external-services", &err,
+		metrics.Log(o.log, "store.upsert-external-services", &err,
 			"count", len(svcs),
 			"names", ExternalServices(svcs).DisplayNames(),
 		)
@@ -441,7 +425,7 @@ func (o *ObservedStore) ListRepos(ctx context.Context, args StoreListReposArgs) 
 		count := float64(len(rs))
 
 		o.metrics.ListRepos.Observe(secs, count, &err)
-		log(o.log, "store.list-repos", &err,
+		metrics.Log(o.log, "store.list-repos", &err,
 			"args", fmt.Sprintf("%+v", args),
 			"count", len(rs),
 		)
@@ -463,7 +447,7 @@ func (o *ObservedStore) ListAllRepoNames(ctx context.Context) (names []api.RepoN
 		count := float64(len(names))
 
 		o.metrics.ListAllRepoNames.Observe(secs, count, &err)
-		log(o.log, "store.list-all-repo-names", &err, "count", len(names))
+		metrics.Log(o.log, "store.list-all-repo-names", &err, "count", len(names))
 
 		tr.LogFields(otlog.Int("count", len(names)))
 		tr.SetError(err)
@@ -483,7 +467,7 @@ func (o *ObservedStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err er
 		count := float64(len(repos))
 
 		o.metrics.UpsertRepos.Observe(secs, count, &err)
-		log(o.log, "store.upsert-repos", &err, "count", len(repos))
+		metrics.Log(o.log, "store.upsert-repos", &err, "count", len(repos))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -499,15 +483,4 @@ func (o *ObservedStore) trace(ctx context.Context, family string) (*trace.Trace,
 	}
 	tr, _ := o.tracer.New(txctx, family, "")
 	return tr, trace.ContextWithTrace(ctx, tr)
-}
-
-func log(lg ErrorLogger, msg string, err *error, ctx ...interface{}) {
-	if err == nil || *err == nil {
-		return
-	}
-
-	args := append(make([]interface{}, 0, 2+len(ctx)), "error", *err)
-	args = append(args, ctx...)
-
-	lg.Error(msg, args...)
 }

--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -10,20 +10,20 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 // HandlerMetrics encapsulates the Prometheus metrics of an http.Handler.
 type HandlerMetrics struct {
-	ServeHTTP *repos.OperationMetrics
+	ServeHTTP *metrics.OperationMetrics
 }
 
 // NewHandlerMetrics returns HandlerMetrics that need to be registered
 // in a Prometheus registry.
 func NewHandlerMetrics() HandlerMetrics {
 	return HandlerMetrics{
-		ServeHTTP: &repos.OperationMetrics{
+		ServeHTTP: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -75,17 +75,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	var store repos.Store
 	{
 		m := repos.NewStoreMetrics()
-		for _, om := range []*repos.OperationMetrics{
-			m.Transact,
-			m.Done,
-			m.ListRepos,
-			m.UpsertRepos,
-			m.ListExternalServices,
-			m.UpsertExternalServices,
-			m.ListAllRepoNames,
-		} {
-			om.MustRegister(prometheus.DefaultRegisterer)
-		}
+		m.MustRegister(prometheus.DefaultRegisterer)
 
 		store = repos.NewObservedStore(
 			repos.NewDBStore(db, sql.TxOptions{Isolation: sql.LevelSerializable}),

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,4 +1,4 @@
-package metrics
+package logging
 
 // ErrorLogger captures the method required for logging an error.
 type ErrorLogger interface {

--- a/internal/metrics/logging.go
+++ b/internal/metrics/logging.go
@@ -1,0 +1,15 @@
+package metrics
+
+// ErrorLogger captures the method required for logging an error.
+type ErrorLogger interface {
+	Error(msg string, ctx ...interface{})
+}
+
+// Log logs the given message and context when the given error is defined.
+func Log(lg ErrorLogger, msg string, err *error, ctx ...interface{}) {
+	if err == nil || *err == nil {
+		return
+	}
+
+	lg.Error(msg, append(append(make([]interface{}, 0, 2+len(ctx)), "error", *err), ctx...)...)
+}

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -34,10 +34,10 @@ func (m *OperationMetrics) MustRegister(r prometheus.Registerer) {
 	r.MustRegister(m.Errors)
 }
 
-// NewBasicOperationMetrics creates an OperationMetrics value without any
+// NewOperationMetrics creates an OperationMetrics value without any
 // specific labels. The supplied operationName should be underscore_cased
 // as it is used in the metric name.
-func NewBasicOperationMetrics(subsystem, metricPrefix, operationName string) *OperationMetrics {
+func NewOperationMetrics(subsystem, metricPrefix, operationName string) *OperationMetrics {
 	return &OperationMetrics{
 		Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "src",

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// OperationMetrics contains three common metrics for any operation.
+type OperationMetrics struct {
+	Duration *prometheus.HistogramVec // How long did it take?
+	Count    *prometheus.CounterVec   // How many things were processed?
+	Errors   *prometheus.CounterVec   // How many errors occurred?
+}
+
+// Observe registers an observation of a single operation.
+func (m *OperationMetrics) Observe(secs, count float64, err *error, lvals ...string) {
+	if m == nil {
+		return
+	}
+
+	m.Duration.WithLabelValues(lvals...).Observe(secs)
+	m.Count.WithLabelValues(lvals...).Add(count)
+	if err != nil && *err != nil {
+		m.Errors.WithLabelValues(lvals...).Add(1)
+	}
+}
+
+// MustRegister registers all metrics in OperationMetrics in the given
+// prometheus.Registerer. It panics in case of failure.
+func (m *OperationMetrics) MustRegister(r prometheus.Registerer) {
+	r.MustRegister(m.Duration)
+	r.MustRegister(m.Count)
+	r.MustRegister(m.Errors)
+}
+
+// NewBasicOperationMetrics creates an OperationMetrics value without any
+// specific labels. The supplied operationName should be underscore_cased
+// as it is used in the metric name.
+func NewBasicOperationMetrics(subsystem, metricPrefix, operationName string) *OperationMetrics {
+	return &OperationMetrics{
+		Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "src",
+			Subsystem: subsystem,
+			Name:      fmt.Sprintf("%s_%s_duration_seconds", metricPrefix, operationName),
+			Help:      "Time spent performing %s operations",
+		}, []string{}),
+		Count: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "src",
+			Subsystem: subsystem,
+			Name:      fmt.Sprintf("%s_%s_total", metricPrefix, operationName),
+			Help:      fmt.Sprintf("Total number of %s operations", operationName),
+		}, []string{}),
+		Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "src",
+			Subsystem: subsystem,
+			Name:      fmt.Sprintf("%s_%s_errors_total", metricPrefix, operationName),
+			Help:      fmt.Sprintf("Total number of errors when performing %s operations", operationName),
+		}, []string{}),
+	}
+}


### PR DESCRIPTION
The rewrite of precise-code-intel services will need to add observability metrics to a lot of places. There are some definitions in the repoupdater package that would be useful here to be used in multiple places. This PR does the following:

**Edit:** Simplified diff.