### PR TITLE
campaigns: Support more generic PullRequest events from Bitbucket server

### DIFF
--- a/enterprise/internal/campaigns/testdata/fixtures/webhooks/bitbucketserver/add-comment.json
+++ b/enterprise/internal/campaigns/testdata/fixtures/webhooks/bitbucketserver/add-comment.json
@@ -1,7 +1,7 @@
 {
     "payloads": [
       {
-        "payload_type": "IGNORED_FOR_THIS_EVENT",
+        "payload_type": "pr:activity:status",
         "data": {
           "createdDate": "2020-04-29T2:13:01+0000",
           "user": {

--- a/enterprise/internal/campaigns/testdata/fixtures/webhooks/bitbucketserver/needswork-to-unapproved.json
+++ b/enterprise/internal/campaigns/testdata/fixtures/webhooks/bitbucketserver/needswork-to-unapproved.json
@@ -1,9 +1,9 @@
 {
     "payloads": [
       {
-        "payload_type": "pr:activity:status",
+        "payload_type": "pr:activity:event",
         "data": {
-          "createdDate": "2020-04-29T2:34:04+0000",
+          "createdDate": 1588667488870,
           "user": {
             "name": "milton",
             "emailAddress": "dev@sourcegraph.com",
@@ -22,19 +22,19 @@
             "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
           },
           "pullRequest": {
-            "id": 19,
-            "version": 3,
-            "title": "test failure",
-            "description": "foobar\n\n- one\n- two\n- three\n\nnow a checklist\n\n- [ ] foobar\n- [ ] checkbar\n- [ ] blub\n\nHere a separator:\n\n---\n\nCheck this out",
+            "id": 69,
+            "version": 0,
+            "title": "foobar",
+            "description": "testing",
             "state": "OPEN",
             "open": true,
             "closed": false,
-            "createdDate": 1575182062149,
-            "updatedDate": 1575367552547,
+            "createdDate": 1584460001757,
+            "updatedDate": 1584460001757,
             "fromRef": {
-              "id": "refs/heads/sourcegraph/campaign-19",
-              "displayId": "sourcegraph/campaign-19",
-              "latestCommit": "97e23097783c5197849527b496c6365f43d5eb0b",
+              "id": "refs/heads/foobar",
+              "displayId": "foobar",
+              "latestCommit": "18ca4a8427d54620dee34832f20554553a0c481e",
               "repository": {
                 "slug": "automation-testing",
                 "id": 10070,
@@ -159,224 +159,7 @@
                   },
                   "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
                 },
-                "role": "REVIEWER",
-                "approved": false,
-                "status": "UNAPPROVED"
-              }
-            ],
-            "participants": [],
-            "links": {
-              "self": [
-                {
-                  "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/19"
-                }
-              ]
-            }
-          },
-          "activity": {
-            "id": 3003,
-            "createdDate": 1588170844885,
-            "user": {
-              "name": "milton",
-              "emailAddress": "dev@sourcegraph.com",
-              "id": 1,
-              "displayName": "milton woof",
-              "active": true,
-              "slug": "milton",
-              "type": "NORMAL",
-              "links": {
-                "self": [
-                  {
-                    "href": "https://bitbucket.sgdev.org/users/milton"
-                  }
-                ]
-              },
-              "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
-            },
-            "action": "UPDATED",
-            "addedReviewers": [
-              {
-                "name": "milton",
-                "emailAddress": "dev@sourcegraph.com",
-                "id": 1,
-                "displayName": "milton woof",
-                "active": true,
-                "slug": "milton",
-                "type": "NORMAL",
-                "links": {
-                  "self": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/users/milton"
-                    }
-                  ]
-                },
-                "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
-              }
-            ],
-            "removedReviewers": []
-          }
-        }
-      },
-      {
-        "payload_type": "pr:activity:status",
-        "data": {
-          "createdDate": "2020-04-29T2:35:05+0000",
-          "user": {
-            "name": "milton",
-            "emailAddress": "dev@sourcegraph.com",
-            "id": 1,
-            "displayName": "milton woof",
-            "active": true,
-            "slug": "milton",
-            "type": "NORMAL",
-            "links": {
-              "self": [
-                {
-                  "href": "https://bitbucket.sgdev.org/users/milton"
-                }
-              ]
-            },
-            "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
-          },
-          "pullRequest": {
-            "id": 19,
-            "version": 3,
-            "title": "test failure",
-            "description": "foobar\n\n- one\n- two\n- three\n\nnow a checklist\n\n- [ ] foobar\n- [ ] checkbar\n- [ ] blub\n\nHere a separator:\n\n---\n\nCheck this out",
-            "state": "OPEN",
-            "open": true,
-            "closed": false,
-            "createdDate": 1575182062149,
-            "updatedDate": 1575367552547,
-            "fromRef": {
-              "id": "refs/heads/sourcegraph/campaign-19",
-              "displayId": "sourcegraph/campaign-19",
-              "latestCommit": "97e23097783c5197849527b496c6365f43d5eb0b",
-              "repository": {
-                "slug": "automation-testing",
-                "id": 10070,
-                "name": "automation-testing",
-                "scmId": "git",
-                "state": "AVAILABLE",
-                "statusMessage": "Available",
-                "forkable": true,
-                "project": {
-                  "key": "SOUR",
-                  "id": 1,
-                  "name": "sourcegraph",
-                  "public": false,
-                  "type": "NORMAL",
-                  "links": {
-                    "self": [
-                      {
-                        "href": "https://bitbucket.sgdev.org/projects/SOUR"
-                      }
-                    ]
-                  },
-                  "avatarUrl": "/projects/SOUR/avatar.png?s=64\u0026v=1564708360389"
-                },
-                "public": false,
-                "links": {
-                  "clone": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/scm/sour/automation-testing.git",
-                      "name": "http"
-                    }
-                  ],
-                  "self": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"
-                    }
-                  ]
-                }
-              }
-            },
-            "toRef": {
-              "id": "refs/heads/master",
-              "displayId": "master",
-              "latestCommit": "e833db3fe2bdbc28b58cd72def1b0078e77aa171",
-              "repository": {
-                "slug": "automation-testing",
-                "id": 10070,
-                "name": "automation-testing",
-                "scmId": "git",
-                "state": "AVAILABLE",
-                "statusMessage": "Available",
-                "forkable": true,
-                "project": {
-                  "key": "SOUR",
-                  "id": 1,
-                  "name": "sourcegraph",
-                  "public": false,
-                  "type": "NORMAL",
-                  "links": {
-                    "self": [
-                      {
-                        "href": "https://bitbucket.sgdev.org/projects/SOUR"
-                      }
-                    ]
-                  },
-                  "avatarUrl": "/projects/SOUR/avatar.png?s=64\u0026v=1564708360389"
-                },
-                "public": false,
-                "links": {
-                  "clone": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/scm/sour/automation-testing.git",
-                      "name": "http"
-                    }
-                  ],
-                  "self": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"
-                    }
-                  ]
-                }
-              }
-            },
-            "locked": false,
-            "author": {
-              "user": {
-                "name": "thorsten",
-                "emailAddress": "thorsten@sourcegraph.com",
-                "id": 104,
-                "displayName": "thorsten",
-                "active": true,
-                "slug": "thorsten",
-                "type": "NORMAL",
-                "links": {
-                  "self": [
-                    {
-                      "href": "https://bitbucket.sgdev.org/users/thorsten"
-                    }
-                  ]
-                },
-                "avatarUrl": "https://secure.gravatar.com/avatar/3019a6cedc57148130de2a9c97977eb3.jpg?s=64\u0026d=mm"
-              },
-              "role": "AUTHOR",
-              "approved": false,
-              "status": "UNAPPROVED"
-            },
-            "reviewers": [
-              {
-                "user": {
-                  "name": "milton",
-                  "emailAddress": "dev@sourcegraph.com",
-                  "id": 1,
-                  "displayName": "milton woof",
-                  "active": true,
-                  "slug": "milton",
-                  "type": "NORMAL",
-                  "links": {
-                    "self": [
-                      {
-                        "href": "https://bitbucket.sgdev.org/users/milton"
-                      }
-                    ]
-                  },
-                  "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
-                },
-                "lastReviewedCommit": "97e23097783c5197849527b496c6365f43d5eb0b",
+                "lastReviewedCommit": "18ca4a8427d54620dee34832f20554553a0c481e",
                 "role": "REVIEWER",
                 "approved": false,
                 "status": "NEEDS_WORK"
@@ -386,14 +169,15 @@
             "links": {
               "self": [
                 {
-                  "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/19"
+                  "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/69"
                 }
               ]
             }
           },
+          "action": "REVIEWED",
           "activity": {
-            "id": 3004,
-            "createdDate": 1588170905768,
+            "id": 3009,
+            "createdDate": 1588667488870,
             "user": {
               "name": "milton",
               "emailAddress": "dev@sourcegraph.com",
@@ -414,19 +198,11 @@
             "action": "REVIEWED"
           }
         }
-      }
-    ],
-    "changeset_events": [
+      },
       {
-        "ID": 1,
-        "ChangesetID": 2,
-        "Kind": "bitbucketserver:updated",
-        "Key": "3003",
-        "CreatedAt": "2020-04-29T16:02:16.877813Z",
-        "UpdatedAt": "2020-04-29T16:02:16.877813Z",
-        "Metadata": {
-          "id": 3003,
-          "createdDate": 1588170844885,
+        "payload_type": "pr:participant:status",
+        "data": {
+          "createdDate": 1588667491744,
           "user": {
             "name": "milton",
             "emailAddress": "dev@sourcegraph.com",
@@ -434,32 +210,184 @@
             "displayName": "milton woof",
             "active": true,
             "slug": "milton",
-            "type": "NORMAL"
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://bitbucket.sgdev.org/users/milton"
+                }
+              ]
+            },
+            "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
           },
