### PR TITLE
Reference gulp directly in LSIF workflow

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: yarn --ignore-engines --ignore-scripts
       - name: Generate
-        run: yarn gulp generate
+        run: ./node_modules/.bin/gulp generate
       - name: Generate LSIF data
         working-directory: web/
         run: lsif-tsc -p .


### PR DESCRIPTION
This is a workaround until we have nvm in LSIF actions. Our build scripts are generally not that likely to break with other Node versions, so the risk is low. This unblocks us to upgrade the Node version in package.json and .nvmrc.