### PR TITLE
dbtest: Always rollback transaction, even if test failed

### DIFF
--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -31,9 +31,7 @@ func NewTx(t testing.TB, db *sql.DB) *sql.Tx {
 	}
 
 	t.Cleanup(func() {
-		if !t.Failed() {
-			_ = tx.Rollback()
-		}
+		_ = tx.Rollback()
 	})
 
 	return tx


### PR DESCRIPTION
I'm not sure why we we never rolled back a transaction, nor committed
it. I suspect the idea was to leave test state available in the test
database. But if the transaction is never committed, that state is never
available anyway.

And with the previous behaviour I can into problems when multiple tests,
such as the ones in `campaigns.TestIntegration`, use the same test
database and one of the tests fails. The failing test then leaves a
transaction dangling, which can block other tests.
