### PR TITLE
search: implement new literal search parser

### DIFF
--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -1,0 +1,41 @@
+package query
+
+type none struct{}
+
+var empty = none{}
+
+var allFields = map[string]struct{}{
+	FieldCase:               empty,
+	FieldRepo:               empty,
+	"r":                     empty,
+	FieldRepoGroup:          empty,
+	"g":                     empty,
+	FieldFile:               empty,
+	"f":                     empty,
+	FieldFork:               empty,
+	FieldArchived:           empty,
+	FieldLang:               empty,
+	"l":                     empty,
+	"language":              empty,
+	FieldType:               empty,
+	FieldPatternType:        empty,
+	FieldContent:            empty,
+	FieldRepoHasFile:        empty,
+	FieldRepoHasCommitAfter: empty,
+	FieldBefore:             empty,
+	"until":                 empty,
+	FieldAfter:              empty,
+	"since":                 empty,
+	FieldAuthor:             empty,
+	FieldCommitter:          empty,
+	FieldMessage:            empty,
+	"m":                     empty,
+	"msg":                   empty,
+	FieldIndex:              empty,
+	FieldCount:              empty,
+	FieldStable:             empty,
+	FieldMax:                empty,
+	FieldTimeout:            empty,
+	FieldReplace:            empty,
+	FieldCombyRule:          empty,
+}

--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -1,8 +1,6 @@
 package query
 
