### PR TITLE
Add a metric utility function to export ristretto cache stats

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/metrics.go
+++ b/cmd/precise-code-intel-bundle-manager/metrics.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/dgraph-io/ristretto"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// registerer exists so we can override it in tests
+var registerer = prometheus.DefaultRegisterer
+
+// MustRegisterRistrettoMonitor exports three prometheus metrics
+// "src_ristretto_cache_hits{cache=$cache}",
+// "src_ristretto_cache_misses{cache=$cache}", and
+// "src_ristretto_cache_cost{cache=$cache}".
+//
+// It is safe to call this function more than once for the same cache name.
+func MustRegisterRistrettoMonitor(cacheName string, metrics *ristretto.Metrics) {
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_hits",
+		Help:        "Total number of cache hits.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.Hits())
+	}))
+
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_misses",
+		Help:        "Total number of cache misses.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.Misses())
+	}))
+
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_cost",
+		Help:        "Current cost of the cache.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.CostAdded() - metrics.CostEvicted())
+	}))
+}
+
+func mustRegisterOnce(c prometheus.Collector) {
+	err := registerer.Register(c)
+	if err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return
+		}
+		panic(err)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/ristretto"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -130,38 +129,6 @@ func MustRegisterDiskMonitor(path string) {
 		var stat syscall.Statfs_t
 		_ = syscall.Statfs(path, &stat)
 		return float64(stat.Blocks * uint64(stat.Bsize))
-	}))
-}
-
-// MustRegisterRistrettoMonitor exports three prometheus metrics
-// "src_ristretto_cache_hits{cache=$cache}",
-// "src_ristretto_cache_misses{cache=$cache}", and
-// "src_ristretto_cache_cost{cache=$cache}".
-//
-// It is safe to call this function more than once for the same cache name.
-func MustRegisterRistrettoMonitor(cacheName string, metrics *ristretto.Metrics) {
-	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name:        "src_ristretto_cache_hits",
-		Help:        "Total number of cache hits.",
-		ConstLabels: prometheus.Labels{"cache": cacheName},
-	}, func() float64 {
-		return float64(metrics.Hits())
-	}))
-
-	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name:        "src_ristretto_cache_misses",
-		Help:        "Total number of cache misses.",
-		ConstLabels: prometheus.Labels{"cache": cacheName},
-	}, func() float64 {
-		return float64(metrics.Misses())
-	}))
-
-	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name:        "src_ristretto_cache_cost",
-		Help:        "Current cost of the cache.",
-		ConstLabels: prometheus.Labels{"cache": cacheName},
-	}, func() float64 {
-		return float64(metrics.CostAdded() - metrics.CostEvicted())
 	}))
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dgraph-io/ristretto"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -130,7 +131,38 @@ func MustRegisterDiskMonitor(path string) {
 		_ = syscall.Statfs(path, &stat)
 		return float64(stat.Blocks * uint64(stat.Bsize))
 	}))
+}
 
+// MustRegisterRistrettoMonitor exports three prometheus metrics
+// "src_ristretto_cache_hits{cache=$cache}",
+// "src_ristretto_cache_misses{cache=$cache}", and
+// "src_ristretto_cache_cost{cache=$cache}".
+//
+// It is safe to call this function more than once for the same cache name.
+func MustRegisterRistrettoMonitor(cacheName string, metrics *ristretto.Metrics) {
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_hits",
+		Help:        "Total number of cache hits.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.Hits())
+	}))
+
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_misses",
+		Help:        "Total number of cache misses.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.Misses())
+	}))
+
+	mustRegisterOnce(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:        "src_ristretto_cache_cost",
+		Help:        "Current cost of the cache.",
+		ConstLabels: prometheus.Labels{"cache": cacheName},
+	}, func() float64 {
+		return float64(metrics.CostAdded() - metrics.CostEvicted())
+	}))
 }
 
 func mustRegisterOnce(c prometheus.Collector) {


### PR DESCRIPTION
The precise code intel services have adopted [ristretto](https://github.com/dgraph-io/ristretto) for a high-performance in-memory LRU cache. This exports metrics so we can determine the number of hits and misses of the cache as well as its current cost.

I'm putting this in internal rather than in the bundle manager as it could be useful elsewhere (@keegancsmith suggested the cache in the first place, so I assume he has his eye on it).