### PR TITLE
codeintel: Add FileExists and Archive to gitserver client

### DIFF
--- a/internal/codeintel/gitserver/archive.go
+++ b/internal/codeintel/gitserver/archive.go
@@ -1,0 +1,28 @@
+package gitserver
+
+import (
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+// Archive retrieves a tar-formatted archive of the given commit.
+func Archive(ctx context.Context, db db.DB, repositoryID int, commit string) (io.Reader, error) {
+	repo, err := repositoryIDToRepo(ctx, db, repositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := git.ResolveRevision(ctx, repo, nil, commit, nil); err != nil {
+		return nil, errors.Wrap(err, "git.ResolveRevision")
+	}
+
+	return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{
+		Treeish: commit,
+		Format:  "tar",
+	})
+}

--- a/internal/codeintel/gitserver/client.go
+++ b/internal/codeintel/gitserver/client.go
@@ -2,6 +2,7 @@ package gitserver
 
 import (
 	"context"
+	"io"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
@@ -20,6 +21,12 @@ type Client interface {
 	// of git ls-tree. The keys of the resulting map are the input (unsanitized) dirnames, and the value of
 	// that key are the files nested under that directory.
 	DirectoryChildren(ctx context.Context, db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error)
+
+	// Archive retrieves a tar-formatted archive of the given commit.
+	Archive(ctx context.Context, db db.DB, repositoryID int, commit string) (io.Reader, error)
+
+	// FileExists determines whether a file exists in a particular commit of a repository.
+	FileExists(ctx context.Context, db db.DB, repositoryID int, commit, file string) (bool, error)
 }
 
 type defaultClient struct{}
@@ -36,4 +43,12 @@ func (c *defaultClient) CommitsNear(ctx context.Context, db db.DB, repositoryID 
 
 func (c *defaultClient) DirectoryChildren(ctx context.Context, db db.DB, repositoryID int, commit string, dirnames []string) (map[string][]string, error) {
 	return DirectoryChildren(ctx, db, repositoryID, commit, dirnames)
+}
+
+func (c *defaultClient) Archive(ctx context.Context, db db.DB, repositoryID int, commit string) (io.Reader, error) {
+	return Archive(ctx, db, repositoryID, commit)
+}
+
+func (c *defaultClient) FileExists(ctx context.Context, db db.DB, repositoryID int, commit, file string) (bool, error) {
+	return FileExists(ctx, db, repositoryID, commit, file)
 }

--- a/internal/codeintel/gitserver/files.go
+++ b/internal/codeintel/gitserver/files.go
@@ -1,0 +1,33 @@
+package gitserver
+
+import (
+	"context"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+// FileExists determines whether a file exists in a particular commit of a repository.
+func FileExists(ctx context.Context, db db.DB, repositoryID int, commit, file string) (bool, error) {
+	repo, err := repositoryIDToRepo(ctx, db, repositoryID)
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := git.ResolveRevision(ctx, repo, nil, commit, nil); err != nil {
+		return false, errors.Wrap(err, "git.ResolveRevision")
+	}
+
+	if _, err := git.Stat(ctx, repo, api.CommitID(commit), file); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/codeintel/gitserver/mocks/mock_client.go
+++ b/internal/codeintel/gitserver/mocks/mock_client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	gitserver "github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
+	"io"
 	"sync"
 )
 
@@ -13,12 +14,18 @@ import (
 // package github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver)
 // used for unit testing.
 type MockClient struct {
+	// ArchiveFunc is an instance of a mock function object controlling the
+	// behavior of the method Archive.
+	ArchiveFunc *ClientArchiveFunc
 	// CommitsNearFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitsNear.
 	CommitsNearFunc *ClientCommitsNearFunc
 	// DirectoryChildrenFunc is an instance of a mock function object
 	// controlling the behavior of the method DirectoryChildren.
 	DirectoryChildrenFunc *ClientDirectoryChildrenFunc
+	// FileExistsFunc is an instance of a mock function object controlling
+	// the behavior of the method FileExists.
+	FileExistsFunc *ClientFileExistsFunc
 	// HeadFunc is an instance of a mock function object controlling the
 	// behavior of the method Head.
 	HeadFunc *ClientHeadFunc
@@ -28,6 +35,11 @@ type MockClient struct {
 // return zero values for all results, unless overwritten.
 func NewMockClient() *MockClient {
 	return &MockClient{
+		ArchiveFunc: &ClientArchiveFunc{
+			defaultHook: func(context.Context, db.DB, int, string) (io.Reader, error) {
+				return nil, nil
+			},
+		},
 		CommitsNearFunc: &ClientCommitsNearFunc{
 			defaultHook: func(context.Context, db.DB, int, string) (map[string][]string, error) {
 				return nil, nil
@@ -36,6 +48,11 @@ func NewMockClient() *MockClient {
 		DirectoryChildrenFunc: &ClientDirectoryChildrenFunc{
 			defaultHook: func(context.Context, db.DB, int, string, []string) (map[string][]string, error) {
 				return nil, nil
+			},
+		},
+		FileExistsFunc: &ClientFileExistsFunc{
+			defaultHook: func(context.Context, db.DB, int, string, string) (bool, error) {
+				return false, nil
 			},
 		},
 		HeadFunc: &ClientHeadFunc{
@@ -50,16 +67,136 @@ func NewMockClient() *MockClient {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockClientFrom(i gitserver.Client) *MockClient {
 	return &MockClient{
+		ArchiveFunc: &ClientArchiveFunc{
+			defaultHook: i.Archive,
+		},
 		CommitsNearFunc: &ClientCommitsNearFunc{
 			defaultHook: i.CommitsNear,
 		},
 		DirectoryChildrenFunc: &ClientDirectoryChildrenFunc{
 			defaultHook: i.DirectoryChildren,
 		},
+		FileExistsFunc: &ClientFileExistsFunc{
+			defaultHook: i.FileExists,
+		},
 		HeadFunc: &ClientHeadFunc{
 			defaultHook: i.Head,
 		},
 	}
+}
+
+// ClientArchiveFunc describes the behavior when the Archive method of the
+// parent MockClient instance is invoked.
+type ClientArchiveFunc struct {
+	defaultHook func(context.Context, db.DB, int, string) (io.Reader, error)
+	hooks       []func(context.Context, db.DB, int, string) (io.Reader, error)
+	history     []ClientArchiveFuncCall
+	mutex       sync.Mutex
+}
+
+// Archive delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockClient) Archive(v0 context.Context, v1 db.DB, v2 int, v3 string) (io.Reader, error) {
+	r0, r1 := m.ArchiveFunc.nextHook()(v0, v1, v2, v3)
+	m.ArchiveFunc.appendCall(ClientArchiveFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Archive method of
+// the parent MockClient instance is invoked and the hook queue is empty.
+func (f *ClientArchiveFunc) SetDefaultHook(hook func(context.Context, db.DB, int, string) (io.Reader, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Archive method of the parent MockClient instance inovkes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *ClientArchiveFunc) PushHook(hook func(context.Context, db.DB, int, string) (io.Reader, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *ClientArchiveFunc) SetDefaultReturn(r0 io.Reader, r1 error) {
+	f.SetDefaultHook(func(context.Context, db.DB, int, string) (io.Reader, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *ClientArchiveFunc) PushReturn(r0 io.Reader, r1 error) {
+	f.PushHook(func(context.Context, db.DB, int, string) (io.Reader, error) {
+		return r0, r1
+	})
+}
+
+func (f *ClientArchiveFunc) nextHook() func(context.Context, db.DB, int, string) (io.Reader, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ClientArchiveFunc) appendCall(r0 ClientArchiveFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ClientArchiveFuncCall objects describing
+// the invocations of this function.
+func (f *ClientArchiveFunc) History() []ClientArchiveFuncCall {
+	f.mutex.Lock()
+	history := make([]ClientArchiveFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ClientArchiveFuncCall is an object that describes an invocation of method
+// Archive on an instance of MockClient.
+type ClientArchiveFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 db.DB
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 io.Reader
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ClientArchiveFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ClientArchiveFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // ClientCommitsNearFunc describes the behavior when the CommitsNear method
@@ -291,6 +428,123 @@ func (c ClientDirectoryChildrenFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientDirectoryChildrenFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ClientFileExistsFunc describes the behavior when the FileExists method of
+// the parent MockClient instance is invoked.
+type ClientFileExistsFunc struct {
+	defaultHook func(context.Context, db.DB, int, string, string) (bool, error)
+	hooks       []func(context.Context, db.DB, int, string, string) (bool, error)
+	history     []ClientFileExistsFuncCall
+	mutex       sync.Mutex
+}
+
+// FileExists delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockClient) FileExists(v0 context.Context, v1 db.DB, v2 int, v3 string, v4 string) (bool, error) {
+	r0, r1 := m.FileExistsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.FileExistsFunc.appendCall(ClientFileExistsFuncCall{v0, v1, v2, v3, v4, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the FileExists method of
+// the parent MockClient instance is invoked and the hook queue is empty.
+func (f *ClientFileExistsFunc) SetDefaultHook(hook func(context.Context, db.DB, int, string, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// FileExists method of the parent MockClient instance inovkes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *ClientFileExistsFunc) PushHook(hook func(context.Context, db.DB, int, string, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *ClientFileExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, db.DB, int, string, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *ClientFileExistsFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, db.DB, int, string, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *ClientFileExistsFunc) nextHook() func(context.Context, db.DB, int, string, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ClientFileExistsFunc) appendCall(r0 ClientFileExistsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ClientFileExistsFuncCall objects describing
+// the invocations of this function.
+func (f *ClientFileExistsFunc) History() []ClientFileExistsFuncCall {
+	f.mutex.Lock()
+	history := make([]ClientFileExistsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ClientFileExistsFuncCall is an object that describes an invocation of
+// method FileExists on an instance of MockClient.
+type ClientFileExistsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 db.DB
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ClientFileExistsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ClientFileExistsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
This is part of [RFC 153: Automatic LSIF indexing](https://docs.google.com/document/d/1LFwtfIqTgxzyNQDRvKsWbY9pZKiXVhwPyrNB04gnpDQ).

These new method will be required for the indexer to (1) determine if go.mod exists in a repo so that it's eligible for indexing, and (2) grabbing the content of the repo so we can index it with a clal to lsif-go.