### PR TITLE
Fix: version context dropdown increased height

### DIFF
--- a/web/src/nav/VersionContextDropdown.scss
+++ b/web/src/nav/VersionContextDropdown.scss
@@ -1,7 +1,8 @@
 @import '~@reach/listbox/styles.css';
 
 .version-context-dropdown {
-    width: fit-content;
+    width: max-content;
+
     &__button {
         display: flex;
         border-radius: 0;


### PR DESCRIPTION
The dropdown increases height when the content is too long. We should make the width max-content so it never vertically overflows. We have a 14 character limit on the version context names so it should never take up too much horizontal space.

![image](https://user-images.githubusercontent.com/16265452/81948503-64b0de00-9634-11ea-8742-b0f75683cb1a.png)