### PR TITLE
dev: Don't install goreman as go module

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -63,7 +63,6 @@ fi
 popd >/dev/null || exit 1
 
 INSTALL_GO_PKGS=(
-  "github.com/mattn/goreman"
   "github.com/google/zoekt/cmd/zoekt-archive-index"
   "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"
   "github.com/google/zoekt/cmd/zoekt-webserver"


### PR DESCRIPTION
Before this, `./enterprise/dev/start.sh` failed after running `go mod
vendor`. This fixes it.