### PR TITLE
campaigns: Refactor CalcCounts to use concrete types instead of custom interfaces

### DIFF
--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -21,7 +21,7 @@ func TestCalcCounts(t *testing.T) {
 		changesets []*campaigns.Changeset
 		start      time.Time
 		end        time.Time
-		events     []Event
+		events     []*campaigns.ChangesetEvent
 		want       []*ChangesetCounts
 	}{
 		{
@@ -31,7 +31,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -47,7 +47,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -63,7 +63,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(4),
 			end:   daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -80,7 +80,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(4),
 			end:   daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(7), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -97,7 +97,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(4),
 			end:   daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(7), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -113,7 +113,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(3),
 			end:   now.Add(-18 * time.Hour),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
@@ -130,7 +130,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(2, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 2),
 			},
@@ -148,7 +148,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(2, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 			},
@@ -166,7 +166,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(2, daysAgo(2)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubMerged, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 2),
 			},
@@ -186,7 +186,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(2, daysAgo(2)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 			},
@@ -205,7 +205,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 			},
@@ -222,7 +222,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
@@ -239,7 +239,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(4)),
 			},
 			start: daysAgo(5),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubReopened, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
@@ -260,7 +260,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(4)),
 			},
 			start: daysAgo(5),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
@@ -282,7 +282,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(2, daysAgo(4)),
 			},
 			start: daysAgo(6),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(4), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 2),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubReopened, 1),
@@ -308,7 +308,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(2, daysAgo(4)),
 			},
 			start: daysAgo(6),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(4), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 2),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
@@ -333,7 +333,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(4)),
 			},
 			start: daysAgo(5),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubReopened, 1),
@@ -354,7 +354,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(4)),
 			},
 			start: daysAgo(5),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
@@ -375,7 +375,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
@@ -394,7 +394,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
@@ -413,7 +413,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
@@ -432,7 +432,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
@@ -451,7 +451,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
@@ -471,7 +471,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
@@ -491,7 +491,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
@@ -510,7 +510,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
@@ -529,7 +529,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubMerged, 1),
@@ -548,7 +548,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(3), "user1", "COMMENTED"),
 				ghReview(1, daysAgo(2), "user2", "APPROVED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
@@ -568,7 +568,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(3), "user1", campaigns.ChangesetEventKindBitbucketServerCommented),
 				bbsActivity(1, daysAgo(2), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
@@ -588,7 +588,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "APPROVED"),
 				ghReview(1, daysAgo(0), "user2", "APPROVED"),
 			},
@@ -604,7 +604,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
 			},
@@ -620,7 +620,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
 				ghReview(1, daysAgo(0), "user2", "CHANGES_REQUESTED"),
 			},
@@ -636,7 +636,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerReviewed),
 			},
@@ -652,7 +652,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
@@ -671,7 +671,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
@@ -692,7 +692,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(3, daysAgo(6)),
 			},
 			start: daysAgo(7),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
 				ghReview(2, daysAgo(4), "user1", "APPROVED"),
@@ -722,7 +722,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(3, daysAgo(6)),
 			},
 			start: daysAgo(7),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(5), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 				bbsActivity(2, daysAgo(4), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
@@ -754,7 +754,7 @@ func TestCalcCounts(t *testing.T) {
 			// Same test as above, except we only look at 3 days in the middle
 			start: daysAgo(4),
 			end:   daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
 				ghReview(2, daysAgo(4), "user1", "APPROVED"),
@@ -775,7 +775,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
 				ghReview(1, daysAgo(0), "user1", "APPROVED"),
 			},
@@ -791,7 +791,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(0), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 			},
@@ -807,7 +807,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "APPROVED"),
 				ghReview(1, daysAgo(0), "user1", "CHANGES_REQUESTED"),
 			},
@@ -823,7 +823,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 			},
@@ -839,7 +839,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "APPROVED"),
 				ghReview(1, daysAgo(0), "user2", "CHANGES_REQUESTED"), // This has higher precedence
 			},
@@ -855,7 +855,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerReviewed),
 			},
@@ -871,7 +871,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
 				ghReview(1, daysAgo(0), "user2", "APPROVED"),
 			},