-          "action": "UPDATED",
-          "addedReviewers": [
-            {
-              "name": "milton",
-              "emailAddress": "dev@sourcegraph.com",
-              "id": 1,
-              "displayName": "milton woof",
-              "active": true,
-              "slug": "milton",
-              "type": "NORMAL"
+          "pullRequest": {
+            "id": 69,
+            "version": 0,
+            "title": "foobar",
+            "description": "testing",
+            "state": "OPEN",
+            "open": true,
+            "closed": false,
+            "createdDate": 1584460001757,
+            "updatedDate": 1584460001757,
+            "fromRef": {
+              "id": "refs/heads/foobar",
+              "displayId": "foobar",
+              "latestCommit": "18ca4a8427d54620dee34832f20554553a0c481e",
+              "repository": {
+                "slug": "automation-testing",
+                "id": 10070,
+                "name": "automation-testing",
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "statusMessage": "Available",
+                "forkable": true,
+                "project": {
+                  "key": "SOUR",
+                  "id": 1,
+                  "name": "sourcegraph",
+                  "public": false,
+                  "type": "NORMAL",
+                  "links": {
+                    "self": [
+                      {
+                        "href": "https://bitbucket.sgdev.org/projects/SOUR"
+                      }
+                    ]
+                  },
+                  "avatarUrl": "/projects/SOUR/avatar.png?s=64\u0026v=1564708360389"
+                },
+                "public": false,
+                "links": {
+                  "clone": [
+                    {
+                      "href": "https://bitbucket.sgdev.org/scm/sour/automation-testing.git",
+                      "name": "http"
+                    }
+                  ],
+                  "self": [
+                    {
+                      "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"
+                    }
+                  ]
+                }
+              }
+            },
+            "toRef": {
+              "id": "refs/heads/master",
+              "displayId": "master",
+              "latestCommit": "e833db3fe2bdbc28b58cd72def1b0078e77aa171",
+              "repository": {
+                "slug": "automation-testing",
+                "id": 10070,
+                "name": "automation-testing",
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "statusMessage": "Available",
+                "forkable": true,
+                "project": {
+                  "key": "SOUR",
+                  "id": 1,
+                  "name": "sourcegraph",
+                  "public": false,
+                  "type": "NORMAL",
+                  "links": {
+                    "self": [
+                      {
+                        "href": "https://bitbucket.sgdev.org/projects/SOUR"
+                      }
+                    ]
+                  },
+                  "avatarUrl": "/projects/SOUR/avatar.png?s=64\u0026v=1564708360389"
+                },
+                "public": false,
+                "links": {
+                  "clone": [
+                    {
+                      "href": "https://bitbucket.sgdev.org/scm/sour/automation-testing.git",
+                      "name": "http"
+                    }
+                  ],
+                  "self": [
+                    {
+                      "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"
+                    }
+                  ]
+                }
+              }
+            },
+            "locked": false,
+            "author": {
+              "user": {
+                "name": "thorsten",
+                "emailAddress": "thorsten@sourcegraph.com",
+                "id": 104,
+                "displayName": "thorsten",
+                "active": true,
+                "slug": "thorsten",
+                "type": "NORMAL",
+                "links": {
+                  "self": [
+                    {
+                      "href": "https://bitbucket.sgdev.org/users/thorsten"
+                    }
+                  ]
+                },
+                "avatarUrl": "https://secure.gravatar.com/avatar/3019a6cedc57148130de2a9c97977eb3.jpg?s=64\u0026d=mm"
+              },
+              "role": "AUTHOR",
+              "approved": false,
+              "status": "UNAPPROVED"
+            },
+            "reviewers": [
+              {
+                "user": {
+                  "name": "milton",
+                  "emailAddress": "dev@sourcegraph.com",
+                  "id": 1,
+                  "displayName": "milton woof",
+                  "active": true,
+                  "slug": "milton",
+                  "type": "NORMAL",
+                  "links": {
+                    "self": [
+                      {
+                        "href": "https://bitbucket.sgdev.org/users/milton"
+                      }
+                    ]
+                  },
+                  "avatarUrl": "/users/milton/avatar.png?s=64\u0026v=1576525349000"
+                },
+                "lastReviewedCommit": "18ca4a8427d54620dee34832f20554553a0c481e",
+                "role": "REVIEWER",
+                "approved": false,
+                "status": "UNAPPROVED"
+              }
+            ],
+            "participants": [],
+            "links": {
+              "self": [
+                {
+                  "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/69"
+                }
+              ]
             }
-          ]
+          },
+          "action": "UNAPPROVED"
         }
