### PR TITLE
graphql: make mutation support multi-level permissions

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -73,9 +73,11 @@ type UserIDArgs struct {
 }
 
 type RepoPermsArgs struct {
-	Repository graphql.ID
-	BindIDs    []string
-	Perm       string
+	Repository      graphql.ID
+	UserPermissions []struct {
+		BindID     string
+		Permission string
+	}
 }
 
 type AuthorizedRepoArgs struct {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -306,7 +306,7 @@ func (r *RepositoryResolver) LSIFUploads(ctx context.Context, args *LSIFUploadsQ
 
 type AuthorizedUserArgs struct {
 	RepositoryID graphql.ID
-	Perm         string
+	Permission   string
 	First        int32
 	After        *string
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -395,14 +395,10 @@ type Mutation {
     setRepositoryPermissionsForUsers(
         # The repository whose permissions to set.
         repository: ID!
-        # A list of user identifiers, which define the set of users who may view the repository. All
-        # users not included in the list will not be permitted to view the repository on
-        # Sourcegraph. Depending on the bindID option in the permissions.userMapping site
-        # configuration property, the elements of the list are either all usernames (bindID of
-        # "username") or all email addresses (bindID of "email").
-        bindIDs: [String!]!
-        # The level of repository permission.
-        perm: RepositoryPermission = READ
+        # A list of user identifiers and their repository permissions, which defines the set of
+        # users who may view the repository. All users not included in the list will not be
+        # permitted to view the repository on Sourcegraph.
+        userPermissions: [UserPermission!]!
     ): EmptyResponse!
     # Schedule a permissions sync for given repository. This queries the repository's code host for
     # all users' permissions associated with the repository, so that the current permissions apply
@@ -412,6 +408,16 @@ type Mutation {
     # repository permissions and syncs them to Sourcegraph, so that the current permissions apply to
     # the user's operations on Sourcegraph.
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
+}
+
+# A user (identified either by username or email address) with its repository permission.
+input UserPermission {
+    # Depending on the bindID option in the permissions.userMapping site configuration property,
+    # the elements of the list are either all usernames (bindID of "username") or all email
+    # addresses (bindID of "email").
+    bindID: String!
+    # The highest level of repository permission.
+    permission: RepositoryPermission = READ
 }
 
 # A patch to apply to a repository (in a new branch) when a campaign is created
@@ -1760,7 +1766,7 @@ type Repository implements Node & GenericSearchResultInterface {
     # "permissions.userMapping" in site configuration.
     authorizedUsers(
         # Permission that the user has on this repository.
-        perm: RepositoryPermission = READ
+        permission: RepositoryPermission = READ
         # Number of users to return after the given cursor.
         first: Int!
         # Opaque pagination cursor.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -402,14 +402,10 @@ type Mutation {
     setRepositoryPermissionsForUsers(
         # The repository whose permissions to set.
         repository: ID!
-        # A list of user identifiers, which define the set of users who may view the repository. All
-        # users not included in the list will not be permitted to view the repository on
-        # Sourcegraph. Depending on the bindID option in the permissions.userMapping site
-        # configuration property, the elements of the list are either all usernames (bindID of
-        # "username") or all email addresses (bindID of "email").
-        bindIDs: [String!]!
-        # The level of repository permission.
-        perm: RepositoryPermission = READ
+        # A list of user identifiers and their repository permissions, which defines the set of
+        # users who may view the repository. All users not included in the list will not be
+        # permitted to view the repository on Sourcegraph.
+        userPermissions: [UserPermission!]!
     ): EmptyResponse!
     # Schedule a permissions sync for given repository. This queries the repository's code host for
     # all users' permissions associated with the repository, so that the current permissions apply
@@ -419,6 +415,16 @@ type Mutation {
     # repository permissions and syncs them to Sourcegraph, so that the current permissions apply to
     # the user's operations on Sourcegraph.
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
+}
+
+# A user (identified either by username or email address) with its repository permission.
+input UserPermission {
+    # Depending on the bindID option in the permissions.userMapping site configuration property,
+    # the elements of the list are either all usernames (bindID of "username") or all email
+    # addresses (bindID of "email").
+    bindID: String!
+    # The highest level of repository permission.
+    permission: RepositoryPermission = READ
 }
 
 # A patch to apply to a repository (in a new branch) when a campaign is created
@@ -1767,7 +1773,7 @@ type Repository implements Node & GenericSearchResultInterface {
     # "permissions.userMapping" in site configuration.
     authorizedUsers(
         # Permission that the user has on this repository.
-        perm: RepositoryPermission = READ
+        permission: RepositoryPermission = READ
         # Number of users to return after the given cursor.
         first: Int!
         # Opaque pagination cursor.

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -251,13 +251,17 @@ Next, set the list of users allowed to view the repository:
 
 ```graphql
 mutation {
-  setRepositoryPermissionsForUsers(repository: "<repo ID>", bindIDs: ["user@example.com"]) {
+  setRepositoryPermissionsForUsers(
+    repository: "<repo ID>", 
+    userPermissions: [
+      { bindID: "user@example.com" }
+    ]) {
     alwaysNil
   }
 }
 ```
 
-Now, only the users specified in the `bindIDs` parameter will be allowed to view the repository. Sourcegraph automatically enforces these permissions for all operations. (Site admins bypass all permissions checks and can always view all repositories.)
+Now, only the users specified in the `userPermissions` parameter will be allowed to view the repository. Sourcegraph automatically enforces these permissions for all operations. (Site admins bypass all permissions checks and can always view all repositories.)
 
 You can call `setRepositoryPermissionsForUsers` repeatedly to set permissions for each repository, and whenever you want to change the list of authorized users.
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -54,13 +54,13 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	}
 
 	// Filter out bind IDs that only contains whitespaces.
-	bindIDs := args.BindIDs[:0]
-	for i := range args.BindIDs {
-		args.BindIDs[i] = strings.TrimSpace(args.BindIDs[i])
-		if len(args.BindIDs[i]) == 0 {
+	bindIDs := make([]string, 0, len(args.UserPermissions))
+	for _, perms := range args.UserPermissions {
+		bindID := strings.TrimSpace(perms.BindID)
+		if bindID == "" {
 			continue
 		}
-		bindIDs = append(bindIDs, args.BindIDs[i])
+		bindIDs = append(bindIDs, bindID)
 	}
 
 	bindIDSet := make(map[string]struct{})

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -98,7 +98,10 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				mutation {
 					setRepositoryPermissionsForUsers(
 						repository: "UmVwb3NpdG9yeTox",
-						bindIDs: ["alice@example.com", "bob"]) {
+						userPermissions: [
+							{ bindID: "alice@example.com"},
+							{ bindID: "bob"}
+						]) {
 						alwaysNil
 					}
 				}
@@ -137,7 +140,10 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				mutation {
 					setRepositoryPermissionsForUsers(
 						repository: "UmVwb3NpdG9yeTox",
-						bindIDs: ["alice", "bob"]) {
+						userPermissions: [
+							{ bindID: "alice"},
+							{ bindID: "bob"}
+						]) {
 						alwaysNil
 					}
 				}
@@ -146,7 +152,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				{
 					"setRepositoryPermissionsForUsers": {
 						"alwaysNil": null
-    				}
+					}
 				}
 			`,
 				},


### PR DESCRIPTION
Makes our `setRepositoryPermissionsForUsers` mutation support multi-level permissions.

We don't have multi-level permission as of now and no one is actually using this mutation AFAIK. But good to be prepared for RFC 151.

Fixes #10952