@@ -887,7 +887,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
 			},
@@ -903,7 +903,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				ghReview(1, daysAgo(1), "user2", "APPROVED"),
 				ghReview(1, daysAgo(0), "user1", "APPROVED"),
@@ -921,7 +921,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(1), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
@@ -939,7 +939,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				ghReview(1, daysAgo(1), "user2", "CHANGES_REQUESTED"),
 				ghReview(1, daysAgo(0), "user1", "CHANGES_REQUESTED"),
@@ -957,7 +957,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(1), "user2", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(0), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
@@ -975,7 +975,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerUnapproved),
 			},
@@ -994,7 +994,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user1", campaigns.ChangesetEventKindBitbucketServerUnapproved),
@@ -1014,7 +1014,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerUnapproved),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
@@ -1034,7 +1034,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(4),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(1), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(1, daysAgo(0), "user2", campaigns.ChangesetEventKindBitbucketServerUnapproved),
@@ -1059,7 +1059,7 @@ func TestCalcCounts(t *testing.T) {
 				bbsChangeset(6, daysAgo(6)),
 			},
 			start: daysAgo(7),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				// GitHub Events
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
 				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
@@ -1113,7 +1113,7 @@ func TestCalcCounts(t *testing.T) {
 				setExternalDeletedAt(bbsChangeset(2, daysAgo(3)), daysAgo(1)),
 			},
 			start: daysAgo(3),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubClosed, 1),
 				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerDeclined, 2),
 			},
@@ -1132,7 +1132,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				// GitHub updates the state of the reviews when they're dismissed
 				ghReview(1, daysAgo(0), "user1", "DISMISSED"),
 				ghReviewDismissed(1, daysAgo(0), "user2", "user1"),
@@ -1149,7 +1149,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
 				// GitHub updates the state of the changesets when they're dismissed
 				ghReview(1, daysAgo(1), "user2", "DISMISSED"),
@@ -1168,7 +1168,7 @@ func TestCalcCounts(t *testing.T) {
 				ghChangeset(1, daysAgo(1)),
 			},
 			start: daysAgo(1),
