### PR TITLE
Fix: version contexts via URL wouldn't persist

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -113,7 +113,7 @@ export interface LayoutProps
         versionContext: string | undefined,
         { extensionsController }: ExtensionsControllerProps<'services'>
     ) => Observable<GQL.ISearchResults | ErrorLike>
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 
     isSourcegraphDotCom: boolean

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -471,7 +471,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         })
     }
 
-    private setVersionContext = (versionContext: string): void => {
+    private setVersionContext = (versionContext: string | undefined): void => {
         const resolvedVersionContext = resolveVersionContext(versionContext, this.state.availableVersionContexts)
         if (!resolvedVersionContext) {
             localStorage.removeItem(LAST_VERSION_CONTEXT_KEY)

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -476,9 +476,10 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         if (!resolvedVersionContext) {
             localStorage.removeItem(LAST_VERSION_CONTEXT_KEY)
             this.setState({ versionContext: undefined })
+        } else {
+            localStorage.setItem(LAST_VERSION_CONTEXT_KEY, resolvedVersionContext)
+            this.setState({ versionContext: resolvedVersionContext })
         }
-        localStorage.setItem(LAST_VERSION_CONTEXT_KEY, versionContext)
-        this.setState({ versionContext })
     }
 }
 

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -69,7 +69,7 @@ interface Props
     splitSearchModes: boolean
     interactiveSearchMode: boolean
     toggleSearchMode: (event: React.MouseEvent<HTMLAnchorElement>) => void
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 
     /** For testing only. Used because reactstrap's Popover is incompatible with react-test-renderer. */

--- a/web/src/nav/VersionContextDropdown.tsx
+++ b/web/src/nav/VersionContextDropdown.tsx
@@ -27,7 +27,7 @@ export interface VersionContextDropdownProps
         Pick<CaseSensitivityProps, 'caseSensitive'>,
         Partial<Pick<InteractiveSearchProps, 'filtersInQuery'>>,
         VersionContextProps {
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
     history: H.History
     navbarSearchQuery: string
@@ -63,7 +63,7 @@ export const VersionContextDropdown: React.FunctionComponent<VersionContextDropd
     }
 
     const disableValue = (): void => {
-        props.setVersionContext('')
+        props.setVersionContext(undefined)
     }
 
     if (!props.availableVersionContexts || props.availableVersionContexts.length === 0) {

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -53,7 +53,7 @@ interface Props
     location: H.Location
     history: H.History
     isSourcegraphDotCom: boolean
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 
     // For NavLinks

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -54,7 +54,7 @@ interface InteractiveModeProps
     showCampaigns: boolean
     isSourcegraphDotCom: boolean
 
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 }
 

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -193,9 +193,8 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                                             if (caseSensitive !== this.props.caseSensitive) {
                                                 this.props.setCaseSensitivity(caseSensitive)
                                             }
-                                            if (versionContext !== this.props.versionContext) {
-                                                this.props.setVersionContext(versionContext || '')
-                                            }
+
+                                            this.props.setVersionContext(versionContext || '')
                                         },
                                         error => {
                                             this.props.telemetryService.log('SearchResultsFetchFailed', {

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -59,7 +59,7 @@ export interface SearchResultsProps
     ) => Observable<GQL.ISearchResults | ErrorLike>
     isSourcegraphDotCom: boolean
     deployType: DeployType
-    setVersionContext: (versionContext: string) => void
+    setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 }
 
@@ -194,7 +194,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                                                 this.props.setCaseSensitivity(caseSensitive)
                                             }
 
-                                            this.props.setVersionContext(versionContext || '')
+                                            this.props.setVersionContext(versionContext)
                                         },
                                         error => {
                                             this.props.telemetryService.log('SearchResultsFetchFailed', {


### PR DESCRIPTION
Version contexts in localStorage should be updated when a URL uses a different version context. It wasn't occurring previously.

edit: added commit to make `setVersionContext` accept undefined, so callers can pass it instead of an empty string.