### PR TITLE
authz: add GraphQL mutations to schedule permissions sync

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -11,10 +11,17 @@ import (
 var NewAuthzResolver func() AuthzResolver
 
 type AuthzResolver interface {
+	// Mutations
 	SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error)
+	ScheduleRepositoryPermissionsSync(ctx context.Context, args *RepositoryIDArgs) (*EmptyResponse, error)
+	ScheduleUserPermissionsSync(ctx context.Context, args *UserIDArgs) (*EmptyResponse, error)
+
+	// Queries
 	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
+
+	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
 	UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error)
 }
@@ -26,6 +33,14 @@ var _ AuthzResolver = (*defaultAuthzResolver)(nil)
 type defaultAuthzResolver struct{}
 
 func (defaultAuthzResolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error) {
+	return nil, authzInEnterprise
+}
+
+func (defaultAuthzResolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *RepositoryIDArgs) (*EmptyResponse, error) {
+	return nil, authzInEnterprise
+}
+
+func (defaultAuthzResolver) ScheduleUserPermissionsSync(ctx context.Context, args *UserIDArgs) (*EmptyResponse, error) {
 	return nil, authzInEnterprise
 }
 
@@ -47,6 +62,14 @@ func (defaultAuthzResolver) RepositoryPermissionsInfo(ctx context.Context, repoI
 
 func (defaultAuthzResolver) UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error) {
 	return nil, authzInEnterprise
+}
+
+type RepositoryIDArgs struct {
+	Repository graphql.ID
+}
+
+type UserIDArgs struct {
+	User graphql.ID
 }
 
 type RepoPermsArgs struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -407,6 +407,10 @@ type Mutation {
         # The level of repository permission.
         perm: RepositoryPermission = READ
     ): EmptyResponse!
+    # Schedule a permissions sync for given repository.
+    scheduleRepositoryPermissionsSync(repository: ID!): EmptyResponse!
+    # Schedule a permissions sync for given user.
+    scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 }
 
 # A patch to apply to a repository (in a new branch) when a campaign is created

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -414,6 +414,10 @@ type Mutation {
         # The level of repository permission.
         perm: RepositoryPermission = READ
     ): EmptyResponse!
+    # Schedule a permissions sync for given repository.
+    scheduleRepositoryPermissionsSync(repository: ID!): EmptyResponse!
+    # Schedule a permissions sync for given user.
+    scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 }
 
 # A patch to apply to a repository (in a new branch) when a campaign is created

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -124,6 +124,11 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 }
 
 func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *graphqlbackend.RepositoryIDArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site admins can query repository permissions.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	repoID, err := graphqlbackend.UnmarshalRepositoryID(args.Repository)
 	if err != nil {
 		return nil, err
@@ -139,6 +144,11 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 }
 
 func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphqlbackend.UserIDArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site admins can query repository permissions.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	userID, err := graphqlbackend.UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -207,6 +207,31 @@ func (c *Client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
 	return errors.New(res.Error)
 }
 
+func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncRequest) error {
+	resp, err := c.httpPost(ctx, "schedule-perms-sync", args)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "read response body")
+	}
+
+	var res protocol.PermsSyncResponse
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return errors.New(string(bs))
+	} else if err = json.Unmarshal(bs, &res); err != nil {
+		return err
+	}
+
+	if res.Error == "" {
+		return nil
+	}
+	return errors.New(res.Error)
+}
+
 // SyncExternalService requests the given external service to be synced.
 func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
 	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}


### PR DESCRIPTION
Adds two GraphQL mutations of scheduling permissions sync for user and repository.

Step two of three steps for #8990.