### PR TITLE
Add golangci-lint GitHub Action

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,16 +1,13 @@
 name: reviewdog
-on: [pull_request]
+on: [push, pull_request]
 jobs:
   golangci-lint:
-    name: runner / golangci-lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: List files
-        run: ls -laht
       - name: golangci-lint
         uses: docker://reviewdog/action-golangci-lint:latest
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: -v

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,10 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: List files
         run: ls -laht
       - name: golangci-lint
+        uses: docker://reviewdog/action-golangci-lint:latest
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        uses: docker://reviewdog/action-golangci-lint:latest
+          golangci_lint_flags: -v

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,6 +8,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v1.1.3
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: reviewdog/action-golangci-lint@v1
+        with:
+          golangci_lint_flags: "--config=.golangci.yml"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,5 +9,5 @@ jobs:
         uses: actions/checkout@v1
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1.1.3
-        with:
-          golangci_lint_flags: "--enable-all --exclude-use-default=false"
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,3 +11,5 @@ jobs:
         uses: docker://reviewdog/action-golangci-lint:latest
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: file
+          reporter: github-pr-review

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
-      - uses: docker://reviewdog/action-golangci-lint:latest
-        name: golangci-lint
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: List files
+        run: ls -laht
+      - name: golangci-lint
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker://reviewdog/action-golangci-lint:latest

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,7 +2,7 @@ name: reviewdog
 on: [pull_request]
 jobs:
   golangci-lint:
-    name: runner / golangci-lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,4 +11,3 @@ jobs:
         uses: docker://reviewdog/action-golangci-lint:latest
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: -v --timeout=5m

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,4 +12,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: file
-          reporter: github-pr-review
+          reporter: github-pr-check
+          level: info

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,7 +2,7 @@ name: reviewdog
 on: [pull_request]
 jobs:
   golangci-lint:
-    name: golangci-lint
+    name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -11,3 +11,4 @@ jobs:
         uses: docker://reviewdog/action-golangci-lint:latest
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_flags: -v --timeout=5m

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,5 @@
 name: reviewdog
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   golangci-lint:
     name: golangci-lint

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,9 +7,7 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
-      - name: golangci-lint
+      - uses: docker://reviewdog/action-golangci-lint:latest
+        name: golangci-lint
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: reviewdog/action-golangci-lint@v1
-        with:
-          golangci_lint_flags: "--config=.golangci.yml"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,13 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1.1.3
+        with:
+          golangci_lint_flags: "--enable-all --exclude-use-default=false"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters:
     - funlen
     - goconst
     - gocritic
-    - gocyclo
     - gofmt
     - goimports
     - golint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,108 @@
+run:
+  timeout: 3m
+
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/sourcegraph/sourcegraph
+  golint:
+    min-confidence: 0
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    - nakedret
+    - nolintlint
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+
+    # https://github.com/go-critic/go-critic/issues/926
+    - linters:
+        - gocritic
+      text: "unnecessaryDefer:"
+
+run:
+  skip-dirs:
+    - browser
+    - client
+    - web
+    - ui
+    - vendor
+    - shared
+    - node_modules

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,18 +81,6 @@ linters:
     - varcheck
     - whitespace
 
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-
 run:
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,21 +20,12 @@ linters-settings:
       - octalLiteral
       - whyNoLint
       - wrapperFunc
-  gocyclo:
-    min-complexity: 15
   goimports:
     local-prefixes: github.com/sourcegraph/sourcegraph
   golint:
     min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
   govet:
     check-shadowing: true
-  lll:
-    line-length: 140
   maligned:
     suggest-new: true
   misspell:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  timeout: 3m
-
 linters-settings:
   dupl:
     threshold: 100
@@ -97,6 +94,8 @@ issues:
       text: "unnecessaryDefer:"
 
 run:
+  timeout: 5m
+
   skip-dirs:
     - browser
     - client

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -202,7 +202,9 @@ func (p *parser) matchKeyword(keyword keyword) bool {
 	if after+1 > len(p.buf) || !isSpace(p.buf[after:after+1]) {
 		return false
 	}
+	// Bar
 	return strings.ToLower(v) == string(keyword)
+	// Foo
 }
 
 // skipSpaces advances the input and places the parser position at the next
@@ -703,7 +705,6 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
 			// Reduce left node.
 			return append(operator.Operands, right...), true
-
 		}
 	}
 	if len(right) > 1 {


### PR DESCRIPTION
This PR adds a GitHub Action that runs golangci-lint and reports results back as a PR review using reviewdog. The enabled linters are configured in the `.golangci.yml` file, so we can run locally the same thing during development if so wanted.

The enabled linters aren't set in stone, but I think are a useful initial choice — we can enable and disable some as we learn more about their usefulness with practice.

Review dog 🐶 will report any issues in any changed files, rather than only changed lines of code. I believe this is a good way for us to incrementally reduce these warnings, short of one big PR addressing them all. Please share your thoughts on this if you disagree.

Fixes #9193 