### PR TITLE
search: fix dynamic filter archive count

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -224,7 +224,7 @@ var commonFileFilters = []struct {
 func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 	filters := map[string]*searchFilterResolver{}
 	repoToMatchCount := make(map[string]int)
-	add := func(value string, label string, count int, limitHit bool, kind string) {
+	add := func(value string, label string, count int, limitHit bool, kind string, score score) {
 		sf, ok := filters[value]
 		if !ok {
 			sf = &searchFilterResolver{
@@ -239,7 +239,7 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 			sf.count = int32(count)
 		}
 
-		sf.score++
+		sf.score = score
 	}
 
 	addRepoFilter := func(uri string, rev string, lineMatchCount int) {
@@ -252,13 +252,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 		_, limitHit := sr.searchResultsCommon.partial[api.RepoName(uri)]
 		// Increment number of matches per repo. Add will override previous entry for uri
 		repoToMatchCount[uri] += lineMatchCount
-		add(filter, uri, repoToMatchCount[uri], limitHit, "repo")
+		add(filter, uri, repoToMatchCount[uri], limitHit, "repo", Default)
 	}
 
 	addFileFilter := func(fileMatchPath string, lineMatchCount int, limitHit bool) {
 		for _, ff := range commonFileFilters {
 			if ff.Regexp.MatchString(fileMatchPath) {
-				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file")
+				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file", Default)
 			}
 		}
 	}
@@ -275,16 +275,16 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 					language = strconv.Quote(language)
 				}
 				value := fmt.Sprintf(`lang:%s`, language)
-				add(value, value, lineMatchCount, limitHit, "lang")
+				add(value, value, lineMatchCount, limitHit, "lang", Default)
 			}
 		}
 	}
 
 	if sr.searchResultsCommon.excluded.forks > 0 {
-		add("fork:yes", "fork:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo")
+		add("fork:yes", "fork:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo", Important)
 	}
 	if sr.searchResultsCommon.excluded.archived > 0 {
-		add("archived:yes", "archived:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo")
+		add("archived:yes", "archived:yes", sr.searchResultsCommon.excluded.archived, sr.limitHit, "repo", Important)
 	}
 	for _, result := range sr.SearchResults {
 		if fm, ok := result.ToFileMatch(); ok {
@@ -297,7 +297,7 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 			addFileFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
 
 			if len(fm.symbols) > 0 {
-				add("type:symbol", "type:symbol", 1, fm.JLimitHit, "symbol")
+				add("type:symbol", "type:symbol", 1, fm.JLimitHit, "symbol", Default)
 			}
 		} else if r, ok := result.ToRepository(); ok {
 			// It should be fine to leave this blank since revision specifiers
@@ -326,7 +326,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 
 	allFilters := append(filterSlice, repoFilterSlice...)
 	sort.Slice(allFilters, func(i, j int) bool {
-		return allFilters[j].score < allFilters[i].score
+		left := allFilters[i]
+		right := allFilters[j]
+		if left.score == right.score {
+			// Order alphabetically for equal scores.
+			return strings.Compare(left.value, right.value) < 0
+		}
+		return left.score < right.score
 	})
 
 	return allFilters
@@ -347,9 +353,16 @@ type searchFilterResolver struct {
 	// the kind of filter. Should be "repo", "file", or "lang".
 	kind string
 
-	// score is used to select potential filters
-	score int
+	// score is used to prioritize the order that filters appear in
+	score score
 }
+
+type score int
+
+const (
+	Important score = iota
+	Default
+)
 
 func (sf *searchFilterResolver) Value() string {
 	return sf.value

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -252,13 +252,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 		_, limitHit := sr.searchResultsCommon.partial[api.RepoName(uri)]
 		// Increment number of matches per repo. Add will override previous entry for uri
 		repoToMatchCount[uri] += lineMatchCount
-		add(filter, uri, repoToMatchCount[uri], limitHit, "repo", Default)
+		add(filter, uri, repoToMatchCount[uri], limitHit, "repo", scoreDefault)
 	}
 
 	addFileFilter := func(fileMatchPath string, lineMatchCount int, limitHit bool) {
 		for _, ff := range commonFileFilters {
 			if ff.Regexp.MatchString(fileMatchPath) {
-				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file", Default)
+				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file", scoreDefault)
 			}
 		}
 	}
@@ -275,16 +275,16 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 					language = strconv.Quote(language)
 				}
 				value := fmt.Sprintf(`lang:%s`, language)
-				add(value, value, lineMatchCount, limitHit, "lang", Default)
+				add(value, value, lineMatchCount, limitHit, "lang", scoreDefault)
 			}
 		}
 	}
 
 	if sr.searchResultsCommon.excluded.forks > 0 {
-		add("fork:yes", "fork:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo", Important)
+		add("fork:yes", "fork:yes", sr.searchResultsCommon.excluded.forks, sr.limitHit, "repo", scoreImportant)
 	}
 	if sr.searchResultsCommon.excluded.archived > 0 {
-		add("archived:yes", "archived:yes", sr.searchResultsCommon.excluded.archived, sr.limitHit, "repo", Important)
+		add("archived:yes", "archived:yes", sr.searchResultsCommon.excluded.archived, sr.limitHit, "repo", scoreImportant)
 	}
 	for _, result := range sr.SearchResults {
 		if fm, ok := result.ToFileMatch(); ok {
@@ -297,7 +297,7 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 			addFileFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
 
 			if len(fm.symbols) > 0 {
-				add("type:symbol", "type:symbol", 1, fm.JLimitHit, "symbol", Default)
+				add("type:symbol", "type:symbol", 1, fm.JLimitHit, "symbol", scoreDefault)
 			}
 		} else if r, ok := result.ToRepository(); ok {
 			// It should be fine to leave this blank since revision specifiers
@@ -360,8 +360,8 @@ type searchFilterResolver struct {
 type score int
 
 const (
-	Important score = iota
-	Default
+	scoreImportant score = iota
+	scoreDefault
 )
 
 func (sf *searchFilterResolver) Value() string {

--- a/internal/cmd/search-integration-tester/search.go
+++ b/internal/cmd/search-integration-tester/search.go
@@ -79,6 +79,10 @@ const gqlSearch = `query Search($query: String!) {
 					query
 				}
 			}
+			dynamicFilters {
+				value
+				count
+			}
 		}
 	}
 }

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -138,6 +138,10 @@ var tests = []test{
 		Name:  `Global search, fork included if exact without option, nonzero result`,
 		Query: `repo:^github\.com/sgtest/mux$`,
 	},
+	{
+		Name:  `Global search, exclude counts for fork and archive`,
+		Query: `repo:mux|archive|caddy`,
+	},
 }
 
 func sanitizeFilename(s string) string {
@@ -170,7 +174,7 @@ func runSearchTests() error {
 		filename := strings.ToLower(sanitizeFilename(test.Name))
 		goldenPath := path.Join(searchTestDataDir, fmt.Sprintf("%s.golden", filename))
 		if err := assertGolden(test.Name, goldenPath, got, update); err != nil {
-			return err
+			return fmt.Errorf("TEST FAILURE: %s\n%s", test.Name, err.Error())
 		}
 	}
 	return nil

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -174,7 +174,7 @@ func runSearchTests() error {
 		filename := strings.ToLower(sanitizeFilename(test.Name))
 		goldenPath := path.Join(searchTestDataDir, fmt.Sprintf("%s.golden", filename))
 		if err := assertGolden(test.Name, goldenPath, got, update); err != nil {
-			return fmt.Errorf("TEST FAILURE: %s\n%s", test.Name, err.Error())
+			return fmt.Errorf("TEST FAILURE: %s\n%s", test.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Played around with this on Sourcegraph.com after landing #10624 and saw some suspect things (fork/archive counts being the same when they both show up). Copy paste error, see inline comment.

Additionally, this behavior was in the DynamicFilter part of the code, which is more annoying to test for (more mock resolvers and mock DB's leave me alone :'( ) so instead I've added the regression test to the integration-tester I'm using and we can migrate those tests into CI when Joe's work is ready. 

To make this test reliable, I also tracked down the source of nondeterminism for the filter order (it's `sort.Slice` rather than sort.SliceStable) and refactored the code to order the dynamic filter chips according to an overridable score, and if it's a tie, to order them alphabetically.

