### PR TITLE
major syntax highlighting improvements (update syntect_server)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ All notable changes to Sourcegraph are documented in this file.
 - [Major syntax highlighting improvements](https://github.com/sourcegraph/syntect_server/pull/29), including:
   - 228 commits / 1 year of improvements to the syntax highlighter library Sourcegraph uses ([syntect](https://github.com/trishume/syntect)).
   - 432 commits / 1 year of improvements to the base syntax definitions for ~36 languages Sourcegraph uses ([sublimehq/Packages](https://github.com/sublimehq/Packages)).
-  - 30 new file extensions/names now properly detected.
-  - Added support for: ASP vb.NET, ASP.net HTML, COBOL, jcl, CUDA C++, Solidity/Vyper (Ethereum), Smarty
-  - Likely fixes other major instability and language support issues.
+  - 30 new file extensions/names now detected.
+  - Likely fixes other major instability and language support issues. #9557
+  - Added [Smarty](#2885), [Ethereum / Solidity / Vyper)](#2440), [Cuda](#5907), [COBOL](#10154), [vb.NET](#4901), and [ASP.NET](#4262) syntax highlighting.
+  - Fixed OCaml syntax highlighting #3545
+  - Bazel/Starlark support improved (.star, BUILD, and many more extensions now properly highlighted). #8123
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to Sourcegraph are documented in this file.
 - Autocompletion for `repogroup` filters in search queries. [#10141](https://github.com/sourcegraph/sourcegraph/pull/10286)
 - If the experimental feature flag `codeInsights` is enabled, extensions can contribute content to directory pages through the experimental `ViewProvider` API. [#10236](https://github.com/sourcegraph/sourcegraph/pull/10236)
   - Directory pages are then represented as an experimental `DirectoryViewer` in the `visibleViewComponents` of the extension API. **Note: This may break extensions that were assuming `visibleViewComponents` were always `CodeEditor`s and did not check the `type` property.** Extensions checking the `type` property will continue to work. [#10236](https://github.com/sourcegraph/sourcegraph/pull/10236)
+- [Major syntax highlighting improvements](https://github.com/sourcegraph/syntect_server/pull/29), including:
+  - 228 commits / 1 year of improvements to the syntax highlighter library Sourcegraph uses ([syntect](https://github.com/trishume/syntect)).
+  - 432 commits / 1 year of improvements to the base syntax definitions for ~36 languages Sourcegraph uses ([sublimehq/Packages](https://github.com/sublimehq/Packages)).
+  - 30 new file extensions/names now properly detected.
+  - Added support for: ASP vb.NET, ASP.net HTML, COBOL, jcl, CUDA C++, Solidity/Vyper (Ethereum), Smarty
+  - Likely fixes other major instability and language support issues.
 
 ### Changed
 

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -55,7 +55,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:c0297a1@sha256:333abb45cfaae9c9d37e576c3853843b00eca33a40a7c71f6b93211ed96528df /syntect_server /usr/local/bin/
+COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 COPY --from=precise-code-intel-builder /precise-code-intel /precise-code-intel
 

--- a/dev/syntect_server.sh
+++ b/dev/syntect_server.sh
@@ -23,4 +23,4 @@ if [[ "${INSECURE_DEV:-}" == '1' ]]; then
 fi
 
 docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server
-exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:c0297a1@sha256:333abb45cfaae9c9d37e576c3853843b00eca33a40a7c71f6b93211ed96528df
+exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:c0297a1@sha256:333abb45cfaae9c9d37e576c3853843b00eca33a40a7c71f6b93211ed96528df
-docker tag index.docker.io/sourcegraph/syntect_server:c0297a1@sha256:333abb45cfaae9c9d37e576c3853843b00eca33a40a7c71f6b93211ed96528df "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
+docker tag index.docker.io/sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff "$IMAGE"


### PR DESCRIPTION
See the changelog for details, or the linked PR for detailed information: https://github.com/sourcegraph/syntect_server/pull/29

- Fixes sourcegraph/sourcegraph#2885 (Smarty support)
- Fixes sourcegraph/sourcegraph#2440 (Ethereum / Solidity / Vyper support)
- Fixes sourcegraph/sourcegraph#5907 (Cuda support)
- Helps sourcegraph/sourcegraph#10154 (adds COBOL syntax highlighting)
- Fixes sourcegraph/sourcegraph#8123 (Treat .build_defs, .star, and BUILD files as Bazel/Starlark files)
- Helps sourcegraph/sourcegraph#4901 (adds VB.Net syntax highlighting)
- Helps sourcegraph/sourcegraph#4262 (adds ASP.NET syntax highlighting)
- Fixes sourcegraph/sourcegraph#3545 (OCaml support)
- Helps sourcegraph/sourcegraph#9557 (likely fixes, but needs confirmation from customer)
