### PR TITLE
docker-images: publish cadvisor

### DIFF
--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -11,6 +11,7 @@ If you are looking for our non-derivative Docker images, see e.g. `/cmd/.../Dock
 
 All images in this directory are built and published automatically on CI:
 
+- To add an image to the automated builds pipeline, make sure to add it to [`allDockerImages`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40distribution/publish-cadvisor+file:%5Eenterprise/dev/ci/ci/pipeline-steps%5C.go+var+allDockerImages&patternType=literal)
 - See [the handbook](https://about.sourcegraph.com/handbook/engineering/deployments) for more information
 - Or see [how to build a test image](https://about.sourcegraph.com/handbook/engineering/deployments#building-docker-images-for-a-specific-branch) if you need to build a test image without merging your change to `master` first.
 

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -11,7 +11,7 @@ If you are looking for our non-derivative Docker images, see e.g. `/cmd/.../Dock
 
 All images in this directory are built and published automatically on CI:
 
-- To add an image to the automated builds pipeline, make sure to add it to [`allDockerImages`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40distribution/publish-cadvisor+file:%5Eenterprise/dev/ci/ci/pipeline-steps%5C.go+var+allDockerImages&patternType=literal)
+- To add an image to the automated builds pipeline, make sure to add it to [`allDockerImages`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph+file:%5Eenterprise/dev/ci/ci/pipeline-steps%5C.go+var+allDockerImages&patternType=literal)
 - See [the handbook](https://about.sourcegraph.com/handbook/engineering/deployments) for more information
 - Or see [how to build a test image](https://about.sourcegraph.com/handbook/engineering/deployments#building-docker-images-for-a-specific-branch) if you need to build a test image without merging your change to `master` first.
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -23,6 +23,7 @@ var allDockerImages = []string{
 	"precise-code-intel-worker",
 
 	// Images under docker-images/
+	"cadvisor",
 	"grafana",
 	"indexed-searcher",
 	"postgres-11.4",


### PR DESCRIPTION
#10938 didn't publish `cadvisor:insiders` and I poked around and think it's because I missed this :(

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
