### PR TITLE
codeintel: Create correct directories on startup

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
@@ -9,7 +9,7 @@ import (
 // PrepDirectories
 func PrepDirectories(bundleDir string) error {
 	for _, dir := range []string{UploadsDir(bundleDir), DBsDir(bundleDir)} {
-		if err := os.MkdirAll(filepath.Join(bundleDir, dir), os.ModePerm); err != nil {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Create /lsif-storage/dbs and /lsif-storage/uploads, not /lsif-storage/lsif-storage/dbs, etc.