### PR TITLE
codeintel: Bump minimum migration version in TypeScript code

### DIFF
--- a/cmd/precise-code-intel/src/shared/database/postgres.ts
+++ b/cmd/precise-code-intel/src/shared/database/postgres.ts
@@ -16,7 +16,7 @@ import * as settings from './settings'
  * directory, as we watch the DB to ensure we're on at least this version prior to
  * making use of the DB (which the frontend may still be migrating).
  */
-const MINIMUM_MIGRATION_VERSION = 1528395670
+const MINIMUM_MIGRATION_VERSION = 1528395671
 
 /**
  * Create a Postgres connection. This creates a typorm connection pool with


### PR DESCRIPTION
Insta-merging this to prevent dotcom from writing to an outdated schema.