### PR TITLE
search: perform -repo exclusion for Sourcegraph.com

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -634,7 +634,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		getIndexedRepos := func(ctx context.Context, revs []*search.RepositoryRevisions) (indexed, unindexed []*search.RepositoryRevisions, err error) {
 			return zoektIndexedRepos(ctx, search.Indexed(), revs, nil)
 		}
-		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, getIndexedRepos)
+		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, getIndexedRepos, excludePatterns)
 		if err != nil {
 			return nil, nil, false, errors.Wrap(err, "getting list of default repos")
 		}
@@ -754,12 +754,25 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 type indexedReposFunc func(ctx context.Context, revs []*search.RepositoryRevisions) (indexed, unindexed []*search.RepositoryRevisions, err error)
 type defaultReposFunc func(ctx context.Context) ([]*types.Repo, error)
 
-func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, getIndexedRepos indexedReposFunc) ([]*types.Repo, error) {
+func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, getIndexedRepos indexedReposFunc, excludePatterns []string) ([]*types.Repo, error) {
 	// Get the list of default repos from the db.
 	defaultRepos, err := getRawDefaultRepos(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "querying db for default repos")
 	}
+
+	// Remove excluded repos
+	if excludePatterns != nil {
+		patterns := `(?i)` + unionRegExps(excludePatterns)
+		filteredRepos := defaultRepos[:0]
+		for _, repo := range defaultRepos {
+			if matched, _ := regexp.Match(patterns, []byte(strings.ToLower(string(repo.Name)))); false == matched {
+				filteredRepos = append(filteredRepos, repo)
+			}
+		}
+		defaultRepos = filteredRepos
+	}
+
 	// Find out which of the default repos have been indexed.
 	defaultRepoRevs := make([]*search.RepositoryRevisions, 0, len(defaultRepos))
 	for _, r := range defaultRepos {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -763,10 +763,10 @@ func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFun
 
 	// Remove excluded repos
 	if len(excludePatterns) > 0 {
-		patterns := `(?i)` + unionRegExps(excludePatterns)
+		patterns, _ := regexp.Compile(`(?i)` + unionRegExps(excludePatterns))
 		filteredRepos := defaultRepos[:0]
 		for _, repo := range defaultRepos {
-			if matched, _ := regexp.MatchString(patterns, string(repo.Name)); false == matched {
+			if matched := patterns.MatchString(string(repo.Name)); false == matched {
 				filteredRepos = append(filteredRepos, repo)
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -762,11 +762,11 @@ func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFun
 	}
 
 	// Remove excluded repos
-	if excludePatterns != nil {
+	if len(excludePatterns) > 0 {
 		patterns := `(?i)` + unionRegExps(excludePatterns)
 		filteredRepos := defaultRepos[:0]
 		for _, repo := range defaultRepos {
-			if matched, _ := regexp.Match(patterns, []byte(strings.ToLower(string(repo.Name)))); false == matched {
+			if matched, _ := regexp.MatchString(patterns, string(repo.Name)); false == matched {
 				filteredRepos = append(filteredRepos, repo)
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -259,7 +259,7 @@ func Test_defaultRepositories(t *testing.T) {
 		defaultsInDb     []string
 		indexedRepoNames map[string]bool
 		want             []string
-		excludePatterns []string
+		excludePatterns  []string
 	}{
 		{
 			name:             "none in db => none returned",

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -259,6 +259,7 @@ func Test_defaultRepositories(t *testing.T) {
 		defaultsInDb     []string
 		indexedRepoNames map[string]bool
 		want             []string
+		excludePatterns []string
 	}{
 		{
 			name:             "none in db => none returned",
@@ -272,9 +273,31 @@ func Test_defaultRepositories(t *testing.T) {
 			indexedRepoNames: map[string]bool{"indexedrepo": true},
 			want:             []string{"indexedrepo"},
 		},
+		{
+			name:             "should not return excluded repo",
+			defaultsInDb:     []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2", "indexedrepo3"},
+			indexedRepoNames: map[string]bool{"indexedrepo1": true, "indexedrepo2": true, "indexedrepo3": true},
+			excludePatterns:  []string{"indexedrepo3"},
+			want:             []string{"indexedrepo1", "indexedrepo2"},
+		},
+		{
+			name:             "should not return excluded repo (case insensitive)",
+			defaultsInDb:     []string{"unindexedrepo1", "indexedrepo1", "indexedrepo2", "Indexedrepo3"},
+			indexedRepoNames: map[string]bool{"indexedrepo1": true, "indexedrepo2": true, "Indexedrepo3": true},
+			excludePatterns:  []string{"indexedrepo3"},
+			want:             []string{"indexedrepo1", "indexedrepo2"},
+		},
+		{
+			name:             "should not return excluded repos ending in `test`",
+			defaultsInDb:     []string{"repo1", "repo2", "repo-test", "repoTEST"},
+			indexedRepoNames: map[string]bool{"repo1": true, "repo2": true, "repo-test": true, "repoTEST": true},
+			excludePatterns:  []string{"test$"},
+			want:             []string{"repo1", "repo2"},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+
 			var drs []*types.Repo
 			for i, name := range tc.defaultsInDb {
 				r := &types.Repo{
@@ -300,7 +323,7 @@ func Test_defaultRepositories(t *testing.T) {
 				return indexed, unindexed, nil
 			}
 			ctx := context.Background()
-			drs, err := defaultRepositories(ctx, getRawDefaultRepos, indexedRepos)
+			drs, err := defaultRepositories(ctx, getRawDefaultRepos, indexedRepos, tc.excludePatterns)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Hey @rvantonder, here's the PR to fixes #10481 

Basically, the problem was what you pointed out: you are not applying `excludePatterns`. I thought a bit where the exclusion should take place and I've came to the conclusion that either we could do it after [this](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@457f09b4c52ccde2bdf114f44f9ce77cca2efd63/-/blob/cmd/frontend/graphqlbackend/search.go#L637) line or, we could change the signature of `defaultRepositories` (I checked it's only called from one and only one place) to receive also the `excludePatterns` and do the filtering inside there. And I went for the latter option (I also thought about instead of passing `excludePatterns`to `defaultRepositories` function,  to pass a function that filters elements but then I though it could be of overthinking).

For the tests, I've just added more cases on [search_test.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@60d51e2e3f1f90094cebc38ca0af822a6c7b0bf5/-/blob/cmd/frontend/graphqlbackend/search_test.go#L256)

What do you think about this approach? I have anyways made the PR a draft one.


Fixes #10481 