### PR TITLE
Do not show error message when 'authbind' is not found

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -139,7 +139,7 @@ build_ts_pid="$!"
 printf >&2 "\nStarting all binaries...\n\n"
 export GOREMAN="goreman --set-ports=false --exit-on-error -f dev/Procfile"
 
-if ! [ "$(id -u)" = 0 ] && hash authbind; then
+if ! [ "$(id -u)" = 0 ] && hash authbind >dev/null 2>&1; then
   # ignoring because $GOREMAN is used in other handle-change.sh
   # shellcheck disable=SC2086
   # Support using authbind to bind to port 443 as non-root

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -139,7 +139,7 @@ build_ts_pid="$!"
 printf >&2 "\nStarting all binaries...\n\n"
 export GOREMAN="goreman --set-ports=false --exit-on-error -f dev/Procfile"
 
-if ! [ "$(id -u)" = 0 ] && hash authbind >dev/null 2>&1; then
+if ! [ "$(id -u)" = 0 ] && command -v authbind; then
   # ignoring because $GOREMAN is used in other handle-change.sh
   # shellcheck disable=SC2086
   # Support using authbind to bind to port 443 as non-root


### PR DESCRIPTION
Since this is a check with a fallback, I don't think it makes sense to
print this

    ../dev/start.sh: line 142: hash: authbind: not found

every time we start the environment.
