### PR TITLE
codeintel: Ensure paths respect root when checking existence in git

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestPrune(t *testing.T) {
 	gitContentsOracle := map[string][]string{
-		"root":     {"sub/", "foo.go", "bar.go"},
-		"root/sub": {"sub/baz.go"},
+		"root":     {"root/sub/", "root/foo.go", "root/bar.go"},
+		"root/sub": {"root/sub/baz.go"},
 	}
 
 	getChildren := func(dirnames []string) (map[string][]string, error) {

--- a/cmd/precise-code-intel-worker/internal/existence/existence_checker.go
+++ b/cmd/precise-code-intel-worker/internal/existence/existence_checker.go
@@ -23,7 +23,9 @@ func NewExistenceChecker(root string, paths []string, getChildren GetChildrenFun
 
 // Exists determines if the given path exists in the git clone at the target commit.
 func (ec *ExistenceChecker) Exists(path string) bool {
-	if children, ok := ec.directoryContents[dirWithoutDot(filepath.Join(ec.root, path))]; ok {
+	path = filepath.Join(ec.root, path)
+
+	if children, ok := ec.directoryContents[dirWithoutDot(path)]; ok {
 		if _, ok := children[path]; ok {
 			return true
 		}


### PR DESCRIPTION
Forgot to prepend the root into paths when checking their existence in git. Currently any LSIF upload with a non-nil root will evict all contents as it doesn't think any of the files exist in the repo.

This now matches the previous behavior.