### PR TITLE
codeintel: Support numeric identifiers in LSIF input

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/datastructures/idset.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/datastructures/idset.go
@@ -2,8 +2,6 @@ package datastructures
 
 import "sort"
 
-// TODO(efritz) - these need to be IDs not strings
-
 // IDSet is a set of string identifiers.
 type IDSet map[string]struct{}
 

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
@@ -40,7 +40,6 @@ type Edge struct {
 }
 
 func UnmarshalEdge(element Element) (Edge, error) {
-
 	var payload struct {
 		OutV     ID   `json:"outV"`
 		InV      ID   `json:"inV"`

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
@@ -15,13 +15,11 @@ type Element struct {
 }
 
 func UnmarshalElement(raw []byte) (Element, error) {
-	type RawElement struct {
+	var payload struct {
 		ID    ID     `json:"id"`
 		Type  string `json:"type"`
 		Label string `json:"label"`
 	}
-
-	var payload RawElement
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return Element{}, err
 	}
@@ -42,14 +40,13 @@ type Edge struct {
 }
 
 func UnmarshalEdge(element Element) (Edge, error) {
-	type RawEdge struct {
+
+	var payload struct {
 		OutV     ID   `json:"outV"`
 		InV      ID   `json:"inV"`
 		InVs     []ID `json:"inVs"`
 		Document ID   `json:"document"`
 	}
-
-	var payload RawEdge
 	if err := json.Unmarshal(element.Raw, &payload); err != nil {
 		return Edge{}, err
 	}

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/element.go
@@ -2,29 +2,87 @@ package lsif
 
 import (
 	"encoding/json"
+	"strconv"
 )
 
+type ID string
+
 type Element struct {
-	ID    string `json:"id"` // TODO - string or int
-	Type  string `json:"type"`
-	Label string `json:"label"`
+	ID    string
+	Type  string
+	Label string
 	Raw   json.RawMessage
 }
 
-func UnmarshalElement(Raw []byte) (payload Element, err error) {
-	err = json.Unmarshal(Raw, &payload)
-	payload.Raw = json.RawMessage(Raw)
-	return payload, err
+func UnmarshalElement(raw []byte) (Element, error) {
+	type RawElement struct {
+		ID    ID     `json:"id"`
+		Type  string `json:"type"`
+		Label string `json:"label"`
+	}
+
+	var payload RawElement
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return Element{}, err
+	}
+
+	return Element{
+		ID:    string(payload.ID),
+		Type:  payload.Type,
+		Label: payload.Label,
+		Raw:   json.RawMessage(raw),
+	}, nil
 }
 
 type Edge struct {
-	OutV     string   `json:"outV"`
-	InV      string   `json:"inV"`
-	InVs     []string `json:"inVs"`
-	Document string   `json:"document"`
+	OutV     string
+	InV      string
+	InVs     []string
+	Document string
 }
 
-func UnmarshalEdge(element Element) (payload Edge, err error) {
-	err = json.Unmarshal(element.Raw, &payload)
-	return payload, err
+func UnmarshalEdge(element Element) (Edge, error) {
+	type RawEdge struct {
+		OutV     ID   `json:"outV"`
+		InV      ID   `json:"inV"`
+		InVs     []ID `json:"inVs"`
+		Document ID   `json:"document"`
+	}
+
+	var payload RawEdge
+	if err := json.Unmarshal(element.Raw, &payload); err != nil {
+		return Edge{}, err
+	}
+
+	var inVs []string
+	for _, inV := range payload.InVs {
+		inVs = append(inVs, string(inV))
+	}
+
+	return Edge{
+		OutV:     string(payload.OutV),
+		InV:      string(payload.InV),
+		InVs:     inVs,
+		Document: string(payload.Document),
+	}, nil
+}
+
+func (id *ID) UnmarshalJSON(raw []byte) error {
+	if raw[0] == '"' {
+		var v string
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return err
+		}
+
+		*id = ID(v)
+		return nil
+	}
+
+	var v int64
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	*id = ID(strconv.FormatInt(v, 10))
+	return nil
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/element_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/element_test.go
@@ -26,6 +26,25 @@ func TestUnmarshalElement(t *testing.T) {
 	}
 }
 
+func TestUnmarshalElementNumericIDs(t *testing.T) {
+	raw := `{"id": 47, "type": "edge", "label": "contains", "outV": 2, "inVs": [4, 5, 6]}`
+
+	element, err := UnmarshalElement([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error unmarshalling element data: %s", err)
+	}
+
+	expectedElement := Element{
+		ID:    "47",
+		Type:  "edge",
+		Label: "contains",
+		Raw:   json.RawMessage(raw),
+	}
+	if diff := cmp.Diff(expectedElement, element); diff != "" {
+		t.Errorf("unexpected element (-want +got):\n%s", diff)
+	}
+}
+
 func TestUnmarshalEdge(t *testing.T) {
 	edge, err := UnmarshalEdge(Element{
 		ID:    "35",
@@ -42,6 +61,28 @@ func TestUnmarshalEdge(t *testing.T) {
 		InV:      "",
 		InVs:     []string{"07"},
 		Document: "03",
+	}
+	if diff := cmp.Diff(expectedEdge, edge); diff != "" {
+		t.Errorf("unexpected edge (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnmarshalEdgeNumericIDs(t *testing.T) {
+	edge, err := UnmarshalEdge(Element{
+		ID:    "35",
+		Type:  "edge",
+		Label: "item",
+		Raw:   json.RawMessage(`{"id": 35, "type": "edge", "label": "item", "outV": 12, "inVs": [7], "document": 3}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error unmarshalling meta data: %s", err)
+	}
+
+	expectedEdge := Edge{
+		OutV:     "12",
+		InV:      "",
+		InVs:     []string{"7"},
+		Document: "3",
 	}
 	if diff := cmp.Diff(expectedEdge, edge); diff != "" {
 		t.Errorf("unexpected edge (-want +got):\n%s", diff)


### PR DESCRIPTION
IDs in LSIF may be strings or integers. This PR adds support for loading ints and strings in the same way.