### PR TITLE
authz: add permissions page to user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Added [Smarty](#2885), [Ethereum / Solidity / Vyper)](#2440), [Cuda](#5907), [COBOL](#10154), [vb.NET](#4901), and [ASP.NET](#4262) syntax highlighting.
   - Fixed OCaml syntax highlighting #3545
   - Bazel/Starlark support improved (.star, BUILD, and many more extensions now properly highlighted). #8123
-- New permissions page in both user and repository settings when background permissions syncing is enabled (`"permissions.backgroundSync": {"enabled": true}`). #10473 
+- New permissions page in both user and repository settings when background permissions syncing is enabled (`"permissions.backgroundSync": {"enabled": true}`). #10473
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Added [Smarty](#2885), [Ethereum / Solidity / Vyper)](#2440), [Cuda](#5907), [COBOL](#10154), [vb.NET](#4901), and [ASP.NET](#4262) syntax highlighting.
   - Fixed OCaml syntax highlighting #3545
   - Bazel/Starlark support improved (.star, BUILD, and many more extensions now properly highlighted). #8123
+- New permissions page in both user and repository settings when background permissions syncing is enabled (`"permissions.backgroundSync": {"enabled": true}`). #10473 
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -16,6 +16,7 @@ type AuthzResolver interface {
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
+	UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error)
 }
 
 var authzInEnterprise = errors.New("authorization mutations and queries are only available in enterprise")
@@ -41,6 +42,10 @@ func (defaultAuthzResolver) AuthorizedUsers(ctx context.Context, args *RepoAutho
 }
 
 func (defaultAuthzResolver) RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error) {
+	return nil, authzInEnterprise
+}
+
+func (defaultAuthzResolver) UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error) {
 	return nil, authzInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2884,6 +2884,9 @@ type User implements Node & SettingsSubject & Namespace {
 
     # The name of this user namespace's component. For users, this is the username.
     namespaceName: String!
+
+    # The permissions information of the user over repositories.
+    permissionsInfo: PermissionsInfo
 }
 
 # An access token that grants to the holder the privileges of the user who created it.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1759,6 +1759,7 @@ type Repository implements Node & GenericSearchResultInterface {
     ): UserConnection!
 
     # The permissions information of the repository for the authenticated user.
+    # It is null when there is no permissions data stored for the repository.
     permissionsInfo: PermissionsInfo
 }
 
@@ -2886,6 +2887,7 @@ type User implements Node & SettingsSubject & Namespace {
     namespaceName: String!
 
     # The permissions information of the user over repositories.
+    # It is null when there is no permissions data stored for the user.
     permissionsInfo: PermissionsInfo
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2891,6 +2891,9 @@ type User implements Node & SettingsSubject & Namespace {
 
     # The name of this user namespace's component. For users, this is the username.
     namespaceName: String!
+
+    # The permissions information of the user over repositories.
+    permissionsInfo: PermissionsInfo
 }
 
 # An access token that grants to the holder the privileges of the user who created it.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1766,6 +1766,7 @@ type Repository implements Node & GenericSearchResultInterface {
     ): UserConnection!
 
     # The permissions information of the repository for the authenticated user.
+    # It is null when there is no permissions data stored for the repository.
     permissionsInfo: PermissionsInfo
 }
 
