### PR TITLE
Ignore changes to ThirdPartyLicenses in go generate check

### DIFF
--- a/dev/check/go-generate.sh
+++ b/dev/check/go-generate.sh
@@ -14,7 +14,7 @@ main() {
   # Runs generate.sh and ensures no files changed. This relies on the go
   # generation that ran are idempotent.
   ./dev/generate.sh
-  git diff --exit-code -- . ':!go.sum'
+  git diff --exit-code -- . ':!go.sum' ':!ThirdPartyLicensesNpm.csv'
 }
 
 main "$@"


### PR DESCRIPTION
This caused flakiness because the licenses are expected to change, but the check runs in parallel, so it will sometimes already be changed and sometimes not.