### PR TITLE
codeintel: (Temporarily) allow unbounded results from bundle manager

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -139,8 +139,8 @@ func (s *Server) handleMonikerResults(w http.ResponseWriter, r *http.Request) {
 			return nil, errors.New("illegal skip supplied")
 		}
 
-		take := getQueryIntDefault(r, "take", DefaultMonikerResultPageSize)
-		if take <= 0 {
+		take := getQueryInt(r, "take")
+		if take < 0 {
 			return nil, errors.New("illegal take supplied")
 		}
 

--- a/internal/codeintel/bundles/reader/sqlite_reader.go
+++ b/internal/codeintel/bundles/reader/sqlite_reader.go
@@ -83,20 +83,23 @@ func (r *sqliteReader) ReadResultChunk(ctx context.Context, id int) (types.Resul
 }
 
 func (r *sqliteReader) ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) ([]types.DefinitionReferenceRow, int, error) {
-	query := `
-		SELECT ` + strings.Join(definitionReferenceColumns, ", ") + `
-		FROM definitions
-		WHERE scheme = %s AND identifier = %s
-		LIMIT %d OFFSET %d
-	`
+	var query *sqlf.Query
+	if take == 0 && skip == 0 {
+		query = sqlf.Sprintf(`
+			SELECT `+strings.Join(definitionReferenceColumns, ", ")+`
+			FROM definitions
+			WHERE scheme = %s AND identifier = %s
+		`, scheme, identifier)
+	} else {
+		query = sqlf.Sprintf(`
+			SELECT `+strings.Join(definitionReferenceColumns, ", ")+`
+			FROM definitions
+			WHERE scheme = %s AND identifier = %s
+			LIMIT %d OFFSET %d
+		`, scheme, identifier, take, skip)
+	}
 
-	rows, err := scanDefinitionReferenceRows(r.query(ctx, sqlf.Sprintf(
-		query,
-		scheme,
-		identifier,
-		take,
-		skip,
-	)))
+	rows, err := scanDefinitionReferenceRows(r.query(ctx, query))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -115,20 +118,23 @@ func (r *sqliteReader) ReadDefinitions(ctx context.Context, scheme, identifier s
 }
 
 func (r *sqliteReader) ReadReferences(ctx context.Context, scheme, identifier string, skip, take int) ([]types.DefinitionReferenceRow, int, error) {
-	query := `
-		SELECT ` + strings.Join(definitionReferenceColumns, ", ") + `
-		FROM "references"
-		WHERE scheme = %s AND identifier = %s
-		LIMIT %d OFFSET %d
-	`
+	var query *sqlf.Query
+	if take == 0 && skip == 0 {
+		query = sqlf.Sprintf(`
+			SELECT `+strings.Join(definitionReferenceColumns, ", ")+`
+			FROM "references"
+			WHERE scheme = %s AND identifier = %s
+		`, scheme, identifier)
+	} else {
+		query = sqlf.Sprintf(`
+			SELECT `+strings.Join(definitionReferenceColumns, ", ")+`
+			FROM "references"
+			WHERE scheme = %s AND identifier = %s
+			LIMIT %s OFFSET %d
+		`, scheme, identifier, take, skip)
+	}
 
-	rows, err := scanDefinitionReferenceRows(r.query(ctx, sqlf.Sprintf(
-		query,
-		scheme,
-		identifier,
-		take,
-		skip,
-	)))
+	rows, err := scanDefinitionReferenceRows(r.query(ctx, query))
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Adding a default limit when `?limit=0` to the bundle manager causes the number of references that can be returned from the same dump to 100. This reverts that change and allows an unbounded moniker results query in the bundle manager.

Follow-up issue: https://github.com/sourcegraph/sourcegraph/issues/10510