### PR TITLE
Add integration-tester utility

### DIFF
--- a/internal/cmd/search-integration-tester/api.go
+++ b/internal/cmd/search-integration-tester/api.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+func post(query string, path string) (GQLResult, error) {
+	gqlRequest := GQLRequest{Query: gqlSearch, Variables: &GQLSearchVariable{SearchQuery: query}}
+	b, err := json.Marshal(gqlRequest)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal query: %s", err)
+	}
+	client := &http.Client{}
+	url := fmt.Sprintf("%s:%s", endpoint, path)
+	request, err := http.NewRequest("POST", url, bytes.NewReader(b))
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+	response, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("response error: %s", err)
+	}
+	resultString, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(string(resultString), "{") {
+		return "", errors.New(string(resultString))
+	}
+	var result interface{}
+	err = json.Unmarshal(resultString, &result)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/internal/cmd/search-integration-tester/assert.go
+++ b/internal/cmd/search-integration-tester/assert.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func assertGolden(name, path string, got GQLResult, update bool) error {
+	gotBytes, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal response %s", string(gotBytes)))
+	}
+	if update {
+		if err := ioutil.WriteFile(path, gotBytes, 0640); err != nil {
+			return fmt.Errorf("failed to update golden file %q: %s", path, err)
+		}
+	}
+
+	wantString, err := ioutil.ReadFile(path)
+	if err != nil {
+		// Doesn't exist, set empty to empty object to see the diff.
+		wantString = []byte("{}")
+	}
+	var want interface{}
+	err = json.Unmarshal(wantString, &want)
+	if err != nil {
+		return err
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		return errors.New(diff)
+	}
+	return nil
+}

--- a/internal/cmd/search-integration-tester/main.go
+++ b/internal/cmd/search-integration-tester/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	endpoint = env.Get("ENDPOINT", "http://localhost:3080", "Sourcegraph frontend endpoint")
+	endpoint = env.Get("ENDPOINT", "http://127.0.0.1:3080", "Sourcegraph frontend endpoint")
 	token    = env.Get("ACCESS_TOKEN", "", "Access token")
 	update   bool
 )

