### PR TITLE
Use URL constructor to  build API URLs

### DIFF
--- a/shared/src/graphql/graphql.ts
+++ b/shared/src/graphql/graphql.ts
@@ -65,7 +65,7 @@ export function requestGraphQL<T extends GQL.IQuery | GQL.IMutation>({
 }): Observable<GraphQLResult<T>> {
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     return fromFetch(
-        `${baseUrl}/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`,
+        new URL(`/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`, baseUrl).href,
         {
             ...options,
             method: 'POST',


### PR DESCRIPTION
Fixes #6521

Avoids building invalid URLs when the base Sourcegraph URL has a trailing slash, across all platforms (browser extension, native integrations).

