### PR TITLE
authz: add docs and links to background permissions syncing

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -207,6 +207,12 @@ Since the syncing of permissions happens in the background, there are a few thin
 
 Please contact [support@sourcegraph.com](mailto:support@sourcegraph.com) if you have any concerns/questions about enabling this feature for your Sourcegraph instance.
 
+### Complete sync vs incremental sync
+
+A complete sync means a repository or user has done a repository-centric or user-centric syncing respectively, which presists the most accurate permissions from code hosts to Sourcegraph.
+
+An incremental sync is in fact a side effect of a complete sync because a user may grant or lose access to repositories and we react to such changes as soon as we know to improve permissions accuracy.
+
 ## Explicit permissions API
 
 Sourcegraph exposes a GraphQL API to explicitly set repository permissions. This will become the primary

--- a/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -56,6 +56,9 @@ export const RepoSettingsPermissionsPage: React.FunctionComponent<{ repo: GQL.IR
                     <ScheduleRepositoryPermissionsSyncActionContainer repo={repo} history={history} />
                 </div>
             )}
+            <a href="/help/admin/repo/permissions#background-permissions-syncing">
+                Learn more about background permissions synching.
+            </a>
         </div>
     )
 }

--- a/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -56,6 +56,9 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: GQL.IU
                     <ScheduleUserPermissionsSyncActionContainer user={user} history={history} />
                 </div>
             )}
+            <a href="/help/admin/repo/permissions#background-permissions-syncing">
+                Learn more about background permissions synching.
+            </a>
         </div>
     )
 }


### PR DESCRIPTION
Adds a section in docs to explain "complete sync vs incremental sync", and adds links to docs in corresponding pages.

Fixes #10190