### PR TITLE
search: separate parameters and pattern types in parse tree

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -874,10 +874,13 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 			r.query = query.AndOrQuery{Query: q}
 			return r.evaluateLeaf(ctx)
 		}
-	case query.Parameter:
+	case query.Pattern:
 		q := append(scopeParameters, term)
 		r.query = query.AndOrQuery{Query: q}
 		return r.evaluateLeaf(ctx)
+	case query.Parameter:
+		// evaluatePatternExpression does not process Parameter nodes.
+		return nil, nil
 	}
 	// Unreachable.
 	return nil, fmt.Errorf("unrecognized type %s in evaluatePatternExpression", reflect.TypeOf(node).String())

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -740,7 +740,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 	want := 5
 
 	var countStr string
-	query.VisitField(scopeParameters, "count", func(value string, _, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
 		countStr = value
 	})
 	if countStr != "" {
@@ -812,7 +812,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 
 	var countStr string
 	wantCount := defaultMaxSearchResults
-	query.VisitField(scopeParameters, "count", func(value string, _, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
 		countStr = value
 	})
 	if countStr != "" {

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -142,6 +142,19 @@ var tests = []test{
 		Name:  `Global search, exclude counts for fork and archive`,
 		Query: `repo:mux|archive|caddy`,
 	},
+	// And/Or queries.
+	{
+		Name:  `Literals, escaped`,
+		Query: `repo:^github\.com/facebook/react$ (\(\) or \(\)) stable:yes type:file count:1 patterntype:regexp`,
+	},
+	{
+		Name:  `Literals, no parens escaped`,
+		Query: `repo:^github\.com/facebook/react$ \(\) or \(\) stable:yes type:file count:1 patterntype:regexp`,
+	},
+	{
+		Name:  `And operator, basic`,
+		Query: `repo:^github\.com/facebook/react$ func and main stable:yes type:file count:1 file:^dangerfile.js$`,
+	},
 }
 
 func sanitizeFilename(s string) string {

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -7,6 +7,7 @@ type Mapper interface {
 	MapNodes(v Mapper, node []Node) []Node
 	MapOperator(v Mapper, kind operatorKind, operands []Node) []Node
 	MapParameter(v Mapper, field, value string, negated bool) Node
+	MapPattern(v Mapper, value string, negated, quoted bool) Node
 }
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
@@ -18,6 +19,8 @@ func (*BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
 	mapped := []Node{}
 	for _, node := range nodes {
 		switch v := node.(type) {
+		case Pattern:
+			mapped = append(mapped, visitor.MapPattern(visitor, v.Value, v.Negated, v.Quoted))
 		case Parameter:
 			mapped = append(mapped, visitor.MapParameter(visitor, v.Field, v.Value, v.Negated))
 		case Operator:
@@ -35,6 +38,11 @@ func (*BaseMapper) MapOperator(visitor Mapper, kind operatorKind, operands []Nod
 // Base mapper for Parameters. It is the identity function.
 func (*BaseMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
 	return Parameter{Field: field, Value: value, Negated: negated}
+}
+
+// Base mapper for Patterns. It is the identity function.
+func (*BaseMapper) MapPattern(visitor Mapper, value string, negated bool, quoted bool) Node {
+	return Pattern{Value: value, Negated: negated, Quoted: quoted}
 }
 
 // ParameterMapper is a helper mapper that only maps parameters in a query. It

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -41,7 +41,7 @@ func (*BaseMapper) MapParameter(visitor Mapper, field, value string, negated boo
 }
 
 // Base mapper for Patterns. It is the identity function.
-func (*BaseMapper) MapPattern(visitor Mapper, value string, negated bool, quoted bool) Node {
+func (*BaseMapper) MapPattern(visitor Mapper, value string, negated, quoted bool) Node {
 	return Pattern{Value: value, Negated: negated, Quoted: quoted}
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -33,15 +33,22 @@ type Node interface {
 }
 
 // All terms that implement Node.
+func (Pattern) node()   {}
 func (Parameter) node() {}
 func (Operator) node()  {}
 
-// Parameter is a leaf node of expressions.
+// Pattern is a leaf node of expressions representing a search pattern fragment.
+type Pattern struct {
+	Value   string `json:"value"`   // The sourcegraph part in repo:sourcegraph.
+	Negated bool   `json:"negated"` // True if this pattern is negated.
+	Quoted  bool   `json:"quoted"`  // True if the parsed value was quoted.
+}
+
+// Parameter is a leaf node of expressions representing a parameter of format "repo:foo".
 type Parameter struct {
 	Field   string `json:"field"`   // The repo part in repo:sourcegraph.
 	Value   string `json:"value"`   // The sourcegraph part in repo:sourcegraph.
 	Negated bool   `json:"negated"` // True if the - prefix exists, as in -repo:sourcegraph.
-	Quoted  bool   `json:"quoted"`  // True if the parsed value was quoted.
 }
 
 type operatorKind int
@@ -56,6 +63,16 @@ const (
 type Operator struct {
 	Kind     operatorKind
 	Operands []Node
+}
+
+func (node Pattern) String() string {
+	var v string
+	if node.Negated {
+		v = fmt.Sprintf("NOT %s", node.Value)
+	} else {
+		v = node.Value
+	}
+	return strconv.Quote(v)
 }
 
 func (node Parameter) String() string {
@@ -446,10 +463,10 @@ loop:
 // be interpreted as a pattern, and not, e.g., as a filter:value parameter.
 func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	if !p.heuristic.parensAsPatterns || p.heuristic.allowDanglingParens {
-		return Parameter{Field: "", Value: ""}, false
+		return Pattern{}, false
 	}
 	if value, ok := p.TryParseDelimiter(); ok {
-		return Parameter{Field: "", Value: value}, true
+		return Pattern{Value: value}, true
 	}
 
 	start := p.pos
@@ -458,18 +475,18 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	if !ok || len(p.buf[start:end]) == 0 || !isPureSearchPattern(p.buf[start:end]) {
 		// We tried validating the pattern but it is either unbalanced
 		// or malformed, empty, or an invalid and/or expression.
-		return Parameter{Field: "", Value: ""}, false
+		return Pattern{}, false
 	}
 	// The heuristic succeeds: we can process the string as a pure search pattern.
 	p.pos += advance
 	if len(pieces) == 1 {
-		return Parameter{Field: "", Value: pieces[0]}, true
+		return Pattern{Value: pieces[0]}, true
 	}
-	parameters := []Node{}
+	patterns := []Node{}
 	for _, piece := range pieces {
-		parameters = append(parameters, Parameter{Field: "", Value: piece})
+		patterns = append(patterns, Pattern{Value: piece})
 	}
-	return Operator{Kind: Concat, Operands: parameters}, true
+	return Operator{Kind: Concat, Operands: patterns}, true
 }
 
 // ScanValue scans for a value (e.g., of a parameter, or a string corresponding
@@ -536,8 +553,8 @@ func ScanValue(buf []byte, allowDanglingParens bool) (string, int) {
 	return string(result), count
 }
 
-// TryParseDelimiter tries to parse a delimited, returning whether it succeeded,
-// and the interpreted (i.e., unquoted) value if it succeeds.
+// TryParseDelimiter tries to parse a delimited string, returning whether it
+// succeeded, and the interpreted (i.e., unquoted) value if it succeeds.
 func (p *parser) TryParseDelimiter() (string, bool) {
 	delimited := func(delimiter rune) (string, error) {
 		value, advance, err := ScanDelimited(p.buf[p.pos:], delimiter)
@@ -562,72 +579,86 @@ func (p *parser) TryParseDelimiter() (string, bool) {
 	return "", false
 }
 
-// ParseValue parses a value at the current position and whether it was quoted.
-// A value may belong to a parameter like repo:<value> or the <value> may be a
-// search pattern. Values may be quoted. ParseValue cannot fail: it will first
-// try to scan well-formed delimiters, like quoted strings. If that fails, it
-// will accept unbalanced strings as patterns. Uses of value can then be
-// validated along other concerns for different search types (literal, regexp,
-// etc.).
-func (p *parser) ParseValue() (string, bool) {
-	if value, ok := p.TryParseDelimiter(); ok {
-		return value, true
+// ParseFieldValue parses a value followed by a field like "repo:". If the value
+// starts with a recognized quoting delimiter but does not close it, an error is
+// returned.
+func (p *parser) ParseFieldValue() (string, error) {
+	delimited := func(delimiter rune) (string, error) {
+		value, advance, err := ScanDelimited(p.buf[p.pos:], delimiter)
+		if err != nil {
+			return "", err
+		}
+		p.pos += advance
+		return value, nil
+	}
+	if p.match(SQUOTE) {
+		return delimited('\'')
+	}
+	if p.match(DQUOTE) {
+		return delimited('"')
 	}
 	value, advance := ScanValue(p.buf[p.pos:], p.heuristic.allowDanglingParens)
 	p.pos += advance
-	return value, false
+	return value, nil
 }
 
-// ParseParameter returns a leaf node usable by _any_ kind of search (e.g.,
-// literal or regexp, or...) and always succeeds.
-//
-// A parameter is a contiguous sequence of characters, where the following two forms are distinguished:
-// (1) a string of syntax field:<string> where : matches the first encountered colon, and field must match ^-?[a-zA-Z]+
-// (2) <string>
-//
-// When a parameter is of form (1), the <string> corresponds to Parameter.Value,
-// field corresponds to Parameter.Field and Parameter.Negated is set if Field
-// starts with '-'. When form (1) does not match, Value corresponds to <string>
-// and Field is the empty string.
-func (p *parser) ParseParameter() Parameter {
-	field, advance := ScanField(p.buf[p.pos:])
-	p.pos += advance
+// ParsePattern parses a leaf node Pattern that corresponds to a search pattern.
+// Note that ParsePattern may be called multiple times (a query can have
+// multiple Patterns concatenated together).
+func (p *parser) ParsePattern() Pattern {
+	if p.heuristic.literalSearchPatterns {
+		// Accept unconditionally as pattern, even if the pattern
+		// contains dangling quotes like " or ', and do not interpret
+		// quoted strings as quoted, but interpret them literally.
+		value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
+		p.pos += advance
+		return Pattern{Value: value, Negated: false, Quoted: false}
+	}
 
-	negated := len(field) > 0 && field[0] == '-'
+	// If we can parse a well-delimited value, that takes precedence, and we
+	// denote it with Quoted set to true.
+	if value, ok := p.TryParseDelimiter(); ok {
+		return Pattern{Value: value, Negated: false, Quoted: true}
+	}
+
+	value, advance := ScanValue(p.buf[p.pos:], p.heuristic.allowDanglingParens)
+	p.pos += advance
+	// Invariant: the pattern can't be quoted since we checked for that.
+	return Pattern{Value: value, Negated: false, Quoted: false}
+}
+
+// ParseParameter returns a leaf node corresponding to the syntax
+// (-?)field:<string> where : matches the first encountered colon, and field
+// must match ^[a-zA-Z]+ and be whitelisted by allFields. Field may optionally
+// be preceded by '-' which means the parameter is negated.
+func (p *parser) ParseParameter() (Parameter, bool, error) {
+	field, advance := ScanField(p.buf[p.pos:])
+	if len(field) == 0 {
+		return Parameter{}, false, nil
+	}
+
+	negated := field[0] == '-'
 	if negated {
 		field = field[1:]
 	}
 
-	if p.heuristic.literalSearchPatterns {
-		if field == "" {
-			// No foo: prefix was parsed, accept as pattern.
-			value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
-			p.pos += advance
-			return Parameter{Field: "", Value: value, Negated: false, Quoted: false}
-		}
-		if _, exists := allFields[field]; !exists {
-			// A foo: prefix was parsed, but it's not a recognized
-			// field. Accept as pattern.
-			value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
-			// Rebuild the (-?)foo:bar string.
-			value = field + ":" + value
-			if negated {
-				value = "-" + value
-			}
-			p.pos += advance
-			return Parameter{Field: "", Value: value, Negated: false, Quoted: false}
-		}
+	if _, exists := allFields[strings.ToLower(field)]; !exists {
+		// Not a recognized parameter field.
+		return Parameter{}, false, nil
 	}
 
-	value, quoted := p.ParseValue()
-	return Parameter{Field: field, Value: value, Negated: negated, Quoted: quoted}
+	p.pos += advance
+	value, err := p.ParseFieldValue()
+	if err != nil {
+		return Parameter{}, false, err
+	}
+	return Parameter{Field: field, Value: value, Negated: negated}, true, nil
 }
 
-// containsPattern returns true if any descendent of nodes is a search pattern
-// (i.e., a parameter where the field is the empty string).
+// containsPattern returns true if any descendent of nodes is a search pattern.
 func containsPattern(node Node) bool {
 	var result bool
-	VisitField([]Node{node}, "", func(_ string, _, _ bool) {
+	VisitPattern([]Node{node}, func(_ string, _, _ bool) {
 		result = true
 	})
 	return result
@@ -646,8 +677,7 @@ func containsAndOrExpression(nodes []Node) bool {
 
 // partitionParameters constructs a parse tree to distinguish terms where
 // ordering is insignificant (e.g., "repo:foo file:bar") versus terms where
-// ordering may be significant (e.g., search patterns like "foo bar"). Search
-// patterns are parameters whose field is the empty string.
+// ordering may be significant (e.g., search patterns like "foo bar").
 //
 // The resulting tree defines an ordering relation on nodes in the following cases:
 // (1) When more than one search patterns exist at the same operator level, they
@@ -657,13 +687,11 @@ func containsAndOrExpression(nodes []Node) bool {
 func partitionParameters(nodes []Node) []Node {
 	var patterns, unorderedParams []Node
 	for _, n := range nodes {
-		switch v := n.(type) {
+		switch n.(type) {
+		case Pattern:
+			patterns = append(patterns, n)
 		case Parameter:
-			if v.Field == "" {
-				patterns = append(patterns, n)
-			} else {
-				unorderedParams = append(unorderedParams, n)
-			}
+			unorderedParams = append(unorderedParams, n)
 		case Operator:
 			if containsPattern(n) {
 				patterns = append(patterns, n)
@@ -714,10 +742,10 @@ loop:
 				// We parsed "()".
 				if p.heuristic.parensAsPatterns {
 					// Interpret literally.
-					nodes = []Node{Parameter{Value: "()"}}
+					nodes = []Node{Pattern{Value: "()"}}
 				} else {
 					// Interpret as a group: return an empty non-nil node.
-					nodes = []Node{Parameter{Value: ""}}
+					nodes = []Node{Parameter{}}
 				}
 			}
 			break loop
@@ -726,11 +754,19 @@ loop:
 			break loop
 		default:
 			// First try parse a parameter as a search pattern containing parens.
-			if parameter, ok := p.ParseSearchPatternHeuristic(); ok {
-				nodes = append(nodes, parameter)
+			if pattern, ok := p.ParseSearchPatternHeuristic(); ok {
+				nodes = append(nodes, pattern)
 			} else {
-				parameter := p.ParseParameter()
-				nodes = append(nodes, parameter)
+				parameter, ok, err := p.ParseParameter()
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					nodes = append(nodes, parameter)
+				} else {
+					pattern := p.ParsePattern()
+					nodes = append(nodes, pattern)
+				}
 			}
 		}
 	}
@@ -759,6 +795,18 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 	case Parameter:
 		if term.Value == "" {
 			// Remove empty string parameter.
+			if len(right) > 1 {
+				return append(left, right[1:]...), true
+			}
+			return left, true
+		}
+		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
+			// Reduce left node.
+			return append(operator.Operands, right...), true
+		}
+	case Pattern:
+		if term.Value == "" {
+			// Remove empty string pattern.
 			if len(right) > 1 {
 				return append(left, right[1:]...), true
 			}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -579,7 +579,7 @@ func (p *parser) TryParseDelimiter() (string, bool) {
 	return "", false
 }
 
-// ParseFieldValue parses a value followed by a field like "repo:". If the value
+// ParseFieldValue parses a value after a field like "repo:". If the value
 // starts with a recognized quoting delimiter but does not close it, an error is
 // returned.
 func (p *parser) ParseFieldValue() (string, error) {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -141,11 +141,11 @@ func TestSearchUppercase(t *testing.T) {
 		},
 		{
 			input: `content:TeSt`,
-			want:  `(and "content:TeSt" "case:yes")`,
+			want:  `(and "TeSt" "case:yes")`,
 		},
 		{
 			input: `content:test`,
-			want:  `"content:test"`,
+			want:  `"test"`,
 		},
 		{
 			input: `repo:foo TeSt`,
@@ -157,11 +157,11 @@ func TestSearchUppercase(t *testing.T) {
 		},
 		{
 			input: `repo:foo content:TeSt`,
-			want:  `(and "repo:foo" "content:TeSt" "case:yes")`,
+			want:  `(and "repo:foo" "TeSt" "case:yes")`,
 		},
 		{
 			input: `repo:foo content:test`,
-			want:  `(and "repo:foo" "content:test")`,
+			want:  `(and "repo:foo" "test")`,
 		},
 		{
 			input: `TeSt1 TesT2`,
@@ -175,8 +175,8 @@ func TestSearchUppercase(t *testing.T) {
 	for _, c := range cases {
 		t.Run("searchUppercase", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
-			got := prettyPrint(SearchUppercase(query))
-			if diff := cmp.Diff(got, c.want); diff != "" {
+			got := prettyPrint(SearchUppercase(SubstituteAliases(query)))
+			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -204,7 +204,7 @@ func TestMap(t *testing.T) {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
 			got := prettyPrint(Map(query, c.fns...))
-			if diff := cmp.Diff(got, c.want); diff != "" {
+			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -102,7 +102,7 @@ func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
 
 func (q AndOrQuery) Values(field string) []*types.Value {
 	var values []*types.Value
-	if field == "" || field == "content" {
+	if field == "" {
 		VisitPattern(q.Query, func(value string, _, quoted bool) {
 			values = append(values, valueToTypedValue(field, value, quoted)...)
 		})
@@ -117,12 +117,10 @@ func (q AndOrQuery) Values(field string) []*types.Value {
 func (q AndOrQuery) Fields() map[string][]*types.Value {
 	fields := make(map[string][]*types.Value)
 	VisitPattern(q.Query, func(value string, _, quoted bool) {
-		// FIXME. NOTE: overrides. Seems not good, how is Fields() used?
-		// For existence? What about "content"?
-		fields[""] = valueToTypedValue("", value, quoted)
+		fields[""] = q.Values("")
 	})
-	VisitParameter(q.Query, func(field, value string, _ bool) {
-		fields[field] = valueToTypedValue(field, value, false)
+	VisitParameter(q.Query, func(field, _ string, _ bool) {
+		fields[field] = q.Values(field)
 	})
 	return fields
 }

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -21,10 +21,9 @@ func (e *UnsupportedError) Error() string {
 // a search pattern.
 func isPatternExpression(nodes []Node) bool {
 	result := true
-	VisitParameter(nodes, func(field, _ string, _, _ bool) {
-		if field != "" && field != "content" {
-			result = false
-		}
+	// Any non-pattern, i.e., Parameter, falsifies the predicate.
+	VisitParameter(nodes, func(_, _ string, _ bool) {
+		result = false
 	})
 	return result
 }
@@ -270,7 +269,7 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 func validate(nodes []Node) error {
 	var err error
 	seen := map[string]struct{}{}
-	VisitParameter(nodes, func(field, value string, negated, _ bool) {
+	VisitParameter(nodes, func(field, value string, negated bool) {
 		if err != nil {
 			return
 		}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -34,10 +34,6 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			want:  `invalid boolean "???"`,
 		},
 		{
-			input: "mr:potato",
-			want:  `unrecognized field "mr"`,
-		},
-		{
 			input: "count:sedonuts",
 			want:  "field count has value sedonuts, sedonuts is not a number",
 		},

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -3,6 +3,8 @@ package query
 // VisitNode calls f on all nodes rooted at node.
 func VisitNode(node Node, f func(node Node)) {
 	switch v := node.(type) {
+	case Pattern:
+		f(v)
 	case Parameter:
 		f(v)
 	case Operator:
@@ -31,10 +33,10 @@ func VisitOperator(nodes []Node, f func(kind operatorKind, operands []Node)) {
 
 // VisitParameter calls f on all parameter nodes. f supplies the node's field,
 // value, and whether the value is negated.
-func VisitParameter(nodes []Node, f func(field, value string, negated, quoted bool)) {
+func VisitParameter(nodes []Node, f func(field, value string, negated bool)) {
 	visitor := func(node Node) {
 		if v, ok := node.(Parameter); ok {
-			f(v.Field, v.Value, v.Negated, v.Quoted)
+			f(v.Field, v.Value, v.Negated)
 		}
 	}
 	Visit(nodes, visitor)
@@ -42,11 +44,22 @@ func VisitParameter(nodes []Node, f func(field, value string, negated, quoted bo
 
 // VisitField calls f on all parameter nodes whose field matches the field
 // argument. f supplies the node's value and whether the value is negated.
-func VisitField(nodes []Node, field string, f func(value string, negated, quoted bool)) {
-	visitor := func(visitedField, value string, negated, quoted bool) {
+func VisitField(nodes []Node, field string, f func(value string, negated bool)) {
+	visitor := func(visitedField, value string, negated bool) {
 		if field == visitedField {
-			f(value, negated, quoted)
+			f(value, negated)
 		}
 	}
 	VisitParameter(nodes, visitor)
+}
+
+// VisitPattern calls f on all parameter nodes. f supplies the node's value
+// value, and whether the value is negated or quoted.
+func VisitPattern(nodes []Node, f func(value string, negated, quoted bool)) {
+	visitor := func(node Node) {
+		if v, ok := node.(Pattern); ok {
+			f(v.Value, v.Negated, v.Quoted)
+		}
+	}
+	Visit(nodes, visitor)
 }


### PR DESCRIPTION
TL;DR: 

The change separates a singular datatype `Parameter` that currently represents both search patterns and `field:value` parameters to be separate (a new `Pattern` type is created). Everything else is updated around that change (separate functions for parsing these, visitor interface, tree reduction, etc.).

We can have confidence in the change because tests pass, and affected tests are updated to the correct desired behavior.

---

Long description so I can trace my thinking and how this changed.

The thing motivating this change is that we currently use a convention that search patterns are represented as a `type Parameter` in the AST where field is `""` and value represents the pattern value. This same convention is in the existing (older) parser and can simplify some implementation details. Initially I didn't think we need to separate `field:value` versus patterns (`"":value`) at the parsing level, but since https://github.com/sourcegraph/sourcegraph/pull/9844 combining the two in the same datatype started bothering me because we do have some properties that we semantically distinguish in patterns versus parameters:

> Adding Quoted is not the desired end goal for the Parameter types. It currently pollutes the visitor interface a bit. I will be turning parameter values into better structures with type members later.

Basically, we want to track whether a search pattern was quoted (it has semantic implications for our search: quoting in regex mode implies literal search) but we do not care about that for `field:value` parameters, since we will process `field:value` versus `field:"value"` or `field:'value'` all the same.

Thus, while this change adds extra logic to deal with the extra `Pattern` case, it produces a final tree that better introspection, simplifies the visitor interface, and simplifies other parts of query validation.