### PR TITLE
authz: add "Schedule now" button to permissions pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Added [Smarty](#2885), [Ethereum / Solidity / Vyper)](#2440), [Cuda](#5907), [COBOL](#10154), [vb.NET](#4901), and [ASP.NET](#4262) syntax highlighting.
   - Fixed OCaml syntax highlighting #3545
   - Bazel/Starlark support improved (.star, BUILD, and many more extensions now properly highlighted). #8123
-- New permissions page in both user and repository settings when background permissions syncing is enabled (`"permissions.backgroundSync": {"enabled": true}`). #10473
+- New permissions page in both user and repository settings when background permissions syncing is enabled (`"permissions.backgroundSync": {"enabled": true}`). [#10473](https://github.com/sourcegraph/sourcegraph/pull/10473) [#10655](https://github.com/sourcegraph/sourcegraph/pull/10655)
 - A new dropdown for choosing version contexts appears on the left of the query input when version contexts are specified in `experimentalFeatures.versionContext` in site configuration. Version contexts allow you to scope your search to specific sets of repos at revisions.
 - Campaign changeset usage counts including changesets created, added and merged will be sent back in pings. [#10591](https://github.com/sourcegraph/sourcegraph/pull/10591)
 - Diff views now feature syntax highlighting and can be properly copy-pasted. [#10437](https://github.com/sourcegraph/sourcegraph/pull/10437)

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -221,7 +221,7 @@ export function scheduleRepositoryPermissionsSync(args: { repository: GQL.ID }):
     ).pipe(
         map(dataOrThrowErrors),
         tap(() => resetAllMemoizationCaches()),
-        map(() => undefined)
+        mapTo(undefined)
     )
 }
 

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -208,6 +208,23 @@ export function checkMirrorRepositoryConnection(
     )
 }
 
+export function scheduleRepositoryPermissionsSync(args: { repository: GQL.ID }): Observable<void> {
+    return mutateGraphQL(
+        gql`
+            mutation ScheduleRepositoryPermissionsSync($repository: ID!) {
+                scheduleRepositoryPermissionsSync(repository: $repository) {
+                    alwaysNil
+                }
+            }
+        `,
+        args
+    ).pipe(
+        map(dataOrThrowErrors),
+        tap(() => resetAllMemoizationCaches()),
+        map(() => undefined)
+    )
+}
+
 /**
  * Fetches usage statistics for all users.
  *

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -238,7 +238,7 @@ export function scheduleUserPermissionsSync(args: { user: GQL.ID }): Observable<
     ).pipe(
         map(dataOrThrowErrors),
         tap(() => resetAllMemoizationCaches()),
-        map(() => undefined)
+        mapTo(undefined)
     )
 }
 

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -225,6 +225,23 @@ export function scheduleRepositoryPermissionsSync(args: { repository: GQL.ID }):
     )
 }
 
+export function scheduleUserPermissionsSync(args: { user: GQL.ID }): Observable<void> {
+    return mutateGraphQL(
+        gql`
+            mutation ScheduleUserPermissionsSync($user: ID!) {
+                scheduleUserPermissionsSync(user: $user) {
+                    alwaysNil
+                }
+            }
+        `,
+        args
+    ).pipe(
+        map(dataOrThrowErrors),
+        tap(() => resetAllMemoizationCaches()),
+        map(() => undefined)
+    )
+}
+
 /**
  * Fetches usage statistics for all users.
  *

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -1,6 +1,6 @@
 import { parse as parseJSONC } from '@sqs/jsonc-parser'
 import { Observable } from 'rxjs'
-import { map, tap } from 'rxjs/operators'
+import { map, tap, mapTo } from 'rxjs/operators'
 import { repeatUntil } from '../../../shared/src/util/rxjs/repeatUntil'
 import { createInvalidGraphQLMutationResponseError, dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'

--- a/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -3,11 +3,17 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { PageTitle } from '../../../components/PageTitle'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { eventLogger } from '../../../tracking/eventLogger'
+import * as H from 'history'
+import { ActionContainer } from '../../../repo/settings/components/ActionContainer'
+import { scheduleUserPermissionsSync } from '../../../site-admin/backend'
 
 /**
  * The user settings permissions page.
  */
-export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IUser }> = ({ user }) => {
+export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IUser; history: H.History }> = ({
+    user,
+    history,
+}) => {
     useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'))
 
     return (
@@ -24,29 +30,58 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IU
                     is finished.
                 </div>
             ) : (
-                <table className="table">
-                    <tbody>
-                        <tr>
-                            <th>Last complete sync</th>
-                            <td>
-                                {user.permissionsInfo.syncedAt ? (
-                                    <Timestamp date={user.permissionsInfo.syncedAt} />
-                                ) : (
-                                    'Never'
-                                )}
-                            </td>
-                            <td className="text-muted">Updated by user permissions syncing</td>
-                        </tr>
-                        <tr>
-                            <th>Last incremental sync</th>
-                            <td>
-                                <Timestamp date={user.permissionsInfo.updatedAt} />
-                            </td>
-                            <td className="text-muted">Updated by repository permissions syncing</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div>
+                    <table className="table">
+                        <tbody>
+                            <tr>
+                                <th>Last complete sync</th>
+                                <td>
+                                    {user.permissionsInfo.syncedAt ? (
+                                        <Timestamp date={user.permissionsInfo.syncedAt} />
+                                    ) : (
+                                        'Never'
+                                    )}
+                                </td>
+                                <td className="text-muted">Updated by user permissions syncing</td>
+                            </tr>
+                            <tr>
+                                <th>Last incremental sync</th>
+                                <td>
+                                    <Timestamp date={user.permissionsInfo.updatedAt} />
+                                </td>
+                                <td className="text-muted">Updated by repository permissions syncing</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <ScheduleUserPermissionsSyncActionContainer user={user} history={history} />
+                </div>
             )}
         </div>
     )
+}
+
+interface ScheduleUserPermissionsSyncActionContainerProps {
+    user: GQL.IUser
+    history: H.History
+}
+
+class ScheduleUserPermissionsSyncActionContainer extends React.PureComponent<
+    ScheduleUserPermissionsSyncActionContainerProps
+> {
+    public render(): JSX.Element | null {
+        return (
+            <ActionContainer
+                title="Manually schedule a permissions sync"
+                description={<div>Site admins are able to manually schedule a permissions sync for this user.</div>}
+                buttonLabel="Schedule now"
+                flashText="Added to queue"
+                run={this.scheduleUserPermissions}
+                history={this.props.history}
+            />
+        )
+    }
+
+    private scheduleUserPermissions = async (): Promise<void> => {
+        await scheduleUserPermissionsSync({ user: this.props.user.id }).toPromise()
+    }
 }


### PR DESCRIPTION
Adds "Schedule now" button to permissions pages of both user and repository settings, which basically hits corresponding GraphQL mutations.

![image](https://user-images.githubusercontent.com/2946214/81903714-ba659600-95f4-11ea-9f1a-e68b6b9b8608.png)

This finally fixes #8990 as the last mile.