### PR TITLE
Make subsystem optional in OperationMetrics

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/observability.go
+++ b/cmd/precise-code-intel-api-server/internal/api/observability.go
@@ -24,7 +24,6 @@ var _ CodeIntelAPI = &ObservedCodeIntelAPI{}
 func NewObserved(codeIntelAPI CodeIntelAPI, observationContext *observation.Context) CodeIntelAPI {
 	metrics := metrics.NewOperationMetrics(
 		observationContext.Registerer,
-		"precise_code_intel_api_server",
 		"code_intel_api",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of results returned"),
@@ -58,30 +57,21 @@ func NewObserved(codeIntelAPI CodeIntelAPI, observationContext *observation.Cont
 // FindClosestDumps calls into the inner CodeIntelAPI and registers the observed results.
 func (api *ObservedCodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) (dumps []db.Dump, err error) {
 	ctx, endObservation := api.findClosestDumpsOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(dumps)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(dumps)), observation.Args{}) }()
 	return api.codeIntelAPI.FindClosestDumps(ctx, repositoryID, commit, file)
 }
 
 // Definitions calls into the inner CodeIntelAPI and registers the observed results.
 func (api *ObservedCodeIntelAPI) Definitions(ctx context.Context, file string, line, character, uploadID int) (definitions []ResolvedLocation, err error) {
 	ctx, endObservation := api.definitionsOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(definitions)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(definitions)), observation.Args{}) }()
 	return api.codeIntelAPI.Definitions(ctx, file, line, character, uploadID)
 }
 
 // References calls into the inner CodeIntelAPI and registers the observed results.
 func (api *ObservedCodeIntelAPI) References(ctx context.Context, repositoryID int, commit string, limit int, cursor Cursor) (references []ResolvedLocation, _ Cursor, _ bool, err error) {
 	ctx, endObservation := api.referencesOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(references)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(references)), observation.Args{}) }()
 	return api.codeIntelAPI.References(ctx, repositoryID, commit, limit, cursor)
 }
 
@@ -89,6 +79,5 @@ func (api *ObservedCodeIntelAPI) References(ctx context.Context, repositoryID in
 func (api *ObservedCodeIntelAPI) Hover(ctx context.Context, file string, line, character, uploadID int) (_ string, _ bundles.Range, _ bool, err error) {
 	ctx, endObservation := api.hoverOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
-
 	return api.codeIntelAPI.Hover(ctx, file, line, character, uploadID)
 }

--- a/cmd/precise-code-intel-api-server/main.go
+++ b/cmd/precise-code-intel-api-server/main.go
@@ -44,7 +44,7 @@ func main() {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db := db.NewObserved(mustInitializeDatabase(), observationContext, "precise_code_intel_api_server")
+	db := db.NewObserved(mustInitializeDatabase(), observationContext)
 	bundleManagerClient := bundles.New(bundleManagerURL)
 	codeIntelAPI := api.NewObserved(api.New(db, bundleManagerClient, gitserver.DefaultClient), observationContext)
 	resetterMetrics := resetter.NewResetterMetrics(prometheus.DefaultRegisterer)

--- a/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
@@ -32,8 +32,7 @@ func NewObserved(database Database, observationContext *observation.Context) Dat
 	metrics := singletonMetrics.Get(func() *metrics.OperationMetrics {
 		return metrics.NewOperationMetrics(
 			observationContext.Registerer,
-			"precise_code_intel_bundle_manager",
-			"database",
+			"bundle_database",
 			metrics.WithLabels("op"),
 			metrics.WithCountHelp("Total number of results returned"),
 		)
@@ -88,27 +87,20 @@ func (db *ObservedDatabase) Close() error {
 func (db *ObservedDatabase) Exists(ctx context.Context, path string) (_ bool, err error) {
 	ctx, endObservation := db.existsOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
-
 	return db.database.Exists(ctx, path)
 }
 
 // Definitions calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) Definitions(ctx context.Context, path string, line, character int) (definitions []Location, err error) {
 	ctx, endObservation := db.definitionsOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(definitions)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(definitions)), observation.Args{}) }()
 	return db.database.Definitions(ctx, path, line, character)
 }
 
 // References calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) References(ctx context.Context, path string, line, character int) (references []Location, err error) {
 	ctx, endObservation := db.referencesOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(references)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(references)), observation.Args{}) }()
 	return db.database.References(ctx, path, line, character)
 }
 
@@ -116,7 +108,6 @@ func (db *ObservedDatabase) References(ctx context.Context, path string, line, c
 func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, character int) (_ string, _ Range, _ bool, err error) {
 	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
-
 	return db.database.Hover(ctx, path, line, character)
 }
 