-      },
+      }
+    ],
+    "changeset_events": [
       {
-        "ID": 2,
-        "ChangesetID": 2,
+        "ID": 1,
+        "ChangesetID": 1,
         "Kind": "bitbucketserver:reviewed",
-        "Key": "3004",
-        "CreatedAt": "2020-04-29T16:02:16.877813Z",
-        "UpdatedAt": "2020-04-29T16:02:16.877813Z",
+        "Key": "3009",
+        "CreatedAt": "2020-05-05T08:38:07.9098Z",
+        "UpdatedAt": "2020-05-05T08:38:07.9098Z",
         "Metadata": {
-          "id": 3004,
-          "createdDate": 1588170905768,
+          "id": 3009,
+          "createdDate": 1588667488870,
           "user": {
             "name": "milton",
             "emailAddress": "dev@sourcegraph.com",
@@ -470,6 +398,27 @@
             "type": "NORMAL"
           },
           "action": "REVIEWED"
+        }
+      },
+      {
+        "ID": 2,
+        "ChangesetID": 1,
+        "Kind": "bitbucketserver:participant_status:unapproved",
+        "Key": "UNAPPROVED:1:1588667491744",
+        "CreatedAt": "2020-05-05T08:38:07.9098Z",
+        "UpdatedAt": "2020-05-05T08:38:07.9098Z",
+        "Metadata": {
+          "createdDate": 1588667491744,
+          "user": {
+            "name": "milton",
+            "emailAddress": "dev@sourcegraph.com",
+            "id": 1,
+            "displayName": "milton woof",
+            "active": true,
+            "slug": "milton",
+            "type": "NORMAL"
+          },
+          "action": "UNAPPROVED"
         }
       }
     ]

