### PR TITLE
Display webhook URL on external services page

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -90,11 +90,7 @@ func (r *externalServiceResolver) WebhookURL() (*string, error) {
 			r.webhookErr = errors.Wrap(err, "parsing external service config")
 			return
 		}
-		u, err := extsvc.WebhookURL(r.externalService.Kind, r.externalService.ID, conf.ExternalURL())
-		if err != nil {
-			r.webhookErr = errors.Wrap(err, "creating webhook url")
-			return
-		}
+		u := extsvc.WebhookURL(r.externalService.Kind, r.externalService.ID, conf.ExternalURL())
 		switch c := parsed.(type) {
 		case *schema.BitbucketServerConnection:
 			if c.Webhooks != nil {

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -36,7 +36,20 @@ To set up webhooks:
 1. Sourcegraph now automatically creates a webhook on your Bitbucket Server instance with the name `sourcegraph-`, followed by the unique ID of your Sourcegraph instance. It is configured to deliver `pr` and `repo` events.
 1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph** and make sure that the new `sourcegraph-campaigns` webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
+If the webhook was not automatically added, see the [Manual Configuration](bitbucket_server.md#manual-configuration) section below.
+
 Done! Sourcegraph will now receive webhook events from Bitbucket Server and use them to sync pull request events, used by [Campaigns](../../user/campaigns/index.md), fast and more efficiently.
+
+### Manual configuration
+
+1. Note the webhook URL displayed when you configured webhooks on Sourcegraph at **Site admin > Manage repositories** 
+1. On your Bitbucket Server instance, go to **Administration > Add-ons > Sourcegraph**
+1. Fill in the **Add a webhook** form
+   * Name: A unique name representing your Sourcegraph instance
+   * Scope: `global`
+   * Endpoint: The URL from step 1
+   * Events: `pr, repo`
+   * Secret: The secret you configured in Sourcegraph
 
 ## Repository permissions
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -62,7 +62,7 @@ The `webhooks` setting allows specifying the org webhook secrets necessary to au
 ]
 ```
 
-These organization webhooks are optional, but if configured on GitHub, they allow faster metadata updates than the background syncing (i.e. polling) with `repo-updater` permits.
+These organization webhooks are optional, but if configured on GitHub, they allow faster metadata updates than the background syncing (i.e. polling) which `repo-updater` permits.
 
 The following [webhook events](https://developer.github.com/webhooks/) are currently used:
 
@@ -76,7 +76,7 @@ The following [webhook events](https://developer.github.com/webhooks/) are curre
 
 To set up a organization webhook on GitHub, go to the settings page of your organization. From there, click **Webhooks**, then **Add webhook**.
 
-Fill in your Sourcegraph external URL with `/.api/github-webhooks` as the path and make sure it is publicly available.
+Fill in the URL displayed after saving the `webhooks` setting mentioned above and make sure it is publicly available.
 
 The **Content Type** of the webhook should be `application/json`. Generate the secret with `openssl rand -hex 32` and paste it in the respective field. This value is what you need to specify in the GitHub config.
 

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -58,7 +58,7 @@ To disable native code intelligence, simply set **Sourcegraph URL** to an empty 
 
 Once the plugin is installed, go to **Administration > Add-ons > Sourcegraph** to see a list of all configured webhooks and to create a new one.
 
-To configure a webhook on the Sourcegraph side, set the [`"webhooks"` property in the Bitbucket Server configuration](../admin/external_service/bitbucket_server.md#webhooks). Once that is configured Sourcegraph automatically makes sure in the background that a global webhook for usage with [Campaigns](../user/campaigns/index.md) is created on the Bitbucket Server instance.
+To configure a webhook on the Sourcegraph side, set the [`"webhooks"` property in the Bitbucket Server configuration](../admin/external_service/bitbucket_server.md#webhooks). Once that is configured Sourcegraph automatically makes sure in the background that a global webhook for usage with [Campaigns](../user/campaigns/index.md) is created on the Bitbucket Server instance. If you need to configure the webhook on your instance manually, see [manual configuration](../admin/external_service/bitbucket_server.md#manual-configuration).
 
 Disabling the webhook is as easy as removing the `"webhooks"` property from the `"plugin"` section and deleting the webhook pointing to your Sourcegraph instance under **Administration > Add-ons > Sourcegraph**.
 
@@ -110,7 +110,7 @@ Once the plugin is installed it registers an asynchronous listener (see [`Webhoo
 
 In order to persist the configured webhooks across restarts of the Bitbucket Server instance the plugin uses the [Active Objects ORM](https://developer.atlassian.com/server/framework/atlassian-sdk/active-objects/) of the Atlassian SDK. It registers two Active Objects: [`WebhookEntity` and `EventEntity`](https://github.com/sourcegraph/bitbucket-server-plugin/blob/94e4be96b57286429cc543205164586af03e9b9b/src/main/resources/atlassian-plugin.xml#L10-L14).
 
-If Sourcegraph is configured to make use of the Bitbucket Server plugin webhooks (which is done by setting the [`"plugin.webhooks"` property in the Bitbucket Server configuration](../admin/external_service/bitbucket_server.md#webhooks)), it sends a request to the Bitbucket Server instance, every 30 seconds, to make sure that a webhook on the Bitbucket Server instance exists and points to the Sourcegraph instance.
+If Sourcegraph is configured to make use of the Bitbucket Server plugin webhooks (which is done by setting the [`"plugin.webhooks"` property in the Bitbucket Server configuration](../admin/external_service/bitbucket_server.md#webhooks)), it sends a request to the Bitbucket Server instance, every minute, to make sure that a webhook on the Bitbucket Server instance exists and points to the Sourcegraph instance.
 
 #### Fast permission syncing
 

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -837,10 +837,7 @@ func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schem
 	}
 
 	// Secret has changed to a non blank value, upsert
-	endpoint, err := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID, conf.ExternalURL())
-	if err != nil {
-		return errors.Wrap(err, "getting webhook URL")
-	}
+	endpoint := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID, conf.ExternalURL())
 	wh := bbs.Webhook{
 		Name:     h.Name,
 		Scope:    "global",

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -136,10 +136,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL(github.ServiceType, extSvc.ID, "https://example.com/")
-						if err != nil {
-							t.Fatal(err)
-						}
+						u := extsvc.WebhookURL(github.ServiceType, extSvc.ID, "https://example.com/")
 
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
@@ -300,10 +297,8 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						u, err := extsvc.WebhookURL(bitbucketserver.ServiceType, extSvc.ID, "https://example.com/")
-						if err != nil {
-							t.Fatal(err)
-						}
+						u := extsvc.WebhookURL(bitbucketserver.ServiceType, extSvc.ID, "https://example.com/")
+
 						req, err := http.NewRequest("POST", u, bytes.NewReader(event.Data))
 						if err != nil {
 							t.Fatal(err)

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -100,7 +100,7 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 
 const IDParam = "externalServiceID"
 
-func WebhookURL(kind string, externalServiceID int64, externalURL string) (string, error) {
+func WebhookURL(kind string, externalServiceID int64, externalURL string) string {
 	var path string
 	switch strings.ToLower(kind) {
 	case "github":
@@ -108,8 +108,8 @@ func WebhookURL(kind string, externalServiceID int64, externalURL string) (strin
 	case "bitbucketserver":
 		path = "bitbucket-server-webhooks"
 	default:
-		return "", fmt.Errorf("unknown external service kind: %q", kind)
+		return ""
 	}
 	// eg. https://example.com/.api/github-webhooks?externalServiceID=1
-	return fmt.Sprintf("%s/.api/%s?%s=%d", externalURL, path, IDParam, externalServiceID), nil
+	return fmt.Sprintf("%s/.api/%s?%s=%d", externalURL, path, IDParam, externalServiceID)
 }

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -50,7 +50,7 @@
       },
       "default": {
         "enabled": true,
-        "requestsPeHour": 5000
+        "requestsPerHour": 5000
       }
     },
     "certificate": {

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -55,7 +55,7 @@ const GitHubSchemaJSON = `{
       },
       "default": {
         "enabled": true,
-        "requestsPeHour": 5000
+        "requestsPerHour": 5000
       }
     },
     "certificate": {

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -85,7 +85,7 @@ export class SiteAdminAddExternalServicePage extends React.Component<Props, Stat
                         // eslint-disable-next-line rxjs/no-nested-subscribe, rxjs/no-ignored-subscription
                         refreshSiteFlags().subscribe({ error: err => console.error(err) })
                         this.setState({ loading: false })
-                        this.props.history.push('/site-admin/external-services')
+                        this.props.history.push('/site-admin/external-services/' + externalService.id)
                     }
                 })
         )

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -79,7 +79,7 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                 </div>
                 <button
                     type="submit"
-                    className={`btn btn-primary ${
+                    className={`btn btn-primary mb-3 ${
                         this.props.mode === 'create'
                             ? 'e2e-add-external-service-button'
                             : 'e2e-update-external-service-button'

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -184,7 +184,19 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 )}
                 {externalService?.webhookURL && (
                     <div className="alert alert-info">
-                        <h3>Webhooks</h3>
+                        <h3>Campaign webhooks</h3>
+                        <p>
+                            Note that this only supports Sourcegraph’s Campaigns product currently. To enable webhooks
+                            to trigger repository updates on Sourcegraph,{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/admin/repo/webhooks"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                see the docs on how to use them
+                            </a>
+                            .
+                        </p>
                         {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
                             <p>
                                 <a

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -184,7 +184,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 )}
                 {externalService?.webhookURL && (
                     <div className="alert alert-info">
-                        <h3>Campaigns webhooks</h3>
+                        <h3>Webhooks</h3>
                         {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
                             <p>
                                 <a

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -220,10 +220,21 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                                 for this code host connection at the following URL:
                             </p>
                         )}
-                        <CopyableText text={externalService.webhookURL} size={externalService.webhookURL.length} />
-                        <p>
-                            Note that this only supports Sourcegraph’s Campaigns product currently. To enable webhooks
-                            to trigger repository updates on Sourcegraph,{' '}
+                        <CopyableText
+                            className="mb-2"
+                            text={externalService.webhookURL}
+                            size={externalService.webhookURL.length}
+                        />
+                        <p className="mb-0">
+                            Note that only{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/user/campaigns"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Campaigns
+                            </a>{' '}
+                            make use of this webhook. To enable webhooks to trigger repository updates on Sourcegraph,{' '}
                             <a
                                 href="https://docs.sourcegraph.com/admin/repo/webhooks"
                                 target="_blank"

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -184,7 +184,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 )}
                 {externalService?.webhookURL && (
                     <div className="alert alert-info">
-                        <h3>Webhooks</h3>
+                        <h3>Campaigns webhooks</h3>
                         {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
                             <p>
                                 <a

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -185,7 +185,32 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 {externalService?.webhookURL && (
                     <div className="alert alert-info">
                         <h3>Webhooks</h3>
-                        <p>Point webhooks for this external service at the following URL:</p>
+                        {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
+                            <p>
+                                <a
+                                    href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#webhooks"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Webhooks
+                                </a>{' '}
+                                will be created automatically on the configured Bitbucket Server instance.
+                                <br />
+                                To set up another webhook manually, use the following URL:
+                            </p>
+                        ) : (
+                            <p>
+                                Point{' '}
+                                <a
+                                    href="https://docs.sourcegraph.com/admin/external_service/github#webhooks"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    webhooks
+                                </a>{' '}
+                                for this code host connection at the following URL:
+                            </p>
+                        )}
                         <CopyableText text={externalService.webhookURL} size={externalService.webhookURL.length} />
                     </div>
                 )}

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -185,18 +185,6 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 {externalService?.webhookURL && (
                     <div className="alert alert-info">
                         <h3>Campaign webhooks</h3>
-                        <p>
-                            Note that this only supports Sourcegraph’s Campaigns product currently. To enable webhooks
-                            to trigger repository updates on Sourcegraph,{' '}
-                            <a
-                                href="https://docs.sourcegraph.com/admin/repo/webhooks"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                see the docs on how to use them
-                            </a>
-                            .
-                        </p>
                         {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
                             <p>
                                 <a
@@ -233,6 +221,18 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                             </p>
                         )}
                         <CopyableText text={externalService.webhookURL} size={externalService.webhookURL.length} />
+                        <p>
+                            Note that this only supports Sourcegraph’s Campaigns product currently. To enable webhooks
+                            to trigger repository updates on Sourcegraph,{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/admin/repo/webhooks"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                see the docs on how to use them
+                            </a>
+                            .
+                        </p>
                     </div>
                 )}
             </div>

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -206,7 +206,16 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                                 >
                                     Webhooks
                                 </a>{' '}
-                                will be created automatically on the configured Bitbucket Server instance.
+                                will be created automatically on the configured Bitbucket Server instance. In case you
+                                don't provide an admin token,{' '}
+                                <a
+                                    href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#manual-configuration"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    follow the docs on how to set up webhooks manually
+                                </a>
+                                .
                                 <br />
                                 To set up another webhook manually, use the following URL:
                             </p>

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -17,6 +17,8 @@ import { defaultExternalServices, codeHostExternalServices } from './externalSer
 import { hasProperty } from '../../../shared/src/util/types'
 import * as H from 'history'
 
+type ExternalService = Pick<GQL.IExternalService, 'id' | 'kind' | 'displayName' | 'config' | 'warning' | 'webhookURL'>
+
 interface Props extends RouteComponentProps<{ id: GQL.ID }> {
     isLightTheme: boolean
     history: H.History
@@ -25,7 +27,7 @@ interface Props extends RouteComponentProps<{ id: GQL.ID }> {
 const LOADING = 'loading' as const
 
 interface State {
-    externalServiceOrError: typeof LOADING | GQL.IExternalService | ErrorLike
+    externalServiceOrError: typeof LOADING | ExternalService | ErrorLike
 
     /**
      * The result of updating the external service: null when complete or not started yet,
@@ -72,12 +74,16 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                         concat(
                             [{ updatedOrError: LOADING, warning: null }],
                             updateExternalService(input).pipe(
-                                mergeMap(({ warning }) =>
-                                    warning
-                                        ? of({ warning, updatedOrError: null })
+                                mergeMap(service =>
+                                    service.warning
+                                        ? of({
+                                              warning: service.warning,
+                                              externalServiceOrError: service,
+                                              updatedOrError: null,
+                                          })
                                         : concat(
                                               // Flash "updated" text
-                                              of({ updatedOrError: true }),
+                                              of({ updatedOrError: true, externalServiceOrError: service }),
                                               // Hide "updated" text again after 1s
                                               of({ updatedOrError: null }).pipe(delay(1000))
                                           )
@@ -114,22 +120,30 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
             undefined
 
         let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
-        if (externalService && externalService.kind === GQL.ExternalServiceKind.GITHUB) {
+        if (
+            externalService &&
+            [GQL.ExternalServiceKind.GITHUB, GQL.ExternalServiceKind.GITLAB].includes(externalService.kind)
+        ) {
             const parsedConfig: unknown = parseJSONC(externalService.config)
-            // we have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the url
-            if (
+            const url =
                 typeof parsedConfig === 'object' &&
                 parsedConfig !== null &&
                 hasProperty('url')(parsedConfig) &&
-                typeof parsedConfig.url === 'string' &&
-                !parsedConfig.url.startsWith('https://github.com/')
-            ) {
+                typeof parsedConfig.url === 'string'
+                    ? new URL(parsedConfig.url)
+                    : undefined
+            // We have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the URL.
+            if (externalService.kind === GQL.ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
                 externalServiceCategory = codeHostExternalServices.ghe
+            }
+            // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-histed, so we need to guess based on the URL.
+            if (externalService.kind === GQL.ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
+                externalServiceCategory = codeHostExternalServices.gitlab
             }
         }
 
         return (
-            <div className="site-admin-configuration-page mt-3">
+            <div className="site-admin-configuration-page">
                 {externalService ? (
                     <PageTitle title={`External service - ${externalService.displayName}`} />
                 ) : (
@@ -167,6 +181,13 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 {this.state.updatedOrError === true && (
                     <p className="alert alert-success user-settings-profile-page__alert">Updated!</p>
                 )}
+                {externalService?.webhookURL && (
+                    <div className="alert alert-info">
+                        <h3>Webhooks</h3>
+                        <p>Point webhooks for this external service at the following URL:</p>
+                        <p>{externalService.webhookURL}</p>
+                    </div>
+                )}
             </div>
         )
     }
@@ -191,21 +212,32 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
 }
 
 function isExternalService(
-    externalServiceOrError: typeof LOADING | GQL.IExternalService | ErrorLike
+    externalServiceOrError: typeof LOADING | ExternalService | ErrorLike
 ): externalServiceOrError is GQL.IExternalService {
     return externalServiceOrError !== LOADING && !isErrorLike(externalServiceOrError)
 }
 
-function updateExternalService(
-    input: GQL.IUpdateExternalServiceInput
-): Observable<Pick<GQL.IExternalService, 'warning'>> {
+const externalServiceFragment = gql`
+    fragment externalServiceFields on ExternalService {
+        id
+        kind
+        displayName
+        config
+        warning
+        webhookURL
+    }
+`
+
+function updateExternalService(input: GQL.IUpdateExternalServiceInput): Observable<ExternalService> {
     return mutateGraphQL(
         gql`
             mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
                 updateExternalService(input: $input) {
-                    warning
+                    ...externalServiceFields
                 }
             }
+
+            ${externalServiceFragment}
         `,
         { input }
     ).pipe(
@@ -214,23 +246,29 @@ function updateExternalService(
     )
 }
 
-function fetchExternalService(id: GQL.ID): Observable<GQL.IExternalService> {
+function fetchExternalService(id: GQL.ID): Observable<ExternalService> {
     return queryGraphQL(
         gql`
             query ExternalService($id: ID!) {
                 node(id: $id) {
-                    ... on ExternalService {
-                        id
-                        kind
-                        displayName
-                        config
-                    }
+                    __typename
+                    ...externalServiceFields
                 }
             }
+
+            ${externalServiceFragment}
         `,
         { id }
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => data.node as GQL.IExternalService)
+        map(({ node }) => {
+            if (!node) {
+                throw new Error('External service not found')
+            }
+            if (node.__typename !== 'ExternalService') {
+                throw new Error(`Node is a ${node.__typename}, not a ExternalService`)
+            }
+            return node
+        })
     )
 }

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -16,6 +16,7 @@ import { ErrorAlert } from '../components/alerts'
 import { defaultExternalServices, codeHostExternalServices } from './externalServices'
 import { hasProperty } from '../../../shared/src/util/types'
 import * as H from 'history'
+import { CopyableText } from '../components/CopyableText'
 
 type ExternalService = Pick<GQL.IExternalService, 'id' | 'kind' | 'displayName' | 'config' | 'warning' | 'webhookURL'>
 
@@ -185,7 +186,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                     <div className="alert alert-info">
                         <h3>Webhooks</h3>
                         <p>Point webhooks for this external service at the following URL:</p>
-                        <p>{externalService.webhookURL}</p>
+                        <CopyableText text={externalService.webhookURL} size={externalService.webhookURL.length} />
                     </div>
                 )}
             </div>

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -136,7 +136,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
             if (externalService.kind === GQL.ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
                 externalServiceCategory = codeHostExternalServices.ghe
             }
-            // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-histed, so we need to guess based on the URL.
+            // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
             if (externalService.kind === GQL.ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
                 externalServiceCategory = codeHostExternalServices.gitlab
             }

--- a/web/src/site-admin/__snapshots__/SiteAdminExternalServiceForm.test.tsx.snap
+++ b/web/src/site-admin/__snapshots__/SiteAdminExternalServiceForm.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`<SiteAdminExternalServiceForm /> create GitHub 1`] = `
     </p>
   </div>
   <button
-    className="btn btn-primary e2e-add-external-service-button"
+    className="btn btn-primary mb-3 e2e-add-external-service-button"
     disabled={false}
     type="submit"
   >
@@ -93,7 +93,7 @@ exports[`<SiteAdminExternalServiceForm /> edit GitHub 1`] = `
     </p>
   </div>
   <button
-    className="btn btn-primary e2e-add-external-service-button"
+    className="btn btn-primary mb-3 e2e-add-external-service-button"
     disabled={false}
     type="submit"
   >
@@ -144,7 +144,7 @@ exports[`<SiteAdminExternalServiceForm /> edit GitHub, loading 1`] = `
     </p>
   </div>
   <button
-    className="btn btn-primary e2e-add-external-service-button"
+    className="btn btn-primary mb-3 e2e-add-external-service-button"
     disabled={true}
     type="submit"
   >

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -862,6 +862,15 @@ const BITBUCKET_SERVER: AddExternalServiceOptions = {
                 return { edits, selectText: value }
             },
         },
+        {
+            id: 'enableWebhooks',
+            label: 'Enable webhooks',
+            run: config => {
+                const value = { webhooks: { secret: '<any_secret_string>' } }
+                const edits = setProperty(config, ['plugin'], value, defaultFormattingOptions)
+                return { edits, selectText: '<any_secret_string>' }
+            },
+        },
     ],
 }
 const GITLAB_DOTCOM: AddExternalServiceOptions = {

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -312,6 +312,15 @@ const githubEditorActions = (isEnterprise: boolean): EditorAction[] => [
             return { edits: [edit], selectText: comment }
         },
     },
+    {
+        id: 'addWebhooks',
+        label: 'Add webhook',
+        run: config => {
+            const value = { org: '<your_org_on_GitHub>', secret: '<any_secret_string>' }
+            const edits = setProperty(config, ['webhooks', -1], value, defaultFormattingOptions)
+            return { edits, selectText: '<your_org_on_GitHub>' }
+        },
+    },
 ]
 
 const gitlabEditorActions = (isSelfManaged: boolean): EditorAction[] => [


### PR DESCRIPTION
This PR:
- Adds quick actions for GitHub and Bitbucket Server to add webhooks to the config
- Displays the webhook info box as shown in the screenshot below
- Stays on the page after creating the external service, so the user is not navigated away from the derived information
- Fixes retrieving the config for external services other than GitHub and Bitbucket server cc @ryanslade https://github.com/sourcegraph/sourcegraph/commit/cf003e015b46abc958733fe9ab7e61d809b3e422 Hence, I marked as release blocking
- Fixes detection of code host types

![image](https://user-images.githubusercontent.com/19534377/81818654-9a6b9f00-952e-11ea-8781-4a62847c493a.png)

Closes #10300 

ping @ryanslade 