### PR TITLE
Use asyncScheduler instead of animationFrameScheduler

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ const config = {
           {
             name: 'rxjs',
             importNames: 'animationFrameScheduler',
-            message: 'Code using animationFrameScheduler with breaks in Firefox when using Sentry.',
+            message: 'Code using animationFrameScheduler breaks in Firefox when using Sentry.',
           },
           {
             name: 'rxjs/fetch',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ const config = {
           'rxjs/ajax',
           {
             name: 'rxjs',
-            importNames: 'animationFrameScheduler',
+            importNames: ['animationFrameScheduler'],
             message: 'Code using animationFrameScheduler breaks in Firefox when using Sentry.',
           },
           {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,11 @@ const config = {
           'marked',
           'rxjs/ajax',
           {
+            name: 'rxjs',
+            importNames: 'animationFrameScheduler',
+            message: 'Code using animationFrameScheduler with breaks in Firefox when using Sentry.',
+          },
+          {
             name: 'rxjs/fetch',
             message:
               'rxjs fromFetch is broken. Until https://github.com/ReactiveX/rxjs/pull/5306 is merged, please use shared/src/graphql/fromFetch.ts',

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -11,7 +11,7 @@ import * as H from 'history'
 import * as React from 'react'
 import { render as reactDOMRender } from 'react-dom'
 import {
-    animationFrameScheduler,
+    asyncScheduler,
     combineLatest,
     EMPTY,
     from,
@@ -781,7 +781,7 @@ export function handleCodeHost({
                 })
             )
         ),
-        observeOn(animationFrameScheduler)
+        observeOn(asyncScheduler)
     )
 
     /** Map from workspace URI to number of editors referencing it */

--- a/browser/src/libs/code_intelligence/content_views.ts
+++ b/browser/src/libs/code_intelligence/content_views.ts
@@ -1,4 +1,4 @@
-import { animationFrameScheduler, merge, Observable, of, Subject, Subscription, Unsubscribable } from 'rxjs'
+import { asyncScheduler, merge, Observable, of, Subject, Subscription, Unsubscribable } from 'rxjs'
 import { distinctUntilChanged, map, mapTo, mergeMap, observeOn, tap, throttleTime } from 'rxjs/operators'
 import { LinkPreviewProviderRegistry } from '../../../../shared/src/api/client/services/linkPreview'
 import { applyLinkPreview } from '../../../../shared/src/components/linkPreviews/linkPreviews'
@@ -36,10 +36,7 @@ export function handleContentViews(
     }: Pick<CodeHost, 'contentViewResolvers' | 'linkPreviewContentClass' | 'setElementTooltip'>
 ): Unsubscribable {
     /** A stream of added or removed content views. */
-    const contentViews = mutations.pipe(
-        trackViews<ContentView>(contentViewResolvers || []),
-        observeOn(animationFrameScheduler)
-    )
+    const contentViews = mutations.pipe(trackViews<ContentView>(contentViewResolvers || []), observeOn(asyncScheduler))
 
     /** Pause DOM MutationObserver while we are making changes to avoid duplicating work. */
     const pauseMutationObserver = new Subject<boolean>()
@@ -82,7 +79,7 @@ export function handleContentViews(
                      * jsdom.
                      */
                     observeMutations(contentViewEvent.element, { childList: true }, pauseMutationObserver).pipe(
-                        observeOn(animationFrameScheduler),
+                        observeOn(asyncScheduler),
                         map(() => contentViewEvent.element.innerHTML),
                         distinctUntilChanged(),
                         tap(() => console.log('Content view updated', { contentViewEvent })),

--- a/browser/src/libs/code_intelligence/text_fields.tsx
+++ b/browser/src/libs/code_intelligence/text_fields.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { animationFrameScheduler, fromEvent, Observable, Subscription, Unsubscribable } from 'rxjs'
+import { asyncScheduler, fromEvent, Observable, Subscription, Unsubscribable } from 'rxjs'
 import { observeOn } from 'rxjs/operators'
 import { COMMENT_URI_SCHEME } from '../../../../shared/src/api/client/types/textDocument'
 import { EditorCompletionWidget } from '../../../../shared/src/components/completion/EditorCompletionWidget'
@@ -30,7 +30,7 @@ export function handleTextFields(
     }: Pick<CodeHost, 'textFieldResolvers' | 'completionWidgetClassProps'>
 ): Unsubscribable {
     /** A stream of added or removed text fields. */
-    const textFields = mutations.pipe(trackViews(textFieldResolvers || []), observeOn(animationFrameScheduler))
+    const textFields = mutations.pipe(trackViews(textFieldResolvers || []), observeOn(asyncScheduler))
 
     // Don't use lodash.uniqueId because that makes it harder to hard-code expected URI values in
     // test code (because the URIs would change depending on test execution order).
@@ -77,7 +77,7 @@ function synchronizeTextField(
     // Keep the text field in sync with the editor and model.
     subscriptions.add(
         fromEvent(element, 'input')
-            .pipe(observeOn(animationFrameScheduler))
+            .pipe(observeOn(asyncScheduler))
             .subscribe(() => {
                 EditorTextFieldUtils.updateModelFromElement(modelService, modelUri, element)
                 EditorTextFieldUtils.updateEditorSelectionFromElement(viewerService, editor, element)
@@ -85,7 +85,7 @@ function synchronizeTextField(
     )
     subscriptions.add(
         fromEvent(element, 'keydown')
-            .pipe(observeOn(animationFrameScheduler))
+            .pipe(observeOn(asyncScheduler))
             .subscribe(() => {
                 EditorTextFieldUtils.updateEditorSelectionFromElement(viewerService, editor, element)
             })


### PR DESCRIPTION
Fixes #7689

The root cause seems to be https://github.com/getsentry/sentry-javascript/issues/2352.

Using `asyncScheduler` should be better for performance anyway.