### PR TITLE
codeintel: Reduce chance of creating unknown database on open

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -282,7 +282,7 @@ func (s *Server) dbQueryErr(w http.ResponseWriter, r *http.Request, handler dbQu
 			return nil, pkgerrors.Wrap(err, "database.OpenDatabase")
 		}
 
-		return s.wrapDatabase(database, filename), nil
+		return s.wrapDatabase(database), nil
 	}
 
 	cacheHandler := func(db database.Database) error {
@@ -302,6 +302,6 @@ func (s *Server) wrapReader(innerReader reader.Reader) reader.Reader {
 	return reader.NewObserved(innerReader, s.observationContext)
 }
 
-func (s *Server) wrapDatabase(innerDatabase database.Database, filename string) database.Database {
+func (s *Server) wrapDatabase(innerDatabase database.Database) database.Database {
 	return database.NewObserved(innerDatabase, s.observationContext)
 }


### PR DESCRIPTION
If the bundle manager is queried with an unknown database, the sqlite driver will create a new, empty database and will immediately fail. We should instead ensure that the file exists before opening, and return a 404 otherwise.
