### PR TITLE
Reducing feedback request from 60 to 30 days

### DIFF
--- a/web/src/marketing/SurveyToast.tsx
+++ b/web/src/marketing/SurveyToast.tsx
@@ -62,11 +62,11 @@ export class SurveyToast extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
         this.state = {
-            visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 60 === 3,
+            visible: localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' && daysActiveCount % 30 === 3,
         }
         if (this.state.visible) {
             eventLogger.log('SurveyReminderViewed')
-        } else if (daysActiveCount % 60 === 0) {
+        } else if (daysActiveCount % 30 === 0) {
             // Reset toast dismissal 3 days before it will be shown
             localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'false')
         }


### PR DESCRIPTION
The NPS request will now show every 30 days of use (~6 weeks if they use it every work day).
