### PR TITLE
Provide DisableNonCriticalTelemetry config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Files and directories that are not found now return a 404 status code. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 - The site admin flag `disableNonCriticalTelemetry` now allows Sourcegraph admins to disable most anonymous telemetry. Visit https://docs.sourcegraph.com/admin/pings to learn more.
 
-
 ### Fixed
 
 - In the OSS version of Sourcegraph, authorization providers are properly initialized and GraphQL APIs are no longer blocked. [#3487](https://github.com/sourcegraph/sourcegraph/issues/3487)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to Sourcegraph are documented in this file.
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)
 - Tree pages now redirect to blob pages if the path is not a tree and vice versa. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 - Files and directories that are not found now return a 404 status code. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
+- The site admin flag `disableNonCriticalTelemetry` now allows Sourcegraph admins to disable most anonymous telemetry. Visit https://docs.sourcegraph.com/admin/pings to learn more.
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `userID` and `orgID` fields in the SavedSearch type in the GraphQL API have been replaced with a `namespace` field. To get the ID of the user or org that owns the saved search, use `namespace.id`. [#5327](https://github.com/sourcegraph/sourcegraph/pull/5327)
 - Tree pages now redirect to blob pages if the path is not a tree and vice versa. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
 - Files and directories that are not found now return a 404 status code. [#10193](https://github.com/sourcegraph/sourcegraph/pull/10193)
-- The site admin flag `disableNonCriticalTelemetry` now allows Sourcegraph admins to disable most anonymous telemetry. Visit https://docs.sourcegraph.com/admin/pings to learn more.
+- The site admin flag `disableNonCriticalTelemetry` now allows Sourcegraph admins to disable most anonymous telemetry. Visit https://docs.sourcegraph.com/admin/pings to learn more. [#10402](https://github.com/sourcegraph/sourcegraph/pull/10402)
 
 ### Fixed
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -148,13 +148,13 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 	}
 
 	r := &pingRequest{
-		ClientSiteID:         siteid.Get(),
-		DeployType:           conf.DeployType(),
-		ClientVersionString:  version.Version(),
-		LicenseKey: conf.Get().LicenseKey,
-		CodeIntelUsage: []byte("{}"),
-		SearchUsage: []byte("{}"),
-		CampaignsUsage: []byte("{}"),
+		ClientSiteID:        siteid.Get(),
+		DeployType:          conf.DeployType(),
+		ClientVersionString: version.Version(),
+		LicenseKey:          conf.Get().LicenseKey,
+		CodeIntelUsage:      []byte("{}"),
+		SearchUsage:         []byte("{}"),
+		CampaignsUsage:      []byte("{}"),
 	}
 
 	totalUsers, err := db.Users.Count(ctx, &db.UsersListOptions{})

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -319,14 +319,14 @@ func Start() {
 	}
 
 	ctx := context.Background()
-	const delay = 30 * time.Second
+	const delay = 30 * time.Minute
 	for {
 		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		_, _ = check(ctx) // updates global state on its own, can safely ignore return value
 		cancel()
 
 		// Randomize sleep to prevent thundering herds.
-		randomDelay := time.Duration(1) * time.Second
+		randomDelay := time.Duration(rand.Intn(600)) * time.Second
 		time.Sleep(delay + randomDelay)
 	}
 }

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -62,7 +62,7 @@ func IsPending() bool {
 
 var baseURL = &url.URL{
 	Scheme: "https",
-	Host:   "sourcegraph.test:3443",
+	Host:   "sourcegraph.com",
 	Path:   "/.api/updates",
 }
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	// "math/rand"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -106,7 +106,7 @@ func getAndMarshalCodeIntelUsageJSON(ctx context.Context) (json.RawMessage, erro
 		DayPeriods:            &days,
 		WeekPeriods:           &weeks,
 		MonthPeriods:          &months,
-		IncludeEventCounts:    !conf.Get().DisableNonCriticalTelemetry,
+		IncludeEventCounts:    true,
 		IncludeEventLatencies: true,
 	})
 	if err != nil {
@@ -125,7 +125,7 @@ func getAndMarshalSearchUsageJSON(ctx context.Context) (json.RawMessage, error) 
 		DayPeriods:         &days,
 		WeekPeriods:        &weeks,
 		MonthPeriods:       &months,
-		IncludeEventCounts: !conf.Get().DisableNonCriticalTelemetry,
+		IncludeEventCounts: true,
 	})
 	if err != nil {
 		return nil, err
@@ -151,6 +151,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		ClientSiteID:         siteid.Get(),
 		DeployType:           conf.DeployType(),
 		ClientVersionString:  version.Version(),
+		LicenseKey: conf.Get().LicenseKey,
 		CodeIntelUsage: []byte("{}"),
 		SearchUsage: []byte("{}"),
 		CampaignsUsage: []byte("{}"),
@@ -211,7 +212,6 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 			logFunc("externalServicesKinds failed", "error", err)
 		}
 
