### PR TITLE
codeintel: Add context param to gitserver functions

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/api/exists.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists.go
@@ -56,7 +56,7 @@ func (api *codeIntelAPI) updateCommitsAndVisibility(ctx context.Context, reposit
 		return nil
 	}
 
-	newCommits, err := api.gitserverClient.CommitsNear(api.db, repositoryID, commit)
+	newCommits, err := api.gitserverClient.CommitsNear(ctx, api.db, repositoryID, commit)
 	if err != nil {
 		return errors.Wrap(err, "gitserverClient.CommitsNear")
 	}
@@ -64,7 +64,7 @@ func (api *codeIntelAPI) updateCommitsAndVisibility(ctx context.Context, reposit
 		return errors.Wrap(err, "db.UpdateCommits")
 	}
 
-	tipCommit, err := api.gitserverClient.Head(api.db, repositoryID)
+	tipCommit, err := api.gitserverClient.Head(ctx, api.db, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserverClient.Head")
 	}

--- a/cmd/precise-code-intel-api-server/internal/api/exists_test.go
+++ b/cmd/precise-code-intel-api-server/internal/api/exists_test.go
@@ -43,7 +43,7 @@ func TestFindClosestDatabase(t *testing.T) {
 	mockGitserverClient.HeadFunc.SetDefaultReturn(makeCommit(30), nil)
 
 	// Return some ancestors for each commit args
-	mockGitserverClient.CommitsNearFunc.SetDefaultHook(func(db db.DB, repositoryID int, commit string) (map[string][]string, error) {
+	mockGitserverClient.CommitsNearFunc.SetDefaultHook(func(ctx context.Context, db db.DB, repositoryID int, commit string) (map[string][]string, error) {
 		offset, err := strconv.ParseInt(commit, 10, 64)
 		if err != nil {
 			return nil, err

--- a/cmd/precise-code-intel-api-server/internal/janitor/remove_processed_uploads_without_bundle_file.go
+++ b/cmd/precise-code-intel-api-server/internal/janitor/remove_processed_uploads_without_bundle_file.go
@@ -40,7 +40,7 @@ func (j *Janitor) removeProcessedUploadsWithoutBundleFile() error {
 		}
 
 		deleted, err := j.db.DeleteUploadByID(ctx, id, func(repositoryID int) (string, error) {
-			tipCommit, err := gitserver.Head(j.db, repositoryID)
+			tipCommit, err := gitserver.Head(ctx, j.db, repositoryID)
 			if err != nil {
 				return "", errors.Wrap(err, "gitserver.Head")
 			}

--- a/cmd/precise-code-intel-api-server/internal/server/handler.go
+++ b/cmd/precise-code-intel-api-server/internal/server/handler.go
@@ -51,8 +51,10 @@ func (s *Server) handleGetUploadByID(w http.ResponseWriter, r *http.Request) {
 
 // DELETE /uploads/{id:[0-9]+}
 func (s *Server) handleDeleteUploadByID(w http.ResponseWriter, r *http.Request) {
-	exists, err := s.db.DeleteUploadByID(r.Context(), int(idFromRequest(r)), func(repositoryID int) (string, error) {
-		tipCommit, err := gitserver.Head(s.db, repositoryID)
+	ctx := r.Context()
+
+	exists, err := s.db.DeleteUploadByID(ctx, int(idFromRequest(r)), func(repositoryID int) (string, error) {
+		tipCommit, err := gitserver.Head(ctx, s.db, repositoryID)
 		if err != nil {
 			return "", errors.Wrap(err, "gitserver.Head")
 		}

--- a/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -170,7 +170,7 @@ func (p *processor) Process(
 		upload.ID,
 		upload.Root,
 		func(dirnames []string) (map[string][]string, error) {
-			directoryChildren, err := p.gitserverClient.DirectoryChildren(db, upload.RepositoryID, upload.Commit, dirnames)
+			directoryChildren, err := p.gitserverClient.DirectoryChildren(ctx, db, upload.RepositoryID, upload.Commit, dirnames)
 			if err != nil {
 				return nil, errors.Wrap(err, "gitserverClient.DirectoryChildren")
 			}
@@ -243,11 +243,11 @@ func (p *processor) Process(
 // updateCommits updates the lsif_commits table with the current data known to gitserver, then updates the
 // visibility of all dumps for the given repository.
 func (p *processor) updateCommitsAndVisibility(ctx context.Context, db db.DB, repositoryID int, commit string) error {
-	tipCommit, err := p.gitserverClient.Head(db, repositoryID)
+	tipCommit, err := p.gitserverClient.Head(ctx, db, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.Head")
 	}
-	newCommits, err := p.gitserverClient.CommitsNear(db, repositoryID, tipCommit)
+	newCommits, err := p.gitserverClient.CommitsNear(ctx, db, repositoryID, tipCommit)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.CommitsNear")
 	}
@@ -257,7 +257,7 @@ func (p *processor) updateCommitsAndVisibility(ctx context.Context, db db.DB, re
 		// commit and the tip so that we can accurately determine what is visible from the tip. If we
 		// do not do this before the updateDumpsVisibleFromTip call below, no dumps will be reachable
 		// from the tip and all dumps will be invisible.
-		additionalCommits, err := p.gitserverClient.CommitsNear(db, repositoryID, commit)
+		additionalCommits, err := p.gitserverClient.CommitsNear(ctx, db, repositoryID, commit)
 		if err != nil {
 			return errors.Wrap(err, "gitserver.CommitsNear")
 		}

--- a/cmd/precise-code-intel-worker/internal/worker/worker_test.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker_test.go
@@ -221,7 +221,7 @@ func TestProcess(t *testing.T) {
 	gitserverClient.HeadFunc.SetDefaultReturn(makeCommit(30), nil)
 
 	// Return some ancestors for each commit args
-	gitserverClient.CommitsNearFunc.SetDefaultHook(func(db db.DB, repositoryID int, commit string) (map[string][]string, error) {
+	gitserverClient.CommitsNearFunc.SetDefaultHook(func(ctx context.Context, db db.DB, repositoryID int, commit string) (map[string][]string, error) {
 		offset, err := strconv.ParseInt(commit, 10, 64)
 		if err != nil {
 			return nil, err

--- a/internal/codeintel/gitserver/client.go
+++ b/internal/codeintel/gitserver/client.go
@@ -19,7 +19,7 @@ type Client interface {
 	// DirectoryChildren determines all children known to git for the given directory names via an invocation
 	// of git ls-tree. The keys of the resulting map are the input (unsanitized) dirnames, and the value of
 	// that key are the files nested under that directory.
-	DirectoryChildren(db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error)
+	DirectoryChildren(ctx context.Context, db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error)
 }
 
 type defaultClient struct{}
@@ -34,6 +34,6 @@ func (c *defaultClient) CommitsNear(ctx context.Context, db db.DB, repositoryID 
 	return CommitsNear(ctx, db, repositoryID, commit)
 }
 
-func (c *defaultClient) DirectoryChildren(db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error) {
-	return DirectoryChildren(db, repositoryID, commit, dirnames)
+func (c *defaultClient) DirectoryChildren(ctx context.Context, db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error) {
+	return DirectoryChildren(ctx, db, repositoryID, commit, dirnames)
 }

--- a/internal/codeintel/gitserver/client.go
+++ b/internal/codeintel/gitserver/client.go
@@ -1,16 +1,20 @@
 package gitserver
 
-import "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+)
 
 // Client is an interface that wraps all of the queries to gitserver needed by the
 // precise-code-intel services.
 type Client interface {
 	// Head determines the tip commit of the default branch for the given repository.
-	Head(db db.DB, repositoryID int) (string, error)
+	Head(ctx context.Context, db db.DB, repositoryID int) (string, error)
 
 	// CommitsNear returns a map from a commit to parent commits. The commits populating the
 	// map are the MaxCommitsPerUpdate closest ancestors from the given commit.
-	CommitsNear(db db.DB, repositoryID int, commit string) (map[string][]string, error)
+	CommitsNear(ctx context.Context, db db.DB, repositoryID int, commit string) (map[string][]string, error)
 
 	// DirectoryChildren determines all children known to git for the given directory names via an invocation
 	// of git ls-tree. The keys of the resulting map are the input (unsanitized) dirnames, and the value of
@@ -22,12 +26,12 @@ type defaultClient struct{}
 
 var DefaultClient Client = &defaultClient{}
 
-func (c *defaultClient) Head(db db.DB, repositoryID int) (string, error) {
-	return Head(db, repositoryID)
+func (c *defaultClient) Head(ctx context.Context, db db.DB, repositoryID int) (string, error) {
+	return Head(ctx, db, repositoryID)
 }
 
-func (c *defaultClient) CommitsNear(db db.DB, repositoryID int, commit string) (map[string][]string, error) {
-	return CommitsNear(db, repositoryID, commit)
+func (c *defaultClient) CommitsNear(ctx context.Context, db db.DB, repositoryID int, commit string) (map[string][]string, error) {
+	return CommitsNear(ctx, db, repositoryID, commit)
 }
 
 func (c *defaultClient) DirectoryChildren(db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error) {

--- a/internal/codeintel/gitserver/commits.go
+++ b/internal/codeintel/gitserver/commits.go
@@ -11,7 +11,6 @@ import (
 // TODO(efritz) - move this declaration (MaxCommitsPerUpdate = MaxTraversalLimit * 1.5)
 const MaxCommitsPerUpdate = 150
 
-// TODO - pass in context
 // Head determines the tip commit of the default branch for the given repository.
 func Head(ctx context.Context, db db.DB, repositoryID int) (string, error) {
 	return execGitCommand(ctx, db, repositoryID, "rev-parse", "HEAD")

--- a/internal/codeintel/gitserver/commits.go
+++ b/internal/codeintel/gitserver/commits.go
@@ -1,55 +1,31 @@
 package gitserver
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
+// TODO(efritz) - move this declaration (MaxCommitsPerUpdate = MaxTraversalLimit * 1.5)
+const MaxCommitsPerUpdate = 150
+
+// TODO - pass in context
 // Head determines the tip commit of the default branch for the given repository.
-func Head(db db.DB, repositoryID int) (string, error) {
-	// TODO(efritz) - remove dependency on codeintel/db package
-	repoName, err := db.RepoName(context.Background(), repositoryID)
-	if err != nil {
-		return "", errors.Wrap(err, "db.RepoName")
-	}
-
-	cmd := gitserver.DefaultClient.Command("git", "rev-parse", "HEAD")
-	cmd.Repo = gitserver.Repo{Name: api.RepoName(repoName)}
-	out, err := cmd.CombinedOutput(context.Background())
-	if err != nil {
-		return "", errors.Wrap(err, "gitserver.Command")
-	}
-
-	return string(bytes.TrimSpace(out)), nil
+func Head(ctx context.Context, db db.DB, repositoryID int) (string, error) {
+	return execGitCommand(ctx, db, repositoryID, "rev-parse", "HEAD")
 }
 
 // CommitsNear returns a map from a commit to parent commits. The commits populating the
 // map are the MaxCommitsPerUpdate closest ancestors from the given commit.
-func CommitsNear(db db.DB, repositoryID int, commit string) (map[string][]string, error) {
-	// TODO(efritz) - remove dependency on codeintel/db package
-	repoName, err := db.RepoName(context.Background(), repositoryID)
+func CommitsNear(ctx context.Context, db db.DB, repositoryID int, commit string) (map[string][]string, error) {
+	out, err := execGitCommand(ctx, db, repositoryID, "log", "--pretty=%H %P", commit, fmt.Sprintf("-%d", MaxCommitsPerUpdate))
 	if err != nil {
-		return nil, errors.Wrap(err, "db.RepoName")
+		return nil, err
 	}
 
-	// TODO(efritz) - move this declaration
-	const MaxCommitsPerUpdate = 150 // MaxTraversalLimit * 1.5
-
-	cmd := gitserver.DefaultClient.Command("git", "log", "--pretty=%H %P", commit, fmt.Sprintf("-%d", MaxCommitsPerUpdate))
-	cmd.Repo = gitserver.Repo{Name: api.RepoName(repoName)}
-	out, err := cmd.CombinedOutput(context.Background())
-	if err != nil {
-		return nil, errors.Wrap(err, "gitserver.Command")
-	}
-
-	return parseCommitsNear(strings.Split(string(bytes.TrimSpace(out)), "\n")), nil
+	return parseCommitsNear(strings.Split(out, "\n")), nil
 }
 
 // parseCommitsNear converts the output of git log into a map from commits to parent commits.

--- a/internal/codeintel/gitserver/exec.go
+++ b/internal/codeintel/gitserver/exec.go
@@ -1,0 +1,25 @@
+package gitserver
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+// execGitCommand executes a git command for the given repository by identifier.
+func execGitCommand(ctx context.Context, db db.DB, repositoryID int, args ...string) (string, error) {
+	// TODO(efritz) - remove dependency on codeintel/db package
+	repoName, err := db.RepoName(ctx, repositoryID)
+	if err != nil {
+		return "", errors.Wrap(err, "db.RepoName")
+	}
+
+	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd.Repo = gitserver.Repo{Name: api.RepoName(repoName)}
+	out, err := cmd.CombinedOutput(ctx)
+	return string(bytes.TrimSpace(out)), errors.Wrap(err, "gitserver.Command")
+}

--- a/internal/codeintel/gitserver/mocks/mock_client.go
+++ b/internal/codeintel/gitserver/mocks/mock_client.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"context"
 	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	gitserver "github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 	"sync"

--- a/internal/codeintel/gitserver/mocks/mock_client.go
+++ b/internal/codeintel/gitserver/mocks/mock_client.go
@@ -29,17 +29,17 @@ type MockClient struct {
 func NewMockClient() *MockClient {
 	return &MockClient{
 		CommitsNearFunc: &ClientCommitsNearFunc{
-			defaultHook: func(db.DB, int, string) (map[string][]string, error) {
+			defaultHook: func(context.Context, db.DB, int, string) (map[string][]string, error) {
 				return nil, nil
 			},
 		},
 		DirectoryChildrenFunc: &ClientDirectoryChildrenFunc{
-			defaultHook: func(db.DB, int, string, []string) (map[string][]string, error) {
+			defaultHook: func(context.Context, db.DB, int, string, []string) (map[string][]string, error) {
 				return nil, nil
 			},
 		},
 		HeadFunc: &ClientHeadFunc{
-			defaultHook: func(db.DB, int) (string, error) {
+			defaultHook: func(context.Context, db.DB, int) (string, error) {
 				return "", nil
 			},
 		},
@@ -65,23 +65,23 @@ func NewMockClientFrom(i gitserver.Client) *MockClient {
 // ClientCommitsNearFunc describes the behavior when the CommitsNear method
 // of the parent MockClient instance is invoked.
 type ClientCommitsNearFunc struct {
-	defaultHook func(db.DB, int, string) (map[string][]string, error)
-	hooks       []func(db.DB, int, string) (map[string][]string, error)
+	defaultHook func(context.Context, db.DB, int, string) (map[string][]string, error)
+	hooks       []func(context.Context, db.DB, int, string) (map[string][]string, error)
 	history     []ClientCommitsNearFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsNear delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) CommitsNear(v0 db.DB, v1 int, v2 string) (map[string][]string, error) {
-	r0, r1 := m.CommitsNearFunc.nextHook()(v0, v1, v2)
-	m.CommitsNearFunc.appendCall(ClientCommitsNearFuncCall{v0, v1, v2, r0, r1})
+func (m *MockClient) CommitsNear(v0 context.Context, v1 db.DB, v2 int, v3 string) (map[string][]string, error) {
+	r0, r1 := m.CommitsNearFunc.nextHook()(v0, v1, v2, v3)
+	m.CommitsNearFunc.appendCall(ClientCommitsNearFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the CommitsNear method
 // of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientCommitsNearFunc) SetDefaultHook(hook func(db.DB, int, string) (map[string][]string, error)) {
+func (f *ClientCommitsNearFunc) SetDefaultHook(hook func(context.Context, db.DB, int, string) (map[string][]string, error)) {
 	f.defaultHook = hook
 }
 
@@ -89,7 +89,7 @@ func (f *ClientCommitsNearFunc) SetDefaultHook(hook func(db.DB, int, string) (ma
 // CommitsNear method of the parent MockClient instance inovkes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientCommitsNearFunc) PushHook(hook func(db.DB, int, string) (map[string][]string, error)) {
+func (f *ClientCommitsNearFunc) PushHook(hook func(context.Context, db.DB, int, string) (map[string][]string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -98,7 +98,7 @@ func (f *ClientCommitsNearFunc) PushHook(hook func(db.DB, int, string) (map[stri
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *ClientCommitsNearFunc) SetDefaultReturn(r0 map[string][]string, r1 error) {
-	f.SetDefaultHook(func(db.DB, int, string) (map[string][]string, error) {
+	f.SetDefaultHook(func(context.Context, db.DB, int, string) (map[string][]string, error) {
 		return r0, r1
 	})
 }
@@ -106,12 +106,12 @@ func (f *ClientCommitsNearFunc) SetDefaultReturn(r0 map[string][]string, r1 erro
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *ClientCommitsNearFunc) PushReturn(r0 map[string][]string, r1 error) {
-	f.PushHook(func(db.DB, int, string) (map[string][]string, error) {
+	f.PushHook(func(context.Context, db.DB, int, string) (map[string][]string, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCommitsNearFunc) nextHook() func(db.DB, int, string) (map[string][]string, error) {
+func (f *ClientCommitsNearFunc) nextHook() func(context.Context, db.DB, int, string) (map[string][]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -146,13 +146,16 @@ func (f *ClientCommitsNearFunc) History() []ClientCommitsNearFuncCall {
 type ClientCommitsNearFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 db.DB
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 db.DB
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]string
@@ -164,7 +167,7 @@ type ClientCommitsNearFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientCommitsNearFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
@@ -176,24 +179,24 @@ func (c ClientCommitsNearFuncCall) Results() []interface{} {
 // ClientDirectoryChildrenFunc describes the behavior when the
 // DirectoryChildren method of the parent MockClient instance is invoked.
 type ClientDirectoryChildrenFunc struct {
-	defaultHook func(db.DB, int, string, []string) (map[string][]string, error)
-	hooks       []func(db.DB, int, string, []string) (map[string][]string, error)
+	defaultHook func(context.Context, db.DB, int, string, []string) (map[string][]string, error)
+	hooks       []func(context.Context, db.DB, int, string, []string) (map[string][]string, error)
 	history     []ClientDirectoryChildrenFuncCall
 	mutex       sync.Mutex
 }
 
 // DirectoryChildren delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) DirectoryChildren(v0 db.DB, v1 int, v2 string, v3 []string) (map[string][]string, error) {
-	r0, r1 := m.DirectoryChildrenFunc.nextHook()(v0, v1, v2, v3)
-	m.DirectoryChildrenFunc.appendCall(ClientDirectoryChildrenFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockClient) DirectoryChildren(v0 context.Context, v1 db.DB, v2 int, v3 string, v4 []string) (map[string][]string, error) {
+	r0, r1 := m.DirectoryChildrenFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DirectoryChildrenFunc.appendCall(ClientDirectoryChildrenFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the DirectoryChildren
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientDirectoryChildrenFunc) SetDefaultHook(hook func(db.DB, int, string, []string) (map[string][]string, error)) {
+func (f *ClientDirectoryChildrenFunc) SetDefaultHook(hook func(context.Context, db.DB, int, string, []string) (map[string][]string, error)) {
 	f.defaultHook = hook
 }
 
@@ -201,7 +204,7 @@ func (f *ClientDirectoryChildrenFunc) SetDefaultHook(hook func(db.DB, int, strin
 // DirectoryChildren method of the parent MockClient instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ClientDirectoryChildrenFunc) PushHook(hook func(db.DB, int, string, []string) (map[string][]string, error)) {
+func (f *ClientDirectoryChildrenFunc) PushHook(hook func(context.Context, db.DB, int, string, []string) (map[string][]string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -210,7 +213,7 @@ func (f *ClientDirectoryChildrenFunc) PushHook(hook func(db.DB, int, string, []s
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *ClientDirectoryChildrenFunc) SetDefaultReturn(r0 map[string][]string, r1 error) {
-	f.SetDefaultHook(func(db.DB, int, string, []string) (map[string][]string, error) {
+	f.SetDefaultHook(func(context.Context, db.DB, int, string, []string) (map[string][]string, error) {
 		return r0, r1
 	})
 }
@@ -218,12 +221,12 @@ func (f *ClientDirectoryChildrenFunc) SetDefaultReturn(r0 map[string][]string, r
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *ClientDirectoryChildrenFunc) PushReturn(r0 map[string][]string, r1 error) {
-	f.PushHook(func(db.DB, int, string, []string) (map[string][]string, error) {
+	f.PushHook(func(context.Context, db.DB, int, string, []string) (map[string][]string, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientDirectoryChildrenFunc) nextHook() func(db.DB, int, string, []string) (map[string][]string, error) {
+func (f *ClientDirectoryChildrenFunc) nextHook() func(context.Context, db.DB, int, string, []string) (map[string][]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -258,16 +261,19 @@ func (f *ClientDirectoryChildrenFunc) History() []ClientDirectoryChildrenFuncCal
 type ClientDirectoryChildrenFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 db.DB
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 db.DB
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 []string
+	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]string
@@ -279,7 +285,7 @@ type ClientDirectoryChildrenFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientDirectoryChildrenFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
@@ -291,23 +297,23 @@ func (c ClientDirectoryChildrenFuncCall) Results() []interface{} {
 // ClientHeadFunc describes the behavior when the Head method of the parent
 // MockClient instance is invoked.
 type ClientHeadFunc struct {
-	defaultHook func(db.DB, int) (string, error)
-	hooks       []func(db.DB, int) (string, error)
+	defaultHook func(context.Context, db.DB, int) (string, error)
+	hooks       []func(context.Context, db.DB, int) (string, error)
 	history     []ClientHeadFuncCall
 	mutex       sync.Mutex
 }
 
 // Head delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) Head(v0 db.DB, v1 int) (string, error) {
-	r0, r1 := m.HeadFunc.nextHook()(v0, v1)
-	m.HeadFunc.appendCall(ClientHeadFuncCall{v0, v1, r0, r1})
+func (m *MockClient) Head(v0 context.Context, v1 db.DB, v2 int) (string, error) {
+	r0, r1 := m.HeadFunc.nextHook()(v0, v1, v2)
+	m.HeadFunc.appendCall(ClientHeadFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Head method of the
 // parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientHeadFunc) SetDefaultHook(hook func(db.DB, int) (string, error)) {
+func (f *ClientHeadFunc) SetDefaultHook(hook func(context.Context, db.DB, int) (string, error)) {
 	f.defaultHook = hook
 }
 
@@ -315,7 +321,7 @@ func (f *ClientHeadFunc) SetDefaultHook(hook func(db.DB, int) (string, error)) {
 // Head method of the parent MockClient instance inovkes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientHeadFunc) PushHook(hook func(db.DB, int) (string, error)) {
+func (f *ClientHeadFunc) PushHook(hook func(context.Context, db.DB, int) (string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -324,7 +330,7 @@ func (f *ClientHeadFunc) PushHook(hook func(db.DB, int) (string, error)) {
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *ClientHeadFunc) SetDefaultReturn(r0 string, r1 error) {
-	f.SetDefaultHook(func(db.DB, int) (string, error) {
+	f.SetDefaultHook(func(context.Context, db.DB, int) (string, error) {
 		return r0, r1
 	})
 }
@@ -332,12 +338,12 @@ func (f *ClientHeadFunc) SetDefaultReturn(r0 string, r1 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *ClientHeadFunc) PushReturn(r0 string, r1 error) {
-	f.PushHook(func(db.DB, int) (string, error) {
+	f.PushHook(func(context.Context, db.DB, int) (string, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientHeadFunc) nextHook() func(db.DB, int) (string, error) {
+func (f *ClientHeadFunc) nextHook() func(context.Context, db.DB, int) (string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -372,10 +378,13 @@ func (f *ClientHeadFunc) History() []ClientHeadFuncCall {
 type ClientHeadFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 db.DB
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 db.DB
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 string
@@ -387,7 +396,7 @@ type ClientHeadFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientHeadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
Add a context parameter to each gitserver client method in the codeintel internal package.

Also refactor a bit so that the global gitserver client is only invoked from one place.