### PR TITLE
Bump minimum src-cli version

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.11.0"
+const MinimumVersion = "3.12.0"


### PR DESCRIPTION
This is necessary to enable multipart LSIF uploads on 3.16.