### PR TITLE
editor HTTP handler: add tests, refactor, add support for "search in repository"

### DIFF
--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -81,7 +81,7 @@ type editorOpenFileRequest struct {
 
 // editorSearchRequest represents parameters for "search on Sourcegraph" editor requests.
 type editorSearchRequest struct {
-	query string
+	query string // The literal search query
 }
 
 // searchRedirect returns the redirect URL for the pre-validated search request.
@@ -91,10 +91,8 @@ func (r *editorRequest) searchRedirect() string {
 	// repo is not actually very useful, since they can usually do that better in their editor.
 	u := &url.URL{Path: "/search"}
 	q := u.Query()
-	// Escape double quotes in search query.
-	query := strings.Replace(r.searchRequest.query, `"`, `\"`, -1)
-	// Search as a string literal
-	q.Add("q", `"`+query+`"`)
+	q.Add("q", r.searchRequest.query)
+	q.Add("patternType", "literal")
 	q.Add("utm_source", r.editor+"-"+r.version)
 	if r.utmProductName != "" {
 		q.Add("utm_product_name", r.utmProductName)

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -213,7 +213,7 @@ func parseEditorRequest(q url.Values) (*editorRequest, error) {
 		utmProductVersion: q.Get("utm_product_name"),
 	}
 	if v.editor == "" {
-		return nil, fmt.Errorf("expected URL parameter missing: editor=$EDITOR_NAME")
+		return nil, errors.New("expected URL parameter missing: editor=$EDITOR_NAME")
 	}
 	if v.version == "" {
 		return nil, fmt.Errorf("expected URL parameter missing: version=$EDITOR_EXTENSION_VERSION")

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -91,7 +91,8 @@ type editorSearchRequest struct {
 
 	// Optional git repository branch name and revision. When one is present and remoteURL
 	// is present, the search will be performed just at this branch/revision.
-	branch, revision string
+	branch   string
+	revision string
 
 	// Optional unix filepath relative to the repository root. When present, the search
 	// will be performed with a file: search filter.

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,57 +49,66 @@ func editorRev(ctx context.Context, repoName api.RepoName, rev string, beExplici
 	return "@" + rev, nil
 }
 
-// editorRedirect calculates where to redirect a user who has an editor URL
-// from a Sourcegraph editor extension.
-func editorRedirect(ctx context.Context, q url.Values) (redirectURL string, userErr, internalErr error) {
-	// Required query parameters:
-	editor := q.Get("editor")   // Editor name: "Atom", "Sublime", etc.
-	version := q.Get("version") // Editor extension version.
+// editorRequest represents the parameters to a Sourcegraph "open file", "search", etc. editor request.
+type editorRequest struct {
+	// Fields that are required in all requests.
+	editor  string // editor name, e.g. "Atom", "Sublime", etc.
+	version string // editor extension version
 
-	// JetBrains-specific query parameters:
-	utmProductName := q.Get("utm_product_name")    // Editor product name, for JetBrains only (e.g. "IntelliJ", "Gogland").
-	utmProductVersion := q.Get("utm_product_name") // Editor product version, for JetBrains only.
+	// Fields that are optional in all requests.
+	utmProductName    string // Editor product name. Only present in JetBrains today (e.g. "IntelliJ", "Gogland")
+	utmProductVersion string // Editor product version. Only present in JetBrains today.
 
-	// Repo query parameters (required for open-file requests, but optional for
-	// search requests):
-	remoteURL := q.Get("remote_url") // Git repository remote URL.
-	branch := q.Get("branch")        // Git branch name.
-	revision := q.Get("revision")    // Git revision.
-	file := q.Get("file")            // File relative to repository root.
+	// openFileRequest is non-nil if this is an "open file on Sourcegraph" request.
+	openFileRequest *editorOpenFileRequest
 
-	// search query parameters. Only present if it is a search request.
-	search := q.Get("search")
+	// searchRequest is non-nil if this is a "search on Sourcegraph" request.
+	searchRequest *editorSearchRequest
+}
 
-	// open-file parameters. Only present if it is a open-file request.
-	startRow, _ := strconv.Atoi(q.Get("start_row")) // zero-based
-	startCol, _ := strconv.Atoi(q.Get("start_col")) // zero-based
-	endRow, _ := strconv.Atoi(q.Get("end_row"))     // zero-based
-	endCol, _ := strconv.Atoi(q.Get("end_col"))     // zero-based
+// editorSearchRequest represents parameters for "open file on Sourcegraph" editor requests.
+type editorOpenFileRequest struct {
+	remoteURL         string // Git repository remote URL.
+	branch            string // Git branch name.
+	revision          string // Git revision.
+	file              string // File relative to repository root.
+	hostnameToPattern map[string]string
 
-	if search != "" {
-		// Search request. The search is intentionally not scoped to a repository, because it's assumed the
-		// user prefers to perform the search in their last-used search scope. Searching in their current
-		// repo is not actually very useful, since they can usually do that better in their editor.
-		u := &url.URL{Path: "/search"}
-		q := u.Query()
-		// Escape double quotes in search query.
-		search = strings.Replace(search, `"`, `\"`, -1)
-		// Search as a string literal
-		q.Add("q", `"`+search+`"`)
-		q.Add("utm_source", editor+"-"+version)
-		if utmProductName != "" {
-			q.Add("utm_product_name", utmProductName)
-		}
-		if utmProductVersion != "" {
-			q.Add("utm_product_version", utmProductVersion)
-		}
-		u.RawQuery = q.Encode()
-		redirectURL = u.String()
-		return
+	// Zero-based cursor selection parameters. Required.
+	startRow, endRow int
+	startCol, endCol int
+}
+
+// editorSearchRequest represents parameters for "search on Sourcegraph" editor requests.
+type editorSearchRequest struct {
+	query string
+}
+
+// searchRedirect returns the redirect URL for the pre-validated search request.
+func (r *editorRequest) searchRedirect() string {
+	// Search request. The search is intentionally not scoped to a repository, because it's assumed the
+	// user prefers to perform the search in their last-used search scope. Searching in their current
+	// repo is not actually very useful, since they can usually do that better in their editor.
+	u := &url.URL{Path: "/search"}
+	q := u.Query()
+	// Escape double quotes in search query.
+	query := strings.Replace(r.searchRequest.query, `"`, `\"`, -1)
+	// Search as a string literal
+	q.Add("q", `"`+query+`"`)
+	q.Add("utm_source", r.editor+"-"+r.version)
+	if r.utmProductName != "" {
+		q.Add("utm_product_name", r.utmProductName)
 	}
+	if r.utmProductVersion != "" {
+		q.Add("utm_product_version", r.utmProductVersion)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
 
-	// Open-file request.
-
+// openFile returns the redirect URL for the pre-validated open-file request.
+func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
+	of := r.openFileRequest
 	// Determine the repo name and branch.
 	//
 	// TODO(sqs): This used to hit gitserver, which would be more accurate in case of nonstandard
@@ -106,59 +116,105 @@ func editorRedirect(ctx context.Context, q url.Values) (redirectURL string, user
 	// won't work, but it is worth the increase in simplicity (plus there is an error message for
 	// users). In the future we can let users specify a custom mapping to the Sourcegraph repo in
 	// their local Git repo (instead of having them pass it here).
-	var hostnameToPattern map[string]string
-	if hostnameToPatternStr := q.Get("hostname_patterns"); hostnameToPatternStr != "" {
-		if err := json.Unmarshal([]byte(hostnameToPatternStr), &hostnameToPattern); err != nil {
-			internalErr = err
-			return
-		}
-	}
-	repoName := guessRepoNameFromRemoteURL(remoteURL, hostnameToPattern)
+	repoName := guessRepoNameFromRemoteURL(of.remoteURL, of.hostnameToPattern)
 	if repoName == "" {
 		// Any error here is a problem with the user's configured git remote
 		// URL. We want them to actually read this error message.
-		userErr = fmt.Errorf("Git remote URL %q not supported", remoteURL)
-		return
+		return "", fmt.Errorf("Git remote URL %q not supported", of.remoteURL)
 	}
 
-	inputRev, beExplicit := revision, true
+	inputRev, beExplicit := of.revision, true
 	if inputRev == "" {
-		inputRev, beExplicit = branch, false
+		inputRev, beExplicit = of.branch, false
 	}
 	rev, err := editorRev(ctx, repoName, inputRev, beExplicit)
 	if err != nil {
-		internalErr = err
-		return
+		return "", err
 	}
 
-	u := &url.URL{Path: path.Join("/", string(repoName)+rev, "/-/blob/", file)}
-	q = u.Query()
-	q.Add("utm_source", editor+"-"+version)
-	if utmProductName != "" {
-		q.Add("utm_product_name", utmProductName)
+	u := &url.URL{Path: path.Join("/", string(repoName)+rev, "/-/blob/", of.file)}
+	q := u.Query()
+	q.Add("utm_source", r.editor+"-"+r.version)
+	if r.utmProductName != "" {
+		q.Add("utm_product_name", r.utmProductName)
 	}
-	if utmProductVersion != "" {
-		q.Add("utm_product_version", utmProductVersion)
+	if r.utmProductVersion != "" {
+		q.Add("utm_product_version", r.utmProductVersion)
 	}
 	u.RawQuery = q.Encode()
-	if startRow == endRow && startCol == endCol {
-		u.Fragment = fmt.Sprintf("L%d:%d", startRow+1, startCol+1)
+	if of.startRow == of.endRow && of.startCol == of.endCol {
+		u.Fragment = fmt.Sprintf("L%d:%d", of.startRow+1, of.startCol+1)
 	} else {
-		u.Fragment = fmt.Sprintf("L%d:%d-%d:%d", startRow+1, startCol+1, endRow+1, endCol+1)
+		u.Fragment = fmt.Sprintf("L%d:%d-%d:%d", of.startRow+1, of.startCol+1, of.endRow+1, of.endCol+1)
 	}
-	redirectURL = u.String()
-	return
+	return u.String(), nil
+}
+
+// openFile returns the redirect URL for the pre-validated request.
+func (r *editorRequest) redirectURL(ctx context.Context) (string, error) {
+	if r.searchRequest != nil {
+		return r.searchRedirect(), nil
+	} else if r.openFileRequest != nil {
+		return r.openFileRedirect(ctx)
+	}
+	return "", errors.New("could not determine request type, missing ?search or ?remote_url")
+}
+
+// parseEditorRequest parses an editor request from the search query values.
+func parseEditorRequest(q url.Values) (*editorRequest, error) {
+	v := &editorRequest{
+		editor:            q.Get("editor"),
+		version:           q.Get("version"),
+		utmProductName:    q.Get("utm_product_name"),
+		utmProductVersion: q.Get("utm_product_name"),
+	}
+	if v.editor == "" {
+		return nil, fmt.Errorf("expected URL parameter missing: editor=$EDITOR_NAME")
+	}
+	if v.version == "" {
+		return nil, fmt.Errorf("expected URL parameter missing: version=$EDITOR_EXTENSION_VERSION")
+	}
+
+	if search := q.Get("search"); search != "" {
+		// Search request parsing
+		v.searchRequest = &editorSearchRequest{
+			query: q.Get("search"),
+		}
+	} else if remoteURL := q.Get("remote_url"); remoteURL != "" {
+		// Open-file request parsing
+		startRow, _ := strconv.Atoi(q.Get("start_row"))
+		endRow, _ := strconv.Atoi(q.Get("end_row"))
+		startCol, _ := strconv.Atoi(q.Get("start_col"))
+		endCol, _ := strconv.Atoi(q.Get("end_col"))
+		v.openFileRequest = &editorOpenFileRequest{
+			remoteURL: remoteURL,
+			branch:    q.Get("branch"),
+			revision:  q.Get("revision"),
+			file:      q.Get("file"),
+			startRow:  startRow,
+			endRow:    endRow,
+			startCol:  startCol,
+			endCol:    endCol,
+		}
+		if hostnameToPatternStr := q.Get("hostname_patterns"); hostnameToPatternStr != "" {
+			if err := json.Unmarshal([]byte(hostnameToPatternStr), &v.openFileRequest.hostnameToPattern); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return v, nil
 }
 
 func serveEditor(w http.ResponseWriter, r *http.Request) error {
-	q := r.URL.Query()
-	redirectURL, userErr, internalErr := editorRedirect(r.Context(), q)
-	if internalErr != nil {
-		return internalErr
-	}
-	if userErr != nil {
+	editorRequest, err := parseEditorRequest(r.URL.Query())
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "%s", userErr.Error())
+		fmt.Fprintf(w, "%s", err.Error())
+	}
+	redirectURL, err := editorRequest.redirectURL(r.Context())
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "%s", err.Error())
 	}
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	return nil

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -57,7 +57,7 @@ type editorRequest struct {
 	version string // editor extension version
 
 	// Fields that are optional in all requests.
-	utmProductName    string // Editor product name. Only present in JetBrains today (e.g. "IntelliJ", "Gogland")
+	utmProductName    string // Editor product name. Only present in JetBrains today (e.g. "IntelliJ", "GoLand")
 	utmProductVersion string // Editor product version. Only present in JetBrains today.
 
 	// openFileRequest is non-nil if this is an "open file on Sourcegraph" request.

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -217,7 +217,7 @@ func parseEditorRequest(q url.Values) (*editorRequest, error) {
 		return nil, errors.New("expected URL parameter missing: editor=$EDITOR_NAME")
 	}
 	if v.version == "" {
-		return nil, fmt.Errorf("expected URL parameter missing: version=$EDITOR_EXTENSION_VERSION")
+		return nil, errors.New("expected URL parameter missing: version=$EDITOR_EXTENSION_VERSION")
 	}
 
 	if search := q.Get("search"); search != "" {
@@ -264,11 +264,13 @@ func serveEditor(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "%s", err.Error())
+		return nil
 	}
 	redirectURL, err := editorRequest.redirectURL(r.Context())
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "%s", err.Error())
+		return nil
 	}
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	return nil

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -68,11 +68,11 @@ type editorRequest struct {
 
 // editorSearchRequest represents parameters for "open file on Sourcegraph" editor requests.
 type editorOpenFileRequest struct {
-	remoteURL         string // Git repository remote URL.
-	branch            string // Git branch name.
-	revision          string // Git revision.
-	file              string // File relative to repository root.
-	hostnameToPattern map[string]string
+	remoteURL         string            // Git repository remote URL.
+	branch            string            // Git branch name.
+	revision          string            // Git revision.
+	file              string            // File relative to repository root.
+	hostnameToPattern map[string]string // map of Git remote URL hostnames to patterns describing how they map to Sourcegraph repositories
 
 	// Zero-based cursor selection parameters. Required.
 	startRow, endRow int

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -132,6 +132,60 @@ func TestEditorRedirect(t *testing.T) {
 			wantRedirectURL: "/search?patternType=literal&q=foobar&utm_source=Atom-v1.2.1",
 		},
 		{
+			name: "search in repository",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"search":     []string{"foobar"},
+				"remote_url": []string{"git@github.com:a/b"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=repo%3Agithub%5C.com%2Fa%2Fb%24+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
+			name: "search in repository branch",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"search":     []string{"foobar"},
+				"remote_url": []string{"git@github.com:a/b"},
+				"branch":     []string{"dev"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=repo%3Agithub%5C.com%2Fa%2Fb%24%40dev+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
+			name: "search in repository revision",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"search":     []string{"foobar"},
+				"remote_url": []string{"git@github.com:a/b"},
+				"branch":     []string{"dev"},
+				"revision":   []string{"0ad12f"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=repo%3Agithub%5C.com%2Fa%2Fb%24%400ad12f+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
+			name: "search in repository file",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"search":     []string{"foobar"},
+				"remote_url": []string{"git@github.com:a/b"},
+				"file":       []string{"baz"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=repo%3Agithub%5C.com%2Fa%2Fb%24+file%3A%5Ebaz%24+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
+			name: "search in file",
+			q: url.Values{
+				"editor":  []string{"Atom"},
+				"version": []string{"v1.2.1"},
+				"search":  []string{"foobar"},
+				"file":    []string{"baz"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=file%3A%5Ebaz%24+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
 			name:         "empty request",
 			wantParseErr: "expected URL parameter missing: editor=$EDITOR_NAME",
 		},

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -129,7 +129,7 @@ func TestEditorRedirect(t *testing.T) {
 				"version": []string{"v1.2.1"},
 				"search":  []string{"foobar"},
 			},
-			wantRedirectURL: "/search?q=%22foobar%22&utm_source=Atom-v1.2.1",
+			wantRedirectURL: "/search?patternType=literal&q=foobar&utm_source=Atom-v1.2.1",
 		},
 		{
 			name:         "empty request",


### PR DESCRIPTION
This change does three things primarily:

1. Adds tests for the Sourcegraph editor HTTP endpoint (which is what the editor extensions produce).
2. Refactors the code to be more readable and extensible in the future.
3. Adds support for "Search in repository" (previously we only supported global search) as requested by a large user base in https://github.com/sourcegraph/sourcegraph-jetbrains/pull/13

Best reviewed commit-by-commit as this is a large change.