@@ -2893,6 +2894,7 @@ type User implements Node & SettingsSubject & Namespace {
     namespaceName: String!
 
     # The permissions information of the user over repositories.
+    # It is null when there is no permissions data stored for the user.
     permissionsInfo: PermissionsInfo
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -287,6 +287,10 @@ func (r *UserResolver) URLForSiteAdminBilling(ctx context.Context) (*string, err
 
 func (r *UserResolver) NamespaceName() string { return r.user.Username }
 
+func (r *UserResolver) PermissionsInfo(ctx context.Context) (PermissionsInfoResolver, error) {
+	return EnterpriseResolvers.authzResolver.UserPermissionsInfo(ctx, r.ID())
+}
+
 func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	OldPassword string
 	NewPassword string

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -181,8 +181,9 @@ func publicSiteConfiguration() schema.SiteConfiguration {
 		updateChannel = "release"
 	}
 	return schema.SiteConfiguration{
-		CampaignsReadAccessEnabled: c.CampaignsReadAccessEnabled,
 		AuthPublic:                 c.AuthPublic,
+		CampaignsReadAccessEnabled: c.CampaignsReadAccessEnabled,
+		PermissionsBackgroundSync:  c.PermissionsBackgroundSync,
 		UpdateChannel:              updateChannel,
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -612,3 +612,79 @@ func TestResolver_RepositoryPermissionsInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestResolver_UserPermissionsInfo(t *testing.T) {
+	t.Run("authenticated as non-admin", func(t *testing.T) {
+		db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{}, nil
+		}
+		t.Cleanup(func() {
+			db.Mocks.Users.GetByCurrentAuthUser = nil
+		})
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		result, err := (&Resolver{}).UserPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
+		if want := backend.ErrMustBeSiteAdmin; err != want {
+			t.Errorf("err: want %q but got %v", want, err)
+		}
+		if result != nil {
+			t.Errorf("result: want nil but got %v", result)
+		}
+	})
+
+	db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+		return &types.User{SiteAdmin: true}, nil
+	}
+	db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{ID: id}, nil
+	}
+	edb.Mocks.Perms.LoadUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
+		p.UpdatedAt = clock()
+		p.SyncedAt = clock()
+		return nil
+	}
+	defer func() {
+		db.Mocks.Users = db.MockUsers{}
+		edb.Mocks.Perms = edb.MockPerms{}
+	}()
+	tests := []struct {
+		name     string
+		gqlTests []*gqltesting.Test
+	}{
+		{
+			name: "get permissions information",
+			gqlTests: []*gqltesting.Test{
+				{
+					Schema: mustParseGraphQLSchema(t, nil),
+					Query: `
+				{
+					currentUser {
+						permissionsInfo {
+							permissions
+							syncedAt
+							updatedAt
+						}
+					}
+				}
+			`,
+					ExpectedResult: fmt.Sprintf(`
+				{
+					"currentUser": {
+						"permissionsInfo": {
+							"permissions": ["READ"],
+							"syncedAt": "%[1]s",
+							"updatedAt": "%[1]s"
+						}
+    				}
+				}
+			`, clock().Format(time.RFC3339)),
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gqltesting.RunTests(t, test.gqlTests)
+		})
+	}
+}

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -77,7 +77,11 @@ interface SourcegraphContext
      */
     site: Pick<
         import('./schema/site.schema').SiteConfiguration,
-        'auth.public' | 'update.channel' | 'campaigns.readAccess.enabled' | 'disableNonCriticalTelemetry'
+        | 'auth.public'
+        | 'update.channel'
+        | 'campaigns.readAccess.enabled'
+        | 'disableNonCriticalTelemetry'
+        | 'permissions.backgroundSync'
     >
 
     /** Whether access tokens are enabled. */

--- a/web/src/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -24,7 +24,7 @@ export const RepoSettingsPermissionsPage: React.FunctionComponent<{ repo: GQL.IR
                     is finished.
                 </div>
             ) : (
-                <table className="table repo-settings-permissions-page__stats">
+                <table className="table">
                     <tbody>
                         <tr>
                             <th>Last complete sync</th>

--- a/web/src/repo/settings/routes.tsx
+++ b/web/src/repo/settings/routes.tsx
@@ -25,5 +25,6 @@ export const repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] = [
         path: '/permissions',
         exact: true,
         render: props => <RepoSettingsPermissionsPage {...props} />,
+        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
     },
 ]

--- a/web/src/repo/settings/sidebaritems.ts
+++ b/web/src/repo/settings/sidebaritems.ts
@@ -20,5 +20,6 @@ export const repoSettingsSidebarItems: RepoSettingsSideBarItems = [
         to: '/permissions',
         exact: true,
         label: 'Permissions',
+        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
     },
 ]

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -25,10 +25,10 @@ import { PatternTypeProps } from '../../search'
 import { ErrorMessage } from '../../components/alerts'
 import { isDefined } from '../../../../shared/src/util/types'
 
-const fetchUser = (args: { username: string }): Observable<GQL.IUser> =>
+const fetchUser = (args: { username: string; siteAdmin: boolean }): Observable<GQL.IUser> =>
     queryGraphQL(
         gql`
-            query User($username: String!) {
+            query User($username: String!, $siteAdmin: Boolean!) {
                 user(username: $username) {
                     __typename
                     id
@@ -52,7 +52,7 @@ const fetchUser = (args: { username: string }): Observable<GQL.IUser> =>
                             name
                         }
                     }
-                    permissionsInfo {
+                    permissionsInfo @include(if: $siteAdmin) {
                         syncedAt
                         updatedAt
                     }
@@ -160,7 +160,10 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                 .pipe(
                     switchMap(([username, forceRefresh]) => {
                         type PartialStateUpdate = Pick<UserAreaState, 'userOrError'>
-                        return fetchUser({ username }).pipe(
+                        return fetchUser({
+                            username,
+                            siteAdmin: this.props.authenticatedUser?.siteAdmin || false,
+                        }).pipe(
                             filter(isDefined),
                             catchError(error => [asError(error)]),
                             map((c): PartialStateUpdate => ({ userOrError: c })),

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -162,7 +162,7 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                         type PartialStateUpdate = Pick<UserAreaState, 'userOrError'>
                         return fetchUser({
                             username,
-                            siteAdmin: this.props.authenticatedUser?.siteAdmin || false,
+                            siteAdmin: !!this.props.authenticatedUser?.siteAdmin,
                         }).pipe(
                             filter(isDefined),
                             catchError(error => [asError(error)]),

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -52,6 +52,10 @@ const fetchUser = (args: { username: string }): Observable<GQL.IUser> =>
                             name
                         }
                     }
+                    permissionsInfo {
+                        syncedAt
+                        updatedAt
+                    }
                 }
             }
         `,

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -20,7 +20,7 @@ import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
     user: Pick<GQL.IUser, 'id' | 'viewerCanAdminister' | 'builtinAuth'>
-    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'> | null
+    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'>
 }
 
 export type UserSettingsSidebarItems = Record<
