### PR TITLE
gitserver: prevent names that could escape repodir

### DIFF
--- a/internal/gitserver/protocol/util.go
+++ b/internal/gitserver/protocol/util.go
@@ -11,7 +11,10 @@ import (
 func NormalizeRepo(input api.RepoName) api.RepoName {
 	repo := string(input)
 	repo = strings.TrimSuffix(repo, ".git")
-	repo = path.Clean(repo)
+
+	// Clean with a "/" so we get out an absolute path
+	repo = path.Clean("/" + repo)
+	repo = strings.TrimPrefix(repo, "/")
 
 	// Check if we need to do lowercasing. If we don't we can avoid the
 	// allocations we do later in the function.

--- a/internal/gitserver/protocol/util_test.go
+++ b/internal/gitserver/protocol/util_test.go
@@ -1,18 +1,22 @@
 package protocol
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
 
 func TestNormalizeRepo(t *testing.T) {
-	if NormalizeRepo("FooBar.git") != "FooBar" {
-		t.Fail()
+	cases := map[api.RepoName]api.RepoName{
+		"FooBar.git":               "FooBar",
+		"gitHub.Com/FooBar.git":    "github.com/foobar",
+		"myServer.Com/FooBar.git":  "myserver.com/FooBar",
+		"myServer.Com/FooBar/.git": "myserver.com/FooBar",
 	}
-	if NormalizeRepo("gitHub.Com/FooBar.git") != "github.com/foobar" {
-		t.Fail()
-	}
-	if NormalizeRepo("myServer.Com/FooBar.git") != "myserver.com/FooBar" {
-		t.Fail()
-	}
-	if NormalizeRepo("myServer.Com/FooBar/.git") != "myserver.com/FooBar" {
-		t.Fail()
+
+	for k, want := range cases {
+		if got := NormalizeRepo(k); got != want {
+			t.Errorf("NormalizeRepo(%q): got %q want %q", k, got, want)
+		}
 	}
 }

--- a/internal/gitserver/protocol/util_test.go
+++ b/internal/gitserver/protocol/util_test.go
@@ -12,6 +12,16 @@ func TestNormalizeRepo(t *testing.T) {
 		"gitHub.Com/FooBar.git":    "github.com/foobar",
 		"myServer.Com/FooBar.git":  "myserver.com/FooBar",
 		"myServer.Com/FooBar/.git": "myserver.com/FooBar",
+
+		// trying to escape gitserver root
+		"/etc/passwd":                       "etc/passwd",
+		"../../../etc/passwd":               "etc/passwd",
+		"foobar.git/../etc/passwd":          "etc/passwd",
+		"foobar.git/../../../../etc/passwd": "etc/passwd",
+
+		// Degenerate cases
+		"foo/bar/../..":  "",
+		"/foo/bar/../..": "",
 	}
 
 	for k, want := range cases {


### PR DESCRIPTION
If a user found a way to issue a request for a repo name that didn't exist in
our DB, they could escape $REPODIR and treat other parts of the system as a
git dir. This is likely benign and a repo not going through the repos table
indicates a slip up in our permissions code (a worse problem). However, rather
safe than sorry.