### PR TITLE
Allow empty codeIntelUsage and searchUsage fields in pings

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -356,6 +356,9 @@ func reserializeCodeIntelUsage(payload json.RawMessage) (json.RawMessage, error)
 	if err := json.Unmarshal(payload, &codeIntelUsage); err != nil {
 		return nil, err
 	}
+	if codeIntelUsage == nil {
+		return nil, nil
+	}
 
 	singlePeriodUsage := struct {
 		Daily   *types.CodeIntelUsagePeriod
@@ -388,6 +391,9 @@ func reserializeSearchUsage(payload json.RawMessage) (json.RawMessage, error) {
 	var searchUsage *types.SearchUsageStatistics
 	if err := json.Unmarshal(payload, &searchUsage); err != nil {
 		return nil, err
+	}
+	if searchUsage == nil {
+		return nil, nil
 	}
 
 	singlePeriodUsage := struct {


### PR DESCRIPTION
Looks like the ping handler is error-ing out in production for some subset of pings — e.g., screenshot from our [stackdriver logs](https://console.cloud.google.com/logs/viewer?project=sourcegraph-dev&minLogLevel=0&expandAll=false&timestamp=2020-05-06T03:57:23.399000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-05-05T21:57:48.609Z&interval=PT6H&resource=k8s_container%2Fcluster_name%2Fdot-com%2Fnamespace_name%2Fprod%2Fcontainer_name%2Ffrontend&scrollTimestamp=2020-05-06T03:55:00.748698707Z&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22dot-com%22%0Aresource.labels.namespace_name%3D%22prod%22%0Aresource.labels.container_name%3D%22frontend%22%0Aupdatecheck%20AND%20error%0A%0A%0A&dateRangeEnd=2020-05-06T03:57:48.609Z)

![image](https://user-images.githubusercontent.com/5589410/81137624-451f0480-8f14-11ea-8be5-0b3df7aa3c7b.png)

I can't seem to find the actual error message in the logs though... Just an oddly formatted stack trace (?). It seems to fail on line 366 in handler.go: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9c3ecdcf2978261b8390e17b174da0ce6a0dc2f0/-/blob/cmd/frontend/internal/app/pkg/updatecheck/handler.go#L366

Which makes me think that perhaps `codeIntelUsage` is null here. 

This is a bit of a shot in the dark — curious if you have other suggestions for how to inspect logs more produtively.