### PR TITLE
Use helper function to append subtree query param

### DIFF
--- a/shared/src/components/FileMatchChildren.tsx
+++ b/shared/src/components/FileMatchChildren.tsx
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs'
 import { ThemeProps } from '../theme'
 import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
-import { toPositionOrRangeHash } from '../util/url'
+import { toPositionOrRangeHash, appendSubtreeQueryParam } from '../util/url'
 import { CodeExcerpt, FetchFileCtx } from './CodeExcerpt'
 import { CodeExcerpt2 } from './CodeExcerpt2'
 import { IFileMatch, IMatchItem } from './FileMatch'
@@ -124,7 +124,9 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                         className="file-match-children__item-code-wrapper e2e-file-match-children-item-wrapper"
                     >
                         <Link
-                            to={`${props.result.file.url}?subtree=true${toPositionOrRangeHash({ position })}`}
+                            to={appendSubtreeQueryParam(
+                                `${props.result.file.url}${toPositionOrRangeHash({ position })}`
+                            )}
                             className="file-match-children__item file-match-children__item-clickable e2e-file-match-children-item"
                             onClick={props.onSelect}
                         >

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Link } from './Link'
+import { appendSubtreeQueryParam } from '../util/url'
 
 /**
  *  Returns the friendly display form of the repository name (e.g., removing "github.com/").
@@ -43,7 +44,7 @@ export const RepoFileLink: React.FunctionComponent<Props> = ({
     return (
         <>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-            <Link to={`${fileURL}?subtree=true`}>
+            <Link to={appendSubtreeQueryParam(fileURL)}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>
             </Link>

--- a/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/shared/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -10,7 +10,7 @@ Array [
   " ›",
   " ",
   <a
-    href="https://example.com/file?subtree=true"
+    href="/file?subtree=true"
   >
     my/
     <strong>

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -8,6 +8,7 @@ import {
     withWorkspaceRootInputRevision,
     isExternalLink,
     toAbsoluteBlobURL,
+    appendSubtreeQueryParam,
 } from './url'
 import { SearchPatternType } from '../graphql/schema'
 
@@ -484,5 +485,18 @@ describe('isExternalLink', () => {
     it('returns true for a different site', () => {
         jsdom.reconfigure({ url: 'https://github.com/here' })
         expect(isExternalLink('https://sourcegraph.com/here')).toBe(true)
+    })
+})
+
+describe('appendSubtreeQueryParam', () => {
+    it('appends subtree=true to urls', () => {
+        expect(appendSubtreeQueryParam('/github.com/sourcegraph/sourcegraph/-/blob/.gitattributes#L2:24')).toBe(
+            '/github.com/sourcegraph/sourcegraph/-/blob/.gitattributes?subtree=true#L2:24'
+        )
+    })
+    it('appends subtree=true to urls with other query params', () => {
+        expect(
+            appendSubtreeQueryParam('/github.com/sourcegraph/sourcegraph/-/blob/.gitattributes?test=test#L2:24')
+        ).toBe('/github.com/sourcegraph/sourcegraph/-/blob/.gitattributes?test=test&subtree=true#L2:24')
     })
 })

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -676,3 +676,12 @@ export function parseCaseSensitivityFromQuery(query: string): { range: Character
  */
 export const isExternalLink = (url: string): boolean =>
     !!tryCatch(() => new URL(url, window.location.href).origin !== window.location.origin)
+
+/**
+ * Appends the query parameter subtree=true to URLs.
+ */
+export const appendSubtreeQueryParam = (url: string): string => {
+    const newUrl = new URL(url, window.location.href)
+    newUrl.searchParams.set('subtree', 'true')
+    return newUrl.pathname + newUrl.search + newUrl.hash
+}

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -10,6 +10,7 @@ import { SuggestionType, NonFilterSuggestionType } from '../../../../shared/src/
 import { escapeRegExp } from 'lodash'
 import { FilterType } from '../../../../shared/src/search/interactive/util'
 import { SearchSuggestion } from '../../../../shared/src/search/suggestions'
+import { appendSubtreeQueryParam } from '../../../../shared/src/util/url'
 
 export const filterAliases: Record<string, FilterSuggestionTypes | undefined> = {
     r: FilterType.repo,
@@ -97,7 +98,7 @@ export function createSuggestion(item: SearchSuggestion): Suggestion | undefined
                     type: NonFilterSuggestionType.dir,
                     value: '^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
-                    url: `${item.url}?subtree=true`,
+                    url: appendSubtreeQueryParam(item.url),
                     label: 'go to dir',
                 }
             }
@@ -106,7 +107,7 @@ export function createSuggestion(item: SearchSuggestion): Suggestion | undefined
                 value: formatRegExp(item.path),
                 displayValue: item.name,
                 description: descriptionParts.join(' — '),
-                url: `${item.url}?subtree=true`,
+                url: appendSubtreeQueryParam(item.url),
                 label: 'go to file',
             }
         }


### PR DESCRIPTION
Use a helper function to append `subtree=true` query param. Makes sure the param gets appended properly if there are other query params in the URL, in anticipation of version contexts.
