### PR TITLE
Update bundle manager dashboard

### DIFF
--- a/monitoring/precise_code_intel_bundle_manager.go
+++ b/monitoring/precise_code_intel_bundle_manager.go
@@ -78,7 +78,7 @@ func PreciseCodeIntelBundleManager() *Container {
 						{
 							Name:              "cache_miss_percentage",
 							Description:       "percentage of cache misses over all cache activity every 5m",
-							Query:             `(increase(src_cache_misses_total[5m]) / (increase(src_cache_hits_total[5m]) + increase(src_cache_misses_total[5m]))) * 100`,
+							Query:             `(increase(src_cache_misses_total{job="precise-code-intel-bundle-manager"}[5m]) / (increase(src_cache_hits_total{job="precise-code-intel-bundle-manager"}[5m]) + increase(src_cache_misses_total{job="precise-code-intel-bundle-manager"}[5m]))) * 100`,
 							DataMayNotExist:   true,
 							Warning:           Alert{GreaterOrEqual: 80},
 							PanelOptions:      PanelOptions().LegendFormat("{{cache}}").Unit(Percentage),

--- a/monitoring/precise_code_intel_bundle_manager.go
+++ b/monitoring/precise_code_intel_bundle_manager.go
@@ -80,7 +80,7 @@ func PreciseCodeIntelBundleManager() *Container {
 							Description:       "percentage of cache misses over all cache activity every 5m",
 							Query:             `(increase(src_cache_misses_total{job="precise-code-intel-bundle-manager"}[5m]) / (increase(src_cache_hits_total{job="precise-code-intel-bundle-manager"}[5m]) + increase(src_cache_misses_total{job="precise-code-intel-bundle-manager"}[5m]))) * 100`,
 							DataMayNotExist:   true,
-							Warning:           Alert{GreaterOrEqual: 80},
+							Warning:           Alert{GreaterOrEqual: 100},
 							PanelOptions:      PanelOptions().LegendFormat("{{cache}}").Unit(Percentage),
 							PossibleSolutions: "none",
 						},

--- a/monitoring/precise_code_intel_bundle_manager.go
+++ b/monitoring/precise_code_intel_bundle_manager.go
@@ -55,7 +55,7 @@ func PreciseCodeIntelBundleManager() *Container {
 						{
 							Name:            "disk_space_remaining",
 							Description:     "disk space remaining by instance",
-							Query:           `(src_disk_space_available_bytes / src_disk_space_total_bytes) * 100`,
+							Query:           `(src_disk_space_available_bytes{job="precise-code-intel-bundle-manager"} / src_disk_space_total_bytes{job="precise-code-intel-bundle-manager"}) * 100`,
 							DataMayNotExist: true,
 							Warning:         Alert{LessOrEqual: 25},
 							Critical:        Alert{LessOrEqual: 15},


### PR DESCRIPTION
The diskspace metric was showing all metrics for gitserver, causing more graph noise/alerts than necessary.

Also upped the cache alert since it's likely to have bursts of requests to new data. I plan to tune this better during the 3.17 cycle so that we can lower the threshold without it being spurious.