### PR TITLE
campaigns: Handle ParticipantStatusEvent when computing review state

### DIFF
--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -43,7 +43,7 @@ type changesetStatesAtTime struct {
 	reviewState cmpgn.ChangesetReviewState
 }
 
-// computeHistory calcuates the changesetHistory for the given Changeset and
+// computeHistory calculates the changesetHistory for the given Changeset and
 // its ChangesetEvents.
 // The ChangesetEvents MUST be sorted by their Timestamp.
 func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, error) {
@@ -101,7 +101,8 @@ func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, 
 
 		case campaigns.ChangesetEventKindGitHubReviewed,
 			campaigns.ChangesetEventKindBitbucketServerApproved,
-			campaigns.ChangesetEventKindBitbucketServerReviewed:
+			campaigns.ChangesetEventKindBitbucketServerReviewed,
+			campaigns.ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
 
 			s, err := e.ReviewState()
 			if err != nil {

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -625,6 +625,14 @@ func (e *ChangesetEvent) ReviewAuthor() (string, error) {
 			return "", errors.New("activity user is blank")
 		}
 		return username, nil
+
+	case *bitbucketserver.ParticipantStatusEvent:
+		username := meta.User.Name
+		if username == "" {
+			return "", errors.New("activity user is blank")
+		}
+		return username, nil
+
 	default:
 		return "", nil
 	}
@@ -656,7 +664,8 @@ func (e *ChangesetEvent) ReviewState() (ChangesetReviewState, error) {
 		return s, nil
 
 	case ChangesetEventKindGitHubReviewDismissed,
-		ChangesetEventKindBitbucketServerUnapproved:
+		ChangesetEventKindBitbucketServerUnapproved,
+		ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
 		return ChangesetReviewStateDismissed, nil
 
 	default:
@@ -713,6 +722,8 @@ func (e *ChangesetEvent) Timestamp() time.Time {
 	case *github.CheckRun:
 		return e.ReceivedAt
 	case *bitbucketserver.Activity:
+		t = unixMilliToTime(int64(e.CreatedDate))
+	case *bitbucketserver.ParticipantStatusEvent:
 		t = unixMilliToTime(int64(e.CreatedDate))
 	case *bitbucketserver.CommitStatus:
 		t = unixMilliToTime(int64(e.Status.DateAdded))


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/9139