### PR TITLE
authz: make `PermsSyncer` respect rate limit

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestPermsSyncer_ScheduleUsers(t *testing.T) {
-	s := NewPermsSyncer(nil, nil, nil)
+	s := NewPermsSyncer(nil, nil, nil, nil)
 	s.ScheduleUsers(context.Background(), 1)
 
 	expHeap := []*syncRequest{
@@ -35,7 +35,7 @@ func TestPermsSyncer_ScheduleUsers(t *testing.T) {
 }
 
 func TestPermsSyncer_ScheduleRepos(t *testing.T) {
-	s := NewPermsSyncer(nil, nil, nil)
+	s := NewPermsSyncer(nil, nil, nil, nil)
 	s.ScheduleRepos(context.Background(), 1)
 
 	expHeap := []*syncRequest{
@@ -155,7 +155,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
 	permsStore := edb.NewPermsStore(nil, clock)
-	s := NewPermsSyncer(reposStore, permsStore, clock)
+	s := NewPermsSyncer(reposStore, permsStore, clock, nil)
 	s.metrics.syncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{}, []string{"type", "success"})
 	s.metrics.syncErrors = prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"type"})
 
@@ -245,7 +245,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		return time.Now().UTC().Truncate(time.Microsecond)
 	}
 	permsStore := edb.NewPermsStore(nil, clock)
-	s := NewPermsSyncer(reposStore, permsStore, clock)
+	s := NewPermsSyncer(reposStore, permsStore, clock, nil)
 	s.metrics.syncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{}, []string{"type", "success"})
 	s.metrics.syncErrors = prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"type"})
 
@@ -278,6 +278,57 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 }
 
+type fakeExternalServiceLister struct{}
+
+func (*fakeExternalServiceLister) ListExternalServices(context.Context, repos.StoreListExternalServicesArgs) ([]*repos.ExternalService, error) {
+	return []*repos.ExternalService{
+		{
+			ID:          1,
+			Kind:        "GITHUB",
+			DisplayName: "GitHub.com",
+			Config:      `{"url": "https://github.com"}`,
+		},
+	}, nil
+}
+
+func TestPermsSyncer_waitForRateLimit(t *testing.T) {
+	ctx := context.Background()
+	t.Run("no rate limit registry", func(t *testing.T) {
+		s := NewPermsSyncer(nil, nil, nil, nil)
+		err := s.waitForRateLimit(ctx, "https://github.com/", 100000)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("enough quota available", func(t *testing.T) {
+		rateLimiterRegistry, err := repos.NewRateLimiterRegistry(ctx, &fakeExternalServiceLister{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := NewPermsSyncer(nil, nil, nil, rateLimiterRegistry)
+		err = s.waitForRateLimit(ctx, "https://github.com/", 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("not enough quota available", func(t *testing.T) {
+		rateLimiterRegistry, err := repos.NewRateLimiterRegistry(ctx, &fakeExternalServiceLister{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := NewPermsSyncer(nil, nil, nil, rateLimiterRegistry)
+
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		err = s.waitForRateLimit(ctx, "https://github.com/", 10)
+		if err == nil {
+			t.Fatalf("err: want %v but got nil", context.Canceled)
+		}
+	})
+}
+
 func TestPermsSyncer_syncPerms(t *testing.T) {
 	request := &syncRequest{
 		requestMeta: &requestMeta{
@@ -288,7 +339,7 @@ func TestPermsSyncer_syncPerms(t *testing.T) {
 	}
 
 	// Request should be removed from the queue even if error occurred.
-	s := NewPermsSyncer(nil, nil, nil)
+	s := NewPermsSyncer(nil, nil, nil, nil)
 	s.queue.Push(request)
 
 	expErr := "unexpected request type: 3"


### PR DESCRIPTION
Integrate our rate limit registry into background permissions syncing, so we aren't naively requesting APIs when rate limit quota are exhausted.

Fixes #9098