### PR TITLE
codeintel: Do not wrap tx.Done errors twice in worker

### DIFF
--- a/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -88,9 +88,7 @@ func (w *Worker) dequeueAndProcess(ctx context.Context) (_ bool, err error) {
 		return false, errors.Wrap(err, "db.Dequeue")
 	}
 	defer func() {
-		if closeErr := tx.Done(err); closeErr != nil {
-			err = multierror.Append(err, closeErr)
-		}
+		err = tx.Done(err)
 
 		// TODO(efritz) - set error if correlation failed
 		w.metrics.Processor.Observe(time.Since(start).Seconds(), 1, &err)

--- a/cmd/precise-code-intel-worker/internal/worker/worker_test.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker_test.go
@@ -142,6 +142,7 @@ func TestDequeueAndProcessMarkErrorFailure(t *testing.T) {
 	}
 
 	mockDB := dbmocks.NewMockDB()
+	mockDB.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	mockProcessor := NewMockProcessor()
 	mockDB.DequeueFunc.SetDefaultReturn(upload, mockDB, true, nil)
 	mockDB.MarkErroredFunc.SetDefaultReturn(fmt.Errorf("db failure"))


### PR DESCRIPTION
`tx.Done` already wraps a new error from done. What we ended up doing before was doubling the error text, which is unnecessary.