### PR TITLE
authz: improve `waitForRateLimit` docstring and tests timeout

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -339,8 +339,10 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	return nil
 }
 
-// waitForRateLimit blocks until rate limit quota is available for n.
-// Otherwise, it returns immediately.
+// waitForRateLimit blocks until rate limit permits n events to happen. It returns
+// an error if n exceeds the limiter's burst size, the context is canceled, or the
+// expected wait time exceeds the context's deadline. The burst limit is ignored if
+// the rate limit is Inf.
 func (s *PermsSyncer) waitForRateLimit(ctx context.Context, serviceID string, n int) error {
 	if s.rateLimiterRegistry == nil {
 		return nil

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -295,6 +295,9 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 	ctx := context.Background()
 	t.Run("no rate limit registry", func(t *testing.T) {
 		s := NewPermsSyncer(nil, nil, nil, nil)
+
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
 		err := s.waitForRateLimit(ctx, "https://github.com/", 100000)
 		if err != nil {
 			t.Fatal(err)
@@ -307,6 +310,9 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 			t.Fatal(err)
 		}
 		s := NewPermsSyncer(nil, nil, nil, rateLimiterRegistry)
+
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
 		err = s.waitForRateLimit(ctx, "https://github.com/", 1)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Follow up to address https://github.com/sourcegraph/sourcegraph/pull/10950#discussion_r429861195.

Improves docstring of `waitForRateLimit` and cap tests timeout 1s in case of error.