### PR TITLE
docs: remove beta notice for GitHub and GitLab authentication

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -59,8 +59,6 @@ Site configuration example:
 
 ## GitHub
 
-> NOTE: GitHub authentication is currently beta.
-
 [Create a GitHub OAuth
 application](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) (if using
 GitHub Enterprise, create one on your instance, not GitHub.com). Set the following values, replacing
@@ -108,8 +106,6 @@ The `allowOrgs` fields restricts logins to members of the specified GitHub organ
 Once you've configured GitHub as a sign-on provider, you may also want to [add GitHub repositories to Sourcegraph](../external_service/github.md#repository-syncing).
 
 ## GitLab
-
-> NOTE: GitLab authentication is currently beta.
 
 [Create a GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html). Set
 the following values, replacing `sourcegraph.example.com` with the IP or hostname of your


### PR DESCRIPTION
Removes "beta" notices for both GitHub and GitLab authentication, they're being shipped [at least 16 months ago](https://github.com/sourcegraph/sourcegraph/commit/234a2edb5e27f0ce21d9b5f612b1fc6d5d692311) and many customers are using it for long time.

Fixes #10708
