### PR TITLE
Send CODEINTELINTEGRATION logs to sourcegraph.com

### DIFF
--- a/browser/src/shared/backend/userEvents.tsx
+++ b/browser/src/shared/backend/userEvents.tsx
@@ -7,8 +7,6 @@ import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
  * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
  * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
  *
- * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
- *
  * @deprecated Use logEvent
  */
 export const logUserEvent = (
@@ -17,10 +15,6 @@ export const logUserEvent = (
     url: string,
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
-    // Only send the request if this is a private, self-hosted Sourcegraph instance.
-    if (url === DEFAULT_SOURCEGRAPH_URL) {
-        return
-    }
     requestGraphQL<GQL.IMutation>({
         request: gql`
             mutation logUserEvent($event: UserEvent!, $userCookieID: String!) {
@@ -48,7 +42,6 @@ export const logUserEvent = (
  * Log a raw user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
  * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
  *
- * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
  */
 export const logEvent = (
     event: { name: string; userCookieID: string; url: string; argument?: string },

--- a/browser/src/shared/backend/userEvents.tsx
+++ b/browser/src/shared/backend/userEvents.tsx
@@ -41,7 +41,6 @@ export const logUserEvent = (
 /**
  * Log a raw user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
  * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
- *
  */
 export const logEvent = (
     event: { name: string; userCookieID: string; url: string; argument?: string },

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -69,7 +69,6 @@ export class EventLogger implements TelemetryService {
      * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
      * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
      *
-     * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
      */
     public async logCodeIntelligenceEvent(
         event: string,

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -68,7 +68,6 @@ export class EventLogger implements TelemetryService {
     /**
      * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
      * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
-     *
      */
     public async logCodeIntelligenceEvent(
         event: string,

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -104,7 +104,7 @@ Previously, the Sourcegraph browser extension was able to authenticate with inst
 
 ## Privacy
 
-Integrations will only connect to Sourcegraph.com as required to provide code intelligence or other functionality on public code. As a result, no private code, private repository names, usernames, or any other specific data is sent to Sourcegraph.com.
+Sourcegraph integrations will only connect to Sourcegraph.com as required to provide code intelligence or other functionality on public code. As a result, no private code, private repository names, usernames, or any other specific data is sent to Sourcegraph.com.
 
 If connected to a **private, self-hosted Sourcegraph instance**, Sourcegraph integrations never send any logs, pings, usage statistics, or telemetry to Sourcegraph.com. They will send notifications of usage to that private Sourcegraph instance only. This allows the site admins to see usage statistics.
 

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -108,4 +108,4 @@ Sourcegraph integrations will only connect to Sourcegraph.com as required to pro
 
 If connected to a **private, self-hosted Sourcegraph instance**, Sourcegraph integrations never send any logs, pings, usage statistics, or telemetry to Sourcegraph.com. They will send notifications of usage to that private Sourcegraph instance only. This allows the site admins to see usage statistics.
 
-If connected to the **public Sourcegraph.com instance**, Sourcegraph integrations will send notifications of usage to Sourcegraph.com.
+If connected to the **public Sourcegraph.com instance**, Sourcegraph integrations will send notifications of usage on public repositories to Sourcegraph.com.

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -104,6 +104,8 @@ Previously, the Sourcegraph browser extension was able to authenticate with inst
 
 ## Privacy
 
-Sourcegraph integrations never send any logs, pings, usage statistics, or telemetry to Sourcegraph.com. They will only connect to Sourcegraph.com as required to provide code intelligence or other functionality on public code. As a result, no private code, private repository names, usernames, or any other specific data is sent to Sourcegraph.com.
+Integrations will only connect to Sourcegraph.com as required to provide code intelligence or other functionality on public code. As a result, no private code, private repository names, usernames, or any other specific data is sent to Sourcegraph.com.
 
-If connected to a private, self-hosted Sourcegraph instance, Sourcegraph browser extensions will send notifications of usage to that private Sourcegraph instance only. This allows the site admins to see usage statistics.
+If connected to a **private, self-hosted Sourcegraph instance**, Sourcegraph integrations never send any logs, pings, usage statistics, or telemetry to Sourcegraph.com. They will send notifications of usage to that private Sourcegraph instance only. This allows the site admins to see usage statistics.
+
+If connected to the **public Sourcegraph.com instance**, Sourcegraph integrations will send notifications of usage to Sourcegraph.com.


### PR DESCRIPTION
Code host integration logs were never sent to sourcegraph.com by the browser extension,
preventing us from tracking usage of public code host integration users for our OKRs.