### PR TITLE
indexed-search: use zoekt.FileMatch.Version for SHA

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1290,23 +1290,21 @@ func Test_ZoektSingleIndexedRepo(t *testing.T) {
 			},
 		}
 	}
-	zoektRepos := []*zoekt.RepoListEntry{
-		{
-			Repository: zoekt.Repository{
-				Name: "test/repo",
-				Branches: []zoekt.RepositoryBranch{
-					{
-						Name:    "HEAD",
-						Version: "df3f4e499698e48152b39cd655d8901eaf583fa5",
-					},
-					{
-						Name:    "NOT-HEAD",
-						Version: "8ec975423738fe7851676083ebf660a062ed1578",
-					},
+	zoektRepos := []*zoekt.RepoListEntry{{
+		Repository: zoekt.Repository{
+			Name: "test/repo",
+			Branches: []zoekt.RepositoryBranch{
+				{
+					Name:    "HEAD",
+					Version: "df3f4e499698e48152b39cd655d8901eaf583fa5",
+				},
+				{
+					Name:    "NOT-HEAD",
+					Version: "8ec975423738fe7851676083ebf660a062ed1578",
 				},
 			},
 		},
-	}
+	}}
 	z := &searchbackend.Zoekt{
 		Client: &fakeSearcher{
 			repos: &zoekt.RepoList{Repos: zoektRepos},
@@ -1314,58 +1312,68 @@ func Test_ZoektSingleIndexedRepo(t *testing.T) {
 		DisableCache: true,
 	}
 	cases := []struct {
-		rev           *search.RepositoryRevisions
+		rev           string
 		wantIndexed   []*search.RepositoryRevisions
 		wantUnindexed []*search.RepositoryRevisions
 	}{
 		{
-			rev:           repoRev(""),
+			rev:           "",
 			wantIndexed:   []*search.RepositoryRevisions{repoRev("")},
 			wantUnindexed: []*search.RepositoryRevisions{},
 		},
 		{
-			rev:           repoRev("HEAD"),
+			rev:           "HEAD",
 			wantIndexed:   []*search.RepositoryRevisions{repoRev("HEAD")},
 			wantUnindexed: []*search.RepositoryRevisions{},
 		},
 		{
-			rev:           repoRev("df3f4e499698e48152b39cd655d8901eaf583fa5"),
+			rev:           "df3f4e499698e48152b39cd655d8901eaf583fa5",
 			wantIndexed:   []*search.RepositoryRevisions{repoRev("df3f4e499698e48152b39cd655d8901eaf583fa5")},
 			wantUnindexed: []*search.RepositoryRevisions{},
 		},
 		{
-			rev:           repoRev("df3f4e"),
+			rev:           "df3f4e",
 			wantIndexed:   []*search.RepositoryRevisions{repoRev("df3f4e")},
 			wantUnindexed: []*search.RepositoryRevisions{},
 		},
 		{
-			rev:           repoRev("d"),
+			rev:           "d",
 			wantIndexed:   []*search.RepositoryRevisions{},
 			wantUnindexed: []*search.RepositoryRevisions{repoRev("d")},
 		},
 		{
-			rev:           repoRev("HEAD^1"),
+			rev:           "HEAD^1",
 			wantIndexed:   []*search.RepositoryRevisions{},
 			wantUnindexed: []*search.RepositoryRevisions{repoRev("HEAD^1")},
 		},
 		{
-			rev:           repoRev("8ec975423738fe7851676083ebf660a062ed1578"),
-			wantIndexed:   []*search.RepositoryRevisions{},
-			wantUnindexed: []*search.RepositoryRevisions{repoRev("8ec975423738fe7851676083ebf660a062ed1578")},
+			rev:           "8ec975423738fe7851676083ebf660a062ed1578",
+			wantUnindexed: []*search.RepositoryRevisions{},
+			wantIndexed:   []*search.RepositoryRevisions{repoRev("8ec975423738fe7851676083ebf660a062ed1578")},
 		},
 	}
 
+	type ret struct {
+		Indexed, Unindexed []*search.RepositoryRevisions
+	}
+
 	for _, tt := range cases {
-		t.Run("classify indexed repo by commit", func(t *testing.T) {
-			filter := func(*zoekt.Repository) bool { return true }
-			indexed, unindexed, _ := zoektSingleIndexedRepo(context.Background(), z, tt.rev, filter)
-			if cmp.Diff(indexed, tt.wantIndexed) != "" {
-				t.Errorf("Got indexed repo %v, want %v", indexed, tt.wantIndexed)
-			}
-			if cmp.Diff(unindexed, tt.wantUnindexed) != "" {
-				t.Errorf("Got unindexed repo %v, want %v", unindexed, tt.wantUnindexed)
-			}
-		})
+		filter := func(*zoekt.Repository) bool { return true }
+		indexed, unindexed, err := zoektSingleIndexedRepo(context.Background(), z, repoRev(tt.rev), filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := ret{
+			Indexed:   indexed,
+			Unindexed: unindexed,
+		}
+		want := ret{
+			Indexed:   tt.wantIndexed,
+			Unindexed: tt.wantUnindexed,
+		}
+		if !cmp.Equal(want, got) {
+			t.Errorf("%s mismatch (-want +got):\n%s", tt.rev, cmp.Diff(want, got))
+		}
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -238,7 +238,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 			JLimitHit: fileLimitHit,
 			uri:       fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			Repo:      repoRev.Repo,
-			CommitID:  repoRev.IndexedHEADCommit(),
+			CommitID:  api.CommitID(file.Version),
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -533,7 +533,6 @@ func Test_zoektSearchHEAD(t *testing.T) {
 	}
 
 	rr := &search.RepositoryRevisions{Repo: &types.Repo{}}
-	rr.SetIndexedHEADCommit("abc")
 	singleRepositoryRevisions := []*search.RepositoryRevisions{rr}
 
 	tests := []struct {
@@ -878,7 +877,6 @@ func Test_zoektIndexedRepos(t *testing.T) {
 				Repo: r.Repo,
 				Revs: r.Revs,
 			}
-			rev.SetIndexedHEADCommit("deadbeef")
 			indexed = append(indexed, rev)
 		}
 		return indexed

--- a/internal/search/repo_revs_test.go
+++ b/internal/search/repo_revs_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -45,23 +44,4 @@ func TestParseRepositoryRevisions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestRepositoryRevisions(t *testing.T) {
-
-	// This test has to be run with -race to be effective.
-	t.Run("concurrent access to indexedHEADCommit", func(t *testing.T) {
-		rr := &RepositoryRevisions{}
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			rr.SetIndexedHEADCommit("")
-		}()
-		go func() {
-			defer wg.Done()
-			_ = rr.IndexedHEADCommit()
-		}()
-		wg.Wait()
-	})
 }


### PR DESCRIPTION
A while ago we added "IndexedHEADCommit" for finding the sha for a
branch we searched in zoekt. However, the Zoekt API returns the SHA in
the result struct. It will also be the actual sha, and won't suffer from
potential race conditions. We also get the benefit of a smaller struct
for RepositoryRevisions.

This change is additionally required once we have multiple branches
indexed since we will need a way to resolve the commit for more than
just HEAD.