### PR TITLE
Refactor codeintel db package

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/helpers_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/helpers_test.go
@@ -131,7 +131,7 @@ func setMockDBPackageReferencePager(t *testing.T, mockDB *dbmocks.MockDB, expect
 }
 
 func setMockReferencePagerPageFromOffset(t *testing.T, mockReferencePager *dbmocks.MockReferencePager, expectedOffset int, references []types.PackageReference) {
-	mockReferencePager.PageFromOffsetFunc.SetDefaultHook(func(offset int) ([]types.PackageReference, error) {
+	mockReferencePager.PageFromOffsetFunc.SetDefaultHook(func(ctx context.Context, offset int) ([]types.PackageReference, error) {
 		if offset != expectedOffset {
 			t.Errorf("unexpected offset for PageFromOffset. want=%d have=%d", expectedOffset, offset)
 		}

--- a/cmd/precise-code-intel-api-server/internal/api/references.go
+++ b/cmd/precise-code-intel-api-server/internal/api/references.go
@@ -259,9 +259,9 @@ func (s *ReferencePageResolver) resolveLocationsViaReferencePager(ctx context.Co
 
 		var packageReferences []types.PackageReference
 		for len(packageReferences) < limit && newOffset < totalCount {
-			page, err := pager.PageFromOffset(newOffset)
+			page, err := pager.PageFromOffset(ctx, newOffset)
 			if err != nil {
-				return nil, Cursor{}, false, pager.CloseTx(err)
+				return nil, Cursor{}, false, pager.Done(err)
 			}
 
 			if len(page) == 0 {
@@ -284,7 +284,7 @@ func (s *ReferencePageResolver) resolveLocationsViaReferencePager(ctx context.Co
 		cursor.SkipDumpsWhenBatching = newOffset
 		cursor.TotalDumpsWhenBatching = totalCount
 
-		if err := pager.CloseTx(nil); err != nil {
+		if err := pager.Done(nil); err != nil {
 			return nil, Cursor{}, false, err
 		}
 	}

--- a/cmd/precise-code-intel-worker/internal/worker/worker_test.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker_test.go
@@ -80,7 +80,7 @@ func TestProcess(t *testing.T) {
 	}
 	if len(mockDB.UpdatePackagesFunc.History()) != 1 {
 		t.Errorf("unexpected number of UpdatePackagesFunc calls. want=%d have=%d", 1, len(mockDB.UpdatePackagesFunc.History()))
-	} else if diff := cmp.Diff(expectedPackages, mockDB.UpdatePackagesFunc.History()[0].Arg2); diff != "" {
+	} else if diff := cmp.Diff(expectedPackages, mockDB.UpdatePackagesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackagesFuncargs (-want +got):\n%s", diff)
 	}
 
@@ -98,20 +98,20 @@ func TestProcess(t *testing.T) {
 	}
 	if len(mockDB.UpdatePackageReferencesFunc.History()) != 1 {
 		t.Errorf("unexpected number of UpdatePackageReferencesFunc calls. want=%d have=%d", 1, len(mockDB.UpdatePackageReferencesFunc.History()))
-	} else if diff := cmp.Diff(expectedPackageReferences, mockDB.UpdatePackageReferencesFunc.History()[0].Arg2); diff != "" {
+	} else if diff := cmp.Diff(expectedPackageReferences, mockDB.UpdatePackageReferencesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackageReferencesFunc args (-want +got):\n%s", diff)
 	}
 
 	if len(mockDB.DeleteOverlappingDumpsFunc.History()) != 1 {
 		t.Errorf("unexpected number of DeleteOverlappingDumpsFunc calls. want=%d have=%d", 1, len(mockDB.DeleteOverlappingDumpsFunc.History()))
-	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg2 != 50 {
-		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg2)
-	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg3 != makeCommit(1) {
-		t.Errorf("unexpected value for commit. want=%s have=%s", makeCommit(1), mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg3)
-	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg4 != "root/" {
-		t.Errorf("unexpected value for root. want=%s have=%s", "root/", mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg4)
-	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg5 != "lsif-go" {
-		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg5)
+	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg1 != 50 {
+		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg1)
+	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg2 != makeCommit(1) {
+		t.Errorf("unexpected value for commit. want=%s have=%s", makeCommit(1), mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg2)
+	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg3 != "root/" {
+		t.Errorf("unexpected value for root. want=%s have=%s", "root/", mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg3)
+	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg4 != "lsif-go" {
+		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg4)
 	}
 
 	offsets := []int{1, 30}
@@ -123,16 +123,16 @@ func TestProcess(t *testing.T) {
 	}
 	if len(mockDB.UpdateCommitsFunc.History()) != 1 {
 		t.Errorf("unexpected number of update UpdateCommitsFunc calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
-	} else if diff := cmp.Diff(expectedCommits, mockDB.UpdateCommitsFunc.History()[0].Arg3); diff != "" {
+	} else if diff := cmp.Diff(expectedCommits, mockDB.UpdateCommitsFunc.History()[0].Arg2); diff != "" {
 		t.Errorf("unexpected update UpdateCommitsFunc args (-want +got):\n%s", diff)
 	}
 
 	if len(mockDB.UpdateDumpsVisibleFromTipFunc.History()) != 1 {
 		t.Errorf("unexpected number of UpdateDumpsVisibleFromTipFunc calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
-	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2 != 50 {
-		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2)
-	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg3 != makeCommit(30) {
-		t.Errorf("unexpected value for tip commit. want=%s have=%s", makeCommit(30), mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg3)
+	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1 != 50 {
+		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1)
+	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2 != makeCommit(30) {
+		t.Errorf("unexpected value for tip commit. want=%s have=%s", makeCommit(30), mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2)
 	}
 
 	if len(bundleManagerClient.SendDBFunc.History()) != 1 {

--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -2,24 +2,12 @@ package db
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 )
 
 // UpdateCommits upserts commits/parent-commit relations for the given repository ID.
-func (db *dbImpl) UpdateCommits(ctx context.Context, tx *sql.Tx, repositoryID int, commits map[string][]string) (err error) {
-	if tx == nil {
-		tx, err = db.db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			err = closeTx(tx, err)
-		}()
-	}
-	tw := &transactionWrapper{tx}
-
+func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits map[string][]string) (err error) {
 	var rows []*sqlf.Query
 	for commit, parents := range commits {
 		for _, parent := range parents {
@@ -31,12 +19,9 @@ func (db *dbImpl) UpdateCommits(ctx context.Context, tx *sql.Tx, repositoryID in
 		}
 	}
 
-	query := `
+	return db.exec(ctx, sqlf.Sprintf(`
 		INSERT INTO lsif_commits (repository_id, "commit", parent_commit)
 		VALUES %s
 		ON CONFLICT DO NOTHING
-	`
-
-	_, err = tw.exec(ctx, sqlf.Sprintf(query, sqlf.Join(rows, ",")))
-	return err
+	`, sqlf.Join(rows, ",")))
 }

--- a/internal/codeintel/db/commits_test.go
+++ b/internal/codeintel/db/commits_test.go
@@ -16,7 +16,7 @@ func TestUpdateCommits(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 		makeCommit(2): {makeCommit(1)},
 		makeCommit(3): {makeCommit(1)},
@@ -32,7 +32,7 @@ func TestUpdateCommits(t *testing.T) {
 		ORDER BY "commit", "parent_commit"
 	`
 
-	rows, err := db.db.Query(query)
+	rows, err := dbconn.Global.Query(query)
 	if err != nil {
 		t.Fatalf("unexpected error querying commits: %s", err)
 	}
@@ -73,7 +73,7 @@ func TestUpdateCommitsWithConflicts(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 		makeCommit(2): {makeCommit(1)},
 		makeCommit(3): {makeCommit(1)},
@@ -82,7 +82,7 @@ func TestUpdateCommitsWithConflicts(t *testing.T) {
 		t.Fatalf("unexpected error updating commits: %s", err)
 	}
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(3): {makeCommit(1)},
 		makeCommit(4): {makeCommit(3), makeCommit(5)},
 		makeCommit(5): {makeCommit(6), makeCommit(7)},
@@ -97,7 +97,7 @@ func TestUpdateCommitsWithConflicts(t *testing.T) {
 		ORDER BY "commit", "parent_commit"
 	`
 
-	rows, err := db.db.Query(query)
+	rows, err := dbconn.Global.Query(query)
 	if err != nil {
 		t.Fatalf("unexpected error querying commits: %s", err)
 	}

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -19,19 +19,30 @@ import (
 //
 // These tables are kept separate from the remainder of Sourcegraph tablespace.
 type DB interface {
+	// Transact returns a Database whose methods operate within the context of a transaction.
+	// This method will return an error if the underlying DB cannot be interface upgraded
+	// to a TxBeginner.
+	Transact(ctx context.Context) (DB, error)
+
+	// Done commits underlying the transaction on a nil error value and performs a rollback
+	// otherwise. If an error occurs during commit or rollback of the transaction, the error
+	// is added to the resulting error value. If the Database does not wrap a transaction the
+	// original error value is returned unchanged.
+	Done(err error) error
+
 	// GetUploadByID returns an upload by its identifier and boolean flag indicating its existence.
 	GetUploadByID(ctx context.Context, id int) (Upload, bool, error)
 
 	// GetUploadsByRepo returns a list of uploads for a particular repo and the total count of records matching the given conditions.
 	GetUploadsByRepo(ctx context.Context, repositoryID int, state, term string, visibleAtTip bool, limit, offset int) ([]Upload, int, error)
 
-	// Enqueue inserts a new upload with a "queued" state, returning its identifier and a TxCloser that must be closed to commit the transaction.
-	Enqueue(ctx context.Context, commit, root, tracingContext string, repositoryID int, indexerName string) (int, TxCloser, error)
+	// Enqueue inserts a new upload with a "queued" state and returns its identifier.
+	Enqueue(ctx context.Context, commit, root, tracingContext string, repositoryID int, indexerName string) (int, error)
 
 	// Dequeue selects the oldest queued upload and locks it with a transaction. If there is such an upload, the
 	// upload is returned along with a JobHandle instance which wraps the transaction. This handle must be closed.
-	// If there is no such unlocked upload, a zero-value upload and nil-job handle will be returned alogn with a
-	// false-valued flag.
+	// If there is no such unlocked upload, a zero-value upload and nil-job handle will be returned along with a
+	// false-valued flag.  This method must not be called from within a transaction.
 	Dequeue(ctx context.Context) (Upload, JobHandle, bool, error)
 
 	// GetStates returns the states for the uploads with the given identifiers.
@@ -40,7 +51,7 @@ type DB interface {
 	// DeleteUploadByID deletes an upload by its identifier. If the upload was visible at the tip of its repository's default branch,
 	// the visibility of all uploads for that repository are recalculated. The given function is expected to return the newest commit
 	// on the default branch when invoked.
-	DeleteUploadByID(ctx context.Context, id int, getTipCommit func(repositoryID int) (string, error)) (bool, error)
+	DeleteUploadByID(ctx context.Context, id int, getTipCommit GetTipCommitFn) (bool, error)
 
 	// ResetStalled moves all unlocked uploads processing for more than `StalledUploadMaxAge` back to the queued state.
 	// This method returns a list of updated upload identifiers.
@@ -57,25 +68,25 @@ type DB interface {
 	DeleteOldestDump(ctx context.Context) (int, bool, error)
 
 	// UpdateDumpsVisibleFromTip recalculates the visible_at_tip flag of all dumps of the given repository.
-	UpdateDumpsVisibleFromTip(ctx context.Context, tx *sql.Tx, repositoryID int, tipCommit string) (err error)
+	UpdateDumpsVisibleFromTip(ctx context.Context, repositoryID int, tipCommit string) (err error)
 
 	// DeleteOverlapapingDumps deletes all completed uploads for the given repository with the same
 	// commit, root, and indexer. This is necessary to perform during conversions before changing
 	// the state of a processing upload to completed as there is a unique index on these four columns.
-	DeleteOverlappingDumps(ctx context.Context, tx *sql.Tx, repositoryID int, commit, root, indexer string) error
+	DeleteOverlappingDumps(ctx context.Context, repositoryID int, commit, root, indexer string) error
 
 	// GetPackage returns the dump that provides the package with the given scheme, name, and version and a flag indicating its existence.
 	GetPackage(ctx context.Context, scheme, name, version string) (Dump, bool, error)
 
 	// UpdatePackages bulk upserts package data.
-	UpdatePackages(ctx context.Context, tx *sql.Tx, packages []types.Package) error
+	UpdatePackages(ctx context.Context, packages []types.Package) error
 
 	// SameRepoPager returns a ReferencePager for dumps that belong to the given repository and commit and reference the package with the
 	// given scheme, name, and version.
 	SameRepoPager(ctx context.Context, repositoryID int, commit, scheme, name, version string, limit int) (int, ReferencePager, error)
 
 	// UpdatePackageReferences bulk inserts package reference data.
-	UpdatePackageReferences(ctx context.Context, tx *sql.Tx, packageReferences []types.PackageReference) error
+	UpdatePackageReferences(ctx context.Context, packageReferences []types.PackageReference) error
 
 	// PackageReferencePager returns a ReferencePager for dumps that belong to a remote repository (distinct from the given repository id)
 	// and reference the package with the given scheme, name, and version. All resulting dumps are visible at the tip of their repository's
@@ -83,15 +94,18 @@ type DB interface {
 	PackageReferencePager(ctx context.Context, scheme, name, version string, repositoryID, limit int) (int, ReferencePager, error)
 
 	// UpdateCommits upserts commits/parent-commit relations for the given repository ID.
-	UpdateCommits(ctx context.Context, tx *sql.Tx, repositoryID int, commits map[string][]string) error
+	UpdateCommits(ctx context.Context, repositoryID int, commits map[string][]string) error
 
 	// RepoName returns the name for the repo with the given identifier. This is the only method
 	// in this package that touches any table that does not start with `lsif_`.
 	RepoName(ctx context.Context, repositoryID int) (string, error)
 }
 
+// GetTipCommitFn returns the head commit for the given repository.
+type GetTipCommitFn func(repositoryID int) (string, error)
+
 type dbImpl struct {
-	db *sql.DB
+	db dbutil.DB
 }
 
 var _ DB = &dbImpl{}
@@ -111,22 +125,11 @@ func (db *dbImpl) query(ctx context.Context, query *sqlf.Query) (*sql.Rows, erro
 	return db.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 }
 
-// queryRow performs QueryRowContext on the underlying connection.
-func (db *dbImpl) queryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
-	return db.db.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-}
-
-// exec performs ExecContext on the underlying connection.
-func (db *dbImpl) exec(ctx context.Context, query *sqlf.Query) (sql.Result, error) {
-	return db.db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-}
-
-// beginTx performs BeginTx on the underlying connection and wraps the transaction.
-func (db *dbImpl) beginTx(ctx context.Context) (*transactionWrapper, error) {
-	tx, err := db.db.BeginTx(ctx, nil)
+// exec performs a query and throws away the result.
+func (db *dbImpl) exec(ctx context.Context, query *sqlf.Query) error {
+	rows, err := db.query(ctx, query)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return &transactionWrapper{tx}, nil
+	return rows.Close()
 }

--- a/internal/codeintel/db/helpers_test.go
+++ b/internal/codeintel/db/helpers_test.go
@@ -81,7 +81,7 @@ func insertUploads(t *testing.T, db *sql.DB, uploads ...Upload) {
 
 // insertPackageReferences populates the lsif_references table with the given package references.
 func insertPackageReferences(t *testing.T, db *dbImpl, packageReferences []types.PackageReference) {
-	if err := db.UpdatePackageReferences(context.Background(), nil, packageReferences); err != nil {
+	if err := db.UpdatePackageReferences(context.Background(), packageReferences); err != nil {
 		t.Fatalf("unexpected error updating package references: %s", err)
 	}
 }

--- a/internal/codeintel/db/packages.go
+++ b/internal/codeintel/db/packages.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
@@ -10,7 +9,7 @@ import (
 
 // GetPackage returns the dump that provides the package with the given scheme, name, and version and a flag indicating its existence.
 func (db *dbImpl) GetPackage(ctx context.Context, scheme, name, version string) (Dump, bool, error) {
-	query := `
+	return scanFirstDump(db.query(ctx, sqlf.Sprintf(`
 		SELECT
 			d.id,
 			d.commit,
@@ -29,54 +28,23 @@ func (db *dbImpl) GetPackage(ctx context.Context, scheme, name, version string) 
 		JOIN lsif_dumps d ON p.dump_id = d.id
 		WHERE p.scheme = %s AND p.name = %s AND p.version = %s
 		LIMIT 1
-	`
-
-	dump, err := scanDump(db.queryRow(ctx, sqlf.Sprintf(query, scheme, name, version)))
-	if err != nil {
-		return Dump{}, false, ignoreErrNoRows(err)
-	}
-
-	return dump, true, nil
+	`, scheme, name, version)))
 }
 
 // UpdatePackages upserts package data tied to the given upload.
-func (db *dbImpl) UpdatePackages(ctx context.Context, tx *sql.Tx, packages []types.Package) (err error) {
+func (db *dbImpl) UpdatePackages(ctx context.Context, packages []types.Package) (err error) {
 	if len(packages) == 0 {
 		return nil
 	}
-
-	if tx == nil {
-		tx, err = db.db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			err = closeTx(tx, err)
-		}()
-	}
-	tw := &transactionWrapper{tx}
-
-	if tw == nil {
-		tw, err = db.beginTx(ctx)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			err = closeTx(tw.tx, err)
-		}()
-	}
-
-	query := `
-		INSERT INTO lsif_packages (dump_id, scheme, name, version)
-		VALUES %s
-		ON CONFLICT DO NOTHING
-	`
 
 	var values []*sqlf.Query
 	for _, p := range packages {
 		values = append(values, sqlf.Sprintf("(%s, %s, %s, %s)", p.DumpID, p.Scheme, p.Name, p.Version))
 	}
 
-	_, err = tw.exec(ctx, sqlf.Sprintf(query, sqlf.Join(values, ",")))
-	return err
+	return db.exec(ctx, sqlf.Sprintf(`
+		INSERT INTO lsif_packages (dump_id, scheme, name, version)
+		VALUES %s
+		ON CONFLICT DO NOTHING
+	`, sqlf.Join(values, ",")))
 }

--- a/internal/codeintel/db/packages_test.go
+++ b/internal/codeintel/db/packages_test.go
@@ -44,7 +44,7 @@ func TestGetPackage(t *testing.T) {
 		Indexer:           "lsif-go",
 	}
 
-	insertUploads(t, db.db, Upload{
+	insertUploads(t, dbconn.Global, Upload{
 		ID:                expected.ID,
 		Commit:            expected.Commit,
 		Root:              expected.Root,
@@ -60,7 +60,7 @@ func TestGetPackage(t *testing.T) {
 		Indexer:           expected.Indexer,
 	})
 
-	if err := db.UpdatePackages(context.Background(), nil, []types.Package{
+	if err := db.UpdatePackages(context.Background(), []types.Package{
 		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"},
 	}); err != nil {
 		t.Fatalf("unexpected error updating packages: %s", err)
@@ -83,9 +83,9 @@ func TestUpdatePackages(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// for foreign key relation
-	insertUploads(t, db.db, Upload{ID: 42})
+	insertUploads(t, dbconn.Global, Upload{ID: 42})
 
-	if err := db.UpdatePackages(context.Background(), nil, []types.Package{
+	if err := db.UpdatePackages(context.Background(), []types.Package{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"},
 		{DumpID: 42, Scheme: "s1", Name: "n1", Version: "v1"},
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"},
@@ -100,7 +100,7 @@ func TestUpdatePackages(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
 	if err != nil {
 		t.Fatalf("unexpected error checking package count: %s", err)
 	}
@@ -116,11 +116,11 @@ func TestUpdatePackagesEmpty(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	if err := db.UpdatePackages(context.Background(), nil, nil); err != nil {
+	if err := db.UpdatePackages(context.Background(), nil); err != nil {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
 	if err != nil {
 		t.Fatalf("unexpected error checking package count: %s", err)
 	}
@@ -137,9 +137,9 @@ func TestUpdatePackagesWithConflicts(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// for foreign key relation
-	insertUploads(t, db.db, Upload{ID: 42})
+	insertUploads(t, dbconn.Global, Upload{ID: 42})
 
-	if err := db.UpdatePackages(context.Background(), nil, []types.Package{
+	if err := db.UpdatePackages(context.Background(), []types.Package{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"},
 		{DumpID: 42, Scheme: "s1", Name: "n1", Version: "v1"},
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"},
@@ -148,7 +148,7 @@ func TestUpdatePackagesWithConflicts(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	if err := db.UpdatePackages(context.Background(), nil, []types.Package{
+	if err := db.UpdatePackages(context.Background(), []types.Package{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"}, // duplicate
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"}, // duplicate
 		{DumpID: 42, Scheme: "s4", Name: "n4", Version: "v4"},
@@ -161,7 +161,7 @@ func TestUpdatePackagesWithConflicts(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_packages"))
 	if err != nil {
 		t.Fatalf("unexpected error checking package count: %s", err)
 	}

--- a/internal/codeintel/db/references.go
+++ b/internal/codeintel/db/references.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
@@ -11,24 +10,25 @@ import (
 // SameRepoPager returns a ReferencePager for dumps that belong to the given repository and commit and reference the package with the
 // given scheme, name, and version.
 func (db *dbImpl) SameRepoPager(ctx context.Context, repositoryID int, commit, scheme, name, version string, limit int) (_ int, _ ReferencePager, err error) {
-	tw, err := db.beginTx(ctx)
-	if err != nil {
-		return 0, nil, err
-	}
-	defer func() {
-		if err != nil {
-			err = closeTx(tw.tx, err)
-		}
-	}()
-
-	visibleIDsQuery := `SELECT id FROM visible_ids`
-	visibleIDs, err := scanInts(tw.query(ctx, withBidirectionalLineage(visibleIDsQuery, repositoryID, commit)))
+	tx, started, err := db.transact(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
 
+	done := noopDoneFn
+	if started {
+		done = tx.Done
+	}
+
+	visibleIDs, err := scanInts(tx.query(
+		ctx,
+		withBidirectionalLineage(`SELECT id FROM visible_ids`, repositoryID, commit),
+	))
+	if err != nil {
+		return 0, nil, done(err)
+	}
 	if len(visibleIDs) == 0 {
-		return 0, newEmptyReferencePager(tw.tx), nil
+		return 0, newReferencePager(noopPageFromOffsetFn, done), nil
 	}
 
 	conds := []*sqlf.Query{
@@ -38,38 +38,41 @@ func (db *dbImpl) SameRepoPager(ctx context.Context, repositoryID int, commit, s
 		sqlf.Sprintf("r.dump_id IN (%s)", sqlf.Join(intsToQueries(visibleIDs), ", ")),
 	}
 
-	countQuery := `SELECT COUNT(1) FROM lsif_references r WHERE %s`
-	totalCount, err := scanInt(tw.queryRow(ctx, sqlf.Sprintf(countQuery, sqlf.Join(conds, " AND "))))
+	totalCount, _, err := scanFirstInt(tx.query(
+		ctx,
+		sqlf.Sprintf(`SELECT COUNT(1) FROM lsif_references r WHERE %s`, sqlf.Join(conds, " AND ")),
+	))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, done(err)
 	}
 
-	pageFromOffset := func(offset int) ([]types.PackageReference, error) {
-		query := `
-			SELECT d.id, r.scheme, r.name, r.version, r.filter FROM lsif_references r
-			LEFT JOIN lsif_dumps d on r.dump_id = d.id
-			WHERE %s ORDER BY d.root LIMIT %d OFFSET %d
-		`
-
-		return scanPackageReferences(tw.query(ctx, sqlf.Sprintf(query, sqlf.Join(conds, " AND "), limit, offset)))
+	pageFromOffset := func(ctx context.Context, offset int) ([]types.PackageReference, error) {
+		return scanPackageReferences(tx.query(
+			ctx,
+			sqlf.Sprintf(`
+				SELECT d.id, r.scheme, r.name, r.version, r.filter FROM lsif_references r
+				LEFT JOIN lsif_dumps d on r.dump_id = d.id
+				WHERE %s ORDER BY d.root LIMIT %d OFFSET %d
+			`, sqlf.Join(conds, " AND "), limit, offset),
+		))
 	}
 
-	return totalCount, newReferencePager(tw.tx, pageFromOffset), nil
+	return totalCount, newReferencePager(pageFromOffset, done), nil
 }
 
 // PackageReferencePager returns a ReferencePager for dumps that belong to a remote repository (distinct from the given repository id)
 // and reference the package with the given scheme, name, and version. All resulting dumps are visible at the tip of their repository's
 // default branch.
 func (db *dbImpl) PackageReferencePager(ctx context.Context, scheme, name, version string, repositoryID, limit int) (_ int, _ ReferencePager, err error) {
-	tw, err := db.beginTx(ctx)
+	tx, started, err := db.transact(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
-	defer func() {
-		if err != nil {
-			err = closeTx(tw.tx, err)
-		}
-	}()
+
+	done := noopDoneFn
+	if started {
+		done = tx.Done
+	}
 
 	conds := []*sqlf.Query{
 		sqlf.Sprintf("r.scheme = %s", scheme),
@@ -79,57 +82,42 @@ func (db *dbImpl) PackageReferencePager(ctx context.Context, scheme, name, versi
 		sqlf.Sprintf("d.visible_at_tip = true"),
 	}
 
-	countQuery := `
-		SELECT COUNT(1) FROM lsif_references r
-		LEFT JOIN lsif_dumps d ON r.dump_id = d.id
-		WHERE %s
-	`
-
-	totalCount, err := scanInt(tw.queryRow(ctx, sqlf.Sprintf(countQuery, sqlf.Join(conds, " AND "))))
+	totalCount, _, err := scanFirstInt(tx.query(
+		ctx,
+		sqlf.Sprintf(`
+			SELECT COUNT(1) FROM lsif_references r
+			LEFT JOIN lsif_dumps d ON r.dump_id = d.id
+			WHERE %s
+		`, sqlf.Join(conds, " AND ")),
+	))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, done(err)
 	}
 
-	pageFromOffset := func(offset int) ([]types.PackageReference, error) {
-		query := `
+	pageFromOffset := func(ctx context.Context, offset int) ([]types.PackageReference, error) {
+		return scanPackageReferences(tx.query(ctx, sqlf.Sprintf(`
 			SELECT d.id, r.scheme, r.name, r.version, r.filter FROM lsif_references r
 			LEFT JOIN lsif_dumps d ON r.dump_id = d.id
 			WHERE %s ORDER BY d.repository_id, d.root LIMIT %d OFFSET %d
-		`
-
-		return scanPackageReferences(tw.query(ctx, sqlf.Sprintf(query, sqlf.Join(conds, " AND "), limit, offset)))
+		`, sqlf.Join(conds, " AND "), limit, offset)))
 	}
 
-	return totalCount, newReferencePager(tw.tx, pageFromOffset), nil
+	return totalCount, newReferencePager(pageFromOffset, done), nil
 }
 
 // UpdatePackageReferences inserts reference data tied to the given upload.
-func (db *dbImpl) UpdatePackageReferences(ctx context.Context, tx *sql.Tx, references []types.PackageReference) (err error) {
+func (db *dbImpl) UpdatePackageReferences(ctx context.Context, references []types.PackageReference) (err error) {
 	if len(references) == 0 {
 		return nil
 	}
-
-	if tx == nil {
-		tx, err = db.db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			err = closeTx(tx, err)
-		}()
-	}
-	tw := &transactionWrapper{tx}
-
-	query := `
-		INSERT INTO lsif_references (dump_id, scheme, name, version, filter)
-		VALUES %s
-	`
 
 	var values []*sqlf.Query
 	for _, r := range references {
 		values = append(values, sqlf.Sprintf("(%s, %s, %s, %s, %s)", r.DumpID, r.Scheme, r.Name, r.Version, r.Filter))
 	}
 
-	_, err = tw.exec(ctx, sqlf.Sprintf(query, sqlf.Join(values, ",")))
-	return err
+	return db.exec(ctx, sqlf.Sprintf(`
+		INSERT INTO lsif_references (dump_id, scheme, name, version, filter)
+		VALUES %s
+	`, sqlf.Join(values, ",")))
 }

--- a/internal/codeintel/db/references_test.go
+++ b/internal/codeintel/db/references_test.go
@@ -17,7 +17,7 @@ func TestSameRepoPager(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(2), Root: "sub1/"},
 		Upload{ID: 2, Commit: makeCommit(3), Root: "sub2/"},
 		Upload{ID: 3, Commit: makeCommit(4), Root: "sub3/"},
@@ -34,7 +34,7 @@ func TestSameRepoPager(t *testing.T) {
 	}
 	insertPackageReferences(t, db, expected)
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 		makeCommit(2): {makeCommit(1)},
 		makeCommit(3): {makeCommit(2)},
@@ -47,13 +47,13 @@ func TestSameRepoPager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 5 {
 		t.Errorf("unexpected dump. want=%d have=%d", 5, totalCount)
 	}
 
-	if references, err := pager.PageFromOffset(0); err != nil {
+	if references, err := pager.PageFromOffset(context.Background(), 0); err != nil {
 		t.Fatalf("unexpected error getting next page: %s", err)
 	} else if diff := cmp.Diff(expected, references); diff != "" {
 		t.Errorf("unexpected references (-want +got):\n%s", diff)
@@ -71,7 +71,7 @@ func TestSameRepoPagerEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 0 {
 		t.Errorf("unexpected dump. want=%d have=%d", 0, totalCount)
@@ -85,7 +85,7 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(1), Root: "sub1/"},
 		Upload{ID: 2, Commit: makeCommit(1), Root: "sub2/"},
 		Upload{ID: 3, Commit: makeCommit(1), Root: "sub3/"},
@@ -110,7 +110,7 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 	}
 	insertPackageReferences(t, db, expected)
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 	}); err != nil {
 		t.Fatalf("unexpected error updating commits: %s", err)
@@ -120,7 +120,7 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 9 {
 		t.Errorf("unexpected dump. want=%d have=%d", 9, totalCount)
@@ -132,7 +132,7 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 			hi = len(expected)
 		}
 
-		if references, err := pager.PageFromOffset(lo); err != nil {
+		if references, err := pager.PageFromOffset(context.Background(), lo); err != nil {
 			t.Fatalf("unexpected error getting page at offset %d: %s", lo, err)
 		} else if diff := cmp.Diff(expected[lo:hi], references); diff != "" {
 			t.Errorf("unexpected references at offset %d (-want +got):\n%s", lo, diff)
@@ -147,7 +147,7 @@ func TestSameRepoPagerVisibility(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(1), Root: "sub1/"}, // not visible
 		Upload{ID: 2, Commit: makeCommit(2), Root: "sub2/"}, // not visible
 		Upload{ID: 3, Commit: makeCommit(3), Root: "sub1/"},
@@ -165,7 +165,7 @@ func TestSameRepoPagerVisibility(t *testing.T) {
 		{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f2")},
 	}, expected...))
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 		makeCommit(2): {makeCommit(1)},
 		makeCommit(3): {makeCommit(2)},
@@ -180,13 +180,13 @@ func TestSameRepoPagerVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 3 {
 		t.Errorf("unexpected dump. want=%d have=%d", 5, totalCount)
 	}
 
-	if references, err := pager.PageFromOffset(0); err != nil {
+	if references, err := pager.PageFromOffset(context.Background(), 0); err != nil {
 		t.Fatalf("unexpected error getting next page: %s", err)
 	} else if diff := cmp.Diff(expected, references); diff != "" {
 		t.Errorf("unexpected references (-want +got):\n%s", diff)
@@ -200,7 +200,7 @@ func TestPackageReferencePager(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(1), VisibleAtTip: true},
 		Upload{ID: 2, Commit: makeCommit(2), VisibleAtTip: true, RepositoryID: 51},
 		Upload{ID: 3, Commit: makeCommit(3), VisibleAtTip: true, RepositoryID: 52},
@@ -226,13 +226,13 @@ func TestPackageReferencePager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 5 {
 		t.Errorf("unexpected dump. want=%d have=%d", 5, totalCount)
 	}
 
-	if references, err := pager.PageFromOffset(0); err != nil {
+	if references, err := pager.PageFromOffset(context.Background(), 0); err != nil {
 		t.Fatalf("unexpected error getting next page: %s", err)
 	} else if diff := cmp.Diff(expected, references); diff != "" {
 		t.Errorf("unexpected references (-want +got):\n%s", diff)
@@ -250,7 +250,7 @@ func TestPackageReferencePagerEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 0 {
 		t.Errorf("unexpected dump. want=%d have=%d", 0, totalCount)
@@ -264,7 +264,7 @@ func TestPackageReferencePagerPages(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(1), VisibleAtTip: true, RepositoryID: 51},
 		Upload{ID: 2, Commit: makeCommit(2), VisibleAtTip: true, RepositoryID: 52},
 		Upload{ID: 3, Commit: makeCommit(3), VisibleAtTip: true, RepositoryID: 53},
@@ -293,7 +293,7 @@ func TestPackageReferencePagerPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting pager: %s", err)
 	}
-	defer func() { _ = pager.CloseTx(nil) }()
+	defer func() { _ = pager.Done(nil) }()
 
 	if totalCount != 9 {
 		t.Errorf("unexpected dump. want=%d have=%d", 9, totalCount)
@@ -316,7 +316,7 @@ func TestPackageReferencePagerPages(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if references, err := pager.PageFromOffset(testCase.offset); err != nil {
+		if references, err := pager.PageFromOffset(context.Background(), testCase.offset); err != nil {
 			t.Fatalf("unexpected error getting page at offset %d: %s", testCase.offset, err)
 		} else if diff := cmp.Diff(expected[testCase.lo:testCase.hi], references); diff != "" {
 			t.Errorf("unexpected references at offset %d (-want +got):\n%s", testCase.offset, diff)
@@ -332,9 +332,9 @@ func TestUpdatePackageReferences(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// for foreign key relation
-	insertUploads(t, db.db, Upload{ID: 42})
+	insertUploads(t, dbconn.Global, Upload{ID: 42})
 
-	if err := db.UpdatePackageReferences(context.Background(), nil, []types.PackageReference{
+	if err := db.UpdatePackageReferences(context.Background(), []types.PackageReference{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"},
 		{DumpID: 42, Scheme: "s1", Name: "n1", Version: "v1"},
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"},
@@ -349,7 +349,7 @@ func TestUpdatePackageReferences(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_references"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}
@@ -365,11 +365,11 @@ func TestUpdatePackageReferencesEmpty(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	if err := db.UpdatePackageReferences(context.Background(), nil, nil); err != nil {
+	if err := db.UpdatePackageReferences(context.Background(), nil); err != nil {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_references"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}
@@ -386,9 +386,9 @@ func TestUpdatePackageReferencesWithDuplicates(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// for foreign key relation
-	insertUploads(t, db.db, Upload{ID: 42})
+	insertUploads(t, dbconn.Global, Upload{ID: 42})
 
-	if err := db.UpdatePackageReferences(context.Background(), nil, []types.PackageReference{
+	if err := db.UpdatePackageReferences(context.Background(), []types.PackageReference{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"},
 		{DumpID: 42, Scheme: "s1", Name: "n1", Version: "v1"},
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"},
@@ -397,7 +397,7 @@ func TestUpdatePackageReferencesWithDuplicates(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	if err := db.UpdatePackageReferences(context.Background(), nil, []types.PackageReference{
+	if err := db.UpdatePackageReferences(context.Background(), []types.PackageReference{
 		{DumpID: 42, Scheme: "s0", Name: "n0", Version: "v0"}, // two copies
 		{DumpID: 42, Scheme: "s2", Name: "n2", Version: "v2"}, // two copies
 		{DumpID: 42, Scheme: "s4", Name: "n4", Version: "v4"},
@@ -410,7 +410,7 @@ func TestUpdatePackageReferencesWithDuplicates(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, err := scanInt(db.db.QueryRow("SELECT COUNT(*) FROM lsif_references"))
+	count, err := scanInt(dbconn.Global.QueryRow("SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}

--- a/internal/codeintel/db/repos.go
+++ b/internal/codeintel/db/repos.go
@@ -4,10 +4,24 @@ import (
 	"context"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
 )
 
-// RepoName returns the name for the repo with the given identfier. This is the only method
+// ErrUnknownRepository occurs when a repository does not exist.
+var ErrUnknownRepository = errors.New("unknown repository")
+
+// RepoName returns the name for the repo with the given identifier. This is the only method
 // in this package that touches any table that does not start with `lsif_`.
 func (db *dbImpl) RepoName(ctx context.Context, repositoryID int) (string, error) {
-	return scanString(db.queryRow(ctx, sqlf.Sprintf(`SELECT name FROM repo WHERE id = %s`, repositoryID)))
+	name, exists, err := scanFirstString(db.query(
+		ctx,
+		sqlf.Sprintf(`SELECT name FROM repo WHERE id = %s`, repositoryID),
+	))
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", ErrUnknownRepository
+	}
+	return name, nil
 }

--- a/internal/codeintel/db/repos_test.go
+++ b/internal/codeintel/db/repos_test.go
@@ -15,7 +15,7 @@ func TestRepoName(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	if _, err := db.db.Exec(`INSERT INTO repo (id, name) VALUES (50, 'github.com/foo/bar')`); err != nil {
+	if _, err := dbconn.Global.Exec(`INSERT INTO repo (id, name) VALUES (50, 'github.com/foo/bar')`); err != nil {
 		t.Fatalf("unexpected error inserting repo: %s", err)
 	}
 

--- a/internal/codeintel/db/tx.go
+++ b/internal/codeintel/db/tx.go
@@ -2,54 +2,70 @@ package db
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
-// TxCloser is a convenience wrapper for closing SQL transactions.
-type TxCloser interface {
-	// CloseTx commits the transaction on a nil error value and performs a rollback
-	// otherwise. If an error occurs during commit or rollback of the transaction,
-	// the error is added to the resulting error value.
-	CloseTx(err error) error
+// DoneFn is the function type of DB's Done method.
+type DoneFn func(err error) error
+
+// noopDoneFn is a behaviorless DoneFn.
+func noopDoneFn(err error) error {
+	return err
 }
 
-type txCloser struct {
-	tx *sql.Tx
+// ErrNotTransactable occurs when Transact is called on a Database whose underlying
+// db handle does not support beginning a transaction.
+var ErrNotTransactable = errors.New("db: not transactable")
+
+// Transact returns a Database whose methods operate within the context of a transaction.
+// This method will return an error if the underlying DB cannot be interface upgraded
+// to a TxBeginner.
+func (db *dbImpl) Transact(ctx context.Context) (DB, error) {
+	tx, _, err := db.transact(ctx)
+	return tx, err
 }
 
-func (txc *txCloser) CloseTx(err error) error {
-	return closeTx(txc.tx, err)
-}
-
-func closeTx(tx *sql.Tx, err error) error {
-	if err != nil {
-		if rollErr := tx.Rollback(); rollErr != nil {
-			err = multierror.Append(err, rollErr)
-		}
-		return err
+// transact returns a Database whose methods operate within the context of a transaction.
+// This method also returns a boolean flag indicating whether a new transaction was created.
+func (db *dbImpl) transact(ctx context.Context) (*dbImpl, bool, error) {
+	if _, ok := db.db.(dbutil.Tx); ok {
+		// Already in a Tx
+		return db, false, nil
 	}
 
-	return tx.Commit()
+	tb, ok := db.db.(dbutil.TxBeginner)
+	if !ok {
+		// Not a Tx nor a TxBeginner
+		return nil, false, ErrNotTransactable
+	}
+
+	tx, err := tb.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "db: BeginTx")
+	}
+
+	return &dbImpl{db: tx}, true, nil
 }
 
-type transactionWrapper struct {
-	tx *sql.Tx
-}
+// Done commits underlying the transaction on a nil error value and performs a rollback
+// otherwise. If an error occurs during commit or rollback of the transaction, the error
+// is added to the resulting error value. If the Database does not wrap a transaction the
+// original error value is returned unchanged.
+func (db *dbImpl) Done(err error) error {
+	if tx, ok := db.db.(dbutil.Tx); ok {
+		if err != nil {
+			if rollErr := tx.Rollback(); rollErr != nil {
+				err = multierror.Append(err, rollErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = multierror.Append(err, commitErr)
+			}
+		}
+	}
 
-// query performs QueryContext on the underlying transaction.
-func (tw *transactionWrapper) query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error) {
-	return tw.tx.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-}
-
-// queryRow performs QueryRow on the underlying transaction.
-func (tw *transactionWrapper) queryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
-	return tw.tx.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-}
-
-// exec performs Exec on the underlying transaction.
-func (tw *transactionWrapper) exec(ctx context.Context, query *sqlf.Query) (sql.Result, error) {
-	return tw.tx.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	return err
 }

--- a/internal/codeintel/db/uploads.go
+++ b/internal/codeintel/db/uploads.go
@@ -2,17 +2,11 @@ package db
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
 )
-
-// StalledUploadMaxAge is the maximum allowable duration between updating the state of an
-// upload as "processing" and locking the upload row during processing. An unlocked row that
-// is marked as processing likely indicates that the worker that dequeued the upload has died.
-// There should be a nearly-zero delay between these states during normal operation.
-const StalledUploadMaxAge = time.Second * 5
 
 // Upload is a subset of the lsif_uploads table and stores both processed and unprocessed
 // records.
@@ -35,7 +29,7 @@ type Upload struct {
 
 // GetUploadByID returns an upload by its identifier and boolean flag indicating its existence.
 func (db *dbImpl) GetUploadByID(ctx context.Context, id int) (Upload, bool, error) {
-	query := `
+	return scanFirstUpload(db.query(ctx, sqlf.Sprintf(`
 		SELECT
 			u.id,
 			u.commit,
@@ -59,71 +53,68 @@ func (db *dbImpl) GetUploadByID(ctx context.Context, id int) (Upload, bool, erro
 		) s
 		ON u.id = s.id
 		WHERE u.id = %s
-	`
-
-	upload, err := scanUpload(db.queryRow(ctx, sqlf.Sprintf(query, id)))
-	if err != nil {
-		return Upload{}, false, ignoreErrNoRows(err)
-	}
-
-	return upload, true, nil
+	`, id)))
 }
 
 // GetUploadsByRepo returns a list of uploads for a particular repo and the total count of records matching the given conditions.
 func (db *dbImpl) GetUploadsByRepo(ctx context.Context, repositoryID int, state, term string, visibleAtTip bool, limit, offset int) (_ []Upload, _ int, err error) {
-	tw, err := db.beginTx(ctx)
+	tx, started, err := db.transact(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() {
-		err = closeTx(tw.tx, err)
-	}()
+	if started {
+		defer func() { err = tx.Done(err) }()
+	}
 
-	var conds []*sqlf.Query
-	conds = append(conds, sqlf.Sprintf("u.repository_id = %s", repositoryID))
-	if state != "" {
-		conds = append(conds, sqlf.Sprintf("u.state = %s", state))
+	conds := []*sqlf.Query{
+		sqlf.Sprintf("u.repository_id = %s", repositoryID),
 	}
 	if term != "" {
 		conds = append(conds, makeSearchCondition(term))
+	}
+	if state != "" {
+		conds = append(conds, sqlf.Sprintf("u.state = %s", state))
 	}
 	if visibleAtTip {
 		conds = append(conds, sqlf.Sprintf("u.visible_at_tip = true"))
 	}
 
-	countQuery := `SELECT COUNT(1) FROM lsif_uploads u WHERE %s`
-	count, err := scanInt(tw.queryRow(ctx, sqlf.Sprintf(countQuery, sqlf.Join(conds, " AND "))))
+	count, _, err := scanFirstInt(tx.query(
+		ctx,
+		sqlf.Sprintf(`SELECT COUNT(1) FROM lsif_uploads u WHERE %s`, sqlf.Join(conds, " AND ")),
+	))
 	if err != nil {
 		return nil, 0, err
 	}
 
-	query := `
-		SELECT
-			u.id,
-			u.commit,
-			u.root,
-			u.visible_at_tip,
-			u.uploaded_at,
-			u.state,
-			u.failure_summary,
-			u.failure_stacktrace,
-			u.started_at,
-			u.finished_at,
-			u.tracing_context,
-			u.repository_id,
-			u.indexer,
-			s.rank
-		FROM lsif_uploads u
-		LEFT JOIN (
-			SELECT r.id, RANK() OVER (ORDER BY r.uploaded_at) as rank
-			FROM lsif_uploads r
-			WHERE r.state = 'queued'
-		) s
-		ON u.id = s.id
-		WHERE %s ORDER BY uploaded_at DESC LIMIT %d OFFSET %d
-	`
-
-	uploads, err := scanUploads(tw.query(ctx, sqlf.Sprintf(query, sqlf.Join(conds, " AND "), limit, offset)))
+	uploads, err := scanUploads(tx.query(
+		ctx,
+		sqlf.Sprintf(`
+			SELECT
+				u.id,
+				u.commit,
+				u.root,
+				u.visible_at_tip,
+				u.uploaded_at,
+				u.state,
+				u.failure_summary,
+				u.failure_stacktrace,
+				u.started_at,
+				u.finished_at,
+				u.tracing_context,
+				u.repository_id,
+				u.indexer,
+				s.rank
+			FROM lsif_uploads u
+			LEFT JOIN (
+				SELECT r.id, RANK() OVER (ORDER BY r.uploaded_at) as rank
+				FROM lsif_uploads r
+				WHERE r.state = 'queued'
+			) s
+			ON u.id = s.id
+			WHERE %s ORDER BY uploaded_at DESC LIMIT %d OFFSET %d
+		`, sqlf.Join(conds, " AND "), limit, offset),
+	))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -149,53 +140,44 @@ func makeSearchCondition(term string) *sqlf.Query {
 	return sqlf.Sprintf("(%s)", sqlf.Join(termConds, " OR "))
 }
 
-// Enqueue inserts a new upload with a "queued" state, returning its identifier and a TxCloser that must be closed to commit the transaction.
-func (db *dbImpl) Enqueue(ctx context.Context, commit, root, tracingContext string, repositoryID int, indexerName string) (_ int, _ TxCloser, err error) {
-	tw, err := db.beginTx(ctx)
+// Enqueue inserts a new upload with a "queued" state and returns its identifier.
+func (db *dbImpl) Enqueue(ctx context.Context, commit, root, tracingContext string, repositoryID int, indexerName string) (int, error) {
+	id, _, err := scanFirstInt(db.query(
+		ctx,
+		sqlf.Sprintf(`
+			INSERT INTO lsif_uploads (commit, root, tracing_context, repository_id, indexer)
+			VALUES (%s, %s, %s, %s, %s)
+			RETURNING id
+		`, commit, root, tracingContext, repositoryID, indexerName),
+	))
 	if err != nil {
-		return 0, nil, err
+		return 0, err
 	}
-	defer func() {
-		if err != nil {
-			err = closeTx(tw.tx, err)
-		}
-	}()
-
-	query := `
-		INSERT INTO lsif_uploads (commit, root, tracing_context, repository_id, indexer)
-		VALUES (%s, %s, %s, %s, %s)
-		RETURNING id
-	`
-
-	id, err := scanInt(tw.queryRow(ctx, sqlf.Sprintf(query, commit, root, tracingContext, repositoryID, indexerName)))
-	if err != nil {
-		return 0, nil, err
-	}
-
-	return id, &txCloser{tw.tx}, nil
+	return id, nil
 }
+
+// ErrDequeueTransaction occurs when Dequeue is called from inside a transaction.
+var ErrDequeueTransaction = errors.New("unexpected transaction")
 
 // Dequeue selects the oldest queued upload and locks it with a transaction. If there is such an upload, the
 // upload is returned along with a JobHandle instance which wraps the transaction. This handle must be closed.
-// If there is no such unlocked upload, a zero-value upload and nil-job handle will be returned alogn with a
-// false-valued flag.
+// If there is no such unlocked upload, a zero-value upload and nil-job handle will be returned along with a
+// false-valued flag. This method must not be called from within a transaction.
 func (db *dbImpl) Dequeue(ctx context.Context) (Upload, JobHandle, bool, error) {
-	selectionQuery := `
-		UPDATE lsif_uploads u SET state = 'processing', started_at = now() WHERE id = (
-			SELECT id FROM lsif_uploads
-			WHERE state = 'queued'
-			ORDER BY uploaded_at
-			FOR UPDATE SKIP LOCKED LIMIT 1
-		)
-		RETURNING u.id
-	`
-
 	for {
 		// First, we try to select an eligible upload record outside of a transaction. This will skip
 		// any rows that are currently locked inside of a transaction of another worker process.
-		id, err := scanInt(db.queryRow(ctx, sqlf.Sprintf(selectionQuery)))
-		if err != nil {
-			return Upload{}, nil, false, ignoreErrNoRows(err)
+		id, ok, err := scanFirstInt(db.query(ctx, sqlf.Sprintf(`
+			UPDATE lsif_uploads u SET state = 'processing', started_at = now() WHERE id = (
+				SELECT id FROM lsif_uploads
+				WHERE state = 'queued'
+				ORDER BY uploaded_at
+				FOR UPDATE SKIP LOCKED LIMIT 1
+			)
+			RETURNING u.id
+		`)))
+		if err != nil || !ok {
+			return Upload{}, nil, false, err
 		}
 
 		upload, jobHandle, ok, err := db.dequeue(ctx, id)
@@ -203,7 +185,7 @@ func (db *dbImpl) Dequeue(ctx context.Context) (Upload, JobHandle, bool, error) 
 			// This will occur if we selected an ID that raced with another worker. If both workers
 			// select the same ID and the other process begins its transaction first, this condition
 			// will occur. We'll re-try the process by selecting a fresh ID.
-			if err == sql.ErrNoRows {
+			if err == ErrDequeueRace {
 				continue
 			}
 
@@ -214,99 +196,113 @@ func (db *dbImpl) Dequeue(ctx context.Context) (Upload, JobHandle, bool, error) 
 	}
 }
 
+// ErrDequeueRace occurs when an upload selected for dequeue has been locked by another worker.
+var ErrDequeueRace = errors.New("unexpected transaction")
+
 // dequeue begins a transaction to lock an upload record for updating. This marks the upload as
-// uneligible for a dequeue to other worker processes. All updates to the database while this record
+// ineligible for a dequeue to other worker processes. All updates to the database while this record
 // is being processes should happen through the JobHandle's transaction, which must be explicitly
 // closed (via CloseTx) at the end of processing by the caller.
 func (db *dbImpl) dequeue(ctx context.Context, id int) (_ Upload, _ JobHandle, _ bool, err error) {
-	tw, err := db.beginTx(ctx)
+	tx, started, err := db.transact(ctx)
 	if err != nil {
 		return Upload{}, nil, false, err
 	}
-	defer func() {
-		if err != nil {
-			err = closeTx(tw.tx, err)
-		}
-	}()
+	if !started {
+		return Upload{}, nil, false, ErrDequeueTransaction
+	}
 
 	// SKIP LOCKED is necessary not to block on this select. We allow the database driver to return
 	// sql.ErrNoRows on this condition so we can determine if we need to select a new upload to process
 	// on race conditions with other worker processes.
-	fetchQuery := `SELECT u.*, NULL FROM lsif_uploads u WHERE id = %s FOR UPDATE SKIP LOCKED LIMIT 1`
-
-	upload, err := scanUpload(tw.queryRow(ctx, sqlf.Sprintf(fetchQuery, id)))
+	upload, exists, err := scanFirstUpload(tx.query(
+		ctx,
+		sqlf.Sprintf(`
+			SELECT u.*, NULL FROM lsif_uploads u
+			WHERE id = %s
+			FOR UPDATE SKIP LOCKED
+			LIMIT 1
+		`, id),
+	))
 	if err != nil {
-		return Upload{}, nil, false, err
+		return Upload{}, nil, false, tx.Done(err)
 	}
-
-	jobHandle := &jobHandleImpl{
-		ctx:      ctx,
-		id:       id,
-		tw:       tw,
-		txCloser: &txCloser{tw.tx},
+	if !exists {
+		return Upload{}, nil, false, tx.Done(ErrDequeueRace)
 	}
-
-	return upload, jobHandle, true, nil
+	return upload, &jobHandleImpl{db: tx, id: id}, true, nil
 }
 
 // GetStates returns the states for the uploads with the given identifiers.
 func (db *dbImpl) GetStates(ctx context.Context, ids []int) (map[int]string, error) {
-	query := `SELECT id, state FROM lsif_uploads WHERE id IN (%s)`
-	return scanStates(db.query(ctx, sqlf.Sprintf(query, sqlf.Join(intsToQueries(ids), ", "))))
+	return scanStates(db.query(ctx, sqlf.Sprintf(`
+		SELECT id, state FROM lsif_uploads
+		WHERE id IN (%s)
+	`, sqlf.Join(intsToQueries(ids), ", "))))
 }
 
 // DeleteUploadByID deletes an upload by its identifier. If the upload was visible at the tip of its repository's default branch,
 // the visibility of all uploads for that repository are recalculated. The given function is expected to return the newest commit
 // on the default branch when invoked.
-func (db *dbImpl) DeleteUploadByID(ctx context.Context, id int, getTipCommit func(repositoryID int) (string, error)) (_ bool, err error) {
-	tw, err := db.beginTx(ctx)
+func (db *dbImpl) DeleteUploadByID(ctx context.Context, id int, getTipCommit GetTipCommitFn) (_ bool, err error) {
+	tx, started, err := db.transact(ctx)
 	if err != nil {
 		return false, err
 	}
-	defer func() {
-		err = closeTx(tw.tx, err)
-	}()
-
-	query := `
-		DELETE FROM lsif_uploads
-		WHERE id = %s
-		RETURNING repository_id, visible_at_tip
-	`
-
-	repositoryID, visibleAtTip, err := scanVisibility(tw.queryRow(ctx, sqlf.Sprintf(query, id)))
-	if err != nil {
-		return false, ignoreErrNoRows(err)
+	if started {
+		defer func() { err = tx.Done(err) }()
 	}
 
-	if !visibleAtTip {
+	visibilities, err := scanVisibilities(tx.query(
+		ctx,
+		sqlf.Sprintf(`
+			DELETE FROM lsif_uploads
+			WHERE id = %s
+			RETURNING repository_id, visible_at_tip
+		`, id),
+	))
+	if err != nil {
+		return false, err
+	}
+
+	for repositoryID, visibleAtTip := range visibilities {
+		if visibleAtTip {
+			tipCommit, err := getTipCommit(repositoryID)
+			if err != nil {
+				return false, err
+			}
+
+			if err := tx.UpdateDumpsVisibleFromTip(ctx, repositoryID, tipCommit); err != nil {
+				return false, err
+			}
+		}
+
 		return true, nil
 	}
 
-	tipCommit, err := getTipCommit(repositoryID)
-	if err != nil {
-		return false, err
-	}
-
-	if err := db.UpdateDumpsVisibleFromTip(ctx, tw.tx, repositoryID, tipCommit); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return false, nil
 }
+
+// StalledUploadMaxAge is the maximum allowable duration between updating the state of an
+// upload as "processing" and locking the upload row during processing. An unlocked row that
+// is marked as processing likely indicates that the worker that dequeued the upload has died.
+// There should be a nearly-zero delay between these states during normal operation.
+const StalledUploadMaxAge = time.Second * 5
 
 // ResetStalled moves all unlocked uploads processing for more than `StalledUploadMaxAge` back to the queued state.
 // This method returns a list of updated upload identifiers.
 func (db *dbImpl) ResetStalled(ctx context.Context, now time.Time) ([]int, error) {
-	query := `
-		UPDATE lsif_uploads u SET state = 'queued', started_at = null WHERE id = ANY(
-			SELECT id FROM lsif_uploads
-			WHERE state = 'processing' AND %s - started_at > (%s * interval '1 second')
-			FOR UPDATE SKIP LOCKED
-		)
-		RETURNING u.id
-	`
-
-	ids, err := scanInts(db.query(ctx, sqlf.Sprintf(query, now.UTC(), StalledUploadMaxAge/time.Second)))
+	ids, err := scanInts(db.query(
+		ctx,
+		sqlf.Sprintf(`
+			UPDATE lsif_uploads u SET state = 'queued', started_at = null WHERE id = ANY(
+				SELECT id FROM lsif_uploads
+				WHERE state = 'processing' AND %s - started_at > (%s * interval '1 second')
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING u.id
+		`, now.UTC(), StalledUploadMaxAge/time.Second),
+	))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/db/uploads_test.go
+++ b/internal/codeintel/db/uploads_test.go
@@ -2,13 +2,12 @@ package db
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
@@ -55,7 +54,7 @@ func TestGetUploadByID(t *testing.T) {
 		Rank:              nil,
 	}
 
-	insertUploads(t, db.db, expected)
+	insertUploads(t, dbconn.Global, expected)
 
 	if upload, exists, err := db.GetUploadByID(context.Background(), 1); err != nil {
 		t.Fatalf("unexpected error getting upload: %s", err)
@@ -80,7 +79,7 @@ func TestGetQueuedUploadRank(t *testing.T) {
 	t5 := t1.Add(+time.Minute * 4)
 	t6 := t1.Add(+time.Minute * 2)
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, UploadedAt: t1, State: "queued"},
 		Upload{ID: 2, UploadedAt: t2, State: "queued"},
 		Upload{ID: 3, UploadedAt: t3, State: "queued"},
@@ -130,7 +129,7 @@ func TestGetUploadsByRepo(t *testing.T) {
 	t10 := t1.Add(-time.Minute * 9)
 	failureSummary := "unlucky 333"
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(3331), UploadedAt: t1, Root: "sub1/", State: "queued"},
 		Upload{ID: 2, UploadedAt: t2, VisibleAtTip: true, State: "errored", FailureSummary: &failureSummary, Indexer: "lsif-tsc"},
 		Upload{ID: 3, Commit: makeCommit(3333), UploadedAt: t3, Root: "sub2/", State: "queued"},
@@ -196,20 +195,10 @@ func TestEnqueue(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	id, closer, err := db.Enqueue(context.Background(), makeCommit(1), "sub/", `{"id": 42}`, 50, "lsif-go")
+	id, err := db.Enqueue(context.Background(), makeCommit(1), "sub/", `{"id": 42}`, 50, "lsif-go")
 	if err != nil {
 		t.Fatalf("unexpected error enqueueing upload: %s", err)
 	}
-
-	// Upload does not exist before transaction commit
-	if _, exists, err := db.GetUploadByID(context.Background(), id); err != nil {
-		t.Fatalf("unexpected error getting upload: %s", err)
-	} else if exists {
-		t.Fatal("unexpected record")
-	}
-
-	// Commit transaction
-	_ = closer.CloseTx(nil)
 
 	rank := 1
 	expected := Upload{
@@ -243,27 +232,6 @@ func TestEnqueue(t *testing.T) {
 	}
 }
 
-func TestEnqueueRollback(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	dbtesting.SetupGlobalTestDB(t)
-	db := &dbImpl{db: dbconn.Global}
-
-	id, closer, err := db.Enqueue(context.Background(), makeCommit(1), "sub/", `{"id": 42}`, 50, "lsif-go")
-	if err != nil {
-		t.Fatalf("unexpected error enqueueing upload: %s", err)
-	}
-	_ = closer.CloseTx(errors.New(""))
-
-	// Upload does not exist after rollback
-	if _, exists, err := db.GetUploadByID(context.Background(), id); err != nil {
-		t.Fatalf("unexpected error getting upload: %s", err)
-	} else if exists {
-		t.Fatal("unexpected record")
-	}
-}
-
 func TestDequeueConversionSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -272,7 +240,7 @@ func TestDequeueConversionSuccess(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// Add dequeueable upload
-	insertUploads(t, db.db, Upload{ID: 1, State: "queued"})
+	insertUploads(t, dbconn.Global, Upload{ID: 1, State: "queued"})
 
 	upload, jobHandle, ok, err := db.Dequeue(context.Background())
 	if err != nil {
@@ -289,20 +257,18 @@ func TestDequeueConversionSuccess(t *testing.T) {
 		t.Errorf("unexpected state. want=%s have=%s", "processing", upload.State)
 	}
 
-	if state, err := scanString(db.db.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
+	if state, err := scanString(dbconn.Global.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting state: %s", err)
 	} else if state != "processing" {
 		t.Errorf("unexpected state outside of txn. want=%s have=%s", "processing", state)
 	}
 
-	if err := jobHandle.MarkComplete(); err != nil {
+	if err := jobHandle.MarkComplete(context.Background()); err != nil {
 		t.Fatalf("unexpected error marking upload complete: %s", err)
 	}
-	if err := jobHandle.CloseTx(nil); err != nil {
-		t.Fatalf("unexpected error closing transaction: %s", err)
-	}
+	_ = jobHandle.Done(nil)
 
-	if state, err := scanString(db.db.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
+	if state, err := scanString(dbconn.Global.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting state: %s", err)
 	} else if state != "completed" {
 		t.Errorf("unexpected state outside of txn. want=%s have=%s", "completed", state)
@@ -317,7 +283,7 @@ func TestDequeueConversionError(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// Add dequeueable upload
-	insertUploads(t, db.db, Upload{ID: 1, State: "queued"})
+	insertUploads(t, dbconn.Global, Upload{ID: 1, State: "queued"})
 
 	upload, jobHandle, ok, err := db.Dequeue(context.Background())
 	if err != nil {
@@ -334,32 +300,30 @@ func TestDequeueConversionError(t *testing.T) {
 		t.Errorf("unexpected state. want=%s have=%s", "processing", upload.State)
 	}
 
-	if state, err := scanString(db.db.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
+	if state, err := scanString(dbconn.Global.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting state: %s", err)
 	} else if state != "processing" {
 		t.Errorf("unexpected state outside of txn. want=%s have=%s", "processing", state)
 	}
 
-	if err := jobHandle.MarkErrored("test summary", "test stacktrace"); err != nil {
+	if err := jobHandle.MarkErrored(context.Background(), "test summary", "test stacktrace"); err != nil {
 		t.Fatalf("unexpected error marking upload complete: %s", err)
 	}
-	if err := jobHandle.CloseTx(nil); err != nil {
-		t.Fatalf("unexpected error closing transaction: %s", err)
-	}
+	_ = jobHandle.Done(nil)
 
-	if state, err := scanString(db.db.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
+	if state, err := scanString(dbconn.Global.QueryRow("SELECT state FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting state: %s", err)
 	} else if state != "errored" {
 		t.Errorf("unexpected state outside of txn. want=%s have=%s", "errored", state)
 	}
 
-	if summary, err := scanString(db.db.QueryRow("SELECT failure_summary FROM lsif_uploads WHERE id = 1")); err != nil {
+	if summary, err := scanString(dbconn.Global.QueryRow("SELECT failure_summary FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting failure_summary: %s", err)
 	} else if summary != "test summary" {
 		t.Errorf("unexpected failure summary outside of txn. want=%s have=%s", "test summary", summary)
 	}
 
-	if stacktrace, err := scanString(db.db.QueryRow("SELECT failure_stacktrace FROM lsif_uploads WHERE id = 1")); err != nil {
+	if stacktrace, err := scanString(dbconn.Global.QueryRow("SELECT failure_stacktrace FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting failure_stacktrace: %s", err)
 	} else if stacktrace != "test stacktrace" {
 		t.Errorf("unexpected failure stacktrace outside of txn. want=%s have=%s", "test stacktrace", stacktrace)
@@ -374,9 +338,10 @@ func TestDequeueWithSavepointRollback(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// Add dequeueable upload
-	insertUploads(t, db.db, Upload{ID: 1, State: "queued", Indexer: "lsif-go"})
+	insertUploads(t, dbconn.Global, Upload{ID: 1, State: "queued", Indexer: "lsif-go"})
 
-	_, jobHandle, ok, err := db.Dequeue(context.Background())
+	ctx := context.Background()
+	_, jobHandle, ok, err := db.Dequeue(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing upload: %s", err)
 	}
@@ -384,28 +349,28 @@ func TestDequeueWithSavepointRollback(t *testing.T) {
 		t.Fatalf("expected something to be dequeueable")
 	}
 
-	if err := jobHandle.Savepoint(); err != nil {
+	if err := jobHandle.Savepoint(ctx); err != nil {
 		t.Fatalf("unexpected error creating savepoint: %s", err)
 	}
 
-	// alter record
-	if _, err := jobHandle.Tx().Exec(`UPDATE lsif_uploads SET indexer = 'lsif-tsc' WHERE id = 1`); err != nil {
+	// alter record in the underlying transacted db
+	if err := jobHandle.(*jobHandleImpl).db.exec(ctx, sqlf.Sprintf(`UPDATE lsif_uploads SET indexer = 'lsif-tsc' WHERE id = 1`)); err != nil {
 		t.Fatalf("unexpected error altering record: %s", err)
 	}
 
 	// undo alteration
-	if err := jobHandle.RollbackToLastSavepoint(); err != nil {
+	if err := jobHandle.RollbackToLastSavepoint(ctx); err != nil {
 		t.Fatalf("unexpected error rolling back to savepoint: %s", err)
 	}
 
-	if err := jobHandle.MarkComplete(); err != nil {
+	if err := jobHandle.MarkComplete(ctx); err != nil {
 		t.Fatalf("unexpected error marking upload complete: %s", err)
 	}
-	if err := jobHandle.CloseTx(nil); err != nil {
+	if err := jobHandle.Done(nil); err != nil {
 		t.Fatalf("unexpected error closing transaction: %s", err)
 	}
 
-	if indexerName, err := scanString(db.db.QueryRow("SELECT indexer FROM lsif_uploads WHERE id = 1")); err != nil {
+	if indexerName, err := scanString(dbconn.Global.QueryRow("SELECT indexer FROM lsif_uploads WHERE id = 1")); err != nil {
 		t.Errorf("unexpected error getting indexer: %s", err)
 	} else if indexerName != "lsif-go" {
 		t.Errorf("unexpected failure summary outside of txn. want=%s have=%s", "lsif-go", indexerName)
@@ -424,13 +389,13 @@ func TestDequeueSkipsLocked(t *testing.T) {
 	t3 := t2.Add(time.Minute)
 	insertUploads(
 		t,
-		db.db,
+		dbconn.Global,
 		Upload{ID: 1, State: "queued", UploadedAt: t1},
 		Upload{ID: 2, State: "processing", UploadedAt: t2},
 		Upload{ID: 3, State: "queued", UploadedAt: t3},
 	)
 
-	tx, err := db.db.BeginTx(context.Background(), nil)
+	tx, err := dbconn.Global.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +413,7 @@ func TestDequeueSkipsLocked(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected something to be dequeueable")
 	}
-	defer func() { _ = jobHandle.CloseTx(nil) }()
+	defer func() { _ = jobHandle.Done(nil) }()
 
 	if upload.ID != 3 {
 		t.Errorf("unexpected upload id. want=%d have=%d", 3, upload.ID)
@@ -465,11 +430,12 @@ func TestDequeueEmpty(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	_, _, ok, err := db.Dequeue(context.Background())
+	_, jobHandle, ok, err := db.Dequeue(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing upload: %s", err)
 	}
 	if ok {
+		_ = jobHandle.Done(nil)
 		t.Fatalf("unexpected dequeue")
 	}
 }
@@ -482,20 +448,20 @@ func TestDequeueConcurrency(t *testing.T) {
 	db := &dbImpl{db: dbconn.Global}
 
 	// Add dequeueable upload
-	insertUploads(t, db.db, Upload{ID: 1, State: "queued"})
+	insertUploads(t, dbconn.Global, Upload{ID: 1, State: "queued"})
 
-	_, closer1, ok1, err1 := db.dequeue(context.Background(), 1)
-	_, closer2, ok2, err2 := db.dequeue(context.Background(), 1)
-
-	if err1 != sql.ErrNoRows && err2 != sql.ErrNoRows {
-		t.Errorf("expected one error to be sql.ErrNoRows. have=%q and %q", err1, err2)
-	}
-
+	_, jobHandle1, ok1, err1 := db.dequeue(context.Background(), 1)
 	if ok1 {
-		_ = closer1.CloseTx(nil)
+		defer func() { _ = jobHandle1.Done(nil) }()
 	}
+
+	_, jobHandle2, ok2, err2 := db.dequeue(context.Background(), 1)
 	if ok2 {
-		_ = closer2.CloseTx(nil)
+		defer func() { _ = jobHandle2.Done(nil) }()
+	}
+
+	if err1 != ErrDequeueRace && err2 != ErrDequeueRace {
+		t.Errorf("expected error. want=%q have=%q and %q", ErrDequeueRace, err1, err2)
 	}
 }
 
@@ -506,7 +472,7 @@ func TestGetStates(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, State: "queued"},
 		Upload{ID: 2},
 		Upload{ID: 3, State: "processing"},
@@ -533,7 +499,7 @@ func TestDeleteUploadByID(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1},
 	)
 
@@ -584,14 +550,14 @@ func TestDeleteUploadByIDUpdatesVisibility(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, Commit: makeCommit(4), Root: "sub1/", VisibleAtTip: true},
 		Upload{ID: 2, Commit: makeCommit(3), Root: "sub2/", VisibleAtTip: true},
 		Upload{ID: 3, Commit: makeCommit(2), Root: "sub1/", VisibleAtTip: false},
 		Upload{ID: 4, Commit: makeCommit(1), Root: "sub2/", VisibleAtTip: false},
 	)
 
-	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
 		makeCommit(1): {},
 		makeCommit(2): {makeCommit(1)},
 		makeCommit(3): {makeCommit(2)},
@@ -615,7 +581,7 @@ func TestDeleteUploadByIDUpdatesVisibility(t *testing.T) {
 	}
 
 	expected := map[int]bool{2: true, 3: true, 4: false}
-	visibilities := getDumpVisibilities(t, db.db)
+	visibilities := getDumpVisibilities(t, dbconn.Global)
 	if diff := cmp.Diff(expected, visibilities); diff != "" {
 		t.Errorf("unexpected visibility (-want +got):\n%s", diff)
 	}
@@ -635,7 +601,7 @@ func TestResetStalled(t *testing.T) {
 	t4 := now.Add(-time.Second * 8) // old
 	t5 := now.Add(-time.Second * 8) // old
 
-	insertUploads(t, db.db,
+	insertUploads(t, dbconn.Global,
 		Upload{ID: 1, State: "processing", StartedAt: &t1},
 		Upload{ID: 2, State: "processing", StartedAt: &t2},
 		Upload{ID: 3, State: "processing", StartedAt: &t3},
@@ -643,7 +609,7 @@ func TestResetStalled(t *testing.T) {
 		Upload{ID: 5, State: "processing", StartedAt: &t5},
 	)
 
-	tx, err := db.db.BeginTx(context.Background(), nil)
+	tx, err := dbconn.Global.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codeintel/db/util.go
+++ b/internal/codeintel/db/util.go
@@ -1,18 +1,8 @@
 package db
 
 import (
-	"database/sql"
-
 	"github.com/keegancsmith/sqlf"
 )
-
-// ignoreErrNoRows returns the given error if it's not sql.ErrNoRows.
-func ignoreErrNoRows(err error) error {
-	if err == sql.ErrNoRows {
-		return nil
-	}
-	return err
-}
 
 // intsToQueries converts a slice of ints into a slice of queries.
 func intsToQueries(values []int) []*sqlf.Query {


### PR DESCRIPTION
The codeintel db package was doing something a bit contrary to Go idioms and the way other stores are currently implemented. Instead of defining a TxCloser and passing around a reference, stores use as `Transact` method that will promote the entire store to work in the context of a transaction.

This is a big (lines of code) change, but very little behavior is actually different except for two callsites in the api-server and worker where transactions really matter. A lot of the changes are due to dropping support for queryRow and exec, so scanning results is a bit different now.

Overview of changes:

- Add Transact and Done methods to Database interface
- Ensure all non-trivial methods take a context
- Use dbutil.DB over sql.DB/Tx
- Regenerate mocks
- Update usage (including new txn technique)

Recommended review order:

- db.go
- tx.go
- one of the methods that no longer take a Tx parameter
- skim the remainder of the db package changes
- skip the tests
- skim over usage changes in cmd/