### PR TITLE
Revert "add extra check to make sure repo name has path"

### DIFF
--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -62,13 +62,6 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 // code hosts' URL hostname component.
 func CodeHostOf(name api.RepoName, codehosts ...*CodeHost) *CodeHost {
 	for _, c := range codehosts {
-
-		// Check if repo name is missing path/namespace by checking if the repo name
-		// is exactly the code host.
-		// https://github.com/sourcegraph/sourcegraph/issues/9274
-		if strings.EqualFold(string(name), c.BaseURL.Hostname()) {
-			return nil
-		}
 		if strings.HasPrefix(strings.ToLower(string(name)), c.BaseURL.Hostname()) {
 			return c
 		}

--- a/internal/extsvc/codehost_test.go
+++ b/internal/extsvc/codehost_test.go
@@ -32,11 +32,6 @@ func TestCodeHostOf(t *testing.T) {
 		repo:      "GITHUB.COM/foo/bar",
 		codehosts: PublicCodeHosts,
 		want:      GitHubDotCom,
-	}, {
-		name:      "missing-path",
-		repo:      "github.com",
-		codehosts: PublicCodeHosts,
-		want:      nil,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			have := CodeHostOf(tc.repo, tc.codehosts...)


### PR DESCRIPTION
This reverts commit 26a91b91a5819d572d071d1c294de0450ffb3420 and potentially closes https://github.com/sourcegraph/sourcegraph/issues/9274

\*deep breath\*

The changes added by https://github.com/sourcegraph/sourcegraph/pull/10182 make the code I am reverting no longer necessary. In brief, if an arbitrary error implements `NotFound(), Temporary(), or Unauthorized()` and bubbles up the stack, a proper response code will be returned from the handler. `repoupdater` was previously missing these error implementations. As a result, some error cases like `not found` would cause 500's instead of 404s. That's not the case anymore!


[See here for a quick look at where repoupdater is used in this branch](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/backend/repos.go#L70)

I have a [dev env patch](https://github.com/notjrbauer/sourcegraph/commit/42bcd6e8aeb87c0e96428da57cca24b69194b44f.patch) on top of the reversion in order to show how I replicated locally (and hitting https://sourcegraph.test:3443/github.com)

Lastly, I couldn't find other tests I could leverage, so I can possibly add some depending on comments.

