### PR TITLE
Force-include core-js polyfills through babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -27,6 +27,15 @@ module.exports = api => {
           modules: isTest ? 'commonjs' : false,
           bugfixes: true,
           useBuiltIns: 'entry',
+          include: [
+            // Polyfill URL because Chrome and Firefox are not spec-compliant
+            // Hostnames of URIs with custom schemes (e.g. git) are not parsed out
+            'web.url',
+            // Commonly needed by extensions (used by vscode-jsonrpc)
+            'web.immediate',
+            // Avoids issues with RxJS interop
+            'esnext.symbol.observable',
+          ],
           // See https://github.com/zloirock/core-js#babelpreset-env
           corejs: semver.minVersion(require('./package.json').dependencies['core-js']),
         },

--- a/package.json
+++ b/package.json
@@ -294,7 +294,6 @@
     "slugify": "^1.4.0",
     "sourcegraph": "link:packages/sourcegraph-extension-api",
     "string-score": "^1.0.1",
-    "symbol-observable": "^1.2.0",
     "tagged-template-noop": "^2.1.1",
     "textarea-caret": "^3.1.0",
     "ts-key-enum": "^2.0.2",

--- a/shared/src/polyfills/polyfill.ts
+++ b/shared/src/polyfills/polyfill.ts
@@ -1,12 +1,2 @@
 // This gets expanded into only the imports we need by @babel/preset-env
 import 'core-js/stable'
-
-// Polyfill URL because Chrome and Firefox are not spec-compliant
-// Hostnames of URIs with custom schemes (e.g. git) are not parsed out
-import 'core-js/web/url'
-
-// Commonly needed by extensions (used by vscode-jsonrpc)
-import 'core-js/web/immediate'
-
-// Avoids issues with RxJS interop
-import 'symbol-observable'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,7 +2071,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -19012,7 +19013,8 @@ source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.4.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -19792,11 +19794,6 @@ svgo@^1.0.0, svgo@^1.1.1:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
Babel removed the imports in the browser extension because we have a stricter browserslist there. Using include in Babel config makes sure it's always included in the expanded import. Fixes the browser extension e2e tests which luckily caught this.