### PR TITLE
campaigns: Remove unused changesets() query resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -110,7 +110,6 @@ type CampaignsResolver interface {
 
 	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ExternalChangesetResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error)
-	Changesets(ctx context.Context, args *ListChangesetsArgs) (ExternalChangesetsConnectionResolver, error)
 
 	AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error)
 
@@ -169,10 +168,6 @@ func (defaultCampaignsResolver) CreateChangesets(ctx context.Context, args *Crea
 }
 
 func (defaultCampaignsResolver) ChangesetByID(ctx context.Context, id graphql.ID) (ExternalChangesetResolver, error) {
-	return nil, campaignsOnlyInEnterprise
-}
-
-func (defaultCampaignsResolver) Changesets(ctx context.Context, args *ListChangesetsArgs) (ExternalChangesetsConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -479,21 +479,6 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	return csr, nil
 }
 
-func (r *Resolver) Changesets(ctx context.Context, args *graphqlbackend.ListChangesetsArgs) (graphqlbackend.ExternalChangesetsConnectionResolver, error) {
-	// 🚨 SECURITY: Only site admins or users when read-access is enabled may access changesets.
-	if err := allowReadAccess(ctx); err != nil {
-		return nil, err
-	}
-	opts, err := listChangesetOptsFromArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	return &changesetsConnectionResolver{
-		store: r.store,
-		opts:  opts,
-	}, nil
-}
-
 func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs) (ee.ListChangesetsOpts, error) {
 	var opts ee.ListChangesetsOpts
 	if args == nil {


### PR DESCRIPTION
I just ran across this while looking at our resolver and noticed that there's no corresponding query in the GraphQL schema and that all the tests pass when I remove it.

I _believe_ it's safe to remove it, can you confirm that @eseliger?

I'm not 100% sure whether my reasoning from "there is no explicit query with this name in the GraphQL schema" to "this is never called so we can remove it" is correct.