--- a/internal/cmd/search-integration-tester/main.go
+++ b/internal/cmd/search-integration-tester/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var (
+	endpoint = env.Get("ENDPOINT", "http://localhost:3080", "Sourcegraph frontend endpoint")
+	token    = env.Get("ACCESS_TOKEN", "", "Access token")
+	update   bool
+)
+
+func main() {
+	flag.BoolVar(&update, "update", false, "Update golden test values in files")
+	flag.Parse()
+	if err := runSearchTests(); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/internal/cmd/search-integration-tester/search.go
+++ b/internal/cmd/search-integration-tester/search.go
@@ -1,0 +1,85 @@
+package main
+
+func search(query string) (GQLResult, error) {
+	response, err := post(query, "/.api/graphql?Search")
+	if err != nil {
+		return "", err
+	}
+	return response, nil
+}
+
+const gqlSearch = `query Search($query: String!) {
+	search(query: $query) {
+		results {
+			limitHit
+			results {
+				__typename
+				... on Repository {
+					name
+				}
+				... on FileMatch {
+					resource
+					limitHit
+					lineMatches {
+						preview
+						lineNumber
+						offsetAndLengths
+					}
+				}
+				... on CommitSearchResult {
+					refs {
+						name
+						displayName
+						prefix
+						repository { uri }
+					}
+					sourceRefs {
+						name
+						displayName
+						prefix
+						repository { uri }
+					}
+					messagePreview {
+						value
+						highlights {
+							line
+							character
+							length
+						}
+					}
+					diffPreview {
+						value
+						highlights {
+							line
+							character
+							length
+						}
+					}
+					commit {
+						repository {
+							uri
+						}
+						oid
+						abbreviatedOID
+						author {
+							person {
+								displayName
+								avatarURL
+							}
+							date
+						}
+						message
+					}
+				}
+			}
+			alert {
+				title
+				proposedQueries {
+					description
+					query
+				}
+			}
+		}
+	}
+}
+`

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+type test struct {
+	Name  string
+	Query string
+}
+
+const searchTestDataDir = "testdata/search"
+
+var tests = []test{
+	// Repo search (part 1).
+	{
+		Name:  `Global search, repo search by name, nonzero result`,
+		Query: `repo:auth0/go-jwt-middleware$`,
+	},
+	{
+		Name:  `Global search, repo search by name, case yes, nonzero result`,
+		Query: `String repo:^github.com/adjust/go-wrk$ case:yes count:1 stable:yes`,
+	},
+	// Text search, focused to repo.
+	{
+		Name:  `Global search, non-master branch, large repo, nonzero result`,
+		Query: `repo:^github.com/facebook/react$@0.3-stable var ExecutionEnvironment = require('ExecutionEnvironment'); patterntype:literal count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, indexed multiline search, nonzero result`,
+		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this patterntype:regexp count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, indexed multiline search, zero results`,
+		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this\.props\.sourcegraph\(`,
+	},
+	{
+		Name:  `Global search, unindexed multiline search, nonzero result`,
+		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this index:no count:1`,
+	},
+	{
+		Name:  `Global search, unindexed multiline search, zero results`,
+		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this\.props\.sourcegraph\( index:no`,
+	},
+	// Commit search.
+	{
+		Name:  `Commit search, nonzero result`,
+		Query: `repo:^github\.com/facebook/react$ type:commit hello world count:1`,
+	},
+	// Diff search.
+	{
+		Name:  `Diff search, nonzero result`,
+		Query: `repo:^github\.com/sgtest/mux$ type:diff main count:1`,
+	},
+	// Timeout search options.
+	{
+		Name:  `Search timeout option, alert raised`,
+		Query: `router index:no timeout:1ns`,
+	},
+	// Global simple text search.
+	{
+		Name:  `Global search, zero results`,
+		Query: `asdfalksd+jflaksjdfklas patterntype:literal`,
+	},
+	{
+		Name:  `Global search, double-quoted pattern, nonzero result`,
+		Query: `"error type:\n" count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, exclude repo, nonzero result`,
+		Query: `"error type:\n" count:1 -repo:DirectXMan12 stable:yes`,
+	},
+	// Repohascommitafter.
+	{
+		Name:  `Global search, repohascommitafter, nonzero result`,
+		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, repohascommitafter, nonzero result`,
+		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1 stable:yes`,
+	},
+	// Global regex text search.
+	{
+		Name:  `Global search, regex, unindexed, nonzero result`,
+		Query: `^func.*$ index:only count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, fork only, nonzero result`,
+		Query: `fork:only FORK_SENTINEL`,
+	},
+	{
+		Name:  `Global search, filter by language`,
+		Query: `\bfunc\b lang:js count:1 stable:yes`,
+	},
+	{
+		Name:  `Global search, filename, zero results`,
+		Query: `file:asdfasdf.go`,
+	},
+	{
+		Name:  `Global search, filename, nonzero result`,
+		Query: `file:router.go count:1 stable:yes`,
+	},
+	// Symbol search.
+	{
+		Name:  `Global search, symbols, nonzero result`,
+		Query: `type:symbol test count:1 stable:yes`,
+	},
+	// Structural search.
+	{
+		Name:  `Global search, structural, index only, nonzero result`,
+		Query: `repo:^github\.com/facebook/react$ index:only patterntype:structural toHaveYielded(:[args]) count:5`,
+	},
+	// Repo search (part 2).
+	{
+		Name:  `Global search, archived excluded, zero results`,
+		Query: `type:repo facebookarchive`,
+	},
+	{
+		Name:  `Global search, archived included, nonzero result`,
+		Query: `type:repo facebookarchive archived:yes`,
+	},
+	{
+		Name:  `Global search, archived included if exact without option, nonzero result`,
+		Query: `repo:^github\.com/facebookarchive/httpcontrol$`,
+	},
+	{
+		Name:  `Global search, fork excluded, zero results`,
+		Query: `type:repo sgtest/mux`,
+	},
+	{
+		Name:  `Global search, fork included, nonzero result`,
+		Query: `type:repo sgtest/mux fork:yes`,
+	},
+	{
+		Name:  `Global search, fork included if exact without option, nonzero result`,
+		Query: `repo:^github\.com/sgtest/mux$`,
+	},
+}
+
+func sanitizeFilename(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ',', ' ', '.', '-':
+			return '_'
+		default:
+			return r
+		}
+	}, s)
+}
+
+func runSearchTests() error {
+	_, err := os.Stat(searchTestDataDir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(searchTestDataDir, os.ModePerm)
+	}
+	if err != nil {
+		fmt.Println(err)
+	}
+	for _, test := range tests {
+		got, err := search(test.Query)
+		if err != nil {
+			return err
+		}
+		filename := strings.ToLower(sanitizeFilename(test.Name))
+		goldenPath := path.Join(searchTestDataDir, fmt.Sprintf("%s.golden", filename))
+		if err := assertGolden(test.Name, goldenPath, got, update); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cmd/search-integration-tester/types.go
+++ b/internal/cmd/search-integration-tester/types.go
@@ -1,0 +1,12 @@
+package main
+
+type GQLRequest struct {
+	Query     string      `json:"query"`
+	Variables interface{} `json:"variables"`
+}
+
+type GQLSearchVariable struct {
+	SearchQuery string `json:"query"`
+}
+
+type GQLResult interface{}


### PR DESCRIPTION
I need something to anchor the behavioral changes for basically all the search things I touch. e2e/regression tests are a pain. This PR adds the barebones integration-testing that suits my needs. I'm putting it up for review and not super attached to merging this in (i.e., going overboard during review is really not the intended outcome, I've not taken ultra care to polish). It just seems generally useful. I will be using it locally either way (better than some  rando bash commands I used before. There's only one guiding principle: testing needs to be super duper easy. Easy to specify a test, easy to observe changes, and easy to update test values.

How it works:

1. You set up your local instance or something that has the current [search repos we use for testing](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/regression/search.test.ts#L66-137). Wait for it to all clone.

1. You add a test like the others you see in this PR:

```
	{
		Name:  `Global search, repo search by name, nonzero result`,
		Query: `repo:auth0/go-jwt-middleware$`,
	},
```

2. Then you run `./integration-tester`. You see some output. Either:

- You decide it looks good to you. Run `./integration-tester update` to add/update the golden test files
- You decide it looks bad. Great, tests are working.

When there's a diff, what you see is just the expected GQL JSON in all it's fullness (though colorized), and what you got instead:

![Screen Shot 2020-05-15 at 1 58 33 AM](https://user-images.githubusercontent.com/888624/82032144-af8c1f00-964f-11ea-8077-d56732115899.png)


Everything else is set up to streamlined to easily submit a query and see the GQL results. To wit: 

**Things I don't do:**

- No defining result types and marshalling the GQL JSON response to them. This means that yes, I can't inspect values/compare values at a finer granularity, but the base GQL definition `gqlSearch` is good enough for my purposes and a whole bunch of integration tests I've now gone through. Because it's so stupidly easy to update the expected test content in files, this definition (and only this definition) needs to change to accommodate other parts of the response that I may be interested in.

**Things I do not really care about right now**

> You know you can have nice JSON/structural diffing instead of the plain JSON text?

I just need to see whether there was a difference and the rough shape of the GQL response at a glance. Don't want to define GQL types to marshal to and comparing to those values.

> Wouldn't this be nice to add to CI?

Maybe but that's not on my mind right now. That needs more effort to figure out the set of frozen repos and such to test against in CI.

---

**Search-specific tests and migration**

I've started going through the [search tests](https://docs.google.com/spreadsheets/d/1lzKnWbI-zTlaqnHqzW5Ju1JF0dsov7s9RE6DyFeQmRk/edit#gid=2004495279) and migrated the ones that make sense. You can have a look at the notes there. In many cases, search results are nondeterministic (and because I'm not interested in comparing values), I use some combinations of `count:1` and `stable:yes` to get a deterministic ordering--in most of the tests we only care about "did we get results yes or no?"

I'm not committing golden test data at this time--I believe we should make the set of repos to test against smaller than what we have in the search regression tests (and what I used when working on these test cases) and tune the tests accordingly. 

It takes about 3.5 seconds to run all the tests included here. That's a tad longer than I like, but it's mostly because I add `stable:yes` to the queries. 3.5 seconds is a heck of a lot better than >30s timeouts for individual tests and browser stuff though.

---

@mrnugget it should be straightforward to run campaign-related queries against the GQL API and use the same testing/updating. You can basically just copy `search.go` and `search_tests.go` and make it `campaigns.go`... and go at it. Don't know if this is realistically useful to you though.