### PR TITLE
campaigns: Include external service id in bitbucket webhook name

### DIFF
--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -882,7 +882,7 @@ func (h *BitbucketServerWebhook) syncWebhook(externalServiceID int64, con *schem
 	// Secret or sync permission has changed, sync
 	endpoint := extsvc.WebhookURL(bitbucketserver.ServiceType, externalServiceID, externalURL)
 	wh := bitbucketserver.Webhook{
-		Name:     h.Name,
+		Name:     fmt.Sprintf("%s-%d", h.Name, externalServiceID),
 		Scope:    "global",
 		Events:   []string{"pr", "repo"},
 		Endpoint: endpoint,


### PR DESCRIPTION
This ensures that when we sync webhooks with bitbucket we create one per
external service.


