### PR TITLE
Fix shellcheck change

### DIFF
--- a/browser/scripts/release-ff.sh
+++ b/browser/scripts/release-ff.sh
@@ -11,12 +11,14 @@ mkdir -p build/web-ext
 web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/firefox --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
 
 # Upload to gcp and make it public
-for filename in $(ls build/web-ext/*); do
-  gsutil cp "build/web-ext/$filename" "gs://sourcegraph-for-firefox/$filename"
-  gsutil cp "build/web-ext/$filename" "gs://sourcegraph-for-firefox/latest.xpi"
+pushd build/web-ext
+for filename in ./*; do
+  gsutil cp "$filename" "gs://sourcegraph-for-firefox/$filename"
+  gsutil cp "$filename" "gs://sourcegraph-for-firefox/latest.xpi"
   gsutil -m acl set -R -a public-read "gs://sourcegraph-for-firefox/$filename"
   gsutil -m acl set -R -a public-read "gs://sourcegraph-for-firefox/latest.xpi"
 done
+popd
 
 export TS_NODE_COMPILER_OPTIONS="{\"module\":\"commonjs\"}"
 

--- a/browser/scripts/release-ff.sh
+++ b/browser/scripts/release-ff.sh
@@ -8,10 +8,10 @@ rm -rf build/web-ext
 mkdir -p build/web-ext
 
 # Sign the bundle
-web-ext sign --source-dir ./build/firefox --artifacts-dir . --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
+web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/firefox --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
 
 # Upload to gcp and make it public
-for filename in build/web-ext/*; do
+for filename in $(ls build/web-ext/*); do
   gsutil cp "build/web-ext/$filename" "gs://sourcegraph-for-firefox/$filename"
   gsutil cp "build/web-ext/$filename" "gs://sourcegraph-for-firefox/latest.xpi"
   gsutil -m acl set -R -a public-read "gs://sourcegraph-for-firefox/$filename"

--- a/browser/scripts/release-ff.sh
+++ b/browser/scripts/release-ff.sh
@@ -8,7 +8,7 @@ rm -rf build/web-ext
 mkdir -p build/web-ext
 
 # Sign the bundle
-web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/firefox --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
+web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/web-ext --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
 
 # Upload to gcp and make it public
 pushd build/web-ext

--- a/browser/scripts/release-ff.sh
+++ b/browser/scripts/release-ff.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 # Setup
 yarn build


### PR DESCRIPTION
@ggilmore there's an important difference in behavior here: `ls` returns _file names_, while the bash iteration returns cwd-relative paths. Since we use the filename in the GCP upload destination, we need file names. (This is the reason for the browser extension release currently being broken)