### PR TITLE
gitserver: limit internal cloning to 1 Gbps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/mschoch/smat v0.2.0 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
 	github.com/opentracing/opentracing-go v1.1.0


### PR DESCRIPTION
zoekt-sourcegraph-indexserver currently limits the rate at which a git archive
is fetched to 1 Gbps. This is to prevent us overloading the network. Before we
had the limit we would cause the docker networking stack to crash. Since zoekt
is moving to using our internal clone endpoint, we want to keep the limiting
behaviour. Instead of limiting on the client side, we limit on the server
side. This is done since introducing limiting in git would require extra tools
to be installed.

The comment and limit is the same we have currently for the archive based approach.
