### PR TITLE
codeintel: only observe DB.Done error if it is a commit/rollback error

### DIFF
--- a/internal/codeintel/db/observability.go
+++ b/internal/codeintel/db/observability.go
@@ -245,10 +245,17 @@ func (db *ObservedDB) RollbackToSavepoint(ctx context.Context, name string) (err
 }
 
 // Done calls into the inner DB and registers the observed results.
-func (db *ObservedDB) Done(e error) (err error) {
-	_, endObservation := db.doneOperation.With(context.Background(), &err, observation.Args{})
+func (db *ObservedDB) Done(e error) error {
+	var observedErr error = nil
+	_, endObservation := db.doneOperation.With(context.Background(), &observedErr, observation.Args{})
 	defer endObservation(1, observation.Args{})
-	return db.db.Done(e)
+
+	err := db.db.Done(e)
+	if err != e {
+		// Only observe the error if it's a commit/rollback failure
+		observedErr = err
+	}
+	return err
 }
 
 // GetUploadByID calls into the inner DB and registers the observed results.


### PR DESCRIPTION
Only emit an error metric when the call to Done produces a new error. The previous behavior emits an error on all rollbacks, which is undesireable.