### PR TITLE
Speed up TestIntegration in campaigns package

### DIFF
--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -1,7 +1,9 @@
 package campaigns
 
 import (
+	"database/sql"
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
@@ -18,11 +20,33 @@ func TestIntegration(t *testing.T) {
 
 	db := dbtest.NewDB(t, *dsn)
 
+	userID := insertTestUser(t, db)
+
 	t.Run("Store", testStore(db))
-	t.Run("GitHubWebhook", testGitHubWebhook(dbtest.NewDB(t, *dsn)))
-	t.Run("BitbucketWebhook", testBitbucketWebhook(dbtest.NewDB(t, *dsn)))
+	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))
+	t.Run("BitbucketWebhook", testBitbucketWebhook(db, userID))
 
 	// The following tests need to be separate because testStore above wraps everything in a global transaction
 	t.Run("StoreLocking", testStoreLocking(db))
-	t.Run("ProcessChangesetJob", testProcessChangesetJob(db))
+	t.Run("ProcessChangesetJob", testProcessChangesetJob(db, userID))
+}
+
+func truncateTables(t *testing.T, db *sql.DB, tables ...string) {
+	t.Helper()
+
+	_, err := db.Exec("TRUNCATE " + strings.Join(tables, ", ") + " RESTART IDENTITY")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertTestUser(t *testing.T, db *sql.DB) (userID int32) {
+	t.Helper()
+
+	err := db.QueryRow("INSERT INTO users (username) VALUES ('bbs-admin') RETURNING id").Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userID
 }

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -35,7 +35,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 		// Create a test repo
 		reposStore := repos.NewDBStore(db, sql.TxOptions{})
 		repo := &repos.Repo{
-			Name: "github.com/sourcegraph/sourcegraph",
+			Name: "github.com/sourcegraph/sourcegraph-test-repo",
 			ExternalRepo: api.ExternalRepoSpec{
 				ID:          "external-id",
 				ServiceType: "github",
@@ -2795,7 +2795,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 	}
 }
 
-func testProcessChangesetJob(db *sql.DB) func(*testing.T) {
+func testProcessChangesetJob(db *sql.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		clock := func() time.Time { return now.UTC().Truncate(time.Microsecond) }
@@ -2804,7 +2804,7 @@ func testProcessChangesetJob(db *sql.DB) func(*testing.T) {
 		// Create a test repo
 		reposStore := repos.NewDBStore(db, sql.TxOptions{})
 		repo := &repos.Repo{
-			Name: "github.com/sourcegraph/sourcegraph",
+			Name: "github.com/sourcegraph/changeset-job-test",
 			ExternalRepo: api.ExternalRepoSpec{
 				ID:          "external-id",
 				ServiceType: "github",
@@ -2821,15 +2821,9 @@ func testProcessChangesetJob(db *sql.DB) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		var userID int32
-		err := db.QueryRow("INSERT INTO users (username) VALUES ('admin') RETURNING id").Scan(&userID)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		s := NewStoreWithClock(db, clock)
 		patchSet := &cmpgn.PatchSet{UserID: userID}
-		err = s.CreatePatchSet(context.Background(), patchSet)
+		err := s.CreatePatchSet(context.Background(), patchSet)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Before:

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    7.521s

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns

    7.239s
    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    7.269s

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    7.487s

After:

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    4.266s

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    4.367s

    $ go test -count=1 .
    ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns
    4.298s



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
