### PR TITLE
Bext: make permissions warning less scary

### DIFF
--- a/browser/src/libs/options/OptionsMenu.tsx
+++ b/browser/src/libs/options/OptionsMenu.tsx
@@ -74,16 +74,22 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
             !currentTabStatus.hasPermissions &&
             !PERMISSIONS_PROTOCOL_BLACKLIST.includes(currentTabStatus.protocol) && (
                 <div className="options-menu__section">
-                    <div className="alert alert-danger">
-                        Sourcegraph is not enabled on <strong>{currentTabStatus.host}</strong>.{' '}
-                        <a
-                            href=""
-                            onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
-                            className="request-permissions__test"
-                        >
-                            Grant permissions
-                        </a>{' '}
-                        to enable Sourcegraph.
+                    <div className="alert alert-info">
+                        <p>
+                            The Sourcegraph browser extension adds hover tooltips to code views on code hosts such as
+                            GitHub, GitLab, Bitbucket Server and Phabricator.
+                        </p>
+                        <p>
+                            To enable Sourcegraph on <strong>{currentTabStatus.host}</strong>, you must{' '}
+                            <a
+                                href=""
+                                onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
+                                className="request-permissions__test"
+                            >
+                                grant permissions
+                            </a>
+                            .
+                        </p>
                     </div>
                 </div>
             )}

--- a/browser/src/libs/options/OptionsMenu.tsx
+++ b/browser/src/libs/options/OptionsMenu.tsx
@@ -35,7 +35,7 @@ const isFullPage = (): boolean => !new URLSearchParams(window.location.search).g
 const buildRequestPermissionsHandler = (
     { protocol, host }: NonNullable<OptionsMenuProps['currentTabStatus']>,
     requestPermissions: OptionsMenuProps['requestPermissions']
-) => (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+) => (event: React.MouseEvent) => {
     event.preventDefault()
     requestPermissions(`${protocol}//${host}`)
 }
@@ -80,19 +80,35 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
                             GitHub, GitLab, Bitbucket Server and Phabricator.
                         </p>
                         <p>
-                            To enable Sourcegraph on <strong>{currentTabStatus.host}</strong>, you must{' '}
-                            <a
-                                href=""
-                                onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
-                                className="request-permissions__test"
-                            >
-                                grant permissions
-                            </a>
+                            You must grant permissions to enable Sourcegraph on <strong>{currentTabStatus.host}</strong>
                             .
                         </p>
+                        <button
+                            type="button"
+                            className="btn btn-outline-info request-permissions__test"
+                            onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
+                        >
+                            Grant permissions
+                        </button>
                     </div>
                 </div>
             )}
+        <div className="options-menu__section">
+            <p>
+                Learn more about privacy concerns, troubleshooting and extension features{' '}
+                <a href="https://docs.sourcegraph.com/integration/browser_extension" target="blank">
+                    here
+                </a>
+                .
+            </p>
+            <p>
+                Search open source software at{' '}
+                <a href="https://sourcegraph.com/search" target="blank">
+                    sourcegraph.com/search
+                </a>
+                .
+            </p>
+        </div>
         {isSettingsOpen && featureFlags && (
             <div className="options-menu__section">
                 <label>Configuration</label>

--- a/browser/src/libs/options/OptionsMenu.tsx
+++ b/browser/src/libs/options/OptionsMenu.tsx
@@ -85,7 +85,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
                         </p>
                         <button
                             type="button"
-                            className="btn btn-outline-info request-permissions__test"
+                            className="btn btn-light request-permissions__test"
                             onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
                         >
                             Grant permissions

--- a/browser/src/libs/options/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/browser/src/libs/options/__snapshots__/OptionsMenu.test.tsx.snap
@@ -90,6 +90,32 @@ exports[`OptionsMenu doesn't render the permissions alert on about://addons 1`] 
       />
     </div>
   </form>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
+  </div>
 </div>
 `;
 
@@ -183,6 +209,32 @@ exports[`OptionsMenu doesn't render the permissions alert on chrome://extensions
       />
     </div>
   </form>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
+  </div>
 </div>
 `;
 
@@ -276,6 +328,32 @@ exports[`OptionsMenu doesn't render the permissions alert on chrome://newtab 1`]
       />
     </div>
   </form>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
+  </div>
 </div>
 `;
 
@@ -369,6 +447,32 @@ exports[`OptionsMenu renders a default state 1`] = `
       />
     </div>
   </form>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
+  </div>
 </div>
 `;
 
@@ -472,22 +576,46 @@ exports[`OptionsMenu renders the current tab permissions alert 1`] = `
         The Sourcegraph browser extension adds hover tooltips to code views on code hosts such as GitHub, GitLab, Bitbucket Server and Phabricator.
       </p>
       <p>
-        To enable Sourcegraph on 
+        You must grant permissions to enable Sourcegraph on 
         <strong>
           gitlab.com
         </strong>
-        , you must
-         
-        <a
-          className="request-permissions__test"
-          href=""
-          onClick={[Function]}
-        >
-          grant permissions
-        </a>
         .
       </p>
+      <button
+        className="btn btn-light request-permissions__test"
+        onClick={[Function]}
+        type="button"
+      >
+        Grant permissions
+      </button>
     </div>
+  </div>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
   </div>
 </div>
 `;
@@ -582,6 +710,32 @@ exports[`OptionsMenu renders the feature flags 1`] = `
       />
     </div>
   </form>
+  <div
+    className="options-menu__section"
+  >
+    <p>
+      Learn more about privacy concerns, troubleshooting and extension features
+       
+      <a
+        href="https://docs.sourcegraph.com/integration/browser_extension"
+        target="blank"
+      >
+        here
+      </a>
+      .
+    </p>
+    <p>
+      Search open source software at
+       
+      <a
+        href="https://sourcegraph.com/search"
+        target="blank"
+      >
+        sourcegraph.com/search
+      </a>
+      .
+    </p>
+  </div>
   <div
     className="options-menu__section"
   >

--- a/browser/src/libs/options/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/browser/src/libs/options/__snapshots__/OptionsMenu.test.tsx.snap
@@ -466,23 +466,27 @@ exports[`OptionsMenu renders the current tab permissions alert 1`] = `
     className="options-menu__section"
   >
     <div
-      className="alert alert-danger"
+      className="alert alert-info"
     >
-      Sourcegraph is not enabled on 
-      <strong>
-        gitlab.com
-      </strong>
-      .
-       
-      <a
-        className="request-permissions__test"
-        href=""
-        onClick={[Function]}
-      >
-        Grant permissions
-      </a>
-       
-      to enable Sourcegraph.
+      <p>
+        The Sourcegraph browser extension adds hover tooltips to code views on code hosts such as GitHub, GitLab, Bitbucket Server and Phabricator.
+      </p>
+      <p>
+        To enable Sourcegraph on 
+        <strong>
+          gitlab.com
+        </strong>
+        , you must
+         
+        <a
+          className="request-permissions__test"
+          href=""
+          onClick={[Function]}
+        >
+          grant permissions
+        </a>
+        .
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/CMT39K56Z/p1589217077358500

A user got concerned when seeing the "grant permissions" notification on a non-GitHub site, thinking that he needed to do it, and uninstalled the browser extension as a result.

This makes the warning more informative, explaining why this is necessary, and on which type of site.

![image](https://user-images.githubusercontent.com/1741180/81656779-9b6dd500-9437-11ea-84a7-43098cda1ee5.png)