--- a/enterprise/internal/campaigns/testdata/vcr/bitbucket-webhooks.yaml
+++ b/enterprise/internal/campaigns/testdata/vcr/bitbucket-webhooks.yaml
@@ -18,13 +18,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f18987c47f7-CPT
+      - 58e924bcfd658050-CPT
       Cf-Request-Id:
-      - 026845c362000047f7af3c5200000001
+      - 0285954a1600008050462aa200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:17 GMT
+      - Tue, 05 May 2020 08:38:09 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -34,11 +34,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961435x0'
+      - '@MWNSEUx518x2203839x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 1i64dxo
+      - dgifq6
       X-Auserid:
       - "1"
       X-Ausername:
@@ -65,13 +65,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f1ebf1747f7-CPT
+      - 58e924c2a8c68050-CPT
       Cf-Request-Id:
-      - 026845c730000047f7af3fe200000001
+      - 0285954daa00008050462d9200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:18 GMT
+      - Tue, 05 May 2020 08:38:09 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -81,11 +81,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961436x0'
+      - '@MWNSEUx518x2203840x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 14jo804
+      - bag6ok
       X-Auserid:
       - "1"
       X-Ausername:
@@ -114,13 +114,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f248a5847f7-CPT
+      - 58e924c85b578050-CPT
       Cf-Request-Id:
