### PR TITLE
docs: Fix branch prefix detection with dashes

### DIFF
--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -124,7 +124,7 @@ window.sgdocs = (() => {
       return
     }
 
-    let branchPrefix = urlPath.match(/(@[\d\w\.]+)/)[0]
+    let branchPrefix = urlPath.match(/(@[\d\w\.-]+)/)[0]
     document.querySelectorAll('#content-nav a').forEach(e => e.setAttribute('href', `/${branchPrefix}${e.getAttribute('href')}`))
   }
 

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -445,7 +445,7 @@
 {{end}}
 
 {{define "afterBody"}}
-    <script src="{{asset "docs.js"}}?15"></script>
+    <script src="{{asset "docs.js"}}?16"></script>
     {{with .Content}}
         <script>sgdocs.init(breadcrumbs = {{ .Breadcrumbs }});</script>
     {{else}}


### PR DESCRIPTION
I noticed this when admiring [the draft campaign documentation](https://docs.sourcegraph.com/@campaigns-new-flow/user/campaigns) in #10921 — if you go to a link that was rewritten to maintain the version prefix, such as any of the links in the sidebar screenshot below, the prefix is erroneously `@campaigns` instead of `@campaigns-new-flow`:

![image](https://user-images.githubusercontent.com/229984/82847657-3937ba00-9ea4-11ea-8f5d-b23cb40e146b.png)

There's probably an argument for this to just match anything except `/`, but I've chosen to be conservative here.