### PR TITLE
codeintel: Fix prune endpoint payload (un)marshalling

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/server/handler.go
+++ b/cmd/precise-code-intel-api-server/internal/server/handler.go
@@ -322,9 +322,9 @@ func (s *Server) handlePrune(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !prunable {
-		writeJSON(w, nil)
-	} else {
+	if prunable {
 		writeJSON(w, map[string]interface{}{"id": id})
+	} else {
+		writeJSON(w, map[string]interface{}{"id": nil})
 	}
 }

--- a/internal/codeintel/lsifserver/client/internal.go
+++ b/internal/codeintel/lsifserver/client/internal.go
@@ -13,15 +13,17 @@ func (c *Client) Prune(ctx context.Context) (int64, bool, error) {
 		path:   "/prune",
 	}
 
-	var id *int64
-	if _, err := c.do(ctx, req, &id); err != nil {
+	var payload struct {
+		ID *int64 `json:"id"`
+	}
+	if _, err := c.do(ctx, req, &payload); err != nil {
 		return 0, false, err
 	}
 
-	if id == nil {
+	if payload.ID == nil {
 		return 0, false, nil
 	}
-	return *id, true, nil
+	return *payload.ID, true, nil
 }
 
 func (c *Client) States(ctx context.Context, ids []int) (map[int]string, error) {


### PR DESCRIPTION
Fix the shape of the `/prune` endpoint payload. This was not being read properly from the bundle-manager, resulting in janitor errors when there's nothing to prune.