### PR TITLE
Make the monitoring stack configurable

### DIFF
--- a/cmd/server/shared/monitoring.go
+++ b/cmd/server/shared/monitoring.go
@@ -10,15 +10,15 @@ const prometheusProcLine = `prometheus: prometheus --config.file=/sg_config_prom
 
 const grafanaProcLine = `grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`
 
-const jagerProcLine = `jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph/jaeger.log 2>&1`
+const jaegerProcLine = `jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph/jaeger.log 2>&1`
 
 func maybeMonitoring() ([]string, error) {
-	if os.Getenv("DISABLE_MONITORING") != "" {
+	if os.Getenv("DISABLE_OBSERVABILITY") != "" {
 		log15.Info("WARNING: Running with monitoring disabled ")
 		return []string{""}, nil
 	}
 	return []string{
 		prometheusProcLine,
 		grafanaProcLine,
-		jagerProcLine}, nil
+		jaegerProcLine}, nil
 }

--- a/cmd/server/shared/monitoring.go
+++ b/cmd/server/shared/monitoring.go
@@ -1,0 +1,24 @@
+package shared
+
+import (
+	"os"
+
+	"github.com/inconshreveable/log15"
+)
+
+const prometheusProcLine = `prometheus: prometheus --config.file=/sg_config_prometheus/prometheus.yml --web.enable-admin-api --storage.tsdb.path=/var/opt/sourcegraph/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`
+
+const grafanaProcLine = `grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`
+
+const jagerProcLine = `jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph/jaeger.log 2>&1`
+
+func maybeMonitoring() ([]string, error) {
+	if os.Getenv("DISABLE_MONITORING") != "" {
+		log15.Info("WARNING: Running with monitoring disabled ")
+		return []string{""}, nil
+	}
+	return []string{
+		prometheusProcLine,
+		grafanaProcLine,
+		jagerProcLine}, nil
+}

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -143,12 +143,17 @@ func Main() {
 		`github-proxy: github-proxy`,
 		`repo-updater: repo-updater`,
 		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
-		`prometheus: prometheus --config.file=/sg_config_prometheus/prometheus.yml --web.enable-admin-api --storage.tsdb.path=/var/opt/sourcegraph/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`,
-		`grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`,
-		`jaeger: jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph/jaeger.log 2>&1`,
 		postgresExporterLine,
 	}
 	procfile = append(procfile, ProcfileAdditions...)
+
+	monitoringLines, err := maybeMonitoring()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(monitoringLines) != 0 {
+		procfile = append(procfile, monitoringLines...)
+	}
 
 	redisStoreLine, err := maybeRedisStoreProcFile()
 	if err != nil {

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -58,6 +58,12 @@ Sourcegraph can be **tested** on Windows 10 using roughly the same steps provide
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.16.0</code></pre>
 
+## Low resource environments
+
+To test sourcegraph in a low resource environment you may want to disable some of the observability tools (Prometheus, Grafana and Jaeger).
+
+Add `-e DISABLE_OBSERVABILITY=true` to your docker run command
+
 ## Insiders build
 
 To test new development builds of Sourcegraph (triggered by commits to master), change the tag to `insiders` in the `docker run` command.


### PR DESCRIPTION
This removes the monitoring components from the procfile when the env var "DISABLE_MONITORING" is set
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

Fixes https://github.com/sourcegraph/sourcegraph/issues/6577