@@ -41,6 +41,10 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
 
     // When the site admin is viewing another user's account.
     const siteAdminViewingOtherUser = props.user.id !== props.authenticatedUser.id
+    const context = {
+        user: props.user,
+        authenticatedUser: props.authenticatedUser,
+    }
 
     return (
         <div className={`user-settings-sidebar ${props.className || ''}`}>
@@ -56,7 +60,7 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                 <SidebarGroupItems>
                     {props.items.account.map(
                         ({ label, to, exact, condition = () => true }) =>
-                            condition({ user: props.user, authenticatedUser: props.authenticatedUser }) && (
+                            condition(context) && (
                                 <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
                                     {label}
                                 </SidebarNavItem>

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -19,7 +19,8 @@ import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
-    user: Pick<GQL.IUser, 'viewerCanAdminister' | 'builtinAuth'>
+    user: Pick<GQL.IUser, 'id' | 'viewerCanAdminister' | 'builtinAuth'>
+    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'> | null
 }
 
 export type UserSettingsSidebarItems = Record<
@@ -55,7 +56,7 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                 <SidebarGroupItems>
                     {props.items.account.map(
                         ({ label, to, exact, condition = () => true }) =>
-                            condition({ user: props.user }) && (
+                            condition({ user: props.user, authenticatedUser: props.authenticatedUser }) && (
                                 <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
                                     {label}
                                 </SidebarNavItem>

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -20,7 +20,7 @@ import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
     user: Pick<GQL.IUser, 'id' | 'viewerCanAdminister' | 'builtinAuth'>
-    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'>
+    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'> | null
 }
 
 export type UserSettingsSidebarItems = Record<

--- a/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/web/src/user/settings/UserSettingsSidebar.tsx
@@ -20,7 +20,7 @@ import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserSettingsSidebarItemConditionContext {
     user: Pick<GQL.IUser, 'id' | 'viewerCanAdminister' | 'builtinAuth'>
-    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'> | null
+    authenticatedUser: Pick<GQL.IUser, 'id' | 'siteAdmin'>
 }
 
 export type UserSettingsSidebarItems = Record<

--- a/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -11,7 +11,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IU
     useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'))
 
     return (
-        <div className="user-settings-permissions-page w-100">
+        <div className="w-100">
             <PageTitle title="Permissions" />
             <h2>Permissions</h2>
             {user.siteAdmin ? (

--- a/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { PageTitle } from '../../../components/PageTitle'
+import { Timestamp } from '../../../components/time/Timestamp'
+import { eventLogger } from '../../../tracking/eventLogger'
+
+/**
+ * The user settings permissions page.
+ */
+export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IUser }> = ({ user }) => {
+    useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'))
+
+    return (
+        <div className="user-settings-permissions-page w-100">
+            <PageTitle title="Permissions" />
+            <h2>Permissions</h2>
+            {user.siteAdmin ? (
+                <div className="alert alert-info">
+                    Site admin can access all repositoires in the Sourcegraph instance.
+                </div>
+            ) : !user.permissionsInfo ? (
+                <div className="alert alert-info">
+                    This user is queued to sync permissions, it can only access non-private repositoires until syncing
+                    is finished.
+                </div>
+            ) : (
+                <table className="table">
+                    <tbody>
+                        <tr>
+                            <th>Last complete sync</th>
+                            <td>
+                                {user.permissionsInfo.syncedAt ? (
+                                    <Timestamp date={user.permissionsInfo.syncedAt} />
+                                ) : (
+                                    'Never'
+                                )}
+                            </td>
+                            <td className="text-muted">Updated by user permissions syncing</td>
+                        </tr>
+                        <tr>
+                            <th>Last incremental sync</th>
+                            <td>
+                                <Timestamp date={user.permissionsInfo.updatedAt} />
+                            </td>
+                            <td className="text-muted">Updated by repository permissions syncing</td>
+                        </tr>
+                    </tbody>
+                </table>
+            )}
+        </div>
+    )
+}

--- a/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -16,11 +16,11 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IU
             <h2>Permissions</h2>
             {user.siteAdmin ? (
                 <div className="alert alert-info">
-                    Site admin can access all repositoires in the Sourcegraph instance.
+                    Site admin can access all repositories in the Sourcegraph instance.
                 </div>
             ) : !user.permissionsInfo ? (
                 <div className="alert alert-info">
-                    This user is queued to sync permissions, it can only access non-private repositoires until syncing
+                    This user is queued to sync permissions, it can only access non-private repositories until syncing
                     is finished.
                 </div>
             ) : (

--- a/web/src/user/settings/routes.tsx
+++ b/web/src/user/settings/routes.tsx
@@ -61,8 +61,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         path: '/permissions',
         exact: true,
         render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
-        condition: ({ user, authenticatedUser }) =>
-            !!window.context.site['permissions.backgroundSync']?.enabled &&
-            (authenticatedUser.siteAdmin || user.id !== authenticatedUser.id),
+        condition: ({ authenticatedUser }) =>
+            !!window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin,
     },
 ]

--- a/web/src/user/settings/routes.tsx
+++ b/web/src/user/settings/routes.tsx
@@ -61,5 +61,8 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         path: '/permissions',
         exact: true,
         render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
+        condition: ({ user, authenticatedUser }) =>
+            !!window.context.site['permissions.backgroundSync']?.enabled &&
+            (authenticatedUser.siteAdmin || user.id !== authenticatedUser.id),
     },
 ]

--- a/web/src/user/settings/routes.tsx
+++ b/web/src/user/settings/routes.tsx
@@ -57,4 +57,9 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         ),
         condition: () => window.context.accessTokensAllow !== 'none',
     },
+    {
+        path: '/permissions',
+        exact: true,
+        render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
+    },
 ]

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -34,7 +34,7 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             to: '/permissions',
             exact: true,
             condition: ({ authenticatedUser }) =>
-                !!(window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser?.siteAdmin),
+                !!(window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin),
         },
     ],
 }

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -29,5 +29,10 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             to: '/tokens',
             condition: () => window.context.accessTokensAllow !== 'none',
         },
