### PR TITLE
codeintel: Remove pointer from upload on db.InsertUpload

### DIFF
--- a/cmd/precise-code-intel-api-server/internal/server/enqueue.go
+++ b/cmd/precise-code-intel-api-server/internal/server/enqueue.go
@@ -164,7 +164,7 @@ func (s *Server) handleEnqueueSinglePayload(r *http.Request, uploadArgs UploadAr
 		err = tx.Done(err)
 	}()
 
-	id, err := tx.InsertUpload(r.Context(), &db.Upload{
+	id, err := tx.InsertUpload(r.Context(), db.Upload{
 		Commit:        uploadArgs.Commit,
 		Root:          uploadArgs.Root,
 		RepositoryID:  uploadArgs.RepositoryID,
@@ -188,7 +188,7 @@ func (s *Server) handleEnqueueSinglePayload(r *http.Request, uploadArgs UploadAr
 // new upload record with state 'uploading' and returns the generated ID to be used in subsequent
 // requests for the same upload.
 func (s *Server) handleEnqueueMultipartSetup(r *http.Request, uploadArgs UploadArgs, numParts int) (interface{}, error) {
-	id, err := s.db.InsertUpload(r.Context(), &db.Upload{
+	id, err := s.db.InsertUpload(r.Context(), db.Upload{
 		Commit:        uploadArgs.Commit,
 		Root:          uploadArgs.Root,
 		RepositoryID:  uploadArgs.RepositoryID,

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -49,7 +49,7 @@ type DB interface {
 	QueueSize(ctx context.Context) (int, error)
 
 	// InsertUpload inserts a new upload and returns its identifier.
-	InsertUpload(ctx context.Context, upload *Upload) (int, error)
+	InsertUpload(ctx context.Context, upload Upload) (int, error)
 
 	// AddUploadPart adds the part index to the given upload's uploaded parts array. This method is idempotent
 	// (the resulting array is deduplicated on update).

--- a/internal/codeintel/db/mocks/mock_db.go
+++ b/internal/codeintel/db/mocks/mock_db.go
@@ -182,7 +182,7 @@ func NewMockDB() *MockDB {
 			},
 		},
 		InsertUploadFunc: &DBInsertUploadFunc{
-			defaultHook: func(context.Context, *db.Upload) (int, error) {
+			defaultHook: func(context.Context, db.Upload) (int, error) {
 				return 0, nil
 			},
 		},
@@ -1926,15 +1926,15 @@ func (c DBHasCommitFuncCall) Results() []interface{} {
 // DBInsertUploadFunc describes the behavior when the InsertUpload method of
 // the parent MockDB instance is invoked.
 type DBInsertUploadFunc struct {
-	defaultHook func(context.Context, *db.Upload) (int, error)
-	hooks       []func(context.Context, *db.Upload) (int, error)
+	defaultHook func(context.Context, db.Upload) (int, error)
+	hooks       []func(context.Context, db.Upload) (int, error)
 	history     []DBInsertUploadFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertUpload delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockDB) InsertUpload(v0 context.Context, v1 *db.Upload) (int, error) {
+func (m *MockDB) InsertUpload(v0 context.Context, v1 db.Upload) (int, error) {
 	r0, r1 := m.InsertUploadFunc.nextHook()(v0, v1)
 	m.InsertUploadFunc.appendCall(DBInsertUploadFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -1942,7 +1942,7 @@ func (m *MockDB) InsertUpload(v0 context.Context, v1 *db.Upload) (int, error) {
 
 // SetDefaultHook sets function that is called when the InsertUpload method
 // of the parent MockDB instance is invoked and the hook queue is empty.
-func (f *DBInsertUploadFunc) SetDefaultHook(hook func(context.Context, *db.Upload) (int, error)) {
+func (f *DBInsertUploadFunc) SetDefaultHook(hook func(context.Context, db.Upload) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1950,7 +1950,7 @@ func (f *DBInsertUploadFunc) SetDefaultHook(hook func(context.Context, *db.Uploa
 // InsertUpload method of the parent MockDB instance inovkes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBInsertUploadFunc) PushHook(hook func(context.Context, *db.Upload) (int, error)) {
+func (f *DBInsertUploadFunc) PushHook(hook func(context.Context, db.Upload) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1959,7 +1959,7 @@ func (f *DBInsertUploadFunc) PushHook(hook func(context.Context, *db.Upload) (in
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *DBInsertUploadFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, *db.Upload) (int, error) {
+	f.SetDefaultHook(func(context.Context, db.Upload) (int, error) {
 		return r0, r1
 	})
 }
@@ -1967,12 +1967,12 @@ func (f *DBInsertUploadFunc) SetDefaultReturn(r0 int, r1 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *DBInsertUploadFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, *db.Upload) (int, error) {
+	f.PushHook(func(context.Context, db.Upload) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *DBInsertUploadFunc) nextHook() func(context.Context, *db.Upload) (int, error) {
+func (f *DBInsertUploadFunc) nextHook() func(context.Context, db.Upload) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2010,7 +2010,7 @@ type DBInsertUploadFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 *db.Upload
+	Arg1 db.Upload
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int

--- a/internal/codeintel/db/observability.go
+++ b/internal/codeintel/db/observability.go
@@ -304,7 +304,7 @@ func (db *ObservedDB) QueueSize(ctx context.Context) (_ int, err error) {
 }
 
 // InsertUpload calls into the inner DB and registers the observed result.
-func (db *ObservedDB) InsertUpload(ctx context.Context, upload *Upload) (_ int, err error) {
+func (db *ObservedDB) InsertUpload(ctx context.Context, upload Upload) (_ int, err error) {
 	ctx, endObservation := db.insertUploadOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return db.db.InsertUpload(ctx, upload)

--- a/internal/codeintel/db/uploads.go
+++ b/internal/codeintel/db/uploads.go
@@ -84,7 +84,7 @@ func (db *dbImpl) GetUploadsByRepo(ctx context.Context, repositoryID int, state,
 
 	count, _, err := scanFirstInt(tx.query(
 		ctx,
-		sqlf.Sprintf(`SELECT COUNT(1) FROM lsif_uploads u WHERE %s`, sqlf.Join(conds, " AND ")),
+		sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_uploads u WHERE %s`, sqlf.Join(conds, " AND ")),
 	))
 	if err != nil {
 		return nil, 0, err
@@ -151,7 +151,7 @@ func (db *dbImpl) QueueSize(ctx context.Context) (int, error) {
 }
 
 // InsertUpload inserts a new upload and returns its identifier.
-func (db *dbImpl) InsertUpload(ctx context.Context, upload *Upload) (int, error) {
+func (db *dbImpl) InsertUpload(ctx context.Context, upload Upload) (int, error) {
 	if upload.UploadedParts == nil {
 		upload.UploadedParts = []int{}
 	}

--- a/internal/codeintel/db/uploads_test.go
+++ b/internal/codeintel/db/uploads_test.go
@@ -217,7 +217,7 @@ func TestInsertUploadUploading(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := testDB()
 
-	id, err := db.InsertUpload(context.Background(), &Upload{
+	id, err := db.InsertUpload(context.Background(), Upload{
 		Commit:       makeCommit(1),
 		Root:         "sub/",
 		State:        "uploading",
@@ -267,7 +267,7 @@ func TestInsertUploadQueued(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	db := &dbImpl{db: dbconn.Global}
 
-	id, err := db.InsertUpload(context.Background(), &Upload{
+	id, err := db.InsertUpload(context.Background(), Upload{
 		Commit:        makeCommit(1),
 		Root:          "sub/",
 		State:         "queued",


### PR DESCRIPTION
No reason for it to be a pointer in the first place.