### PR TITLE
docs: add complete repo rev search syntax

### DIFF
--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -65,7 +65,7 @@ The following keywords can be used on all searches (using [RE2 syntax](https://g
 
 | Keyword | Description | Examples |
 | --- | --- | --- |
-| **repo:regexp-pattern** <br> **repo:regexp-pattern@rev** <br> _alias: r_  | Only include results from repositories whose path matches the regexp. A repository's path is a string such as _github.com/myteam/abc_ or _code.example.com/xyz_ that depends on your organization's repository host. If the regexp ends in **@rev**, that revision is searched instead of the default branch (usually `master`).  | [`repo:gorilla/mux testroute`](https://sourcegraph.com/search?q=repo:gorilla/mux+testroute)<br/>`repo:alice/abc@mybranch`  |
+| **repo:regexp-pattern** <br> **repo:regexp-pattern@rev** <br> _alias: r_  | Only include results from repositories whose path matches the regexp. A repository's path is a string such as _github.com/myteam/abc_ or _code.example.com/xyz_ that depends on your organization's repository host. If the regexp ends in [**@rev** syntax](#repository-revisions), that revision is searched instead of the default branch (usually `master`).  | [`repo:gorilla/mux testroute`](https://sourcegraph.com/search?q=repo:gorilla/mux+testroute)<br/>`repo:alice/abc@mybranch`  |
 | **-repo:regexp-pattern** <br> _alias: -r_ | Exclude results from repositories whose path matches the regexp. | `repo:alice/ -repo:old-repo` |
 | **repogroup:group-name** <br> _alias: g_ | Only include results from the named group of repositories (defined by the server admin). Same as using a repo: keyword that matches all of the group's repositories. Use repo: unless you know that the group exists. | |
 | **file:regexp-pattern** <br> _alias: f_ | Only include results in files whose full path matches the regexp. | [`file:\.js$ httptest`](https://sourcegraph.com/search?q=file:%5C.js%24+httptest) <br> [`file:internal/ httptest`](https://sourcegraph.com/search?q=file:internal/+httptest) |
@@ -139,7 +139,19 @@ The following keywords are only used for **commit diff** and **commit message** 
 | **after:"string specifying time frame"**  | Only include results from diffs or commits which have a commit date after the specified time frame| [`after:"6 weeks ago"`](https://sourcegraph.com/search?q=repo:sourcegraph/sourcegraph$+type:diff+author:nick+after:%226+weeks+ago%22) <br> [`after:"november 1 2019"`](https://sourcegraph.com/search?q=repo:sourcegraph/sourcegraph$+type:diff+author:nick+after:%22november+1+2019%22) |
 | **message:"any string"** | Only include results from diffs or commits which have commit messages containing the string | [`type:commit message:"testing"`](https://sourcegraph.com/search?q=type:commit+repo:sourcegraph/sourcegraph$+message:%22testing%22) <br> [`type:diff message:"testing"`](https://sourcegraph.com/search?q=type:diff+repo:sourcegraph/sourcegraph$+message:%22testing%22) |
 
-## Repository name search
+## Repository search
+
+### Repository revisions
+
+The `repo:` filter accepts a repository pattern followed by `@revs`, like `github.com/myteam/abc@revs`. The `@revs` part refers to repository revisions (e.g., branches or commit hashes), and may take on the following example forms:
+
+- `@feature-branch` - a branch name
+- `@1735d48` - a commit hash
+- `@3.15` - a tag
+- `@feature-branch:1735d48:3.15` - multiple colon-separated revisions of the above forms
+- `@*bar` - revisions that match the glob pattern `bar/*` (as interpreted by [gitlog --glob](https://git-scm.com/docs/git-log#Documentation/git-log.txt---globltglob-patterngt))
+
+### Repository names
 
 A query with only `repo:` filters returns a list of repositories with matching names.
 


### PR DESCRIPTION
This [isn't documented](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1588020522005200?thread_ts=1588019338.005100&cid=CHEKCRWKV). I'm basically assuming that the go doc in [repo_revs.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a25a93ab1843c41d4deab41701084b83a16bf712/-/blob/internal/search/repo_revs.go#L90-108) is accurate.