### PR TITLE
license: show expired notice to users

### DIFF
--- a/enterprise/cmd/frontend/authz/authz.go
+++ b/enterprise/cmd/frontend/authz/authz.go
@@ -109,10 +109,16 @@ func Init(d dbutil.DB, clock func() time.Time) {
 	// (due to an error in parsing or verification, or because the license has expired).
 	hooks.PostAuthMiddleware = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err == nil {
-				// Site admins are exempt from license enforcement screens such that they can
-				// easily update the license key.
+			// Site admins are exempt from license enforcement screens so that they can
+			// easily update the license key. Also ignore backend.ErrNotAuthenticated
+			// because we need to allow site admins to sign in.
+			err := backend.CheckCurrentUserIsSiteAdmin(r.Context())
+			if err == nil || err == backend.ErrNotAuthenticated {
 				next.ServeHTTP(w, r)
+				return
+			} else if err != backend.ErrMustBeSiteAdmin {
+				log15.Error("Error checking current user is site admin", "err", err)
+				http.Error(w, "", http.StatusInternalServerError)
 				return
 			}
 

--- a/enterprise/cmd/frontend/authz/authz.go
+++ b/enterprise/cmd/frontend/authz/authz.go
@@ -106,10 +106,10 @@ func Init(d dbutil.DB, clock func() time.Time) {
 	})
 
 	// Enforce the use of a valid license key by preventing all HTTP requests if the license is invalid
-	// (due to a error in parsing or verification, or because the license has expired).
+	// (due to an error in parsing or verification, or because the license has expired).
 	hooks.PostAuthMiddleware = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+			if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err == nil {
 				// Site admins are exempt from license enforcement screens such that they can
 				// easily update the license key.
 				next.ServeHTTP(w, r)

--- a/enterprise/cmd/frontend/authz/authz.go
+++ b/enterprise/cmd/frontend/authz/authz.go
@@ -118,7 +118,7 @@ func Init(d dbutil.DB, clock func() time.Time) {
 				return
 			} else if err != backend.ErrMustBeSiteAdmin {
 				log15.Error("Error checking current user is site admin", "err", err)
-				http.Error(w, "", http.StatusInternalServerError)
+				http.Error(w, "Error checking current user is site admin. Site admins may check the logs for more information.", http.StatusInternalServerError)
 				return
 			}
 


### PR DESCRIPTION
Correctly displays license expired notice to users by fixing the order of middleware wrapping. It is a bit counter-intuitive that the actual call order is opposite to the order of wrapping.

Fixes #10363 (also see the issue for details why it was not working at all)
