### PR TITLE
codeintel: Remove upload files after processing

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/exists_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists_test.go
@@ -76,13 +76,13 @@ func TestFindClosestDatabase(t *testing.T) {
 		expectedCommits[makeCommit(i)] = []string{makeCommit(i + 1)}
 	}
 	if len(mockDB.UpdateCommitsFunc.History()) != 1 {
-		t.Errorf("unexpected number of update UpdateCommitsFunc calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
+		t.Errorf("unexpected number of update UpdateCommits calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
 	} else if diff := cmp.Diff(expectedCommits, mockDB.UpdateCommitsFunc.History()[0].Arg2); diff != "" {
 		t.Errorf("unexpected update UpdateCommitsFunc args (-want +got):\n%s", diff)
 	}
 
 	if len(mockDB.UpdateDumpsVisibleFromTipFunc.History()) != 1 {
-		t.Errorf("unexpected number of UpdateDumpsVisibleFromTipFunc calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
+		t.Errorf("unexpected number of UpdateDumpsVisibleFromTip calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
 	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1 != 42 {
 		t.Errorf("unexpected value for repository id. want=%d have=%d", 42, mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1)
 	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2 != makeCommit(30) {

--- a/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -123,6 +123,14 @@ func (p *processor) Process(
 	if err != nil {
 		return errors.Wrap(err, "bundleManager.GetUpload")
 	}
+	defer func() {
+		if err != nil {
+			// Remove upload file on error instead of waiting for it to expire
+			if deleteErr := p.bundleManagerClient.DeleteUpload(ctx, upload.ID); deleteErr != nil {
+				log15.Warn("Failed to delete upload file", "err", err)
+			}
+		}
+	}()
 
 	// Create target file for converted database
 	uuid, err := uuid.NewRandom()

--- a/cmd/precise-code-intel-worker/internal/worker/worker_test.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker_test.go
@@ -253,7 +253,7 @@ func TestProcess(t *testing.T) {
 		},
 	}
 	if len(mockDB.UpdatePackagesFunc.History()) != 1 {
-		t.Errorf("unexpected number of UpdatePackagesFunc calls. want=%d have=%d", 1, len(mockDB.UpdatePackagesFunc.History()))
+		t.Errorf("unexpected number of UpdatePackages calls. want=%d have=%d", 1, len(mockDB.UpdatePackagesFunc.History()))
 	} else if diff := cmp.Diff(expectedPackages, mockDB.UpdatePackagesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackagesFuncargs (-want +got):\n%s", diff)
 	}
@@ -271,13 +271,13 @@ func TestProcess(t *testing.T) {
 		},
 	}
 	if len(mockDB.UpdatePackageReferencesFunc.History()) != 1 {
-		t.Errorf("unexpected number of UpdatePackageReferencesFunc calls. want=%d have=%d", 1, len(mockDB.UpdatePackageReferencesFunc.History()))
+		t.Errorf("unexpected number of UpdatePackageReferences calls. want=%d have=%d", 1, len(mockDB.UpdatePackageReferencesFunc.History()))
 	} else if diff := cmp.Diff(expectedPackageReferences, mockDB.UpdatePackageReferencesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackageReferencesFunc args (-want +got):\n%s", diff)
 	}
 
 	if len(mockDB.DeleteOverlappingDumpsFunc.History()) != 1 {
-		t.Errorf("unexpected number of DeleteOverlappingDumpsFunc calls. want=%d have=%d", 1, len(mockDB.DeleteOverlappingDumpsFunc.History()))
+		t.Errorf("unexpected number of DeleteOverlappingDumps calls. want=%d have=%d", 1, len(mockDB.DeleteOverlappingDumpsFunc.History()))
 	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg1 != 50 {
 		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg1)
 	} else if mockDB.DeleteOverlappingDumpsFunc.History()[0].Arg2 != makeCommit(1) {
@@ -296,13 +296,13 @@ func TestProcess(t *testing.T) {
 		}
 	}
 	if len(mockDB.UpdateCommitsFunc.History()) != 1 {
-		t.Errorf("unexpected number of update UpdateCommitsFunc calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
+		t.Errorf("unexpected number of update UpdateCommits calls. want=%d have=%d", 1, len(mockDB.UpdateCommitsFunc.History()))
 	} else if diff := cmp.Diff(expectedCommits, mockDB.UpdateCommitsFunc.History()[0].Arg2); diff != "" {
 		t.Errorf("unexpected update UpdateCommitsFunc args (-want +got):\n%s", diff)
 	}
 
 	if len(mockDB.UpdateDumpsVisibleFromTipFunc.History()) != 1 {
-		t.Errorf("unexpected number of UpdateDumpsVisibleFromTipFunc calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
+		t.Errorf("unexpected number of UpdateDumpsVisibleFromTip calls. want=%d have=%d", 1, len(mockDB.UpdateDumpsVisibleFromTipFunc.History()))
 	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1 != 50 {
 		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg1)
 	} else if mockDB.UpdateDumpsVisibleFromTipFunc.History()[0].Arg2 != makeCommit(30) {
@@ -310,7 +310,7 @@ func TestProcess(t *testing.T) {
 	}
 
 	if len(bundleManagerClient.SendDBFunc.History()) != 1 {
-		t.Errorf("unexpected number of SendDBFunc calls. want=%d have=%d", 1, len(bundleManagerClient.SendDBFunc.History()))
+		t.Errorf("unexpected number of SendDB calls. want=%d have=%d", 1, len(bundleManagerClient.SendDBFunc.History()))
 	} else if bundleManagerClient.SendDBFunc.History()[0].Arg1 != 42 {
 		t.Errorf("unexpected SendDBFunc args. want=%d have=%d", 42, bundleManagerClient.SendDBFunc.History()[0].Arg1)
 	}
@@ -349,8 +349,13 @@ func TestProcessError(t *testing.T) {
 	}
 
 	if len(jobHandle.RollbackToLastSavepointFunc.History()) != 1 {
-		t.Errorf("unexpected number of RollbackToLastSavepointFunc calls. want=%d have=%d", 1, len(jobHandle.RollbackToLastSavepointFunc.History()))
+		t.Errorf("unexpected number of RollbackToLastSavepoint calls. want=%d have=%d", 1, len(jobHandle.RollbackToLastSavepointFunc.History()))
 	}
+
+	if len(bundleManagerClient.DeleteUploadFunc.History()) != 1 {
+		t.Errorf("unexpected number of DeleteUpload calls. want=%d have=%d", 1, len(jobHandle.RollbackToLastSavepointFunc.History()))
+	}
+
 }
 
 //

--- a/internal/codeintel/bundles/client/bundle_manager_client_test.go
+++ b/internal/codeintel/bundles/client/bundle_manager_client_test.go
@@ -51,6 +51,37 @@ func TestSendUploadBadResponse(t *testing.T) {
 	}
 }
 
+func TestDeleteUpload(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("unexpected method. want=%s have=%s", "POST", r.Method)
+		}
+		if r.URL.Path != "/uploads/42" {
+			t.Errorf("unexpected method. want=%s have=%s", "/uploads/42", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	err := client.DeleteUpload(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error sending upload: %s", err)
+	}
+}
+
+func TestDeleteUploadBadResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	err := client.DeleteUpload(context.Background(), 42)
+	if err == nil {
+		t.Fatalf("unexpected nil error sending upload")
+	}
+}
+
 func TestGetUpload(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/internal/codeintel/bundles/mocks/mock_bundle_manager_client.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_manager_client.go
@@ -17,6 +17,9 @@ type MockBundleManagerClient struct {
 	// BundleClientFunc is an instance of a mock function object controlling
 	// the behavior of the method BundleClient.
 	BundleClientFunc *BundleManagerClientBundleClientFunc
+	// DeleteUploadFunc is an instance of a mock function object controlling
+	// the behavior of the method DeleteUpload.
+	DeleteUploadFunc *BundleManagerClientDeleteUploadFunc
 	// GetUploadFunc is an instance of a mock function object controlling
 	// the behavior of the method GetUpload.
 	GetUploadFunc *BundleManagerClientGetUploadFunc
@@ -35,6 +38,11 @@ func NewMockBundleManagerClient() *MockBundleManagerClient {
 	return &MockBundleManagerClient{
 		BundleClientFunc: &BundleManagerClientBundleClientFunc{
 			defaultHook: func(int) client.BundleClient {
+				return nil
+			},
+		},
+		DeleteUploadFunc: &BundleManagerClientDeleteUploadFunc{
+			defaultHook: func(context.Context, int) error {
 				return nil
 			},
 		},
@@ -63,6 +71,9 @@ func NewMockBundleManagerClientFrom(i client.BundleManagerClient) *MockBundleMan
 	return &MockBundleManagerClient{
 		BundleClientFunc: &BundleManagerClientBundleClientFunc{
 			defaultHook: i.BundleClient,
+		},
+		DeleteUploadFunc: &BundleManagerClientDeleteUploadFunc{
+			defaultHook: i.DeleteUpload,
 		},
 		GetUploadFunc: &BundleManagerClientGetUploadFunc{
 			defaultHook: i.GetUpload,
@@ -179,6 +190,115 @@ func (c BundleManagerClientBundleClientFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c BundleManagerClientBundleClientFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// BundleManagerClientDeleteUploadFunc describes the behavior when the
+// DeleteUpload method of the parent MockBundleManagerClient instance is
+// invoked.
+type BundleManagerClientDeleteUploadFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []BundleManagerClientDeleteUploadFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteUpload delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockBundleManagerClient) DeleteUpload(v0 context.Context, v1 int) error {
+	r0 := m.DeleteUploadFunc.nextHook()(v0, v1)
+	m.DeleteUploadFunc.appendCall(BundleManagerClientDeleteUploadFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the DeleteUpload method
+// of the parent MockBundleManagerClient instance is invoked and the hook
+// queue is empty.
+func (f *BundleManagerClientDeleteUploadFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteUpload method of the parent MockBundleManagerClient instance
+// inovkes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *BundleManagerClientDeleteUploadFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *BundleManagerClientDeleteUploadFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *BundleManagerClientDeleteUploadFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *BundleManagerClientDeleteUploadFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BundleManagerClientDeleteUploadFunc) appendCall(r0 BundleManagerClientDeleteUploadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of BundleManagerClientDeleteUploadFuncCall
+// objects describing the invocations of this function.
+func (f *BundleManagerClientDeleteUploadFunc) History() []BundleManagerClientDeleteUploadFuncCall {
+	f.mutex.Lock()
+	history := make([]BundleManagerClientDeleteUploadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BundleManagerClientDeleteUploadFuncCall is an object that describes an
+// invocation of method DeleteUpload on an instance of
+// MockBundleManagerClient.
+type BundleManagerClientDeleteUploadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BundleManagerClientDeleteUploadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BundleManagerClientDeleteUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
Ensure that upload files are removed after successful processing (when a new db is posted to the bundle manager) and after unsuccessful processing without retries (when the upload record is marked as errored). This will stop spurious alerts from the bundle manager janitor from occurring.

This doesn't affect correctness, as the files are _eventually_ deleted by the janitor today. This just increases the efficiency of the janitor process and will keep the disks size below a cleanup threshold for longer.

Closes https://github.com/sourcegraph/sourcegraph/issues/10358.