### PR TITLE
Correctly reset publishing state after immediate error

### DIFF
--- a/web/src/enterprise/campaigns/detail/patches/PatchNode.tsx
+++ b/web/src/enterprise/campaigns/detail/patches/PatchNode.tsx
@@ -35,7 +35,10 @@ export const PatchNode: React.FunctionComponent<PatchNodeProps> = ({
     const [isPublishing, setIsPublishing] = useState<boolean | Error>(false)
     useEffect(() => {
         setIsPublishing(node.publicationEnqueued)
-    }, [node.publicationEnqueued])
+        // Need to watch for the node to change, that means a refetch has happened.
+        // It can be that node.publicationEnqueued never got true,
+        // when it failed between the `publishChangeset` call and the first refetch.
+    }, [node])
 
     const publishChangeset: React.MouseEventHandler = async () => {
         try {


### PR DESCRIPTION
This was caused when the error happened in between the gap
of the request to publishCampaign succeeded and the fetch patches,
causing it to never become truthy, so no flip. Instead, we should listen if
_any_ refetch was triggered.


Closes https://github.com/sourcegraph/sourcegraph/issues/10717