### PR TITLE
codeintel: Simplify LSIF upload proxy

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/server/handler.go
+++ b/cmd/precise-code-intel-api-server/internal/server/handler.go
@@ -154,7 +154,7 @@ func (s *Server) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusAccepted)
-	writeJSON(w, map[string]interface{}{"id": id})
+	writeJSON(w, map[string]interface{}{"id": fmt.Sprintf("%d", id)})
 }
 
 // GET /exists

--- a/cmd/precise-code-intel/src/api-server/routes/lsif.ts
+++ b/cmd/precise-code-intel/src/api-server/routes/lsif.ts
@@ -80,7 +80,7 @@ export function createLsifRouter(
     }
 
     interface UploadResponse {
-        id: number
+        id: string
     }
 
     router.post(
@@ -132,7 +132,7 @@ export function createLsifRouter(
                     // Upload conversion will complete asynchronously, send an accepted response
                     // with the upload id so that the client can continue to track the progress
                     // asynchronously.
-                    res.status(202).send({ id })
+                    res.status(202).send({ id: `${id}` })
                 } finally {
                     // Remove local file
                     await fs.unlink(filename)

--- a/internal/codeintel/lsifserver/client/proxy.go
+++ b/internal/codeintel/lsifserver/client/proxy.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+)
+
+func (c *Client) RawRequest(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "lsifserver.client.do")
+	defer func() {
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.SetTag("err", err.Error())
+		}
+		span.Finish()
+	}()
+
+	req, ht := nethttp.TraceRequest(
+		span.Tracer(),
+		req.WithContext(ctx),
+		nethttp.OperationName("LSIF client"),
+		nethttp.ClientTrace(false),
+	)
+	defer ht.Finish()
+
+	// Do not use ctxhttp.Do here as it will re-wrap the request
+	// with a context and this will causes the ot-headers not to
+	// propagate correctly.
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		return nil, errors.Wrap(err, "lsif request failed")
+	}
+
+	return resp, nil
+}
+
+func SelectRandomHost() (string, error) {
+	endpoints, err := LSIFURLs().Endpoints()
+	if err != nil {
+		return "", err
+	}
+
+	for host := range endpoints {
+		return host, nil
+	}
+
+	return "", fmt.Errorf("no endpoints available")
+}

--- a/internal/codeintel/lsifserver/client/query.go
+++ b/internal/codeintel/lsifserver/client/query.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -37,40 +35,6 @@ func (c *Client) Exists(ctx context.Context, args *struct {
 	}
 
 	return payload.Uploads, nil
-}
-
-func (c *Client) Upload(ctx context.Context, args *struct {
-	RepoID      api.RepoID
-	Commit      api.CommitID
-	Root        string
-	IndexerName string
-	Body        io.ReadCloser
-}) (int64, bool, error) {
-	query := queryValues{}
-	query.SetInt("repositoryId", int64(args.RepoID))
-	query.Set("commit", string(args.Commit))
-	query.Set("root", args.Root)
-	query.Set("indexerName", args.IndexerName)
-
-	req := &lsifRequest{
-		path:       "/upload",
-		method:     "POST",
-		query:      query,
-		body:       args.Body,
-		routingKey: fmt.Sprintf("%d:%s", args.RepoID, args.Commit),
-	}
-
-	payload := struct {
-		ID int64 `json:"id"`
-	}{}
-
-	meta, err := c.do(ctx, req, &payload)
-	if err != nil {
-		return 0, false, err
-	}
-
-	return payload.ID, meta.statusCode == http.StatusAccepted, nil
-
 }
 
 func (c *Client) Definitions(ctx context.Context, args *struct {


### PR DESCRIPTION
Remove the lsifserver-client `Upload` method and instead have the LSIF upload endpoint perform a raw request to the backend.

This is going to simplify the effort in https://github.com/sourcegraph/sourcegraph/pull/10456 as it introduces a handful of new query parameters which would otherwise need to be threaded through to this call.

In order to keep backwards compatibility, we have the api-server (both Go and TypeScript, for now) return string identifiers instead of integers. Previously this conversion was done in the proxy. This behavior is necessary to retain back-compat with src-cli.