### PR TITLE
codeintel: Update metadata vertex buffer size

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/server/enqueue.go
+++ b/cmd/precise-code-intel-api-server/internal/server/enqueue.go
@@ -37,6 +37,11 @@ func (s *Server) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if err == ErrMetadataExceedsBuffer {
+			http.Error(w, "Could not read indexer name from metaData vertex. Please supply it explicitly.", http.StatusBadRequest)
+			return
+		}
+
 		log15.Error("Failed to enqueue payload", "error", err)
 		http.Error(w, fmt.Sprintf("failed to enqueue payload: %s", err.Error()), http.StatusInternalServerError)
 		return

--- a/cmd/precise-code-intel-api-server/internal/server/indexer_name.go
+++ b/cmd/precise-code-intel-api-server/internal/server/indexer_name.go
@@ -17,6 +17,14 @@ type toolInfo struct {
 	Name string `json:"name"`
 }
 
+// MaxBufferSize is the maximum size of the metaData line in the dump. This should be large enough
+// to be able to read the output of lsif-tsc for most cases, which will contain all glob-expanded
+// file names in the indexing of JavaScript projects.
+//
+// Data point: lodash's metaData vertex constructed by the args `*.js test/*.js --AllowJs --checkJs`
+// is 10639 characters long.
+const MaxBufferSize = 128 * 1024
+
 // ErrMetadataExceedsBuffer occurs when the first line of an LSIF index is too long to read.
 var ErrMetadataExceedsBuffer = errors.New("metaData vertex exceeds buffer")
 
@@ -27,7 +35,7 @@ var ErrInvalidMetaDataVertex = errors.New("invalid metaData vertex")
 // This function reads only the first line of the file, where the metadata vertex is
 // assumed to be in all valid dumps.
 func readIndexerName(r io.Reader) (string, error) {
-	line, isPrefix, err := bufio.NewReader(r).ReadLine()
+	line, isPrefix, err := bufio.NewReaderSize(r, MaxBufferSize).ReadLine()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Related change in src-cli: https://github.com/sourcegraph/src-cli/pull/204