### PR TITLE
update docs for new campaign flow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,7 +18,7 @@ web/src/schema/
 ts-node-*
 testdata
 .github/*
-doc/
+/doc/**/*.md
 **/.cache
 shared/dev/**/*.js
 **/__snapshots__

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -32,66 +32,6 @@ scalar JSONCString
 
 # A mutation.
 type Mutation {
-    # Create a list of changesets in a specific repository on a code host (e.g.,
-    # pull requests on GitHub). If a changeset with the given input already
-    # exists, it is returned instead of a new entry being added to the database.
-    createChangesets(input: [CreateChangesetInput!]!): [ExternalChangeset!]!
-    # Add a list of changesets to a campaign. The campaign must not have a patchset.
-    addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
-    # Create a campaign in a namespace. The newly created campaign is returned.
-    createCampaign(input: CreateCampaignInput!): Campaign!
-    # Create a patchset from patches (in unified diff format) that are computed by the caller.
-    #
-    # To create the campaign, call createCampaign with the returned PatchSet.id in the
-    # CreateCampaignInput.patchSet field.
-    createPatchSetFromPatches(
-        # A list of patches (diffs) to apply to repositories (in new branches) when a campaign is
-        # created from this PatchSet.
-        patches: [PatchInput!]!
-    ): PatchSet!
-    # Updates a campaign. Updating is not allowed when any of the following are true:
-    #
-    # - The campaign has been closed.
-    # - A campaign has one or more patches that are being published.
-    # - The new patch set contains no patches.
-    updateCampaign(input: UpdateCampaignInput!): Campaign!
-    # Retry publishing all changesets in the campaign that could not be
-    # successfully created on the code host. Retrying will clear the errors
-    # list of a campaign.
-    retryCampaignChangesets(campaign: ID!): Campaign!
-    # Delete a campaign.
-    deleteCampaign(
-        campaign: ID!
-        # Whether to close the changesets associated with this campaign on their respective code
-        # hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
-        # GitHub and "declined" on Bitbucket Server).
-        closeChangesets: Boolean = false
-    ): EmptyResponse
-    # Close a campaign.
-    closeCampaign(
-        campaign: ID!
-        # Whether to close the changesets associated with this campaign on their respective code
-        # hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
-        # GitHub and "declined" on Bitbucket Server).
-        closeChangesets: Boolean = false
-    ): Campaign!
-    # Create an ExternalChangeset on the code host asynchronously for each
-    # patch belonging to the patchset that has been attached to a campaign;
-    # otherwise, an error is returned and no ExternalChangesets are created.
-    # Callers can query the campaign's status to track the progress of this async operation.
-    # If one of the patches has previously been published but the publication failed,
-    # publication is NOT retried.
-    publishCampaignChangesets(campaign: ID!): Campaign!
-    # Create an ExternalChangeset on the code host asynchronously. The patch
-    # must belong to a patchset that has been attached to a campaign;
-    # otherwise, an error is returned and no ExternalChangeset is created.
-    # Callers can query the campaign's status to track the progress of this async operation.
-    # If the patch has previously been published but the publication failed,
-    # the patch is reset and publication will be retried.
-    publishChangeset(patch: ID!): EmptyResponse!
-    # Enqueue the given changeset for high-priority syncing.
-    syncChangeset(changeset: ID!): EmptyResponse!
-
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.
@@ -427,6 +367,222 @@ type Mutation {
     # repository permissions and syncs them to Sourcegraph, so that the current permissions apply to
     # the user's operations on Sourcegraph.
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
+
+    #
+    # CAMPAIGNS
+    #
+
+    # Create a campaign from a campaign spec and locally computed changeset specs. If a campaign in
+    # the same namespace with the same name already exists, an error is returned. The newly created
+    # campaign is returned.
+    createCampaign(
+        # The campaign spec that describes the desired state of the campaign.
+        campaignSpec: ID!
+    ): Campaign!
+
+    # Create or update a campaign from a campaign spec and locally computed changeset specs. If no
+    # campaign exists in the namespace with the name given in the campaign spec, a campaign will be
+    # created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    applyCampaign(
+        # The campaign spec that describes the new desired state of the campaign.
+        campaignSpec: ID!
+
+        # If set, return an error if the campaign identified using the namespace and campaignSpec
+        # parameters does not match the campaign with this ID. This lets callers use a stable ID
+        # that refers to a specific campaign during an edit session (and is not susceptible to
+        # conflicts if the underlying campaign is moved to a different namespace, renamed, or
+        # deleted).
+        ensureCampaign: ID
+    ): Campaign!
+
+    # Move a campaign to a different namespace, or rename it in the current namespace.
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+
+    # Close a campaign.
+    closeCampaign(
+        campaign: ID!
+        # Whether to close the changesets associated with this campaign on their respective code
+        # hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
+        # GitHub and "declined" on Bitbucket Server).
+        closeChangesets: Boolean = false
+    ): Campaign!
+
+    # Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
+    # campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
+    deleteCampaign(campaign: ID!): EmptyResponse
+
+    # Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
+    # is stored and can be referenced by its ID in the createCampaignSpec mutation. Just uploading
+    # the changeset spec does not result in changes to the campaign or any of its changesets; you
+    # need to call applyCampaign to use it.
+    #
+    # You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
+    # individual HTTP requests. Then, in the eventual createCampaignSpec call, you just refer to the
+    # changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
+    # a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
+    # rejected by the web server/proxy or would be very slow.
+    #
+    # The returned ChangesetSpec is immutable and expires after a certain period of time (if not
+    # used), which can be queried on ChangesetSpec.expiresAt.
+    createChangesetSpec(
+        # The raw changeset spec (as JSON).
+        changesetSpec: String!
+    ): ChangesetSpec!
+
+    # Create a campaign spec that will be used to create a campaign (with the createCampaign
+    # mutation), to update to a campaign (with the applyCampaign mutation), or to preview either
+    # operation (with the campaignDelta query).
+    #
+    # The returned CampaignSpec is immutable and expires after a certain period of time (if not used
+    # in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+    createCampaignSpec(
+        # The namespace (either a user or organization). A campaign spec can only be applied to (or
+        # used to create) campaigns in this namespace.
+        namespace: ID!
+
+        # The campaign spec as YAML (or the equivalent JSON).
+        campaignSpec: String!
+
+        # Changeset specs that were locally computed and then uploaded using createChangesetSpec.
+        changesetSpecs: [ID!]!
+    ): CampaignSpec!
+
+    # Enqueue the given changeset for high-priority syncing.
+    syncChangeset(changeset: ID!): EmptyResponse!
+}
+
+# A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+# create a changeset spec, use the createChangesetSpec mutation.
+type ChangesetSpec implements Node {
+    # The unique ID for a changeset spec.
+    #
+    # The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    # even though repository permissions also apply to viewers of changeset specs, because being
+    # allowed to view a repository should not entitle a person to view all not-yet-published
+    # changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    # campaign author may prefer to prepare all of the changesets in private so that the window
+    # between revealing the problem and merging the fixes is as short as possible.
+    id: ID!
+
+    # The description of the changeset.
+    description: ChangesetDescription!
+
+    # The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    # spec never expires (and this field is null) if its campaign spec has been applied.
+    expiresAt: DateTime
+}
+
+# All possible types of changesets that can be specified in a changeset spec.
+union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDescription
+
+# A reference to a changeset that already exists on a code host (and was not created by the
+# campaign).
+type ExistingChangesetReference {
+    # The repository that contains the existing changeset on the code host.
+    baseRepository: ID!
+
+    # The ID that uniquely identifies the existing changeset on the code host.
+    #
+    # For GitHub and Bitbucket Server, this is the pull request number (as a string) in the
+    # base repository. For example, "1234" for PR #1234.
+    externalID: String!
+}
+
+# A description of a changeset that represents the proposal to merge one branch into another.
+#
+# This is used to describe a pull request (on GitHub and Bitbucket Server).
+type GitBranchChangesetDescription {
+    # The repository that this changeset spec is proposing to change.
+    baseRepository: ID!
+
+    # The full name of the Git ref in the base repository that this changeset is based on (and is
+    # proposing to be merged into). This ref must exist on the base repository. For example,
+    # "refs/heads/master" or "refs/heads/main".
+    baseRef: String!
+
+    # The repository that contains the branch with this changeset's changes.
+    #
+    # Fork repositories and cross-repository changesets are not yet supported. Therefore,
+    # headRepository must be equal to baseRepository.
+    headRepository: ID!
+
+    # The full name of the Git ref that holds the changes proposed by this changeset. This ref will
+    # be created or updated with the commits. For example, "refs/heads/fix-foo" (for
+    # the Git branch "fix-foo").
+    headRef: String!
+
+    # The Git commits with the proposed changes. These commits are pushed to the head ref.
+    #
+    # Only 1 commit is supported.
+    commits: [GitCommitDescription!]!
+}
+
+# A description of a Git commit.
+#
+# TODO: Support specifying committer/author.
+type GitCommitDescription {
+    # The Git commit message.
+    message: String!
+
+    # The commit diff (in unified diff format).
+    #
+    # The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
+    # to omit the prefix.
+    diff: String!
+}
+
+# A campaign spec is an immutable description of the desired state of a campaign. To create a
+# campaign spec, use the createCampaignSpec mutation.
+type CampaignSpec implements Node {
+    # The unique ID for a campaign spec.
+    #
+    # TODO(sqs): document permissions and ID guessability
+    id: ID!
+
+    # The original YAML or JSON input that was used to create this campaign spec.
+    originalInput: String!
+
+    # The parsed JSON value of the original input. If the original input was YAML, the YAML is
+    # converted to the equivalent JSON.
+    parsedInput: JSONValue!
+
+    # The specs for changesets associated with this campaign.
+    changesetSpecs: [ChangesetSpec!]!
+
+    # The user who created this campaign spec (or null if the user no longer exists).
+    creator: User
+
+    # The date when this campaign spec was created.
+    createdAt: DateTime
+
+    # The namespace (either a user or organization) of the campaign spec.
+    namespace: Namespace
+
+    # The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
+    # never expires if it has been applied.
+    expiresAt: DateTime
+
+    # The URL of a web page that displays a preview of applying this campaign spec. If the campaign
+    # spec's name refers to an existing campaign in the namespace, the preview shows what will be
+    # updated. Otherwise it shows what will be created.
+    previewURL: String!
+}
+
+# The delta (difference) between a campaign's desired state (spec) and its actual state (status) at
+# a given point in time. Because the campaign delta is computed based on external state, it may
+# become out-of-date immediately after creation (e.g., if the external state changes), so it must be
+# treated as a snapshot only and not as a definitive plan.
+type CampaignDelta {
+    # TODO(sqs): add more fields here to describe the delta
+
+    # The point in time when the delta was created and the actual state was captured. Since this
+    # time, the actual state may have changed; those changes are not captured in this delta.
+    createdAt: DateTime!
+
+    # The date when this campaign delta expires and is automatically purged. Campaign deltas are
+    # temporary to avoid consuming resources when they are no longer relevant. Purging a campaign
+    # delta does not modify the campaign or any changesets.
+    expiresAt: DateTime!
 }
 
 # A user (identified either by username or email address) with its repository permission.
