### PR TITLE
Rename ref to rev in version context configuration

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -680,7 +680,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 			for _, vcRepoRef := range versionContext.Revisions {
 				if vcRepoRef.Repo == string(repo.Name) {
 					repoRev.Repo = repo
-					revs = append(revs, search.RevisionSpecifier{RevSpec: vcRepoRef.Ref})
+					revs = append(revs, search.RevisionSpecifier{RevSpec: vcRepoRef.Rev})
 					break
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -677,10 +677,10 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		var revs []search.RevisionSpecifier
 		// versionContext will be nil if the query contains revision specifiers
 		if versionContext != nil {
-			for _, vcRepoRef := range versionContext.Revisions {
-				if vcRepoRef.Repo == string(repo.Name) {
+			for _, vcRepoRev := range versionContext.Revisions {
+				if vcRepoRev.Repo == string(repo.Name) {
 					repoRev.Repo = repo
-					revs = append(revs, search.RevisionSpecifier{RevSpec: vcRepoRef.Rev})
+					revs = append(revs, search.RevisionSpecifier{RevSpec: vcRepoRev.Rev})
 					break
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -628,9 +628,9 @@ func TestVersionContext(t *testing.T) {
 							{
 								Name: "ctx-1",
 								Revisions: []*schema.VersionContextRevision{
-									{Repo: "github.com/sourcegraph/foo", Ref: "some-branch"},
-									{Repo: "github.com/sourcegraph/foobar", Ref: "v1.0.0"},
-									{Repo: "github.com/sourcegraph/bar", Ref: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"},
+									{Repo: "github.com/sourcegraph/foo", Rev: "some-branch"},
+									{Repo: "github.com/sourcegraph/foobar", Rev: "v1.0.0"},
+									{Repo: "github.com/sourcegraph/bar", Rev: "e62b6218f61cc1564d6ebcae19f9dafdf1357567"},
 								},
 							},
 						},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1053,10 +1053,10 @@ type VersionContext struct {
 
 // VersionContextRevision description: Description of the chosen repository and revision
 type VersionContextRevision struct {
-	// Ref description: Branch, tag, or commit hash
-	Ref string `json:"ref"`
 	// Repo description: Repository name
 	Repo string `json:"repo"`
+	// Rev description: Branch, tag, or commit hash
+	Rev string `json:"rev"`
 }
 
 // Webhooks description: DEPRECATED: Switch to "plugin.webhooks"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -176,13 +176,13 @@
                   "description": "Description of the chosen repository and revision",
                   "type": "object",
                   "additionalProperties": false,
-                  "required": ["repo", "ref"],
+                  "required": ["repo", "rev"],
                   "properties": {
                     "repo": {
                       "description": "Repository name",
                       "type": "string"
                     },
-                    "ref": {
+                    "rev": {
                       "description": "Branch, tag, or commit hash",
                       "type": "string"
                     }
@@ -201,15 +201,15 @@
               "revisions": [
                 {
                   "repo": "github.com/sourcegraph/sourcegraph",
-                  "ref": "3.15"
+                  "rev": "3.15"
                 },
                 {
                   "repo": "github.com/sourcegraph/lib1",
-                  "ref": "23edr233r"
+                  "rev": "23edr233r"
                 },
                 {
                   "repo": "github.com/sourcegraph/lib2",
-                  "ref": "2.4"
+                  "rev": "2.4"
                 }
               ]
             }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -181,13 +181,13 @@ const SiteSchemaJSON = `{
                   "description": "Description of the chosen repository and revision",
                   "type": "object",
                   "additionalProperties": false,
-                  "required": ["repo", "ref"],
+                  "required": ["repo", "rev"],
                   "properties": {
                     "repo": {
                       "description": "Repository name",
                       "type": "string"
                     },
-                    "ref": {
+                    "rev": {
                       "description": "Branch, tag, or commit hash",
                       "type": "string"
                     }
@@ -206,15 +206,15 @@ const SiteSchemaJSON = `{
               "revisions": [
                 {
                   "repo": "github.com/sourcegraph/sourcegraph",
-                  "ref": "3.15"
+                  "rev": "3.15"
                 },
                 {
                   "repo": "github.com/sourcegraph/lib1",
-                  "ref": "23edr233r"
+                  "rev": "23edr233r"
                 },
                 {
                   "repo": "github.com/sourcegraph/lib2",
-                  "ref": "2.4"
+                  "rev": "2.4"
                 }
               ]
             }

--- a/web/src/nav/VersionContextDropdown.story.tsx
+++ b/web/src/nav/VersionContextDropdown.story.tsx
@@ -24,9 +24,9 @@ const commonProps = subTypeOf<Partial<VersionContextDropdownProps>>()({
     caseSensitive: false,
     patternType: SearchPatternType.literal,
     availableVersionContexts: [
-        { name: 'test 1', description: 'test 1', revisions: [{ ref: 'test', repo: 'github.com/test/test' }] },
-        { name: 'test 2', description: 'test 2', revisions: [{ ref: 'test', repo: 'github.com/test/test' }] },
-        { name: 'test 3', description: 'test 3', revisions: [{ ref: 'test', repo: 'github.com/test/test' }] },
+        { name: 'test 1', description: 'test 1', revisions: [{ rev: 'test', repo: 'github.com/test/test' }] },
+        { name: 'test 2', description: 'test 2', revisions: [{ rev: 'test', repo: 'github.com/test/test' }] },
+        { name: 'test 3', description: 'test 3', revisions: [{ rev: 'test', repo: 'github.com/test/test' }] },
     ],
     navbarSearchQuery: 'test',
     setVersionContext,

--- a/web/src/search/index.test.tsx
+++ b/web/src/search/index.test.tsx
@@ -52,12 +52,12 @@ describe('search/index', () => {
     test('resolveVersionContext', () => {
         expect(
             resolveVersionContext('3.16', [
-                { name: '3.16', description: '3.16', revisions: [{ ref: '3.16', repo: 'github.com/example/example' }] },
+                { name: '3.16', description: '3.16', revisions: [{ rev: '3.16', repo: 'github.com/example/example' }] },
             ])
         ).toBe('3.16')
         expect(
             resolveVersionContext('3.15', [
-                { name: '3.16', description: '3.16', revisions: [{ ref: '3.16', repo: 'github.com/example/example' }] },
+                { name: '3.16', description: '3.16', revisions: [{ rev: '3.16', repo: 'github.com/example/example' }] },
             ])
         ).toBe(undefined)
         expect(resolveVersionContext('3.15', undefined)).toBe(undefined)


### PR DESCRIPTION
As asked by @felixfbecker in this [comment](https://docs.google.com/document/d/1Zfxl13iJzexsOsQQncmnR1gISFrQ6MhjsoDKqEqOX-4/edit?disco=AAAAGhD76w8), the "ref" field in the version context configuration has been renamed to "rev".
@attfarhan Is there anything to change on frontend side?
