### PR TITLE
Make externalRepository non-nullable

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1626,7 +1626,7 @@ type Repository implements Node & GenericSearchResultInterface {
     mirrorInfo: MirrorRepositoryInfo!
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
-    externalRepository: ExternalRepository
+    externalRepository: ExternalRepository!
     # Whether the repository is a fork.
     isFork: Boolean!
     # Whether the repository has been archived.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1633,7 +1633,7 @@ type Repository implements Node & GenericSearchResultInterface {
     mirrorInfo: MirrorRepositoryInfo!
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
-    externalRepository: ExternalRepository
+    externalRepository: ExternalRepository!
     # Whether the repository is a fork.
     isFork: Boolean!
     # Whether the repository has been archived.


### PR DESCRIPTION
In the code, it has already been non-nullable, but the schema was wrong.

https://sourcegraph.com/github.com/sourcegraph/sourcegraph@5204b66f7505d7d40fa2d1df125fdb712f060d9b/-/blob/cmd/frontend/graphqlbackend/repository_external.go#L13
