### PR TITLE
Fix bad typeorm query when ids are empty

### DIFF
--- a/cmd/precise-code-intel/src/shared/store/dumps.ts
+++ b/cmd/precise-code-intel/src/shared/store/dumps.ts
@@ -58,6 +58,10 @@ export class DumpManager {
      * @param ids The dump identifiers.
      */
     public async getDumpsByIds(ids: pgModels.DumpId[]): Promise<Map<pgModels.DumpId, pgModels.LsifDump>> {
+        if (ids.length === 0) {
+            return new Map()
+        }
+
         const dumps = await instrumentQuery(() =>
             this.connection.getRepository(pgModels.LsifDump).createQueryBuilder().select().whereInIds(ids).getMany()
         )


### PR DESCRIPTION
If `ids` are empty then it produces a postgres query that contains `... field IN ()`, which is illegal.

Fixing this here to the new integration tests run without issue.