### PR TITLE
Fix GitHub file path detection on PRs

### DIFF
--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -28,7 +28,8 @@ export function getDiffFileName(container: HTMLElement): { headFilePath: string;
         }
         // On commit code views, or code views on a PR's files tab,
         // find the link contained in the .file-info element.
-        const link = fileInfoElement.querySelector<HTMLElement>('a')
+        // It is located right of the diffstat (makes sure to not match the code owner link on PRs left of the diffstat).
+        const link = fileInfoElement.querySelector<HTMLAnchorElement>('.diffstat + a')
         if (link) {
             return getPathNamesFromElement(link)
         }


### PR DESCRIPTION
Browser extension is broken right now because GitHub changed their DOM.