### PR TITLE
Don't run e2e tests on Renovate branches

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -194,10 +194,10 @@ func wait(pipeline *bk.Pipeline) {
 }
 
 func triggerE2E(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
-	// Run e2e tests for renovate and release branches
+	// Run e2e tests for release branches
 	// We do not run e2e tests on other branches until we can make them reliable.
 	// See RFC 137: https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit
-	runE2E := c.isRenovateBranch || c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
+	runE2E := c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch
 
 	env := copyEnv(
 		"BUILDKITE_PULL_REQUEST",


### PR DESCRIPTION
All Renovate branches are currently failing because our e2e test infrastructure (the part that runs the Docker container) is broken.
I propose we don't run e2e tests on Renovate branches until this is fixed. 

While I am not happy with that because it prevents us from merging riskier upgrades without manual testing, at least this allows us to merge low or no-risk upgrades.