@@ -739,9 +895,6 @@ type Patch implements PatchInterface & Node {
     # - A campaign has been created with the patchset to which this patch belongs.
     # - The patch has been individually published through the publishChangeset mutation.
     publicationEnqueued: Boolean!
-
-    # True, when the code host of the associated repository is supported by campaigns.
-    publishable: Boolean!
 }
 
 # A hidden patch is a patch in a repository that the user does NOT have
@@ -903,6 +1056,52 @@ type ChangesetConnection {
 
     # Pagination information.
     pageInfo: PageInfo!
+
+    # Information about filters that can be applied to the list.
+    filters: ChangesetConnectionFilters!
+}
+
+# Filters that can be applied to a list of changesets.
+type ChangesetConnectionFilters {
+    # Repository filters.
+    repository: [RepositoryFilter!]!
+
+    # Label filters.
+    label: [LabelFilter!]!
+
+    # The number of changesets in the connection (ignoring pagination) that are open.
+    openCount: Int!
+
+    # The number of changesets in the connection (ignoring pagination) that are closed or merged.
+    closedCount: Int!
+}
+
+# A repository filter that can be applied to a list.
+type RepositoryFilter {
+    # The repository.
+    repository: Repository!
+
+    # The item count for this filter.
+    count: Int
+
+    # Whether this filter is currently applied to the list.
+    isApplied: Boolean!
+}
+
+# A label filter that can be applied to a list.
+type LabelFilter {
+    # The label. If the list contains items labeled with labels of the same name from different
+    # repositories, this field is null.
+    label: ChangesetLabel
+
+    # The label name.
+    labelName: String!
+
+    # The item count for this filter.
+    count: Int
+
+    # Whether this filter is currently applied to the list.
+    isApplied: Boolean!
 }
 
 # A list of patches.
