### PR TITLE
Integrate version contexts in the GraphQL API

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -241,11 +241,12 @@ type ReposListOptions struct {
 	// returned in the list.
 	ExcludePattern string
 
-	// VersionContextRepositories is a list of repository names used to limit the results to that
+	// Names is a list of repository names used to limit the results to that
 	// set of repositories.
-	// Note: In future iterations, version contexts may have their own table
+	// Note: This is currently used for version contexts. In future iterations,
+	// version contexts may have their own table
 	// and this may be replaced by the version context name.
-	VersionContextRepositories []string
+	Names []string
 
 	// PatternQuery is an expression tree of patterns to query. The atoms of
 	// the query are strings which are regular expression patterns.
@@ -463,13 +464,13 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	if opt.OnlyPrivate {
 		conds = append(conds, sqlf.Sprintf("private"))
 	}
-	if len(opt.VersionContextRepositories) > 0 {
+	if len(opt.Names) > 0 {
 		var builder strings.Builder
 		builder.WriteString("name IN (")
-		args := make([]interface{}, 0, len(opt.VersionContextRepositories))
-		for i, repo := range opt.VersionContextRepositories {
+		args := make([]interface{}, 0, len(opt.Names))
+		for i, repo := range opt.Names {
 			builder.WriteString("%s")
-			if i < len(opt.VersionContextRepositories)-1 {
+			if i < len(opt.Names)-1 {
 				builder.WriteString(", ")
 			}
 			args = append(args, repo)

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -464,17 +464,18 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 		conds = append(conds, sqlf.Sprintf("private"))
 	}
 	if len(opt.VersionContextRepositories) > 0 {
-		cond := fmt.Sprintf("name IN (")
+		var builder strings.Builder
+		builder.WriteString("name IN (")
 		args := make([]interface{}, 0, len(opt.VersionContextRepositories))
 		for i, repo := range opt.VersionContextRepositories {
-			cond += "%s"
+			builder.WriteString("%s")
 			if i < len(opt.VersionContextRepositories)-1 {
-				cond += ", "
+				builder.WriteString(", ")
 			}
 			args = append(args, repo)
 		}
-		cond += ")"
-		conds = append(conds, sqlf.Sprintf(cond, args...))
+		builder.WriteString(")")
+		conds = append(conds, sqlf.Sprintf(builder.String(), args...))
 	}
 
 	if opt.Index != nil {

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -465,18 +465,11 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 		conds = append(conds, sqlf.Sprintf("private"))
 	}
 	if len(opt.Names) > 0 {
-		var builder strings.Builder
-		builder.WriteString("name IN (")
-		args := make([]interface{}, 0, len(opt.Names))
-		for i, repo := range opt.Names {
-			builder.WriteString("%s")
-			if i < len(opt.Names)-1 {
-				builder.WriteString(", ")
-			}
-			args = append(args, repo)
+		queries := make([]*sqlf.Query, 0, len(opt.Names))
+		for _, repo := range opt.Names {
+			queries = append(queries, sqlf.Sprintf("%s", repo))
 		}
-		builder.WriteString(")")
-		conds = append(conds, sqlf.Sprintf(builder.String(), args...))
+		conds = append(conds, sqlf.Sprintf("NAME IN (%s)", sqlf.Join(queries, ", ")))
 	}
 
 	if opt.Index != nil {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -478,6 +478,11 @@ func (r *NodeResolver) ToLSIFUpload() (LSIFUploadResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToVersionContext() (*versionContextResolver, bool) {
+	n, ok := r.Node.(*versionContextResolver)
+	return n, ok
+}
+
 // schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it
 // uses subresolvers which are globals. Enterprise-only resolvers are assigned
 // to a field of EnterpriseResolvers.

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -77,6 +77,7 @@ func TestResolverTo(t *testing.T) {
 		&searchSuggestionResolver{},
 		&settingsSubject{},
 		&statusMessageResolver{},
+		&versionContextResolver{},
 	}
 	for _, r := range resolvers {
 		typ := reflect.TypeOf(r)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1126,7 +1126,7 @@ type Query {
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
 
-        # PREVIEW: Optionally specify the versionContext. If not specified the
+        # (experimental) Optionally specify the versionContext. If not specified the
         # default version context is used (all repositories on the default branch).
         versionContext: String
 
@@ -1154,7 +1154,7 @@ type Query {
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
-    # PREVIEW: All version contexts.
+    # (experimental) All version contexts.
     versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
@@ -1856,13 +1856,13 @@ type ExternalRepository {
     serviceID: String!
 }
 
-# PREVIEW: A version context. Used to change the set of default repository and
+# (experimental) A version context. Used to change the set of default repository and
 # revisions searched.
 #
 # Note: We do not expose the list of repositories and revisions in the version
 # context. This is intentional. However, if a need arises we can add it in.
 type VersionContext implements Node {
-    # The version context's unique ID.
+    # The version context ID is its name.
     id: ID!
 
     # The name of the version context.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1128,9 +1128,7 @@ type Query {
 
         # PREVIEW: Optionally specify the versionContext. If not specified the
         # default version context is used (all repositories on the default branch).
-        #
-        # GraphQL experts: Should this be the name or the ID?
-        versionContext: ID
+        versionContext: String
 
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
@@ -1157,11 +1155,6 @@ type Query {
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
     # PREVIEW: All version contexts.
-    #
-    # graphql experts: I made this a dumb list since I don't expect this to be a
-    # large list. If it ever does become a large list, I assume it is fine to
-    # just update the schema to be connection based. Or should we avoid just
-    # simple lists?
     versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
@@ -1873,8 +1866,6 @@ type VersionContext implements Node {
     id: ID!
 
     # The name of the version context.
-    #
-    # Should this be unique?
     name: String!
 
     # The description of the version context.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1126,6 +1126,12 @@ type Query {
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
 
+        # PREVIEW: Optionally specify the versionContext. If not specified the
+        # default version context is used (all repositories on the default branch).
+        #
+        # GraphQL experts: Should this be the name or the ID?
+        versionContext: ID
+
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
         # https://docs.sourcegraph.com/api/graphql/search
@@ -1150,6 +1156,13 @@ type Query {
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
+    # PREVIEW: All version contexts.
+    #
+    # graphql experts: I made this a dumb list since I don't expect this to be a
+    # large list. If it ever does become a large list, I assume it is fine to
+    # just update the schema to be connection based. Or should we avoid just
+    # simple lists?
+    versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
     # Retrieve responses to surveys.
@@ -1848,6 +1861,24 @@ type ExternalRepository {
     #
     # Example: For GitHub.com, this is "https://github.com/".
     serviceID: String!
+}
+
+# PREVIEW: A version context. Used to change the set of default repository and
+# revisions searched.
+#
+# Note: We do not expose the list of repositories and revisions in the version
+# context. This is intentional. However, if a need arises we can add it in.
+type VersionContext implements Node {
+    # The version context's unique ID.
+    id: ID!
+
+    # The name of the version context.
+    #
+    # Should this be unique?
+    name: String!
+
+    # The description of the version context.
+    description: String!
 }
 
 # Information about a repository's text search index.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1133,7 +1133,7 @@ type Query {
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
 
-        # PREVIEW: Optionally specify the versionContext. If not specified the
+        # (experimental) Optionally specify the versionContext. If not specified the
         # default version context is used (all repositories on the default branch).
         versionContext: String
 
@@ -1161,7 +1161,7 @@ type Query {
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
-    # PREVIEW: All version contexts.
+    # (experimental) All version contexts.
     versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
@@ -1863,13 +1863,13 @@ type ExternalRepository {
     serviceID: String!
 }
 
-# PREVIEW: A version context. Used to change the set of default repository and
+# (experimental) A version context. Used to change the set of default repository and
 # revisions searched.
 #
 # Note: We do not expose the list of repositories and revisions in the version
 # context. This is intentional. However, if a need arises we can add it in.
 type VersionContext implements Node {
-    # The version context's unique ID.
+    # The version context ID is its name.
     id: ID!
 
     # The name of the version context.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1135,9 +1135,7 @@ type Query {
 
         # PREVIEW: Optionally specify the versionContext. If not specified the
         # default version context is used (all repositories on the default branch).
-        #
-        # GraphQL experts: Should this be the name or the ID?
-        versionContext: ID
+        versionContext: String
 
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
@@ -1164,11 +1162,6 @@ type Query {
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
     # PREVIEW: All version contexts.
-    #
-    # graphql experts: I made this a dumb list since I don't expect this to be a
-    # large list. If it ever does become a large list, I assume it is fine to
-    # just update the schema to be connection based. Or should we avoid just
-    # simple lists?
     versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
@@ -1880,8 +1873,6 @@ type VersionContext implements Node {
     id: ID!
 
     # The name of the version context.
-    #
-    # Should this be unique?
     name: String!
 
     # The description of the version context.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1133,6 +1133,12 @@ type Query {
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
 
+        # PREVIEW: Optionally specify the versionContext. If not specified the
+        # default version context is used (all repositories on the default branch).
+        #
+        # GraphQL experts: Should this be the name or the ID?
+        versionContext: ID
+
         # (experimental) Sourcegraph 3.9 added support for cursor-based paginated
         # search requests when this field is specified. For details, see
         # https://docs.sourcegraph.com/api/graphql/search
@@ -1157,6 +1163,13 @@ type Query {
     savedSearches: [SavedSearch!]!
     # All repository groups for the current user, merged from all configurations.
     repoGroups: [RepoGroup!]!
+    # PREVIEW: All version contexts.
+    #
+    # graphql experts: I made this a dumb list since I don't expect this to be a
+    # large list. If it ever does become a large list, I assume it is fine to
+    # just update the schema to be connection based. Or should we avoid just
+    # simple lists?
+    versionContexts: [VersionContext!]!
     # The current site.
     site: Site!
     # Retrieve responses to surveys.
@@ -1855,6 +1868,24 @@ type ExternalRepository {
     #
     # Example: For GitHub.com, this is "https://github.com/".
     serviceID: String!
+}
+
+# PREVIEW: A version context. Used to change the set of default repository and
+# revisions searched.
+#
+# Note: We do not expose the list of repositories and revisions in the version
+# context. This is intentional. However, if a need arises we can add it in.
+type VersionContext implements Node {
+    # The version context's unique ID.
+    id: ID!
+
+    # The name of the version context.
+    #
+    # Should this be unique?
+    name: String!
+
+    # The description of the version context.
+    description: String!
 }
 
 # Information about a repository's text search index.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -333,7 +333,7 @@ func resolveRepoGroups(ctx context.Context) (map[string][]*types.Repo, error) {
 }
 
 func resolveVersionContext(versionContext string) (*schema.VersionContext, error) {
-	for _, vc := range conf.Get().VersionContexts {
+	for _, vc := range conf.Get().ExperimentalFeatures.VersionContexts {
 		if vc.Name == versionContext {
 			return vc, nil
 		}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -675,6 +675,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	for _, repo := range repos {
 		var repoRev search.RepositoryRevisions
 		var revs []search.RevisionSpecifier
+		// versionContext will be nil if the query contains revision specifiers
 		if versionContext != nil {
 			for _, vcRepoRef := range versionContext.Revisions {
 				if vcRepoRef.Repo == string(repo.Name) {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -507,12 +507,14 @@ func TestVersionContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			conf.Mock(&conf.Unified{
 				SiteConfiguration: schema.SiteConfiguration{
-					VersionContexts: []*schema.VersionContext{
-						{
-							Name: "ctx-1",
-							Revisions: []*schema.VersionContextRevision{
-								{Repo: "github.com/sourcegraph/foo", Ref: "some-branch"},
-								{Repo: "github.com/sourcegraph/bar", Ref: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"},
+					ExperimentalFeatures: &schema.ExperimentalFeatures{
+						VersionContexts: []*schema.VersionContext{
+							{
+								Name: "ctx-1",
+								Revisions: []*schema.VersionContextRevision{
+									{Repo: "github.com/sourcegraph/foo", Ref: "some-branch"},
+									{Repo: "github.com/sourcegraph/bar", Ref: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"},
+								},
 							},
 						},
 					},

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -491,15 +491,108 @@ func TestVersionContext(t *testing.T) {
 			name:           "query with version context should return the right repositories",
 			searchQuery:    "foo",
 			versionContext: "ctx-1",
-			reposGetList: func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error) {
+			reposGetList: func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+				expectedOpts := db.ReposListOptions{
+					Names: []string{
+						"github.com/sourcegraph/foo",
+						"github.com/sourcegraph/foobar",
+						"github.com/sourcegraph/bar",
+					},
+					NoForks:     true,
+					NoArchived:  true,
+					OnlyRepoIDs: true,
+					LimitOffset: &db.LimitOffset{Limit: 1073741824},
+				}
+				if diff := cmp.Diff(opts, expectedOpts); diff != "" {
+					t.Fatalf(diff)
+				}
 				return []*types.Repo{
 					{Name: "github.com/sourcegraph/foo"},
+					{Name: "github.com/sourcegraph/foobar"},
 					{Name: "github.com/sourcegraph/bar"},
 				}, nil
 			},
 			wantResults: []*search.RepositoryRevisions{
 				{Repo: &types.Repo{Name: "github.com/sourcegraph/foo"}, Revs: []search.RevisionSpecifier{{RevSpec: "some-branch"}}},
+				{Repo: &types.Repo{Name: "github.com/sourcegraph/foobar"}, Revs: []search.RevisionSpecifier{{RevSpec: "v1.0.0"}}},
 				{Repo: &types.Repo{Name: "github.com/sourcegraph/bar"}, Revs: []search.RevisionSpecifier{{RevSpec: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"}}},
+			},
+		},
+		{
+			name:           "query with version context and subset of repos",
+			searchQuery:    "repo:github.com/sourcegraph/foo.*",
+			versionContext: "ctx-1",
+			reposGetList: func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+				expectedOpts := db.ReposListOptions{
+					Names: []string{
+						"github.com/sourcegraph/foo",
+						"github.com/sourcegraph/foobar",
+						"github.com/sourcegraph/bar",
+					},
+					IncludePatterns: []string{"github\\.com/sourcegraph/foo.*"},
+					NoForks:         true,
+					NoArchived:      true,
+					OnlyRepoIDs:     true,
+					LimitOffset:     &db.LimitOffset{Limit: 1073741824},
+				}
+				if diff := cmp.Diff(opts, expectedOpts); diff != "" {
+					t.Fatalf(diff)
+				}
+				return []*types.Repo{
+					{Name: "github.com/sourcegraph/foo"},
+					{Name: "github.com/sourcegraph/foobar"},
+				}, nil
+			},
+			wantResults: []*search.RepositoryRevisions{
+				{Repo: &types.Repo{Name: "github.com/sourcegraph/foo"}, Revs: []search.RevisionSpecifier{{RevSpec: "some-branch"}}},
+				{Repo: &types.Repo{Name: "github.com/sourcegraph/foobar"}, Revs: []search.RevisionSpecifier{{RevSpec: "v1.0.0"}}},
+			},
+		},
+		{
+			name:           "query with version context and non-exact search",
+			searchQuery:    "repo:github.com/sourcegraph/notincontext",
+			versionContext: "ctx-1",
+			reposGetList: func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+				expectedOpts := db.ReposListOptions{
+					Names: []string{
+						"github.com/sourcegraph/foo",
+						"github.com/sourcegraph/foobar",
+						"github.com/sourcegraph/bar",
+					},
+					IncludePatterns: []string{"github\\.com/sourcegraph/notincontext"},
+					NoForks:         true,
+					NoArchived:      true,
+					OnlyRepoIDs:     true,
+					LimitOffset:     &db.LimitOffset{Limit: 1073741824},
+				}
+				if diff := cmp.Diff(opts, expectedOpts); diff != "" {
+					t.Fatalf(diff)
+				}
+				return []*types.Repo{}, nil
+			},
+			wantResults: []*search.RepositoryRevisions{},
+		},
+		{
+			name:           "query with version context and exact repo search",
+			searchQuery:    "repo:github.com/sourcegraph/notincontext@v1.0.0",
+			versionContext: "ctx-1",
+			reposGetList: func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+				expectedOpts := db.ReposListOptions{
+					IncludePatterns: []string{"github\\.com/sourcegraph/notincontext"},
+					NoForks:         true,
+					NoArchived:      true,
+					OnlyRepoIDs:     true,
+					LimitOffset:     &db.LimitOffset{Limit: 1073741824},
+				}
+				if diff := cmp.Diff(opts, expectedOpts); diff != "" {
+					t.Fatalf(diff)
+				}
+				return []*types.Repo{
+					{Name: "github.com/sourcegraph/notincontext"},
+				}, nil
+			},
+			wantResults: []*search.RepositoryRevisions{
+				{Repo: &types.Repo{Name: "github.com/sourcegraph/notincontext"}, Revs: []search.RevisionSpecifier{{RevSpec: "v1.0.0"}}},
 			},
 		},
 	}
@@ -513,6 +606,7 @@ func TestVersionContext(t *testing.T) {
 								Name: "ctx-1",
 								Revisions: []*schema.VersionContextRevision{
 									{Repo: "github.com/sourcegraph/foo", Ref: "some-branch"},
+									{Repo: "github.com/sourcegraph/foobar", Ref: "v1.0.0"},
 									{Repo: "github.com/sourcegraph/bar", Ref: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"},
 								},
 							},
@@ -531,8 +625,8 @@ func TestVersionContext(t *testing.T) {
 			}
 
 			resolver := searchResolver{
-				query:              qinfo,
-				versionContextName: &tc.versionContext,
+				query:          qinfo,
+				versionContext: &tc.versionContext,
 			}
 
 			db.Mocks.Repos.List = tc.reposGetList

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -541,8 +541,8 @@ func TestVersionContext(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(gotResults, tc.wantResults) {
-				t.Fatalf("results = %+v, want %+v", gotResults, tc.wantResults)
+			if diff := cmp.Diff(gotResults, tc.wantResults); diff != "" {
+				t.Fatalf(diff)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/version_context.go
+++ b/cmd/frontend/graphqlbackend/version_context.go
@@ -21,7 +21,7 @@ func (v *versionContextResolver) Name() string {
 }
 
 func (v *versionContextResolver) Description() string {
-	return ""
+	return v.vc.Description
 }
 
 func NewVersionContextResolver(vc *schema.VersionContext) *versionContextResolver {

--- a/cmd/frontend/graphqlbackend/version_context.go
+++ b/cmd/frontend/graphqlbackend/version_context.go
@@ -33,7 +33,7 @@ func NewVersionContextResolver(vc *schema.VersionContext) *versionContextResolve
 func (r *schemaResolver) VersionContexts(ctx context.Context) ([]*versionContextResolver, error) {
 	var versionContexts []*versionContextResolver
 
-	for _, vc := range conf.Get().VersionContexts {
+	for _, vc := range conf.Get().ExperimentalFeatures.VersionContexts {
 		versionContexts = append(versionContexts, NewVersionContextResolver(vc))
 	}
 

--- a/cmd/frontend/graphqlbackend/version_context.go
+++ b/cmd/frontend/graphqlbackend/version_context.go
@@ -1,0 +1,41 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type versionContextResolver struct {
+	vc *schema.VersionContext
+}
+
+func (v *versionContextResolver) ID() graphql.ID {
+	return graphql.ID(v.vc.Name)
+}
+
+func (v *versionContextResolver) Name() string {
+	return v.vc.Name
+}
+
+func (v *versionContextResolver) Description() string {
+	return ""
+}
+
+func NewVersionContextResolver(vc *schema.VersionContext) *versionContextResolver {
+	return &versionContextResolver{
+		vc: vc,
+	}
+}
+
+func (r *schemaResolver) VersionContexts(ctx context.Context) ([]*versionContextResolver, error) {
+	var versionContexts []*versionContextResolver
+
+	for _, vc := range conf.Get().VersionContexts {
+		versionContexts = append(versionContexts, NewVersionContextResolver(vc))
+	}
+
+	return versionContexts, nil
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -405,6 +405,8 @@ type ExperimentalFeatures struct {
 	StructuralSearch string `json:"structuralSearch,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
 	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
+	// VersionContexts description: List of version contexts
+	VersionContexts []*VersionContext `json:"versionContexts,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.
@@ -1047,8 +1049,6 @@ type SiteConfiguration struct {
 	UpdateChannel string `json:"update.channel,omitempty"`
 	// UseJaeger description: DEPRECATED. Use `"observability.tracing": { "sampling": "all" }`, instead. Enables Jaeger tracing.
 	UseJaeger bool `json:"useJaeger,omitempty"`
-	// VersionContexts description: List of version contexts
-	VersionContexts []*VersionContext `json:"versionContexts,omitempty"`
 }
 
 // TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -405,7 +405,7 @@ type ExperimentalFeatures struct {
 	StructuralSearch string `json:"structuralSearch,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
 	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
-	// VersionContexts description: List of version contexts
+	// VersionContexts description: JSON array of version context configuration
 	VersionContexts []*VersionContext `json:"versionContexts,omitempty"`
 }
 
@@ -1063,8 +1063,10 @@ type UsernameIdentity struct {
 	Type string `json:"type"`
 }
 
-// VersionContext description: Description of the version context
+// VersionContext description: Configuration of the version context
 type VersionContext struct {
+	// Description description: Description of the version context
+	Description string `json:"description,omitempty"`
 	// Name description: Name of the version context, it must be unique.
 	Name string `json:"name"`
 	// Revisions description: List of repositories of the version context

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1047,6 +1047,8 @@ type SiteConfiguration struct {
 	UpdateChannel string `json:"update.channel,omitempty"`
 	// UseJaeger description: DEPRECATED. Use `"observability.tracing": { "sampling": "all" }`, instead. Enables Jaeger tracing.
 	UseJaeger bool `json:"useJaeger,omitempty"`
+	// VersionContexts description: List of version contexts
+	VersionContexts []*VersionContext `json:"versionContexts,omitempty"`
 }
 
 // TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
@@ -1059,6 +1061,22 @@ type TlsExternal struct {
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`
+}
+
+// VersionContext description: Description of the version context
+type VersionContext struct {
+	// Name description: Name of the version context, it must be unique.
+	Name string `json:"name"`
+	// Revisions description: List of repositories of the version context
+	Revisions []*VersionContextRevision `json:"revisions"`
+}
+
+// VersionContextRevision description: Description of the chosen repository and revision
+type VersionContextRevision struct {
+	// Ref description: Branch, tag, or commit hash
+	Ref string `json:"ref"`
+	// Repo description: Repository name
+	Repo string `json:"repo"`
 }
 
 // Webhooks description: DEPRECATED: Switch to "plugin.webhooks"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -157,6 +157,63 @@
               }
             ]
           ]
+        },
+        "versionContexts": {
+          "description": "List of version contexts",
+          "type": "array",
+          "items": {
+            "title": "VersionContext",
+            "description": "Description of the version context",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "revisions"],
+            "properties": {
+              "name": {
+                "description": "Name of the version context, it must be unique.",
+                "type": "string"
+              },
+              "revisions": {
+                "description": "List of repositories of the version context",
+                "type": "array",
+                "items": {
+                  "title": "VersionContextRevision",
+                  "description": "Description of the chosen repository and revision",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["repo", "ref"],
+                  "properties": {
+                    "repo": {
+                      "description": "Repository name",
+                      "type": "string"
+                    },
+                    "ref": {
+                      "description": "Branch, tag, or commit hash",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "examples": [
+            {
+              "name": "Release foo",
+              "revisions": [
+                {
+                  "repo": "github.com/sourcegraph/sourcegraph",
+                  "ref": "3.15"
+                },
+                {
+                  "repo": "github.com/sourcegraph/lib1",
+                  "ref": "23edr233r"
+                },
+                {
+                  "repo": "github.com/sourcegraph/lib2",
+                  "ref": "2.4"
+                }
+              ]
+            }
+          ]
         }
       },
       "examples": [
@@ -696,63 +753,6 @@
       "default": "release",
       "examples": ["none"],
       "group": "Misc."
-    },
-    "versionContexts": {
-      "description": "List of version contexts",
-      "type": "array",
-      "items": {
-        "title": "VersionContext",
-        "description": "Description of the version context",
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["name", "revisions"],
-        "properties": {
-          "name": {
-            "description": "Name of the version context, it must be unique.",
-            "type": "string"
-          },
-          "revisions": {
-            "description": "List of repositories of the version context",
-            "type": "array",
-            "items": {
-              "title": "VersionContextRevision",
-              "description": "Description of the chosen repository and revision",
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["repo", "ref"],
-              "properties": {
-                "repo": {
-                  "description": "Repository name",
-                  "type": "string"
-                },
-                "ref": {
-                  "description": "Branch, tag, or commit hash",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "examples": [
-        {
-          "name": "Release foo",
-          "revisions": [
-            {
-              "repo": "github.com/sourcegraph/sourcegraph",
-              "ref": "3.15"
-            },
-            {
-              "repo": "github.com/sourcegraph/lib1",
-              "ref": "23edr233r"
-            },
-            {
-              "repo": "github.com/sourcegraph/lib2",
-              "ref": "2.4"
-            }
-          ]
-        }
-      ]
     }
   },
   "definitions": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -159,11 +159,11 @@
           ]
         },
         "versionContexts": {
-          "description": "List of version contexts",
+          "description": "JSON array of version context configuration",
           "type": "array",
           "items": {
             "title": "VersionContext",
-            "description": "Description of the version context",
+            "description": "Configuration of the version context",
             "type": "object",
             "additionalProperties": false,
             "required": ["name", "revisions"],
@@ -192,6 +192,10 @@
                     }
                   }
                 }
+              },
+              "description": {
+                "description": "Description of the version context",
+                "type": "string"
               }
             }
           },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -696,6 +696,63 @@
       "default": "release",
       "examples": ["none"],
       "group": "Misc."
+    },
+    "versionContexts": {
+      "description": "List of version contexts",
+      "type": "array",
+      "items": {
+        "title": "VersionContext",
+        "description": "Description of the version context",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "revisions"],
+        "properties": {
+          "name": {
+            "description": "Name of the version context, it must be unique.",
+            "type": "string"
+          },
+          "revisions": {
+            "description": "List of repositories of the version context",
+            "type": "array",
+            "items": {
+              "title": "VersionContextRevision",
+              "description": "Description of the chosen repository and revision",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["repo", "ref"],
+              "properties": {
+                "repo": {
+                  "description": "Repository name",
+                  "type": "string"
+                },
+                "ref": {
+                  "description": "Branch, tag, or commit hash",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "Release foo",
+          "revisions": [
+            {
+              "repo": "github.com/sourcegraph/sourcegraph",
+              "ref": "3.15"
+            },
+            {
+              "repo": "github.com/sourcegraph/lib1",
+              "ref": "23edr233r"
+            },
+            {
+              "repo": "github.com/sourcegraph/lib2",
+              "ref": "2.4"
+            }
+          ]
+        }
+      ]
     }
   },
   "definitions": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -162,6 +162,63 @@ const SiteSchemaJSON = `{
               }
             ]
           ]
+        },
+        "versionContexts": {
+          "description": "List of version contexts",
+          "type": "array",
+          "items": {
+            "title": "VersionContext",
+            "description": "Description of the version context",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "revisions"],
+            "properties": {
+              "name": {
+                "description": "Name of the version context, it must be unique.",
+                "type": "string"
+              },
+              "revisions": {
+                "description": "List of repositories of the version context",
+                "type": "array",
+                "items": {
+                  "title": "VersionContextRevision",
+                  "description": "Description of the chosen repository and revision",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["repo", "ref"],
+                  "properties": {
+                    "repo": {
+                      "description": "Repository name",
+                      "type": "string"
+                    },
+                    "ref": {
+                      "description": "Branch, tag, or commit hash",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "examples": [
+            {
+              "name": "Release foo",
+              "revisions": [
+                {
+                  "repo": "github.com/sourcegraph/sourcegraph",
+                  "ref": "3.15"
+                },
+                {
+                  "repo": "github.com/sourcegraph/lib1",
+                  "ref": "23edr233r"
+                },
+                {
+                  "repo": "github.com/sourcegraph/lib2",
+                  "ref": "2.4"
+                }
+              ]
+            }
+          ]
         }
       },
       "examples": [
@@ -701,63 +758,6 @@ const SiteSchemaJSON = `{
       "default": "release",
       "examples": ["none"],
       "group": "Misc."
-    },
-    "versionContexts": {
-      "description": "List of version contexts",
-      "type": "array",
-      "items": {
-        "title": "VersionContext",
-        "description": "Description of the version context",
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["name", "revisions"],
-        "properties": {
-          "name": {
-            "description": "Name of the version context, it must be unique.",
-            "type": "string"
-          },
-          "revisions": {
-            "description": "List of repositories of the version context",
-            "type": "array",
-            "items": {
-              "title": "VersionContextRevision",
-              "description": "Description of the chosen repository and revision",
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["repo", "ref"],
-              "properties": {
-                "repo": {
-                  "description": "Repository name",
-                  "type": "string"
-                },
-                "ref": {
-                  "description": "Branch, tag, or commit hash",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "examples": [
-        {
-          "name": "Release foo",
-          "revisions": [
-            {
-              "repo": "github.com/sourcegraph/sourcegraph",
-              "ref": "3.15"
-            },
-            {
-              "repo": "github.com/sourcegraph/lib1",
-              "ref": "23edr233r"
-            },
-            {
-              "repo": "github.com/sourcegraph/lib2",
-              "ref": "2.4"
-            }
-          ]
-        }
-      ]
     }
   },
   "definitions": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -164,11 +164,11 @@ const SiteSchemaJSON = `{
           ]
         },
         "versionContexts": {
-          "description": "List of version contexts",
+          "description": "JSON array of version context configuration",
           "type": "array",
           "items": {
             "title": "VersionContext",
-            "description": "Description of the version context",
+            "description": "Configuration of the version context",
             "type": "object",
             "additionalProperties": false,
             "required": ["name", "revisions"],
@@ -197,6 +197,10 @@ const SiteSchemaJSON = `{
                     }
                   }
                 }
+              },
+              "description": {
+                "description": "Description of the version context",
+                "type": "string"
               }
             }
           },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -701,6 +701,63 @@ const SiteSchemaJSON = `{
       "default": "release",
       "examples": ["none"],
       "group": "Misc."
+    },
+    "versionContexts": {
+      "description": "List of version contexts",
+      "type": "array",
+      "items": {
+        "title": "VersionContext",
+        "description": "Description of the version context",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "revisions"],
+        "properties": {
+          "name": {
+            "description": "Name of the version context, it must be unique.",
+            "type": "string"
+          },
+          "revisions": {
+            "description": "List of repositories of the version context",
+            "type": "array",
+            "items": {
+              "title": "VersionContextRevision",
+              "description": "Description of the chosen repository and revision",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["repo", "ref"],
+              "properties": {
+                "repo": {
+                  "description": "Repository name",
+                  "type": "string"
+                },
+                "ref": {
+                  "description": "Branch, tag, or commit hash",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "Release foo",
+          "revisions": [
+            {
+              "repo": "github.com/sourcegraph/sourcegraph",
+              "ref": "3.15"
+            },
+            {
+              "repo": "github.com/sourcegraph/lib1",
+              "ref": "23edr233r"
+            },
+            {
+              "repo": "github.com/sourcegraph/lib2",
+              "ref": "2.4"
+            }
+          ]
+        }
+      ]
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR adds backend support for version context:
- Version contexts are defined in the site configuration
- They can be used in the GraphQL search query to resolve the right repository revisions
- The list of version contexts is accessible through the GraphQL API

This PR is based on #10219 and fixes #10194
