### PR TITLE
codeintel: Add context in logs for bundle manager errors

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
@@ -267,5 +267,5 @@ func openTestDatabase(t *testing.T) Database {
 	t.Cleanup(func() { _ = db.Close })
 
 	// Wrap in observed, as that's how it's used in production
-	return NewObserved(db, &observation.TestContext)
+	return NewObserved(db, filename, &observation.TestContext)
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -11,6 +12,7 @@ import (
 // An ObservedDatabase wraps another Database with error logging, Prometheus metrics, and tracing.
 type ObservedDatabase struct {
 	database                    Database
+	filename                    string
 	existsOperation             *observation.Operation
 	definitionsOperation        *observation.Operation
 	referencesOperation         *observation.Operation
@@ -28,7 +30,7 @@ var _ Database = &ObservedDatabase{}
 var singletonMetrics = &metrics.SingletonOperationMetrics{}
 
 // NewObservedDatabase wraps the given Database with error logging, Prometheus metrics, and tracing.
-func NewObserved(database Database, observationContext *observation.Context) Database {
+func NewObserved(database Database, filename string, observationContext *observation.Context) Database {
 	metrics := singletonMetrics.Get(func() *metrics.OperationMetrics {
 		return metrics.NewOperationMetrics(
 			observationContext.Registerer,
@@ -40,6 +42,7 @@ func NewObserved(database Database, observationContext *observation.Context) Dat
 
 	return &ObservedDatabase{
 		database: database,
+		filename: filename,
 		existsOperation: observationContext.Operation(observation.Op{
 			Name:         "Database.Exists",
 			MetricLabels: []string{"exists"},
@@ -85,35 +88,66 @@ func (db *ObservedDatabase) Close() error {
 
 // Exists calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) Exists(ctx context.Context, path string) (_ bool, err error) {
-	ctx, endObservation := db.existsOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.existsOperation.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("filename", db.filename),
+		log.String("path", path),
+	}})
 	defer endObservation(1, observation.Args{})
 	return db.database.Exists(ctx, path)
 }
 
 // Definitions calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) Definitions(ctx context.Context, path string, line, character int) (definitions []Location, err error) {
-	ctx, endObservation := db.definitionsOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.definitionsOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("path", path),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
 	defer func() { endObservation(float64(len(definitions)), observation.Args{}) }()
 	return db.database.Definitions(ctx, path, line, character)
 }
 
 // References calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) References(ctx context.Context, path string, line, character int) (references []Location, err error) {
-	ctx, endObservation := db.referencesOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.referencesOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("path", path),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
 	defer func() { endObservation(float64(len(references)), observation.Args{}) }()
 	return db.database.References(ctx, path, line, character)
 }
 
 // Hover calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, character int) (_ string, _ Range, _ bool, err error) {
-	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("path", path),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
 	defer endObservation(1, observation.Args{})
 	return db.database.Hover(ctx, path, line, character)
 }
 
 // MonikersByPosition calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string, line, character int) (monikers [][]types.MonikerData, err error) {
-	ctx, endObservation := db.monikersByPositionOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.monikersByPositionOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("path", path),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
 	defer func() {
 		count := 0
 		for _, group := range monikers {
@@ -128,14 +162,27 @@ func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string,
 
 // MonikerResults calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (locations []Location, _ int, err error) {
-	ctx, endObservation := db.monikerResultsOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.monikerResultsOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("tableName", tableName),
+			log.String("scheme", scheme),
+			log.String("identifier", identifier),
+		},
+	})
 	defer func() { endObservation(float64(len(locations)), observation.Args{}) }()
 	return db.database.MonikerResults(ctx, tableName, scheme, identifier, skip, take)
 }
 
 // PackageInformation calls into the inner Database and registers the observed results.
 func (db *ObservedDatabase) PackageInformation(ctx context.Context, path string, packageInformationID types.ID) (_ types.PackageInformationData, _ bool, err error) {
-	ctx, endObservation := db.packageInformationOperation.With(ctx, &err, observation.Args{})
+	ctx, endObservation := db.packageInformationOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("path", path),
+			log.String("packageInformationId", string(packageInformationID)),
+		},
+	})
 	defer endObservation(1, observation.Args{})
 	return db.database.PackageInformation(ctx, path, packageInformationID)
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -260,7 +260,7 @@ func (s *Server) dbQueryErr(w http.ResponseWriter, r *http.Request, handler dbQu
 			return nil, pkgerrors.Wrap(err, "database.OpenDatabase")
 		}
 
-		return s.wrapDatabase(database), nil
+		return s.wrapDatabase(database, filename), nil
 	}
 
 	cacheHandler := func(db database.Database) error {
@@ -280,6 +280,6 @@ func (s *Server) wrapReader(innerReader reader.Reader) reader.Reader {
 	return reader.NewObserved(innerReader, s.observationContext)
 }
 
-func (s *Server) wrapDatabase(innerDatabase database.Database) database.Database {
-	return database.NewObserved(innerDatabase, s.observationContext)
+func (s *Server) wrapDatabase(innerDatabase database.Database, filename string) database.Database {
+	return database.NewObserved(innerDatabase, filename, s.observationContext)
 }


### PR DESCRIPTION
Bundle manager error messages are useless unless we know what filename errors are coming from.