### PR TITLE
Only aggregate weekly data for pings

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -88,7 +88,7 @@ func getAndMarshalSiteActivityJSON(ctx context.Context, criticalOnly bool) (json
 	if criticalOnly {
 		months = 1
 	} else {
-		days, weeks, months = 2, 1, 1
+		days, weeks, months = 1, 1, 1
 	}
 	siteActivity, err := usagestats.GetSiteUsageStatistics(ctx, &usagestats.SiteUsageStatisticsOptions{
 		DayPeriods:   &days,
@@ -159,7 +159,7 @@ func getAndMarshalCampaignsUsageJSON(ctx context.Context) (json.RawMessage, erro
 
 func getAndMarshalCodeIntelUsageJSON(ctx context.Context) (json.RawMessage, error) {
 	rec := recordOperation("getAndMarshalCodeIntelUsageJSON")
-	days, weeks, months := 2, 1, 1
+	days, weeks, months := 0, 1, 0
 	codeIntelUsage, err := usagestats.GetCodeIntelUsageStatistics(ctx, &usagestats.CodeIntelUsageStatisticsOptions{
 		DayPeriods:            &days,
 		WeekPeriods:           &weeks,
@@ -180,7 +180,7 @@ func getAndMarshalCodeIntelUsageJSON(ctx context.Context) (json.RawMessage, erro
 
 func getAndMarshalSearchUsageJSON(ctx context.Context) (json.RawMessage, error) {
 	rec := recordOperation("getAndMarshalSearchUsageJSON")
-	days, weeks, months := 2, 1, 1
+	days, weeks, months := 0, 1, 0
 	searchUsage, err := usagestats.GetSearchUsageStatistics(ctx, &usagestats.SearchUsageStatisticsOptions{
 		DayPeriods:         &days,
 		WeekPeriods:        &weeks,

--- a/cmd/frontend/internal/usagestats/codeintel.go
+++ b/cmd/frontend/internal/usagestats/codeintel.go
@@ -84,13 +84,10 @@ func codeIntelActivity(ctx context.Context, periodType db.PeriodType, periods in
 
 	eventStatisticByName := map[string]func(p *ciUsagePeriod) *ciEventStatistics{
 		"codeintel.lsifHover":         func(p *ciUsagePeriod) *ciEventStatistics { return p.Hover.LSIF },
-		"codeintel.lspHover":          func(p *ciUsagePeriod) *ciEventStatistics { return p.Hover.LSP },
 		"codeintel.searchHover":       func(p *ciUsagePeriod) *ciEventStatistics { return p.Hover.Search },
 		"codeintel.lsifDefinitions":   func(p *ciUsagePeriod) *ciEventStatistics { return p.Definitions.LSIF },
-		"codeintel.lspDefinitions":    func(p *ciUsagePeriod) *ciEventStatistics { return p.Definitions.LSP },
 		"codeintel.searchDefinitions": func(p *ciUsagePeriod) *ciEventStatistics { return p.Definitions.Search },
 		"codeintel.lsifReferences":    func(p *ciUsagePeriod) *ciEventStatistics { return p.References.LSIF },
-		"codeintel.lspReferences":     func(p *ciUsagePeriod) *ciEventStatistics { return p.References.LSP },
 		"codeintel.searchReferences":  func(p *ciUsagePeriod) *ciEventStatistics { return p.References.Search },
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/10612

Now is your chance @efritz @attfarhan to change the "period" that we aggregate by! I'm making it so that we ONLY aggregate by week now, but if you need something else, or think something else would be more helpful, feel free to suggest changes. We can do multiple periods if needed of course.

@tsenart this doesn't "solve" the issues we're seeing but it certainly helps with https://github.com/sourcegraph/sourcegraph/issues/10598