-			events: []Event{
+			events: []*campaigns.ChangesetEvent{
 				ghReview(1, daysAgo(1), "user1", "CHANGES_REQUESTED"),
 				// After a dismissal, GitHub removes all of the author's
 				// reviews from the overall review state, which is why we don't

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -32,7 +32,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 1, Open: 1, OpenPending: 1},
@@ -48,7 +48,7 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 1, Open: 1, OpenPending: 1},
@@ -64,7 +64,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			end:   daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -81,7 +81,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			end:   daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(7), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(7), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 1, Merged: 1},
@@ -98,7 +98,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			end:   daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(7), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(7), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 1, Merged: 1},
@@ -114,7 +114,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			end:   now.Add(-18 * time.Hour),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2).Add(-18 * time.Hour), Total: 0, Merged: 0},
@@ -131,8 +131,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 2},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 2, Open: 2, OpenPending: 2},
@@ -149,8 +149,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 2},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 2, Open: 2, OpenPending: 2},
@@ -167,8 +167,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(4),
 			events: []Event{
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubMerged, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -187,8 +187,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(4),
 			events: []Event{
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -206,8 +206,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 1, Open: 1, OpenPending: 1},
@@ -223,8 +223,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(2),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(2), Total: 1, Open: 1, OpenPending: 1},
@@ -240,9 +240,9 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(5),
 			events: []Event{
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubReopened, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(5), Total: 0, Open: 0},
@@ -261,9 +261,9 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(5),
 			events: []Event{
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(5), Total: 0, Open: 0},
@@ -283,12 +283,12 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(6),
 			events: []Event{
-				fakeEvent{t: daysAgo(4), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubClosed, id: 2},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubReopened, id: 2},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubMerged, id: 2},
+				event(t, daysAgo(4), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 2),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubReopened, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubReopened, 2),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(6), Total: 0, Open: 0},
@@ -309,12 +309,12 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(6),
 			events: []Event{
-				fakeEvent{t: daysAgo(4), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 2},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 2},
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 2},
+				event(t, daysAgo(4), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 2),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerReopened, 2),
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(6), Total: 0, Open: 0},
@@ -334,9 +334,9 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(5),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(5), Total: 0, Open: 0},
@@ -355,9 +355,9 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(5),
 			events: []Event{
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(5), Total: 0, Open: 0},
@@ -377,7 +377,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -396,7 +396,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			events: []Event{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -415,8 +415,8 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -434,8 +434,8 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -453,9 +453,9 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -473,9 +473,9 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -493,8 +493,8 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -512,8 +512,8 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindBitbucketServerReopened, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerDeclined, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindBitbucketServerReopened, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -531,8 +531,8 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(3),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(0), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(0), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 1, Open: 1, OpenPending: 1},
@@ -551,7 +551,7 @@ func TestCalcCounts(t *testing.T) {
 			events: []Event{
 				ghReview(1, daysAgo(3), "user1", "COMMENTED"),
 				ghReview(1, daysAgo(2), "user2", "APPROVED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -571,7 +571,7 @@ func TestCalcCounts(t *testing.T) {
 			events: []Event{
 				bbsActivity(1, daysAgo(3), "user1", campaigns.ChangesetEventKindBitbucketServerCommented),
 				bbsActivity(1, daysAgo(2), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -654,7 +654,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			events: []Event{
 				ghReview(1, daysAgo(2), "user1", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -673,7 +673,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			events: []Event{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},
@@ -694,13 +694,13 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(7),
 			events: []Event{
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
 				ghReview(2, daysAgo(4), "user1", "APPROVED"),
 				ghReview(2, daysAgo(3), "user2", "APPROVED"),
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubMerged, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubMerged, 2),
 				ghReview(3, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				ghReview(3, daysAgo(1), "user2", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 3},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 3),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(7), Total: 0, Open: 0},
@@ -724,13 +724,13 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(7),
 			events: []Event{
 				bbsActivity(1, daysAgo(5), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerMerged, 1),
 				bbsActivity(2, daysAgo(4), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(2, daysAgo(3), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 				bbsActivity(3, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(3, daysAgo(1), "user2", campaigns.ChangesetEventKindBitbucketServerReviewed),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 3},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 3),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(7), Total: 0, Open: 0},
@@ -756,11 +756,11 @@ func TestCalcCounts(t *testing.T) {
 			end:   daysAgo(2),
 			events: []Event{
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
 				ghReview(2, daysAgo(4), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubMerged, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubMerged, 2),
 				ghReview(3, daysAgo(2), "user1", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 3},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 3),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 3, Open: 3, OpenPending: 1, OpenApproved: 2},
@@ -1062,22 +1062,22 @@ func TestCalcCounts(t *testing.T) {
 			events: []Event{
 				// GitHub Events
 				ghReview(1, daysAgo(5), "user1", "APPROVED"),
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindGitHubMerged, id: 1},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindGitHubMerged, 1),
 				ghReview(3, daysAgo(4), "user1", "APPROVED"),
 				ghReview(3, daysAgo(3), "user2", "APPROVED"),
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubMerged, id: 3},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubMerged, 3),
 				ghReview(5, daysAgo(2), "user1", "CHANGES_REQUESTED"),
 				ghReview(5, daysAgo(1), "user2", "CHANGES_REQUESTED"),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindGitHubMerged, id: 5},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindGitHubMerged, 5),
 				// Bitbucket Server Events
 				bbsActivity(2, daysAgo(5), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(3), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 2},
+				event(t, daysAgo(3), campaigns.ChangesetEventKindBitbucketServerMerged, 2),
 				bbsActivity(4, daysAgo(4), "user1", campaigns.ChangesetEventKindBitbucketServerApproved),
 				bbsActivity(4, daysAgo(3), "user2", campaigns.ChangesetEventKindBitbucketServerApproved),
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 4},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerMerged, 4),
 				bbsActivity(6, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
 				bbsActivity(6, daysAgo(1), "user2", campaigns.ChangesetEventKindBitbucketServerReviewed),
-				fakeEvent{t: daysAgo(1), kind: campaigns.ChangesetEventKindBitbucketServerMerged, id: 6},
+				event(t, daysAgo(1), campaigns.ChangesetEventKindBitbucketServerMerged, 6),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(7), Total: 0, Open: 0},
@@ -1114,8 +1114,8 @@ func TestCalcCounts(t *testing.T) {
 			},
 			start: daysAgo(3),
 			events: []Event{
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindGitHubClosed, id: 1},
-				fakeEvent{t: daysAgo(2), kind: campaigns.ChangesetEventKindBitbucketServerDeclined, id: 2},
+				event(t, daysAgo(2), campaigns.ChangesetEventKindGitHubClosed, 1),
+				event(t, daysAgo(2), campaigns.ChangesetEventKindBitbucketServerDeclined, 2),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(3), Total: 2, Open: 2, OpenPending: 2},
@@ -1205,16 +1205,6 @@ func TestCalcCounts(t *testing.T) {
 	}
 }
 
