### PR TITLE
fix casing of settings and docs for search.uppercase feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Jaeger is now included in the Sourcegraph deployment configuration by default if you are using Kubernetes, Docker Compose, or the pure Docker cluster deployment model. (It is not yet included in the single Docker container distribution.) It will be included as part of upgrading to 3.15 in these deployment models, unless disabled.
   - The site configuration field, `useJaeger`, is deprecated in favor of `observability.tracing`.
   - Support for configuring Lightstep as a distributed tracer is deprecated and will be removed in a subsequent release. Instances that use Lightstep with Sourcegraph are encouraged to migrate to Jaeger (directions for running Jaeger alongside Sourcegraph are included in the installation instructions).
-  - Added search option where mixed-case patterns imply case-sensitivity. Used when searching for file contents using `and`- and `or`-expressions in queries and enabled via the existing global settings value `{"experimentalFeatures": {"andOrQuery": "enabled"}}` and the new setting `search.defaultPatternType`. [#10057](https://github.com/sourcegraph/sourcegraph/issues/10057)
+  - Added user setting `search.uppercase` that, when enabled, causes queries containing uppercase characters to be treated as case-insensitive. Used when searching for file contents using `and`- and `or`-expressions in queries and enabled via the existing global settings value `{"experimentalFeatures": {"andOrQuery": "enabled"}}` and the new setting `search.defaultPatternType`. [#10057](https://github.com/sourcegraph/sourcegraph/issues/10057)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -882,13 +882,13 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	case *query.OrdinaryQuery:
 		return r.evaluateLeaf(ctx)
 	case *query.AndOrQuery:
-		//get settings to check if SearchUpperCase is active or not and, if so, run transformer
+		// Get settings to check if `search.uppercase` is active. If so, run transformer.
 		settings, err := decodedViewerFinalSettings(ctx)
 		if err != nil {
 			return nil, err
 		}
-		if v := settings.SearchUpperCase; v != nil && *v {
-			q.Query = query.SearchUpperCase(q.Query)
+		if v := settings.SearchUppercase; v != nil && *v {
+			q.Query = query.SearchUppercase(q.Query)
 		}
 		return r.evaluate(ctx, q.Query)
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -84,12 +84,12 @@ func Hoist(nodes []Node) ([]Node, error) {
 	return append(scopeParameters, newOperator(pattern, expression.Kind)...), nil
 }
 
-// SearchUpperCase adds case:yes to queries if any pattern is mixed-case.
-func SearchUpperCase(nodes []Node) []Node {
+// SearchUppercase adds case:yes to queries if any pattern is mixed-case.
+func SearchUppercase(nodes []Node) []Node {
 	var foundMixedCase bool
 	VisitParameter(nodes, func(field, value string, negated, _ bool) {
 		if field == "" || field == "content" {
-			if match := containsUpperCase(value); match {
+			if match := containsUppercase(value); match {
 				foundMixedCase = true
 			}
 		}
@@ -101,7 +101,7 @@ func SearchUpperCase(nodes []Node) []Node {
 	return nodes
 }
 
-func containsUpperCase(s string) bool {
+func containsUppercase(s string) bool {
 	for _, r := range s {
 		if unicode.IsUpper(r) && unicode.IsLetter(r) {
 			return true

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -126,7 +126,7 @@ func Test_Hoist(t *testing.T) {
 	}
 }
 
-func Test_SearchUpperCase(t *testing.T) {
+func TestSearchUppercase(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -173,9 +173,9 @@ func Test_SearchUpperCase(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		t.Run("searchUpperCase", func(t *testing.T) {
+		t.Run("searchUppercase", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
-			got := prettyPrint(SearchUpperCase(query))
+			got := prettyPrint(SearchUppercase(query))
 			if diff := cmp.Diff(got, c.want); diff != "" {
 				t.Fatal(diff)
 			}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -901,8 +901,6 @@ type Settings struct {
 	Notices []*Notice `json:"notices,omitempty"`
 	// Quicklinks description: Links that should be accessible quickly from the home and search pages.
 	Quicklinks []*QuickLink `json:"quicklinks,omitempty"`
-	// SearchUpperCase description: When active, any upper case characters in the pattern will make the entire query case-sensitive.
-	SearchUpperCase *bool `json:"search.UpperCase,omitempty"`
 	// SearchContextLines description: The default number of lines to show as context below and above search results. Default is 1.
 	SearchContextLines int `json:"search.contextLines,omitempty"`
 	// SearchDefaultPatternType description: The default pattern type (literal or regexp) that search queries will be intepreted as.
@@ -917,6 +915,8 @@ type Settings struct {
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
 	// SearchScopes description: Predefined search scopes
 	SearchScopes []*SearchScope `json:"search.scopes,omitempty"`
+	// SearchUppercase description: When active, any uppercase characters in the pattern will make the entire query case-sensitive.
+	SearchUppercase *bool `json:"search.uppercase,omitempty"`
 }
 
 // SettingsExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -178,8 +178,8 @@
       "type": "boolean",
       "default": false
     },
-    "search.UpperCase": {
-      "description": "When active, any upper case characters in the pattern will make the entire query case-sensitive.",
+    "search.uppercase": {
+      "description": "When active, any uppercase characters in the pattern will make the entire query case-sensitive.",
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -183,8 +183,8 @@ const SettingsSchemaJSON = `{
       "type": "boolean",
       "default": false
     },
-    "search.UpperCase": {
-      "description": "When active, any upper case characters in the pattern will make the entire query case-sensitive.",
+    "search.uppercase": {
+      "description": "When active, any uppercase characters in the pattern will make the entire query case-sensitive.",
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }


### PR DESCRIPTION
- `Uppercase` is a single word, so it should be rendered like that and not `UpperCase`.
- By convention, we use `lowerCamel.case` for settings properties (so `search.uppercase` not `search.Uppercase` or `search.UpperCase`).
- The changelog entry should mention the settings property.