### PR TITLE
fix large value of ElapsedMilliseconds when empty search returns instantly

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -861,9 +861,10 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 
 // evaluate evaluates all expressions of a search query.
 func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchResultsResolver, error) {
+	startTime := time.Now()
 	scopeParameters, pattern, err := query.PartitionSearchPattern(q)
 	if err != nil {
-		return &SearchResultsResolver{alert: alertForQuery("", err)}, nil
+		return &SearchResultsResolver{alert: alertForQuery("", startTime, err), start: startTime}, nil
 	}
 	if pattern == nil {
 		r.query = query.AndOrQuery{Query: scopeParameters}
@@ -916,7 +917,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 	if shouldShowAlert {
 		usedTime := time.Since(start)
 		suggestTime := longer(2, usedTime)
-		return &SearchResultsResolver{alert: alertForTimeout(usedTime, suggestTime, r)}, nil
+		return &SearchResultsResolver{alert: alertForTimeout(usedTime, suggestTime, r), start: start}, nil
 	}
 	return rr, err
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1466,7 +1466,7 @@ func TestSearchResolver_evaluateWarning(t *testing.T) {
 	})
 
 	_, err := query.ProcessAndOr("file:foo or or or")
-	gotAlert := alertForQuery("", err)
+	gotAlert := alertForQuery("", time.Now(), err)
 	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(gotAlert.description, wantPrefix) {
 			t.Fatalf("got alert description %s, want %s", got.alert.description, wantPrefix)

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
@@ -414,7 +415,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 		if err == nil {
 			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
-		alert := alertForQuery(raw, err)
+		alert := alertForQuery(raw, time.Now(), err)
 		if !strings.Contains(strings.ToLower(alert.title), "regexp") {
 			t.Errorf("title is '%s', want it to contain 'regexp'", alert.title)
 		}
@@ -437,7 +438,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 		if err == nil {
 			t.Fatalf("error returned from query.Process(%q) is nil", raw)
 		}
-		alert := alertForQuery(raw, err)
+		alert := alertForQuery(raw, time.Now(), err)
 		if strings.Contains(strings.ToLower(alert.title), "regexp") {
 			t.Errorf("title is '%s', want it not to contain 'regexp'", alert.title)
 		}
@@ -452,7 +453,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 		if err == nil {
 			t.Fatal("query.Process failed to detect the invalid regex in the f: field")
 		}
-		alert := alertForQuery(raw, err)
+		alert := alertForQuery(raw, time.Now(), err)
 		if len(alert.proposedQueries) != 1 {
 			t.Fatalf("got %d proposed queries (%v), want exactly 1", len(alert.proposedQueries), alert.proposedQueries)
 		}


### PR DESCRIPTION
TODO: write description
Draft PR that fixes the large value of ElapsedMilliseconds when empty search returns instantly


Fixes #10701 