### PR TITLE
codeintel: Rename poll interval envvar

### DIFF
--- a/cmd/precise-code-intel-worker/env.go
+++ b/cmd/precise-code-intel-worker/env.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	rawBundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-	rawPollInterval     = env.Get("PRECISE_CODE_INTEL_POLL_INTERVAL", "1s", "Interval between queries to the work queue.")
-	rawResetInterval    = env.Get("PRECISE_CODE_INTEL_RESET_INTERVAL", "1m", "How often to reset stalled uploads.")
+	rawBundleManagerURL   = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
+	rawWorkerPollInterval = env.Get("PRECISE_CODE_INTEL_WORKER_POLL_INTERVAL", "1s", "Interval between queries to the upload queue.")
+	rawResetInterval      = env.Get("PRECISE_CODE_INTEL_RESET_INTERVAL", "1m", "How often to reset stalled uploads.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.

--- a/cmd/precise-code-intel-worker/main.go
+++ b/cmd/precise-code-intel-worker/main.go
@@ -32,9 +32,9 @@ func main() {
 	sqliteutil.MustRegisterSqlite3WithPcre()
 
 	var (
-		bundleManagerURL = mustGet(rawBundleManagerURL, "PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL")
-		pollInterval     = mustParseInterval(rawPollInterval, "PRECISE_CODE_INTEL_POLL_INTERVAL")
-		resetInterval    = mustParseInterval(rawResetInterval, "PRECISE_CODE_INTEL_RESET_INTERVAL")
+		bundleManagerURL   = mustGet(rawBundleManagerURL, "PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL")
+		workerPollInterval = mustParseInterval(rawWorkerPollInterval, "PRECISE_CODE_INTEL_WORKER_POLL_INTERVAL")
+		resetInterval      = mustParseInterval(rawResetInterval, "PRECISE_CODE_INTEL_RESET_INTERVAL")
 	)
 
 	observationContext := &observation.Context{
@@ -59,7 +59,7 @@ func main() {
 		db,
 		bundles.New(bundleManagerURL),
 		gitserver.DefaultClient,
-		pollInterval,
+		workerPollInterval,
 		workerMetrics,
 	)
 


### PR DESCRIPTION
This will reduce conflicts when we introduce auto-indexing.