### PR TITLE
Remove special characters from suggested branch name

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -199,7 +199,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
     const onNameChange = useCallback(
         (newName: string): void => {
             if (!branchModified) {
-                setBranch(slugify(newName, { lower: true }))
+                setBranch(slugify(newName, { remove: /[*+~\\^.()'"!:@]/g, lower: true }))
             }
             setName(newName)
         },


### PR DESCRIPTION
This should help customers avoid the majority of problems that result
from an autogenerated branch name based on the campaign name.
