### PR TITLE
search: introduce Map helper function

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -825,11 +825,11 @@ func ProcessAndOr(in string) (QueryInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	query = LowercaseFieldNames(query)
+	query = Map(query, LowercaseFieldNames, SubstituteAliases)
 	err = validate(query)
 	if err != nil {
 		return nil, err
 	}
-	query = SubstituteAliases(query)
+
 	return &AndOrQuery{Query: query}, nil
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -109,3 +109,11 @@ func containsUppercase(s string) bool {
 	}
 	return false
 }
+
+// Map pipes query through one or more query transformer functions.
+func Map(query []Node, fns ...func([]Node) []Node) []Node {
+	for _, fn := range fns {
+		query = fn(query)
+	}
+	return query
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -182,3 +182,31 @@ func TestSearchUppercase(t *testing.T) {
 		})
 	}
 }
+
+func TestMap(t *testing.T) {
+	cases := []struct {
+		input string
+		fns   []func(_ []Node) []Node
+		want  string
+	}{
+		{
+			input: "RePo:foo",
+			fns:   []func(_ []Node) []Node{LowercaseFieldNames},
+			want:  `"repo:foo"`,
+		},
+		{
+			input: "RePo:foo r:bar",
+			fns:   []func(_ []Node) []Node{LowercaseFieldNames, SubstituteAliases},
+			want:  `(and "repo:foo" "repo:bar")`,
+		},
+	}
+	for _, c := range cases {
+		t.Run("Map query", func(t *testing.T) {
+			query, _ := ParseAndOr(c.input)
+			got := prettyPrint(Map(query, c.fns...))
+			if diff := cmp.Diff(got, c.want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -209,20 +209,20 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldCase:
 		return satisfies(isSingular, isBoolean, isNotNegated)
 	case
-		FieldRepo, "r":
+		FieldRepo:
 		return satisfies(isValidRegexp)
 	case
-		FieldRepoGroup, "g":
+		FieldRepoGroup:
 		return satisfies(isSingular, isNotNegated)
 	case
-		FieldFile, "f":
+		FieldFile:
 		return satisfies(isValidRegexp)
 	case
 		FieldFork,
 		FieldArchived:
 		return satisfies(isSingular, isNotNegated)
 	case
-		FieldLang, "l", "language":
+		FieldLang:
 		return satisfies(isLanguage)
 	case
 		FieldType:
@@ -238,13 +238,13 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldRepoHasCommitAfter:
 		return satisfies(isSingular, isNotNegated)
 	case
-		FieldBefore, "until",
-		FieldAfter, "since":
+		FieldBefore,
+		FieldAfter:
 		return satisfies(isNotNegated)
 	case
 		FieldAuthor,
 		FieldCommitter,
-		FieldMessage, "m", "msg":
+		FieldMessage:
 		return satisfies(isValidRegexp)
 	case
 		FieldIndex:


### PR DESCRIPTION
Adds `Map` helper function that pipes queries through transformers. The refactor simplifies validation by substituting (IE normalizing) aliases beforehand.
