### PR TITLE
codeintel: Rename bundle manager janitor metrics

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/free_space.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/free_space.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-bundle-manager/internal/paths"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/lsifserver/client"
@@ -22,7 +23,7 @@ func defaultPruneFn(ctx context.Context) (int64, bool, error) {
 }
 
 // freeSpace determines the space available on the device containing the bundle directory,
-// then calls cleanOldDumps to free enough space to get back below the disk usage threshold.
+// then calls cleanOldBundles to free enough space to get back below the disk usage threshold.
 func (j *Janitor) freeSpace(pruneFn PruneFn) error {
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(j.BundleDir, &fs); err != nil {
@@ -34,17 +35,17 @@ func (j *Janitor) freeSpace(pruneFn PruneFn) error {
 	desiredFreeBytes := uint64(float64(diskSizeBytes) * float64(j.DesiredPercentFree) / 100.0)
 
 	if freeBytes < desiredFreeBytes {
-		return j.cleanOldDumps(pruneFn, uint64(desiredFreeBytes-freeBytes))
+		return j.evictBundles(pruneFn, uint64(desiredFreeBytes-freeBytes))
 	}
 
 	return nil
 }
 
-// cleanOldDumps removes dumps from the database (via precise-code-intel-api-server)
-// and the filesystem until at least bytesToFree, or there are no more prunable dumps.
-func (j *Janitor) cleanOldDumps(pruneFn func(ctx context.Context) (int64, bool, error), bytesToFree uint64) error {
+// evictBundles removes bundles from the database (via precise-code-intel-api-server)
+// and the filesystem until at least bytesToFree, or there are no more prunable bundles.
+func (j *Janitor) evictBundles(pruneFn func(ctx context.Context) (int64, bool, error), bytesToFree uint64) error {
 	for bytesToFree > 0 {
-		bytesRemoved, pruned, err := j.cleanOldDump(pruneFn)
+		bytesRemoved, pruned, err := j.evictBundle(pruneFn)
 		if err != nil {
 			return err
 		}
@@ -62,27 +63,28 @@ func (j *Janitor) cleanOldDumps(pruneFn func(ctx context.Context) (int64, bool, 
 	return nil
 }
 
-// cleanOldDump calls the precise-code-intel-api-server for the identifier of
-// the oldest dump to remove then deletes the associated file. This method
+// evictBundle calls the precise-code-intel-api-server for the identifier of
+// the oldest bundle to remove then deletes the associated file. This method
 // returns the size of the deleted file on success, and returns a false-valued
-// flag if there are no prunable dumps.
-func (j *Janitor) cleanOldDump(pruneFn func(ctx context.Context) (int64, bool, error)) (uint64, bool, error) {
+// flag if there are no prunable bundles.
+func (j *Janitor) evictBundle(pruneFn func(ctx context.Context) (int64, bool, error)) (uint64, bool, error) {
 	id, prunable, err := pruneFn(context.Background())
 	if err != nil || !prunable {
 		return 0, false, err
 	}
 
-	filename := paths.DBFilename(j.BundleDir, id)
+	path := paths.DBFilename(j.BundleDir, id)
 
-	fileInfo, err := os.Stat(filename)
+	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return 0, false, err
 	}
 
-	if err := os.Remove(filename); err != nil {
+	if err := os.Remove(path); err != nil {
 		return 0, false, err
 	}
 
-	j.Metrics.EvictedDumps.Add(1)
+	log15.Debug("Removed evicted bundle file", "id", id, "path", path)
+	j.Metrics.EvictedBundleFilesRemoved.Add(1)
 	return uint64(fileInfo.Size()), true, nil
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/free_space_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/free_space_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestCleanOldDumpsStopsAfterFreeingDesiredSpace(t *testing.T) {
+func TestEvictBundlesStopsAfterFreeingDesiredSpace(t *testing.T) {
 	bundleDir := testRoot(t)
 	sizes := map[int]int{
 		1:  20,
@@ -43,8 +43,8 @@ func TestCleanOldDumpsStopsAfterFreeingDesiredSpace(t *testing.T) {
 		Metrics:   NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.cleanOldDumps(pruneFn, 100); err != nil {
-		t.Fatalf("unexpected error cleaning old dumps: %s", err)
+	if err := j.evictBundles(pruneFn, 100); err != nil {
+		t.Fatalf("unexpected error evicting bundles: %s", err)
 	}
 
 	names, err := getFilenames(filepath.Join(bundleDir, "dbs"))
@@ -58,7 +58,7 @@ func TestCleanOldDumpsStopsAfterFreeingDesiredSpace(t *testing.T) {
 	}
 }
 
-func TestCleanOldDumpsStopsWithNoPrunableDatabases(t *testing.T) {
+func TestEvictBundlesStopsWithNoPrunableDatabases(t *testing.T) {
 	bundleDir := testRoot(t)
 	sizes := map[int]int{
 		1:  10,
@@ -96,8 +96,8 @@ func TestCleanOldDumpsStopsWithNoPrunableDatabases(t *testing.T) {
 		Metrics:   NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.cleanOldDumps(pruneFn, 100); err != nil {
-		t.Fatalf("unexpected error cleaning old dumps: %s", err)
+	if err := j.evictBundles(pruneFn, 100); err != nil {
+		t.Fatalf("unexpected error evicting bundles: %s", err)
 	}
 
 	names, err := getFilenames(filepath.Join(bundleDir, "dbs"))

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
@@ -17,7 +17,7 @@ type Janitor struct {
 
 // step performs a best-effort cleanup. See the following methods for more specifics.
 // Run periodically performs a best-effort cleanup process. See the following methods
-// for more specifics: cleanOldUploads, removeOrphanedDumps, and freeSpace.
+// for more specifics: removeOldUploadFiles, removeOrphanedBundleFiles, and freeSpace.
 func (j *Janitor) Run() {
 	for {
 		if err := j.run(); err != nil {
@@ -30,12 +30,14 @@ func (j *Janitor) Run() {
 }
 
 func (j *Janitor) run() error {
-	if err := j.cleanOldUploads(); err != nil {
-		return errors.Wrap(err, "janitor.cleanOldUploads")
+	// TODO(efritz) - should also remove orphaned upload files
+
+	if err := j.removeOldUploadFiles(); err != nil {
+		return errors.Wrap(err, "janitor.removeOldUploadFiles")
 	}
 
-	if err := j.removeOrphanedDumps(defaultStatesFn); err != nil {
-		return errors.Wrap(err, "janitor.removeOrphanedDumps")
+	if err := j.removeOrphanedBundleFiles(defaultStatesFn); err != nil {
+		return errors.Wrap(err, "janitor.removeOrphanedBundleFiles")
 	}
 
 	if err := j.freeSpace(defaultPruneFn); err != nil {

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/metrics.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/metrics.go
@@ -3,45 +3,49 @@ package janitor
 import "github.com/prometheus/client_golang/prometheus"
 
 type JanitorMetrics struct {
-	OldUploads    prometheus.Counter
-	OrphanedDumps prometheus.Counter
-	EvictedDumps  prometheus.Counter
-	Errors        prometheus.Counter
+	UploadFilesRemoved          prometheus.Counter
+	OprphanedBundleFilesRemoved prometheus.Counter
+	EvictedBundleFilesRemoved   prometheus.Counter
+	Errors                      prometheus.Counter
 }
 
 func NewJanitorMetrics(r prometheus.Registerer) JanitorMetrics {
-	oldUploads := prometheus.NewCounter(prometheus.CounterOpts{
+	uploadFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
-		Subsystem: "precise_code_intel_bundle_manager",
-		Name:      "janitor_old_uploads",
-		Help:      "Total number of old upload removed",
+		Subsystem: "bundle_manager_janitor",
+		Name:      "upload_files_removed_total",
+		Help:      "Total number of upload files removed (due to age)",
 	})
+	r.MustRegister(uploadFilesRemoved)
 
-	orphanedDumps := prometheus.NewCounter(prometheus.CounterOpts{
+	oprphanedBundleFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
-		Subsystem: "precise_code_intel_bundle_manager",
-		Name:      "janitor_orphaned_dumps",
-		Help:      "Total number of orphaned dumps removed",
+		Subsystem: "bundle_manager_janitor",
+		Name:      "orphaned_bundle_files_removed_total",
+		Help:      "Total number of bundle files removed (with no corresponding database entry)",
 	})
+	r.MustRegister(oprphanedBundleFilesRemoved)
 
-	evictedDumps := prometheus.NewCounter(prometheus.CounterOpts{
+	evictedBundleFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
-		Subsystem: "precise_code_intel_bundle_manager",
-		Name:      "janitor_old_dumps",
-		Help:      "Total number of dumps evicted from disk",
+		Subsystem: "bundle_manager_janitor",
+		Name:      "evicted_bundle_files_removed_total",
+		Help:      "Total number of bundles files removed (after evicting them from the database)",
 	})
+	r.MustRegister(evictedBundleFilesRemoved)
 
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
-		Subsystem: "precise_code_intel_bundle_manager",
-		Name:      "janitor_errors",
+		Subsystem: "bundle_manager_janitor",
+		Name:      "errors_total",
 		Help:      "Total number of errors when running the janitor",
 	})
+	r.MustRegister(errors)
 
 	return JanitorMetrics{
-		OldUploads:    oldUploads,
-		OrphanedDumps: orphanedDumps,
-		EvictedDumps:  evictedDumps,
-		Errors:        errors,
+		UploadFilesRemoved:          uploadFilesRemoved,
+		OprphanedBundleFilesRemoved: oprphanedBundleFilesRemoved,
+		EvictedBundleFilesRemoved:   evictedBundleFilesRemoved,
+		Errors:                      errors,
 	}
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/metrics.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/metrics.go
@@ -11,34 +11,26 @@ type JanitorMetrics struct {
 
 func NewJanitorMetrics(r prometheus.Registerer) JanitorMetrics {
 	uploadFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "src",
-		Subsystem: "bundle_manager_janitor",
-		Name:      "upload_files_removed_total",
-		Help:      "Total number of upload files removed (due to age)",
+		Name: "src_bundle_manager_janitor_upload_files_removed_total",
+		Help: "Total number of upload files removed (due to age)",
 	})
 	r.MustRegister(uploadFilesRemoved)
 
 	oprphanedBundleFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "src",
-		Subsystem: "bundle_manager_janitor",
-		Name:      "orphaned_bundle_files_removed_total",
-		Help:      "Total number of bundle files removed (with no corresponding database entry)",
+		Name: "src_bundle_manager_janitor_orphaned_bundle_files_removed_total",
+		Help: "Total number of bundle files removed (with no corresponding database entry)",
 	})
 	r.MustRegister(oprphanedBundleFilesRemoved)
 
 	evictedBundleFilesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "src",
-		Subsystem: "bundle_manager_janitor",
-		Name:      "evicted_bundle_files_removed_total",
-		Help:      "Total number of bundles files removed (after evicting them from the database)",
+		Name: "src_bundle_manager_janitor_evicted_bundle_files_removed_total",
+		Help: "Total number of bundles files removed (after evicting them from the database)",
 	})
 	r.MustRegister(evictedBundleFilesRemoved)
 
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "src",
-		Subsystem: "bundle_manager_janitor",
-		Name:      "errors_total",
-		Help:      "Total number of errors when running the janitor",
+		Name: "src_bundle_manager_janitor_errors_total",
+		Help: "Total number of errors when running the janitor",
 	})
 	r.MustRegister(errors)
 

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files.go
@@ -10,15 +10,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-bundle-manager/internal/paths"
 )
 
-// cleanOldUploads removes all upload files that are older than the configured
+// removeOldUploadFiles removes all upload files that are older than the configured
 // max unconverted upload age.
-func (j *Janitor) cleanOldUploads() error {
+func (j *Janitor) removeOldUploadFiles() error {
 	fileInfos, err := ioutil.ReadDir(paths.UploadsDir(j.BundleDir))
 	if err != nil {
 		return err
 	}
 
-	count := 0
 	for _, fileInfo := range fileInfos {
 		age := time.Since(fileInfo.ModTime())
 		if age < j.MaxUploadAge {
@@ -30,10 +29,9 @@ func (j *Janitor) cleanOldUploads() error {
 			return err
 		}
 
-		count++
-		log15.Debug("Removed old upload", "path", fileInfo.Name(), "age", age)
+		log15.Debug("Removed old upload file", "path", path, "age", age)
+		j.Metrics.UploadFilesRemoved.Add(1)
 	}
 
-	j.Metrics.OldUploads.Add(float64(count))
 	return nil
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestCleanOldUploads(t *testing.T) {
+func TestremoveOldUploadFiles(t *testing.T) {
 	bundleDir := testRoot(t)
 	mtimes := map[string]time.Time{
 		"u1": time.Now().Local().Add(-time.Minute * 3),  // older than 1m
@@ -31,7 +31,7 @@ func TestCleanOldUploads(t *testing.T) {
 		Metrics:      NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.cleanOldUploads(); err != nil {
+	if err := j.removeOldUploadFiles(); err != nil {
 		t.Fatalf("unexpected error cleaning failed uploads: %s", err)
 	}
 

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_old_upload_files_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestremoveOldUploadFiles(t *testing.T) {
+func TestRemoveOldUploadFiles(t *testing.T) {
 	bundleDir := testRoot(t)
 	mtimes := map[string]time.Time{
 		"u1": time.Now().Local().Add(-time.Minute * 3),  // older than 1m

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_orphaned_bundle_files.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_orphaned_bundle_files.go
@@ -14,9 +14,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/lsifserver/client"
 )
 
-// DeadDumpBatchSize is the maximum number of dump ids to request at once from
-// the precise-code-intel-api-server.
-const DeadDumpBatchSize = 100
+// OrphanedBundleBatchSize is the maximum number of bundle ids to request at
+// once from the precise-code-intel-api-server.
+const OrphanedBundleBatchSize = 100
 
 type StatesFn func(ctx context.Context, ids []int) (map[int]string, error)
 
@@ -29,10 +29,10 @@ func defaultStatesFn(ctx context.Context, ids []int) (map[int]string, error) {
 	return states, nil
 }
 
-// removeOrphanedDumps calls the precise-code-intel-api-server to get the current
-// state of the dumps known by this bundle manager. Any dump on disk that is
-// in an errored state or is unknown by the API is removed.
-func (j *Janitor) removeOrphanedDumps(statesFn StatesFn) error {
+// removeOrphanedBundleFiles calls the precise-code-intel-api-server to get the
+// current state of the bundle known by this bundle manager. Any bundle on disk
+// that is in an errored state or is unknown by the API is removed.
+func (j *Janitor) removeOrphanedBundleFiles(statesFn StatesFn) error {
 	pathsByID, err := j.databasePathsByID()
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func (j *Janitor) removeOrphanedDumps(statesFn StatesFn) error {
 	}
 
 	allStates := map[int]string{}
-	for _, batch := range batchIntSlice(ids, DeadDumpBatchSize) {
+	for _, batch := range batchIntSlice(ids, OrphanedBundleBatchSize) {
 		states, err := statesFn(context.Background(), batch)
 		if err != nil {
 			return err
@@ -55,23 +55,21 @@ func (j *Janitor) removeOrphanedDumps(statesFn StatesFn) error {
 		}
 	}
 
-	count := 0
 	for id, path := range pathsByID {
 		if state, exists := allStates[id]; !exists || state == "errored" {
 			if err := os.Remove(path); err != nil {
 				return err
 			}
 
-			count++
-			log15.Debug("Removed dead dump", "id", id)
+			log15.Debug("Removed orphaned bundle file", "id", id, "path", path)
+			j.Metrics.OprphanedBundleFilesRemoved.Add(1)
 		}
 	}
 
-	j.Metrics.OrphanedDumps.Add(float64(count))
 	return nil
 }
 
-// databasePathsByID returns map of dump ids to their path on disk.
+// databasePathsByID returns map of bundle ids to their path on disk.
 func (j *Janitor) databasePathsByID() (map[int]string, error) {
 	fileInfos, err := ioutil.ReadDir(paths.DBsDir(j.BundleDir))
 	if err != nil {

--- a/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_orphaned_bundle_files_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/janitor/remove_orphaned_bundle_files_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestRemoveOrphanedDumps(t *testing.T) {
+func TestRemoveOrphanedBundleFile(t *testing.T) {
 	bundleDir := testRoot(t)
 	ids := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
@@ -44,8 +44,8 @@ func TestRemoveOrphanedDumps(t *testing.T) {
 		}, nil
 	}
 
-	if err := j.removeOrphanedDumps(statesFn); err != nil {
-		t.Fatalf("unexpected error removing dead dumps: %s", err)
+	if err := j.removeOrphanedBundleFiles(statesFn); err != nil {
+		t.Fatalf("unexpected error removing orphaned bundle files: %s", err)
 	}
 
 	names, err := getFilenames(filepath.Join(bundleDir, "dbs"))
@@ -64,7 +64,7 @@ func TestRemoveOrphanedDumps(t *testing.T) {
 	}
 }
 
-func TestRemoveOrphanedDumpsMaxRequestBatchSize(t *testing.T) {
+func TestRemoveOrphanedBundleFilesMaxRequestBatchSize(t *testing.T) {
 	bundleDir := testRoot(t)
 	var ids []int
 	for i := 1; i <= 225; i++ {
@@ -96,7 +96,7 @@ func TestRemoveOrphanedDumpsMaxRequestBatchSize(t *testing.T) {
 		return states, nil
 	}
 
-	if err := j.removeOrphanedDumps(statesFn); err != nil {
+	if err := j.removeOrphanedBundleFiles(statesFn); err != nil {
 		t.Fatalf("unexpected error removing dead dumps: %s", err)
 	}
 
@@ -111,8 +111,8 @@ func TestRemoveOrphanedDumpsMaxRequestBatchSize(t *testing.T) {
 
 	var allArgs []int
 	for _, args := range idArgs {
-		if len(args) > DeadDumpBatchSize {
-			t.Errorf("unexpected large slice: want < %d have=%d", DeadDumpBatchSize, len(args))
+		if len(args) > OrphanedBundleBatchSize {
+			t.Errorf("unexpected large slice: want < %d have=%d", OrphanedBundleBatchSize, len(args))
 		}
 
 		allArgs = append(allArgs, args...)


### PR DESCRIPTION
Rename metrics (and methods) in bundle-manager janitor to be less ambiguous (and replace uses of dumb with bundle).