### PR TITLE
repo-updater: Change Postgres isolation level to default

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -78,7 +78,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		m.MustRegister(prometheus.DefaultRegisterer)
 
 		store = repos.NewObservedStore(
-			repos.NewDBStore(db, sql.TxOptions{Isolation: sql.LevelSerializable}),
+			repos.NewDBStore(db, sql.TxOptions{Isolation: sql.LevelDefault}),
 			log15.Root(),
 			m,
 			trace.Tracer{Tracer: opentracing.GlobalTracer()},


### PR DESCRIPTION
We have no current requirements that justify serializable isolation level and on
sourcegraph.com it can lead to errors such as these:

```
pq: could not serialize access due to concurrent update
```

Since in `repoLookup` concurrent writes to the same repo are idempotent, it's better for
concurrent requests to succeed like this, rather than only one
succeeding and others failing.

Fixes part of #10930