### PR TITLE
schema: Allow underscores in GitHub repository names

### DIFF
--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -749,7 +749,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   "GITHUB",
 			desc:   "invalid repos",
 			config: `{"repos": [""]}`,
-			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.\-_]+$'`),
 		},
 		{
 			kind:   "GITHUB",
@@ -785,7 +785,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   "GITHUB",
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
-			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.\-_]+$'`),
+		},
+		{
+			kind:   "GITHUB",
+			desc:   "valid exclude item name",
+			config: `{"exclude": [{"name": "sourcegraph-testing/the-way-to-go"}]}`,
+			assert: excludes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.\-_]+$'`),
 		},
 		{
 			kind:   "GITHUB",

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -62,7 +62,7 @@
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.\\-_]+$" },
       "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "orgs": {
@@ -120,7 +120,7 @@
           "name": {
             "description": "The name of a GitHub repository (\"owner/name\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^[\\w-]+/[\\w.\\-_]+$"
           },
           "id": {
             "description": "The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -67,7 +67,7 @@ const GitHubSchemaJSON = `{
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.\\-_]+$" },
       "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "orgs": {
@@ -125,7 +125,7 @@ const GitHubSchemaJSON = `{
           "name": {
             "description": "The name of a GitHub repository (\"owner/name\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^[\\w-]+/[\\w.\\-_]+$"
           },
           "id": {
             "description": "The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",


### PR DESCRIPTION
I ran into this when trying to exclude https://github.com/sourcegraph-testing/the-way-to-go_ZH_CN from being cloned in my GitHub config.