-      - 026845cad6000047f7af02a200000001
+      - 028595513300008050462ff200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:19 GMT
+      - Tue, 05 May 2020 08:38:10 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -130,11 +130,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961438x0'
+      - '@MWNSEUx518x2203842x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 1td4mfr
+      - 1mu0vzh
       X-Auserid:
       - "1"
       X-Ausername:
@@ -165,13 +165,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f2a3d1547f7-CPT
+      - 58e924ce2e618050-CPT
       Cf-Request-Id:
-      - 026845ce62000047f7af064200000001
+      - 02859554dd0000805046340200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:20 GMT
+      - Tue, 05 May 2020 08:38:11 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -181,11 +181,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961439x0'
+      - '@MWNSEUx518x2203843x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 1l1r9qp
+      - 1r98me8
       X-Auserid:
       - "1"
       X-Ausername:
@@ -215,13 +215,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f2fdfb547f7-CPT
+      - 58e924d05f838050-CPT
       Cf-Request-Id:
-      - 026845d1e2000047f7af089200000001
+      - 0285955636000080504634f200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:21 GMT
+      - Tue, 05 May 2020 08:38:12 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -231,11 +231,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961440x0'
+      - '@MWNSEUx518x2203844x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - szgi6n
+      - 1ym0jfb
       X-Auserid:
       - "1"
       X-Ausername:
@@ -263,13 +263,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f3569ea47f7-CPT
+      - 58e924d68afe8050-CPT
       Cf-Request-Id:
-      - 026845d565000047f7af0b4200000001
+      - 0285955a13000080504639b200000001
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Apr 2020 16:02:21 GMT
+      - Tue, 05 May 2020 08:38:12 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -279,11 +279,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961442x0'
+      - '@MWNSEUx518x2203845x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - lwgaf4
+      - d4y5aq
       X-Auserid:
       - "1"
       X-Ausername:
@@ -313,13 +313,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f37ad6d47f7-CPT
+      - 58e924d89c618050-CPT
       Cf-Request-Id:
-      - 026845d6cb000047f7af0ba200000001
+      - 0285955b5d00008050463b1200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:22 GMT
+      - Tue, 05 May 2020 08:38:12 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -329,11 +329,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961443x0'
+      - '@MWNSEUx518x2203846x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - vgjm6
+      - khk9g7
       X-Auserid:
       - "1"
       X-Ausername:
