### PR TITLE
add clear incentive for tweeting feedback

### DIFF
--- a/web/src/marketing/SurveyPage.tsx
+++ b/web/src/marketing/SurveyPage.tsx
@@ -192,7 +192,7 @@ const TweetFeedback: React.FunctionComponent<TweetFeedbackProps> = ({ feedback, 
         return (
             <>
                 <p className="mt-2">
-                    One more favor, could you share your feedback on Twitter? We'd really appreciate it!
+                    Want Sourcegraph swag? Post a tweet with your feedback and we'll send some over to you. 
                 </p>
                 <a
                     className="d-inline-block mt-2 btn btn-primary"


### PR DESCRIPTION
Updating the copy to encourage users to share feedback on Twitter and receive a box of swag. We haven't seen tweets from implementing the button (yet) and this text would more clearly incentivize users to publicly post on Twitter.