### PR TITLE
codeintel: Minimize the number of duplicate rows inserted in UpdateCommits

### DIFF
--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -8,19 +8,62 @@ import (
 
 // HasCommit determines if the given commit is known for the given repository.
 func (db *dbImpl) HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error) {
-	count, _, err := scanFirstInt(db.query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_commits WHERE repository_id = %s and commit = %s LIMIT 1`, repositoryID, commit)))
+	count, _, err := scanFirstInt(db.query(ctx, sqlf.Sprintf(`
+		SELECT COUNT(*)
+		FROM lsif_commits
+		WHERE repository_id = %s and commit = %s
+		LIMIT 1
+	`, repositoryID, commit)))
+
 	return count > 0, err
 }
 
 // UpdateCommits upserts commits/parent-commit relations for the given repository ID.
-func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits map[string][]string) (err error) {
+func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits map[string][]string) error {
+	if len(commits) == 0 {
+		return nil
+	}
+
+	var qs []*sqlf.Query
+	for commit := range commits {
+		qs = append(qs, sqlf.Sprintf("%s", commit))
+	}
+
+	knownCommits, err := scanCommits(db.query(
+		ctx,
+		sqlf.Sprintf(`
+			SELECT "commit", parent_commit
+			FROM lsif_commits
+			WHERE repository_id = %s AND "commit" IN (%s)
+		`, repositoryID, sqlf.Join(qs, ",")),
+	))
+	if err != nil {
+		return err
+	}
+
+	unknownCommits := map[string][]string{}
+	for commit, parentCommits := range commits {
+		if knownParents, ok := knownCommits[commit]; ok {
+			// Filter out any known parents. Only keep this commit in the map
+			// if we have at least one new unknown parent, otherwise we'll end
+			// up inserting the `(commit, NULL)` which will pollute the table.
+			if d := diff(parentCommits, knownParents); len(d) > 0 {
+				unknownCommits[commit] = d
+			}
+		} else {
+			// New commit, all parents unknown
+			unknownCommits[commit] = parentCommits
+		}
+	}
+
 	var rows []*sqlf.Query
-	for commit, parents := range commits {
+	for commit, parents := range unknownCommits {
 		for _, parent := range parents {
 			rows = append(rows, sqlf.Sprintf("(%d, %s, %s)", repositoryID, commit, parent))
 		}
 
 		if len(parents) == 0 {
+			// Insert a commit even if its parent is not known
 			rows = append(rows, sqlf.Sprintf("(%d, %s, NULL)", repositoryID, commit))
 		}
 	}

--- a/internal/codeintel/db/commits_test.go
+++ b/internal/codeintel/db/commits_test.go
@@ -105,7 +105,7 @@ func TestUpdateCommits(t *testing.T) {
 	}
 }
 
-func TestUpdateCommitsWithConflicts(t *testing.T) {
+func TestUpdateCommitsWithOverlap(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/internal/codeintel/db/scan.go
+++ b/internal/codeintel/db/scan.go
@@ -279,3 +279,31 @@ func scanVisibilities(rows *sql.Rows, err error) (map[int]bool, error) {
 
 	return visibilities, nil
 }
+
+// scanCommit populates a pair of strings from teh given scanner.
+func scanCommit(scanner scanner) (commit, parentCommit string, err error) {
+	err = scanner.Scan(&commit, &parentCommit)
+	return commit, parentCommit, err
+}
+
+// scanCommits reads the given set of `(commit, parent_commit)` row sand returns
+// a map from commits to its parents. This method should be called directly from
+// the return value of` *db.query`.
+func scanCommits(rows *sql.Rows, err error) (map[string][]string, error) {
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	commits := map[string][]string{}
+	for rows.Next() {
+		commit, parentCommit, err := scanCommit(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		commits[commit] = append(commits[commit], parentCommit)
+	}
+
+	return commits, nil
+}

--- a/internal/codeintel/db/scan.go
+++ b/internal/codeintel/db/scan.go
@@ -286,9 +286,9 @@ func scanCommit(scanner scanner) (commit, parentCommit string, err error) {
 	return commit, parentCommit, err
 }
 
-// scanCommits reads the given set of `(commit, parent_commit)` row sand returns
+// scanCommits reads the given set of `(commit, parent_commit)` rows and returns
 // a map from commits to its parents. This method should be called directly from
-// the return value of` *db.query`.
+// the return value of `*db.query`.
 func scanCommits(rows *sql.Rows, err error) (map[string][]string, error) {
 	if err != nil {
 		return nil, err

--- a/internal/codeintel/db/util.go
+++ b/internal/codeintel/db/util.go
@@ -13,3 +13,20 @@ func intsToQueries(values []int) []*sqlf.Query {
 
 	return queries
 }
+
+// diff returns a slice containing the elements of left not present in right.
+func diff(left, right []string) []string {
+	rightSet := map[string]struct{}{}
+	for _, v := range right {
+		rightSet[v] = struct{}{}
+	}
+
+	var diff []string
+	for _, v := range left {
+		if _, ok := rightSet[v]; !ok {
+			diff = append(diff, v)
+		}
+	}
+
+	return diff
+}


### PR DESCRIPTION
The new services are causing a periodic deadlock between the api-server and the worker trying to insert records into the lsif_commits table. The worker does this inside of a long transaction, and the api-server does this as a means to discover what dumps it can use to serve the current query.

One way to mitigate this is to shorten the transaction in the worker. This will also be done, but in a separate effort. Another way is to reduce the number of clashing rows that are inserted into a unique index (see [this article](https://rcoh.svbtle.com/postgres-unique-constraints-can-cause-deadlock)). That is this PR's focus.

For context, see https://sourcegraph.slack.com/archives/C07KZF47K/p1589231888204200.