### PR TITLE
campaigns: Lower log level from Error to Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Drop webhook sync error logs from Error to Debug level. [#10978](https://github.com/sourcegraph/sourcegraph/pull/10978)
-
 ### Fixed
 
 ### Removed
+
+## 3.16.1
+
+### Changed
+
+- Drop webhook sync error logs from Error to Debug level. [#10978](https://github.com/sourcegraph/sourcegraph/pull/10978)
 
 ## 3.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Drop webhook sync error logs from Error to Debug level. [#10978](https://github.com/sourcegraph/sourcegraph/pull/10978)
+
 ### Fixed
 
 ### Removed

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -816,7 +816,7 @@ func (h *BitbucketServerWebhook) SyncWebhooks(every time.Duration) {
 			}
 			err = h.syncWebhook(e.ID, con, externalURL())
 			if err != nil {
-				log15.Error("Upserting BBS Webhook failed", "err", err)
+				log15.Debug("Upserting BBS Webhook failed", "err", err)
 			}
 		}
 


### PR DESCRIPTION
We have a bug that causes the error to be logged every minute so
dropping to Debug for now.

This feature will be removed in 3.17 so this change is temporary and
intended to be part of a patch release.

Note that the feature has already been removed in `master` 
