### PR TITLE
zoekt: build updates to enable multiple branch indexing

### DIFF
--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -66,6 +66,7 @@ PACKAGES=(
   github.com/sourcegraph/sourcegraph/cmd/symbols
 
   github.com/google/zoekt/cmd/zoekt-archive-index
+  github.com/google/zoekt/cmd/zoekt-git-index
   github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
   github.com/google/zoekt/cmd/zoekt-webserver
 )

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -27,7 +27,7 @@ func maybeZoektProcFile() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("zoekt-indexserver: env GOGC=50 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
+		fmt.Sprintf("zoekt-indexserver: env GOGC=50 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 -cpu_fraction 0.25 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
 		fmt.Sprintf("zoekt-webserver: env GOGC=50 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
 	}
 }

--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -65,6 +65,7 @@ popd >/dev/null || exit 1
 INSTALL_GO_PKGS=(
   "github.com/mattn/goreman"
   "github.com/google/zoekt/cmd/zoekt-archive-index"
+  "github.com/google/zoekt/cmd/zoekt-git-index"
   "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"
   "github.com/google/zoekt/cmd/zoekt-webserver"
 )

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -24,4 +24,3 @@ import (
 	// used in many places
 	_ "golang.org/x/tools/cmd/stringer"
 )
-

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -5,6 +5,7 @@ package main
 import (
 	// zoekt-* used in sourcegraph/server docker image build
 	_ "github.com/google/zoekt/cmd/zoekt-archive-index"
+	_ "github.com/google/zoekt/cmd/zoekt-git-index"
 	_ "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"
 	_ "github.com/google/zoekt/cmd/zoekt-webserver"
 
@@ -23,3 +24,4 @@ import (
 	// used in many places
 	_ "golang.org/x/tools/cmd/stringer"
 )
+

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -26,7 +26,8 @@ indexserver)
         -index "$index" \
         -hostname "localhost:$webport" \
         -interval 1m \
-        -listen ":$indexport"
+        -listen ":$indexport" \
+        -cpu_fraction 0.25
     ;;
 
 webserver)

--- a/doc/dev/zoekt.md
+++ b/doc/dev/zoekt.md
@@ -30,7 +30,7 @@ $ go install ./cmd/...
 $ go install ./cmd/<specific command> (ex zoekt-archive-index)
 ```
 
-The components that Sourcegraph uses from Zoekt are `zoekt-archive-index`, `zoekt-sourcegraph-indexserver`, and `zoekt-webserver`.
+The components that Sourcegraph uses from Zoekt are `zoekt-archive-index`, `zoekt-git-index`, `zoekt-sourcegraph-indexserver`, and `zoekt-webserver`.
 
 ```
 # Direct usage

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200511113954-b56036a3b745
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -905,6 +905,10 @@ github.com/sourcegraph/zoekt v0.0.0-20200505140849-75b1c46a56f9 h1:SckEKQLCrxd/5
 github.com/sourcegraph/zoekt v0.0.0-20200505140849-75b1c46a56f9/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
 github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1 h1:B617BWi5fKeuXTsp/jJxwSraBVkWjzcocLul8J6bFqw=
 github.com/sourcegraph/zoekt v0.0.0-20200505143549-65235a0cdcf1/go.mod h1:Ujpwzx4P55N/bXA5Yei85SMhkf/86bOvbmFLvGkYP9Y=
+github.com/sourcegraph/zoekt v0.0.0-20200508201459-ddddd932c5b8 h1:zB51dIi5LAvd7J/us5KtjMwOaWCzlwgzuu76SjbQvmw=
+github.com/sourcegraph/zoekt v0.0.0-20200508201459-ddddd932c5b8/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200511113954-b56036a3b745 h1:o0pdeZagP1z3/k2Dwt41zW7H/ymuaRUSYcRhTPCpEjA=
+github.com/sourcegraph/zoekt v0.0.0-20200511113954-b56036a3b745/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This does not enable indexing of multiple branches. The main purpose of this change is to build zoekt-git-index. zoekt-git-index is used instead of zoekt-archive-index when we want to index multiple branches.

See individual commits, summaries included below with `git log --pretty=format:'### %s%n%n%b%n'`

Part of #6728 

### all: build and include zoekt-git-index

If you are indexing multiple branches this command is required. This
adds the command to our dev and single docker image environments. The
docker images for cluster already include the command (see zoekt repo).


### zoekt: set cpu_fraction flag for indexserver

The default was 0.25, but was bumped to 1.0. This bump was done to align
the flag defaults with how we run indexserver in cluster
environments. We update our dev and single image environments to use the
same value. Those environmemts don't have resource isolation so we need
to continue using 0.25 rather than allowing indexing to use all cores.


### gomod: update zoekt

Includes the following commits

- https://github.com/sourcegraph/zoekt/commit/9d90c1c gitindex: allocate buffer of correct size
- https://github.com/sourcegraph/zoekt/commit/aa0e667 zoekt: verbose flag prints shard metadata
- https://github.com/sourcegraph/zoekt/commit/ddddd93 gitindex: do not resolve HEAD ref
- https://github.com/sourcegraph/zoekt/commit/8c0aee7 build: handle nil Options in largeFilesFlag
- https://github.com/sourcegraph/zoekt/commit/36a801c indexserver: use temp directory on same mount as indexes
- https://github.com/sourcegraph/zoekt/commit/070c191 indexserver: align flag defaults with dockerfile
- https://github.com/sourcegraph/zoekt/commit/35dabc7 indexserver: optionally shallow clone and use zoekt-git-index
- https://github.com/sourcegraph/zoekt/commit/f89b8e3 indexserver: inline CmdArgs into archiveIndex
- https://github.com/sourcegraph/zoekt/commit/ef52f4b indexserver: consistently use a pointer to indexArgs
- https://github.com/sourcegraph/zoekt/commit/e407d68 indexserver: store root in indexArgs
- https://github.com/sourcegraph/zoekt/commit/70628e0 indexserver: factor out index logic
- https://github.com/sourcegraph/zoekt/commit/4961ee9 indexserver: add cli flags to debug indexing and listing
- https://github.com/sourcegraph/zoekt/commit/4abd60f indexserver: log success
- https://github.com/sourcegraph/zoekt/commit/605d890 indexserver: metrics track if we skipped indexing
- https://github.com/sourcegraph/zoekt/commit/1a62bb8 indexserver: rename metric vars to have metric prefix
- https://github.com/sourcegraph/zoekt/commit/a2233e1 indexserver: check incremental in process
- https://github.com/sourcegraph/zoekt/commit/ddccdf9 indexserver: use build.Options to generate flags
- https://github.com/sourcegraph/zoekt/commit/8463ade Do not ignore large files.