### PR TITLE
Don't set unidiff-zero anymore

### DIFF
--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -177,9 +177,7 @@ func ExecChangesetJob(
 		// We use unified diffs, not git diffs, which means they're missing the
 		// `a/` and `/b` filename prefixes. `-p0` tells `git apply` to not
 		// expect and strip prefixes.
-		// Since we also produce diffs manually, we might not have context lines,
-		// so we need to disable that check with `--unidiff-zero`.
-		GitApplyArgs: []string{"-p0", "--unidiff-zero"},
+		GitApplyArgs: []string{"-p0"},
 		Push:         true,
 	})
 	if err != nil {


### PR DESCRIPTION
Discussion: Merge not required if we find reasons against it.

This was set for legacy reasons when we hand-crafted patches
in the backend. Since we don't do that since campaigns changed
drastically, and it can be unsafe, I think we can remove it at this point. @mrnugget I think you added that back then - WDYT, can we get rid of it? 