### PR TITLE
repo-updater: Use code host URL as key for rate limit registry

### DIFF
--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -983,7 +983,7 @@ func (r *RateLimiterRegistry) GetRateLimiter(baseURL string) *rate.Limiter {
 	return l
 }
 
-// SyncRateLimiters will sync all rate limiters with current config.
+// SyncRateLimiters syncs all rate limiters with current config.
 // We need to sync all as we need to pick the lowest configured limit per code host
 // and rate limits can be defined in multiple external services for the same host.
 func (r *RateLimiterRegistry) SyncRateLimiters(ctx context.Context) error {

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -946,12 +946,12 @@ func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices
 	return clone
 }
 
-type ExternalServicesLister interface {
+type externalServiceLister interface {
 	ListExternalServices(context.Context, StoreListExternalServicesArgs) ([]*ExternalService, error)
 }
 
 type RateLimiterRegistry struct {
-	serviceLister ExternalServicesLister
+	serviceLister externalServiceLister
 	mu            sync.Mutex
 	// Rate limiter per code host, keys are the normalized base URL for a
 	// code host.
@@ -960,7 +960,7 @@ type RateLimiterRegistry struct {
 
 // NewRateLimitRegistry returns a new registry and attempts to populate it. On error, an
 // empty registry is returned which can still to handle syncs.
-func NewRateLimiterRegistry(ctx context.Context, serviceLister ExternalServicesLister) (*RateLimiterRegistry, error) {
+func NewRateLimiterRegistry(ctx context.Context, serviceLister externalServiceLister) (*RateLimiterRegistry, error) {
 	r := &RateLimiterRegistry{
 		serviceLister: serviceLister,
 		rateLimiters:  make(map[string]*rate.Limiter),

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -967,7 +967,7 @@ func NewRateLimiterRegistry(ctx context.Context, serviceLister ExternalServicesL
 	}
 
 	// We'll return r either way as we'll try again if a service is added or updated
-	return r, r.syncRateLimiters(ctx)
+	return r, r.SyncRateLimiters(ctx)
 }
 
 // GetRateLimiter fetches the rate limiter associated with the given code host. If none has been
@@ -983,18 +983,10 @@ func (r *RateLimiterRegistry) GetRateLimiter(baseURL string) *rate.Limiter {
 	return l
 }
 
-// HandleExternalServiceSync will update the rate limiter associated with the supplied external service
-// so that it's settings match the service config.
-func (r *RateLimiterRegistry) HandleExternalServiceSync() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	return r.syncRateLimiters(ctx)
-}
-
-// syncRateLimiters will sync all rate limiters with current config.
+// SyncRateLimiters will sync all rate limiters with current config.
 // We need to sync all as we need to pick the lowest configured limit per code host
 // and rate limits can be defined in multiple external services for the same host.
-func (r *RateLimiterRegistry) syncRateLimiters(ctx context.Context) error {
+func (r *RateLimiterRegistry) SyncRateLimiters(ctx context.Context) error {
 	svcs, err := r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{})
 	if err != nil {
 		return errors.Wrap(err, "fetching external services")

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -95,6 +95,42 @@ func (e ExternalService) Configuration() (cfg interface{}, _ error) {
 	return extsvc.ParseConfig(e.Kind, e.Config)
 }
 
+// BaseURL will fetch the normalised base URL from the service if
+// supported.
+func (e ExternalService) BaseURL() (*url.URL, error) {
+	config, err := extsvc.ParseConfig(e.Kind, e.Config)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing config")
+	}
+
+	var rawURL string
+	switch c := config.(type) {
+	case *schema.AWSCodeCommitConnection:
+		return nil, errors.New("BaseURL unavailable for AWSCodeCommit")
+	case *schema.BitbucketServerConnection:
+		rawURL = c.Url
+	case *schema.GitHubConnection:
+		rawURL = c.Url
+	case *schema.GitLabConnection:
+		rawURL = c.Url
+	case *schema.GitoliteConnection:
+		rawURL = c.Host
+	case *schema.PhabricatorConnection:
+		rawURL = c.Url
+	case *schema.OtherExternalServiceConnection:
+		rawURL = c.Url
+	default:
+		return nil, fmt.Errorf("unknown external service type %T", config)
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing service URL")
+	}
+
+	return extsvc.NormalizeBaseURL(parsed), nil
+}
+
 // Exclude changes the configuration of an external service to exclude the given
 // repos from being synced.
 func (e *ExternalService) Exclude(rs ...*Repo) error {
@@ -910,117 +946,145 @@ func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices
 	return clone
 }
 
+type ExternalServicesLister interface {
+	ListExternalServices(context.Context, StoreListExternalServicesArgs) ([]*ExternalService, error)
+}
+
 type RateLimiterRegistry struct {
-	mu sync.Mutex
-	// Rate limiter per external service, keys are database ID of external services.
-	rateLimiters map[int64]*rate.Limiter
+	serviceLister ExternalServicesLister
+	mu            sync.Mutex
+	// Rate limiter per code host, keys are the normalized base URL for a
+	// code host.
+	rateLimiters map[string]*rate.Limiter
 }
 
 // NewRateLimitRegistry returns a new registry and attempts to populate it. On error, an
 // empty registry is returned which can still to handle syncs.
-func NewRateLimiterRegistry(ctx context.Context, store Store) (*RateLimiterRegistry, error) {
+func NewRateLimiterRegistry(ctx context.Context, serviceLister ExternalServicesLister) (*RateLimiterRegistry, error) {
 	r := &RateLimiterRegistry{
-		rateLimiters: make(map[int64]*rate.Limiter),
+		serviceLister: serviceLister,
+		rateLimiters:  make(map[string]*rate.Limiter),
 	}
 
-	svcs, err := store.ListExternalServices(ctx, StoreListExternalServicesArgs{})
-	if err != nil {
-		return r, errors.Wrap(err, "fetching external services")
-	}
-
-	for _, svc := range svcs {
-		err = r.updateRateLimiter(svc)
-		if err != nil {
-			if _, ok := err.(errRateLimitUnsupported); ok {
-				continue
-			}
-			// Errors here are not fatal, so we can log them
-			log15.Warn("Updating rate limiter", "kind", svc.Kind, "err", err)
-		}
-	}
-
-	return r, nil
+	// We'll return r either way as we'll try again if a service is added or updated
+	return r, r.syncRateLimiters(ctx)
 }
 
-// GetRateLimiter fetches the rate limiter associated with the given external service. If none has been
+// GetRateLimiter fetches the rate limiter associated with the given code host. If none has been
 // configured an infinite limiter is returned.
-func (r *RateLimiterRegistry) GetRateLimiter(externalServiceID int64) *rate.Limiter {
+func (r *RateLimiterRegistry) GetRateLimiter(baseURL string) *rate.Limiter {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	l := r.rateLimiters[externalServiceID]
+	l := r.rateLimiters[baseURL]
 	if l == nil {
 		l = rate.NewLimiter(rate.Inf, 100)
-		r.rateLimiters[externalServiceID] = l
+		r.rateLimiters[baseURL] = l
 	}
 	return l
 }
 
 // HandleExternalServiceSync will update the rate limiter associated with the supplied external service
 // so that it's settings match the service config.
-func (r *RateLimiterRegistry) HandleExternalServiceSync(apiService api.ExternalService) error {
-	svc := &ExternalService{
-		ID:          apiService.ID,
-		Kind:        apiService.Kind,
-		DisplayName: apiService.DisplayName,
-		Config:      apiService.Config,
-		CreatedAt:   apiService.CreatedAt,
-		UpdatedAt:   apiService.UpdatedAt,
-		DeletedAt:   time.Time{},
-	}
-	if apiService.DeletedAt != nil {
-		svc.DeletedAt = *apiService.DeletedAt
-	}
-	return r.updateRateLimiter(svc)
+func (r *RateLimiterRegistry) HandleExternalServiceSync() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return r.syncRateLimiters(ctx)
 }
 
-func (r *RateLimiterRegistry) updateRateLimiter(svc *ExternalService) error {
-	config, err := svc.Configuration()
+// syncRateLimiters will sync all rate limiters with current config.
+// We need to sync all as we need to pick the lowest configured limit per code host
+// and rate limits can be defined in multiple external services for the same host.
+func (r *RateLimiterRegistry) syncRateLimiters(ctx context.Context) error {
+	svcs, err := r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{})
 	if err != nil {
-		return errors.Wrap(err, "getting external service configuration")
+		return errors.Wrap(err, "fetching external services")
 	}
 
+	byURL := make(map[string]rate.Limit)
+	for _, svc := range svcs {
+		config, err := svc.Configuration()
+		if err != nil {
+			return errors.Wrap(err, "loading service configuration")
+		}
+
+		limit, baseURL, err := getLimitFromConfig(svc.Kind, config)
+		if err != nil {
+			if _, ok := err.(errRateLimitUnsupported); ok {
+				continue
+			}
+			// Errors here are not fatal, so we can log them
+			log15.Warn("Updating rate limiter", "kind", svc.Kind, "err", err)
+			continue
+		}
+		current, ok := byURL[baseURL]
+		if !ok {
+			byURL[baseURL] = limit
+			continue
+		}
+		// Use the lower limit
+		if limit < current {
+			byURL[baseURL] = limit
+		}
+	}
+
+	for u, rl := range byURL {
+		l := r.GetRateLimiter(u)
+		l.SetLimit(rl)
+	}
+
+	return nil
+}
+
+func getLimitFromConfig(kind string, config interface{}) (limit rate.Limit, baseURL string, err error) {
 	// Rate limit config can be in a few states:
 	// 1. Not defined: We fall back to default specified in code.
 	// 2. Defined and enabled: We use their defined limit.
 	// 3. Defined and disabled: We use an infinite limiter.
 
-	var limit rate.Limit
 	switch c := config.(type) {
 	case *schema.GitLabConnection:
 		// 10/s is the default enforced by GitLab on their end
 		limit = rate.Limit(10)
 		if c != nil && c.RateLimit != nil {
-			limit = getLimit(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+		baseURL = c.Url
 	case *schema.GitHubConnection:
 		// 5000 per hour is the default enforced by GitHub on their end
 		limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
-			limit = getLimit(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+		baseURL = c.Url
 	case *schema.BitbucketServerConnection:
 		// 8/s is the default limit we enforce
 		limit = rate.Limit(8)
 		if c != nil && c.RateLimit != nil {
-			limit = getLimit(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+		baseURL = c.Url
 	case *schema.BitbucketCloudConnection:
 		// 2/s is the default limit we enforce
 		limit = rate.Limit(2)
 		if c != nil && c.RateLimit != nil {
-			limit = getLimit(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+		baseURL = c.Url
 	default:
-		return errRateLimitUnsupported{codehostKind: svc.Kind}
+		return 0, "", errRateLimitUnsupported{codehostKind: kind}
 	}
 
-	l := r.GetRateLimiter(svc.ID)
-	l.SetLimit(limit)
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "parsing external service URL")
+	}
 
-	return nil
+	baseURL = extsvc.NormalizeBaseURL(u).String()
+
+	return limit, baseURL, nil
 }
 
-func getLimit(enabled bool, perHour float64) rate.Limit {
+func limitOrInf(enabled bool, perHour float64) rate.Limit {
 	if enabled {
 		return rate.Limit(perHour / 3600)
 	}

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -1,6 +1,8 @@
 package repos
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -470,11 +472,54 @@ func formatJSON(t testing.TB, s string) string {
 }
 
 func TestRateLimiterRegistry(t *testing.T) {
-	r := &RateLimiterRegistry{
-		rateLimiters: make(map[int64]*rate.Limiter),
+	now := time.Now()
+
+	baseURL := "http://gitlab.com/"
+	makeConfig := func(u string, perHour int) string {
+		return fmt.Sprintf(
+			`
+{
+  "url": "%s",
+  "rateLimit": {
+    "enabled": true,
+    "requestsPerHour": %d,
+  }
+}
+`, u, perHour)
 	}
 
-	l := r.GetRateLimiter(1)
+	// Two services for the same code host
+	mockLister := &MockExternalServicesLister{
+		listExternalServices: func(ctx context.Context, args StoreListExternalServicesArgs) ([]*ExternalService, error) {
+			return []*ExternalService{
+				{
+					ID:          1,
+					Kind:        "GitLab",
+					DisplayName: "GitLab",
+					Config:      makeConfig(baseURL, 3600),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+					DeletedAt:   time.Time{},
+				},
+				{
+					ID:          2,
+					Kind:        "GitLab",
+					DisplayName: "GitLab",
+					Config:      makeConfig(baseURL, 7200),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+					DeletedAt:   time.Time{},
+				},
+			}, nil
+		},
+	}
+
+	r := &RateLimiterRegistry{
+		serviceLister: mockLister,
+		rateLimiters:  make(map[string]*rate.Limiter),
+	}
+
+	l := r.GetRateLimiter(baseURL)
 	if l == nil {
 		t.Fatalf("Expected a limiter")
 	}
@@ -483,47 +528,13 @@ func TestRateLimiterRegistry(t *testing.T) {
 		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
 	}
 
-	now := time.Now()
-	s := api.ExternalService{
-		ID:          1,
-		Kind:        "GitLab",
-		DisplayName: "GitLab",
-		Config:      "",
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		DeletedAt:   nil,
-	}
-	err := r.HandleExternalServiceSync(s)
+	err := r.HandleExternalServiceSync()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// We should have default limit
-	l = r.GetRateLimiter(1)
-	if l == nil {
-		t.Fatalf("Expected a limiter")
-	}
-	expectedLimit = rate.Limit(10)
-	if l.Limit() != expectedLimit {
-		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
-	}
-
-	// Add config
-	s.Config = `
-{
-  "RateLimit": {
-    "Enabled": true,
-    "RequestsPerHour": 3600,
-  }
-}
-`
-	err = r.HandleExternalServiceSync(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// We should have new limit
-	l = r.GetRateLimiter(1)
+	l = r.GetRateLimiter(baseURL)
 	if l == nil {
 		t.Fatalf("Expected a limiter")
 	}
@@ -531,4 +542,27 @@ func TestRateLimiterRegistry(t *testing.T) {
 	if l.Limit() != expectedLimit {
 		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
 	}
+
+	err = r.HandleExternalServiceSync()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have new limit
+	l = r.GetRateLimiter(baseURL)
+	if l == nil {
+		t.Fatalf("Expected a limiter")
+	}
+	expectedLimit = rate.Limit(1)
+	if l.Limit() != expectedLimit {
+		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
+	}
+}
+
+type MockExternalServicesLister struct {
+	listExternalServices func(context.Context, StoreListExternalServicesArgs) ([]*ExternalService, error)
+}
+
+func (m MockExternalServicesLister) ListExternalServices(ctx context.Context, args StoreListExternalServicesArgs) ([]*ExternalService, error) {
+	return m.listExternalServices(ctx, args)
 }

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -473,6 +473,7 @@ func formatJSON(t testing.TB, s string) string {
 
 func TestRateLimiterRegistry(t *testing.T) {
 	now := time.Now()
+	ctx := context.Background()
 
 	baseURL := "http://gitlab.com/"
 	makeConfig := func(u string, perHour int) string {
@@ -528,7 +529,7 @@ func TestRateLimiterRegistry(t *testing.T) {
 		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
 	}
 
-	err := r.HandleExternalServiceSync()
+	err := r.SyncRateLimiters(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -543,7 +544,7 @@ func TestRateLimiterRegistry(t *testing.T) {
 		t.Fatalf("Expected limit %f, got %f", expectedLimit, l.Limit())
 	}
 
-	err = r.HandleExternalServiceSync()
+	err = r.SyncRateLimiters(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -54,7 +54,7 @@ type Server struct {
 	RateLimiterRegistry interface {
 		// HandleExternalServiceSync should be called when an external service changes so that
 		// our internal rate limiter are kept in sync
-		HandleExternalServiceSync(apiService api.ExternalService) error
+		HandleExternalServiceSync() error
 	}
 
 	notClonedCountMu        sync.Mutex
@@ -341,7 +341,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	}
 
 	if s.RateLimiterRegistry != nil {
-		err = s.RateLimiterRegistry.HandleExternalServiceSync(req.ExternalService)
+		err = s.RateLimiterRegistry.HandleExternalServiceSync()
 		if err != nil {
 			log15.Warn("Handling rate limiter sync", "err", err)
 		}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -52,9 +52,9 @@ type Server struct {
 		HandleExternalServiceSync(es api.ExternalService)
 	}
 	RateLimiterRegistry interface {
-		// HandleExternalServiceSync should be called when an external service changes so that
+		// SyncRateLimiters should be called when an external service changes so that
 		// our internal rate limiter are kept in sync
-		HandleExternalServiceSync() error
+		SyncRateLimiters(ctx context.Context) error
 	}
 
 	notClonedCountMu        sync.Mutex
@@ -341,7 +341,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	}
 
 	if s.RateLimiterRegistry != nil {
-		err = s.RateLimiterRegistry.HandleExternalServiceSync()
+		err = s.RateLimiterRegistry.SyncRateLimiters(ctx)
 		if err != nil {
 			log15.Warn("Handling rate limiter sync", "err", err)
 		}

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -628,7 +628,11 @@ func GroupChangesetsBySource(ctx context.Context, reposStore RepoStore, cf *http
 	for _, e := range es {
 		var rl *rate.Limiter
 		if rlr != nil {
-			rl = rlr.GetRateLimiter(e.ID)
+			u, err := e.BaseURL()
+			if err != nil {
+				return nil, errors.Wrap(err, "getting base URL")
+			}
+			rl = rlr.GetRateLimiter(u.String())
 		}
 		css, err := repos.NewChangesetSource(e, cf, rl)
 		if err != nil {


### PR DESCRIPTION
Related to: https://github.com/orgs/sourcegraph/teams/core-services/discussions/4

I'll do a follow up PR that adds the warning when more than one external service for the same host has been configured with a rate limiter.