### PR TITLE
wip search config endpoint for multiple branches

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -133,15 +133,35 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// serveSearchConfiguration is _only_ used by the zoekt index server. Zoekt does
-// not depend on frontend and therefore does not have access to `conf.Watch`.
-// Additionally, it only cares about certain search specific settings so this
-// search specific endpoint is used rather than serving the entire site settings
-// from /.internal/configuration.
+// serveSearchConfiguration is _only_ used by the
+// zoekt-sourcegraph-indexserver. Zoekt does not depend on frontend and
+// therefore does not have access to `conf.Watch`.  Additionally, it only
+// cares about certain search specific settings so this search specific
+// endpoint is used rather than serving the entire site settings from
+// /.internal/configuration.
+//
+// See getIndexOptions in the zoekt repository.
 func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
+	// TODO parse out a repo name. Currently zoekt-sourcegraph-indexserver does
+	// not send the repo name in this request. However, it could quite easily
+	// send it as a query param. We will likely need to support no repo name
+	// specified for one release just to ease the rollout of this feature.
+
 	opts := struct {
+		// LargeFiles is a slice of glob patterns where matching file paths should
+		// be indexed regardless of their size. The pattern syntax can be found
+		// here: https://golang.org/pkg/path/filepath/#Match.
 		LargeFiles []string
+
+		// Symbols if true will make zoekt index the output of ctags.
 		Symbols    bool
+
+		// Branches is a slice of branches to index. By default it will be
+		// HEAD. These will be resolved, so you can pass in tags/refs/commits.
+		//
+		// Indexing multiple branches is still experimental. As such this should
+		// only be set if an admin has opted into it.
+		Branches []string
 	}{
 		LargeFiles: conf.Get().SearchLargeFiles,
 		Symbols:    conf.SymbolIndexEnabled(),

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
@@ -298,4 +300,93 @@ func (b suffixIndexers) ReposSubset(ctx context.Context, hostname string, indexe
 
 func (b suffixIndexers) Enabled() bool {
 	return bool(b)
+}
+
+func TestServeSearchConfiguration(t *testing.T) {
+	var cfg conf.Unified
+	cfg.SearchLargeFiles = []string{"**/*.jar", "*.bin"}
+	symbolsEnabled := true
+	cfg.SearchIndexSymbolsEnabled = &symbolsEnabled
+	cfg.ExperimentalFeatures = &schema.ExperimentalFeatures{
+		SearchMultipleBranchIndexing: []*schema.SearchMultipleBranchIndexing{
+			{
+				Name: "foo",
+				Branches: []*schema.SearchMultipleBranchIndexingConfig{
+					{Name: "branch1"},
+					{Name: "branch2", Version: "abcde"},
+				},
+			},
+		},
+	}
+
+	conf.Mock(&cfg)
+
+	cases := []struct {
+		name   string
+		repo   string // optional repo query parameter
+		status int    // optional, defaults to 200
+		want   string
+	}{
+		{
+			name: "default",
+			want: `{"LargeFiles":["**/*.jar","*.bin"],"Symbols":true}`,
+		},
+		{
+			name: "with valid repo",
+			repo: "foo",
+			want: `{"LargeFiles":["**/*.jar","*.bin"],"Symbols":true, "Branches": [{"Name": "branch1"}, {"Name": "branch2", "Version": "abcde"}]}`,
+		},
+		{
+			name:   "with unknown repo",
+			repo:   "bar",
+			status: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "/"
+			if tc.repo != "" {
+				url = "/?repo=" + tc.repo
+			}
+			req := httptest.NewRequest("POST", url, nil)
+			w := httptest.NewRecorder()
+			err := serveSearchConfiguration(w, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+			expectedStatus := http.StatusOK
+			if tc.status != 0 {
+				expectedStatus = tc.status
+			}
+			if resp.StatusCode != expectedStatus {
+				t.Fatalf("got status %v", resp.StatusCode)
+			}
+			if resp.StatusCode == http.StatusNotFound {
+				return
+			}
+
+			var got, want struct {
+				LargeFiles []string
+				Symbols    bool
+				Branches   []struct {
+					Name    string
+					Version string
+				}
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(body, &want); err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(want, got) {
+				t.Fatalf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -389,6 +389,8 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// SearchMultipleBranchIndexing description: JSON array of repositories and branches to index
+	SearchMultipleBranchIndexing []*SearchMultipleBranchIndexing `json:"searchMultipleBranchIndexing,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.
@@ -821,6 +823,22 @@ type SMTPServerConfig struct {
 	Port int `json:"port"`
 	// Username description: The username to use when communicating with the SMTP server.
 	Username string `json:"username,omitempty"`
+}
+
+// SearchMultipleBranchIndexing description: Repository and branches to index
+type SearchMultipleBranchIndexing struct {
+	// Branches description: List of branches to index
+	Branches []*SearchMultipleBranchIndexingConfig `json:"branches"`
+	// Name description: Name of the repository
+	Name string `json:"name"`
+}
+
+// SearchMultipleBranchIndexingConfig description: Configuration of the branch to index. Revisions or commit can optionally be specified.
+type SearchMultipleBranchIndexingConfig struct {
+	// Name description: Name of the branch to index
+	Name string `json:"name"`
+	// Version description: Revision or commit
+	Version string `json:"version,omitempty"`
 }
 type SearchSavedQueries struct {
 	// Description description: Description of this saved query

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -214,6 +214,58 @@
               ]
             }
           ]
+        },
+        "searchMultipleBranchIndexing": {
+          "description": "JSON array of repositories and branches to index",
+          "type": "array",
+          "items": {
+            "description": "Repository and branches to index",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "branches"],
+            "properties": {
+              "name": {
+                "description": "Name of the repository",
+                "type": "string",
+                "minLength": 1
+              },
+              "branches": {
+                "description": "List of branches to index",
+                "type": "array",
+                "items": {
+                  "title": "searchMultipleBranchIndexingConfig",
+                  "description": "Configuration of the branch to index. Revisions or commit can optionally be specified.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "description": "Name of the branch to index",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Revision or commit",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "examples": [
+            {
+              "name": "github.com/sourcegraph/sourcegraph",
+              "branches": [
+                {
+                  "name": "master"
+                },
+                {
+                  "name": "3.16",
+                  "version": "864fd1f3fd4b0c4c63b04cb40ee00a3d76e5c096"
+                }
+              ]
+            }
+          ]
         }
       },
       "examples": [

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -219,6 +219,58 @@ const SiteSchemaJSON = `{
               ]
             }
           ]
+        },
+        "searchMultipleBranchIndexing": {
+          "description": "JSON array of repositories and branches to index",
+          "type": "array",
+          "items": {
+            "description": "Repository and branches to index",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "branches"],
+            "properties": {
+              "name": {
+                "description": "Name of the repository",
+                "type": "string",
+                "minLength": 1
+              },
+              "branches": {
+                "description": "List of branches to index",
+                "type": "array",
+                "items": {
+                  "title": "searchMultipleBranchIndexingConfig",
+                  "description": "Configuration of the branch to index. Revisions or commit can optionally be specified.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "description": "Name of the branch to index",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Revision or commit",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "examples": [
+            {
+              "name": "github.com/sourcegraph/sourcegraph",
+              "branches": [
+                {
+                  "name": "master"
+                },
+                {
+                  "name": "3.16",
+                  "version": "864fd1f3fd4b0c4c63b04cb40ee00a3d76e5c096"
+                }
+              ]
+            }
+          ]
         }
       },
       "examples": [


### PR DESCRIPTION
This is a WIP commit illustrating how we will pass down which branches
to index for a repository to Zoekt. It is only documenting which fields
we need to send.

Note: zoekt-sourcegraph-indexserver doesn't yet support this. If you
want you can also update zoekt-sourcegraph-indexserver to support
this. I would suggest that if Branches is non-empty
zoekt-sourcegraph-indexserver would use zoekt-git-index instead of
zoekt-archive-index. This would be a nice way to feature flag.

Part of https://github.com/sourcegraph/sourcegraph/issues/6728