### PR TITLE
search: avoid computing large value of ElapsedMilliseconds for search alert result

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -598,7 +598,7 @@ func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 		description:     a.description,
 		proposedQueries: a.proposedQueries,
 	}
-	return &SearchResultsResolver{alert: alert}, nil
+	return &SearchResultsResolver{alert: alert, start: time.Now()}, nil
 }
 
 func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -598,6 +598,7 @@ func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 		description:     a.description,
 		proposedQueries: a.proposedQueries,
 	}
+	// Passing time.now() is a workaround that prevents (sr *SearchResultsResolver) ElapsedMilliseconds() from returning a wrong calculation
 	return &SearchResultsResolver{alert: alert, start: time.Now()}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -598,7 +598,7 @@ func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 		description:     a.description,
 		proposedQueries: a.proposedQueries,
 	}
-	// Passing time.now() is a workaround that prevents (sr *SearchResultsResolver) ElapsedMilliseconds() from returning a wrong calculation
+	// ElapsedMilliseconds() will calculate a very large value for duration if start takes on the nil-value of year 1. As a workaround, instantiate start with time.now(). TODO(rvantonder): #10801.
 	return &SearchResultsResolver{alert: alert, start: time.Now()}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -254,6 +254,19 @@ func TestSearchResults(t *testing.T) {
 			t.Error("calledSearchSymbols")
 		}
 	})
+
+	t.Run("test start time is not null when alert thrown", func(t *testing.T) {
+		for _, v := range searchVersions {
+			r, err := (&schemaResolver{}).Search(&SearchArgs{Query: `repo:*`, Version: v})
+			if err != nil {
+				t.Fatal("Search:", err)
+			}
+			results, err := r.Results(context.Background())
+			if results.start.IsZero() {
+				t.Error("Start value is not set")
+			}
+		}
+	})
 }
 
 func BenchmarkSearchResults(b *testing.B) {


### PR DESCRIPTION
This PR  fixes the large value of ElapsedMilliseconds when empty search returns instantly

Fixes #10701 