@@ -138,10 +129,7 @@ func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string,
 // MonikerResults calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (locations []Location, _ int, err error) {
 	ctx, endObservation := db.monikerResultsOperation.With(ctx, &err, observation.Args{})
-	defer func() {
-		endObservation(float64(len(locations)), observation.Args{})
-	}()
-
+	defer func() { endObservation(float64(len(locations)), observation.Args{}) }()
 	return db.database.MonikerResults(ctx, tableName, scheme, identifier, skip, take)
 }
 
@@ -149,6 +137,5 @@ func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, schem
 func (db *ObservedDatabase) PackageInformation(ctx context.Context, path string, packageInformationID types.ID) (_ types.PackageInformationData, _ bool, err error) {
 	ctx, endObservation := db.packageInformationOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
-
 	return db.database.PackageInformation(ctx, path, packageInformationID)
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -260,7 +260,7 @@ func (s *Server) dbQueryErr(w http.ResponseWriter, r *http.Request, handler dbQu
 }
 
 func (s *Server) wrapReader(innerReader reader.Reader) reader.Reader {
-	return reader.NewObserved(innerReader, s.ObservationContext, "precise_code_intel_bundle_manager")
+	return reader.NewObserved(innerReader, s.ObservationContext)
 }
 
 func (s *Server) wrapDatabase(innerDatabase database.Database) database.Database {

--- a/cmd/precise-code-intel-worker/internal/worker/metrics.go
+++ b/cmd/precise-code-intel-worker/internal/worker/metrics.go
@@ -10,7 +10,7 @@ type WorkerMetrics struct {
 }
 
 func NewWorkerMetrics(r prometheus.Registerer) WorkerMetrics {
-	jobs := metrics.NewOperationMetrics(r, "precise_code_intel_worker", "jobs")
+	jobs := metrics.NewOperationMetrics(r, "jobs", metrics.WithSubsystem("precise_code_intel_worker"))
 
 	return WorkerMetrics{
 		Jobs: jobs,

--- a/cmd/precise-code-intel-worker/main.go
+++ b/cmd/precise-code-intel-worker/main.go
@@ -40,7 +40,7 @@ func main() {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	db := db.NewObserved(mustInitializeDatabase(), observationContext, "precise_code_intel_worker")
+	db := db.NewObserved(mustInitializeDatabase(), observationContext)
 	MustRegisterQueueMonitor(observationContext.Registerer, db)
 	workerMetrics := worker.NewWorkerMetrics(prometheus.DefaultRegisterer)
 

--- a/internal/codeintel/bundles/reader/sqlite_reader_test.go
+++ b/internal/codeintel/bundles/reader/sqlite_reader_test.go
@@ -151,5 +151,5 @@ func testReader(t *testing.T) Reader {
 	t.Cleanup(func() { _ = reader.Close() })
 
 	// Wrap in observed, as that's how it's used in production
-	return NewObserved(reader, &observation.TestContext, "test")
+	return NewObserved(reader, &observation.TestContext)
 }

--- a/internal/codeintel/db/db_test.go
+++ b/internal/codeintel/db/db_test.go
@@ -16,6 +16,6 @@ func rawTestDB() *dbImpl {
 
 func testDB() DB {
 	// Wrap in observed, as that's how it's used in production
-	return NewObserved(rawTestDB(), &observation.TestContext, "test")
+	return NewObserved(rawTestDB(), &observation.TestContext)
 
 }

--- a/internal/codeintel/db/observability.go
+++ b/internal/codeintel/db/observability.go
@@ -43,11 +43,10 @@ type ObservedDB struct {
 var _ DB = &ObservedDB{}
 
 // NewObservedDB wraps the given DB with error logging, Prometheus metrics, and tracing.
-func NewObserved(db DB, observationContext *observation.Context, subsystem string) DB {
+func NewObserved(db DB, observationContext *observation.Context) DB {
 	metrics := metrics.NewOperationMetrics(
 		observationContext.Registerer,
-		subsystem,
-		"db",
+		"codeintel_db",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of results returned"),
 	)

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -24,7 +24,6 @@
 //
 //     metrics := metrics.NewOperationMetrics(
 //         observationContext.Registerer,
-//         "some_service",
 //         "thing",
 //         metrics.WithLabels("op"),
 //     )


### PR DESCRIPTION
I was using subsystem in the incorrect way (basically reiterating what the _job_ field will be once aggregated).

This PR changes the subsystem argument to be an optional function arg when constructing operation metrics.