### PR TITLE
support predefined icons for badges (backward compat)

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1159,7 +1159,7 @@ declare module 'sourcegraph' {
         backgroundColor?: string
 
         /**
-         *  The CSS color property value for the attachment.
+         * The CSS color property value for the attachment.
          *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
          */
@@ -1178,14 +1178,14 @@ declare module 'sourcegraph' {
         linkURL?: string
 
         /**
-         *  Overwrite style for light themes.
+         * Overwrite style for light themes.
          *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
          */
         light?: ThemableBadgeAttachmentStyle
 
         /**
-         *  Overwrite style for dark themes.
+         * Overwrite style for dark themes.
          *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
          */

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1145,19 +1145,24 @@ declare module 'sourcegraph' {
      */
     export interface ThemableBadgeAttachmentStyle {
         /**
-         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
          * The icon (a base64-encoded image icon) to display next to the wrapped value.
-         * */
+         *
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         */
         icon?: string
 
         /**
+         * The CSS background-color property value for the attachment.
+         *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
-         * The CSS background-color property value for the attachment. */
+         */
         backgroundColor?: string
 
         /**
+         *  The CSS color property value for the attachment.
+         *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
-         *  The CSS color property value for the attachment. */
+         */
         color?: string
     }
 
@@ -1173,13 +1178,17 @@ declare module 'sourcegraph' {
         linkURL?: string
 
         /**
+         *  Overwrite style for light themes.
+         *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
-         *  Overwrite style for light themes. */
+         */
         light?: ThemableBadgeAttachmentStyle
 
         /**
+         *  Overwrite style for dark themes.
+         *
          * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
-         *  Overwrite style for dark themes. */
+         */
         dark?: ThemableBadgeAttachmentStyle
     }
 

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1144,28 +1144,42 @@ declare module 'sourcegraph' {
      * A style for {@link BadgeAttachmentRenderOptions}.
      */
     export interface ThemableBadgeAttachmentStyle {
-        /** The icon (a base64-encoded image icon) to display next to the wrapped value. */
+        /**
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         * The icon (a base64-encoded image icon) to display next to the wrapped value.
+         * */
         icon?: string
 
-        /** The CSS background-color property value for the attachment. */
+        /**
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         * The CSS background-color property value for the attachment. */
         backgroundColor?: string
 
-        /** The CSS color property value for the attachment. */
+        /**
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         *  The CSS color property value for the attachment. */
         color?: string
     }
 
     /** An attachment adds content to a hover tooltip or result in a locations panel. */
     export interface BadgeAttachmentRenderOptions extends ThemableBadgeAttachmentStyle {
+        /** Predefined icons for badge attachments */
+        kind: 'info' | 'error' | 'warning'
+
         /** Tooltip text to display when hovering over the attachment. */
         hoverMessage?: string
 
         /** If set, the attachment becomes a link with this destination URL. */
         linkURL?: string
 
-        /** Overwrite style for light themes. */
+        /**
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         *  Overwrite style for light themes. */
         light?: ThemableBadgeAttachmentStyle
 
-        /** Overwrite style for dark themes. */
+        /**
+         * @deprecated Use {@link BadgeAttachmentRenderOptions#kind} to pick a predefined icon
+         *  Overwrite style for dark themes. */
         dark?: ThemableBadgeAttachmentStyle
     }
 

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -1,3 +1,5 @@
+@import '../../src/global-styles/colors.scss';
+
 .badge-decoration-attachment {
     &__icon-svg,
     &__contents {

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -10,6 +10,17 @@
         background-color: rgba($body-bg-color-dark, 0.8);
     }
 
+    &__icon-svg {
+        width: 1.75rem;
+        height: 1.75rem;
+        margin: 0.25rem;
+        background: transparent;
+        z-index: 1;
+        border: none;
+        border-radius: 100%;
+        background-color: rgba($body-bg-color-dark, 0.8);
+    }
+
     width: 100%;
     text-align: right;
 }
@@ -17,6 +28,10 @@
 .theme-light {
     .badge-decoration-attachment {
         &__contents {
+            background-color: rgba($body-bg-color-light, 0.8);
+        }
+
+        &__icon-svg {
             background-color: rgba($body-bg-color-light, 0.8);
         }
     }

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -12,7 +12,7 @@
         background-color: rgba($body-bg-color-dark, 0.8);
     }
     &__icon-svg {
-        // TODO is there a better way to style this?
+        // TODO is there a better way to style this? padding vs margin (see __contents)
         margin: 0.25rem;
     }
     &__contents {

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -17,17 +17,6 @@
         padding: 0.25rem;
     }
 
-    &__icon-svg {
-        width: 1.75rem;
-        height: 1.75rem;
-        margin: 0.25rem;
-        background: transparent;
-        z-index: 1;
-        border: none;
-        border-radius: 100%;
-        background-color: rgba($body-bg-color-dark, 0.8);
-    }
-
     width: 100%;
     text-align: right;
     color: inherit;

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -17,6 +17,17 @@
         padding: 0.25rem;
     }
 
+    &__icon-svg {
+        width: 1.75rem;
+        height: 1.75rem;
+        margin: 0.25rem;
+        background: transparent;
+        z-index: 1;
+        border: none;
+        border-radius: 100%;
+        background-color: rgba($body-bg-color-dark, 0.8);
+    }
+
     width: 100%;
     text-align: right;
     color: inherit;

--- a/shared/src/components/BadgeAttachment.scss
+++ b/shared/src/components/BadgeAttachment.scss
@@ -1,28 +1,33 @@
 .badge-decoration-attachment {
+    &__icon-svg,
     &__contents {
         width: 1.75rem;
         height: 1.75rem;
-        padding: 0.25rem;
         background: transparent;
         z-index: 1;
         border: none;
         border-radius: 100%;
         background-color: rgba($body-bg-color-dark, 0.8);
     }
-
     &__icon-svg {
-        width: 1.75rem;
-        height: 1.75rem;
+        // TODO is there a better way to style this?
         margin: 0.25rem;
-        background: transparent;
-        z-index: 1;
-        border: none;
-        border-radius: 100%;
-        background-color: rgba($body-bg-color-dark, 0.8);
+    }
+    &__contents {
+        padding: 0.25rem;
     }
 
     width: 100%;
     text-align: right;
+    color: inherit;
+
+    &:hover {
+        color: #ffffff;
+
+        .theme-light & {
+            color: $color-light-text-2;
+        }
+    }
 }
 
 .theme-light {

--- a/shared/src/components/BadgeAttachment.story.tsx
+++ b/shared/src/components/BadgeAttachment.story.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
+import { BadgeAttachment } from './BadgeAttachment'
+import badgeStyles from './BadgeAttachment.scss'
+import webStyles from '../../../web/src/SourcegraphWebApp.scss'
+import { BadgeAttachmentRenderOptions } from 'sourcegraph'
+
+import { radios } from '@storybook/addon-knobs'
+
+const label = 'Theme'
+const options = {
+    Light: 'light',
+    Dark: 'dark',
+}
+const defaultValue = 'light'
+const groupId = 'GROUP-ID1'
+
+const isLightTheme = () => radios(label, options, defaultValue, groupId) === 'light'
+
+const { add } = storiesOf('BadgeAttachment', module).addDecorator(story => (
+    <>
+        <style>{webStyles}</style>
+        <style>{badgeStyles}</style>
+        <div style={{ color: 'var(--body-color)' }} className={isLightTheme() ? 'theme-light' : 'theme-dark'}>
+            <div>{story()}</div>
+        </div>
+    </>
+))
+
+add('info', () => (
+    <BadgeAttachment
+        attachment={{ kind: 'info', hoverMessage: ' this is hover tooltip(info)' }}
+        isLightTheme={isLightTheme()}
+    />
+))
+
+add('warning', () => (
+    <BadgeAttachment
+        attachment={{ kind: 'warning', hoverMessage: 'this is hover tooltip(warning)' }}
+        isLightTheme={isLightTheme()}
+    />
+))
+
+add('error', () => (
+    <BadgeAttachment
+        attachment={{ kind: 'error', hoverMessage: 'this is hover tooltip(error)' }}
+        isLightTheme={isLightTheme()}
+    />
+))
+
+const oldFormatBadge: Omit<BadgeAttachmentRenderOptions, 'kind'> = {
+    icon: makeInfoIcon('#ffffff'),
+    light: { icon: makeInfoIcon('#000000') },
+}
+
+add('old format icon', () => (
+    <BadgeAttachment attachment={oldFormatBadge as BadgeAttachmentRenderOptions} isLightTheme={isLightTheme()} />
+))
+
+function makeIcon(svg: string): string {
+    return `data:image/svg+xml;base64,${btoa(
+        svg
+            .split('\n')
+            .map(r => r.trimStart())
+            .join(' ')
+    )}`
+}
+
+function makeInfoIcon(color: string): string {
+    return makeIcon(`
+        <svg xmlns='http://www.w3.org/2000/svg' style="width:24px;height:24px" viewBox="0 0 24 24" fill="${color}">
+            <path d="
+                M11,
+                9H13V7H11M12,
+                20C7.59,
+                20 4,
+                16.41 4,
+                12C4,
+                7.59 7.59,
+                4 12,
+                4C16.41,
+                4 20,
+                7.59 20,
+                12C20,
+                16.41 16.41,
+                20 12,
+                20M12,
+                2A10,
+                10 0 0,
+                0 2,
+                12A10,
+                10 0 0,
+                0 12,
+                22A10,
+                10 0 0,
+                0 22,
+                12A10,
+                10 0 0,
+                0 12,
+                2M11,
+                17H13V11H11V17Z"
+            />
+        </svg>
+    `)
+}

--- a/shared/src/components/BadgeAttachment.test.tsx
+++ b/shared/src/components/BadgeAttachment.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { BadgeAttachment } from './BadgeAttachment'
+import { BadgeAttachmentRenderOptions } from 'sourcegraph'
+
+const base64icon =
+    'data:image/svg+xml;base64,IDxzdmcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyBzdHlsZT0id2lkdGg6MjRweDtoZWlnaHQ6MjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZmZmZmZmIj4gPHBhdGggZD0iIE0xMSwgOUgxM1Y3SDExTTEyLCAyMEM3LjU5LCAyMCA0LCAxNi40MSA0LCAxMkM0LCA3LjU5IDcuNTksIDQgMTIsIDRDMTYuNDEsIDQgMjAsIDcuNTkgMjAsIDEyQzIwLCAxNi40MSAxNi40MSwgMjAgMTIsIDIwTTEyLCAyQTEwLCAxMCAwIDAsIDAgMiwgMTJBMTAsIDEwIDAgMCwgMCAxMiwgMjJBMTAsIDEwIDAgMCwgMCAyMiwgMTJBMTAsIDEwIDAgMCwgMCAxMiwgMk0xMSwgMTdIMTNWMTFIMTFWMTdaIiAvPiA8L3N2Zz4g'
+
+export const oldFormatBadge: Omit<BadgeAttachmentRenderOptions, 'kind'> = {
+    icon: base64icon,
+    light: { icon: base64icon },
+    hoverMessage:
+        'Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF.',
+    linkURL: 'https://docs.sourcegraph.com/user/code_intelligence/basic_code_intelligence',
+}
+
+export const newFormatBadge: BadgeAttachmentRenderOptions = {
+    ...oldFormatBadge,
+    kind: 'info',
+}
+
+describe('BadgeAttachment', () => {
+    afterAll(cleanup)
+
+    it('renders an img element with old format props', () => {
+        // any because ts will error with '"kind" is missing'
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { container } = render(<BadgeAttachment attachment={oldFormatBadge as any} isLightTheme={true} />)
+        const item = container.querySelector('.badge-decoration-attachment__contents')
+        expect(item).toBeTruthy()
+        // we used to render an image with base64 content as a source
+        expect(item?.nodeName.toLowerCase()).toBe('img')
+    })
+
+    it('renders an svg element with new format props', () => {
+        const { container } = render(<BadgeAttachment attachment={newFormatBadge} isLightTheme={true} />)
+        const item = container.querySelector('.badge-decoration-attachment__icon-svg')
+        expect(item).toBeTruthy()
+        // now we are using a proper svg for icons
+        expect(item?.nodeName.toLowerCase()).toBe('svg')
+    })
+})

--- a/shared/src/components/BadgeAttachment.test.tsx
+++ b/shared/src/components/BadgeAttachment.test.tsx
@@ -23,9 +23,10 @@ describe('BadgeAttachment', () => {
     afterAll(cleanup)
 
     it('renders an img element with a base64 icon', () => {
-        // any because ts will error with '"kind" is missing'
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { container } = render(<BadgeAttachment attachment={oldFormatBadge as any} isLightTheme={true} />)
+        // note '"kind" is missing'
+        const { container } = render(
+            <BadgeAttachment attachment={oldFormatBadge as BadgeAttachmentRenderOptions} isLightTheme={true} />
+        )
         const item = container.querySelector('.badge-decoration-attachment__contents')
         expect(item).toBeTruthy()
         // we used to render an image with base64 content as a source

--- a/shared/src/components/BadgeAttachment.test.tsx
+++ b/shared/src/components/BadgeAttachment.test.tsx
@@ -22,7 +22,7 @@ export const newFormatBadge: BadgeAttachmentRenderOptions = {
 describe('BadgeAttachment', () => {
     afterAll(cleanup)
 
-    it('renders an img element with old format props', () => {
+    it('renders an img element with a base64 icon', () => {
         // any because ts will error with '"kind" is missing'
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { container } = render(<BadgeAttachment attachment={oldFormatBadge as any} isLightTheme={true} />)
@@ -32,7 +32,7 @@ describe('BadgeAttachment', () => {
         expect(item?.nodeName.toLowerCase()).toBe('img')
     })
 
-    it('renders an svg element with new format props', () => {
+    it('renders an svg element with a predefined icon', () => {
         const { container } = render(<BadgeAttachment attachment={newFormatBadge} isLightTheme={true} />)
         const item = container.querySelector('.badge-decoration-attachment__icon-svg')
         expect(item).toBeTruthy()

--- a/shared/src/components/BadgeAttachment.tsx
+++ b/shared/src/components/BadgeAttachment.tsx
@@ -8,25 +8,18 @@ import { badgeAttachmentStyleForTheme } from '../api/client/services/decoration'
 import { LinkOrSpan } from './LinkOrSpan'
 import { isEncodedImage } from '../util/icon'
 import { MdiReactIconComponentType } from 'mdi-react'
-import classNames from 'classnames'
 
-const chooseIconComponent = (icon: BadgeAttachmentRenderOptions['kind']): MdiReactIconComponentType => {
-    switch (icon) {
-        case 'info':
-            return InformationIcon
-        case 'warning':
-            return WarningIcon
-        case 'error':
-            return ErrorIcon
-    }
+const iconComponents: Record<BadgeAttachmentRenderOptions['kind'], MdiReactIconComponentType> = {
+    info: InformationIcon,
+    warning: WarningIcon,
+    error: ErrorIcon,
 }
 
-const isPredefinedIcon = (badge: BadgeAttachmentRenderOptions): boolean => 'kind' in badge
-
 const renderIcon = (badge: BadgeAttachmentRenderOptions, isLightTheme: boolean): JSX.Element | null => {
-    if (isPredefinedIcon(badge)) {
-        const Icon = chooseIconComponent(badge.kind)
-        return <Icon className={classNames('icon-inline', 'badge-decoration-attachment__icon-svg')} />
+    if ('kind' in badge) {
+        // means that we are using predefined icons
+        const Icon = iconComponents[badge.kind]
+        return <Icon className="icon-inline badge-decoration-attachment__icon-svg" />
     }
 
     const style = badgeAttachmentStyleForTheme(badge, isLightTheme)
@@ -52,9 +45,8 @@ export const BadgeAttachment: React.FunctionComponent<{
     attachment: BadgeAttachmentRenderOptions
     isLightTheme: boolean
 }> = ({ attachment, isLightTheme }) => (
-    // 'badge-decoration-attachment__contents'
     <LinkOrSpan
-        className={classNames('badge-decoration-attachment', isPredefinedIcon(attachment) && 'btn-icon')}
+        className="badge-decoration-attachment"
         to={attachment.linkURL}
         data-tooltip={attachment.hoverMessage}
         data-placement="left"

--- a/shared/src/components/BadgeAttachment.tsx
+++ b/shared/src/components/BadgeAttachment.tsx
@@ -1,38 +1,68 @@
 import * as React from 'react'
 import isAbsoluteUrl from 'is-absolute-url'
+import InformationIcon from 'mdi-react/InfoCircleOutlineIcon'
+import WarningIcon from 'mdi-react/AlertCircleOutlineIcon'
+import ErrorIcon from 'mdi-react/AlertDecagramOutlineIcon'
 import { BadgeAttachmentRenderOptions } from 'sourcegraph'
 import { badgeAttachmentStyleForTheme } from '../api/client/services/decoration'
 import { LinkOrSpan } from './LinkOrSpan'
 import { isEncodedImage } from '../util/icon'
+import { MdiReactIconComponentType } from 'mdi-react'
+import classNames from 'classnames'
+
+const chooseIconComponent = (icon: BadgeAttachmentRenderOptions['kind']): MdiReactIconComponentType => {
+    switch (icon) {
+        case 'info':
+            return InformationIcon
+        case 'warning':
+            return WarningIcon
+        case 'error':
+            return ErrorIcon
+    }
+}
+
+const isPredefinedIcon = (badge: BadgeAttachmentRenderOptions): boolean => 'kind' in badge
+
+const renderIcon = (badge: BadgeAttachmentRenderOptions, isLightTheme: boolean): JSX.Element | null => {
+    if (isPredefinedIcon(badge)) {
+        const Icon = chooseIconComponent(badge.kind)
+        return <Icon className={classNames('icon-inline', 'badge-decoration-attachment__icon-svg')} />
+    }
+
+    const style = badgeAttachmentStyleForTheme(badge, isLightTheme)
+
+    if (!style.icon || !isEncodedImage(style.icon)) {
+        return null
+    }
+
+    return (
+        <img
+            className="badge-decoration-attachment__contents"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                color: style.color,
+                backgroundColor: style.backgroundColor,
+            }}
+            src={style.icon}
+        />
+    )
+}
 
 export const BadgeAttachment: React.FunctionComponent<{
     attachment: BadgeAttachmentRenderOptions
     isLightTheme: boolean
-}> = ({ attachment, isLightTheme }) => {
-    const style = badgeAttachmentStyleForTheme(attachment, isLightTheme)
-
-    return (
-        <LinkOrSpan
-            className="badge-decoration-attachment"
-            to={attachment.linkURL}
-            data-tooltip={attachment.hoverMessage}
-            data-placement="left"
-            // Use target to open external URLs
-            target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
-            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-            rel="noreferrer noopener"
-        >
-            {style.icon && isEncodedImage(style.icon) && (
-                <img
-                    className="badge-decoration-attachment__contents"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{
-                        color: style.color,
-                        backgroundColor: style.backgroundColor,
-                    }}
-                    src={style.icon}
-                />
-            )}
-        </LinkOrSpan>
-    )
-}
+}> = ({ attachment, isLightTheme }) => (
+    // 'badge-decoration-attachment__contents'
+    <LinkOrSpan
+        className={classNames('badge-decoration-attachment', isPredefinedIcon(attachment) && 'btn-icon')}
+        to={attachment.linkURL}
+        data-tooltip={attachment.hoverMessage}
+        data-placement="left"
+        // Use target to open external URLs
+        target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
+        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+        rel="noreferrer noopener"
+    >
+        {renderIcon(attachment, isLightTheme)}
+    </LinkOrSpan>
+)

--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -25,7 +25,6 @@
             position: absolute;
             top: 0;
             right: 0;
-            width: 100%;
             text-align: right;
         }
     }

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -91,7 +91,6 @@
         top: 1px;
         right: 1px;
         text-align: right;
-        // display: flex;
     }
     &:hover &__badge--offset {
         right: 1.5rem;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -91,7 +91,7 @@
         top: 1px;
         right: 1px;
         text-align: right;
-        display: flex;
+        // display: flex;
     }
     &:hover &__badge--offset {
         right: 1.5rem;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -90,8 +90,8 @@
         position: absolute;
         top: 1px;
         right: 1px;
-        width: 100%;
         text-align: right;
+        display: flex;
     }
     &:hover &__badge--offset {
         right: 1.5rem;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -91,6 +91,7 @@
         top: 1px;
         right: 1px;
         text-align: right;
+        display: flex;
     }
     &:hover &__badge--offset {
         right: 1.5rem;


### PR DESCRIPTION
- added `kind` prop for predefined icons
- marked as deprecated styling and icon source props
- icon is going to be styled by host with themes support
- I made changes backward compatible (both visually and logically)
