### PR TITLE
Update Docker Compose versions in docs

### DIFF
--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -19,7 +19,7 @@ It takes less than 5 minutes to run and install Sourcegraph using Docker Compose
 ```bash
 git clone git@github.com:sourcegraph/deploy-sourcegraph-docker.git
 cd deploy-sourcegraph-docker/docker-compose
-git checkout v3.14.2
+git checkout v3.15.1
 docker-compose up -d
 ```
 
@@ -39,7 +39,7 @@ We **strongly** recommend that you create your own fork of [sourcegraph/deploy-s
 * Create a `release` branch (to track all of your customizations to Sourcegraph. When you upgrade Sourcegraph's Docker Compose definition, you will merge upstream into this branch.
 
 ```bash
-SOURCEGRAPH_VERSION="v3.14.2"
+SOURCEGRAPH_VERSION="v3.15.1"
 git checkout $SOURCEGRAPH_VERSION -b release
 ```
 


### PR DESCRIPTION
Looks like these got left off of the last few updates. The docker-compose.yaml file seems to be on 3.15.1 though: https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml