### PR TITLE
Fix: don't wrap text in version context dropdown

### DIFF
--- a/web/src/nav/VersionContextDropdown.scss
+++ b/web/src/nav/VersionContextDropdown.scss
@@ -1,6 +1,8 @@
 @import '~@reach/listbox/styles.css';
 
 .version-context-dropdown {
+    width: max-content;
+
     &__button {
         display: flex;
         border-radius: 0;

--- a/web/src/nav/VersionContextDropdown.scss
+++ b/web/src/nav/VersionContextDropdown.scss
@@ -1,8 +1,6 @@
 @import '~@reach/listbox/styles.css';
 
 .version-context-dropdown {
-    width: max-content;
-
     &__button {
         display: flex;
         border-radius: 0;

--- a/web/src/nav/VersionContextDropdown.tsx
+++ b/web/src/nav/VersionContextDropdown.tsx
@@ -83,7 +83,7 @@ export const VersionContextDropdown: React.FunctionComponent<VersionContextDropd
     return (
         <>
             {props.availableVersionContexts ? (
-                <div className="version-context-dropdown">
+                <div className="version-context-dropdown text-nowrap">
                     <ListboxInput value={props.versionContext} onChange={updateValue}>
                         {({ isExpanded }) => (
                             <>
@@ -102,7 +102,7 @@ export const VersionContextDropdown: React.FunctionComponent<VersionContextDropd
                                     })}
                                 >
                                     <div className="version-context-dropdown__title pl-2 mb-1">
-                                        <span>Select version context</span>
+                                        <span className="text-nowrap">Select version context</span>
                                         <button type="button" className="btn btn-icon" onClick={showInfo}>
                                             <HelpCircleOutlineIcon className="icon-inline small" />
                                         </button>


### PR DESCRIPTION
The original fix (https://github.com/sourcegraph/sourcegraph/pull/10682) did not work. This applies `whitespace: no-wrap` on the button to ensure it stays only on one line.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
