### PR TITLE
gitserver: fetch GitLab and Bitbucket pull refs

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1307,7 +1307,13 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 	} else if useRefspecOverrides() {
 		cmd = refspecOverridesFetchCmd(ctx, url)
 	} else {
-		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url, "+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*", "+refs/pull/*:refs/pull/*", "+refs/sourcegraph/*:refs/sourcegraph/*")
+		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url,
+			// Normal git refs
+			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",
+			// GitHub pull requests
+			"+refs/pull/*:refs/pull/*",
+			// Possibly deprecated refs for sourcegraph zap experiment?
+			"+refs/sourcegraph/*:refs/sourcegraph/*")
 	}
 	cmd.Dir = string(dir)
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1312,6 +1312,10 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",
 			// GitHub pull requests
 			"+refs/pull/*:refs/pull/*",
+			// GitLab merge requests
+			"+refs/merge-requests/*:refs/merge-requests/*",
+			// Bitbucket pull requests
+			"+refs/pull-requests/*:refs/pull-requests/*",
 			// Possibly deprecated refs for sourcegraph zap experiment?
 			"+refs/sourcegraph/*:refs/sourcegraph/*")
 	}


### PR DESCRIPTION
We have EnsureRevision logic which will trigger a fetch if a revision is
missing. This will run when browsing a pull request on GitLab. However,
if the pull request is not from a branch in the same repository our
fetch would not fetch the relevant commit. This leads to us constantly
fetching and failing.

In particular we are noticing "git fetch" constantly running for
gitlab.com/gitlab-org/gitlab and in some cases it running very slowly. I
assume this gitlab rate limiting/metering our requests. The metering
leads to an unresponsive Sourcegraph request since we wait upto 60s for
the fetch to happen for a missing revision.

Fixes https://github.com/sourcegraph/sourcegraph/issues/10960