### PR TITLE
search: fork/archived UI notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- The search results page now shows a small UI notification if either repository forks or archives are excluded, when `fork` or `archived` options are not explicitly set. [#10624](https://github.com/sourcegraph/sourcegraph/pull/10624)
+
 ### Changed
 
 ### Fixed

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1322,7 +1322,7 @@ type SearchResults {
     repositoriesCount: Int!
     # Repositories that were actually searched. Excludes repositories that would have been searched but were not
     # because a timeout or error occurred while performing the search, or because the result limit was already
-    # reached.
+    # reached, or because they were excluded due to being forks or archives.
     #
     # In paginated search requests, this represents the set of repositories searched for the
     # individual paginated request / input cursor and not the global set of repositories that

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1329,7 +1329,7 @@ type SearchResults {
     repositoriesCount: Int!
     # Repositories that were actually searched. Excludes repositories that would have been searched but were not
     # because a timeout or error occurred while performing the search, or because the result limit was already
-    # reached.
+    # reached, or because they were excluded due to being forks or archives.
     #
     # In paginated search requests, this represents the set of repositories searched for the
     # individual paginated request / input cursor and not the global set of repositories that

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -39,7 +39,7 @@ import (
 
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
-var mockResolveRepositories func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error)
+var mockResolveRepositories func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, excludedRepos *excludedRepos, overLimit bool, err error)
 
 func maxReposToSearch() int {
 	switch max := conf.Get().MaxReposToSearch; {
@@ -245,6 +245,7 @@ type searchResolver struct {
 	// Cached resolveRepositories results.
 	reposMu                   sync.Mutex
 	repoRevs, missingRepoRevs []*search.RepositoryRevisions
+	excludedRepos             *excludedRepos
 	repoOverLimit             bool
 	repoErr                   error
 
@@ -365,9 +366,45 @@ func exactlyOneRepo(repoFilters []string) bool {
 	return false
 }
 
+// A type that counts how many repos with a certain label were excluded from search results.
+type excludedRepos = struct {
+	forks    int
+	archived int
+}
+
+// computeExcludedRepositories returns a list of excluded repositories (forks or
+// archives) based on the search query.
+func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.ReposListOptions) (excluded *excludedRepos) {
+	if q == nil {
+		return &excludedRepos{}
+	}
+	var numExcludedForks, numExcludedArchived int
+	forkStr, _ := q.StringValue(query.FieldFork)
+	fork := parseYesNoOnly(forkStr)
+	if fork == Invalid && !exactlyOneRepo(op.IncludePatterns) {
+		// 'fork:...' was not specified and forks are excluded, find out
+		// which repos are excluded.
+		selectForks := op
+		selectForks.OnlyForks = true
+		selectForks.NoForks = false
+		numExcludedForks, _ = db.Repos.Count(ctx, selectForks)
+	}
+	archivedStr, _ := q.StringValue(query.FieldArchived)
+	archived := parseYesNoOnly(archivedStr)
+	if archived == Invalid && !exactlyOneRepo(op.IncludePatterns) {
+		// archived...: was not specified and archives are excluded,
+		// find out which repos are excluded.
+		selectArchived := op
+		selectArchived.OnlyArchived = true
+		selectArchived.NoArchived = false
+		numExcludedArchived, _ = db.Repos.Count(ctx, selectArchived)
+	}
+	return &excludedRepos{forks: numExcludedForks, archived: numExcludedArchived}
+}
+
 // resolveRepositories calls doResolveRepositories, caching the result for the common
 // case where effectiveRepoFieldValues == nil.
-func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
+func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, excludedRepos *excludedRepos, overLimit bool, err error) {
 	if mockResolveRepositories != nil {
 		return mockResolveRepositories(effectiveRepoFieldValues)
 	}
@@ -384,9 +421,9 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	if effectiveRepoFieldValues == nil {
 		r.reposMu.Lock()
 		defer r.reposMu.Unlock()
-		if r.repoRevs != nil || r.missingRepoRevs != nil || r.repoErr != nil {
+		if r.repoRevs != nil || r.missingRepoRevs != nil || r.excludedRepos != nil || r.repoErr != nil {
 			tr.LazyPrintf("cached")
-			return r.repoRevs, r.missingRepoRevs, r.repoOverLimit, r.repoErr
+			return r.repoRevs, r.missingRepoRevs, r.excludedRepos, r.repoOverLimit, r.repoErr
 		}
 	}
 
@@ -398,7 +435,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 
 	settings, err := decodedViewerFinalSettings(ctx)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, nil, false, err
 	}
 	var settingForks, settingArchived bool
 	if v := settings.SearchIncludeForks; v != nil {
@@ -437,7 +474,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	}
 
 	tr.LazyPrintf("resolveRepositories - start")
-	repoRevs, missingRepoRevs, overLimit, err = resolveRepositories(ctx, resolveRepoOp{
+	options := resolveRepoOp{
 		repoFilters:        repoFilters,
 		minusRepoFilters:   minusRepoFilters,
 		repoGroupFilters:   repoGroupFilters,
@@ -449,15 +486,18 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		onlyPrivate:        visibility == query.Private,
 		onlyPublic:         visibility == query.Public,
 		commitAfter:        commitAfter,
-	})
+		query:              r.query,
+	}
+	repoRevs, missingRepoRevs, overLimit, excludedRepos, err = resolveRepositories(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")
 	if effectiveRepoFieldValues == nil {
 		r.repoRevs = repoRevs
 		r.missingRepoRevs = missingRepoRevs
+		r.excludedRepos = excludedRepos
 		r.repoOverLimit = overLimit
 		r.repoErr = err
 	}
-	return repoRevs, missingRepoRevs, overLimit, err
+	return repoRevs, missingRepoRevs, excludedRepos, overLimit, err
 }
 
 // a patternRevspec maps an include pattern to a list of revisions
@@ -565,9 +605,10 @@ type resolveRepoOp struct {
 	commitAfter        string
 	onlyPrivate        bool
 	onlyPublic         bool
+	query              query.QueryInfo
 }
 
-func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, missingRepoRevisions []*search.RepositoryRevisions, overLimit bool, err error) {
+func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, missingRepoRevisions []*search.RepositoryRevisions, overLimit bool, excludedRepos *excludedRepos, err error) {
 	tr, ctx := trace.New(ctx, "resolveRepositories", fmt.Sprintf("%+v", op))
 	defer func() {
 		tr.SetError(err)
@@ -590,7 +631,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	if groupNames := op.repoGroupFilters; len(groupNames) > 0 {
 		groups, err := resolveRepoGroups(ctx)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, nil, err
 		}
 		var patterns []string
 		for _, groupName := range groupNames {
@@ -610,7 +651,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	// revision specs, if they had any.
 	includePatternRevs, err := findPatternRevs(includePatterns)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, nil, err
 	}
 
 	// If a version context is specified, gather the list of repository names
@@ -621,7 +662,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	if len(includePatternRevs) == 0 && op.versionContextName != "" {
 		versionContext, err = resolveVersionContext(op.versionContextName)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, nil, err
 		}
 
 		for _, revision := range versionContext.Revisions {
@@ -636,7 +677,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		}
 		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, getIndexedRepos, excludePatterns)
 		if err != nil {
-			return nil, nil, false, errors.Wrap(err, "getting list of default repos")
+			return nil, nil, false, nil, errors.Wrap(err, "getting list of default repos")
 		}
 	}
 
@@ -648,7 +689,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		}
 	} else {
 		tr.LazyPrintf("Repos.List - start")
-		repos, err = db.Repos.List(ctx, db.ReposListOptions{
+		options := db.ReposListOptions{
 			OnlyRepoIDs:     true,
 			IncludePatterns: includePatterns,
 			Names:           versionContextRepositories,
@@ -661,10 +702,12 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 			OnlyArchived: op.onlyArchived,
 			NoPrivate:    op.onlyPublic,
 			OnlyPrivate:  op.onlyPrivate,
-		})
+		}
+		excludedRepos = computeExcludedRepositories(ctx, op.query, options)
+		repos, err = db.Repos.List(ctx, options)
 		tr.LazyPrintf("Repos.List - done")
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, nil, err
 		}
 	}
 	overLimit = len(repos) >= maxRepoListSize
