### PR TITLE
graphql: document that FileMatch.lineNumber is 0-based

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2798,7 +2798,8 @@ type FileMatch {
 type LineMatch {
     # The preview.
     preview: String!
-    # The line number.
+    # The line number. 0-based. The first line will have lineNumber 0. Note: A
+    # UI will normally display line numbers 1-based.
     lineNumber: Int!
     # Tuples of [offset, length] measured in characters (not bytes).
     offsetAndLengths: [[Int!]!]!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2805,7 +2805,8 @@ type FileMatch {
 type LineMatch {
     # The preview.
     preview: String!
-    # The line number.
+    # The line number. 0-based. The first line will have lineNumber 0. Note: A
+    # UI will normally display line numbers 1-based.
     lineNumber: Int!
     # Tuples of [offset, length] measured in characters (not bytes).
     offsetAndLengths: [[Int!]!]!


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/9587