### PR TITLE
codeintel: Observability tweaks

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -177,13 +177,8 @@ func initCodeIntel() {
 
 	db := codeinteldb.NewObserved(codeinteldb.NewWithHandle(dbconn.Global), observationContext)
 	bundleManagerClient := bundles.New(bundleManagerURL)
-
-	client := lsifserverclient.New(
-		db,
-		bundleManagerClient,
-		codeintelapi.New(db, bundleManagerClient, codeintelgitserver.DefaultClient),
-	)
-
+	api := codeintelapi.NewObserved(codeintelapi.New(db, bundleManagerClient, codeintelgitserver.DefaultClient), observationContext)
+	client := lsifserverclient.New(db, bundleManagerClient, api)
 	enqueuer := enqueuer.NewEnqueuer(db, bundleManagerClient)
 
 	graphqlbackend.NewCodeIntelResolver = func() graphqlbackend.CodeIntelResolver {

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -144,7 +144,7 @@ var _ DB = &dbImpl{}
 
 // New creates a new instance of DB connected to the given Postgres DSN.
 func New(postgresDSN string) (DB, error) {
-	db, err := dbutil.NewDB(postgresDSN, "precise-code-intel-api-server")
+	db, err := dbutil.NewDB(postgresDSN, "codeintel")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/db/db_test.go
+++ b/internal/codeintel/db/db_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	dbtesting.DBNameSuffix = "precise-code-intel-api-server"
+	dbtesting.DBNameSuffix = "codeintel"
 }
 
 func rawTestDB() *dbImpl {


### PR DESCRIPTION
- Ensure that the code intel API is observed from the frontend
- Name dbconns correctly from internal/codeintel