### PR TITLE
move {User,Repo}SettingsPermissionsPage to enterprise

### DIFF
--- a/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react'
-import * as GQL from '../../../../shared/src/graphql/schema'
-import { PageTitle } from '../../components/PageTitle'
-import { Timestamp } from '../../components/time/Timestamp'
-import { eventLogger } from '../../tracking/eventLogger'
-import { ActionContainer } from './components/ActionContainer'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { PageTitle } from '../../../components/PageTitle'
+import { Timestamp } from '../../../components/time/Timestamp'
+import { eventLogger } from '../../../tracking/eventLogger'
 import * as H from 'history'
-import { scheduleRepositoryPermissionsSync } from '../../site-admin/backend'
+import { scheduleRepositoryPermissionsSync } from '../../../site-admin/backend'
+import { ActionContainer } from '../../../repo/settings/components/ActionContainer'
 
 /**
  * The repository settings permissions page.

--- a/web/src/enterprise/repo/settings/routes.tsx
+++ b/web/src/enterprise/repo/settings/routes.tsx
@@ -3,9 +3,16 @@ import { RepoSettingsCodeIntelligencePage } from './RepoSettingsCodeIntelligence
 import { RepoSettingsAreaRoute } from '../../../repo/settings/RepoSettingsArea'
 import { repoSettingsAreaRoutes } from '../../../repo/settings/routes'
 import { RepoSettingsLsifUploadPage } from './RepoSettingsLsifUploadPage'
+import { RepoSettingsPermissionsPage } from './RepoSettingsPermissionsPage'
 
 export const enterpriseRepoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] = [
     ...repoSettingsAreaRoutes,
+    {
+        path: '/permissions',
+        exact: true,
+        render: props => <RepoSettingsPermissionsPage {...props} />,
+        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
+    },
     {
         path: '/code-intelligence',
         exact: true,

--- a/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react'
-import * as GQL from '../../../../../shared/src/graphql/schema'
-import { PageTitle } from '../../../components/PageTitle'
-import { Timestamp } from '../../../components/time/Timestamp'
-import { eventLogger } from '../../../tracking/eventLogger'
+import * as GQL from '../../../../../../shared/src/graphql/schema'
+import { PageTitle } from '../../../../components/PageTitle'
+import { Timestamp } from '../../../../components/time/Timestamp'
+import { eventLogger } from '../../../../tracking/eventLogger'
 import * as H from 'history'
-import { ActionContainer } from '../../../repo/settings/components/ActionContainer'
-import { scheduleUserPermissionsSync } from '../../../site-admin/backend'
+import { ActionContainer } from '../../../../repo/settings/components/ActionContainer'
+import { scheduleUserPermissionsSync } from '../../../../site-admin/backend'
 
 /**
  * The user settings permissions page.

--- a/web/src/enterprise/user/settings/routes.ts
+++ b/web/src/enterprise/user/settings/routes.ts
@@ -7,6 +7,13 @@ import { authExp } from '../../site-admin/SiteAdminAuthenticationProvidersPage'
 export const enterpriseUserSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     ...userSettingsAreaRoutes,
     {
+        path: '/permissions',
+        exact: true,
+        render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
+        condition: ({ authenticatedUser }) =>
+            !!window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin,
+    },
+    {
         path: '/external-accounts',
         exact: true,
         render: lazyComponent(() => import('./UserSettingsExternalAccountsPage'), 'UserSettingsExternalAccountsPage'),

--- a/web/src/enterprise/user/settings/sidebaritems.ts
+++ b/web/src/enterprise/user/settings/sidebaritems.ts
@@ -19,5 +19,12 @@ export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = {
             condition: () => authExp,
         },
         ...userSettingsSideBarItems.account.slice(2),
+        {
+            label: 'Permissions',
+            to: '/permissions',
+            exact: true,
+            condition: ({ authenticatedUser }) =>
+                !!(window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin),
+        },
     ],
 }

--- a/web/src/repo/settings/routes.tsx
+++ b/web/src/repo/settings/routes.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { RepoSettingsIndexPage } from './RepoSettingsIndexPage'
 import { RepoSettingsMirrorPage } from './RepoSettingsMirrorPage'
 import { RepoSettingsOptionsPage } from './RepoSettingsOptionsPage'
-import { RepoSettingsPermissionsPage } from './RepoSettingsPermissionsPage'
 import { RepoSettingsAreaRoute } from './RepoSettingsArea'
 
 export const repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] = [
@@ -20,11 +19,5 @@ export const repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] = [
         path: '/mirror',
         exact: true,
         render: props => <RepoSettingsMirrorPage {...props} />,
-    },
-    {
-        path: '/permissions',
-        exact: true,
-        render: props => <RepoSettingsPermissionsPage {...props} />,
-        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
     },
 ]

--- a/web/src/user/settings/routes.tsx
+++ b/web/src/user/settings/routes.tsx
@@ -57,11 +57,4 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         ),
         condition: () => window.context.accessTokensAllow !== 'none',
     },
-    {
-        path: '/permissions',
-        exact: true,
-        render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
-        condition: ({ authenticatedUser }) =>
-            !!window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin,
-    },
 ]

--- a/web/src/user/settings/sidebaritems.ts
+++ b/web/src/user/settings/sidebaritems.ts
@@ -29,12 +29,5 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
             to: '/tokens',
             condition: () => window.context.accessTokensAllow !== 'none',
         },
-        {
-            label: 'Permissions',
-            to: '/permissions',
-            exact: true,
-            condition: ({ authenticatedUser }) =>
-                !!(window.context.site['permissions.backgroundSync']?.enabled && authenticatedUser.siteAdmin),
-        },
     ],
 }


### PR DESCRIPTION
Repository permissions are an enterprise (non-OSS) feature, so the UI should be in the enterprise tree.