### PR TITLE
graphqlbackend: use db.Repos Names for restricting

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -40,12 +39,7 @@ func (r *schemaResolver) Repositories(args *struct {
 		}},
 	}
 	if args.Names != nil {
-		// Make an exact-match regexp for each name.
-		patterns := make([]string, len(*args.Names))
-		for i, name := range *args.Names {
-			patterns[i] = regexp.QuoteMeta(name)
-		}
-		opt.IncludePatterns = []string{"^(" + strings.Join(patterns, "|") + ")$"}
+		opt.Names = *args.Names
 	}
 	if args.Query != nil {
 		opt.Query = *args.Query


### PR DESCRIPTION
The version contexts PR introduced a new option for restricting the list
of repositories listed. Before this existed the only way to limit the
listing of repositories was to create a regexp.

I noticed this improvement while working on something else.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
