### PR TITLE
golangci: remove several linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,19 +36,15 @@ linters-settings:
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
+# See explanation of linters at https://golangci-lint.run/usage/linters/
 linters:
   disable-all: true
   enable:
     - bodyclose
     - deadcode
-    - depguard
     - dogsled
     - dupl
     - errcheck
-    - funlen
-    - goconst
-    - gocritic
-    - gofmt
     - goimports
     - golint
     - goprintffuncname
@@ -61,7 +57,6 @@ linters:
     - nakedret
     - nolintlint
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,6 @@
 linters-settings:
   dupl:
     threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
   gocritic:
     enabled-tags:
       - diagnostic
@@ -25,7 +19,7 @@ linters-settings:
   golint:
     min-confidence: 0
   govet:
-    check-shadowing: true
+    check-shadowing: false
   maligned:
     suggest-new: true
   misspell:
@@ -45,6 +39,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - gocritic
     - goimports
     - golint
     - goprintffuncname


### PR DESCRIPTION
Went through the list of linters and removed the following:

- depguard - Go linter that checks if package imports are in a list of
  acceptable packages - We don't have it configured.
- funlen - Tool for detection of long functions - noisy
- goconst - Finds repeated strings that could be replaced by a
  constant - I'd rather write ".git" than kDOTGIT. We aren't C++/objc.
- gocritic - The most opinionated Go source code linter - the
  description made me remove it.
- gofmt - goimports does everything gofmt does.
- scopelint - Scopelint checks for unpinned variables in go programs -
  we already have warnings about shadowing in more robust tools.
