### PR TITLE
Limit version context name to 14 characters

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -170,7 +170,9 @@
             "properties": {
               "name": {
                 "description": "Name of the version context, it must be unique.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 14
               },
               "revisions": {
                 "description": "List of repositories of the version context",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -175,7 +175,9 @@ const SiteSchemaJSON = `{
             "properties": {
               "name": {
                 "description": "Name of the version context, it must be unique.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 14
               },
               "revisions": {
                 "description": "List of repositories of the version context",


### PR DESCRIPTION
This adds a rule in the JSON schema of version contexts limiting version context names to 14 characters