### PR TITLE
codeintel: Write to the lsif_commits table in a deterministic order

### DIFF
--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"sort"
 
 	"github.com/keegancsmith/sqlf"
 )
@@ -56,13 +57,26 @@ func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits m
 		}
 	}
 
+	// Make the order in which we construct the values for insertion determinstic.
+	// We want this to happen because many workers/api-servers can be inserting
+	// commits for the same repository. Having them inserted in random order may
+	// cause a dealock to occur where two threads are writing the same tuples in
+	// different orders: e.g. A writes t1 then t2, and B writes t2 then t1. If we
+	// always write in the same order, then such a deadlock is impossible.
+	var keys []string
+	for commit, parentCommits := range unknownCommits {
+		keys = append(keys, commit)
+		sort.Strings(parentCommits)
+	}
+	sort.Strings(keys)
+
 	var rows []*sqlf.Query
-	for commit, parents := range unknownCommits {
-		for _, parent := range parents {
+	for _, commit := range keys {
+		for _, parent := range unknownCommits[commit] {
 			rows = append(rows, sqlf.Sprintf("(%d, %s, %s)", repositoryID, commit, parent))
 		}
 
-		if len(parents) == 0 {
+		if len(unknownCommits[commit]) == 0 {
 			// Insert a commit even if its parent is not known
 			rows = append(rows, sqlf.Sprintf("(%d, %s, NULL)", repositoryID, commit))
 		}

--- a/internal/codeintel/db/commits.go
+++ b/internal/codeintel/db/commits.go
@@ -60,7 +60,7 @@ func (db *dbImpl) UpdateCommits(ctx context.Context, repositoryID int, commits m
 	if len(unknownCommits) == 0 {
 		return nil
 	}
-  
+
 	// Make the order in which we construct the values for insertion determinstic.
 	// We want this to happen because many workers/api-servers can be inserting
 	// commits for the same repository. Having them inserted in random order may

--- a/internal/codeintel/db/dumps.go
+++ b/internal/codeintel/db/dumps.go
@@ -54,7 +54,7 @@ func (db *dbImpl) FindClosestDumps(ctx context.Context, repositoryID int, commit
 		defer func() { err = tx.Done(err) }()
 	}
 
-	ids, err := scanInts(tx.query(
+	ids, err := scanInts(tx.querys(
 		ctx,
 		withBidirectionalLineage(`
 			SELECT d.dump_id FROM lineage_with_dumps d

--- a/internal/codeintel/db/dumps.go
+++ b/internal/codeintel/db/dumps.go
@@ -54,7 +54,7 @@ func (db *dbImpl) FindClosestDumps(ctx context.Context, repositoryID int, commit
 		defer func() { err = tx.Done(err) }()
 	}
 
-	ids, err := scanInts(tx.querys(
+	ids, err := scanInts(tx.query(
 		ctx,
 		withBidirectionalLineage(`
 			SELECT d.dump_id FROM lineage_with_dumps d


### PR DESCRIPTION
Reduce deadlock probability by always writing tuples in a deterministic order. This should (hopefully) make it impossible for two threads to be blocked on writing the same tuples.

This was tested with the following script. A deadlock occurred immediately on the first attempt without this change, and went a few dozen rounds without error afterwards:

```go
func TestDeadlockPrevention(t *testing.T) {
	if testing.Short() {
		t.Skip()
	}
	dbtesting.SetupGlobalTestDB(t)
	db := testDB()

	commits := map[string][]string{}
	for i := 0; i < 10000; i++ {
		commits[makeCommit(i)] = []string{makeCommit(i + 1), makeCommit(i + 2)}
	}

	i := 0

	f := func() {
		errs := make(chan error)

		tx1, err1 := db.Transact(context.Background())
		if err1 != nil {
			t.Fatal(err1)
		}

		tx2, err2 := db.Transact(context.Background())
		if err2 != nil {
			t.Fatal(err2)
		}

		go func() {
			errs <- tx1.UpdateCommits(context.Background(), i, commits)
			errs <- tx1.Done(nil)
		}()

		go func() {
			errs <- tx2.UpdateCommits(context.Background(), i, commits)
			errs <- tx2.Done(nil)
		}()

		for i := 0; i < 4; i++ {
			if err := <-errs; err != nil {
				t.Fatal(err)
			}
		}
		close(errs)
	}

	for {
		f()
		i++
	}
}
```