### PR TITLE
all: Address golang-ci run warnings

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -188,7 +188,7 @@ func (e *ExternalServicesStore) validateGithubConnection(ctx context.Context, id
 		err = multierror.Append(err, errors.New("at least one of repositoryQuery, repos or orgs must be set"))
 	}
 
-	multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITHUB", c))
+	err = multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITHUB", c))
 
 	return err.ErrorOrNil()
 }
@@ -199,7 +199,7 @@ func (e *ExternalServicesStore) validateGitlabConnection(ctx context.Context, id
 		err = multierror.Append(err, validate(c, ps))
 	}
 
-	multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITLAB", c))
+	err = multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITLAB", c))
 
 	return err.ErrorOrNil()
 }
@@ -214,7 +214,7 @@ func (e *ExternalServicesStore) validateBitbucketServerConnection(ctx context.Co
 		err = multierror.Append(err, errors.New("at least one of repositoryQuery or repos must be set"))
 	}
 
-	multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "BITBUCKETSERVER", c))
+	err = multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "BITBUCKETSERVER", c))
 
 	return err.ErrorOrNil()
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -766,7 +766,7 @@ func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFun
 		patterns, _ := regexp.Compile(`(?i)` + unionRegExps(excludePatterns))
 		filteredRepos := defaultRepos[:0]
 		for _, repo := range defaultRepos {
-			if matched := patterns.MatchString(string(repo.Name)); false == matched {
+			if matched := patterns.MatchString(string(repo.Name)); !matched {
 				filteredRepos = append(filteredRepos, repo)
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -46,7 +46,7 @@ func alertForCappedAndExpression() *searchAlert {
 	return &searchAlert{
 		prometheusType: "exceed_and_expression_search_limit",
 		title:          "Too many files to search for and-expression",
-		description:    fmt.Sprintf("One and-expression in the query requires a lot of work! Try using the 'repo:' or 'file:' filters to narrow your search. We're working on improving this experience in https://github.com/sourcegraph/sourcegraph/issues/9824"),
+		description:    "One and-expression in the query requires a lot of work! Try using the 'repo:' or 'file:' filters to narrow your search. We're working on improving this experience in https://github.com/sourcegraph/sourcegraph/issues/9824",
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -261,7 +261,12 @@ func TestSearchResults(t *testing.T) {
 			if err != nil {
 				t.Fatal("Search:", err)
 			}
+
 			results, err := r.Results(context.Background())
+			if err != nil {
+				t.Fatal("Search: ", err)
+			}
+
 			if results.start.IsZero() {
 				t.Error("Start value is not set")
 			}

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1311,7 +1311,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 	// We need campaigns attached to each changeset
 	for _, cs := range changesets {
 		c := &cmpgn.Campaign{
-			Name:           fmt.Sprintf("ListChangesetSyncData test"),
+			Name:           "ListChangesetSyncData test",
 			ChangesetIDs:   []int64{cs.ID},
 			NamespaceOrgID: 23,
 		}

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -154,7 +154,10 @@ func sanitizeFilename(s string) string {
 func runSearchTests() error {
 	_, err := os.Stat(searchTestDataDir)
 	if os.IsNotExist(err) {
-		os.MkdirAll(searchTestDataDir, os.ModePerm)
+		err := os.MkdirAll(searchTestDataDir, os.ModePerm)
+		if err != nil {
+			return err
+		}
 	}
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
```
cmd/frontend/internal/app/pkg/updatecheck/client.go:107:6: `getTotalUsersCount` is unused (deadcode)
func getTotalUsersCount(ctx context.Context) (int, error) {
     ^
cmd/frontend/internal/app/pkg/updatecheck/client.go:125:6: `getInitialSiteAdminEmail` is unused (deadcode)
func getInitialSiteAdminEmail(ctx context.Context) (string, error) {
     ^
internal/cmd/search-integration-tester/search_tests.go:157:14: Error return value of `os.MkdirAll` is not checked (errcheck)
                os.MkdirAll(searchTestDataDir, os.ModePerm)
                           ^
cmd/frontend/db/external_services.go:191:19: Error return value of `multierror.Append` is not checked (errcheck)
        multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITHUB", c))
                         ^
cmd/frontend/db/external_services.go:202:19: Error return value of `multierror.Append` is not checked (errcheck)
        multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "GITLAB", c))
                         ^
cmd/frontend/db/external_services.go:217:19: Error return value of `multierror.Append` is not checked (errcheck)
        multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, "BITBUCKETSERVER", c))
                         ^
cmd/frontend/internal/app/pkg/updatecheck/client.go:87:11: Error return value of `rec` is not checked (errcheck)
        defer rec(err)
                 ^
cmd/frontend/internal/app/pkg/updatecheck/client.go:134:11: Error return value of `rec` is not checked (errcheck)
        defer rec(err)
                 ^
cmd/frontend/internal/app/pkg/updatecheck/client.go:144:11: Error return value of `rec` is not checked (errcheck)
        defer rec(err)
                 ^
cmd/frontend/graphqlbackend/search_results_test.go:264:13: ineffectual assignment to `err` (ineffassign)
                        results, err := r.Results(context.Background())
                                 ^
cmd/frontend/graphqlbackend/search_alert.go:49:19: S1039: unnecessary use of fmt.Sprintf (gosimple)
                description:    fmt.Sprintf("One and-expression in the query requires a lot of work! Try using the 'repo:' or 'file:' filters to narrow your search. We're working on improving this experience in https://github.com/sourcegraph/sourcegraph/issues/9824"),
                                ^
enterprise/internal/campaigns/store_test.go:1314:20: S1039: unnecessary use of fmt.Sprintf (gosimple)
                        Name:           fmt.Sprintf("ListChangesetSyncData test"),
                                        ^
cmd/frontend/graphqlbackend/search.go:769:59: S1002: should omit comparison to bool constant, can be simplified to `!matched` (gosimple)
                        if matched := patterns.MatchString(string(repo.Name)); false == matched {
                                                                               ^
```