### PR TITLE
ui: no blob or tree redirect if no commit ID provided

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -261,6 +261,13 @@ func serveSignIn(w http.ResponseWriter, r *http.Request) error {
 // redirectTreeOrBlob redirects a blob page to a tree page if the file is actually a directory,
 // or a tree page to a blob page if the directory is actually a file.
 func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseWriter, r *http.Request) (requestHandled bool, err error) {
+	// NOTE: It makes no sense for this function to proceed if the commit ID
+	// for the repository is empty. It is most likely the repository is still
+	// clone in progress.
+	if common.CommitID == "" {
+		return false, nil
+	}
+
 	if path == "/" || path == "" {
 		if routeName != routeRepo {
 			// Redirect to repo route

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -174,15 +174,32 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 		expLocation   string
 	}{
 		{
-			name:          "empty path, no redirect",
-			route:         routeRepo,
-			path:          "",
+			name:          "empty commit ID, no redirect",
+			common:        &Common{},
 			expStatusCode: http.StatusOK,
 		},
 		{
-			name:          "root path, no redirect",
-			route:         routeRepo,
-			path:          "/",
+			name:  "empty path, no redirect",
+			route: routeRepo,
+			path:  "",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
+			},
+			expStatusCode: http.StatusOK,
+		},
+		{
+			name:  "root path, no redirect",
+			route: routeRepo,
+			path:  "/",
+			common: &Common{
+				Repo: &types.Repo{
+					Name: "github.com/user/repo",
+				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
+			},
 			expStatusCode: http.StatusOK,
 		},
 		{
@@ -193,6 +210,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
 			expStatusCode: http.StatusOK,
@@ -205,6 +223,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{}, // Not a directory
 			expStatusCode: http.StatusOK,
@@ -219,6 +238,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{}, // Not a directory
 			expHandled:    true,
@@ -234,6 +254,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
 			expHandled:    true,
@@ -249,7 +270,8 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
-				Rev: "@master",
+				Rev:      "@master",
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{}, // Not a directory
 			expHandled:    true,
@@ -265,7 +287,8 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
-				Rev: "@master",
+				Rev:      "@master",
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			mockStat:      &util.FileInfo{Mode_: os.ModeDir},
 			expHandled:    true,
@@ -282,6 +305,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			expHandled:    true,
 			expStatusCode: http.StatusTemporaryRedirect,
@@ -296,6 +320,7 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			expHandled:    true,
 			expStatusCode: http.StatusTemporaryRedirect,
@@ -310,7 +335,8 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
-				Rev: "@master",
+				Rev:      "@master",
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			expHandled:    true,
 			expStatusCode: http.StatusTemporaryRedirect,
@@ -325,7 +351,8 @@ func Test_redirectTreeOrBlob(t *testing.T) {
 				Repo: &types.Repo{
 					Name: "github.com/user/repo",
 				},
-				Rev: "@master",
+				Rev:      "@master",
+				CommitID: "eca7e807356b887ee24b7a7497973bbfc5688dac",
 			},
 			expHandled:    true,
 			expStatusCode: http.StatusTemporaryRedirect,


### PR DESCRIPTION
When repository is clone in progress, user is able to visit the repository but with empty commit ID, which leads to `git.Stat` call to fail in `redirectTreeOrBlob` function.

Adds a check for empty commit ID.

Part of #10709.