@@ -363,13 +363,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f3d68ca47f7-CPT
+      - 58e924dafdb18050-CPT
       Cf-Request-Id:
-      - 026845da62000047f7af0ec200000001
+      - 0285955cdd00008050463c1200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:23 GMT
+      - Tue, 05 May 2020 08:38:13 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -379,11 +379,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961444x0'
+      - '@MWNSEUx518x2203847x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 1t1qmum
+      - 1jdgnqm
       X-Auserid:
       - "1"
       X-Ausername:
@@ -412,13 +412,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f3ffd9947f7-CPT
+      - 58e924dd0f1d8050-CPT
       Cf-Request-Id:
-      - 026845dbfe000047f7af0fe200000001
+      - 0285955e2700008050463dc200000001
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Apr 2020 16:02:24 GMT
+      - Tue, 05 May 2020 08:38:13 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -428,11 +428,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961445x0'
+      - '@MWNSEUx518x2203848x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 6se2nm
+      - 12mr0kb
       X-Auserid:
       - "1"
       X-Ausername:
@@ -459,13 +459,13 @@ interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Ray:
-      - 58ba3f459fcc47f7-CPT
+      - 58e924df78b08050-CPT
       Cf-Request-Id:
-      - 026845df80000047f7af128200000001
+      - 0285955faa00008050463f6200000001
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Apr 2020 16:02:24 GMT
+      - Tue, 05 May 2020 08:38:14 GMT
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Pragma:
@@ -475,11 +475,11 @@ interactions:
       Vary:
       - X-AUSERNAME,Accept-Encoding
       X-Arequestid:
-      - '@MWNSEUx962x1961446x0'
+      - '@MWNSEUx518x2203850x0'
       X-Asen:
       - SEN-11363689
       X-Asessionid:
