### PR TITLE
LSIF diagnostics GraphQL API proposal

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2479,6 +2479,11 @@ interface TreeEntry {
         # Return symbols matching the query.
         query: String
     ): SymbolConnection!
+    # LSIF data for this tree entry.
+    lsif(
+        # An optional filter for the tool name provided in the meta data vertex.
+        toolName: String
+    ): TreeEntryLSIFData
     # Submodule metadata if this tree points to a submodule
     submodule: Submodule
     # Whether this tree entry is a single child
@@ -2703,12 +2708,21 @@ type GitBlob implements TreeEntry & File2 {
     # CHANGELOG during this time.
     # A wrapper around LSIF query methods. If no LSIF upload can be used to answer code
     # intelligence queries for this path-at-revision, this resolves to null.
-    lsif: LSIFQueryResolver
+    lsif(
+        # An optional filter for the tool name provided in the meta data vertex.
+        toolName: String
+    ): GitBlobLSIFData
+}
+
+# LSIF data available for a tree entry.
+interface TreeEntryLSIFData {
+    # Code diagnostics provided through LSIF.
+    diagnostics(first: Int): DiagnosticConnection!
 }
 
 # A wrapper object around LSIF query methods for a particular path-at-revision. When this node is
 # null, no LSIF data is available for containing git blob.
-type LSIFQueryResolver {
+type GitBlobLSIFData implements TreeEntryLSIFData {
     # (experimental) The LSIF API may change substantially in the near future as we
     # continue to adjust it for our use cases. Changes will not be documented in the
     # CHANGELOG during this time.
@@ -2756,6 +2770,56 @@ type LSIFQueryResolver {
         # The character (not byte) of the start line on which the symbol occurs (zero-based, inclusive).
         character: Int!
     ): Hover
+
+    # Code diagnostics provided through LSIF.
+    diagnostics(first: Int): DiagnosticConnection!
+}
+
+type DiagnosticConnection {
+    # A list of diagnostics.
+    nodes: [Diagnostic!]!
+
+    # The total count of diagnostics (which may be larger than nodes.length if the connection is paginated).
+    totalCount: Int!
+
+    # Pagination information.
+    pageInfo: PageInfo!
+}
+
+# Represents a diagnostic, such as a compiler error or warning.
+type Diagnostic {
+    # The location at which the message applies.
+    location: Location!
+
+    # The diagnostic's severity.
+    severity: DiagnosticSeverity
+
+    # The diagnostic's code as provided by the tool.
+    code: String
+
+    # A human-readable string describing the source of this
+    # diagnostic, e.g. "typescript" or "super lint".
+    source: String
+
+    # The diagnostic's message.
+    message: String
+
+    # Additional metadata about the diagnostic.
+    tags: [DiagnosticTag!]!
+}
+
+enum DiagnosticSeverity {
+    ERROR
+    WARNING
+    INFORMATION
+    HINT
+}
+
+enum DiagnosticTag {
+    # Unused or unnecessary code.
+    UNNECESSARY
+    # Deprecated or obsolete code.
+    DEPRECATED
 }
 
 # A highlighted file.


### PR DESCRIPTION
This is a GraphQL API to query LSIF diagnostics, which would be used by code insights and can also be displayed in the UI when browsing files (#4102).

Code insights will query `diagnostics.pageInfo.totalCount` for 7 past revisions on the current directory (which may be the root directory of the repo), for a specific tool (e.g. the ESLint extension would filter to `eslint`).

The blob component would query diagnostics on the current file with ranges, messages, source and severity.

References:
- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic
- https://github.com/microsoft/language-server-protocol/blob/master/indexFormat/specification.md#request-textdocumentdiagnostic

Differences:
- Used `Location` instead of `Range` to expose the file path
- Omitted `relatedInformation` for now for simplicity
- Made `code` always a string because GraphQL does not support scalar union types (backend can convert numbers to strings)
- Enums are GraphQL enums
- Made `tags` non-nullable, they are only optional in LSP for BC, backend can fill them with empty list if not provided

Future extensions of this would be:
- Querying diagnostic counts across all repositories
- Easy/performant way to query data at multiple past points in time at once
- Filter by severity etc.