### PR TITLE
codeintel: Do not fail on relative (but non-subset) document paths

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
@@ -25,8 +25,8 @@ func TestCorrelate(t *testing.T) {
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///test/root",
 		DocumentData: map[string]lsif.DocumentData{
-			"02": {URI: "/foo.go", Contains: datastructures.IDSet{"04": {}, "05": {}, "06": {}}},
-			"03": {URI: "/bar.go", Contains: datastructures.IDSet{"07": {}, "08": {}, "09": {}}},
+			"02": {URI: "foo.go", Contains: datastructures.IDSet{"04": {}, "05": {}, "06": {}}},
+			"03": {URI: "bar.go", Contains: datastructures.IDSet{"07": {}, "08": {}, "09": {}}},
 		},
 		RangeData: map[string]lsif.RangeData{
 			"04": {

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/document_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/document_test.go
@@ -29,3 +29,25 @@ func TestUnmarshalDocumentData(t *testing.T) {
 		t.Errorf("unexpected document (-want +got):\n%s", diff)
 	}
 }
+
+func TestUnmarshalDocumentDataComplexPaths(t *testing.T) {
+	element := Element{
+		ID:    "02",
+		Type:  "vertex",
+		Label: "document",
+		Raw:   json.RawMessage(`{"id": "02", "type": "vertex", "label": "document", "uri": "file:///__w/sourcegraph/sourcegraph/node_modules/@types/history/index.d.ts"}`),
+	}
+
+	document, err := UnmarshalDocumentData(element, "file:///__w/sourcegraph/sourcegraph/shared/")
+	if err != nil {
+		t.Fatalf("unexpected error unmarshalling document data: %s", err)
+	}
+
+	expectedDocument := DocumentData{
+		URI:      "../node_modules/@types/history/index.d.ts",
+		Contains: datastructures.IDSet{},
+	}
+	if diff := cmp.Diff(expectedDocument, document); diff != "" {
+		t.Errorf("unexpected document (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Small regression fix: the Go port disallows all dumps that contain a document that isn't properly nested in the index root. This PR introduces the proper (and old) behavior.