### PR TITLE
campaigns: Validate branch names

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -131,9 +131,10 @@ func (s *Service) CreateCampaign(ctx context.Context, c *campaigns.Campaign, dra
 		return err
 	}
 
-	if c.PatchSetID != 0 && c.Branch == "" {
-		err = ErrCampaignBranchBlank
-		return err
+	if c.PatchSetID != 0 {
+		if err := validateCampaignBranch(c.Branch); err != nil {
+			return err
+		}
 	}
 
 	if c.PatchSetID == 0 || draft {
@@ -458,9 +459,13 @@ type UpdateCampaignArgs struct {
 // specified Campaign name is blank.
 var ErrCampaignNameBlank = errors.New("Campaign title cannot be blank")
 
-// ErrCampaignBranchBlank is returned by CreateCampaign if the specified Campaign's
+// ErrCampaignBranchBlank is returned by CreateCampaign or UpdateCampaign if the specified Campaign's
 // branch is blank. This is only enforced when creating published campaigns with a patch set.
 var ErrCampaignBranchBlank = errors.New("Campaign branch cannot be blank")
+
+// ErrCampaignBranchInvalid is returned by CreateCampaign or UpdateCampaign if the specified Campaign's
+// branch is invalid. This is only enforced when creating published campaigns with a patch set.
+var ErrCampaignBranchInvalid = errors.New("Campaign branch is invalid")
 
 // ErrPublishedCampaignBranchChange is returned by UpdateCampaign if there is an
 // attempt to change the branch of a published campaign with a patch set (or a campaign with individually published changesets).
@@ -538,8 +543,8 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	}
 
 	if args.Branch != nil && campaign.Branch != *args.Branch {
-		if *args.Branch == "" {
-			return nil, nil, ErrCampaignBranchBlank
+		if err := validateCampaignBranch(*args.Branch); err != nil {
+			return nil, nil, err
 		}
 
 		campaign.Branch = *args.Branch
@@ -644,6 +649,16 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 	}
 
 	return campaign, changesets, tx.UpdateCampaign(ctx, campaign)
+}
+
+func validateCampaignBranch(branch string) error {
+	if branch == "" {
+		return ErrCampaignBranchBlank
+	}
+	if err := git.ValidateBranchName(branch); err != nil {
+		return ErrCampaignBranchInvalid
+	}
+	return nil
 }
 
 // campaignPublished returns true if all ChangesetJobs have been created yet

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -655,7 +655,7 @@ func validateCampaignBranch(branch string) error {
 	if branch == "" {
 		return ErrCampaignBranchBlank
 	}
-	if err := git.ValidateBranchName(branch); err != nil {
+	if !git.ValidateBranchName(branch) {
 		return ErrCampaignBranchInvalid
 	}
 	return nil

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -316,6 +316,13 @@ func TestService(t *testing.T) {
 				process: true,
 				err:     ErrCampaignBranchBlank.Error(),
 			},
+			{
+				name:    "change campaign invalid branch",
+				branch:  strPointer("invalid-branch."),
+				draft:   true,
+				process: true,
+				err:     ErrCampaignBranchInvalid.Error(),
+			},
 		}
 		for _, tc := range subTests {
 			t.Run(tc.name, func(t *testing.T) {

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -344,7 +344,7 @@ var invalidBranch = lazyregexp.New(`\.\.|/\.|\.lock$|[\000-\037\177 ~^:?*[]+|^/|
 // It follows the rules here: https://git-scm.com/docs/git-check-ref-format
 // NOTE: It does not require a slash as mentioned in point 2.
 func ValidateBranchName(branch string) error {
-	if invalidBranch.MatchString(branch) {
+	if invalidBranch.MatchString(branch) || strings.EqualFold(branch, "head") {
 		return errors.New("invalid git branch")
 	}
 	return nil

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -340,12 +340,9 @@ func showRef(ctx context.Context, repo gitserver.Repo, args ...string) ([]Ref, e
 
 var invalidBranch = lazyregexp.New(`\.\.|/\.|\.lock$|[\000-\037\177 ~^:?*[]+|^/|/$|//|\.$|@{|^@$|\\`)
 
-// ValidateBranchName returns an error if the given string is not a valid branch name.
+// ValidateBranchName returns false if the given string is not a valid branch name.
 // It follows the rules here: https://git-scm.com/docs/git-check-ref-format
 // NOTE: It does not require a slash as mentioned in point 2.
-func ValidateBranchName(branch string) error {
-	if invalidBranch.MatchString(branch) || strings.EqualFold(branch, "head") {
-		return errors.New("invalid git branch")
-	}
-	return nil
+func ValidateBranchName(branch string) bool {
+	return !(invalidBranch.MatchString(branch) || strings.EqualFold(branch, "head"))
 }

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -311,124 +311,33 @@ func TestValidateBranchName(t *testing.T) {
 		branch string
 		valid  bool
 	}{
-		{
-			name:   "Valid branch",
-			branch: "valid-branch",
-			valid:  true,
-		},
-		{
-			name:   "Valid branch with slash",
-			branch: "rgs/valid-branch",
-			valid:  true,
-		},
-		{
-			name:   "Valid branch with @",
-			branch: "valid@branch",
-			valid:  true,
-		},
-		{
-			name:   "Path component with .",
-			branch: "valid-/.branch",
-			valid:  false,
-		},
-		{
-			name:   "Double dot",
-			branch: "valid..branch",
-			valid:  false,
-		},
-		{
-			name:   "End with .lock",
-			branch: "valid-branch.lock",
-			valid:  false,
-		},
-		{
-			name:   "No space",
-			branch: "valid branch",
-			valid:  false,
-		},
-		{
-			name:   "No tilde",
-			branch: "valid~branch",
-			valid:  false,
-		},
-		{
-			name:   "No carat",
-			branch: "valid^branch",
-			valid:  false,
-		},
-		{
-			name:   "No colon",
-			branch: "valid:branch",
-			valid:  false,
-		},
-		{
-			name:   "No question mark",
-			branch: "valid?branch",
-			valid:  false,
-		},
-		{
-			name:   "No asterisk",
-			branch: "valid*branch",
-			valid:  false,
-		},
-		{
-			name:   "No open bracket",
-			branch: "valid[branch",
-			valid:  false,
-		},
-		{
-			name:   "No trailing slash",
-			branch: "valid-branch/",
-			valid:  false,
-		},
-		{
-			name:   "No beginning slash",
-			branch: "/valid-branch",
-			valid:  false,
-		},
-		{
-			name:   "No double slash",
-			branch: "valid//branch",
-			valid:  false,
-		},
-		{
-			name:   "No trailing dot",
-			branch: "valid-branch.",
-			valid:  false,
-		},
-		{
-			name:   "Cannot contain @{",
-			branch: "valid@{branch",
-			valid:  false,
-		},
-		{
-			name:   "Cannot be @",
-			branch: "@",
-			valid:  false,
-		},
-		{
-			name:   "Cannot contain backslash",
-			branch: "valid\\branch",
-			valid:  false,
-		},
-		{
-			name:   "head not allowed",
-			branch: "head",
-			valid:  false,
-		},
-		{
-			name:   "Head not allowed",
-			branch: "Head",
-			valid:  false,
-		},
+		{name: "Valid branch", branch: "valid-branch", valid: true},
+		{name: "Valid branch with slash", branch: "rgs/valid-branch", valid: true},
+		{name: "Valid branch with @", branch: "valid@branch", valid: true},
+		{name: "Path component with .", branch: "valid-/.branch", valid: false},
+		{name: "Double dot", branch: "valid..branch", valid: false},
+		{name: "End with .lock", branch: "valid-branch.lock", valid: false},
+		{name: "No space", branch: "valid branch", valid: false},
+		{name: "No tilde", branch: "valid~branch", valid: false},
+		{name: "No carat", branch: "valid^branch", valid: false},
+		{name: "No colon", branch: "valid:branch", valid: false},
+		{name: "No question mark", branch: "valid?branch", valid: false},
+		{name: "No asterisk", branch: "valid*branch", valid: false},
+		{name: "No open bracket", branch: "valid[branch", valid: false},
+		{name: "No trailing slash", branch: "valid-branch/", valid: false},
+		{name: "No beginning slash", branch: "/valid-branch", valid: false},
+		{name: "No double slash", branch: "valid//branch", valid: false},
+		{name: "No trailing dot", branch: "valid-branch.", valid: false},
+		{name: "Cannot contain @{", branch: "valid@{branch", valid: false},
+		{name: "Cannot be @", branch: "@", valid: false},
+		{name: "Cannot contain backslash", branch: "valid\\branch", valid: false},
+		{name: "head not allowed", branch: "head", valid: false},
+		{name: "Head not allowed", branch: "Head", valid: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateBranchName(tc.branch)
-			if !tc.valid && err == nil {
-				t.Fatal("Expected an error, got none")
-			}
-			if tc.valid && err != nil {
-				t.Fatalf("Expected nil error, got %v", err)
+			valid := ValidateBranchName(tc.branch)
+			if tc.valid != valid {
+				t.Fatalf("Expected %t, got %t", tc.valid, valid)
 			}
 		})
 	}

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -411,6 +411,16 @@ func TestValidateBranchName(t *testing.T) {
 			branch: "valid\\branch",
 			valid:  false,
 		},
+		{
+			name:   "head not allowed",
+			branch: "head",
+			valid:  false,
+		},
+		{
+			name:   "Head not allowed",
+			branch: "Head",
+			valid:  false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateBranchName(tc.branch)

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -304,3 +304,122 @@ func TestRepository_ListTags(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateBranchName(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		branch string
+		valid  bool
+	}{
+		{
+			name:   "Valid branch",
+			branch: "valid-branch",
+			valid:  true,
+		},
+		{
+			name:   "Valid branch with slash",
+			branch: "rgs/valid-branch",
+			valid:  true,
+		},
+		{
+			name:   "Valid branch with @",
+			branch: "valid@branch",
+			valid:  true,
+		},
+		{
+			name:   "Path component with .",
+			branch: "valid-/.branch",
+			valid:  false,
+		},
+		{
+			name:   "Double dot",
+			branch: "valid..branch",
+			valid:  false,
+		},
+		{
+			name:   "End with .lock",
+			branch: "valid-branch.lock",
+			valid:  false,
+		},
+		{
+			name:   "No space",
+			branch: "valid branch",
+			valid:  false,
+		},
+		{
+			name:   "No tilde",
+			branch: "valid~branch",
+			valid:  false,
+		},
+		{
+			name:   "No carat",
+			branch: "valid^branch",
+			valid:  false,
+		},
+		{
+			name:   "No colon",
+			branch: "valid:branch",
+			valid:  false,
+		},
+		{
+			name:   "No question mark",
+			branch: "valid?branch",
+			valid:  false,
+		},
+		{
+			name:   "No asterisk",
+			branch: "valid*branch",
+			valid:  false,
+		},
+		{
+			name:   "No open bracket",
+			branch: "valid[branch",
+			valid:  false,
+		},
+		{
+			name:   "No trailing slash",
+			branch: "valid-branch/",
+			valid:  false,
+		},
+		{
+			name:   "No beginning slash",
+			branch: "/valid-branch",
+			valid:  false,
+		},
+		{
+			name:   "No double slash",
+			branch: "valid//branch",
+			valid:  false,
+		},
+		{
+			name:   "No trailing dot",
+			branch: "valid-branch.",
+			valid:  false,
+		},
+		{
+			name:   "Cannot contain @{",
+			branch: "valid@{branch",
+			valid:  false,
+		},
+		{
+			name:   "Cannot be @",
+			branch: "@",
+			valid:  false,
+		},
+		{
+			name:   "Cannot contain backslash",
+			branch: "valid\\branch",
+			valid:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBranchName(tc.branch)
+			if !tc.valid && err == nil {
+				t.Fatal("Expected an error, got none")
+			}
+			if tc.valid && err != nil {
+				t.Fatalf("Expected nil error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We follow the rules here:
https://git-scm.com/docs/git-check-ref-format

Note, we do not require a slash as mentioned in rule 2 since a prefix of
refs/heads/ is implied.

Closes: https://github.com/sourcegraph/sourcegraph/issues/10718
