### PR TITLE
Allow filtering out errors on database-level when fetching campaign status

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -333,7 +333,7 @@ func (r *campaignResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffSt
 }
 
 func (r *campaignResolver) Status(ctx context.Context) (graphqlbackend.BackgroundProcessStatus, error) {
-	return r.store.GetCampaignStatus(ctx, r.Campaign.ID)
+	return r.store.GetCampaignStatus(ctx, ee.GetCampaignStatusOpts{ID: r.Campaign.ID})
 }
 
 type changesetDiffsConnectionResolver struct {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -555,7 +555,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 		return campaign, nil, nil
 	}
 
-	status, err := tx.GetCampaignStatus(ctx, campaign.ID)
+	status, err := tx.GetCampaignStatus(ctx, GetCampaignStatusOpts{ID: campaign.ID})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -885,7 +885,7 @@ func mergeByRepoID(
 }
 
 func campaignIsProcessing(ctx context.Context, store *Store, campaign int64) (bool, error) {
-	status, err := store.GetCampaignStatus(ctx, campaign)
+	status, err := store.GetCampaignStatus(ctx, GetCampaignStatusOpts{ID: campaign})
 	if err != nil {
 		return false, err
 	}

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1740,7 +1740,10 @@ func getPatchSetQuery(opts *GetPatchSetOpts) *sqlf.Query {
 // GetCampaignStatusOpts captures the query options needed for getting the
 // BackgroundProcessStatus for a Campaign.
 type GetCampaignStatusOpts struct {
-	ID            int64
+	ID int64
+	// When ExcludeErrors is set the ProcessErrors slice of the
+	// BackgroundProcessStatus returned by GetCampaignStatus won't be
+	// populated.
 	ExcludeErrors bool
 }
 

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2548,6 +2548,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 		tests := []struct {
 			jobs []*cmpgn.ChangesetJob
 			want *cmpgn.BackgroundProcessStatus
+			opts GetCampaignStatusOpts
 		}{
 			{
 				jobs: []*cmpgn.ChangesetJob{}, // no jobs
@@ -2634,7 +2635,10 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				}
 			}
 
-			status, err := s.GetCampaignStatus(ctx, int64(campaignID))
+			opts := tc.opts
+			opts.ID = int64(campaignID)
+
+			status, err := s.GetCampaignStatus(ctx, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2597,6 +2597,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 					ProcessState:  cmpgn.BackgroundProcessStateErrored,
 					Total:         1,
 					Completed:     1,
+					Failed:        1,
 					Pending:       0,
 					ProcessErrors: []string{"error1"},
 				},
@@ -2618,8 +2619,26 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 					ProcessState:  cmpgn.BackgroundProcessStateProcessing,
 					Total:         5,
 					Completed:     3,
+					Failed:        2,
 					Pending:       2,
 					ProcessErrors: []string{"error1", "error2"},
+				},
+			},
+
+			{
+				jobs: []*cmpgn.ChangesetJob{
+					// completed, error
+					{StartedAt: clock.now(), FinishedAt: clock.now(), Error: "error1"},
+				},
+				// but we want to exclude errors
+				opts: GetCampaignStatusOpts{ExcludeErrors: true},
+				want: &cmpgn.BackgroundProcessStatus{
+					ProcessState:  cmpgn.BackgroundProcessStateErrored,
+					Total:         1,
+					Completed:     1,
+					Failed:        1,
+					Pending:       0,
+					ProcessErrors: nil,
 				},
 			},
 		}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -199,6 +199,7 @@ type BackgroundProcessStatus struct {
 	Total         int32
 	Completed     int32
 	Pending       int32
+	Failed        int32
 	ProcessState  BackgroundProcessState
 	ProcessErrors []string
 }


### PR DESCRIPTION
I need this for #10808, which I'm working on in #10961 

