### PR TITLE
Fix port in 301 redirect to match port of SSL server config

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -42,7 +42,7 @@ http {
     ...
     server {
         listen 7080;
-        return 301 https://$host:7433$request_uri;
+        return 301 https://$host:7443$request_uri;
     }
 
     server {


### PR DESCRIPTION
The port in the SSL server config is 7443

For the 301 redirect, the redirect wrongfully redirects to 7433 instead of 7443 as seen here:

```
    server {
        # Do not remove. The contents of sourcegraph_server.conf can change
        # between versions and may include improvements to the configuration.
        include nginx/sourcegraph_server.conf;

        listen 7443 ssl;
        server_name sourcegraph.example.com;  # change to your URL
        ssl_certificate         sourcegraph.crt;
        ssl_certificate_key     sourcegraph.key;
```