### PR TITLE
Fix requestGraphQL when no baseURL is provided

### DIFF
--- a/shared/src/graphql/graphql.ts
+++ b/shared/src/graphql/graphql.ts
@@ -56,16 +56,17 @@ export interface GraphQLRequestOptions extends Omit<RequestInit, 'method' | 'bod
 
 export function requestGraphQL<T extends GQL.IQuery | GQL.IMutation>({
     request,
+    baseUrl,
     variables = {},
-    baseUrl = '',
     ...options
 }: GraphQLRequestOptions & {
     request: string
     variables?: {}
 }): Observable<GraphQLResult<T>> {
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
+    const apiURL = `/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`
     return fromFetch(
-        new URL(`/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`, baseUrl).href,
+        baseUrl ? new URL(`/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`, baseUrl).href : apiURL,
         {
             ...options,
             method: 'POST',

--- a/shared/src/graphql/graphql.ts
+++ b/shared/src/graphql/graphql.ts
@@ -66,7 +66,7 @@ export function requestGraphQL<T extends GQL.IQuery | GQL.IMutation>({
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     const apiURL = `/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`
     return fromFetch(
-        baseUrl ? new URL(`/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`, baseUrl).href : apiURL,
+        baseUrl ? new URL(apiURL, baseUrl).href : apiURL,
         {
             ...options,
             method: 'POST',


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/10443 introduced a regression breaking the webapp with `TypeError: Invalid base URL: `. When no base URL is passed to requestGraphQL, we should simply use a relative URL, not attempt to build an absolute URL.

This is really 🤦 , sorry about that (and integration tests would've caught this)