@@ -748,7 +791,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		repoRevisions, err = filterRepoHasCommitAfter(ctx, repoRevisions, op.commitAfter)
 	}
 
-	return repoRevisions, missingRepoRevisions, overLimit, err
+	return repoRevisions, missingRepoRevisions, overLimit, excludedRepos, err
 }
 
 type indexedReposFunc func(ctx context.Context, revs []*search.RepositoryRevisions) (indexed, unindexed []*search.RepositoryRevisions, err error)
@@ -873,7 +916,7 @@ func optimizeRepoPatternWithHeuristics(repoPattern string) string {
 }
 
 func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*searchSuggestionResolver, error) {
-	repos, _, overLimit, err := r.resolveRepositories(ctx, nil)
+	repos, _, _, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -131,7 +131,7 @@ func alertForQuotesInQueryInLiteralMode(p syntax.ParseTree) *searchAlert {
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func reposExist(ctx context.Context, options resolveRepoOp) bool {
-	repos, _, _, err := resolveRepositories(ctx, options)
+	repos, _, _, _, err := resolveRepositories(ctx, options)
 	return err == nil && len(repos) > 0
 }
 
@@ -387,7 +387,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 		}
 	}
 
-	repos, _, _, _ := r.resolveRepositories(ctx, nil)
+	repos, _, _, _, _ := r.resolveRepositories(ctx, nil)
 	if len(repos) > 0 {
 		paths := make([]string, len(repos))
 		pathPatterns := make([]string, len(repos))
@@ -418,7 +418,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 			repoFieldValues = append(repoFieldValues, repoParentPattern)
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
-			_, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
+			_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
 			if ctx.Err() != nil {
 				continue
 			} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -222,11 +222,11 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	}
 
 	setMockResolveRepositories := func(numRepos int) {
-		mockResolveRepositories = func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
+		mockResolveRepositories = func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, excludedRepos *excludedRepos, overLimit bool, err error) {
 			calledResolveRepositories = true
 			missingRepoRevs = make([]*search.RepositoryRevisions, 0)
 			repoRevs = generateRepoRevs(numRepos)
-			return repoRevs, missingRepoRevs, true, nil
+			return repoRevs, missingRepoRevs, excludedRepos, true, nil
 		}
 	}
 	defer func() { mockResolveRepositories = nil }()

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -132,7 +132,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	repos, missingRepoRevs, alertResult, err := r.determineRepos(ctx, tr, start)
+	repos, missingRepoRevs, _, alertResult, err := r.determineRepos(ctx, tr, start)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,14 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	}
 	common.update(*fileCommon)
 
