### PR TITLE
Make NotificationItem story not flaky

### DIFF
--- a/shared/src/notifications/NotificationItem.story.tsx
+++ b/shared/src/notifications/NotificationItem.story.tsx
@@ -3,8 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { number, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
-import { interval } from 'rxjs'
-import { map, startWith } from 'rxjs/operators'
+import { of } from 'rxjs'
 import { NotificationType as NotificationTypeType } from 'sourcegraph'
 import { NotificationItem } from './NotificationItem'
 import notificationItemStyles from './NotificationItem.scss'
@@ -30,42 +29,24 @@ const { add } = storiesOf('NotificationItem', module).addDecorator(story => (
     </>
 ))
 
-for (const [name, type] of Object.entries(NotificationType)) {
-    // TS enums are reverse-indexed, so filter the number keys out
-    if (!isNaN(parseInt(name, 10))) {
-        continue
-    }
-
-    add(name, () => (
+add('Without Progress', () => {
+    const message = text('Message', 'My *custom* message')
+    const type = select<NotificationTypeType>(
+        'Type',
+        NotificationType as Record<keyof typeof NotificationType, NotificationTypeType>,
+        NotificationType.Error
+    )
+    const source = text('Source', 'some source')
+    return (
         <NotificationItem
-            notification={{
-                message: 'Formatted *message*',
-                type: type as NotificationTypeType,
-            }}
+            notification={{ message, type, source }}
             notificationClassNames={notificationClassNames}
             onDismiss={onDismiss}
         />
-    ))
+    )
+})
 
-    add(`${name} - Progress`, () => (
-        <NotificationItem
-            notification={{
-                type: type as NotificationTypeType,
-                progress: interval(100).pipe(
-                    startWith(0),
-                    map(i => ({
-                        message: 'Formatted progress *message*',
-                        percentage: i % 25 < 15 ? (i + 15) % 101 : undefined,
-                    }))
-                ),
-            }}
-            notificationClassNames={notificationClassNames}
-            onDismiss={onDismiss}
-        />
-    ))
-}
-
-add('⚙', () => {
+add('With progress', () => {
     const message = text('Message', 'My *custom* message')
     const type = select<NotificationTypeType>(
         'Type',
@@ -81,13 +62,10 @@ add('⚙', () => {
                 message,
                 type,
                 source,
-                progress: interval(1000).pipe(
-                    startWith(0),
-                    map(i => ({
-                        message: progressMessage,
-                        percentage: progressPercentage,
-                    }))
-                ),
+                progress: of({
+                    message: progressMessage,
+                    percentage: progressPercentage,
+                }),
             }}
             notificationClassNames={notificationClassNames}
             onDismiss={onDismiss}


### PR DESCRIPTION
These were programmed to change over time.
Removed that, and also consolidated stories (we pay $$$ per story now, and they weren't valuable).