### PR TITLE
app: add tests for `redirectTreeOrBlob`

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -260,8 +260,7 @@ func serveSignIn(w http.ResponseWriter, r *http.Request) error {
 
 // redirectTreeOrBlob redirects a blob page to a tree page if the file is actually a directory,
 // or a tree page to a blob page if the directory is actually a file.
-func redirectTreeOrBlob(routeName string, common *Common, w http.ResponseWriter, r *http.Request) (requestHandled bool, err error) {
-	path := mux.Vars(r)["Path"]
+func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseWriter, r *http.Request) (requestHandled bool, err error) {
 	if path == "/" || path == "" {
 		if routeName != routeRepo {
 			// Redirect to repo route
@@ -309,7 +308,7 @@ func serveTree(title func(c *Common, r *http.Request) string) handlerFunc {
 			return nil // request was handled
 		}
 
-		handled, err := redirectTreeOrBlob(routeTree, common, w, r)
+		handled, err := redirectTreeOrBlob(routeTree, mux.Vars(r)["Path"], common, w, r)
 		if handled {
 			return nil
 		}
@@ -332,7 +331,7 @@ func serveRepoOrBlob(routeName string, title func(c *Common, r *http.Request) st
 			return nil // request was handled
 		}
 
-		handled, err := redirectTreeOrBlob(routeName, common, w, r)
+		handled, err := redirectTreeOrBlob(routeName, mux.Vars(r)["Path"], common, w, r)
 		if handled {
 			return nil
 		}

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -20,6 +21,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 )
 
 func TestRedirects(t *testing.T) {
@@ -154,6 +157,207 @@ func TestNewCommon_repo_error(t *testing.T) {
 			}
 			if tt.code != code {
 				t.Errorf("unexpected status code: got=%d want=%d", code, tt.code)
+			}
+		})
+	}
+}
+
+func Test_redirectTreeOrBlob(t *testing.T) {
+	tests := []struct {
+		name          string
+		route         string
+		path          string
+		common        *Common
+		mockStat      os.FileInfo
+		expHandled    bool
+		expStatusCode int
+		expLocation   string
+	}{
+		{
+			name:          "empty path, no redirect",
+			route:         routeRepo,
+			path:          "",
+			expStatusCode: http.StatusOK,
+		},
+		{
+			name:          "root path, no redirect",
+			route:         routeRepo,
+			path:          "/",
+			expStatusCode: http.StatusOK,
+		},
+		{
+			name:  "view tree, no redirect",
+			route: routeTree,
+			path:  "/some/dir",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
+			expStatusCode: http.StatusOK,
+		},
+		{
+			name:  "view blob, no redirect",
+			route: routeBlob,
+			path:  "/some/file.go",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			mockStat:      &util.FileInfo{}, // Not a directory
+			expStatusCode: http.StatusOK,
+		},
+
+		// "/github.com/user/repo/-/tree/some/file.go" -> "/github.com/user/repo/-/blob/some/file.go"
+		{
+			name:  "redirct tree to blob",
+			route: routeTree,
+			path:  "/some/file.go",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			mockStat:      &util.FileInfo{}, // Not a directory
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo/-/blob/some/file.go",
+		},
+		// "/github.com/user/repo/-/blob/some/dir" -> "/github.com/user/repo/-/tree/some/dir"
+		{
+			name:  "redirct blob to tree",
+			route: routeBlob,
+			path:  "/some/dir",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo/-/tree/some/dir",
+		},
+		// "/github.com/user/repo@master/-/tree/some/file.go" -> "/github.com/user/repo@master/-/blob/some/file.go"
+		{
+			name:  "redirct tree to blob on a revision",
+			route: routeTree,
+			path:  "/some/file.go",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				Rev: "@master",
+			},
+			mockStat:      &util.FileInfo{}, // Not a directory
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo@master/-/blob/some/file.go",
+		},
+		// "/github.com/user/repo@master/-/blob/some/dir" -> "/github.com/user/repo@master/-/tree/some/dir"
+		{
+			name:  "redirct blob to tree on a revision",
+			route: routeBlob,
+			path:  "/some/dir",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				Rev: "@master",
+			},
+			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo@master/-/tree/some/dir",
+		},
+
+		// "/github.com/user/repo/-/tree" -> "/github.com/user/repo"
+		{
+			name:  "redirct tree to root",
+			route: routeTree,
+			path:  "",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo",
+		},
+		// "/github.com/user/repo/-/blob" -> "/github.com/user/repo"
+		{
+			name:  "redirct blob to root",
+			route: routeBlob,
+			path:  "",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+			},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo",
+		},
+		// "/github.com/user/repo@master/-/tree" -> "/github.com/user/repo"
+		{
+			name:  "redirct tree to root on a revision",
+			route: routeTree,
+			path:  "",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				Rev: "@master",
+			},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo@master",
+		},
+		// "/github.com/user/repo@master/-/blob" -> "/github.com/user/repo"
+		{
+			name:  "redirct blob to root on a revision",
+			route: routeBlob,
+			path:  "",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				Rev: "@master",
+			},
+			expHandled:    true,
+			expStatusCode: http.StatusTemporaryRedirect,
+			expLocation:   "/github.com/user/repo@master",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			git.Mocks.Stat = func(commit api.CommitID, name string) (os.FileInfo, error) {
+				return test.mockStat, nil
+			}
+			t.Cleanup(git.ResetMocks)
+
+			w := httptest.NewRecorder()
+			r, err := http.NewRequest("GET", test.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			handled, err := redirectTreeOrBlob(test.route, test.path, test.common, w, r)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if handled != test.expHandled {
+				t.Fatalf("handled: want %v but got %v", test.expHandled, handled)
+			} else if w.Code != test.expStatusCode {
+				t.Fatalf("code: want %d but got %d", test.expStatusCode, w.Code)
+			}
+
+			if got := w.Header().Get("Location"); got != test.expLocation {
+				t.Fatalf("redirect location: want %q but got %q", test.expLocation, got)
 			}
 		})
 	}


### PR DESCRIPTION
NOTE: Couldn't find a way to mock `mux.Vars(r)` so make that as an argument instead.

Fixes #10260.