@@ -1113,17 +1312,6 @@ type Query {
     root: Query! @deprecated(reason: "this will be removed.")
     # Looks up a node by ID.
     node(id: ID!): Node
-
-    # A list of campaigns.
-    campaigns(
-        # Returns the first n campaigns from the list.
-        first: Int
-        state: CampaignState
-        # Only return campaigns that have a patchset.
-        hasPatchSet: Boolean
-        # Only include campaigns that the viewer can administer.
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
 
     # Looks up a repository by either name or cloneURL.
     repository(
@@ -1369,6 +1557,46 @@ type Query {
         # 'LSIFIndexConnection.pageInfo.endCursor' that is returned.
         after: String
     ): LSIFIndexConnection!
+
+    #
+    # CAMPAIGNS
+    #
+
+    # A list of campaigns.
+    campaigns(
+        # Returns the first n campaigns from the list.
+        first: Int
+        state: CampaignState
+        # Only return campaigns that have a patchset.
+        hasPatchSet: Boolean
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    # Preview the effect of applying a campaign spec. If an existing campaign exists in the
+    # namespace with the same name as that in the campaign spec, it returns the delta (difference)
+    # between the campaign's desired state (spec) and its actual state (status), as a list of
+    # changes to be applied to external state (such as repositories and changesets on code hosts).
+    # Otherwise, it returns the operations that need to be performed to create the campaign.
+    #
+    # The result is a snapshot and may immediately become stale because it is dependent on external
+    # state that can change at any time (e.g., a repository on a code host is updated).
+    #
+    # The result is computed using the viewer's credentials. Two viewers with different access
+    # levels to the associated repositories may see different results from this query.
+    campaignDelta(
+        # The namespace in which to compute the delta.
+        namespace: ID!
+
+        # The desired state of the campaign.
+        campaignSpec: ID!
+
+        # If set, return an error if the campaign identified using the namespace and campaignSpec
+        # parameters does not match the campaign with this ID. This lets callers use a stable ID
+        # that refers to a specific campaign during an edit session (and is not susceptible to
+        # conflicts if the underlying campaign is moved to a different namespace, renamed, or deleted).
+        ensureCampaign: ID
+    ): CampaignDelta!
 }
 
 # The version of the search syntax.
@@ -1868,8 +2096,6 @@ type Repository implements Node & GenericSearchResultInterface {
         base: String
         # The head of the diff ("new" or "right-hand side"), or "HEAD" if not specified.
         head: String
-        # Attempt to fetch missing revisions from remote if they are not found
-        fetchMissing: Boolean = true
     ): RepositoryComparison!
     # The repository's contributors.
     contributors(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -500,6 +500,11 @@ type GitBranchChangesetDescription {
     # "refs/heads/master" or "refs/heads/main".
     baseRef: String!
 
+    # The base revision this changeset is based on. It is the latest commit in
+    # baseRef at the time when the changeset spec was created.
+    # For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
+    baseRev: String!
+
     # The repository that contains the branch with this changeset's changes.
     #
     # Fork repositories and cross-repository changesets are not yet supported. Therefore,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -511,10 +511,30 @@ type GitBranchChangesetDescription {
     # the Git branch "fix-foo").
     headRef: String!
 
+    # The title of the changeset on the code host.
+    #
+    # On Bitbucket Server or GitHub this is the title of the pull request.
+    title: String!
+
+    # The body of the changeset on the code host.
+    #
+    # On Bitbucket Server or GitHub this is the body/description of the pull request.
+    body: String!
+
     # The Git commits with the proposed changes. These commits are pushed to the head ref.
     #
     # Only 1 commit is supported.
     commits: [GitCommitDescription!]!
+
+    # Whether or not the changeset described here should be created right after
+    # applying the ChangesetSpec this description belongs to.
+    #
+    # If this is false, the changeset will only be created on Sourcegraph and
+    # can be previewed.
+    #
+    # Another ChangesetSpec with the same description, but "published: true",
+    # can later be applied publish the changeset.
+    published: Boolean!
 }
 
 # A description of a Git commit.

--- a/doc/dev/campaigns_design.md
+++ b/doc/dev/campaigns_design.md
@@ -1,0 +1,126 @@
+# Campaigns design doc
+
+Why are [campaigns](../user/campaigns/index.md) designed the way they are?
+
+## Principles
+
+- **Declarative API** (not imperative). You declare your intent, such as "lint files in all repositories with a `package.json` file"<!-- TODO(sqs): thorsten had a suggestion to make this quote use non-imperative language but I can't find the comment -->. The campaign figures out how to achieve your desired state. The external state (of repositories, changesets, code hosts, access tokens, etc.) can change at any time, and temporary errors frequently occur when reading and writing to code hosts. These factors would make an imperative API very cumbersome because each API client would need to handle the complexity of the distributed system.
+- **Define a campaign in a file** (not some online API). The source of truth of a campaign's definition is a file that can be stored in version control, reviewed in code review, and re-applied by CI. This is in the same spirit as IaaC (infrastructure as code; e.g., storing your Terraform/Kubernetes/etc. files in Git). We prefer this approach over a (worse) alternative where you define a campaign in a UI with a bunch of text fields, checkboxes, buttons, etc., and need to write a custom API client to import/export the campaign definition.
+- **Shareable and portable.** You can share your campaign specs, and it's easy for other people to use them. A campaign spec expresses an intent that's high-level enough to (usually) not be specific to your own particular repositories. You declare and inject configuration and secrets to customize it instead of hard-coding those values.
+- **Large-scale.** You can run campaigns across 10,000s of repositories. It might take a while to compute and push everything, and the current implementation might cap out lower than that, but the fundamental design scales well.
+- **Accommodates a variety of code hosts and review/merge processes.** Specifically, we don't to limit campaigns to only working for GitHub pull requests. (See [current support list](../user/campaigns/index.md#supported-code-hosts-and-changeset-types).)
+
+## Comparison to other distributed systems
+
+Kubernetes is a distributed system with an API that many people are familiar with. Campaigns is also a distributed system. All APIs for distributed systems need to handle a similar set of concerns around robustness, consistency, etc. Here's a comparison showing how these concerns are handled for a Kubernetes [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) and a Sourcegraph campaign. In some cases, we've found Kubernetes to be a good source of inspiration for the campaigns API, but resembling Kubernetes is **not** an explicit goal.
+
+<table>
+  <tr>
+    <td/>
+    <th>Kubernetes <a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/">Deployment</a></th>
+    <th>Sourcegraph campaign</th>
+  </tr>
+  <tr>
+    <th>What underlying thing does this API manage?</th>
+    <td>Pods running on many (possibly unreliable) nodes</td>
+    <td>Branches and changesets on many repositories that can be rate-limited and externally modified (and our authorization can change)</td>
+  </tr>
+  <tr>
+    <th>Spec YAML</th>
+    <td>
+      <pre><code><em># File: foo.Deployment.yaml</em>
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:<div style="padding:0.5rem;margin:0 -0.5rem;background-color:rgba(0,0,255,0.25)"><strong>  # Evaluate this to enumerate instances of...</strong>
+  replicas: 2</div>
+<div style="padding:0.5rem;margin:0 -0.5rem;background-color:rgba(255,0,255,0.25)"><strong>  # ...this template.</strong>
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80</div></pre></code>
+    </td>
+    <td>
+      <pre><code><em># File: hello-world.campaign.yaml</em>
+name: hello-world
+description: Add Hello World to READMEs
+
+<div style="padding:0.5rem;margin:0 -0.5rem;background-color:rgba(0,0,255,0.25)"><strong># Evaluate this to enumerate instances of...</strong>
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+steps:
+  - run: echo Hello | tee -a $(find -name '*.md')
+    container: alpine:3
+</div>
+<div style="padding:0.5rem;margin:0 -0.5rem;background-color:rgba(255,0,255,0.25)"><strong># ...this template.</strong>
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world
+  commit:
+    message: Append Hello to .md files
+  published: false</pre></code>
+    </td>
+  </tr>
+  <tr>
+    <th>How desired state is computed</th>
+    <td>
+      <ol>
+        <li>Evaluate <code>replicas</code>, etc. (blue) to determine pod count and other template inputs</li>
+        <li>Instantiate <code>template</code> (pink) once for each pod to produce PodSpecs</li>
+      </ol>
+    </td>
+    <td>
+      <ol>
+        <li>Evaluate <code>on</code>, <code>steps</code> (blue) to determine list of patches</li>
+        <li>Instantiate <code>changesetTemplate</code> (purple) once for each patch to produce ChangesetSpecs
+</li>
+      </ol>
+    </td>
+  </tr>
+  <tr>
+    <th>Desired state consists of...</th>
+    <td>
+      <ul>
+        <li>DeploymentSpec file (the YAML above)</li>
+        <li>List of PodSpecs (template instantiations)</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>CampaignSpec file (the YAML above)</li>
+        <li>List of ChangesetSpecs (template instantiations)</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <th>Where is the desired state computed?</th>
+    <td>The deployment controller (part of the Kubernetes cluster) consults the DeploymentSpec and continuously computes the desired state.</td>
+    <td>
+      <p>The <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> (running on your local machine, not on the Sourcegraph server) consults the campaign spec and computes the desired state when you invoke <code>src campaign apply</code>.</p>
+      <p><strong>Difference vs. Kubernetes:</strong> A campaign's desired state is computed locally, not on the server. It requires executing arbitrary commands, which is not yet supported by the Sourcegraph server. See campaigns known issue "<a href="../user/campaigns/index.md#server-execution">Campaign steps are run locally...</a>".</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Reconciling desired state vs. actual state</th>
+    <td>The "deployment controller" reconciles the resulting PodSpecs against the current actual PodSpecs (and does smart things like rolling deploy).</td>
+    <td>The "campaign controller" (i.e., our backend) reconciles the resulting ChangesetSpecs against the current actual changesets (and does smart things like gradual roll-out/publishing and auto-merging when checks pass).</td>
+  </tr>
+</table>
+
+These docs explain more about Kubernetes' design:
+
+- [Kubernetes Object Management](https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/)
+- [Kubernetes Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
+  - [Desired versus current state](https://kubernetes.io/docs/concepts/architecture/controller/#desired-vs-current)
+- [Kubernetes Architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/architecture.md)
+- [Kubernetes General Configuration Tips](https://kubernetes.io/docs/concepts/configuration/overview/#general-configuration-tips)
+- [Kubernetes Design and Development Explained](https://thenewstack.io/kubernetes-design-and-development-explained/)

--- a/doc/dev/campaigns_development.md
+++ b/doc/dev/campaigns_development.md
@@ -7,6 +7,10 @@ Before diving into the technical part of campaigns, make sure to read up on what
 1. Start by looking at the product page for [code change management](https://about.sourcegraph.com/product/code-change-management)
 1. Read through the first page of the [campaigns documentation](https://docs.sourcegraph.com/user/campaigns/) **IMPORTANT:** Watch the video!
 
+## [Campaigns design doc](campaigns_design.md)
+
+See "[Campaigns design doc](campaigns_design.md)".
+
 ## Starting up your environment
 
 1. Run `./enterprise/dev/start.sh` — Wait until all repositories are cloned.
@@ -15,11 +19,11 @@ Before diving into the technical part of campaigns, make sure to read up on what
 
 ## Glossary
 
-The code campaigns feature introduces a lot of new names, GraphQL queries and mutations and database tables. This section tries to explain the most common names and provide a mapping between the GraphQL types and their internal counterpart in the Go backend.
+The campaigns feature introduces a lot of new names, GraphQL queries and mutations and database tables. This section tries to explain the most common names and provide a mapping between the GraphQL types and their internal counterpart in the Go backend.
 
 | GraphQL type        | Go type              | Database table     | Description |
 | ------------------- | -------------------- | -------------------| ----------- |
-| `Campaign`          | `campaigns.Campaign`       | `campaigns`        | A campaign is a collection of changesets on code hosts. The central entity. |
+| `Campaign`          | `campaigns.Campaign`       | `campaigns`        | A campaign is a collection of changesets. The central entity. |
 | `ExternalChangeset` | `campaigns.Changeset`      | `changesets`       | Changeset is the unified name for pull requests/merge requests/etc. on code hosts.        |
 | `PatchSet`          | `campaigns.PatchSet`       | `patch_sets`       | A patch set is a collection of patches that will be applied by creating and publishing a campaign. A campaign *has one* patch set. |
 | `Patch`             | `campaigns.Patch`          | `patches`          | A patch for a repository that *can* be turned into a changeset on a code host. It belongs to a patch set, which has multiple patches, one per repository. |

--- a/doc/user/campaigns/CampaignSpec.schema.json
+++ b/doc/user/campaigns/CampaignSpec.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CampaignSpec",
+  "description": "A campaign specification, which describes the campaign and what kinds of changes to make (or what existing changesets to track).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.",
+      "pattern": "^[\\w.-]+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the campaign."
+    },
+    "on": {
+      "type": "array",
+      "description": "The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.",
+      "items": {
+        "title": "OnQueryOrRepository",
+        "oneOf": [
+          {
+            "title": "OnQuery",
+            "type": "object",
+            "description": "A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.",
+            "additionalProperties": false,
+            "required": ["repositoriesMatchingQuery"],
+            "properties": {
+              "repositoriesMatchingQuery": {
+                "type": "string",
+                "description": "A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.",
+                "examples": ["file:README.md"]
+              }
+            }
+          },
+          {
+            "title": "OnRepository",
+            "type": "object",
+            "description": "A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.",
+            "additionalProperties": false,
+            "required": ["repository"],
+            "properties": {
+              "repository": {
+                "type": "string",
+                "description": "The name of the repository (as it is known to Sourcegraph).",
+                "examples": ["github.com/foo/bar"]
+              },
+              "branch": {
+                "type": "string",
+                "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              }
+            }
+          }
+        ]
+      }
+    },
+    "steps": {
+      "type": "array",
+      "description": "The sequence of commands to run (for each repository branch matched in the `on` property) to produce the campaign's changes.",
+      "items": {
+        "title": "Step",
+        "type": "object",
+        "description": "A command to run (as part of a sequence) in a repository branch to produce the campaign's changes.",
+        "additionalProperties": false,
+        "required": ["run", "container"],
+        "properties": {
+          "run": {
+            "type": "string",
+            "description": "The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout."
+          },
+          "container": {
+            "type": "string",
+            "description": "The Docker image used to launch the Docker container in which the shell command is run.",
+            "examples": ["alpine:3"]
+          },
+          "env": {
+            "type": "object",
+            "description": "Environment variables to set in the environment when running this command."
+          }
+        }
+      }
+    },
+    "changesetTemplate": {
+      "type": "object",
+      "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
+      "additionalProperties": false,
+      "required": ["title", "branch", "commit", "published"],
+      "properties": {
+        "title": { "type": "string", "description": "The title of the changeset." },
+        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "branch": {
+          "type": "string",
+          "description": "The name of the Git branch to create or update on each repository with the changes."
+        },
+        "commit": {
+          "title": "GitCommitDescription",
+          "type": "object",
+          "description": "The Git commit to create with the changes.",
+          "additionalProperties": false,
+          "required": ["message"],
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "The Git commit message."
+            }
+          }
+        },
+        "published": {
+          "type": "boolean",
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
+          "$comment": "TODO(sqs): Come up with a way to specify that only a subset of changesets should be published. For example, making `published` an array with some include/exclude syntax items."
+        }
+      }
+    }
+  }
+}

--- a/doc/user/campaigns/CampaignTemplate.schema.json
+++ b/doc/user/campaigns/CampaignTemplate.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CampaignTemplate",
+  "description": "CampaignTemplate describes how to produce a CampaignSpec.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "fooscripts": {
+      "description": "A list of scripts that are executed to produce changesets.",
+      "type": "array",
+      "items": {"$ref": "#/definitions/Script"}
+    }
+  },
+    "definitions": {
+      "Script": {
+        "description": "A script that is executed to produce changesets.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": {"type":"string", "enum": ["docker", "command"]},
+
+        }
+      }
+    }
+}

--- a/doc/user/campaigns/campaigns-icon.svg
+++ b/doc/user/campaigns/campaigns-icon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"  width="24" height="24" viewBox="0 0 24 24">
+   <path fill="#000000" d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z" />
+</svg>

--- a/doc/user/campaigns/examples/index.md
+++ b/doc/user/campaigns/examples/index.md
@@ -4,4 +4,4 @@ The following examples demonstrate various types of campaigns for different lang
 
 * [Using ESLint to automatically migrate to a new TypeScript version](./eslint_typescript_version.md)
 * [Adding a GitHub action to upload LSIF data to Sourcegraph](./lsif_action.md)
-* [Refactor Go code using Comby](./refactor_go_comby.md)
+* [Refactoring Go code using Comby](./refactor_go_comby.md)

--- a/doc/user/campaigns/examples/refactor_go_comby.md
+++ b/doc/user/campaigns/examples/refactor_go_comby.md
@@ -1,4 +1,4 @@
-# Example: Refactor Go code using Comby
+# Example: Refactoring Go code using Comby
 
 Our goal for this campaign is to simplify Go code by using [Comby](https://comby.dev/) to rewrite statements of this form
 

--- a/doc/user/campaigns/hello_world_campaign.md
+++ b/doc/user/campaigns/hello_world_campaign.md
@@ -1,0 +1,93 @@
+# Hello World Campaign
+
+> TODO(sqs): This will eventually go in a new "Sourcegraph Guides" docs section, but it lives here for now.
+
+Have you ever needed to make the same kind of change to many repositories at once? Campaigns make this much easier. To get you started, let's run a very simple campaign: adding the line `Hello World` to all of your repositories' `README.md` files. After completing this exercise, you'll be able to create your own campaigns to make useful changes, fixes, refactors, and more.
+
+You'll learn how to:
+
+- Create a new campaign
+- Select the repositories to work with
+- Write the script to make changes to each repository
+- Publish and monitor the status of your proposed changes
+
+For more detailed information, see "[Campaigns](index.md)" in Sourcegraph documentation.
+
+## What is a campaign?
+
+A campaign lets you make many related code changes, creating many branches and changesets (such as GitHub pull requests) across many repositories. You can track the progress as they are reviewed and merged. See "[About campaigns](index.md#about-campaigns)" for more information.
+
+To use campaigns, you need to:
+
+- [Set up a Sourcegraph instance](../../index.md#quickstart) and add some repositories to it.
+- [Install Sourcegraph CLI](https://github.com/sourcegraph/src-cli) (`src`).
+
+## Step 1. Write a campaign spec
+
+A **campaign spec** is a YAML file that defines a campaign, including:
+
+- The name and description of the campaign
+- The set of repositories to change
+- Commands to run in each repository to make the changes
+- The commit message and branch name
+
+Save the following campaign spec as `hello-world.campaign.yaml`:
+
+```yaml
+name: hello-world
+description: Add Hello World to READMEs
+
+# Find all repositories that contain a README.md file.
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+# In each repository, run this command. Each repository's resulting diff is captured.
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world # Push the commit to this branch.
+  commit:
+    message: Append Hello World to all README.md files
+  published: false
+```
+
+## Step 2. Create the campaign
+
+Let's see the changes that will be made. Don't worry---no commits, branches, or changesets will be published yet (the repositories on your code host will be untouched).
+
+1. In your terminal, run this command:
+
+    <pre><code>src campaign apply -f hello-world.campaign.yaml -preview</code></pre>
+1. Wait for it to run and compute the changes for each repository.
+1. When it's done, click the displayed link to see all of the changes that will be made.
+1. Make sure the changes look right.
+
+    > If you want to run the campaign on fewer repositories, change the roots query in `hello-world.campaign.yaml` to something like `file:README.md repo:myproject` (to only match repositories whose name contains `myproject`).
+1. Click the **Create campaign** button.
+
+You created your first campaign! The campaign's changesets are still unpublished, which means they exist only on Sourcegraph and haven't been pushed to your code host yet.
+
+## Step 3. Publish the changes (optional)
+
+Publishing causes commits, branches, and changesets to be created on your code host.
+
+You probably don't want to publish these toy "Hello World" changesets to actively developed repositories, because that might confuse people ("Why did you add this line to our READMEs?"). On a real campaign, you would click the **Publish** button next to a changeset to publish it (or the **Publish all** button to publish all changesets).
+
+## Congratulations!
+
+You've created your first campaign! 🎉🎉
+
+You can customize your campaign spec and experiment with making other types of changes. To update your campaign, edit `hello-world.campaign.yaml` and run `src campaign apply -f hello-world.campaign.yaml -preview` again. (As before, you'll see a preview before any changes are applied.)
+
+Here are some [example campaigns](examples/index.md) for inspiratiopn:
+
+- [Using ESLint to automatically migrate to a new TypeScript version](examples/eslint_typescript_version.md)
+- [Adding a GitHub action to upload LSIF data to Sourcegraph](examples/lsif_action.md)
+- [Refactoring Go code using Comby](examples/refactor_go_comby.md)
+
+To learn what else you can do with campaigns, see "[Campaigns](index.md)" in Sourcegraph documentation.

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -1,90 +1,294 @@
 # Campaigns
 
->NOTE: **Campaigns are currently in beta.** We're actively building out the feature set and improving the user experience with every update. Let us know what you think! [File an issue](https://github.com/sourcegraph/sourcegraph) with feedback/problems/questions, or [contact us directly](https://about.sourcegraph.com/contact).
+Campaigns let you make large-scale code changes across many repositories.
 
-## What are campaigns?
+> NOTE: Campaigns are in beta.
 
-Campaigns are part of [Sourcegraph code change management](https://about.sourcegraph.com/product/code-change-management) and let you make large-scale code changes across many repositories and different code hosts.
+## About campaigns
 
-You provide the code to make the change, and campaigns provide the plumbing to turn it into a large-scale code change campaign and monitor its progress.
+A campaign streamlines the creation and tracking of pull requests across many repositories and code hosts. After you create a campaign, you tell it what changes to make (by providing a list of repositories and a script to run in each). The campaign lets you create pull requests on all affected repositories, and it tracks their progress until they're all merged. You can preview the changes and update them at any time.
 
-<div class="text-center">
-  <iframe
-      width="560"
-      height="315"
-      src="https://www.youtube.com/embed/aqcCrqRB17w"
-      frameborder="0"
-      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen="true"
-  ></iframe>
-</div>
+People usually use campaigns to make the following kinds of changes:
 
-## Are you a first time user of campaigns?
+- Cleaning up common problems using linters
+- Updating uses of deprecated library APIs
+- Upgrading dependencies
+- Patching critical security issues
+- Standardizing build, configuration, and deployment files
 
-If you are a first-time user of campaigns, we recommend that you read through the following sections of the documentation:
+For step-by-step instructions to create your first campaign, see [Hello World Campaign](hello_world_campaign.md) in Sourcegraph Guides.
 
-1. Read through the **[How it works](#how-it-works)** section below and **watch the video** to get an understanding of how campaigns work.
-1. Go through the "[Getting started](./getting_started.md)" instructions to setup your Sourcegraph instance for campaigns.
-1. Create your first campaign from a set of patches by reading "[Creating a campaign from patches](./creating_campaign_from_patches.md)".
-1. Create a manual campaign to track the progress of already-existing pull requests on your code host: "[Creating a manual campaign](./creating_manual_campaign.md)".
+<!-- TODO(sqs): link to about site for "why use campaigns?"
 
-At this point you're ready to explore the [**example campaigns**](./examples/index.md) and [create your own action definitions](./actions.md) and campaigns.
+Why use campaigns?
 
-## When should I use campaigns?
+With campaigns, making large-scale changes becomes:
 
-Campaigns allow you to **leverage Sourcegraph's search powers** and **execute code and Docker containers in all the repositories** yielded by a single Sourcegraph search query.
+- Simpler: Just provide a script and select the repositories.
+- Easier to follow through on: You can track the progress of all pull requests, including checks and review statuses, to see where to help out and to confirm when everything's merged.
+- Less scary: You can preview everything, roll out changes gradually, and update all changes even after creation.
+- Collaborative: Other people can see all the changes, including those still in preview, in one place.
 
-The created set of patches can then be turned into multiple **changesets** (a generic name for what some code hosts call _pull requests_ and others _merge requests_) on different code hosts by creating a **campaign**.
+-->
 
-<div style="max-width: 300px;" class="float-none float-xl-right ml-xl-3 mx-auto">
-  <figure class="figure">
-    <div class="figure-img">
-      <a href="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/manual_campaign.png">
-        <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/manual_campaign.png" />
-      </a>
-    </div>
-    <figcaption class="figure-caption text-right">A campaign tracking multiple changesets in different repositories.</figcaption>
-  </figure>
-</div>
+<!-- TODO(sqs): Add video here, similar to https://www.youtube.com/aqcCrqRB17w (which will need to be updated for the new campaign flow). -->
 
-Once the campaign is created, you can track the **review state, CI status and open/closed/merged lifecycle of each changeset in the Sourcegraph UI**.
+## Supported code hosts and changeset types
 
-You should use campaigns if you want to
+The generic term **changeset** is used to refer to any of the following:
 
-* run code to make changes across a large number of repositories.
-* keep track of a large number of pull requests and their status on GitHub or Bitbucket Server instances.
-* execute commands to upgrade dependencies in multiple repositories.
-* use Sourcegraph's search and replace matches by running code in the matched repositories.
+- GitHub pull requests
+- Bitbucket Server pull requests
+- Bitbucket Cloud pull requests (not yet supported)
+- GitLab merge requests (not yet supported)
+- Phabricator diffs (not yet supported)
+- Gerrit changes (not yet supported)
 
-<div class="clearfix"></div>
+A single campaign can span many repositories and many code hosts.
 
-## How it works
+## Viewing campaigns
 
-See this video for a demonstration of lifecycle of a campaign:
+You can view a list of all campaigns by clicking the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
 
-<div style="max-width: 450px;" class="mx-auto">
-  <figure class="figure">
-    <div class="figure-img">
-      <iframe src="https://player.vimeo.com/video/398878670?color=0CB6F4&title=0&byline=0&portrait=0" style="max-height: 250px; width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-    </div>
-    <figcaption class="figure-caption text-right">Campaign: Running <code>gofmt</code> in each repository containing a <code>go.mod</code> file.</figcaption>
-  </figure>
-</div>
+Use the filters to switch between showing all campaigns, open campaigns, or closed campaigns.
 
-1. With the `src` CLI the user **generates a set of patches** by running `gofmt` over every repository that has a `go.mod` file, leveraging Sourcegraphs search capabilities.
+If you lack read access to a repository in a campaign, you can only see [limited information about the changes to that repository](managing_access.md#repository-permissions-for-campaigns) (and not the repository name, file paths, or diff).
 
-    This is called **executing an _action_** (an _action_ is a series of commands and Docker containers to run in each repository) and yields **set of patches**, one for each repository, which you can inspect either in the CLI or in the Sourcegraph UI.
-1. The patches are then used to **create a draft campaign**.
-1. At this point, since it's a draft camapaign, no changesets (_pull requests_ in the case of GitHub here) have been created on the code host.
-1. The user then selectively **creates GitHub pull requests** by publishing single patches.
+### Campaign specs
 
-<div class="clearfix"></div>
+You can create or update a campaign from a [**campaign spec**](spec_reference.md), which is a YAML file that defines a campaign.
 
-## Requirements
+See the "[Creating a campaign](#creating-a-campaign)" section for an example campaign spec YAML file.
 
-* Sourcegraph instance [configured for campaigns](./configuration.md).
-* `src` CLI: [Installation and setup instructions](https://github.com/sourcegraph/src-cli/#installation)
+For more information, see:
 
-## Limitations
+- [Creating a campaign](#creating-a-campaign) from a campaign spec
+- [Updating a campaign](#updating-a-campaign) from a campaign spec
+- [Campaign spec YAML reference](spec_reference.md)
+- [Example campaign specs](examples/index.md)
 
-Campaigns currently only support **GitHub** and **Bitbucket Server** repositories. If you're interested in using campaigns on other code hosts, [let us know](https://about.sourcegraph.com/contact).
+## Creating a campaign
+
+> **Creating your first campaign?** See [Hello World Campaign](hello_world_campaign.md) in Sourcegraph Guides for step-by-step instructions.
+
+You can create a campaign from a [campaign spec](#campaign-specs), which is a YAML file that describes your campaign.
+
+The following example campaign spec adds "Hello World" to all `README.md` files:
+
+```yaml
+name: hello-world
+description: Add Hello World to READMEs
+
+# Find all repositories that contain a README.md file.
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+# In each repository, run this command. Each repository's resulting diff is captured.
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world # Push the commit to this branch.
+  commit:
+    message: Append Hello World to all README.md files
+  published: false
+```
+
+1. Create a campaign from the campaign spec:
+
+    <pre><code>src campaign apply -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -preview</code></pre>
+
+    > **Don't worry!** Before any branches are pushed or changesets (e.g., GitHub pull requests) are created, you will see a preview of all changes and can confirm each one before it's published.
+1. Wait for it to run and compute the changes for each repository (using the repositories and commands in the campaign spec).
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changes are what you intended. (If not, edit the campaign spec and then rerun the command above.)
+1. Click the **Create campaign** button. TODO(sqs)
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. In the list of campaigns, click the campaign where you'd like to apply the template.
+1. In the campaign, click the **Update template** button.
+1. In your terminal, run the command shown. The command will execute your [campaign template](template.md) to generate changes and then upload them to the campaign for you to preview and accept.
+
+    > You need [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) for this step. For reference, the command shown by the campaign is the following (with <code><em>CAMPAIGN-ID</em></code> filled in):
+   <pre><code>src campaign apply -template=<em>MY-TEMPLATE.campaign.yml</em> -preview -campaign=<em>CAMPAIGN-ID</em></code></pre>
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changes are what you intended. (If not, edit your campaign template and then rerun the command above.)
+1. Click the **Update campaign** button.
+
+After you've applied a campaign template, you can [publish changesets](#publishing-changesets-to-the-code-host) to the code host when you're ready. This will turn the patches into commits, branches, and changesets (such as GitHub pull requests) for others to review and merge.
+
+You can share the link to your campaign with other people if you want their help. Any person on your Sourcegraph instance can [view it in the campaigns list](#viewing-campaigns).
+
+If a person viewing the campaign lacks read access to a repository in the campaign, they can only see [limited information about the changes to that repository](managing_access.md#repository-permissions-for-campaigns) (and not the repository name, file paths, or diff).
+
+You can update a campaign's changes at any time, even after you've published changesets. For more information, see "[Updating a campaign](#updating-a-campaign)".
+
+### Example campaigns
+
+The [example campaigns](examples/index.md) show how to use campaigns to make useful, real-world changes:
+
+- [Using ESLint to automatically migrate to a new TypeScript version](examples/eslint_typescript_version.md)
+- [Adding a GitHub action to upload LSIF data to Sourcegraph](examples/lsif_action.md)
+- [Refactoring Go code using Comby](examples/refactor_go_comby.md)
+
+## Creating an empty campaign on the web
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. Click the **＋ New campaign** button.
+1. Type a name for your campaign.
+1. Type an optional description.
+1. Click the **Create campaign** button.
+
+You've created a new campaign, but it's empty (it has no changesets). Next, you can:
+
+- [Update the campaign's spec to create new changesets](#creating-and-updating-a-campaign)
+- [Track existing changesets](#tracking-existing-changesets)
+
+## Publishing changesets to the code host
+
+After you've added patches, you can see a preview of the changesets (e.g., GitHub pull requests) that will be created from the patches. Publishing the changesets will, for each repository:
+
+- Create a commit with the changes (from the patches for that repository)
+- Push a branch (using the branch name you chose when creating the campaign)
+- Create a changeset (e.g., GitHub pull request) on the code host for review and merging
+
+When you're ready, you can publish all of a campaign's changesets, or just an individual changeset.
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. In the list of campaigns, click the campaign that has changesets you'd like to publish.
+1. Click the **Publish** button next to a preview changeset to publish it.
+1. To publish all changesets (that have not already been published), click the **Publish all** button. If all changesets are already published, this button is not shown.
+
+You'll see a progress indicator when changesets are being published. Any errors will be shown, and you can retry publishing after you've resolved the problem. You don't need to worry about it creating multiple branches or pull requests when you retry, because it uses the same branch name.
+
+To publish a changeset, you need admin access to the campaign and write access to the changeset's repository (on the code host). For more information, see "[Code host interactions in campaigns](managing_access.md#code-host-interactions-in-campaigns)". [Forking the repository](#known-issues) is not yet supported.
+
+## Tracking campaign progress and changeset statuses
+
+A campaign tracks all of its changesets for updates to:
+
+- Status: open, merged, or closed
+- Checks: passed (green), failed (red), or pending (yellow)
+- Review status: approved, changes requested, pending, or other statuses (depending on your code host or code review tool)
+
+You can see the overall trend of a campaign in the burndown chart, which shows the proportion of changesets that have been merged over time since the campaign was created.
+
+> TODO(sqs) screenshot
+
+In the list of changesets, you can see the detailed status for each changeset.
+
+> TODO(sqs) screenshot
+
+If you lack read access to a repository, you can only see [limited information about the changes to that repository](managing_access.md#repository-permissions-for-campaigns) (and not the repository name, file paths, or diff).
+
+## Updating a campaign
+
+<!-- TODO(sqs): needs wireframes/mocks -->
+
+You can edit a campaign's name and description, and apply a new campaign template, at any time.
+
+To update a campaign, you need [admin access to the campaign](managing_access.md#campaign-access-for-each-permission-level), and [write access to all affected repositories](managing_access.md#repository-permissions-for-campaigns) with published changesets.
+
+### Editing the campaign's name and description
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. In the list of campaigns, click the campaign that you want to edit.
+1. Click the **Edit** button.
+1. Type a new name and/or description.
+1. Click the **Update campaign** button.
+
+Changes to the campaign's name and description do not automatically propagate to all of the campaign's changesets. You need to [re-apply the campaign template](#applying-a-new-campaign-template-to-update-changesets) to propagate these changes.
+
+### Applying a new campaign template to update changesets
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. In the list of campaigns, click the campaign that you want to update.
+1. In the campaign, click the ***Update template** button.
+1. In your terminal, run the command shown. The command will execute your [campaign template](template.md) to generate changes and then upload them to the campaign for you to preview and accept.
+
+    > You need [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) for this step. For reference, the command shown by the campaign is the following (with <code><em>CAMPAIGN-ID</em></code> filled in):
+   <pre><code>src campaign apply -template=<em>MY-TEMPLATE.campaign.yml</em> -preview -campaign=<em>CAMPAIGN-ID</em></code></pre>
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changes are what you intended. (If not, edit your campaign template and then rerun the command above.)
+1. Click the **Update campaign** button.
+
+All of the changesets on your code host will be updated to the desired state that was shown in the preview.
+
+## Tracking existing changesets
+
+<!-- TODO(sqs): needs wireframes/mocks -->
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. *To use an existing campaign:* In the list of campaigns, click the campaign where you'd like to track existing changesets.
+
+    *To create a new campaign:* Click the **＋ New campaign** button. For more information, see "[Creating a new campaign](#creating-a-new-campaign)".
+1. Click the **Track existing changeset** button in the top right of the **Changesets** list.
+1. Type in the name of the changeset's repository.
+
+    This is the repository's name on Sourcegraph. If you can visit the repository at `https://sourcegraph.example.com/foo/bar`, the name is `foo/bar`. Depending on the configuration, it may or may not begin with a hostname (such as `github.com/foo/bar`).
+1. Type in the changeset number (e.g., the GitHub pull request number).
+1. Click **Add**. <!-- TODO(sqs): button label -->
+
+You'll see the existing changeset in the list. The campaign will track the changeset's status and include it in the overall campaign progress (in the same way as if it had been created by the campaign). For more information, see "[Tracking campaign progress and changeset statuses](#tracking-campaign-progress-and-changeset-statuses)".
+
+## Closing or deleting a campaign
+
+You can close a campaign when you don't need it anymore, when all changes have been merged, or when you decided not to proceed with making all of the changes. A closed campaign still appears in the [campaigns list](#viewing-campaigns). To completely remove it, you can delete the campaign.
+
+Any person with [admin access to the campaign](managing_access.md#permission-levels-for-campaigns) can close or delete it.
+
+1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
+1. In the list of campaigns, click the campaign that you'd like to close or delete.
+1. In the top right, click the **Close**.
+1. Select whether you want to close all of the campaign's changesets (e.g., closing all associated GitHub pull requests on the code host).
+1. Click **TODO(sqs)** <!-- decide/confirm button label -->.
+
+## [Managing access to campaigns](managing_access.md)
+
+See "[Managing access to campaigns](managing_access.md)".
+
+## Code host and repository permissions in campaigns
+
+All actions on the code host (such as pushing a branch or opening a changeset) are performed by your individual user account, not by a bot user. For more information, see "[Code host interactions in campaigns](managing_access.md#code-host-interactions-in-campaigns)".
+
+[Repository permissions](../../admin/repo/permission.md) are enforced when campaigns display information. For more information, see "[Repository permissions in campaigns](managing_access.md#repository-permissions-for-campaigns)".
+
+## Site admin configuration for campaigns
+
+Using campaigns requires a [code host connection](../../admin/external_service/index.md) to a supported code host (currently GitHub and Bitbucket Server).
+
+Site admins can also:
+
+- [Allow users to authenticate via the code host](../../admin/auth/index.md#github), which makes it easier for users to authorize [code host interactions in campaigns](managing_access.md#code-host-interactions-in-campaigns)
+- [Configure repository permissions](../../admin/repo/permission.md), which campaigns will respect
+- [Disable campaigns for all users](managing_access.md#disabling-campaigns-for-all-users)
+
+## Concepts
+
+- A **campaign** is group of related changes to code, along with a title and description.
+- The campaign has associated **changesets**, which is a generic term for pull requests, merge requests, or any other reviewable chunk of code. (Code hosts use different terms for this, which is why we chose a generic term.)
+- A **published changeset** means the commit, branch, and changeset have been created on the code host. An **unpublished changeset** is just a preview that you can view in the campaign but does not exist on the code host yet.
+- A **spec** (campaign spec or changeset spec) is a "record of intent". When you provide a spec for a thing, the system will continuously try to reconcile the actual thing with your desired intent (as described by the spec). This involves creating, updating, and deleting things as needed.
+- A [**campaign spec**](campaign_spec.md) is a YAML file describing the campaign: repositories to change, commands to run, and a template for changesets and commits. You describe your high-level intent in the campaign spec, such as "lint files in all repositories with a `package.json` file".
+- A campaign has many **changeset specs**, which are produced by executing the campaign spec (i.e., running the commands on each selected repository) and then using its changeset template to produce a list of changesets, including the diffs, commit messages, changeset title, and changeset body. You don't need to view or edit the raw changeset specs; you will edit the campaign spec and view the changesets in the UI.
+- The **campaign controller** reconciles the actual state of the campaign's changesets on the code host so that they match your desired intent (as described in the changeset specs).
+
+To learn about the internals of campaigns, see "[Campaigns](../../dev/campaigns_development.md)" in the developer documentation.
+
+## Roadmap
+
+<!-- TODO(sqs): This section is rough/incomplete/outline-only. -->
+
+### Known issues
+
+<!-- TODO(sqs): This section is rough/incomplete/outline-only. -->
+
+- The only supported code hosts are GitHub and Bitbucket Server. Support for [all other code hosts](../../admin/external_service/index.md) is planned.
+- It is not yet possible for a campaign to have multiple changesets in a single repository (e.g., to make changes to multiple subtrees in a monorepo).
+- Forking a repository and creating a pull request on the fork is not yet supported. Because of this limitation, you need write access to each repository that your campaign will change (in order to push a branch to it).
+- Campaign steps are run locally (in the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)). Sourcegraph does not yet support executing campaign steps (which can be arbitrary commands) on the server. For this reason, the APIs for creating and updating a campaign require you to upload all of the changeset specs (which are produced by executing the campaign spec locally). {#server-execution}
+

--- a/doc/user/campaigns/managing_access.md
+++ b/doc/user/campaigns/managing_access.md
@@ -1,0 +1,81 @@
+# Managing access to campaigns
+
+You can customize access to a campaign and propose changes to repositories with varying permission levels. Other people see the campaign's proposed changes to a repository if they can view that repository; otherwise, they can see only limited, non-identifying information about the change.
+
+## Permission levels for campaigns
+
+Any person with a user account can create a campaign.
+
+The permission levels for a campaign are:
+
+- **Read:** For people who need to view the campaign. 
+- **Admin:** For people who need full access to the campaign, including editing, closing, and deleting it.
+
+To see the campaign's proposed changes on a repository, a person *also* needs read access to that specific repository. Read or admin access on the campaign does not (by itself) entitle a person to viewing all of the campaign's changes. For more information, see "[Repository permissions for campaigns](#repository-permissions-for-campaigns)".
+
+Site admins have admin permissions on all campaigns.
+
+### Campaign access for each permission level
+
+Campaign action | Read | Admin
+--------------- | :--: | :----:
+View campaign name and description<br/><small class="text-muted">Also applies to viewing the input branch name, created/updated date, and campaign status</small> | ⬤ | ⬤
+View burndown chart (aggregate changeset statuses over time) | ⬤ | ⬤
+View list of patches and changesets | ⬤ | ⬤
+View diffstat (aggregate count of added/changed/deleted lines) | ⬤ | ⬤
+View error messages (related to creating or syncing changesets) |  | ⬤
+Edit campaign name, description, and branch name | ⬤ | ⬤
+Update campaign patches (and changesets on code hosts) |  | ⬤
+Publish changesets to code host |  | ⬤
+Add/remove existing changesets to/from campaign |  | ⬤
+Refresh changeset statuses |  | ⬤
+Close campaign |  | ⬤
+Delete campaign |  | ⬤
+
+Authorization for all actions is also subject to [repository permissions](#repository-permissions-for-campaigns).
+
+## Setting and viewing permissions for a campaign
+
+When you create a campaign, you are given admin permissions on the campaign.
+
+All users are automatically given read permissions to a campaign. Granular permissions are not yet supported. Assigning admin permissions on a campaign to another person or to all organization members is not yet supported. Transferring ownership of a campaign is not yet supported.
+
+## Code host interactions in campaigns
+
+All interactions with the code host are performed by your individual user account on the code host, not by a bot user or Sourcegraph machine account. These operations include:
+
+- Pushing a branch with the changes (the Git author and committer will be you, and the Git push will be authenticated with your credentials)
+- Creating a changeset (e.g., on GitHub, the pull request author will be you)
+- Updating a changeset
+- Closing a changeset
+
+If you attempt to perform these operations and haven't yet linked your code host account to your Sourcegraph account, you'll be prompted to do so. You can either:
+
+- Manually enter a personal access token in your user profile
+- Sign in via your code host (currently only supported for GitHub; requires a site admin to [configure GitHub user authentication](../../admin/auth/index.md#github))
+
+## Repository permissions for campaigns
+
+Your [repository permissions](../../admin/repo/permission.md) determine what information in a campaign you can view. You can only see a campaign's proposed changes to a repository if you have read access to that repository. Read or admin permissions on a campaign does not (by itself) permit you to view all of the campaign's changes.
+
+When you view a campaign, you can see a list of patches and changesets. For each patch and changeset:
+
+- **If you have read access** to the repository for a patch or changeset, you can see the diff, changeset title, changeset link, detailed status, and other information.
+- **If you do not have read access** to the repository for a patch or changeset, you can only see the status, last-updated date, and whether an error occurred (but not the error message). You can't see the diff, changeset title, changeset link, repository name, or any other information.
+
+When you perform any campaign operation that involves repositories or code host interaction, your current repository permissions are taken into account.
+
+- Creating, updating, or publishing a campaign; or publishing a single changeset: You must have access to push a branch to the repositories and create the changesets on your code host (e.g., push branches to and open pull requests on the GitHub repositories).
+- Adding existing changesets to a campaign: You must have read access to the existing changesets' repository.
+- Closing or deleting a campaign: If you choose to also close associated changesets on the code host, you must have access to do so on the code host. If you do not have access to close a changeset on the code host, the changeset will remain in its current state. A person with repository permissions for the remaining changesets can view them and manually close them.
+
+Your repository permissions can change at any time:
+
+- If you've already published a changeset to a repository that you no longer have access to, then you won't be able to view its details or update it in your campaign. The changeset on the code host will remain in its current state. A person with permissions to the changeset on the code host will need to manually manage or close it. When possible, you'll be informed of this when updating a campaign that contains changesets you've lost access to.
+- You need access to all repositories mentioned in a campaign plan to use it when updating a campaign.
+
+If you are not permitted to view a repository on Sourcegraph, then you won't be able to perform any operations on it, even if you are authorized on the code host.
+
+## Disabling campaigns for all users
+
+A site admin can completely disable campaigns on an instance by setting the [site configuration](../../admin/config/site_config.md) property `campaigns.disable` to `true`. This setting applies to everyone, including site admins. It prevents all viewing, creation, editing, syncing, and other actions on campaigns. Existing campaign changesets on code hosts are left in their current state and are not affected by this setting.

--- a/doc/user/campaigns/template.md
+++ b/doc/user/campaigns/template.md
@@ -1,0 +1,61 @@
+# Campaign templates
+
+> TODO(sqs)
+
+A campaign template describes how to produce the campaign's changesets. The format resembles that of [GitHub Actions workflows](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+
+``` yaml
+# What repositories do you want to change? The script is executed independently in each root specified here. A root is usually a repository on a particular branch, but it can also be a subdirectory of a repository (e.g., for monorepos).
+roots:
+  - query: repo:github.com/sourcegraph/ file:package.json react-router-dom
+  - repository: github.com/acmecorp/foo
+    branch: dev
+    path: pkg/webapp
+
+# The Docker container in which steps (that don't specify a container) will be executed.
+container: node:14
+
+# The name of the branch where the changes are pushed.
+branch: upgrade-react-router-dom
+
+# The steps are executed sequentially in each root.
+steps:
+  - name: Upgrade react-router-dom
+    run: yarn upgrade -L react-router-dom
+  - name: Rewrite <Redirect> to <Navigate>
+    run: comby '<Redirect :[1] />' '<Navigate :[1] />' .tsx -i
+    container: comby/comby
+```
+
+
+
+### Campaign spec
+
+You never need to read or edit a campaign spec. Instead, you'll create a [campaign template](#campaign-templates), then run `src campaign apply -template foo.campaign.yml -campaign <ID> [-preview]` to generate, upload, and apply the campaign spec. In case you're curious, though, here's what a campaign spec looks like:
+
+```json
+{
+  "changesets": [
+    {
+      "base": {
+        "repository": "<ID>",
+        "branch": "master"
+      },
+      "head": {
+        "repository": "<ID>",
+        "branch": "upgrade-react-router-dom",
+        "commit": "35da342b5fb78d315713efebb3431095c1d1de16"
+      },
+      "title": "Upgrade react-router-dom, migrate <Redirect> -> <Navigate>",
+      "description": "...",
+      "commits": [
+        {
+          "message": "{{.Title}}"",
+          "patch": "..." // unified diff format
+        }
+      ]
+    },
+    { ... }, // other changesets
+  ]
+}
+```


### PR DESCRIPTION
I am pre-writing the docs so we have a concise description of the new flow from the user's POV.

**Preview as rendered docs at:**

- https://docs.sourcegraph.com/@campaigns-new-flow/user/campaigns
- https://docs.sourcegraph.com/@campaigns-new-flow/user/campaigns/hello_world_campaign
- https://docs.sourcegraph.com/@campaigns-new-flow/dev/campaigns_design

**Figma mock (slightly behind the docs pages above):** https://www.figma.com/file/kRf5i7xf1p4zs3OyX0DUVp/Campaigns


---

Docs that led to this change: [RFC 157](https://docs.google.com/document/d/1-Ed6s3yiB-pmL7Up8H6nMlUhgmLn5BVu34Zpvf-_YNo/edit#) and [Campaigns CLI and naming/concepts idea](https://docs.google.com/document/d/1zsN7NND7Lyc7Cm2KNdPYLwYs6pV7fvuPwLunV_u_tnY/edit#heading=h.by0rs1hib7mp). The proposals and motivations from those docs will be fully incorporated into this PR's `.md` doc changes.