### PR TITLE
Polyfill URLSearchParams for Firefox

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -31,6 +31,8 @@ module.exports = api => {
             // Polyfill URL because Chrome and Firefox are not spec-compliant
             // Hostnames of URIs with custom schemes (e.g. git) are not parsed out
             'web.url',
+            // URLSearchParams.prototype.keys() is not iterable in Firefox
+            'web.url-search-params',
             // Commonly needed by extensions (used by vscode-jsonrpc)
             'web.immediate',
             // Avoids issues with RxJS interop

--- a/shared/src/polyfills/configure-core-js.ts
+++ b/shared/src/polyfills/configure-core-js.ts
@@ -2,7 +2,11 @@
 import configure from 'core-js/configurator'
 
 configure({
-    // Polyfill URL because Chrome and Firefox are not spec-compliant
-    // Hostnames of URIs with custom schemes (e.g. git) are not parsed out
-    usePolyfill: ['URL'],
+    usePolyfill: [
+        // Polyfill URL because Chrome and Firefox are not spec-compliant
+        // Hostnames of URIs with custom schemes (e.g. git) are not parsed out
+        'URL',
+        // URLSearchParams.prototype.keys() is not iterable in Firefox
+        'URLSearchParams',
+    ],
 })


### PR DESCRIPTION
e2e tests were still failing for Firefox because of this