### PR TITLE
Add error metric in updatecheck handler

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -86,15 +86,14 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	latestReleaseBuild := getLatestRelease(pr.DeployType)
 	hasUpdate, err := canUpdate(pr.ClientVersionString, latestReleaseBuild)
-	if err != nil {
-		// Still log pings on malformed version strings.
-		logPing(r, pr, false)
 
+	// Always log, even on malformed version strings
+	logPing(r, pr, hasUpdate)
+
+	if err != nil {
 		http.Error(w, pr.ClientVersionString+" is a bad version string: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	logPing(r, pr, hasUpdate)
 
 	if !hasUpdate {
 		// No newer version.

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -441,4 +441,5 @@ var (
 func init() {
 	prometheus.MustRegister(requestCounter)
 	prometheus.MustRegister(requestHasUpdateCounter)
+	prometheus.MustRegister(errorCounter)
 }


### PR DESCRIPTION
Stackdriver shows panics happening due to a nil dereference on update checks. We should have an alert based on these conditions, so I'm adding an error metric in the updatecheck handler to enable that work later.