### PR TITLE
redis checks: Do not shadow err so it's reported correctly

### DIFF
--- a/internal/redispool/sysreq.go
+++ b/internal/redispool/sysreq.go
@@ -49,7 +49,8 @@ func redisCheck(name, addr string, timeout time.Duration, pool *redis.Pool) sysr
 		deadline := time.Now().Add(timeout)
 
 		for time.Now().Before(deadline) {
-			if err := check(); err == nil {
+			err = check()
+			if err == nil {
 				// Success
 				return "", "", nil
 			}


### PR DESCRIPTION
Right now, the real error would never be reported and the error message
printed would look like this:

    11:38:35 frontend |  !!!!!  Redis Store is required
    11:38:35 frontend |     Problem: Redis "Store" is unavailable or misconfigured
    11:38:35 frontend |     Possible fix: Start a Redis server listening at port 127.0.0.1:6379
    11:38:35 frontend |     Skip this check by setting the env var SRC_SKIP_REQS="Redis Store"
    11:38:35 frontend |             (separate multiple entries with spaces). Note: Sourcegraph may not
    11:38:35 frontend |             function properly without Redis Store.

With this fix, the error is included:

    11:38:01 frontend |  !!!!!  Redis Store is required
    11:38:01 frontend |     Problem: Redis "Store" is unavailable or misconfigured
    11:38:01 frontend |     Error: MISCONF Redis is configured to save RDB snapshots, but it is currently
    11:38:01 frontend |             not able to persist on disk. Commands that may modify the data set are
    11:38:01 frontend |             disabled, because this instance is configured to report errors during
    11:38:01 frontend |             writes if RDB snapshotting fails (stop-writes-on-bgsave-error option).
    11:38:01 frontend |             Please check the Redis logs for details about the RDB error.
    11:38:01 frontend |     Possible fix: Start a Redis server listening at port 127.0.0.1:6379
    11:38:01 frontend |     Skip this check by setting the env var SRC_SKIP_REQS="Redis Store"
    11:38:01 frontend |             (separate multiple entries with spaces). Note: Sourcegraph may not
    11:38:01 frontend |             function properly without Redis Store.

---

There's another issue with these checks: if the error returned by the check is non-transient, it'll still retry the check for the default timeout length (90s right now).