+        {
+            label: 'Permissions',
+            to: '/permissions',
+            exact: true,
+        },
     ],
 }

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -35,7 +35,7 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             exact: true,
             condition: ({ user, authenticatedUser }) =>
                 !!window.context.site['permissions.backgroundSync']?.enabled &&
-                (authenticatedUser?.siteAdmin || user.id !== authenticatedUser?.id),
+                (authenticatedUser.siteAdmin || user.id !== authenticatedUser.id),
         },
     ],
 }

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -33,6 +33,9 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             label: 'Permissions',
             to: '/permissions',
             exact: true,
+            condition: ({ user, authenticatedUser }) =>
+                !!window.context.site['permissions.backgroundSync']?.enabled &&
+                (authenticatedUser?.siteAdmin || user.id !== authenticatedUser?.id),
         },
     ],
 }

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -33,9 +33,8 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             label: 'Permissions',
             to: '/permissions',
             exact: true,
-            condition: ({ user, authenticatedUser }) =>
-                !!window.context.site['permissions.backgroundSync']?.enabled &&
-                (authenticatedUser.siteAdmin || user.id !== authenticatedUser.id),
+            condition: ({ authenticatedUser }) =>
+                !!(window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser?.siteAdmin),
         },
     ],
 }


### PR DESCRIPTION
Adds a new page in user settings page for permissions, currently only showing time for **Last complete sync** and **Last incremental sync**, which corresponding to `synced_at` and `updated_at` in database table respectively.

In addition to the new page, it also hides the sidebar item from site admin if the background permission syncing is not enabled in the site configuration.

---

Preview:

![image](https://user-images.githubusercontent.com/2946214/81288871-01550800-9098-11ea-9030-3bc54629d8eb.png)
(normal user)

![image](https://user-images.githubusercontent.com/2946214/81289003-395c4b00-9098-11ea-86d0-7b687fd6ba9e.png)
(site admin)

![image](https://user-images.githubusercontent.com/2946214/81289078-57c24680-9098-11ea-9f9a-65efe8d2c29d.png)
(queued to sync)

Please feel free to suggest better wording for descriptions, thanks!