### PR TITLE
Fix hover tooltips on diff views

### DIFF
--- a/web/src/repo/compare/dom-functions.ts
+++ b/web/src/repo/compare/dom-functions.ts
@@ -55,5 +55,5 @@ export const diffDomFunctions: DOMFunctions = {
         throw new Error('Could not figure out diff part for code element')
     },
 
-    isFirstCharacterDiffIndicator: () => true,
+    isFirstCharacterDiffIndicator: () => false,
 }


### PR DESCRIPTION
After syntax highlighting was introduced, we dropped the leading ' ', '-', '+', because reinserting it into the generated HTML would have been slow and also it's hard to copy the content. Hence they were off-by-one on diff views now.