### PR TITLE
gomod: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,10 @@ github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 h1:gclg6gY70GLy
 github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
 github.com/go-critic/go-critic v0.4.1 h1:4DTQfT1wWwLg/hzxwD9bkdhDQrdJtxe6DUTadPlrIeE=
 github.com/go-critic/go-critic v0.4.1/go.mod h1:7/14rZGnZbY6E38VEGk2kVhoq6itzc1E68facVDK23g=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
+github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
+github.com/go-git/go-git/v5 v5.0.0/go.mod h1:oYD8y9kWsGINPFJoLdaScGCN6dlKg23blmClfZwtUVA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -889,6 +893,16 @@ github.com/sourcegraph/zoekt v0.0.0-20200429072728-1a9304f241c9 h1:6wfwD6/CE5vze
 github.com/sourcegraph/zoekt v0.0.0-20200429072728-1a9304f241c9/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
 github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f h1:5SvCsZHC8K7apQ+RsWimTds2aDCuEl4/Mwr3QHC/k4c=
 github.com/sourcegraph/zoekt v0.0.0-20200504095446-118acdf7aa8f/go.mod h1:myt55/e315SlJX+bvPR+Y1wnOijZ+tcoG0gkjexi9F4=
+github.com/sourcegraph/zoekt v0.0.0-20200505133012-65afa9fca706 h1:8hq3lLF53h+3Gu+BeqBhl2Y6/rsXx+X/PVc0dSFTofE=
+github.com/sourcegraph/zoekt v0.0.0-20200505133012-65afa9fca706/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
+github.com/sourcegraph/zoekt v0.0.0-20200505135300-5a1aed890fc2 h1:bH3wpciZgiIcR/QX7lgsXnivcHsWTzPDiC0byMXAehQ=
+github.com/sourcegraph/zoekt v0.0.0-20200505135300-5a1aed890fc2/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
+github.com/sourcegraph/zoekt v0.0.0-20200505140534-ef80237d5a29 h1:adSklELQdqa9QaYxJ53PUpkiuG48+O0fgxFYzNvt/uA=
+github.com/sourcegraph/zoekt v0.0.0-20200505140534-ef80237d5a29/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
+github.com/sourcegraph/zoekt v0.0.0-20200505140849-75b1c46a56f9 h1:SckEKQLCrxd/5G/OOjroBQEhr/HuhaJflSG2U/59F6g=
+github.com/sourcegraph/zoekt v0.0.0-20200505140849-75b1c46a56f9/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
+github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1 h1:B617BWi5fKeuXTsp/jJxwSraBVkWjzcocLul8J6bFqw=
+github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Includes the following changes:

- [3a0c63c](https://github.com/sourcegraph/zoekt/commit/3a0c63c) build: SetDefaults uses same defaults as cmd line
- [6a12018](https://github.com/sourcegraph/zoekt/commit/6a12018) Do not ignore large files.
- [f53752c](https://github.com/sourcegraph/zoekt/commit/f53752c) build: move incremental decision into options
- [3a7bd00](https://github.com/sourcegraph/zoekt/commit/3a7bd00) all: migrate go-git to new package
- [ba74b6d](https://github.com/sourcegraph/zoekt/commit/ba74b6d) gomod: set minimum version to go 1.13
- [5dd4713](https://github.com/sourcegraph/zoekt/commit/5dd4713) build: factor out build flags
- [4ff72d6](https://github.com/sourcegraph/zoekt/commit/4ff72d6) Improve performance for concatened queries
- [9220fb2](https://github.com/sourcegraph/zoekt/commit/9220fb2) web: print name in file view
- [983e877](https://github.com/sourcegraph/zoekt/commit/983e877) web: focus on searchbox for '/' keypress
- [77beb0f](https://github.com/sourcegraph/zoekt/commit/77beb0f) cmd/zoekt: support -l flag, for compatibility with grep
- [b0c18f6](https://github.com/sourcegraph/zoekt/commit/b0c18f6) zoekt-mirror-github: add arguments to filter repos on topics criteria

And for completeness, here are the changes from the previous update
which didn't include this log:

- [118acdf](https://github.com/sourcegraph/zoekt/commit/118acdf) docker: use go.mod psuedo-version for tag
- [1a9304f](https://github.com/sourcegraph/zoekt/commit/1a9304f) ctags: use same command line flags as sourcegraph
- [02b77c3](https://github.com/sourcegraph/zoekt/commit/02b77c3) docker: put .ctags.d into $HOME
- [f75c48e](https://github.com/sourcegraph/zoekt/commit/f75c48e) bump ctags version to match sourcegraph repo
- [d723377](https://github.com/sourcegraph/zoekt/commit/d723377) Improve performance for concatened queries
- [6727685](https://github.com/sourcegraph/zoekt/commit/6727685) zoekt-webserver: Allow sourcegraph admin proxy to access net/trace
