### PR TITLE
codeintel: Update scanCommits to handle null parent commits

### DIFF
--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -56,6 +56,10 @@ func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits m
 		}
 	}
 
+	if len(unknownCommits) == 0 {
+		return nil
+	}
+
 	var rows []*sqlf.Query
 	for commit, parents := range unknownCommits {
 		for _, parent := range parents {

--- a/internal/codeintel/db/commits_test.go
+++ b/internal/codeintel/db/commits_test.go
@@ -173,6 +173,32 @@ func TestUpdateCommitsWithOverlap(t *testing.T) {
 	}
 }
 
+func TestUpdateCommitsNoUnknownData(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := testDB()
+
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(1)},
+		makeCommit(4): {makeCommit(2), makeCommit(3)},
+	}); err != nil {
+		t.Fatalf("unexpected error updating commits: %s", err)
+	}
+
+	if err := db.UpdateCommits(context.Background(), 50, map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(1)},
+		makeCommit(4): {makeCommit(2), makeCommit(3)},
+	}); err != nil {
+		t.Fatalf("unexpected error updating commits: %s", err)
+	}
+}
+
 func strPtr(v string) *string {
 	return &v
 }

--- a/internal/codeintel/db/scan.go
+++ b/internal/codeintel/db/scan.go
@@ -280,8 +280,8 @@ func scanVisibilities(rows *sql.Rows, err error) (map[int]bool, error) {
 	return visibilities, nil
 }
 
-// scanCommit populates a pair of strings from teh given scanner.
-func scanCommit(scanner scanner) (commit, parentCommit string, err error) {
+// scanCommit populates a pair of strings from the given scanner.
+func scanCommit(scanner scanner) (commit string, parentCommit *string, err error) {
 	err = scanner.Scan(&commit, &parentCommit)
 	return commit, parentCommit, err
 }
@@ -302,7 +302,13 @@ func scanCommits(rows *sql.Rows, err error) (map[string][]string, error) {
 			return nil, err
 		}
 
-		commits[commit] = append(commits[commit], parentCommit)
+		if _, ok := commits[commit]; !ok {
+			commits[commit] = nil
+		}
+
+		if parentCommit != nil {
+			commits[commit] = append(commits[commit], *parentCommit)
+		}
 	}
 
 	return commits, nil


### PR DESCRIPTION
We currently crash the query on null parents. Update tests to actually this this eege case.