-		r.LicenseKey = conf.Get().LicenseKey
 		r.HasExtURL = conf.UsingExternalURL()
 		r.BuiltinSignupAllowed = conf.IsBuiltinSignupAllowed()
 		r.AuthProviders = authProviderTypes()

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -2,29 +2,38 @@
 
 Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and customer teams. It sends only the high-level data below. It never sends code, repository names, usernames, or any other specific data. To learn more, go to the **Site admin > Pings** page on your instance. (The URL is `https://sourcegraph.example.com/site-admin/pings`.)
 
-- Sourcegraph version string
-- Deployment type (single-node or Kubernetes cluster)
-- Whether the instance is deployed on localhost (true/false)
+## Critical telemetry
+
+Critical telemetry includes only the high-level data below required for billing, support, updates, and security notices. This cannot be disabled.
+
 - Randomly generated site identifier
+- The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, security updates, and policy updates
+- Sourcegraph version string (e.g. "vX.X.X")
+- Deployment type (single Docker image, Docker Compose, Kubernetes cluster, or pure Docker cluster)
 - License key associated with your Sourcegraph subscription
-- The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, and policy updates
+- Aggregate count of current monthly users
+- Total count of existing user accounts
+
+## Other telemetry
+
+By default, Sourcegraph also aggregates usage and performance metrics for some product features. No personal or specific information is ever included. Starting in May 2020 (Sourcegraph version 3.16), Sourcegraph admins can disable the telemetry items below by setting the `DisableNonCriticalTelemetry` setting to `true` on the **Site-admin** > **Site configuration** page.
+
+- Whether the instance is deployed on localhost (true/false)
 - Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, SAML, GitHub, GitLab)
 - Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS CodeCommit, Other)
 - Whether new user signup is allowed (true/false)
 - Whether a repository has ever been added (true/false)
 - Whether a code search has ever been executed (true/false)
 - Whether code intelligence has ever been used (true/false)
-- Total count of existing user accounts
 - Aggregate counts of current daily, weekly, and monthly users
-- Aggregate counts of current users using code host integrations
-- Aggregate counts of current users by product feature (site management, code search and navigation, code review, saved searches, diff searches)
+- Aggregate counts of current daily, weekly, and monthly users, by:
+  - Whether they are using code host integrations
+  - Product area (site management, code search and navigation, code review, saved searches, diff searches)
+  - Search modes used (interactive search, plain-text search)
+  - Search filters used (e.g. "type:", "repo:", "file:", "lang:", etc.)
 - Aggregate daily, weekly, and monthly latencies (in ms) of code intelligence events (e.g., hover tooltips) and search queries
-- Aggregate daily, weekly, and monthly total counts of code intelligence events (e.g., hover tooltips)
+- Aggregate daily, weekly, and monthly counts of:
+  - Code intelligence events (e.g., hover tooltips) 
+  - Searches using each search mode (interactive search, plain-text search)
+  - Searches using each search filter (e.g. "type:", "repo:", "file:", "lang:", etc.)
 - Total count of code campaigns created
