### PR TITLE
Cache diff stats on patches to speed up computing combined diff stat of patch sets/campaigns

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -538,16 +538,19 @@ Referenced by:
 
 # Table "public.patches"
 ```
-    Column    |           Type           |                         Modifiers                          
---------------+--------------------------+------------------------------------------------------------
- id           | bigint                   | not null default nextval('campaign_jobs_id_seq'::regclass)
- patch_set_id | bigint                   | not null
- repo_id      | bigint                   | not null
- rev          | text                     | not null
- diff         | text                     | not null
- created_at   | timestamp with time zone | not null default now()
- updated_at   | timestamp with time zone | not null default now()
- base_ref     | text                     | not null
+      Column       |           Type           |                         Modifiers                          
+-------------------+--------------------------+------------------------------------------------------------
+ id                | bigint                   | not null default nextval('campaign_jobs_id_seq'::regclass)
+ patch_set_id      | bigint                   | not null
+ repo_id           | bigint                   | not null
+ rev               | text                     | not null
+ diff              | text                     | not null
+ created_at        | timestamp with time zone | not null default now()
+ updated_at        | timestamp with time zone | not null default now()
+ base_ref          | text                     | not null
+ diff_stat_added   | integer                  | 
+ diff_stat_changed | integer                  | 
+ diff_stat_deleted | integer                  | 
 Indexes:
     "campaign_jobs_pkey" PRIMARY KEY, btree (id)
     "campaign_jobs_campaign_plan_repo_rev_unique" UNIQUE CONSTRAINT, btree (patch_set_id, repo_id, rev) DEFERRABLE

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -25,6 +25,7 @@ func TestIntegration(t *testing.T) {
 	t.Run("Store", testStore(db))
 	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))
 	t.Run("BitbucketWebhook", testBitbucketWebhook(db, userID))
+	t.Run("MigratePatchesWithoutDiffStats", testMigratePatchesWithoutDiffStats(db, userID))
 
 	// The following tests need to be separate because testStore above wraps everything in a global transaction
 	t.Run("StoreLocking", testStoreLocking(db))

--- a/enterprise/internal/campaigns/migrations.go
+++ b/enterprise/internal/campaigns/migrations.go
@@ -2,7 +2,6 @@ package campaigns
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -23,7 +22,6 @@ func MigratePatchesWithoutDiffStats(ctx context.Context, s *Store) (err error) {
 	patches, _, err := s.ListPatches(ctx, opts)
 
 	for _, p := range patches {
-		fmt.Printf("migrating patch!\n")
 		err = p.ComputeDiffStat()
 		if err != nil {
 			return errors.Wrapf(err, "failed to compute diff stat for patch %d", p.ID)
@@ -33,7 +31,6 @@ func MigratePatchesWithoutDiffStats(ctx context.Context, s *Store) (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "failed to update patch %d", p.ID)
 		}
-		fmt.Printf("patch migrated!\n")
 	}
 
 	return nil

--- a/enterprise/internal/campaigns/migrations.go
+++ b/enterprise/internal/campaigns/migrations.go
@@ -1,0 +1,40 @@
+package campaigns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// MigratePatchesWithoutDiffStats loads all Patches from the database where
+// the DiffStat* fields are not set. It then computes the diff for each Patch
+// and updates the Patch in the database.
+// It is a blocking operation that does all work in a database transaction and
+// fails if setting the diff stat on a single patch failed.
+func MigratePatchesWithoutDiffStats(ctx context.Context, s *Store) (err error) {
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return errors.Wrap(err, "starting transaction")
+	}
+	defer tx.Done(&err)
+
+	opts := ListPatchesOpts{OnlyWithoutDiffStats: true, Limit: -1}
+	patches, _, err := s.ListPatches(ctx, opts)
+
+	for _, p := range patches {
+		fmt.Printf("migrating patch!\n")
+		err = p.ComputeDiffStat()
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute diff stat for patch %d", p.ID)
+		}
+
+		err = s.UpdatePatch(ctx, p)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update patch %d", p.ID)
+		}
+		fmt.Printf("patch migrated!\n")
+	}
+
+	return nil
+}

--- a/enterprise/internal/campaigns/migrations_test.go
+++ b/enterprise/internal/campaigns/migrations_test.go
@@ -1,0 +1,106 @@
+package campaigns
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+func testMigratePatchesWithoutDiffStats(db *sql.DB, userID int32) func(*testing.T) {
+	const testDiff = `diff --git INSTALL.md INSTALL.md
+index b9f9438..cb1ab9f 100644
+--- INSTALL.md
++++ INSTALL.md
+@@ -2,4 +2,4 @@
+ 
+ Foobar
+ 
+-barfoo
++Pfannkuchen
+diff --git README.md README.md
+index 437e1a8..540f2f3 100644
+--- README.md
++++ README.md
+@@ -1,5 +1,5 @@
+ # README
+ 
+ Line 1
+-Line 2
++Line Foobar
+ Line 3
+diff --git main.c main.c
+new file mode 100644
+index 0000000..44e82e2
+--- /dev/null
++++ main.c
+@@ -0,0 +1 @@
++int main(int argc, char *argv[]) { return 0; }
+`
+
+	return func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		clock := func() time.Time { return now.UTC().Truncate(time.Microsecond) }
+		ctx := context.Background()
+
+		reposStore := repos.NewDBStore(db, sql.TxOptions{})
+		repo := testRepo(1, "github")
+		if err := reposStore.UpsertRepos(context.Background(), repo); err != nil {
+			t.Fatal(err)
+		}
+
+		s := NewStoreWithClock(db, clock)
+
+		patches := make([]*cmpgn.Patch, 0, 3)
+
+		for i := 0; i < cap(patches); i++ {
+			patchSet := &cmpgn.PatchSet{UserID: userID}
+			err := s.CreatePatchSet(context.Background(), patchSet)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p := &cmpgn.Patch{
+				PatchSetID: patchSet.ID,
+				RepoID:     repo.ID,
+				Rev:        api.CommitID("deadbeef"),
+				BaseRef:    "master",
+				Diff:       testDiff,
+			}
+
+			err = s.CreatePatch(ctx, p)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			patches = append(patches, p)
+		}
+
+		withoutStats, _, err := s.ListPatches(ctx, ListPatchesOpts{OnlyWithoutDiffStats: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have, want := len(withoutStats), len(patches); have != want {
+			t.Fatalf("wrong number of patches without stats. have=%d, want=%d", have, want)
+		}
+
+		err = MigratePatchesWithoutDiffStats(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		withoutStats, _, err = s.ListPatches(ctx, ListPatchesOpts{OnlyWithoutDiffStats: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have, want := len(withoutStats), 0; have != want {
+			t.Fatalf("wrong number of patches without stats. have=%d, want=%d", have, want)
+		}
+	}
+}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -929,6 +929,11 @@ func TestCreatePatchSetFromPatchesResolver(t *testing.T) {
 			  }
             }
             previewURL
+            diffStat {
+              added
+              deleted
+              changed
+            }
           }
         }
       }
@@ -948,6 +953,10 @@ func TestCreatePatchSetFromPatchesResolver(t *testing.T) {
 
 		if have, want := result.PreviewURL, "http://example.com/campaigns/new?patchSet=UGF0Y2hTZXQ6MQ%3D%3D"; have != want {
 			t.Fatalf("have PreviewURL %q, want %q", have, want)
+		}
+
+		if have, want := result.DiffStat, (apitest.DiffStat{Changed: 2}); have != want {
+			t.Fatalf("wrong PatchSet.DiffStat.Changed %d, want=%d", have, want)
 		}
 	})
 }
@@ -1007,14 +1016,23 @@ func TestPatchSetResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var (
+		testDiffStatAdded   int32 = 0
+		testDiffStatDeleted int32 = 0
+		testDiffStatChanged int32 = 2
+	)
+
 	var patches []*campaigns.Patch
 	for _, repo := range rs {
 		patch := &campaigns.Patch{
-			PatchSetID: patchSet.ID,
-			RepoID:     repo.ID,
-			Rev:        testingRev,
-			BaseRef:    "master",
-			Diff:       testDiff,
+			PatchSetID:      patchSet.ID,
+			RepoID:          repo.ID,
+			Rev:             testingRev,
+			BaseRef:         "master",
+			Diff:            testDiff,
+			DiffStatAdded:   &testDiffStatAdded,
+			DiffStatDeleted: &testDiffStatDeleted,
+			DiffStatChanged: &testDiffStatChanged,
 		}
 
 		err := store.CreatePatch(ctx, patch)
@@ -1030,7 +1048,7 @@ func TestPatchSetResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	queryPatches := func(first int, after string, response *struct{ Node apitest.PatchSet }) {
+	queryPatchSet := func(first int, after string, response *struct{ Node apitest.PatchSet }) {
 		apitest.MustExec(ctx, t, s, nil, response, fmt.Sprintf(`
         query {
           node(id: %q) {
@@ -1093,7 +1111,7 @@ func TestPatchSetResolver(t *testing.T) {
 
 	for page := 0; page < 3; page++ {
 		var response struct{ Node apitest.PatchSet }
-		queryPatches(1, fmt.Sprintf(`"%d"`, page), &response)
+		queryPatchSet(1, fmt.Sprintf(`"%d"`, page), &response)
 
 		expectedLength := 1
 		if page >= 2 {
@@ -1117,7 +1135,7 @@ func TestPatchSetResolver(t *testing.T) {
 	}
 
 	var response struct{ Node apitest.PatchSet }
-	queryPatches(10000, "null", &response)
+	queryPatchSet(10000, "null", &response)
 
 	if have, want := len(response.Node.Patches.Nodes), len(patches); have != want {
 		t.Fatalf("have %d patches, want %d", have, want)
@@ -1146,6 +1164,26 @@ func TestPatchSetResolver(t *testing.T) {
 			t.Fatal(cmp.Diff(haveFileDiffs, wantFileDiffs))
 		}
 	}
+
+	t.Run("UncachedDiffStat", func(t *testing.T) {
+		for _, p := range patches {
+			p.DiffStatAdded = nil
+			p.DiffStatDeleted = nil
+			p.DiffStatChanged = nil
+
+			if err := store.UpdatePatch(ctx, p); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var response struct{ Node apitest.PatchSet }
+		queryPatchSet(10000, "null", &response)
+
+		if have, want := response.Node.DiffStat.Changed, len(patches)*2; have != want {
+			t.Fatalf("wrong PatchSet.DiffStat.Changed %d, want=%d", have, want)
+		}
+	})
+
 }
 
 func TestCreateCampaignWithPatchSet(t *testing.T) {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1049,6 +1049,8 @@ func TestPatchSetResolver(t *testing.T) {
 	}
 
 	queryPatchSet := func(first int, after string, response *struct{ Node apitest.PatchSet }) {
+		t.Helper()
+
 		apitest.MustExec(ctx, t, s, nil, response, fmt.Sprintf(`
         query {
           node(id: %q) {
@@ -1164,26 +1166,6 @@ func TestPatchSetResolver(t *testing.T) {
 			t.Fatal(cmp.Diff(haveFileDiffs, wantFileDiffs))
 		}
 	}
-
-	t.Run("UncachedDiffStat", func(t *testing.T) {
-		for _, p := range patches {
-			p.DiffStatAdded = nil
-			p.DiffStatDeleted = nil
-			p.DiffStatChanged = nil
-
-			if err := store.UpdatePatch(ctx, p); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		var response struct{ Node apitest.PatchSet }
-		queryPatchSet(10000, "null", &response)
-
-		if have, want := response.Node.DiffStat.Changed, len(patches)*2; have != want {
-			t.Fatalf("wrong PatchSet.DiffStat.Changed %d, want=%d", have, want)
-		}
-	})
-
 }
 
 func TestCreateCampaignWithPatchSet(t *testing.T) {

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -2099,6 +2099,10 @@ type ListPatchesOpts struct {
 	// are _not_ associated with a successfully completed ChangesetJob (meaning
 	// that a Changeset on the codehost was created) for the given Campaign.
 	OnlyUnpublishedInCampaign int64
+
+	// If this is set only the Patches where diff_stat_added OR
+	// diff_stat_changed OR diff_stat_deleted are NULL.
+	OnlyWithoutDiffStats bool
 }
 
 // ListPatches lists Patches with the given filters.
@@ -2167,6 +2171,10 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 
 	if opts.OnlyUnpublishedInCampaign != 0 {
 		preds = append(preds, onlyUnpublishedInCampaignQuery(opts.OnlyUnpublishedInCampaign))
+	}
+
+	if opts.OnlyWithoutDiffStats {
+		preds = append(preds, sqlf.Sprintf("(diff_stat_added IS NULL OR diff_stat_deleted IS NULL OR diff_stat_changed IS NULL)"))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1864,10 +1864,13 @@ INSERT INTO patches (
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   created_at,
   updated_at
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   patch_set_id,
@@ -1875,6 +1878,9 @@ RETURNING
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   created_at,
   updated_at
 `
@@ -1895,6 +1901,9 @@ func (s *Store) createPatchQuery(c *campaigns.Patch) (*sqlf.Query, error) {
 		c.Rev,
 		c.BaseRef,
 		c.Diff,
+		c.DiffStatAdded,
+		c.DiffStatDeleted,
+		c.DiffStatChanged,
 		c.CreatedAt,
 		c.UpdatedAt,
 	), nil
@@ -1922,8 +1931,11 @@ SET (
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   updated_at
-) = (%s, %s, %s, %s, %s, %s)
+) = (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -1932,6 +1944,9 @@ RETURNING
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   created_at,
   updated_at
 `
@@ -1946,6 +1961,9 @@ func (s *Store) updatePatchQuery(c *campaigns.Patch) (*sqlf.Query, error) {
 		c.Rev,
 		c.BaseRef,
 		c.Diff,
+		c.DiffStatAdded,
+		c.DiffStatDeleted,
+		c.DiffStatChanged,
 		c.UpdatedAt,
 		c.ID,
 	), nil
@@ -2046,6 +2064,9 @@ SELECT
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   created_at,
   updated_at
 FROM patches
@@ -2111,6 +2132,9 @@ SELECT
   rev,
   base_ref,
   diff,
+  diff_stat_added,
+  diff_stat_deleted,
+  diff_stat_changed,
   created_at,
   updated_at
 FROM patches
@@ -2757,6 +2781,9 @@ func scanPatch(c *campaigns.Patch, s scanner) error {
 		&c.Rev,
 		&c.BaseRef,
 		&c.Diff,
+		&c.DiffStatAdded,
+		&c.DiffStatDeleted,
+		&c.DiffStatChanged,
 		&c.CreatedAt,
 		&c.UpdatedAt,
 	)

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1797,6 +1797,33 @@ func testStore(db *sql.DB) func(*testing.T) {
 				})
 			})
 
+			t.Run("Listing OnlyWithoutDiffStats", func(t *testing.T) {
+				listOpts := ListPatchesOpts{OnlyWithoutDiffStats: true}
+				have, _, err := s.ListPatches(ctx, listOpts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				want := []*cmpgn.Patch{}
+				for _, p := range patches {
+					_, ok := p.DiffStat()
+					if !ok {
+						want = append(want, p)
+					}
+				}
+
+				if len(want) == 0 {
+					t.Fatalf("test needs patches without diff stats")
+				}
+				if len(have) != len(want) {
+					t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", listOpts, diff)
+				}
+			})
+
 			t.Run("Listing and Counting OnlyWithDiff", func(t *testing.T) {
 				listOpts := ListPatchesOpts{OnlyWithDiff: true}
 				countOpts := CountPatchesOpts{OnlyWithDiff: true}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -58,6 +58,10 @@ type Patch struct {
 
 	Diff string
 
+	DiffStatAdded   *int32
+	DiffStatChanged *int32
+	DiffStatDeleted *int32
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -70,6 +71,23 @@ type Patch struct {
 func (c *Patch) Clone() *Patch {
 	cc := *c
 	return &cc
+}
+
+// DiffStat returns a *diff.Stat if DiffStatAdded, DiffStatChanged,
+// DiffStatDeleted are set. The second return value indicates whether these
+// fields are set and a diff.Stat has been returned.
+func (p *Patch) DiffStat() (diff.Stat, bool) {
+	s := diff.Stat{}
+
+	if p.DiffStatAdded == nil || p.DiffStatDeleted == nil || p.DiffStatChanged == nil {
+		return s, false
+	}
+
+	s.Added = *p.DiffStatAdded
+	s.Deleted = *p.DiffStatDeleted
+	s.Changed = *p.DiffStatChanged
+
+	return s, true
 }
 
 // A Campaign of changesets over multiple Repos over time.

--- a/migrations/1528395676_add_diff_stats_to_patches.down.sql
+++ b/migrations/1528395676_add_diff_stats_to_patches.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE patches DROP COLUMN IF EXISTS diff_stat_added;
+ALTER TABLE patches DROP COLUMN IF EXISTS diff_stat_changed;
+ALTER TABLE patches DROP COLUMN IF EXISTS diff_stat_deleted;
+
+COMMIT;

--- a/migrations/1528395676_add_diff_stats_to_patches.up.sql
+++ b/migrations/1528395676_add_diff_stats_to_patches.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE patches ADD COLUMN IF NOT EXISTS diff_stat_added integer;
+ALTER TABLE patches ADD COLUMN IF NOT EXISTS diff_stat_changed integer;
+ALTER TABLE patches ADD COLUMN IF NOT EXISTS diff_stat_deleted integer;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -52,6 +52,8 @@
 // 1528395674_add_creation_method_columns_to_changesets.up.sql (519B)
 // 1528395675_add_index_event_logs_anonymous_user_id.down.sql (68B)
 // 1528395675_add_index_event_logs_anonymous_user_id.up.sql (120B)
+// 1528395676_add_diff_stats_to_patches.down.sql (198B)
+// 1528395676_add_diff_stats_to_patches.up.sql (231B)
 
 package migrations
 
@@ -1160,6 +1162,46 @@ func _1528395675_add_index_event_logs_anonymous_user_idUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395676_add_diff_stats_to_patchesDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\x48\x2c\x49\xce\x48\x2d\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\xc9\x4c\x4b\x8b\x2f\x2e\x49\x2c\x89\x4f\x4c\x49\x49\x4d\xb1\x26\x4b\x6b\x72\x46\x62\x5e\x3a\xb9\x9a\x53\x52\x73\x52\x4b\x40\x9a\xb9\x9c\xfd\x7d\x7d\x3d\x43\xac\xb9\x00\x01\x00\x00\xff\xff\xe7\x70\xbf\xe0\xc6\x00\x00\x00")
+
+func _1528395676_add_diff_stats_to_patchesDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395676_add_diff_stats_to_patchesDownSql,
+		"1528395676_add_diff_stats_to_patches.down.sql",
+	)
+}
+
+func _1528395676_add_diff_stats_to_patchesDownSql() (*asset, error) {
+	bytes, err := _1528395676_add_diff_stats_to_patchesDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395676_add_diff_stats_to_patches.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x31, 0xe6, 0xc0, 0xd6, 0x8e, 0x4d, 0x87, 0xef, 0xd1, 0xf, 0x5d, 0xc6, 0x8f, 0x2b, 0xb6, 0xdc, 0xe9, 0x1c, 0xa6, 0x79, 0x47, 0x9a, 0xb0, 0xdf, 0x1e, 0xb6, 0xa8, 0xdb, 0x57, 0xaf, 0x55, 0x3a}}
+	return a, nil
+}
+
+var __1528395676_add_diff_stats_to_patchesUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\xcc\x4b\x0a\xc2\x30\x10\x06\xe0\x7d\x4e\xf1\xdf\x23\xab\xb4\x8d\x12\xc8\x03\xec\x08\xee\xca\xd0\x99\x3e\x40\x8a\xd8\xb9\x3f\x6e\x5d\x8b\x17\xf8\xba\x78\x4d\xd5\x3b\x17\x32\xc5\x1b\x28\x74\x39\xe2\xc5\x36\x6f\x7a\x22\x0c\x03\xfa\x96\xef\xa5\x22\x5d\x50\x1b\x21\x3e\xd2\x48\x23\x64\x5f\x96\xe9\x34\xb6\x89\x45\x54\xb0\x1f\xa6\xab\xbe\xfd\xaf\xca\xbc\xf1\xb1\xfe\xc1\x11\x7d\xaa\x7d\x3b\xae\x6f\xa5\x24\xf2\xee\x13\x00\x00\xff\xff\xb0\x25\x5e\x25\xe7\x00\x00\x00")
+
+func _1528395676_add_diff_stats_to_patchesUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395676_add_diff_stats_to_patchesUpSql,
+		"1528395676_add_diff_stats_to_patches.up.sql",
+	)
+}
+
+func _1528395676_add_diff_stats_to_patchesUpSql() (*asset, error) {
+	bytes, err := _1528395676_add_diff_stats_to_patchesUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395676_add_diff_stats_to_patches.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3b, 0x5c, 0xd0, 0x17, 0x72, 0xf7, 0xaf, 0x89, 0x4d, 0x81, 0x6c, 0xa1, 0x99, 0xd4, 0x21, 0xd0, 0x95, 0x7d, 0x6a, 0x56, 0x5e, 0x43, 0xc9, 0xba, 0x83, 0x5e, 0x61, 0xc3, 0x54, 0x1, 0xb, 0x87}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1303,6 +1345,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395674_add_creation_method_columns_to_changesets.up.sql":             _1528395674_add_creation_method_columns_to_changesetsUpSql,
 	"1528395675_add_index_event_logs_anonymous_user_id.down.sql":              _1528395675_add_index_event_logs_anonymous_user_idDownSql,
 	"1528395675_add_index_event_logs_anonymous_user_id.up.sql":                _1528395675_add_index_event_logs_anonymous_user_idUpSql,
+	"1528395676_add_diff_stats_to_patches.down.sql":                           _1528395676_add_diff_stats_to_patchesDownSql,
+	"1528395676_add_diff_stats_to_patches.up.sql":                             _1528395676_add_diff_stats_to_patchesUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -1398,6 +1442,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395674_add_creation_method_columns_to_changesets.up.sql":             {_1528395674_add_creation_method_columns_to_changesetsUpSql, map[string]*bintree{}},
 	"1528395675_add_index_event_logs_anonymous_user_id.down.sql":              {_1528395675_add_index_event_logs_anonymous_user_idDownSql, map[string]*bintree{}},
 	"1528395675_add_index_event_logs_anonymous_user_id.up.sql":                {_1528395675_add_index_event_logs_anonymous_user_idUpSql, map[string]*bintree{}},
+	"1528395676_add_diff_stats_to_patches.down.sql":                           {_1528395676_add_diff_stats_to_patchesDownSql, map[string]*bintree{}},
+	"1528395676_add_diff_stats_to_patches.up.sql":                             {_1528395676_add_diff_stats_to_patchesUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This fixes #10603 by adding nullable `diff_stat_*` fields to the `patches` table that are set when new patches are created (in which case we already parse the diff to validate it).

The cache is then used when computing the combined diff stat for a campaign or patch set.

Since these fields are new and we cannot migrate in pure SQL, they're nullable and we fall back to the old behavior in case they're not set.

That should not (™️) happen, since a new migration in enterprise `frontend` loads all patches without the cached values, computes them and saves the patchees back to the database.