### PR TITLE
Fix link to repo branch in dropdown list

### DIFF
--- a/web/src/repo/GitRef.tsx
+++ b/web/src/repo/GitRef.tsx
@@ -32,7 +32,7 @@ export const GitRefNode: React.FunctionComponent<GitRefNodeProps> = ({ node, url
     url = url !== undefined ? url : node.url
 
     return (
-        <LinkOrSpan key={node.id} className="git-ref-node list-group-item" to={!ancestorIsLink ? url : undefined}>
+        <LinkOrSpan key={node.id} className="git-ref-node list-group-item" to={ancestorIsLink ? url : undefined}>
             <span>
                 <code className="git-ref-tag-2">{node.displayName}</code>
                 {mostRecentSig && (

--- a/web/src/repo/GitRef.tsx
+++ b/web/src/repo/GitRef.tsx
@@ -32,7 +32,7 @@ export const GitRefNode: React.FunctionComponent<GitRefNodeProps> = ({ node, url
     url = url !== undefined ? url : node.url
 
     return (
-        <LinkOrSpan key={node.id} className="git-ref-node list-group-item" to={ancestorIsLink ? url : undefined}>
+        <LinkOrSpan key={node.id} className="git-ref-node list-group-item" to={!ancestorIsLink ? url : undefined}>
             <span>
                 <code className="git-ref-tag-2">{node.displayName}</code>
                 {mostRecentSig && (

--- a/web/src/repo/RevisionsPopover.tsx
+++ b/web/src/repo/RevisionsPopover.tsx
@@ -90,7 +90,7 @@ const GitRefPopoverNode: React.FunctionComponent<GitRefPopoverNodeProps> = ({
         <GitRefNode
             node={node}
             url={replaceRevisionInURL(location.pathname + location.search + location.hash, node.abbrevName)}
-            ancestorIsLink={true}
+            ancestorIsLink={false}
         >
             {isCurrent && (
                 <CircleChevronLeftIcon


### PR DESCRIPTION
Fixes issue #10590

The parent component incorrectly specifies that there is an anchor tag parent higher up the component tree.

~~The bus was introduced in [this commit](https://github.com/sourcegraph/sourcegraph/commit/681dafc36653412bdc136317878638ae42795c0d#diff-d28dde6255157602446aad74a38943aeR35).~~

~~If I was working on the project regularly I'd have raised another small PR with a refactor around the types to catch this sort of thing in future more effectively, but I don't want to step on any toes :)~~