### PR TITLE
codeintel: Ensure we serialize all referenced result ids

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/group.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/group.go
@@ -184,6 +184,13 @@ func addToChunk(state *State, resultChunks []types.ResultChunkData, data map[str
 	for id, documentRanges := range data {
 		resultChunk := resultChunks[types.HashKey(types.ID(id), len(resultChunks))]
 
+		if len(documentRanges) == 0 {
+			// We may have pruned all document/ranges from a definition or reference result,
+			// but we add a dummy set here so that we don't hit an unknown key during queries.
+			// TODO(efritz) - remove these as part of the prune pass instead
+			resultChunk.DocumentIDRangeIDs[types.ID(id)] = nil
+		}
+
 		for documentID, rangeIDs := range documentRanges {
 			doc := state.DocumentData[documentID]
 			resultChunk.DocumentPaths[types.ID(documentID)] = doc.URI


### PR DESCRIPTION
We may prune all of the data from a result set, but still reference it. This causes the bundle manager to 500 when it can't find the wanted identifier.

This ensures that an empty result set is serialized. I'll have a cleanup PR later to address the todo. A longer-term solution is to remove all references from empty result sets, not to serialize them.