### PR TITLE
Update commits for a repo during LSIF exists check

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/api.go
+++ b/cmd/precise-code-intel-api-server/internal/api/api.go
@@ -6,6 +6,7 @@ import (
 
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 )
 
 // CodeIntelAPI is the main interface into precise code intelligence data.
@@ -30,15 +31,17 @@ type CodeIntelAPI interface {
 type codeIntelAPI struct {
 	db                  db.DB
 	bundleManagerClient bundles.BundleManagerClient
+	gitserverClient     gitserver.Client
 }
 
 var _ CodeIntelAPI = &codeIntelAPI{}
 
 var ErrMissingDump = errors.New("no dump")
 
-func New(db db.DB, bundleManagerClient bundles.BundleManagerClient) CodeIntelAPI {
+func New(db db.DB, bundleManagerClient bundles.BundleManagerClient, gitserverClient gitserver.Client) CodeIntelAPI {
 	return &codeIntelAPI{
 		db:                  db,
 		bundleManagerClient: bundleManagerClient,
+		gitserverClient:     gitserverClient,
 	}
 }

--- a/cmd/precise-code-intel-api-server/internal/api/exists.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
 
@@ -11,6 +12,12 @@ import (
 // queries for the given file. These dump IDs should be subsequently passed to invocations of
 // Definitions, References, and Hover.
 func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) ([]db.Dump, error) {
+	// See if we know about this commit. If not, we need to update our commits table
+	// and the visibility of the dumps in this repository.
+	if err := api.updateCommitsAndVisibility(ctx, repositoryID, commit); err != nil {
+		return nil, err
+	}
+
 	candidates, err := api.db.FindClosestDumps(ctx, repositoryID, commit, file)
 	if err != nil {
 		return nil, err
@@ -30,4 +37,34 @@ func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int,
 	}
 
 	return dumps, nil
+}
+
+// updateCommits updates the lsif_commits table with the current data known to gitserver, then updates the
+// visibility of all dumps for the given repository.
+func (api *codeIntelAPI) updateCommitsAndVisibility(ctx context.Context, repositoryID int, commit string) error {
+	commitExists, err := api.db.HasCommit(ctx, repositoryID, commit)
+	if err != nil {
+		return errors.Wrap(err, "db.HasCommit")
+	}
+	if commitExists {
+		return nil
+	}
+
+	newCommits, err := api.gitserverClient.CommitsNear(api.db, repositoryID, commit)
+	if err != nil {
+		return errors.Wrap(err, " gitserverClient.CommitsNear")
+	}
+	if err := api.db.UpdateCommits(ctx, nil, repositoryID, newCommits); err != nil {
+		return errors.Wrap(err, "db.UpdateCommits")
+	}
+
+	tipCommit, err := api.gitserverClient.Head(api.db, repositoryID)
+	if err != nil {
+		return errors.Wrap(err, "gitserverClient.Head")
+	}
+	if err := api.db.UpdateDumpsVisibleFromTip(ctx, nil, repositoryID, tipCommit); err != nil {
+		return errors.Wrap(err, "db.UpdateDumpsVisibleFromTip")
+	}
+
+	return nil
 }

--- a/cmd/precise-code-intel-api-server/internal/api/exists.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists.go
@@ -52,7 +52,7 @@ func (api *codeIntelAPI) updateCommitsAndVisibility(ctx context.Context, reposit
 
 	newCommits, err := api.gitserverClient.CommitsNear(api.db, repositoryID, commit)
 	if err != nil {
-		return errors.Wrap(err, " gitserverClient.CommitsNear")
+		return errors.Wrap(err, "gitserverClient.CommitsNear")
 	}
 	if err := api.db.UpdateCommits(ctx, nil, repositoryID, newCommits); err != nil {
 		return errors.Wrap(err, "db.UpdateCommits")

--- a/cmd/precise-code-intel-api-server/internal/api/exists_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +10,7 @@ import (
 	bundlemocks "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/mocks"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	dbmocks "github.com/sourcegraph/sourcegraph/internal/codeintel/db/mocks"
+	gitservermocks "github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver/mocks"
 )
 
 func TestFindClosestDatabase(t *testing.T) {
@@ -18,6 +20,7 @@ func TestFindClosestDatabase(t *testing.T) {
 	mockBundleClient2 := bundlemocks.NewMockBundleClient()
 	mockBundleClient3 := bundlemocks.NewMockBundleClient()
 	mockBundleClient4 := bundlemocks.NewMockBundleClient()
+	mockGitserverClient := gitservermocks.NewMockClient()
 
 	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "s1/main.go", []db.Dump{
 		{ID: 50, Root: "s1/"},
@@ -36,7 +39,25 @@ func TestFindClosestDatabase(t *testing.T) {
 	setMockBundleClientExists(t, mockBundleClient3, "main.go", true)
 	setMockBundleClientExists(t, mockBundleClient4, "s1/main.go", false)
 
-	api := New(mockDB, mockBundleManagerClient)
+	// Set a different tip commit
+	mockGitserverClient.HeadFunc.SetDefaultReturn(makeCommit(30), nil)
+
+	// Return some ancestors for each commit args
+	mockGitserverClient.CommitsNearFunc.SetDefaultHook(func(db db.DB, repositoryID int, commit string) (map[string][]string, error) {
+		offset, err := strconv.ParseInt(commit, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		commits := map[string][]string{}
+		for i := 0; i < 10; i++ {
+			commits[makeCommit(int(offset)+i)] = []string{makeCommit(int(offset) + i + 1)}
+		}
+
+		return commits, nil
+	})
+
+	api := New(mockDB, mockBundleManagerClient, mockGitserverClient)
 	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "s1/main.go")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest database: %s", err)
@@ -48,5 +69,54 @@ func TestFindClosestDatabase(t *testing.T) {
 	}
 	if diff := cmp.Diff(expected, dumps); diff != "" {
 		t.Errorf("unexpected dumps (-want +got):\n%s", diff)
+	}
+
+	expectedCommits := map[string][]string{}
+	for i := 0; i < 10; i++ {
+		expectedCommits[makeCommit(i)] = []string{makeCommit(i + 1)}
+	}
+	if len(mockDB.UpdateCommitsFunc.History()) != 1 {
+		t.Errorf("unexpected number of update UpdateCommitsFunc calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
+	} else if diff := cmp.Diff(expectedCommits, mockDB.UpdateCommitsFunc.History()[0].Arg3); diff != "" {
+		t.Errorf("unexpected update UpdateCommitsFunc args (-want +got):\n%s", diff)
+	}
+
+	if len(mockDB.UpdateDumpsVisibleFromTipFunc.History()) != 1 {
+		t.Errorf("unexpected number of UpdateDumpsVisibleFromTipFunc calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
+	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2 != 42 {
+		t.Errorf("unexpected value for repository id. want=%d have=%d", 42, mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2)
+	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg3 != makeCommit(30) {
+		t.Errorf("unexpected value for tip commit. want=%s have=%s", makeCommit(30), mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg3)
+	}
+}
+
+func TestFindClosestSkipsGitserverIfCommitIsKnown(t *testing.T) {
+	mockDB := dbmocks.NewMockDB()
+	mockBundleManagerClient := bundlemocks.NewMockBundleManagerClient()
+	mockBundleClient := bundlemocks.NewMockBundleClient()
+	mockGitserverClient := gitservermocks.NewMockClient()
+
+	setMockDBHasCommit(t, mockDB, 42, testCommit, true)
+	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "main.go", []db.Dump{
+		{ID: 50, Root: ""},
+	})
+	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{
+		50: mockBundleClient,
+	})
+	setMockBundleClientExists(t, mockBundleClient, "main.go", true)
+
+	api := New(mockDB, mockBundleManagerClient, mockGitserverClient)
+	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "main.go")
+	if err != nil {
+		t.Fatalf("unexpected error finding closest database: %s", err)
+	}
+
+	expected := []db.Dump{{ID: 50, Root: ""}}
+	if diff := cmp.Diff(expected, dumps); diff != "" {
+		t.Errorf("unexpected dumps (-want +got):\n%s", diff)
+	}
+
+	if len(mockGitserverClient.CommitsNearFunc.History()) != 0 {
+		t.Errorf("expected gitserverClient.CommitsNear not to be called")
 	}
 }

--- a/cmd/precise-code-intel-api-server/internal/api/helpers_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/helpers_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	testCommit             = "0000000000000000000000000000000000000000"
+	testCommit             = makeCommit(0)
 	testDump1              = db.Dump{ID: 42, Root: "sub1/"}
 	testDump2              = db.Dump{ID: 50, Root: "sub2/"}
 	testDump3              = db.Dump{ID: 51, Root: "sub3/"}
@@ -47,6 +47,11 @@ var (
 		End:   bundles.Position{Line: 14, Character: 55},
 	}
 )
+
+// makeCommit formats an integer as a 40-character git commit hash.
+func makeCommit(i int) string {
+	return fmt.Sprintf("%040d", i)
+}
 
 func setMockDBGetDumpByID(t *testing.T, mockDB *dbmocks.MockDB, dumps map[int]db.Dump) {
 	mockDB.GetDumpByIDFunc.SetDefaultHook(func(ctx context.Context, id int) (db.Dump, bool, error) {
@@ -127,6 +132,18 @@ func setMockDBPackageReferencePager(t *testing.T, mockDB *dbmocks.MockDB, expect
 			t.Errorf("unexpected limit for PackageReferencePager. want=%d have=%d", expectedLimit, limit)
 		}
 		return totalCount, pager, nil
+	})
+}
+
+func setMockDBHasCommit(t *testing.T, mockDB *dbmocks.MockDB, expectedRepositoryID int, expectedCommit string, exists bool) {
+	mockDB.HasCommitFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string) (bool, error) {
+		if repositoryID != expectedRepositoryID {
+			t.Errorf("unexpected repository id for HasCommit. want=%d have=%d", expectedRepositoryID, repositoryID)
+		}
+		if commit != expectedCommit {
+			t.Errorf("unexpected commit for HasCommit. want=%s have=%s", expectedCommit, commit)
+		}
+		return exists, nil
 	})
 }
 

--- a/cmd/precise-code-intel-api-server/internal/server/server.go
+++ b/cmd/precise-code-intel-api-server/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-api-server/internal/api"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -26,6 +27,7 @@ type ServerOpts struct {
 	Port                int
 	DB                  db.DB
 	BundleManagerClient bundles.BundleManagerClient
+	GitserverClient     gitserver.Client
 }
 
 func New(opts ServerOpts) *Server {
@@ -34,7 +36,7 @@ func New(opts ServerOpts) *Server {
 		port:                opts.Port,
 		db:                  opts.DB,
 		bundleManagerClient: opts.BundleManagerClient,
-		api:                 api.New(opts.DB, opts.BundleManagerClient),
+		api:                 api.New(opts.DB, opts.BundleManagerClient, opts.GitserverClient),
 	}
 }
 

--- a/cmd/precise-code-intel-api-server/main.go
+++ b/cmd/precise-code-intel-api-server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-api-server/internal/server"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -38,6 +39,7 @@ func main() {
 		Port:                3186,
 		DB:                  db,
 		BundleManagerClient: bundles.New(bundleManagerURL),
+		GitserverClient:     gitserver.DefaultClient,
 	})
 
 	janitorInst := janitor.NewJanitor(janitor.JanitorOpts{

--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -9,7 +9,7 @@ import (
 
 // HasCommit determines if the given commit is known for the given repository.
 func (db *dbImpl) HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error) {
-	count, err := scanInt(db.queryRow(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_commits WHERE repository_id = %s and commit = %s`, repositoryID, commit)))
+	count, err := scanInt(db.queryRow(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_commits WHERE repository_id = %s and commit = %s LIMIT 1`, repositoryID, commit)))
 	return count > 0, err
 }
 

--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -7,6 +7,12 @@ import (
 	"github.com/keegancsmith/sqlf"
 )
 
+// HasCommit determines if the given commit is known for the given repository.
+func (db *dbImpl) HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error) {
+	count, err := scanInt(db.queryRow(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_commits WHERE repository_id = %s and commit = %s`, repositoryID, commit)))
+	return count > 0, err
+}
+
 // UpdateCommits upserts commits/parent-commit relations for the given repository ID.
 func (db *dbImpl) UpdateCommits(ctx context.Context, tx *sql.Tx, repositoryID int, commits map[string][]string) (err error) {
 	if tx == nil {

--- a/internal/codeintel/db/commits_test.go
+++ b/internal/codeintel/db/commits_test.go
@@ -2,12 +2,51 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
+
+func TestHasCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := &dbImpl{db: dbconn.Global}
+
+	testCases := []struct {
+		repositoryID int
+		commit       string
+		exists       bool
+	}{
+		{50, makeCommit(1), true},
+		{50, makeCommit(2), false},
+		{51, makeCommit(1), false},
+	}
+
+	if err := db.UpdateCommits(context.Background(), nil, 50, map[string][]string{
+		makeCommit(1): {},
+	}); err != nil {
+		t.Fatalf("unexpected error updating commits: %s", err)
+	}
+
+	for _, testCase := range testCases {
+		name := fmt.Sprintf("repositoryID=%d commit=%s", testCase.repositoryID, testCase.commit)
+
+		t.Run(name, func(t *testing.T) {
+			exists, err := db.HasCommit(context.Background(), testCase.repositoryID, testCase.commit)
+			if err != nil {
+				t.Fatalf("unexpected error checking if commit exists: %s", err)
+			}
+			if exists != testCase.exists {
+				t.Errorf("unexpected exists. want=%v have=%v", testCase.exists, exists)
+			}
+		})
+	}
+}
 
 func TestUpdateCommits(t *testing.T) {
 	if testing.Short() {

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -82,6 +82,9 @@ type DB interface {
 	// default branch.
 	PackageReferencePager(ctx context.Context, scheme, name, version string, repositoryID, limit int) (int, ReferencePager, error)
 
+	// HasCommit determines if the given commit is known for the given repository.
+	HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error)
+
 	// UpdateCommits upserts commits/parent-commit relations for the given repository ID.
 	UpdateCommits(ctx context.Context, tx *sql.Tx, repositoryID int, commits map[string][]string) error
 

--- a/internal/codeintel/db/mocks/mock_db.go
+++ b/internal/codeintel/db/mocks/mock_db.go
@@ -48,6 +48,9 @@ type MockDB struct {
 	// GetUploadsByRepoFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsByRepo.
 	GetUploadsByRepoFunc *DBGetUploadsByRepoFunc
+	// HasCommitFunc is an instance of a mock function object controlling
+	// the behavior of the method HasCommit.
+	HasCommitFunc *DBHasCommitFunc
 	// PackageReferencePagerFunc is an instance of a mock function object
 	// controlling the behavior of the method PackageReferencePager.
 	PackageReferencePagerFunc *DBPackageReferencePagerFunc
@@ -134,6 +137,11 @@ func NewMockDB() *MockDB {
 				return nil, 0, nil
 			},
 		},
+		HasCommitFunc: &DBHasCommitFunc{
+			defaultHook: func(context.Context, int, string) (bool, error) {
+				return false, nil
+			},
+		},
 		PackageReferencePagerFunc: &DBPackageReferencePagerFunc{
 			defaultHook: func(context.Context, string, string, string, int, int) (int, db.ReferencePager, error) {
 				return 0, nil, nil
@@ -213,6 +221,9 @@ func NewMockDBFrom(i db.DB) *MockDB {
 		},
 		GetUploadsByRepoFunc: &DBGetUploadsByRepoFunc{
 			defaultHook: i.GetUploadsByRepo,
+		},
+		HasCommitFunc: &DBHasCommitFunc{
+			defaultHook: i.HasCommit,
 		},
 		PackageReferencePagerFunc: &DBPackageReferencePagerFunc{
 			defaultHook: i.PackageReferencePager,
@@ -1501,6 +1512,117 @@ func (c DBGetUploadsByRepoFuncCall) Args() []interface{} {
 // invocation.
 func (c DBGetUploadsByRepoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// DBHasCommitFunc describes the behavior when the HasCommit method of the
+// parent MockDB instance is invoked.
+type DBHasCommitFunc struct {
+	defaultHook func(context.Context, int, string) (bool, error)
+	hooks       []func(context.Context, int, string) (bool, error)
+	history     []DBHasCommitFuncCall
+	mutex       sync.Mutex
+}
+
+// HasCommit delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockDB) HasCommit(v0 context.Context, v1 int, v2 string) (bool, error) {
+	r0, r1 := m.HasCommitFunc.nextHook()(v0, v1, v2)
+	m.HasCommitFunc.appendCall(DBHasCommitFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the HasCommit method of
+// the parent MockDB instance is invoked and the hook queue is empty.
+func (f *DBHasCommitFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// HasCommit method of the parent MockDB instance inovkes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *DBHasCommitFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBHasCommitFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBHasCommitFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBHasCommitFunc) nextHook() func(context.Context, int, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBHasCommitFunc) appendCall(r0 DBHasCommitFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBHasCommitFuncCall objects describing the
+// invocations of this function.
+func (f *DBHasCommitFunc) History() []DBHasCommitFuncCall {
+	f.mutex.Lock()
+	history := make([]DBHasCommitFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBHasCommitFuncCall is an object that describes an invocation of method
+// HasCommit on an instance of MockDB.
+type DBHasCommitFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBHasCommitFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBHasCommitFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // DBPackageReferencePagerFunc describes the behavior when the


### PR DESCRIPTION
*Please review by commit*

This adds a missing bit of functionality that exists in the previous version. When a query comes in for a commit we don't know about, we ask gitserver for the ancestors of that commit then update the visibility of the dumps for that repo.

This allows us to determine the closest dump for commits we haven't seen before. This is a necessary step if you are viewing a commit newer than the latest dump to a branch.