### PR TITLE
docs: don't advertise repo globs in search syntax yet

### DIFF
--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -149,7 +149,6 @@ The `repo:` filter accepts a repository pattern followed by `@revs`, like `githu
 - `@1735d48` - a commit hash
 - `@3.15` - a tag
 - `@feature-branch:1735d48:3.15` - multiple colon-separated revisions of the above forms
-- `@*bar` - revisions that match the glob pattern `bar/*` (as interpreted by [gitlog --glob](https://git-scm.com/docs/git-log#Documentation/git-log.txt---globltglob-patterngt))
 
 ### Repository names
 


### PR DESCRIPTION
This example makes it sound like we can do `@*` to search all branches, but this [doesn't currently work](https://github.com/sourcegraph/sourcegraph/pull/10488#discussion_r422313446). I'm not sure why and didn't take time to investigate (filed #10571). We can advertise this once we address that issue.