-	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d timedout=%d", len(results), common.limitHit, len(common.cloning), len(common.missing), len(common.timedout))
+	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d excludedFork=%d excludedArchived=%d timedout=%d",
+		len(results),
+		common.limitHit,
+		len(common.cloning),
+		len(common.missing),
+		common.excluded.forks,
+		common.excluded.archived,
+		len(common.timedout))
 
 	// Alert is a potential alert shown to the user.
 	var alert *searchAlert
@@ -559,6 +566,8 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 	final.indexed = doAppend(final.indexed, common.indexed)
 	final.cloning = doAppend(final.cloning, common.cloning)
 	final.missing = doAppend(final.missing, common.missing)
+	final.excluded.forks = final.excluded.forks + common.excluded.forks
+	final.excluded.archived = final.excluded.archived + common.excluded.archived
 	final.timedout = doAppend(final.timedout, common.timedout)
 	return final
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -54,6 +54,7 @@ type searchResultsCommon struct {
 	indexed  []*types.Repo             // repos that were searched using an index
 	cloning  []*types.Repo             // repos that could not be searched because they were still being cloned
 	missing  []*types.Repo             // repos that could not be searched because they do not exist
+	excluded excludedRepos             // repo counts of excluded repos because the search query doesn't apply to them, but that we want to know about (forks, archives)
 	partial  map[api.RepoName]struct{} // repos that were searched, but have results that were not returned due to exceeded limits
 
 	maxResultsCount, resultCount int32
@@ -122,6 +123,8 @@ func (c *searchResultsCommon) update(other searchResultsCommon) {
 	c.indexed = append(c.indexed, other.indexed...)
 	c.cloning = append(c.cloning, other.cloning...)
 	c.missing = append(c.missing, other.missing...)
+	c.excluded.forks = c.excluded.forks + other.excluded.forks
+	c.excluded.archived = c.excluded.archived + other.excluded.archived
 	c.timedout = append(c.timedout, other.timedout...)
 	c.resultCount += other.resultCount
 
@@ -275,6 +278,12 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 		}
 	}
 
