### PR TITLE
ctags: simplify NewParser and skip long lines

### DIFF
--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -38,31 +38,15 @@ type Parser interface {
 	Close()
 }
 
-func isCommandAvailable(name string) bool {
-	cmd := exec.Command("/bin/sh", "-c", "command -v "+name)
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-	return true
-}
-
 var ctagsCommand = env.Get("CTAGS_COMMAND", "universal-ctags", "ctags command (should point to universal-ctags executable compiled with JSON and seccomp support)")
 
 // Increasing this value may increase the size of the symbols cache, but will also stop long lines containing symbols from
 // being highlighted improperly. See https://github.com/sourcegraph/sourcegraph/issues/7668.
 var rawPatternLengthLimit = env.Get("CTAGS_PATTERN_LENGTH_LIMIT", "250", "the maximum length of the patterns output by ctags")
 
-// GetCommand returns the ctags command from the CTAGS_COMMAND environment
-// variable, falling back to `universal-ctags`. Panics if the command doesn't
-// exist.
-func GetCommand() string {
-	if !isCommandAvailable(ctagsCommand) {
-		panic(fmt.Errorf("ctags command %s not found", ctagsCommand))
-	}
-	return ctagsCommand
-}
-
-func NewParser(ctagsCommand string) (Parser, error) {
+// NewParser runs the ctags command from the CTAGS_COMMAND environment
+// variable, falling back to `universal-ctags`.
+func NewParser() (Parser, error) {
 	patternLengthLimit, err := strconv.Atoi(rawPatternLengthLimit)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern length limit: %s", rawPatternLengthLimit)

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -79,7 +79,7 @@ func New() (Parser, error) {
 	proc := ctagsProcess{
 		cmd:     cmd,
 		in:      in,
-		out:     &scanner{r: bufio.NewReader(out)},
+		out:     &scanner{r: bufio.NewReaderSize(out, 4096)},
 		outPipe: out,
 	}
 

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -44,9 +44,9 @@ var ctagsCommand = env.Get("CTAGS_COMMAND", "universal-ctags", "ctags command (s
 // being highlighted improperly. See https://github.com/sourcegraph/sourcegraph/issues/7668.
 var rawPatternLengthLimit = env.Get("CTAGS_PATTERN_LENGTH_LIMIT", "250", "the maximum length of the patterns output by ctags")
 
-// NewParser runs the ctags command from the CTAGS_COMMAND environment
+// New runs the ctags command from the CTAGS_COMMAND environment
 // variable, falling back to `universal-ctags`.
-func NewParser() (Parser, error) {
+func New() (Parser, error) {
 	patternLengthLimit, err := strconv.Atoi(rawPatternLengthLimit)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern length limit: %s", rawPatternLengthLimit)

--- a/cmd/symbols/internal/pkg/ctags/parser_test.go
+++ b/cmd/symbols/internal/pkg/ctags/parser_test.go
@@ -9,12 +9,11 @@ import (
 
 func TestParser(t *testing.T) {
 	// TODO(sqs): find a way to make it easy to run these tests in local dev (w/o needing to install universal-ctags) and CI
-	const command = "universal-ctags"
-	if _, err := exec.LookPath(command); err != nil {
-		t.Skipf("command not in PATH: %s", command)
+	if _, err := exec.LookPath("universal-ctags"); err != nil {
+		t.Skip("command not in PATH: universal-ctags")
 	}
 
-	p, err := NewParser(command)
+	p, err := NewParser()
 	if err != nil {
 		if os.Getenv("CI") == "" {
 			t.Skipf("failed to start universal-ctags. Assuming it is due to our custom build of universal-ctags not being installed. Reason: %v", err)

--- a/cmd/symbols/internal/pkg/ctags/parser_test.go
+++ b/cmd/symbols/internal/pkg/ctags/parser_test.go
@@ -13,7 +13,7 @@ func TestParser(t *testing.T) {
 		t.Skip("command not in PATH: universal-ctags")
 	}
 
-	p, err := NewParser()
+	p, err := New()
 	if err != nil {
 		if os.Getenv("CI") == "" {
 			t.Skipf("failed to start universal-ctags. Assuming it is due to our custom build of universal-ctags not being installed. Reason: %v", err)

--- a/cmd/symbols/internal/symbols/search_test.go
+++ b/cmd/symbols/internal/symbols/search_test.go
@@ -17,14 +17,13 @@ import (
 
 func BenchmarkSearch(b *testing.B) {
 	sqliteutil.MustRegisterSqlite3WithPcre()
-	ctagsCommand := ctags.GetCommand()
 
 	log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))
 
 	service := Service{
 		FetchTar: testutil.FetchTarFromGithub,
 		NewParser: func() (ctags.Parser, error) {
-			return ctags.NewParser(ctagsCommand)
+			return ctags.NewParser()
 		},
 		Path: "/tmp/symbols-cache",
 	}

--- a/cmd/symbols/internal/symbols/search_test.go
+++ b/cmd/symbols/internal/symbols/search_test.go
@@ -23,7 +23,7 @@ func BenchmarkSearch(b *testing.B) {
 	service := Service{
 		FetchTar: testutil.FetchTarFromGithub,
 		NewParser: func() (ctags.Parser, error) {
-			return ctags.NewParser()
+			return ctags.New()
 		},
 		Path: "/tmp/symbols-cache",
 	}

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -16,7 +15,6 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/pkg/ctags"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/symbols"
@@ -51,14 +49,8 @@ func main() {
 		FetchTar: func(ctx context.Context, repo gitserver.Repo, commit api.CommitID) (io.ReadCloser, error) {
 			return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: "tar"})
 		},
-		NewParser: func() (ctags.Parser, error) {
-			parser, err := ctags.NewParser(ctags.GetCommand())
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("command: %s", ctags.GetCommand()))
-			}
-			return parser, nil
-		},
-		Path: cacheDir,
+		NewParser: ctags.NewParser,
+		Path:      cacheDir,
 	}
 	if mb, err := strconv.ParseInt(cacheSizeMB, 10, 64); err != nil {
 		log.Fatalf("Invalid SYMBOLS_CACHE_SIZE_MB: %s", err)

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -49,7 +49,7 @@ func main() {
 		FetchTar: func(ctx context.Context, repo gitserver.Repo, commit api.CommitID) (io.ReadCloser, error) {
 			return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: "tar"})
 		},
-		NewParser: ctags.NewParser,
+		NewParser: ctags.New,
 		Path:      cacheDir,
 	}
 	if mb, err := strconv.ParseInt(cacheSizeMB, 10, 64); err != nil {


### PR DESCRIPTION
Review commit by commit. Some small changes I noticed while looking into unifying the zoekt and sourcegraph ctags use.