### PR TITLE
authz: skip permissions scheduling if no providers configured

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -557,7 +557,9 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 			return
 		}
 
-		if !globals.PermissionsBackgroundSync().Enabled {
+		// Skip if not enabled or no authz provider is configured
+		if !globals.PermissionsBackgroundSync().Enabled ||
+			len(s.providers()) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
In addition to check if background permissions syncing is enabled, checking number of authz providers in advance so we can avoid scanning of records which will end up doing nothing if the instance hasn't enabled repository authorization/permissions.