+	if sr.searchResultsCommon.excluded.forks > 0 {
+		add("fork:yes", "fork:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo")
+	}
+	if sr.searchResultsCommon.excluded.archived > 0 {
+		add("archived:yes", "archived:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo")
+	}
 	for _, result := range sr.SearchResults {
 		if fm, ok := result.ToFileMatch(); ok {
 			rev := ""
@@ -1282,27 +1291,27 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceO
 	return resultTypes
 }
 
-func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (repos, missingRepoRevs []*search.RepositoryRevisions, res *SearchResultsResolver, err error) {
-	repos, missingRepoRevs, overLimit, err := r.resolveRepositories(ctx, nil)
+func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (repos, missingRepoRevs []*search.RepositoryRevisions, excludedRepos *excludedRepos, res *SearchResultsResolver, err error) {
+	repos, missingRepoRevs, excludedRepos, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		if errors.Is(err, authz.ErrStalePermissions{}) {
 			log15.Debug("searchResolver.determineRepos", "err", err)
 			alert := alertForStalePermissions()
-			return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
+			return nil, nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 		}
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	tr.LazyPrintf("searching %d repos, %d missing", len(repos), len(missingRepoRevs))
 	if len(repos) == 0 {
 		alert := r.alertForNoResolvedRepos(ctx)
-		return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
+		return nil, nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 	}
 	if overLimit {
 		alert := r.alertForOverRepoLimit(ctx)
-		return nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
+		return nil, nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 	}
-	return repos, missingRepoRevs, nil, nil
+	return repos, missingRepoRevs, excludedRepos, nil, nil
 }
 
 // Surface an alert if a query exceeds limits that we place on search. Currently limits
@@ -1354,7 +1363,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 	defer cancel()
 
-	repos, missingRepoRevs, alertResult, err := r.determineRepos(ctx, tr, start)
+	repos, missingRepoRevs, excludedRepos, alertResult, err := r.determineRepos(ctx, tr, start)
 	if err != nil {
 		return nil, err
 	}
@@ -1430,6 +1439,10 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			return &requiredWg
 		}
 		return &optionalWg
+	}
+
+	if excludedRepos != nil {
+		common.excluded = *excludedRepos
 	}
 
 	// Apply search limits and generate warnings before firing off workers.
@@ -1678,7 +1691,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 
 	timer.Stop()
 
