### PR TITLE
merge experimentalFeatures settings

### DIFF
--- a/shared/src/settings/settings.test.ts
+++ b/shared/src/settings/settings.test.ts
@@ -84,6 +84,15 @@ describe('mergeSettings', () => {
         ).toEqual({
             extensions: { 'sourcegraph/cpp': false, 'sourcegraph/go': false, 'sourcegraph/typescript': true },
         }))
+    test('merges experimentalFeatures property', () =>
+        expect(
+            mergeSettings<Settings & { experimentalFeatures: { a?: boolean; b?: boolean; c?: boolean } }>([
+                { experimentalFeatures: { a: true, b: true } },
+                { experimentalFeatures: { b: false, c: true } },
+            ])
+        ).toEqual({
+            experimentalFeatures: { a: true, b: false, c: true },
+        }))
     test('merges search.scopes property', () =>
         expect(
             mergeSettings<

--- a/shared/src/settings/settings.ts
+++ b/shared/src/settings/settings.ts
@@ -183,6 +183,7 @@ export function mergeSettings<S extends Settings>(values: S[]): S | null {
     }
     const customFunctions: CustomMergeFunctions = {
         extensions: (base: any, add: any) => ({ ...base, ...add }),
+        experimentalFeatures: (base: any, add: any) => ({ ...base, ...add }),
         notices: (base: any, add: any) => [...base, ...add],
         'search.scopes': (base: any, add: any) => [...base, ...add],
         'search.savedQueries': (base: any, add: any) => [...base, ...add],


### PR DESCRIPTION
If global settings or organization settings has an `experimentalFeatures` settings object and so does the user, for example, then the values should be merged. The highest-precedence (the user's in this case) should not clobber the object from lower-precedence settings.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->