### PR TITLE
Fix: unneeded scrollbar showing in versionContextDropdown

### DIFF
--- a/web/src/nav/VersionContextDropdown.scss
+++ b/web/src/nav/VersionContextDropdown.scss
@@ -38,7 +38,7 @@
         max-width: 30rem;
         min-height: fit-content;
         max-height: 20rem;
-        overflow-y: scroll;
+        overflow-y: auto;
     }
 
     &__option {


### PR DESCRIPTION
I actually can't reproduce the issue, but there is a scrollbar that shows up in the version context dropdown for others in Chrome, even when the content does not  overflow. This should fix that issue. (See https://sourcegraph.slack.com/archives/CMT39K56Z/p1589748937003800)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