-	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d timedout=%d", len(results), common.limitHit, len(common.cloning), len(common.missing), len(common.timedout))
+	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d excludedFork=%d excludedArchived=%d timedout=%d",
+		len(results),
+		common.limitHit,
+		len(common.cloning),
+		len(common.missing),
+		common.excluded.forks,
+		common.excluded.archived,
+		len(common.timedout))
 
 	multiErr, newAlert := alertForStructuralSearch(multiErr)
 	if newAlert != nil {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -30,6 +30,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+var mockCount = func(_ context.Context, options db.ReposListOptions) (int, error) { return 0, nil }
+
+func assertEqual(t *testing.T, got, want interface{}) {
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
 func TestSearchResults(t *testing.T) {
 	limitOffset := &db.LimitOffset{Limit: maxReposToSearch() + 1}
 
@@ -74,21 +82,18 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 			calledReposList = true
 
-			want := db.ReposListOptions{
-				OnlyRepoIDs:     true,
-				IncludePatterns: []string{"r", "p"},
-				LimitOffset:     limitOffset,
-				NoArchived:      true,
-				NoForks:         true,
-			}
-			if !reflect.DeepEqual(op, want) {
-				t.Fatalf("got %+v, want %+v", op, want)
-			}
+			// Validate that the following options are invariant
+			// when calling the DB through Repos.List, no matter how
+			// many times it is called for a single Search(...) operation.
+			assertEqual(t, op.OnlyRepoIDs, true)
+			assertEqual(t, op.LimitOffset, limitOffset)
+			assertEqual(t, op.IncludePatterns, []string{"r", "p"})
 
 			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 		db.Mocks.Repos.MockGet(t, 1)
+		db.Mocks.Repos.Count = mockCount
 
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			return nil, &searchResultsCommon{repos: []*types.Repo{{ID: 1, Name: "repo"}}}, nil
@@ -112,22 +117,18 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 			calledReposList = true
 
-			want := db.ReposListOptions{
-				OnlyRepoIDs: true,
-				LimitOffset: limitOffset,
-				NoArchived:  true,
-				NoForks:     true,
-			}
-
-			if !reflect.DeepEqual(op, want) {
-				t.Fatalf("got %+v, want %+v", op, want)
-			}
+			// Validate that the following options are invariant
+			// when calling the DB through Repos.List, no matter how
+			// many times it is called for a single Search(...) operation.
+			assertEqual(t, op.OnlyRepoIDs, true)
+			assertEqual(t, op.LimitOffset, limitOffset)
 
 			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 		db.Mocks.Repos.MockGet(t, 1)
+		db.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
 		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
@@ -188,22 +189,18 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 			calledReposList = true
 
-			want := db.ReposListOptions{
-				OnlyRepoIDs: true,
-				LimitOffset: limitOffset,
-				NoArchived:  true,
-				NoForks:     true,
-			}
-
-			if !reflect.DeepEqual(op, want) {
-				t.Fatalf("got %+v, want %+v", op, want)
-			}
+			// Validate that the following options are invariant
+			// when calling the DB through Repos.List, no matter how
+			// many times it is called for a single Search(...) operation.
+			assertEqual(t, op.OnlyRepoIDs, true)
+			assertEqual(t, op.LimitOffset, limitOffset)
 
 			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 		db.Mocks.Repos.MockGet(t, 1)
+		db.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
 		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
@@ -1024,6 +1021,7 @@ func TestSearchResultsHydration(t *testing.T) {
 	db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 		return []*types.Repo{repoWithIDs}, nil
 	}
+	db.Mocks.Repos.Count = mockCount
 
 	defer func() { db.Mocks = db.MockStores{} }()
 
@@ -1111,6 +1109,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 			return nil, false, errors.New("Unexpected repo")
 		}
 	}
+	db.Mocks.Repos.Count = mockCount
 	defer func() { mockSearchFilesInRepo = nil }()
 
 	zoektRepo := &zoekt.RepoListEntry{

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -86,7 +86,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 {
-			repoRevs, _, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
+			repoRevs, _, _, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
 
 			resolvers := make([]*searchSuggestionResolver, 0, len(repoRevs))
 			for _, rev := range repoRevs {
@@ -193,7 +193,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return mockShowSymbolMatches()
 		}
 
-		repoRevs, _, _, err := r.resolveRepositories(ctx, nil)
+		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -19,6 +19,7 @@ import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { ServerBanner, ServerBannerNoRepo } from '../../marketing/ServerBanner'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 import { PatternTypeProps } from '..'
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 
 interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
@@ -76,146 +77,171 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * The info bar shown over the search results list that displays metadata
  * and a few actions like expand all and save query
  */
-export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
-    <div className="search-results-info-bar" data-testid="results-info-bar">
-        {/*
-            If there were no results, still show the "quotes are interpreted literally"
-            notice as this is the most common case where a user will make this mistake.
-        */}
-        {props.results.results.length === 0 && (
-            <small className="search-results-info-bar__row">
-                <div className="search-results-info-bar__row-left">
-                    <QuotesInterpretedLiterallyNotice {...props} />
-                </div>
-                <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end" />
-            </small>
-        )}
-        {(props.results.timedout.length > 0 ||
-            props.results.cloning.length > 0 ||
-            props.results.results.length > 0 ||
-            props.results.missing.length > 0) && (
-            <small className="search-results-info-bar__row">
-                <div className="search-results-info-bar__row-left">
-                    {/* Time stats */}
-                    <div className="search-results-info-bar__notice e2e-search-results-stats">
-                        <span>
-                            <CalculatorIcon className="icon-inline" /> {props.results.approximateResultCount}{' '}
-                            {pluralize('result', props.results.matchCount)} in{' '}
-                            {(props.results.elapsedMilliseconds / 1000).toFixed(2)} seconds
-                            {props.results.indexUnavailable && ' (index unavailable)'}
-                            {/* Nonbreaking space */}
-                            {props.results.limitHit && String.fromCharCode(160)}
-                        </span>
-                        {/* Instantly accessible "show more button" */}
-                        {props.results.limitHit && (
-                            <button
-                                type="button"
-                                className="btn btn-link btn-sm p-0"
-                                onClick={props.onShowMoreResultsClick}
-                            >
-                                (show more)
-                            </button>
-                        )}
+export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
+    const excludeForksFilter = props.results.dynamicFilters.find(filter => filter.value === 'fork:yes')
+    const excludedForksCount = excludeForksFilter?.count || 0
+    const excludeArchivedFilter = props.results.dynamicFilters.find(filter => filter.value === 'archived:yes')
+    const excludedArchivedCount = excludeArchivedFilter?.count || 0
+    return (
+        <div className="search-results-info-bar" data-testid="results-info-bar">
+            {props.results.results.length === 0 && (
+                <small className="search-results-info-bar__row">
+                    <div className="search-results-info-bar__row-left">
+                        <QuotesInterpretedLiterallyNotice {...props} />
                     </div>
+                    <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end" />
+                </small>
+            )}
+            {(props.results.timedout.length > 0 ||
+                props.results.cloning.length > 0 ||
+                props.results.results.length > 0 ||
+                props.results.missing.length > 0 ||
+                excludedForksCount > 0 ||
+                excludedArchivedCount > 0) && (
+                <small className="search-results-info-bar__row">
+                    <div className="search-results-info-bar__row-left">
+                        <div className="search-results-info-bar__notice e2e-search-results-stats">
+                            <span>
+                                <CalculatorIcon className="icon-inline" /> {props.results.approximateResultCount}{' '}
+                                {pluralize('result', props.results.matchCount)} in{' '}
+                                {(props.results.elapsedMilliseconds / 1000).toFixed(2)} seconds
+                                {props.results.indexUnavailable && ' (index unavailable)'}
+                                {props.results.limitHit && String.fromCharCode(160)}
+                            </span>
 
-                    {/* Missing repos */}
-                    {props.results.missing.length > 0 && (
-                        <div
-                            className="search-results-info-bar__notice"
-                            data-tooltip={props.results.missing.map(repo => repo.name).join('\n')}
-                        >
-                            <span>
-                                <MapSearchIcon className="icon-inline" /> {props.results.missing.length}{' '}
-                                {pluralize('repository', props.results.missing.length, 'repositories')} not found
-                            </span>
+                            {props.results.limitHit && (
+                                <button
+                                    type="button"
+                                    className="btn btn-link btn-sm p-0"
+                                    onClick={props.onShowMoreResultsClick}
+                                >
+                                    (show more)
+                                </button>
+                            )}
                         </div>
-                    )}
-                    {/* Timed out repos */}
-                    {props.results.timedout.length > 0 && (
-                        <div
-                            className="search-results-info-bar__notice"
-                            data-tooltip={props.results.timedout.map(repo => repo.name).join('\n')}
-                        >
-                            <span>
-                                <TimerSandIcon className="icon-inline" /> {props.results.timedout.length}{' '}
-                                {pluralize('repository', props.results.timedout.length, 'repositories')} timed out
-                                (reload to try again, or specify a longer "timeout:" in your query)
-                            </span>
-                        </div>
-                    )}
-                    {/* Cloning repos */}
-                    {props.results.cloning.length > 0 && (
-                        <div
-                            className="search-results-info-bar__notice"
-                            data-tooltip={props.results.cloning.map(repo => repo.name).join('\n')}
-                        >
-                            <span>
-                                <CloudDownloadIcon className="icon-inline" /> {props.results.cloning.length}{' '}
-                                {pluralize('repository', props.results.cloning.length, 'repositories')} cloning (reload
-                                to try again)
-                            </span>
-                        </div>
-                    )}
-                    <QuotesInterpretedLiterallyNotice {...props} />
-                </div>
-                <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
-                    <ActionsNavItems
-                        {...props}
-                        extraContext={{ searchQuery: props.query }}
-                        menu={ContributableMenu.SearchResultsToolbar}
-                        wrapInList={false}
-                        showLoadingSpinnerDuringExecution={true}
-                        actionItemClass="btn btn-link nav-link text-decoration-none"
-                    />
-                    {/* Expand all feature */}
-                    {props.results.results.length > 0 && (
-                        <li className="nav-item">
-                            <button
-                                type="button"
-                                onClick={props.onExpandAllResultsToggle}
-                                className="btn btn-link nav-link text-decoration-none"
-                                data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
+
+                        {excludedForksCount > 0 && (
+                            <div
+                                className="search-results-info-bar__notice"
+                                data-tooltip="add fork:yes to include forks"
                             >
-                                {props.allExpanded ? (
-                                    <>
-                                        <ArrowCollapseVerticalIcon className="icon-inline" /> Collapse all
-                                    </>
-                                ) : (
-                                    <>
-                                        <ArrowExpandVerticalIcon className="icon-inline" /> Expand all
-                                    </>
-                                )}
-                            </button>
-                        </li>
-                    )}
-                    {/* Saved Queries */}
-                    {props.authenticatedUser && (
-                        <li className="nav-item">
-                            <button
-                                type="button"
-                                onClick={props.onSaveQueryClick}
-                                className="btn btn-link nav-link text-decoration-none"
-                                disabled={props.didSave}
+                                <span>
+                                    <AlertCircleIcon className="icon-inline" /> {excludedForksCount} forked{' '}
+                                    {pluralize('repository', excludedForksCount, 'repositories')} excluded
+                                </span>
+                            </div>
+                        )}
+
+                        {excludedArchivedCount > 0 && (
+                            <div
+                                className="search-results-info-bar__notice"
+                                data-tooltip="add archived:yes to include archives"
                             >
-                                {props.didSave ? (
-                                    <>
-                                        <CheckIcon className="icon-inline" /> Query saved
-                                    </>
-                                ) : (
-                                    <>
-                                        <DownloadIcon className="icon-inline e2e-save-search-link" /> Save this search
-                                        query
-                                    </>
-                                )}
-                            </button>
-                        </li>
-                    )}
-                </ul>
-            </small>
-        )}
-        {!props.results.alert &&
-            props.showDotComMarketing &&
-            (props.hasRepoishField ? <ServerBanner /> : <ServerBannerNoRepo />)}
-        {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
-    </div>
-)
+                                <span>
+                                    <AlertCircleIcon className="icon-inline" /> {excludedArchivedCount} archived{' '}
+                                    {pluralize('repository', excludedArchivedCount, 'repositories')} excluded
+                                </span>
+                            </div>
+                        )}
+
+                        {props.results.missing.length > 0 && (
+                            <div
+                                className="search-results-info-bar__notice"
+                                data-tooltip={props.results.missing.map(repo => repo.name).join('\n')}
+                            >
+                                <span>
+                                    <MapSearchIcon className="icon-inline" /> {props.results.missing.length}{' '}
+                                    {pluralize('repository', props.results.missing.length, 'repositories')} not found
+                                </span>
+                            </div>
+                        )}
+
+                        {props.results.timedout.length > 0 && (
+                            <div
+                                className="search-results-info-bar__notice"
+                                data-tooltip={props.results.timedout.map(repo => repo.name).join('\n')}
+                            >
+                                <span>
+                                    <TimerSandIcon className="icon-inline" /> {props.results.timedout.length}{' '}
+                                    {pluralize('repository', props.results.timedout.length, 'repositories')} timed out
+                                    (reload to try again, or specify a longer "timeout:" in your query)
+                                </span>
+                            </div>
+                        )}
+
+                        {props.results.cloning.length > 0 && (
+                            <div
+                                className="search-results-info-bar__notice"
+                                data-tooltip={props.results.cloning.map(repo => repo.name).join('\n')}
+                            >
+                                <span>
+                                    <CloudDownloadIcon className="icon-inline" /> {props.results.cloning.length}{' '}
+                                    {pluralize('repository', props.results.cloning.length, 'repositories')} cloning
+                                    (reload to try again)
+                                </span>
+                            </div>
+                        )}
+                        <QuotesInterpretedLiterallyNotice {...props} />
+                    </div>
+                    <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
+                        <ActionsNavItems
+                            {...props}
+                            extraContext={{ searchQuery: props.query }}
+                            menu={ContributableMenu.SearchResultsToolbar}
+                            wrapInList={false}
+                            showLoadingSpinnerDuringExecution={true}
+                            actionItemClass="btn btn-link nav-link text-decoration-none"
+                        />
+
+                        {props.results.results.length > 0 && (
+                            <li className="nav-item">
+                                <button
+                                    type="button"
+                                    onClick={props.onExpandAllResultsToggle}
+                                    className="btn btn-link nav-link text-decoration-none"
+                                    data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
+                                >
+                                    {props.allExpanded ? (
+                                        <>
+                                            <ArrowCollapseVerticalIcon className="icon-inline" /> Collapse all
+                                        </>
+                                    ) : (
+                                        <>
+                                            <ArrowExpandVerticalIcon className="icon-inline" /> Expand all
+                                        </>
+                                    )}
+                                </button>
+                            </li>
+                        )}
+
+                        {props.authenticatedUser && (
+                            <li className="nav-item">
+                                <button
+                                    type="button"
+                                    onClick={props.onSaveQueryClick}
+                                    className="btn btn-link nav-link text-decoration-none"
+                                    disabled={props.didSave}
+                                >
+                                    {props.didSave ? (
+                                        <>
+                                            <CheckIcon className="icon-inline" /> Query saved
+                                        </>
+                                    ) : (
+                                        <>
+                                            <DownloadIcon className="icon-inline e2e-save-search-link" /> Save this
+                                            search query
+                                        </>
+                                    )}
+                                </button>
+                            </li>
+                        )}
+                    </ul>
+                </small>
+            )}
+            {!props.results.alert &&
+                props.showDotComMarketing &&
+                (props.hasRepoishField ? <ServerBanner /> : <ServerBannerNoRepo />)}
+            {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
+        </div>
+    )
+}


### PR DESCRIPTION
This adds a notification as seen below. This shows up if a fork (resp. archive) is excluded  _only if_ the `fork:` (resp. `archive:`) option isn't explicitly specified in the query.

![Screen Shot 2020-05-12 at 11 01 39 PM](https://user-images.githubusercontent.com/888624/81776894-8ed39600-94a4-11ea-921f-73e8b919a411.png)

I plan to still add an e2e web regression test and some backend test, though I would much prefer an integration test for it.

Notes:

- On hover, it says to `add fork:yes` followed by the list of repos. There isn't a lot of freedom to format this, and it will overflow on the width of the hover box if the message is longer. I think the current message is OK.

- A repo may be a fork and an archive, or only a fork/only an archive. It's best if we treat the labels separately as far as showing the notification

**Backend implementation stuff**

- At first I thought to do a query of all repos including forks/archives, and then filter out the forks/archives. But, I discovered that the standard DB call will not populate those fields/labels for repos due to perf issues. Instead of iterating over the entire list and then 'hydrating' whether they are forks or repos, I instead take the original query and modify it to make two additional DB calls where I set `fork:only` and then `archived:only`, and put those matching repos in the 'excluded' list. My intuition is that this is faster than calling `Get(...)` for each repo and then checking fork/archived. The additional DB calls run in the typical case when `fork`/`archived` unspecified, but not otherwise.

- I had to refactor tests that relied on a mocked DB `List` call. These tests want certain invariants to hold for the DB options when matching repos. The current/previous 'easy' way to do this is just to accept all the DB options as default and set the ones that matter. When we changed the default of fork/archive matching in a previous PRs (e.g., https://github.com/sourcegraph/sourcegraph/pull/8739), I had to change these tests to now use the new `NoFork`... default option. Now, these values can change since there are multiple calls to DB `List`. The answer is that these tests should not be relying on such strong invariants on the fork/archive inclusion/exclusion logic because that's not what they're testing. I have updated the tests to check for weaker invariants instead.

- This will conflict with refactor #10489. I'd appreciate if we could hold off on merging #10489 until after branch cut, since I'd like to get this feature in for 3.16 without issues that might crop up due to refactor and/or adjusting to it.

