### PR TITLE
redirect https://sourcegraph.com/help/terms to https://about.sourcegraph.com/terms

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -80,14 +80,15 @@ const (
 // aboutRedirects contains map entries, each of which indicates that
 // sourcegraph.com/$KEY should redirect to about.sourcegraph.com/$VALUE.
 var aboutRedirects = map[string]string{
-	"about":    "about",
-	"plan":     "plan",
-	"contact":  "contact",
-	"pricing":  "pricing",
-	"privacy":  "privacy",
-	"security": "security",
-	"terms":    "terms",
-	"jobs":     "jobs",
+	"about":      "about",
+	"plan":       "plan",
+	"contact":    "contact",
+	"pricing":    "pricing",
+	"privacy":    "privacy",
+	"security":   "security",
+	"terms":      "terms",
+	"jobs":       "jobs",
+	"help/terms": "terms",
 }
 
 // Router returns the router that serves pages for our web app.

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -132,6 +132,11 @@ func TestRouter(t *testing.T) {
 			wantRoute: routeAboutSubdomain,
 			wantVars:  map[string]string{"Path": "privacy"},
 		},
+		{
+			path:      "/help/terms",
+			wantRoute: routeAboutSubdomain,
+			wantVars:  map[string]string{"Path": "help/terms"},
+		},
 
 		// sign-in
 		{


### PR DESCRIPTION
This is for a customer contract that hard-codes the previous URL.