### PR TITLE
search: do not quote rev in dynamic repo filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Dynamic repo search filters on branches which contain special characters are correctly escaped now. [#10810](https://github.com/sourcegraph/sourcegraph/pull/10810)
+
 ### Removed
 
 ## 3.16.0

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -242,7 +242,9 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 	addRepoFilter := func(uri string, rev string, lineMatchCount int) {
 		filter := fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
 		if rev != "" {
-			filter = filter + fmt.Sprintf(`@%s`, regexp.QuoteMeta(rev))
+			// We don't need to quote rev. The only special characters we interpret
+			// are @ and :, both of which are disallowed in git refs
+			filter = filter + fmt.Sprintf(`@%s`, rev)
 		}
 		_, limitHit := sr.searchResultsCommon.partial[api.RepoName(uri)]
 		// Increment number of matches per repo. Add will override previous entry for uri

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -656,7 +656,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		Repo:  repo,
 	}
 
-	rev := "develop"
+	rev := "develop3.0"
 	fileMatchRev := &FileMatchResolver{
 		JPath:    "/testFile.md",
 		Repo:     repo,
@@ -692,8 +692,8 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 			descr:         "single file match with specified revision",
 			searchResults: []SearchResultResolver{fileMatchRev},
 			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:^testRepo$@develop`: {},
-				`lang:markdown`:           {},
+				`repo:^testRepo$@develop3.0`: {},
+				`lang:markdown`:              {},
 			},
 		},
 		{
@@ -738,8 +738,8 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				actualDynamicFilterStrs[filter.Value()] = struct{}{}
 			}
 
-			if !reflect.DeepEqual(actualDynamicFilterStrs, test.expectedDynamicFilterStrs) {
-				t.Errorf("actual: %v, expected: %v", actualDynamicFilterStrs, test.expectedDynamicFilterStrs)
+			if diff := cmp.Diff(test.expectedDynamicFilterStrs, actualDynamicFilterStrs); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
We previously quoted rev as if it was a regex. However, it is a
refglob. The only characters we interpret in our parsing layer after the
'@' are '@' and ':'. However, both of those characters are disallowed in
valid git revisions (refs or shas), so we don't need to quote them.

While testing version contexts we had incorrect filters added since we
were exploring the "3.0" branch. It added the rev specifier "3\.0"
instead of just "3.0".



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
