### PR TITLE
zoekt: use go.mod version for building docker images

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -11,3 +11,7 @@ module="$(go get ${fork}@master 2>&1 | grep -E -o ${fork}'@v0.0.0-[0-9a-z-]+')"
 
 go mod edit "-replace=${upstream}=${module}"
 go mod download ${upstream}
+
+# Ensure we update go.sum by actually compiling some code which depends on
+# zoekt
+go test -run '^$' github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend

--- a/docker-images/indexed-searcher/build.sh
+++ b/docker-images/indexed-searcher/build.sh
@@ -4,6 +4,13 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.webserver
-docker pull index.docker.io/sourcegraph/zoekt-webserver:0.0.20200401202737-ef3ec23@sha256:d48de388d28899fd0c3ad0d6f84d466b3a1f533f6b967a713918d438ab8bc63c
-docker tag index.docker.io/sourcegraph/zoekt-webserver:0.0.20200401202737-ef3ec23@sha256:d48de388d28899fd0c3ad0d6f84d466b3a1f533f6b967a713918d438ab8bc63c "$IMAGE"
+# actual image currently lives here:
+# https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.webserver
+#
+# The images are tagged using the same psuedo-versions as go mod, so we
+# extract the version from our go.mod
+
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
+
+docker pull index.docker.io/sourcegraph/zoekt-webserver:"$version"
+docker tag index.docker.io/sourcegraph/zoekt-webserver:"$version" "$IMAGE"

--- a/docker-images/indexed-searcher/build.sh
+++ b/docker-images/indexed-searcher/build.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here:
 # https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.webserver
 #
-# The images are tagged using the same psuedo-versions as go mod, so we
+# The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
 version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')

--- a/docker-images/search-indexer/build.sh
+++ b/docker-images/search-indexer/build.sh
@@ -4,6 +4,13 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.indexserver
-docker pull index.docker.io/sourcegraph/zoekt-indexserver:0.0.20200401202737-ef3ec23@sha256:354ed968e62a7d011b647476a63116813aea23bdada0a2fc4322df5381acb6b3
-docker tag index.docker.io/sourcegraph/zoekt-indexserver:0.0.20200401202737-ef3ec23@sha256:354ed968e62a7d011b647476a63116813aea23bdada0a2fc4322df5381acb6b3 "$IMAGE"
+# actual image currently lives here:
+# https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.indexserver
+#
+# The images are tagged using the same psuedo-versions as go mod, so we
+# extract the version from our go.mod
+
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
+
+docker pull index.docker.io/sourcegraph/zoekt-indexserver:"$version"
+docker tag index.docker.io/sourcegraph/zoekt-indexserver:"$version" "$IMAGE"

--- a/docker-images/search-indexer/build.sh
+++ b/docker-images/search-indexer/build.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here:
 # https://github.com/sourcegraph/zoekt/blob/master/Dockerfile.indexserver
 #
-# The images are tagged using the same psuedo-versions as go mod, so we
+# The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
 version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200417123535-6727685ef676
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,10 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20200417123535-6727685ef676 h1:1SCZ9cp6ckpn0FWXZEb6rREdoqOSdSmvH3fp6wW/N04=
 github.com/sourcegraph/zoekt v0.0.0-20200417123535-6727685ef676/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
+github.com/sourcegraph/zoekt v0.0.0-20200429072728-1a9304f241c9 h1:6wfwD6/CE5vzecnUSW5V6/OocC/HkCbstIEmn7HFuG8=
+github.com/sourcegraph/zoekt v0.0.0-20200429072728-1a9304f241c9/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
+github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f h1:5SvCsZHC8K7apQ+RsWimTds2aDCuEl4/Mwr3QHC/k4c=
+github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This keeps us in sync between dev/server and the images we use in cluster
environments.

Additionally we update zoekt to include fixes to universal-ctags.

Part of https://github.com/sourcegraph/sourcegraph/issues/10357