### PR TITLE
dev/add_migration.sh: use BSD+GNU-compatible `find` option

### DIFF
--- a/dev/add_migration.sh
+++ b/dev/add_migration.sh
@@ -21,7 +21,7 @@ END {
 EOF
 )
 
-files=$(find -s . -type f -name '[0-9]*.sql' | awk -v name="$1" "$awkcmd")
+files=$(find . -type f -name '[0-9]*.sql' | sort | awk -v name="$1" "$awkcmd")
 
 for f in $files; do
   cat >"$f" <<EOF


### PR DESCRIPTION
The BSD `find` `-s` option is not supported by GNU `find`. In GNU `find`, this script prints an error, and the migration sequence number `1` is erroneously chosen:

```
find: unknown predicate `-s'
```

The BSD `find -s` option does the following:

```
-s	    Cause find to traverse the file hierarchies in lexicographical
	    order, i.e., alphabetical order within each directory. Note:
	    `find -s' and `find | sort' may give different results.
```

For this use case (sorting files in the same directory), `| sort` is equivalent to `find -s`.