### PR TITLE
codeintel: Gracefully fall back on queries to missing bundles

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/exists.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
 
@@ -27,6 +29,10 @@ func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int,
 	for _, dump := range candidates {
 		exists, err := api.bundleManagerClient.BundleClient(dump.ID).Exists(ctx, strings.TrimPrefix(file, dump.Root))
 		if err != nil {
+			if err == client.ErrNotFound {
+				log15.Warn("Bundle does not exist")
+				return nil, nil
+			}
 			return nil, errors.Wrap(err, "bundleManagerClient.BundleClient")
 		}
 		if !exists {

--- a/cmd/precise-code-intel-api-server/internal/api/hover.go
+++ b/cmd/precise-code-intel-api-server/internal/api/hover.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 )
 
@@ -23,6 +25,10 @@ func (api *codeIntelAPI) Hover(ctx context.Context, file string, line, character
 
 	text, rn, exists, err := bundleClient.Hover(ctx, pathInBundle, line, character)
 	if err != nil {
+		if err == client.ErrNotFound {
+			log15.Warn("Bundle does not exist")
+			return "", bundles.Range{}, false, nil
+		}
 		return "", bundles.Range{}, false, errors.Wrap(err, "bundleClient.Hover")
 	}
 	if exists {
@@ -39,6 +45,10 @@ func (api *codeIntelAPI) Hover(ctx context.Context, file string, line, character
 
 	text, rn, exists, err = definitionBundleClient.Hover(ctx, pathInDefinitionBundle, definition.Range.Start.Line, definition.Range.Start.Character)
 	if err != nil {
+		if err == client.ErrNotFound {
+			log15.Warn("Bundle does not exist")
+			return "", bundles.Range{}, false, nil
+		}
 		return "", bundles.Range{}, false, errors.Wrap(err, "definitionBundleClient.Hover")
 	}
 

--- a/cmd/precise-code-intel-api-server/internal/api/monikers.go
+++ b/cmd/precise-code-intel-api-server/internal/api/monikers.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
@@ -24,6 +26,10 @@ func lookupMoniker(
 
 	pid, err := bundleManagerClient.BundleClient(dumpID).PackageInformation(context.Background(), path, moniker.PackageInformationID)
 	if err != nil {
+		if err == client.ErrNotFound {
+			log15.Warn("Bundle does not exist")
+			return nil, 0, nil
+		}
 		return nil, 0, errors.Wrap(err, "bundleManagerClient.BundleClient")
 	}
 
@@ -34,6 +40,10 @@ func lookupMoniker(
 
 	locations, count, err := bundleManagerClient.BundleClient(dump.ID).MonikerResults(context.Background(), modelType, moniker.Scheme, moniker.Identifier, skip, take)
 	if err != nil {
+		if err == client.ErrNotFound {
+			log15.Warn("Bundle does not exist")
+			return nil, 0, nil
+		}
 		return nil, 0, errors.Wrap(err, "bundleManagerClient.BundleClient")
 	}
 

--- a/internal/codeintel/bundles/client/bundle_client_test.go
+++ b/internal/codeintel/bundles/client/bundle_client_test.go
@@ -29,6 +29,19 @@ func TestExists(t *testing.T) {
 	}
 }
 
+func TestExistsNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := &bundleClientImpl{base: &bundleManagerClientImpl{bundleManagerURL: ts.URL}, bundleID: 42}
+	_, err := client.Exists(context.Background(), "main.go")
+	if err != ErrNotFound {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrNotFound, err)
+	}
+}
+
 func TestExistsBadResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/codeintel/bundles/client/bundle_manager_client_test.go
+++ b/internal/codeintel/bundles/client/bundle_manager_client_test.go
@@ -193,6 +193,19 @@ func TestGetUpload(t *testing.T) {
 	}
 }
 
+func TestGetUploadNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := &bundleManagerClientImpl{bundleManagerURL: ts.URL}
+	_, err := client.GetUpload(context.Background(), 42, "")
+	if err != ErrNotFound {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrNotFound, err)
+	}
+}
+
 func TestGetUploadBadResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Bundles can be removed from disk but do not (yet) update the database with this information. Currently, requests to bundles that have been deleted will result in a 404 which is an error condition from the precise-code-intel API.

This PR makes 404 responses a unique error which can be checked at all call sites. When this error is encountered, we return no results but swallow the error. This stops a 500-level error from being returned by the API and allows the code intel extensions to fall back to search-based results.

This check will remain indefinitely, but we will additionally introduce a janitor process (in a later PR) that will ensure that any records in the DB have a valid on the bundle manager's disk (and any records that do not have this property will be marked so they are not used for queries). This check should still remain so that any bundles deleted before the janitor process runs do not affect user queries in a negative way (no results).