### PR TITLE
campaigns: Clarify BitbucketServer Unapprove and Dismiss event handling

### DIFF
--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -172,7 +172,7 @@ func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, 
 			}
 
 			if e.Type() == campaigns.ChangesetEventKindBitbucketServerDismissed {
-				// A BitbucketServer Dismissed event can only follow a previous Review requesting changes by
+				// A BitbucketServer Dismissed event can only follow a previous "Changes Requested" review by
 				// the same author.
 				lastReview, ok := lastReviewByAuthor[author]
 				if !ok || lastReview != campaigns.ChangesetReviewStateChangesRequested {

--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -101,8 +101,7 @@ func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, 
 
 		case campaigns.ChangesetEventKindGitHubReviewed,
 			campaigns.ChangesetEventKindBitbucketServerApproved,
-			campaigns.ChangesetEventKindBitbucketServerReviewed,
-			campaigns.ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
+			campaigns.ChangesetEventKindBitbucketServerReviewed:
 
 			s, err := e.ReviewState()
 			if err != nil {
@@ -144,13 +143,16 @@ func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, 
 				pushStates(et)
 			}
 
-		case campaigns.ChangesetEventKindBitbucketServerUnapproved:
+		case campaigns.ChangesetEventKindGitHubReviewDismissed:
 			// We specifically ignore ChangesetEventKindGitHubReviewDismissed
 			// events since GitHub updates the original
 			// ChangesetEventKindGitHubReviewed event when a review has been
 			// dismissed.
 			// See: https://github.com/sourcegraph/sourcegraph/pull/9461
+			continue
 
+		case campaigns.ChangesetEventKindBitbucketServerUnapproved,
+			campaigns.ChangesetEventKindBitbucketServerDismissed:
 			author, err := e.ReviewAuthor()
 			if err != nil {
 				return nil, err
@@ -169,12 +171,12 @@ func computeHistory(ch *cmpgn.Changeset, ce ChangesetEvents) (changesetHistory, 
 				}
 			}
 
-			if e.Type() == campaigns.ChangesetEventKindGitHubReviewDismissed {
-				// A GitHub Review Dismissed can only follow a previous review by
-				// the author of the review included in the event.
-				_, ok := lastReviewByAuthor[author]
-				if !ok {
-					log15.Warn("GitHub review dismissal not following a review", "event", e)
+			if e.Type() == campaigns.ChangesetEventKindBitbucketServerDismissed {
+				// A BitbucketServer Dismissed event can only follow a previous Review requesting changes by
+				// the same author.
+				lastReview, ok := lastReviewByAuthor[author]
+				if !ok || lastReview != campaigns.ChangesetReviewStateChangesRequested {
+					log15.Warn("Bitbucket Server Dismissal not following a Review", "event", e)
 					continue
 				}
 			}

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -414,7 +414,7 @@ func TestCalcCounts(t *testing.T) {
 			start: daysAgo(4),
 			events: []*campaigns.ChangesetEvent{
 				bbsActivity(1, daysAgo(2), "user1", campaigns.ChangesetEventKindBitbucketServerReviewed),
-				bbsParticipantEvent(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerParticipationStatusUnapproved),
+				bbsParticipantEvent(1, daysAgo(1), "user1", campaigns.ChangesetEventKindBitbucketServerDismissed),
 			},
 			want: []*ChangesetCounts{
 				{Time: daysAgo(4), Total: 0, Open: 0},

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -407,7 +407,7 @@ func TestCalcCounts(t *testing.T) {
 		},
 		{
 			codehosts: "bitbucketserver",
-			name:      "single changeset open, reviewed, unapproved",
+			name:      "single changeset open, changes-requested, unapproved",
 			changesets: []*campaigns.Changeset{
 				bbsChangeset(1, daysAgo(3)),
 			},

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1295,8 +1295,8 @@ const (
 	ChangesetEventKindBitbucketServerMerged       ChangesetEventKind = "bitbucketserver:merged"
 	ChangesetEventKindBitbucketServerCommitStatus ChangesetEventKind = "bitbucketserver:commit_status"
 
-	// BitbucketServer calls this an "Unapprove" event but we've called it Dismissed to more
-	// clearly convey that it only occurs when a request for changes has been removed.
+	// BitbucketServer calls this an Unapprove event but we've called it Dismissed to more
+	// clearly convey that it only occurs when a request for changes has been dismissed.
 	ChangesetEventKindBitbucketServerDismissed ChangesetEventKind = "bitbucketserver:participant_status:unapproved"
 )
 

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -665,7 +665,7 @@ func (e *ChangesetEvent) ReviewState() (ChangesetReviewState, error) {
 
 	case ChangesetEventKindGitHubReviewDismissed,
 		ChangesetEventKindBitbucketServerUnapproved,
-		ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
+		ChangesetEventKindBitbucketServerDismissed:
 		return ChangesetReviewStateDismissed, nil
 
 	default:
@@ -1209,7 +1209,7 @@ func NewChangesetEventMetadata(k ChangesetEventKind) (interface{}, error) {
 		switch k {
 		case ChangesetEventKindBitbucketServerCommitStatus:
 			return new(bitbucketserver.CommitStatus), nil
-		case ChangesetEventKindBitbucketServerParticipationStatusUnapproved:
+		case ChangesetEventKindBitbucketServerDismissed:
 			return new(bitbucketserver.ParticipantStatusEvent), nil
 		default:
 			return new(bitbucketserver.Activity), nil
@@ -1295,7 +1295,9 @@ const (
 	ChangesetEventKindBitbucketServerMerged       ChangesetEventKind = "bitbucketserver:merged"
 	ChangesetEventKindBitbucketServerCommitStatus ChangesetEventKind = "bitbucketserver:commit_status"
 
-	ChangesetEventKindBitbucketServerParticipationStatusUnapproved ChangesetEventKind = "bitbucketserver:participant_status:unapproved"
+	// BitbucketServer calls this an "Unapprove" event but we've called it Dismissed to more
+	// clearly convey that it only occurs when a request for changes has been removed.
+	ChangesetEventKindBitbucketServerDismissed ChangesetEventKind = "bitbucketserver:participant_status:unapproved"
 )
 
 // ChangesetSyncData represents data about the sync status of a changeset


### PR DESCRIPTION
Related to comments left on a previous PR:
https://github.com/sourcegraph/sourcegraph/pull/10420#pullrequestreview-406458891