### PR TITLE
Smart search: show all filter value suggestions

### DIFF
--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -326,4 +326,25 @@ describe('getCompletionItems()', () => {
                 .map(({ insertText }) => insertText)
         ).toStrictEqual(['file:^jsonrpc2\\.go$ ', 'repo:^github\\.com/sourcegraph/jsonrpc2\\.go$ '])
     })
+
+    test('sets current filter value as filterText', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    (parseSearchQuery('f:^jsonrpc') as ParseSuccess<Sequence>).token,
+                    { column: 11 },
+                    of([
+                        {
+                            __typename: 'File',
+                            path: 'jsonrpc2.go',
+                            name: 'jsonrpc2.go',
+                            repository: {
+                                name: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        },
+                    ] as SearchSuggestion[])
+                )
+            )?.suggestions.map(({ filterText }) => filterText)
+        ).toStrictEqual(['^jsonrpc'])
+    })
 })

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -259,6 +259,14 @@ export async function getCompletionItems(
                     .filter(isDefined)
                     .map(partialCompletionItem => ({
                         ...partialCompletionItem,
+                        // Set the current value as filterText, so that all dynamic suggestions
+                        // returned by the server are displayed. otherwise, if the current filter value
+                        // is a regex pattern, Monaco's filtering might hide some suggestions.
+                        filterText:
+                            filterValue &&
+                            (filterValue?.token.type === 'literal'
+                                ? filterValue.token.value
+                                : filterValue.token.quotedValue),
                         range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
                     })),
             }


### PR DESCRIPTION
Fixes #10770

By default, Monaco filters suggestions based on a suggestion's `label`, and the range targeted by the suggestion. This caused suggestions for, eg., repositories not to show up if the filter value was a regex pattern `^github\.com/`, but the suggestion's label is not `github.com/sourcegraph/sourcegraph`. This is fixed by setting the current filter value as `filterText`, essentially bypassing Monaco's filtering.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
