### PR TITLE
codeintel: Add healthcheck server to worker

### DIFF
--- a/cmd/precise-code-intel-api-server/Dockerfile
+++ b/cmd/precise-code-intel-api-server/Dockerfile
@@ -16,4 +16,4 @@ RUN apk update && apk add --no-cache \
 USER sourcegraph
 EXPOSE 3186
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-api-server"]
-COPY precise-code-intel-api-server /usr/local/bin
+COPY precise-code-intel-api-server /usr/local/bin/

--- a/cmd/precise-code-intel-api-server/Dockerfile
+++ b/cmd/precise-code-intel-api-server/Dockerfile
@@ -14,8 +14,6 @@ RUN apk update && apk add --no-cache \
     tini
 
 USER sourcegraph
-COPY ./precise-code-intel-api-server /usr/local/bin/precise-code-intel-api-server
-
 EXPOSE 3186
-ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-api-server"]
+COPY precise-code-intel-api-server /usr/local/bin

--- a/cmd/precise-code-intel-api-server/build.sh
+++ b/cmd/precise-code-intel-api-server/build.sh
@@ -15,6 +15,7 @@ trap cleanup EXIT
 export GO111MODULE=on
 export GOARCH=amd64
 export GOOS=linux
+export CGO_ENABLED=0
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-api-server"

--- a/cmd/precise-code-intel-bundle-manager/Dockerfile
+++ b/cmd/precise-code-intel-bundle-manager/Dockerfile
@@ -33,9 +33,7 @@ USER root
 RUN mkdir -p /lsif-storage && chown -R sourcegraph:sourcegraph /lsif-storage
 
 USER sourcegraph
-COPY ./precise-code-intel-bundle-manager /usr/local/bin/precise-code-intel-bundle-manager
-
 EXPOSE 3187
 VOLUME ["/lsif-storage"]
-ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-bundle-manager"]
+COPY precise-code-intel-bundle-manager /usr/local/bin

--- a/cmd/precise-code-intel-bundle-manager/Dockerfile
+++ b/cmd/precise-code-intel-bundle-manager/Dockerfile
@@ -36,4 +36,4 @@ USER sourcegraph
 EXPOSE 3187
 VOLUME ["/lsif-storage"]
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-bundle-manager"]
-COPY precise-code-intel-bundle-manager /usr/local/bin
+COPY precise-code-intel-bundle-manager /usr/local/bin/

--- a/cmd/precise-code-intel-worker/Dockerfile
+++ b/cmd/precise-code-intel-worker/Dockerfile
@@ -27,4 +27,4 @@ RUN apk --no-cache add pcre-dev
 USER sourcegraph
 EXPOSE 3188
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-worker"]
-COPY precise-code-intel-worker /usr/local/bin
+COPY precise-code-intel-worker /usr/local/bin/

--- a/cmd/precise-code-intel-worker/Dockerfile
+++ b/cmd/precise-code-intel-worker/Dockerfile
@@ -27,5 +27,6 @@ RUN apk --no-cache add pcre-dev
 USER sourcegraph
 COPY ./precise-code-intel-worker /usr/local/bin/precise-code-intel-worker
 
+EXPOSE 3188
 ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-worker"]

--- a/cmd/precise-code-intel-worker/Dockerfile
+++ b/cmd/precise-code-intel-worker/Dockerfile
@@ -25,8 +25,6 @@ ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 RUN apk --no-cache add pcre-dev
 
 USER sourcegraph
-COPY ./precise-code-intel-worker /usr/local/bin/precise-code-intel-worker
-
 EXPOSE 3188
-ENV GO111MODULES=on LANG=en_US.utf8 LOG_LEVEL=debug
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-worker"]
+COPY precise-code-intel-worker /usr/local/bin

--- a/cmd/precise-code-intel-worker/internal/server/handler.go
+++ b/cmd/precise-code-intel-worker/internal/server/handler.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func (s *Server) handler() http.Handler {
+	mux := mux.NewRouter()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
+}

--- a/cmd/precise-code-intel-worker/internal/server/server.go
+++ b/cmd/precise-code-intel-worker/internal/server/server.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+)
+
+type Server struct {
+	Host string
+	Port int
+}
+
+func (s *Server) Start() {
+	addr := net.JoinHostPort(s.Host, strconv.FormatInt(int64(s.Port), 10))
+	handler := ot.Middleware(s.handler())
+	server := &http.Server{Addr: addr, Handler: handler}
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log15.Error("Failed to start server", "err", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/precise-code-intel-worker/main.go
+++ b/cmd/precise-code-intel-worker/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
+	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/server"
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/worker"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"

--- a/cmd/precise-code-intel-worker/main.go
+++ b/cmd/precise-code-intel-worker/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/worker"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
@@ -23,6 +24,11 @@ import (
 )
 
 func main() {
+	host := ""
+	if env.InsecureDev {
+		host = "127.0.0.1"
+	}
+
 	env.Lock()
 	env.HandleHelpFlag()
 	tracer.Init()
@@ -43,6 +49,12 @@ func main() {
 	db := db.NewObserved(mustInitializeDatabase(), observationContext)
 	MustRegisterQueueMonitor(observationContext.Registerer, db)
 	workerMetrics := worker.NewWorkerMetrics(prometheus.DefaultRegisterer)
+
+	server := server.Server{
+		Host: host,
+		Port: 3188,
+	}
+	go server.Start()
 
 	worker := worker.NewWorker(
 		db,


### PR DESCRIPTION
Add HTTP server to worker with healthpoint. We'll probably expand this later for queue control actions and IPC into the worker tasks.

Drive-by: update dockerfile standards to match gitserver/frontend.