### PR TITLE
search: mirror GQL schema and SearchQueryDescription resolver type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_query_description.go
+++ b/cmd/frontend/graphqlbackend/search_query_description.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import "github.com/sourcegraph/sourcegraph/internal/search/query"
 
+// searchQueryDescription is a type for the SearchQueryDescription resolver used
+// by SearchAlert.
 type searchQueryDescription struct {
 	description string
 	query       string


### PR DESCRIPTION
`query` is quite overloaded and `search_query.go` doesn't accurately mirror that this refers to a GQL resolver type `SearchQueryDescription`. I've renamed it and added a comment. 

Before this change I was looking at how to get rid of this file because it seemed like bloat and we have another `searchquery.go` file somewhere else for other things. But I realized this type rightly should have it's own file as a GQL resolver type, so I'm just making it clear.