### PR TITLE
all: remove underscore in test function names

### DIFF
--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func Test_checkEmailAbuse(t *testing.T) {
+func TestCheckEmailAbuse(t *testing.T) {
 	ctx := testContext()
 
 	cfg := conf.Get()

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -152,7 +152,7 @@ func TestAddQueryRegexpField(t *testing.T) {
 	}
 }
 
-func Test_ErrorToAlertStructuralSearch(t *testing.T) {
+func TestErrorToAlertStructuralSearch(t *testing.T) {
 	cases := []struct {
 		name           string
 		errors         []error

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -129,7 +129,7 @@ func TestExpandUsernamesToEmails(t *testing.T) {
 	}
 }
 
-func Test_highlightMatches(t *testing.T) {
+func TestHighlightMatches(t *testing.T) {
 	type args struct {
 		pattern *regexp.Regexp
 		data    []byte

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-func Test_proposedQuotedQueries(t *testing.T) {
+func TestProposedQuotedQueries(t *testing.T) {
 	type args struct {
 		rawQuery string
 	}
@@ -66,7 +66,7 @@ func Test_proposedQuotedQueries(t *testing.T) {
 	}
 }
 
-func Test_capFirst(t *testing.T) {
+func TestCapFirst(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -720,7 +720,7 @@ func TestCompareSearchResults(t *testing.T) {
 	}
 }
 
-func Test_longer(t *testing.T) {
+func TestLonger(t *testing.T) {
 	N := 2
 	noise := time.Nanosecond
 	for dt := time.Millisecond + noise; dt < time.Hour; dt += time.Millisecond {
@@ -738,7 +738,7 @@ func Test_longer(t *testing.T) {
 	}
 }
 
-func Test_roundStr(t *testing.T) {
+func TestRoundStr(t *testing.T) {
 	tests := []struct {
 		name string
 		s    string
@@ -925,7 +925,7 @@ func TestDedupSort(t *testing.T) {
 	}
 }
 
-func Test_commitAndDiffSearchLimits(t *testing.T) {
+func TestCommitAndDiffSearchLimits(t *testing.T) {
 	cases := []struct {
 		name                 string
 		resultTypes          []string

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -45,7 +45,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	}
 }
 
-func Test_limitingSymbolResults(t *testing.T) {
+func TestLimitingSymbolResults(t *testing.T) {
 	t.Run("empty case", func(t *testing.T) {
 		var res []*FileMatchResolver
 

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -254,7 +254,7 @@ func testStringResult(result *searchSuggestionResolver) string {
 	return name
 }
 
-func Test_defaultRepositories(t *testing.T) {
+func TestDefaultRepositories(t *testing.T) {
 	tcs := []struct {
 		name             string
 		defaultsInDb     []string
@@ -339,7 +339,7 @@ func Test_defaultRepositories(t *testing.T) {
 	}
 }
 
-func Test_detectSearchType(t *testing.T) {
+func TestDetectSearchType(t *testing.T) {
 	typeRegexp := "regexp"
 	typeLiteral := "literal"
 	testCases := []struct {
@@ -376,7 +376,7 @@ func Test_detectSearchType(t *testing.T) {
 	}
 }
 
-func Test_exactlyOneRepo(t *testing.T) {
+func TestExactlyOneRepo(t *testing.T) {
 	cases := []struct {
 		repoFilters []string
 		want        bool
@@ -416,7 +416,7 @@ func Test_exactlyOneRepo(t *testing.T) {
 	}
 }
 
-func Test_QuoteSuggestions(t *testing.T) {
+func TestQuoteSuggestions(t *testing.T) {
 	t.Run("regex error", func(t *testing.T) {
 		raw := "*"
 		_, err := query.Process(raw, query.SearchTypeRegex)
@@ -468,7 +468,7 @@ func Test_QuoteSuggestions(t *testing.T) {
 	})
 }
 
-func Test_queryForStableResults(t *testing.T) {
+func TestEueryForStableResults(t *testing.T) {
 	cases := []struct {
 		query           string
 		wantStableCount int32
@@ -659,7 +659,7 @@ func TestVersionContext(t *testing.T) {
 	}
 }
 
-func Test_computeExcludedRepositories(t *testing.T) {
+func TestComputeExcludedRepositories(t *testing.T) {
 	cases := []struct {
 		Name              string
 		Query             string

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -520,7 +520,7 @@ func (es *errorSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt
 	return nil, es.err
 }
 
-func Test_zoektSearchHEAD(t *testing.T) {
+func TestZoektSearchHEAD(t *testing.T) {
 	zeroTimeoutCtx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 	type args struct {
@@ -725,7 +725,7 @@ func (repoURLsFakeSearcher) Close() {
 	panic("unimplemented")
 }
 
-func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
+func TestCreateNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	searcher := repoURLsFakeSearcher{
 		"github.com/test/1": []string{"1.md"},
 		"github.com/test/2": []string{"2.md"},
@@ -831,7 +831,7 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	}
 }
 
-func Test_zoektIndexedRepos(t *testing.T) {
+func TestZoektIndexedRepos(t *testing.T) {
 	repos := makeRepositoryRevisions(
 		"foo/indexed-one@",
 		"foo/indexed-two@",

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -211,7 +211,7 @@ func zoektRPC(s zoekt.Searcher) (zoekt.Searcher, func()) {
 	}
 }
 
-func Test_ZoektSingleIndexedRepo(t *testing.T) {
+func TestZoektSingleIndexedRepo(t *testing.T) {
 	repoRev := func(revSpec string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
 			Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -162,7 +162,7 @@ func TestNewCommon_repo_error(t *testing.T) {
 	}
 }
 
-func Test_redirectTreeOrBlob(t *testing.T) {
+func TestRedirectTreeOrBlob(t *testing.T) {
 	tests := []struct {
 		name          string
 		route         string

--- a/cmd/frontend/internal/app/usage_stats_test.go
+++ b/cmd/frontend/internal/app/usage_stats_test.go
@@ -16,7 +16,7 @@ func init() {
 	dbtesting.DBNameSuffix = "app"
 }
 
-func Test_usageStatsArchiveHandler(t *testing.T) {
+func TestUsageStatsArchiveHandler(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 )
 
-func Test_checkEmailAbuse(t *testing.T) {
+func TestCheckEmailAbuse(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now()

--- a/cmd/gitserver/main_test.go
+++ b/cmd/gitserver/main_test.go
@@ -3,7 +3,7 @@ package main
 
 import "testing"
 
-func Test_parsePercent(t *testing.T) {
+func TestParsePercent(t *testing.T) {
 	tests := []struct {
 		s       string
 		want    int

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -355,7 +355,7 @@ func TestRemoveRepoDirectory_Empty(t *testing.T) {
 	)
 }
 
-func Test_howManyBytesToFree(t *testing.T) {
+func TestHowManyBytesToFree(t *testing.T) {
 	const G = 1024 * 1024 * 1024
 	s := &Server{
 		DesiredPercentFree: 10,

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func Test_projectQueryToURL(t *testing.T) {
+func TestProjectQueryToURL(t *testing.T) {
 	tests := []struct {
 		projectQuery string
 		perPage      int

--- a/cmd/repo-updater/repos/purge_test.go
+++ b/cmd/repo-updater/repos/purge_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Test_isSaturdayNight(t *testing.T) {
+func TestIsSaturdayNight(t *testing.T) {
 	cases := map[string]bool{
 		"2012-11-01T22:08:41+00:00": false,
 		"2012-11-03T22:08:41+00:00": true,

--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -533,7 +533,7 @@ func init() {
 	os.RemoveAll(githubStore.Path)
 }
 
-func Test_regexSearch(t *testing.T) {
+func TestRegexSearch(t *testing.T) {
 	match, err := pathmatch.CompilePathPatterns([]string{`a\.go`}, `README\.md`, pathmatch.CompileOptions{RegExp: true})
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config_test.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func Test_parseConfig(t *testing.T) {
+func TestParseConfig(t *testing.T) {
 	spew.Config.DisablePointerAddresses = true
 	spew.Config.SortKeys = true
 	spew.Config.SpewKeys = true

--- a/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func Test_requestedScopes(t *testing.T) {
+func TestRequestedScopes(t *testing.T) {
 	defer envvar.MockSourcegraphDotComMode(false)
 
 	tests := []struct {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/config_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func Test_parseConfig(t *testing.T) {
+func TestParseConfig(t *testing.T) {
 	spew.Config.DisablePointerAddresses = true
 	spew.Config.SortKeys = true
 	spew.Config.SpewKeys = true

--- a/enterprise/cmd/frontend/authz/authz_test.go
+++ b/enterprise/cmd/frontend/authz/authz_test.go
@@ -53,7 +53,7 @@ func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repos
 	panic("should never be called")
 }
 
-func Test_authzProvidersFromConfig(t *testing.T) {
+func TestAuthzProvidersFromConfig(t *testing.T) {
 	gitlab.NewOAuthProvider = func(op gitlab.OAuthProviderOp) authz.Provider {
 		op.MockCache = nil // ignore cache value
 		return gitlabAuthzProviderParams{OAuthOp: op}

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -227,7 +227,7 @@ func TestProvider_RepoPerms(t *testing.T) {
 	}
 }
 
-func Test_fetchUserRepos(t *testing.T) {
+func TestFetchUserRepos(t *testing.T) {
 	mockClient := &mockClient{
 		MockGetRepositoriesByNodeIDFromAPI: func(ctx context.Context, nodeIDs []string) (map[string]*github.Repository, error) {
 			return map[string]*github.Repository{

--- a/internal/conf/reposource/custom_test.go
+++ b/internal/conf/reposource/custom_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-func Test_customCloneURLToRepoName(t *testing.T) {
+func TestCustomCloneURLToRepoName(t *testing.T) {
 	tests := []struct {
 		cloneURLResolvers  []*cloneURLResolver
 		cloneURLToRepoName map[string]string

--- a/internal/db/dbconn/dbconn_test.go
+++ b/internal/db/dbconn/dbconn_test.go
@@ -2,7 +2,7 @@ package dbconn
 
 import "testing"
 
-func Test_buildConnectionString(t *testing.T) {
+func TestBuildConnectionString(t *testing.T) {
 	tests := []struct {
 		name                   string
 		dataSource             string

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -71,7 +71,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func Test_newRepoCache(t *testing.T) {
+func TestNewRepoCache(t *testing.T) {
 	cmpOpts := cmp.AllowUnexported(rcache.Cache{})
 	t.Run("GitHub.com", func(t *testing.T) {
 		url, _ := url.Parse("https://www.github.com")

--- a/internal/extsvc/gitolite/repos_test.go
+++ b/internal/extsvc/gitolite/repos_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_decodeRepos(t *testing.T) {
+func TestDecodeRepos(t *testing.T) {
 	tests := []struct {
 		name         string
 		host         string

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_parseParameterList(t *testing.T) {
+func TestScanParameter(t *testing.T) {
 	cases := []struct {
 		Name  string
 		Input string
@@ -84,7 +84,7 @@ func Test_parseParameterList(t *testing.T) {
 	}
 }
 
-func Test_ScanField(t *testing.T) {
+func TestScanField(t *testing.T) {
 	type value struct {
 		Field   string
 		Advance int
@@ -215,7 +215,7 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 	return newOperator(nodes, And), nil
 }
 
-func Test_Parse(t *testing.T) {
+func TestParse(t *testing.T) {
 	type relation string         // a relation for comparing test outputs of queries parsed according to grammar and heuristics.
 	const Same relation = "Same" // a constant that says heuristic output is interpreted the same as the grammar spec.
 	type Spec = relation         // constructor for expected output of the grammar spec without heuristics.
@@ -671,7 +671,7 @@ func Test_Parse(t *testing.T) {
 	}
 }
 
-func Test_ScanDelimited(t *testing.T) {
+func TestScanDelimited(t *testing.T) {
 	type result struct {
 		Value  string
 		Count  int
@@ -762,7 +762,7 @@ func Test_ScanDelimited(t *testing.T) {
 	}
 }
 
-func Test_ParseLiteralSearch(t *testing.T) {
+func TestParseLiteralSearch(t *testing.T) {
 	cases := []struct {
 		Input string
 		Want  string

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -15,7 +15,7 @@ func prettyPrint(nodes []Node) string {
 	return strings.Join(resultStr, " ")
 }
 
-func Test_SubstituteAliases(t *testing.T) {
+func TestSubstituteAliases(t *testing.T) {
 	input := "r:repo g:repogroup f:file"
 	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
 	query, _ := ParseAndOr(input)
@@ -25,7 +25,7 @@ func Test_SubstituteAliases(t *testing.T) {
 	}
 }
 
-func Test_LowercaseFieldNames(t *testing.T) {
+func TestLowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
 	query, _ := ParseAndOr(input)
@@ -35,7 +35,7 @@ func Test_LowercaseFieldNames(t *testing.T) {
 	}
 }
 
-func Test_Hoist(t *testing.T) {
+func TestHoist(t *testing.T) {
 	cases := []struct {
 		input      string
 		want       string

--- a/internal/search/query/types/check_test.go
+++ b/internal/search/query/types/check_test.go
@@ -154,7 +154,7 @@ func TestRegexpCompile(t *testing.T) {
 	})
 }
 
-func Test_autoFix(t *testing.T) {
+func TestAutoFix(t *testing.T) {
 	t.Run("handcrafted cases", func(t *testing.T) {
 		tests := []struct {
 			pat  string

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
 
-func Test_valueToTypedValue(t *testing.T) {
+func TestValueToTypedValue(t *testing.T) {
 	value := ".*"
 	t.Run("is quoted is string", func(t *testing.T) {
 		inputQuoted := true

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -146,7 +146,7 @@ func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {
 	}
 }
 
-func Test_PartitionSearchPattern(t *testing.T) {
+func TestPartitionSearchPattern(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -242,7 +242,7 @@ func Test_PartitionSearchPattern(t *testing.T) {
 	}
 }
 
-func Test_ContainsAndOrKeyword(t *testing.T) {
+func TestContainsAndOrKeyword(t *testing.T) {
 	if !ContainsAndOrKeyword("foo OR bar") {
 		t.Errorf("Expected query to contain keyword")
 	}


### PR DESCRIPTION
As in title. I added underscores to my tests because I've seen it in other places, and I realize this is a Go convention for some projects, but should not necessarily be for ours. I tend to agree with @keegancsmith:

>  I think its pretty rare in our codebase and I am not sure I am a fan of it.

For consistency I'm putting up this PR to remove underscores throughout.

If these seem overzealous, LMK.