### PR TITLE
codeintel: Fix typos

### DIFF
--- a/internal/codeintel/bundles/reader/sqlite_reader.go
+++ b/internal/codeintel/bundles/reader/sqlite_reader.go
@@ -57,11 +57,11 @@ func (r *sqliteReader) ReadDocument(ctx context.Context, path string) (types.Doc
 		}
 	}
 
-	x, err := r.serializer.UnmarshalDocumentData(data)
+	documentData, err := r.serializer.UnmarshalDocumentData(data)
 	if err != nil {
 		return types.DocumentData{}, false, err
 	}
-	return x, true, nil
+	return documentData, true, nil
 }
 
 func (r *sqliteReader) ReadResultChunk(ctx context.Context, id int) (types.ResultChunkData, bool, error) {
@@ -74,11 +74,11 @@ func (r *sqliteReader) ReadResultChunk(ctx context.Context, id int) (types.Resul
 		}
 	}
 
-	x, err := r.serializer.UnmarshalResultChunkData(data)
+	resultChunkData, err := r.serializer.UnmarshalResultChunkData(data)
 	if err != nil {
 		return types.ResultChunkData{}, false, err
 	}
-	return x, true, nil
+	return resultChunkData, true, nil
 }
 
 func (r *sqliteReader) ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) ([]types.DefinitionReferenceRow, int, error) {

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -68,7 +68,7 @@ type DB interface {
 	DeleteOldestDump(ctx context.Context) (int, bool, error)
 
 	// UpdateDumpsVisibleFromTip recalculates the visible_at_tip flag of all dumps of the given repository.
-	UpdateDumpsVisibleFromTip(ctx context.Context, repositoryID int, tipCommit string) (err error)
+	UpdateDumpsVisibleFromTip(ctx context.Context, repositoryID int, tipCommit string) error
 
 	// DeleteOverlapapingDumps deletes all completed uploads for the given repository with the same
 	// commit, root, and indexer. This is necessary to perform during conversions before changing


### PR DESCRIPTION
Fix named err in interface signature, fix bad `x` varname.