### PR TITLE
codeintel: Limit bandwidth to/from bundle manager

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
+	"github.com/mxk/go-flowrate/flowrate"
 	"github.com/opentracing/opentracing-go/ext"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,7 +59,7 @@ func (s *Server) handleGetUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	if n, err := io.Copy(w, file); err != nil {
+	if n, err := io.Copy(limitTransferRate(file), file); err != nil {
 		if isConnectionError(err) {
 			log15.Error("Failure to transfer upload from bundle from manager", "n", n)
 		}
@@ -342,6 +343,15 @@ func (s *Server) wrapReader(innerReader reader.Reader) reader.Reader {
 
 func (s *Server) wrapDatabase(innerDatabase database.Database, filename string) database.Database {
 	return database.NewObserved(innerDatabase, filename, s.observationContext)
+}
+
+// limitTransferRate applies a transfer limit to the given writer.
+//
+// In the case that the remote server is running on the same host as this service, an unbounded
+// transfer rate can end up being so fast that we harm our own network connectivity. In order to
+// prevent the disruption of other in-flight requests, we cap the transfer rate of w to 1Gbps.
+func limitTransferRate(w io.Writer) io.Writer {
+	return flowrate.NewWriter(w, 1000*1000*1000)
 }
 
 //

--- a/internal/codeintel/bundles/client/bundle_manager_client.go
+++ b/internal/codeintel/bundles/client/bundle_manager_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
+	"github.com/mxk/go-flowrate/flowrate"
 	"github.com/neelance/parallel"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
@@ -274,7 +275,7 @@ func (c *bundleManagerClientImpl) do(ctx context.Context, method string, url *ur
 		span.Finish()
 	}()
 
-	req, err := http.NewRequest(method, url.String(), body)
+	req, err := http.NewRequest(method, url.String(), limitTransferRate(body))
 	if err != nil {
 		return nil, err
 	}
@@ -341,6 +342,19 @@ func makeURL(baseURL, path string, qs map[string]interface{}) (*url.URL, error) 
 
 func makeBundleURL(baseURL string, bundleID int, op string, qs map[string]interface{}) (*url.URL, error) {
 	return makeURL(baseURL, fmt.Sprintf("dbs/%d/%s", bundleID, op), qs)
+}
+
+// limitTransferRate applies a transfer limit to the given reader.
+//
+// In the case that the bundle manager is running on the same host as this service, an unbounded
+// transfer rate can end up being so fast that we harm our own network connectivity. In order to
+// prevent the disruption of other in-flight requests, we cap the transfer rate of r to 1Gbps.
+func limitTransferRate(r io.Reader) io.ReadCloser {
+	if r == nil {
+		return nil
+	}
+
+	return flowrate.NewReader(r, 1000*1000*1000)
 }
 
 //


### PR DESCRIPTION
This is an attempt to mitigate https://github.com/sourcegraph/sourcegraph/issues/10913. @slimsag has a good theory that hitting a certain bandwidth threshold between two services on the same host results in this behavior (and a similar remedy was applied to gitserver/zoekt transfers in the past).

Additional context in https://sourcegraph.slack.com/archives/CHXHX7XAS/p1590092732193100 and https://sourcegraph.slack.com/archives/CHXHX7XAS/p1590414535217300.