### PR TITLE
authz: turn on background permissions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Repository search within a version context will link to the revision in the version context. [#10860](https://github.com/sourcegraph/sourcegraph/pull/10860)
-- Background permissions syncing becomes the default method to sync permissions from code hosts. Please [read our documentation for things to keep in mind before upgrade](https://docs.sourcegraph.com/admin/repo/permissions#background-permissions-syncing). [#10972](https://github.com/sourcegraph/sourcegraph/pull/10972)  
+- Background permissions syncing becomes the default method to sync permissions from code hosts. Please [read our documentation for things to keep in mind before upgrade](https://docs.sourcegraph.com/admin/repo/permissions#background-permissions-syncing). [#10972](https://github.com/sourcegraph/sourcegraph/pull/10972)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Repository search within a version context will link to the revision in the version context. [#10860](https://github.com/sourcegraph/sourcegraph/pull/10860)
-- Background permissions syncing becomes the default method to sync permissions from code hosts. Please [read our documentation for things to keep in mind before upgrade](https://docs.sourcegraph.com/admin/repo/permissions#background-permissions-syncing). [#10972](https://github.com/sourcegraph/sourcegraph/pull/10972)
+- Background permissions syncing becomes the default method to sync permissions from code hosts. Please [read our documentation for things to keep in mind before upgrading](https://docs.sourcegraph.com/admin/repo/permissions#background-permissions-syncing). [#10972](https://github.com/sourcegraph/sourcegraph/pull/10972)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Repository search within a version context will link to the revision in the version context. [#10860](https://github.com/sourcegraph/sourcegraph/pull/10860)
+- Background permissions syncing becomes the default method to sync permissions from code hosts. Please [read our documentation for things to keep in mind before upgrade](https://docs.sourcegraph.com/admin/repo/permissions#background-permissions-syncing). [#10972](https://github.com/sourcegraph/sourcegraph/pull/10972)  
 
 ### Fixed
 

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -90,6 +90,10 @@ func getNames(rs []*types.Repo) []string {
 }
 
 func Test_authzFilter(t *testing.T) {
+	before := globals.PermissionsBackgroundSync()
+	globals.SetPermissionsBackgroundSync(&schema.PermissionsBackgroundSync{Enabled: false})
+	defer globals.SetPermissionsBackgroundSync(before)
+
 	repos := map[api.RepoName]*types.Repo{}
 	for _, r := range makeRepos(
 		"gitlab.mine/org/r0",
@@ -865,10 +869,6 @@ func Test_authzFilter_permissionsUserMapping(t *testing.T) {
 }
 
 func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
-	before := globals.PermissionsBackgroundSync()
-	globals.SetPermissionsBackgroundSync(&schema.PermissionsBackgroundSync{Enabled: true})
-	defer globals.SetPermissionsBackgroundSync(before)
-
 	publicRepo := makeRepo("gitlab.mine/user/public", 1, false)
 	privateRepo := makeRepo("gitlab.mine/user/private", 2, true)
 

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -117,7 +117,7 @@ func SetPermissionsUserMapping(u *schema.PermissionsUserMapping) {
 // This variable is used to monitor configuration change via conf.Watch and must be operated atomically.
 var permissionsBackgroundSync = func() atomic.Value {
 	var v atomic.Value
-	v.Store(&schema.PermissionsBackgroundSync{Enabled: false})
+	v.Store(&schema.PermissionsBackgroundSync{Enabled: true})
 	return v
 }()
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -393,7 +393,7 @@
         "enabled": {
           "description": "Whether syncing permissions in the background is enabled.",
           "type": "boolean",
-          "default": false
+          "default": true
         }
       },
       "default": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -398,7 +398,7 @@ const SiteSchemaJSON = `{
         "enabled": {
           "description": "Whether syncing permissions in the background is enabled.",
           "type": "boolean",
-          "default": false
+          "default": true
         }
       },
       "default": {


### PR DESCRIPTION
Instances use repository permissions will start using background permissions syncing by default.

Fixes #10657