-      - 1jx3q8g
+      - 7vtjo8
       X-Auserid:
       - "1"
       X-Ausername:

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -951,11 +951,16 @@ func (h *BitbucketServerWebhook) convertEvent(theirs interface{}) (prs []PR, our
 	log15.Debug("Bitbucket Server webhook received", "type", fmt.Sprintf("%T", theirs))
 
 	switch e := theirs.(type) {
-	case *bbs.PullRequestEvent:
+	case *bbs.PullRequestActivityEvent:
 		repoID := strconv.Itoa(e.PullRequest.FromRef.Repository.ID)
 		pr := PR{ID: int64(e.PullRequest.ID), RepoExternalID: repoID}
 		prs = append(prs, pr)
 		return prs, e.Activity
+	case *bbs.PullRequestParticipantStatusEvent:
+		repoID := strconv.Itoa(e.PullRequest.FromRef.Repository.ID)
+		pr := PR{ID: int64(e.PullRequest.ID), RepoExternalID: repoID}
+		prs = append(prs, pr)
+		return prs, e.ParticipantStatusEvent
 	case *bbs.BuildStatusEvent:
 		for _, p := range e.PullRequests {
 			repoID := strconv.Itoa(p.FromRef.Repository.ID)

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1018,6 +1018,21 @@ func (e *ChangesetEvent) Update(o *ChangesetEvent) {
 			e.Commit = o.Commit
 		}
 
+	case *bitbucketserver.ParticipantStatusEvent:
+		o := o.Metadata.(*bitbucketserver.ParticipantStatusEvent)
+
+		if e.CreatedDate == 0 {
+			e.CreatedDate = o.CreatedDate
+		}
+
+		if e.Action == "" {
+			e.Action = o.Action
+		}
+
+		if e.User == (bitbucketserver.User{}) {
+			e.User = o.User
+		}
+
 	case *bitbucketserver.CommitStatus:
 		o := o.Metadata.(*bitbucketserver.CommitStatus)
 		// We always get the full event, so safe to replace it
@@ -1166,6 +1181,8 @@ func ChangesetEventKindFor(e interface{}) ChangesetEventKind {
 		return ChangesetEventKindCheckRun
 	case *bitbucketserver.Activity:
 		return ChangesetEventKind("bitbucketserver:" + strings.ToLower(string(e.Action)))
+	case *bitbucketserver.ParticipantStatusEvent:
+		return ChangesetEventKind("bitbucketserver:participant_status:" + strings.ToLower(string(e.Action)))
 	case *bitbucketserver.CommitStatus:
 		return ChangesetEventKindBitbucketServerCommitStatus
 	default:
@@ -1181,6 +1198,8 @@ func NewChangesetEventMetadata(k ChangesetEventKind) (interface{}, error) {
 		switch k {
 		case ChangesetEventKindBitbucketServerCommitStatus:
 			return new(bitbucketserver.CommitStatus), nil
+		case ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
+			return new(bitbucketserver.ParticipantStatusEvent), nil
 		default:
 			return new(bitbucketserver.Activity), nil
 		}
@@ -1264,6 +1283,8 @@ const (
 	ChangesetEventKindBitbucketServerCommented    ChangesetEventKind = "bitbucketserver:commented"
 	ChangesetEventKindBitbucketServerMerged       ChangesetEventKind = "bitbucketserver:merged"
 	ChangesetEventKindBitbucketServerCommitStatus ChangesetEventKind = "bitbucketserver:commit_status"
+
+	ChangesetEventKindBitbucketServerParticipationStatusUnapproved ChangesetEventKind = "bitbucketserver:participant_status:unapproved"
 )
 
 // ChangesetSyncData represents data about the sync status of a changeset

--- a/internal/extsvc/bitbucketserver/events.go
+++ b/internal/extsvc/bitbucketserver/events.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -23,19 +24,40 @@ func ParseWebhookEvent(eventType string, payload []byte) (e interface{}, err err
 	case "repo:build_status":
 		e = &BuildStatusEvent{}
 		return e, json.Unmarshal(payload, e)
-	default:
-		e = &PullRequestEvent{}
+	case "pr:activity:status", "pr:activity:event", "pr:activity:rescope", "pr:activity:merge", "pr:activity:comment", "pr:activity:reviewers":
+		e = &PullRequestActivityEvent{}
 		return e, json.Unmarshal(payload, e)
+	case "pr:participant:status":
+		e = &PullRequestParticipantStatusEvent{}
+		return e, json.Unmarshal(payload, e)
+	default:
+		return nil, fmt.Errorf("unknown webhook event type: %q", eventType)
 	}
 }
 
 type PingEvent struct{}
 
-type PullRequestEvent struct {
-	Date        time.Time   `json:"date"`
-	Actor       User        `json:"actor"`
+type PullRequestActivityEvent struct {
+	Date        time.Time      `json:"date"`
+	Actor       User           `json:"actor"`
+	PullRequest PullRequest    `json:"pullRequest"`
+	Action      ActivityAction `json:"action"`
+	Activity    *Activity      `json:"activity"`
+}
+
+type PullRequestParticipantStatusEvent struct {
+	*ParticipantStatusEvent
 	PullRequest PullRequest `json:"pullRequest"`
-	Activity    *Activity   `json:"activity"`
+}
+
+type ParticipantStatusEvent struct {
+	CreatedDate int            `json:"createdDate"`
+	User        User           `json:"user"`
+	Action      ActivityAction `json:"action"`
+}
+
+func (a *ParticipantStatusEvent) Key() string {
+	return fmt.Sprintf("%s:%d:%d", a.Action, a.User.ID, a.CreatedDate)
 }
 
 type BuildStatusEvent struct {


### PR DESCRIPTION
This change is able to handle new events produced by .. version 1.3.6 and higher.

It is backwards compatible with older version of the plugin. 

Another PR will follow that interprets the new events to compute review status properly.

Part of: https://github.com/sourcegraph/sourcegraph/issues/9139