-type none struct{}
-
-var empty = none{}
+var empty = struct{}{}
 
 var allFields = map[string]struct{}{
 	FieldCase:               empty,

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -122,8 +122,15 @@ func skipSpace(buf []byte) int {
 }
 
 type heuristic struct {
-	parensAsPatterns    bool // if true, parses parens as patterns rather than expression groups.
-	allowDanglingParens bool // if true, disables parsing parentheses as expression groups.
+	// if true, parses parens as patterns rather than expression groups.
+	parensAsPatterns bool
+	// if true, disables parsing parentheses as expression groups.
+	allowDanglingParens bool
+	// if true, the parser accepts any characters (e.g., unbalanced quotes,
+	// parentheses, backslashes) if they can be associated with a pattern.
+	// Balanced quotes remain expected for non-empty fields like repo:"foo",
+	// if specified.
+	literalSearchPatterns bool
 }
 
 type parser struct {
@@ -221,6 +228,31 @@ func (p *parser) skipSpaces() error {
 	return nil
 }
 
+// ScanLiteral consumes all characters up to a whitespace character and returns
+// the string and how much it consumed.
+func ScanSearchPatternLiteral(buf []byte) (string, int) {
+	var count, advance int
+	var r rune
+	var result []rune
+
+	next := func() rune {
+		r, advance = utf8.DecodeRune(buf)
+		count += advance
+		buf = buf[advance:]
+		return r
+	}
+	for len(buf) > 0 {
+		start := count
+		r = next()
+		if unicode.IsSpace(r) {
+			count = start // Backtrack.
+			break
+		}
+		result = append(result, r)
+	}
+	return string(result), count
+}
+
 // ScanDelimited takes a delimited (e.g., quoted) value for some arbitrary
 // delimiter, returning the undelimited value, and the end position of the
 // original delimited value (i.e., including quotes). `\` is treated as an
@@ -254,7 +286,15 @@ loop:
 			if len(buf[advance:]) > 0 {
 				r = next()
 				switch r {
-				case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', delimiter:
+				case 'a', 'b', 'f', 'v':
+					result = append(result, '\\', r)
+				case 'n':
+					result = append(result, '\n')
+				case 'r':
+					result = append(result, '\r')
+				case 't':
+					result = append(result, '\t')
+				case '\\', delimiter:
 					result = append(result, r)
 				default:
 					return "", count, errors.New("unrecognized escape sequence")
@@ -270,7 +310,7 @@ loop:
 		}
 	}
 
-	if r != delimiter {
+	if r != delimiter || (r == delimiter && count == 1) {
 		return "", count, errors.New("unterminated literal: expected " + string(delimiter))
 	}
 	return string(result), count, nil
@@ -404,7 +444,8 @@ loop:
 // parentheses at the current position. There are cases where we want to
 // interpret parentheses as part of a search pattern, rather than an and/or
 // expression group. For example, In the regex foo(a|b)bar, we want to preserve
-// parentheses as part of the pattern.
+// parentheses as part of the pattern. It only succeeds if the value parsed can
+// be interpreted as a pattern, and not, e.g., as a filter:value parameter.
 func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	if !p.heuristic.parensAsPatterns || p.heuristic.allowDanglingParens {
 		return Parameter{Field: "", Value: ""}, false
@@ -553,11 +594,34 @@ func (p *parser) ParseValue() (string, bool) {
 func (p *parser) ParseParameter() Parameter {
 	field, advance := ScanField(p.buf[p.pos:])
 	p.pos += advance
-	value, quoted := p.ParseValue()
+
 	negated := len(field) > 0 && field[0] == '-'
 	if negated {
 		field = field[1:]
 	}
+
+	if p.heuristic.literalSearchPatterns {
+		if field == "" {
+			// No foo: prefix was parsed, accept as spattern.
+			value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
+			p.pos += advance
+			return Parameter{Field: "", Value: value, Negated: false, Quoted: false}
+		}
+		if _, exists := allFields[field]; !exists {
+			// A foo: prefix was parsed, but it's not a recognized
+			// field. Accept as pattern.
+			value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
+			// Rebuild the (-?)foo:bar string.
+			value = field + ":" + value
+			if negated {
+				value = "-" + value
+			}
+			p.pos += advance
+			return Parameter{Field: "", Value: value, Negated: false, Quoted: false}
+		}
+	}
+
+	value, quoted := p.ParseValue()
 	return Parameter{Field: field, Value: value, Negated: negated, Quoted: quoted}
 }
 
@@ -815,6 +879,29 @@ func ParseAndOr(in string) ([]Node, error) {
 		if hoistedNodes, err := Hoist(nodes); err == nil {
 			nodes = hoistedNodes
 		}
+	}
+	return newOperator(nodes, And), nil
+}
+
+func ParseLiteralSearch(in string) ([]Node, error) {
+	if strings.TrimSpace(in) == "" {
+		return nil, nil
+	}
+	parser := &parser{
+		buf: []byte(in),
+		heuristic: heuristic{
+			allowDanglingParens:   true,
+			literalSearchPatterns: true,
+		},
+	}
+	nodes, err := parser.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	nodes = Map(nodes, LowercaseFieldNames, SubstituteAliases)
+	err = validate(nodes)
+	if err != nil {
+		return nil, err
 	}
 	return newOperator(nodes, And), nil
 }

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -122,11 +122,11 @@ func skipSpace(buf []byte) int {
 }
 
 type heuristic struct {
-	// if true, parses parens as patterns rather than expression groups.
+	// If true, parses parens as patterns rather than expression groups.
 	parensAsPatterns bool
-	// if true, disables parsing parentheses as expression groups.
+	// If true, disables parsing parentheses as expression groups.
 	allowDanglingParens bool
-	// if true, the parser accepts any characters (e.g., unbalanced quotes,
+	// If true, the parser accepts any characters (e.g., unbalanced quotes,
 	// parentheses, backslashes) if they can be associated with a pattern.
 	// Balanced quotes remain expected for non-empty fields like repo:"foo",
 	// if specified.
@@ -602,7 +602,7 @@ func (p *parser) ParseParameter() Parameter {
 
 	if p.heuristic.literalSearchPatterns {
 		if field == "" {
-			// No foo: prefix was parsed, accept as spattern.
+			// No foo: prefix was parsed, accept as pattern.
 			value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
 			p.pos += advance
 			return Parameter{Field: "", Value: value, Negated: false, Quoted: false}


### PR DESCRIPTION
Stacked on #10914 

This PR implements the logic for achieving a literal scanner/parser using the new implementation. My approach takes the [existing tests](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@893f5044d9e545d27a686e81ef1c39d6198bb224/-/blob/internal/search/query/pattern_type_test.go#L13-50) to check whether the literal conversion works and are basically migrated one-to-one (though not all of them seem obviously needed, but this is not a big deal), and a few more I care about. 

This literal parser also fixes three bugs documented in #8780, including: #8363,  #10171. The parser is not "switched on" yet, that will happen later after I do more integration tests. It's also groundwork for prospectively supporting and/or queries in literal search.

There are some other things here that needs doing, but it's in a good state to checkpoint. 