### PR TITLE
gitserver: metric for removing repo due to disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The search results page now shows a small UI notification if either repository forks or archives are excluded, when `fork` or `archived` options are not explicitly set. [#10624](https://github.com/sourcegraph/sourcegraph/pull/10624)
+- Prometheus metric `src_gitserver_repos_removed_disk_pressure` which is incremented everytime we remove a repository due to disk pressure. [#10900](https://github.com/sourcegraph/sourcegraph/pull/10900)
 
 ### Changed
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -44,8 +44,8 @@ var (
 		Name: "src_gitserver_repos_recloned",
 		Help: "number of repos removed and recloned due to age",
 	})
-	reposRemovedDiskSpace = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "src_gitserver_repos_removed_disk_space",
+	reposRemovedDiskPressure = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repos_removed_disk_pressure",
 		Help: "number of repos removed due to not enough disk space",
 	})
 )
@@ -325,7 +325,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return errors.Wrap(err, "removing repo directory")
 		}
 		spaceFreed += delta
-		reposRemovedDiskSpace.Inc()
+		reposRemovedDiskPressure.Inc()
 
 		// Report the new disk usage situation after removing this repo.
 		actualFreeBytes, err := s.DiskSizer.BytesFreeOnDisk(s.ReposDir)

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -283,6 +283,10 @@ func (s *StatDiskSizer) DiskSizeBytes(mountPoint string) (uint64, error) {
 // freeUpSpace removes git directories under ReposDir, in order from least
 // recently to most recently used, until it has freed howManyBytesToFree.
 func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
+	if howManyBytesToFree <= 0 {
+		return nil
+	}
+
 	// Get the git directories and their mod times.
 	gitDirs, err := s.findGitDirs()
 	if err != nil {

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -44,6 +44,10 @@ var (
 		Name: "src_gitserver_repos_recloned",
 		Help: "number of repos removed and recloned due to age",
 	})
+	reposRemovedDiskSpace = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repos_removed_disk_space",
+		Help: "number of repos removed due to not enough disk space",
+	})
 )
 
 // cleanupRepos walks the repos directory and performs maintenance tasks:
@@ -321,6 +325,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return errors.Wrap(err, "removing repo directory")
 		}
 		spaceFreed += delta
+		reposRemovedDiskSpace.Inc()
 
 		// Report the new disk usage situation after removing this repo.
 		actualFreeBytes, err := s.DiskSizer.BytesFreeOnDisk(s.ReposDir)

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -22,14 +22,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/inconshreveable/log15"
 )
-
-func init() {
-	prometheus.MustRegister(reposRemoved)
-	prometheus.MustRegister(reposRecloned)
-}
 
 const (
 	// repoTTL is how often we should reclone a repository
@@ -39,15 +35,16 @@ const (
 	repoTTLGC = time.Hour * 24 * 2
 )
 
-var reposRemoved = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "src_gitserver_repos_removed",
-	Help: "number of repos removed during cleanup",
-})
-
-var reposRecloned = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "src_gitserver_repos_recloned",
-	Help: "number of repos removed and recloned due to age",
-})
+var (
+	reposRemoved = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repos_removed",
+		Help: "number of repos removed during cleanup",
+	})
+	reposRecloned = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repos_recloned",
+		Help: "number of repos removed and recloned due to age",
+	})
+)
 
 // cleanupRepos walks the repos directory and performs maintenance tasks:
 //


### PR DESCRIPTION
See individual commits. This adds a prometheus metric so we can track if we remove repositories due to disk pressure.