### PR TITLE
Browser extension nightly DOM checks

### DIFF
--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -27,6 +27,7 @@ type Config struct {
 	taggedRelease       bool
 	releaseBranch       bool
 	isBextReleaseBranch bool
+	isBextNightly       bool
 	isRenovateBranch    bool
 	patch               bool
 	patchNoTest         bool
@@ -93,6 +94,7 @@ func ComputeConfig() Config {
 		isQuick:             isQuick,
 		isMasterDryRun:      isMasterDryRun,
 		profilingEnabled:    profilingEnabled,
+		isBextNightly:       os.Getenv("BEXT_NIGHTLY") == "true",
 	}
 }
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -156,7 +156,7 @@ func addBrowserExtensionE2ESteps(pipeline *bk.Pipeline) {
 			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("pushd browser"),
 			bk.Cmd("yarn -s run build"),
-			bk.Cmd("yarn -s mocha ./src/e2e/github.test.ts"),
+			bk.Cmd("yarn -s mocha ./src/e2e/github.test.ts ./src/e2e/gitlab.test.ts"),
 			bk.Cmd("popd"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 	}

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -144,8 +144,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 		bk.Cmd("./dev/ci/docker-lint.sh"))
 }
 
-// Release the browser extension.
-func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
+func addBrowserExtensionE2ESteps(pipeline *bk.Pipeline) {
 	for _, browser := range []string{"chrome", "firefox"} {
 		// Run e2e tests
 		pipeline.AddStep(fmt.Sprintf(":%s:", browser),
@@ -161,6 +160,11 @@ func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
 			bk.Cmd("popd"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 	}
+}
+
+// Release the browser extension.
+func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
+	addBrowserExtensionE2ESteps(pipeline)
 
 	pipeline.AddWait()
 

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -82,6 +82,17 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addBrowserExtensionReleaseSteps,
 		}
 
+	case c.isBextReleaseBranch:
+		// If this is a browser extension nightly build, run the browser-extension tests and
+		// e2e tests.
+		pipelineOperations = []func(*bk.Pipeline){
+			addLint,
+			addBrowserExt,
+			addSharedTests,
+			wait,
+			addBrowserExtensionE2ESteps,
+		}
+
 	case c.isQuick:
 		// Run fast steps only
 		pipelineOperations = []func(*bk.Pipeline){

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -82,7 +82,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addBrowserExtensionReleaseSteps,
 		}
 
-	case c.isBextReleaseBranch:
+	case c.isBextNightly:
 		// If this is a browser extension nightly build, run the browser-extension tests and
 		// e2e tests.
 		pipelineOperations = []func(*bk.Pipeline){


### PR DESCRIPTION
This works on #7980
I added a new pipeline to Buildkite that runs on a schedule (every day at midnight) and failures are posted to #web, so we get notified. 
After we finally managed to fix the tests, this tests for DOM changes on github.com and gitlab.com (browser extension, not native integration).
For an example run see here: https://buildkite.com/sourcegraph/browser-extension-nightly/builds/1

TODO after merge: Need to set the target branch for the scheduled build to master