### PR TITLE
Fix pattern type redirection

### DIFF
--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -53,9 +53,8 @@ export function isQuoted(value: string): boolean {
  * Replaces a substring within a string.
  *
  * @param s Original string
- * @param start starting index of the substring to be replaced
- * @param end starting index of the substring to be replaced
- * @param an optional replacement string
+ * @param range The range in of the substring to be replaced
+ * @param replacement an optional replacement string
  */
 export function replaceRange(s: string, { start, end }: { start: number; end: number }, replacement = ''): string {
     return s.slice(0, start) + replacement + s.slice(end)

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -331,10 +331,28 @@ describe('buildSearchURLQuery', () => {
         expect(buildSearchURLQuery('repo:foo/bar', SearchPatternType.regexp, false)).toBe(
             'q=repo:foo/bar&patternType=regexp'
         ))
-    it('overrides the patternType parameter if a patternType field exists in the query', () =>
-        expect(buildSearchURLQuery('foo patternType:literal', SearchPatternType.regexp, false)).toBe(
-            'q=foo+&patternType=literal'
-        ))
+    describe('removal of patternType parameter', () => {
+        it('overrides the patternType parameter at the end', () => {
+            expect(buildSearchURLQuery('foo patternType:literal', SearchPatternType.regexp, false)).toBe(
+                'q=foo&patternType=literal'
+            )
+        })
+        it('overrides the patternType parameter at the beginning', () => {
+            expect(buildSearchURLQuery('patternType:literal foo type:diff', SearchPatternType.regexp, false)).toBe(
+                'q=foo+type:diff&patternType=literal'
+            )
+        })
+        it('overrides the patternType parameter at the end with another operator', () => {
+            expect(buildSearchURLQuery('type:diff foo patternType:literal', SearchPatternType.regexp, false)).toBe(
+                'q=type:diff+foo&patternType=literal'
+            )
+        })
+        it('overrides the patternType parameter in the middle', () => {
+            expect(buildSearchURLQuery('type:diff patternType:literal foo', SearchPatternType.regexp, false)).toBe(
+                'q=type:diff+foo&patternType=literal'
+            )
+        })
+    })
     it('builds the URL query with a case parameter if caseSensitive is true', () =>
         expect(buildSearchURLQuery('foo', SearchPatternType.literal, true)).toBe('q=foo&patternType=literal&case=yes'))
     it('appends the case parameter if `case:yes` exists in the query', () =>

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -577,12 +577,13 @@ export function buildSearchURLQuery(
     let fullQuery = query
 
     if (filtersInQuery && !isEmpty(filtersInQuery)) {
-        fullQuery = [fullQuery, generateFiltersQuery(filtersInQuery)].filter(query => query.length > 0).join(' ')
+        fullQuery = [generateFiltersQuery(filtersInQuery), fullQuery].filter(query => query.length > 0).join(' ')
     }
 
     const patternTypeInQuery = parsePatternTypeFromQuery(fullQuery)
     if (patternTypeInQuery) {
-        fullQuery = replaceRange(fullQuery, patternTypeInQuery.range)
+        const { start, end } = patternTypeInQuery.range
+        fullQuery = replaceRange(fullQuery, { start: Math.max(0, start - 1), end }).trim()
         searchParams.set('q', fullQuery)
         searchParams.set('patternType', patternTypeInQuery.value)
     } else {
@@ -627,10 +628,9 @@ export function buildSearchURLQuery(
  * @param filtersInQuery the map representing the filters currently in an interactive mode query.
  */
 export function generateFiltersQuery(filtersInQuery: FiltersToTypeAndValue): string {
-    const fieldKeys = Object.keys(filtersInQuery)
-    return fieldKeys
-        .filter(key => filtersInQuery[key].value.trim().length > 0)
-        .map(key => `${filtersInQuery[key].negated ? '-' : ''}${filtersInQuery[key].type}:${filtersInQuery[key].value}`)
+    return Object.values(filtersInQuery)
+        .filter(filter => filter.value.trim().length > 0)
+        .map(filter => `${filter.negated ? '-' : ''}${filter.type}:${filter.value}`)
         .join(' ')
 }
 

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -100,7 +100,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
             const newLoc =
                 '/search?' +
                 buildSearchURLQuery(navbarQuery, GQL.SearchPatternType.regexp, this.props.caseSensitive, filtersInQuery)
-            window.location.replace(newLoc)
+            this.props.history.replace(newLoc)
         }
 
         this.props.telemetryService.logViewEvent('SearchResults')


### PR DESCRIPTION
This was a UX problem for search insights, because it links to queries including the `patternType` operator. Review commit by commit.