-type fakeEvent struct {
-	t    time.Time
-	kind campaigns.ChangesetEventKind
-	id   int64
-}
-
-func (e fakeEvent) Timestamp() time.Time               { return e.t }
-func (e fakeEvent) Type() campaigns.ChangesetEventKind { return e.kind }
-func (e fakeEvent) Changeset() int64                   { return e.id }
-
 func ghChangeset(id int64, t time.Time) *campaigns.Changeset {
 	return &campaigns.Changeset{ID: id, Metadata: &github.PullRequest{CreatedAt: t}}
 }
@@ -1234,6 +1224,37 @@ func setExternalDeletedAt(c *campaigns.Changeset, t time.Time) *campaigns.Change
 
 func timeToUnixMilli(t time.Time) int {
 	return int(t.UnixNano()) / int(time.Millisecond)
+}
+
+func event(t *testing.T, ti time.Time, kind campaigns.ChangesetEventKind, id int64) *campaigns.ChangesetEvent {
+	ch := &campaigns.ChangesetEvent{ChangesetID: id, Kind: kind}
+
+	switch kind {
+	case campaigns.ChangesetEventKindGitHubMerged:
+		ch.Metadata = &github.MergedEvent{CreatedAt: ti}
+	case campaigns.ChangesetEventKindGitHubClosed:
+		ch.Metadata = &github.ClosedEvent{CreatedAt: ti}
+	case campaigns.ChangesetEventKindGitHubReopened:
+		ch.Metadata = &github.ReopenedEvent{CreatedAt: ti}
+
+	case campaigns.ChangesetEventKindBitbucketServerMerged,
+		campaigns.ChangesetEventKindBitbucketServerDeclined,
+		campaigns.ChangesetEventKindBitbucketServerReopened:
+
+		ch.Metadata = &bitbucketserver.Activity{CreatedDate: timeToUnixMilli(ti)}
+
+	default:
+		t.Fatalf("unknown changeset event kind: %s", kind)
+	}
+
+	want := ti.UTC().Truncate(time.Millisecond)
+	have := ch.Timestamp().UTC().Truncate(time.Millisecond)
+	if !have.Equal(want) {
+		t.Fatalf("ChangesetEvent.Timestamp() yields wrong timestamp, want=%s, have=%s (make sure to set the right attribute when constructing test event)",
+			want, have)
+	}
+
+	return ch
 }
 
 func ghReview(id int64, t time.Time, login, state string) *campaigns.ChangesetEvent {

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -248,12 +248,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		return resolvers, err
 	}
 
-	events := make([]ee.Event, len(es))
-	for i, e := range es {
-		events[i] = e
-	}
-
-	counts, err := ee.CalcCounts(start, end, cs, events...)
+	counts, err := ee.CalcCounts(start, end, cs, es...)
 	if err != nil {
 		return resolvers, err
 	}


### PR DESCRIPTION
This is a first step torwards  #9101 and loosens `CalcCount`s dependency on the custom types `Event` and `Events`. These were necessary back when the `CalcCounts` was written. But in order to unify the code, we can easily get rid of them now.

Other PRs to follow, but this is a lot of "noise", so I wanted to send this out first for easier reviewing.