-- Aggregate counts of current daily, weekly, and monthly users using search
-- Aggregate daily, weekly, and monthly total users using each search mode
-- Aggregate daily, weekly, and monthly total searches using each search mode
-- Aggregate daily, weekly, and monthly total counts of searches using each search filter.
-- Aggregate daily, weekly, and monthly total counts of users conducting searches using each search filter.
-
-To disable pings, please [contact support](https://about.sourcegraph.com/contact/).

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -77,7 +77,7 @@ interface SourcegraphContext
      */
     site: Pick<
         import('./schema/site.schema').SiteConfiguration,
-        'auth.public' | 'update.channel' | 'campaigns.readAccess.enabled'
+        'auth.public' | 'update.channel' | 'campaigns.readAccess.enabled' | 'disableNonCriticalTelemetry'
     >
 
     /** Whether access tokens are enabled. */

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -61,7 +61,7 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                 <p>
                     By default, Sourcegraph also aggregates usage and performance metrics for some product features. No
                     personal or specific information is ever included. Starting in May 2020 (Sourcegraph version 3.16),
-                    Sourcegraph admins can disable the telemetry items below by setting the
+                    Sourcegraph admins can disable the telemetry items below by setting the{' '}
                     <code>DisableNonCriticalTelemetry</code> setting to <code>true</code> on the{' '}
                     <Link to="/site-admin/configuration">Site configuration page</Link>.
                 </p>

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 import { Subscription } from 'rxjs'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
@@ -24,7 +25,8 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        const pingsEnabled = window.context.site['update.channel'] === 'release'
+        const nonCriticalTelemetryDisabled = window.context.site.disableNonCriticalTelemetry === true
+        const updatesDisabled = window.context.site['update.channel'] === 'release'
 
         return (
             <div className="site-admin-pings-page">
@@ -35,54 +37,79 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                     sends only the high-level data below. It never sends code, repository names, usernames, or any other
                     specific data.
                 </p>
+                <h3>Critical telemetry</h3>
+                <p>
+                    Critical telemetry includes only the high-level data below required for billing, support, updates,
+                    and security notices. This cannot be disabled.
+                </p>
                 <ul>
-                    <li>Sourcegraph version string</li>
-                    <li>Deployment type (Docker, Kubernetes, or dev build)</li>
-                    <li>Whether the instance is deployed on localhost (true/false)</li>
                     <li>Randomly generated site identifier</li>
                     <li>
                         The email address of the initial site installer (or if deleted, the first active site admin), to
-                        know who to contact regarding sales, product updates, and policy updates
+                        know who to contact regarding sales, product updates, security updates, and policy updates
                     </li>
+                    <li>Sourcegraph version string (e.g. "vX.X.X")</li>
+                    <li>
+                        Deployment type (single Docker image, Docker Compose, Kubernetes cluster, or pure Docker
+                        cluster)
+                    </li>
+                    <li>License key associated with your Sourcegraph subscription</li>
+                    <li>Aggregate count of current monthly users</li>
+                    <li>Total count of existing user accounts</li>
+                </ul>
+                <h3>Other telemetry</h3>
+                <p>
+                    By default, Sourcegraph also aggregates usage and performance metrics for some product features. No
+                    personal or specific information is ever included. Starting in May 2020 (Sourcegraph version 3.16),
+                    Sourcegraph admins can disable the telemetry items below by setting the
+                    <code>DisableNonCriticalTelemetry</code> setting to <code>true</code> on the{' '}
+                    <Link to="/site-admin/configuration">Site configuration page</Link>.
+                </p>
+                <ul>
+                    <li>Whether the instance is deployed on localhost (true/false)</li>
                     <li>
                         Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy,
                         SAML, GitHub, GitLab)
                     </li>
                     <li>
-                        Which categories of external service are in use (GitHub, Bitbucket Server, GitLab, Phabricator,
-                        Gitolite, AWS CodeCommit, Other)
+                        Which code hosts are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS
+                        CodeCommit, Other)
                     </li>
                     <li>Whether new user signup is allowed (true/false)</li>
                     <li>Whether a repository has ever been added (true/false)</li>
                     <li>Whether a code search has ever been executed (true/false)</li>
                     <li>Whether code intelligence has ever been used (true/false)</li>
-                    <li>Total count of existing user accounts</li>
                     <li>Aggregate counts of current daily, weekly, and monthly users</li>
-                    <li>Aggregate counts of current users using code host integrations</li>
                     <li>
-                        Aggregate counts of current users by product feature (site management, code search and
-                        navigation, code review, saved searches, diff searches)
+                        Aggregate counts of current daily, weekly, and monthly users, by:
+                        <ul>
+                            <li>Whether they are using code host integrations</li>
+                            <li>
+                                Product area (site management, code search and navigation, code review, saved searches,
+                                diff searches)
+                            </li>
+                            <li>Search modes used (interactive search, plain-text search)</li>
+                            <li>Search filters used (e.g. "type:", "repo:", "file:", "lang:", etc.)</li>
+                        </ul>
                     </li>
                     <li>
                         Aggregate daily, weekly, and monthly latencies (in ms) of code intelligence events (e.g., hover
                         tooltips) and search queries
                     </li>
                     <li>
-                        Aggregate daily, weekly, and monthly total counts of code intelligence events (e.g., hover
-                        tooltips)
+                        Aggregate daily, weekly, and monthly counts of:
+                        <ul>
+                            <li>Code intelligence events (e.g., hover tooltips) </li>
+                            <li>Searches using each search mode (interactive search, plain-text search)</li>
+                            <li>Searches using each search filter (e.g. "type:", "repo:", "file:", "lang:", etc.)</li>
+                        </ul>
                     </li>
                     <li>Total count of code campaigns created</li>
                 </ul>
-                {!pingsEnabled ? (
-                    <p>Pings are disabled.</p>
+                {updatesDisabled ? (
+                    <p>All telemetry is disabled.</p>
                 ) : (
-                    <p>
-                        To disable pings please {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                        <a href="https://about.sourcegraph.com/contact/" target="_blank" rel="noopener">
-                            contact support
-                        </a>
-                        .
-                    </p>
+                    nonCriticalTelemetryDisabled && <p>Non-critical telemetry is disabled.</p>
                 )}
             </div>
         )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/8995

The final list of critical telemetry includes:

* Email address of installer (for contact for security notices, product releases, etc.).
* Unique site ID (random string ID of an instance)
* Sourcegraph version (for security notices)
* Sourcegraph deployment type (for security notices)
* Total user accounts (for billing)
* Monthly active users (for billing)
* The license key in use (for billing)

@ebrodymoore please review the docs and admin page updates (I separate the list into two parts, I reformatted and reworded some of the list items, and I added some more examples). Preview of this:

![image](https://user-images.githubusercontent.com/5589410/81016748-e4110700-8e15-11ea-97ce-9854636063d2.png)
