### PR TITLE
all: Replace common usage of cmp.Diff with testutil.DeepCompare

### DIFF
--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func init() {
@@ -48,9 +48,7 @@ func TestUpdateServiceVersion(t *testing.T) {
 		have := UpdateServiceVersion(ctx, "service", tc.version)
 		want := tc.err
 
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, have, want)
 
 		t.Logf("version = %q", tc.version)
 	}

--- a/cmd/frontend/db/event_logs_test.go
+++ b/cmd/frontend/db/event_logs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestEventLogs_ValidInfo(t *testing.T) {
@@ -363,9 +364,7 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 		VerifyUniquesWeek:       4,
 		MonitorUniquesWeek:      0,
 	}
-	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedSummary, summary)
 }
 
 func TestEventLogs_AggregatedEvents(t *testing.T) {
@@ -461,9 +460,7 @@ func TestEventLogs_AggregatedEvents(t *testing.T) {
 			LatenciesDay:   []float64{1344, 2182.1, 2195.51},
 		},
 	}
-	if diff := cmp.Diff(expectedEvents, events); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedEvents, events)
 }
 
 func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
@@ -519,9 +516,7 @@ func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
 			LatenciesDay:   nil,
 		},
 	}
-	if diff := cmp.Diff(expectedEvents, events); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedEvents, events)
 }
 
 // makeTestEvent sets the required (uninteresting) fields that are required on insertion

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -2,8 +2,9 @@ package db
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
 func TestExternalServicesStore_ValidateConfig(t *testing.T) {

--- a/cmd/frontend/db/repos_perm_filter_test.go
+++ b/cmd/frontend/db/repos_perm_filter_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -889,9 +891,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		}
 
 		expRepos := []*types.Repo{publicRepo}
-		if diff := cmp.Diff(expRepos, repos); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expRepos, repos)
 	})
 
 	t.Run("authenticated user but no authz providers should only see public repos", func(t *testing.T) {
@@ -915,9 +915,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		}
 
 		expRepos := []*types.Repo{publicRepo}
-		if diff := cmp.Diff(expRepos, repos); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expRepos, repos)
 	})
 
 	t.Run("authenticated user with matching external account should see all repos", func(t *testing.T) {
@@ -975,9 +973,7 @@ func Test_authzFilter_permissionsBackgroudSync(t *testing.T) {
 		}
 
 		expRepos := []*types.Repo{publicRepo, privateRepo}
-		if diff := cmp.Diff(expRepos, repos); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expRepos, repos)
 	})
 
 	t.Run("authenticated user without an external account should fetch and grant", func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/highlight"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -301,9 +302,7 @@ func TestRepositoryComparison(t *testing.T) {
 					t.Fatalf("pageInfo HasNextPage wrong. want=%t, have=%t", tc.wantHasNextPage, pageInfo.HasNextPage())
 				}
 
-				if diff := cmp.Diff(tc.wantEndCursor, pageInfo.EndCursor()); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, tc.wantEndCursor, pageInfo.EndCursor())
 
 				totalCount, err := conn.TotalCount(ctx)
 				if err != nil {
@@ -355,9 +354,7 @@ func TestDiffHunk(t *testing.T) {
 	})
 
 	t.Run("Body", func(t *testing.T) {
-		if diff := cmp.Diff(testDiffFirstHunk, hunk.Body()); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, testDiffFirstHunk, hunk.Body())
 	})
 
 	t.Run("Highlight", func(t *testing.T) {

--- a/cmd/frontend/internal/usagestats/aggregated_test.go
+++ b/cmd/frontend/internal/usagestats/aggregated_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestGroupSiteUsageStats(t *testing.T) {
@@ -79,9 +79,7 @@ func TestGroupSiteUsageStats(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(expectedSiteUsageStats, siteUsageStats); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedSiteUsageStats, siteUsageStats)
 }
 
 func TestGroupSiteUsageStatsMonthsOnly(t *testing.T) {
@@ -132,9 +130,7 @@ func TestGroupSiteUsageStatsMonthsOnly(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(expectedSiteUsageStats, siteUsageStats); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedSiteUsageStats, siteUsageStats)
 }
 
 func TestGroupAggregatedStats(t *testing.T) {
@@ -283,9 +279,7 @@ func TestGroupAggregatedStats(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(expectedCodeIntelStats, codeIntelStats); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedCodeIntelStats, codeIntelStats)
 
 	expectedSearchStats := &types.SearchUsageStatistics{
 		Daily: []*types.SearchUsagePeriod{
@@ -409,7 +403,5 @@ func TestGroupAggregatedStats(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(expectedSearchStats, searchStats); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expectedSearchStats, searchStats)
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
@@ -4,8 +4,9 @@ package database
 
 import (
 	"context"
-	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"sync"
+
+	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 )
 
 // MockDatabase is a mock impelementation of the Database interface (from

--- a/cmd/precise-code-intel-worker/internal/worker/mock_processor_test.go
+++ b/cmd/precise-code-intel-worker/internal/worker/mock_processor_test.go
@@ -4,8 +4,9 @@ package worker
 
 import (
 	"context"
-	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	"sync"
+
+	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
 
 // MockProcessor is a mock impelementation of the Processor interface (from

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -3,9 +3,10 @@ package repos
 import (
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"testing"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/schema"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -169,9 +168,7 @@ func TestRecordMetrics(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			got := languageMetric(tt.matcher, tt.includePatterns)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, tt.want, got)
 		})
 	}
 }

--- a/enterprise/cmd/frontend/db/perms_store_test.go
+++ b/enterprise/cmd/frontend/db/perms_store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -1996,9 +1997,7 @@ func testPermsStore_UserIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 
 		expIDs := []int32{1, 2}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expIDs, ids)
 
 		// Give "alice" some permissions
 		err = s.SetRepoPermissions(ctx, &authz.RepoPermissions{
@@ -2017,9 +2016,7 @@ func testPermsStore_UserIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 		}
 
 		expIDs = []int32{2}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expIDs, ids)
 	}
 }
 
@@ -2065,9 +2062,7 @@ func testPermsStore_RepoIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 
 		expIDs := []api.RepoID{1, 3}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expIDs, ids)
 
 		// Give "private_repo" regular permissions and "private_repo_2" pending permissions
 		err = s.SetRepoPermissions(ctx, &authz.RepoPermissions{
@@ -2100,9 +2095,7 @@ func testPermsStore_RepoIDsWithNoPerms(db *sql.DB) func(*testing.T) {
 		}
 
 		expIDs = []api.RepoID{}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expIDs, ids)
 	}
 }
 
@@ -2147,9 +2140,7 @@ WHERE user_id = 2`, clock().AddDate(1, 0, 0))
 		}
 
 		expResults := map[int32]time.Time{1: {}}
-		if diff := cmp.Diff(expResults, results); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expResults, results)
 
 		// Should get both users back
 		results, err = s.UserIDsWithOldestPerms(ctx, 2)
@@ -2161,9 +2152,7 @@ WHERE user_id = 2`, clock().AddDate(1, 0, 0))
 			1: {},
 			2: clock().AddDate(1, 0, 0),
 		}
-		if diff := cmp.Diff(expResults, results); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expResults, results)
 	}
 }
 
@@ -2226,9 +2215,7 @@ INSERT INTO repo(id, name, private, deleted_at)
 		}
 
 		expResults := map[api.RepoID]time.Time{1: clock()}
-		if diff := cmp.Diff(expResults, results); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expResults, results)
 
 		// Should get both repos back
 		results, err = s.ReposIDsWithOldestPerms(ctx, 2)
@@ -2240,9 +2227,7 @@ INSERT INTO repo(id, name, private, deleted_at)
 			1: clock(),
 			2: clock().AddDate(1, 0, 0),
 		}
-		if diff := cmp.Diff(expResults, results); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expResults, results)
 	}
 }
 
@@ -2297,8 +2282,6 @@ func testPermsStore_Metrics(db *sql.DB) func(*testing.T) {
 			ReposWithStalePerms:  1,
 			ReposPermsGapSeconds: 120,
 		}
-		if diff := cmp.Diff(expMetrics, m); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expMetrics, m)
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 // TestProvider_RepoPerms_cacheTTL tests that cache entries are invalidated after the cache TTL
@@ -49,9 +49,7 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if diff := cmp.Diff(wantPerms, perms); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, wantPerms, perms)
 		if cacheMisses != 1 {
 			t.Errorf("expected 1 cache misses, but got %d", cacheMisses)
 		}
@@ -62,9 +60,7 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 		if gotErr != nil {
 			t.Fatal(gotErr)
 		}
-		if diff := cmp.Diff(wantPerms, perms); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, wantPerms, perms)
 		if cacheMisses != 0 {
 			t.Errorf("expected 0 cache misses, but got %d", cacheMisses)
 		}
@@ -77,9 +73,7 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 		if gotErr != nil {
 			t.Fatal(gotErr)
 		}
-		if diff := cmp.Diff(wantPerms, perms); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, wantPerms, perms)
 		if cacheMisses != 1 {
 			t.Errorf("expected 1 cache misses, but got %d", cacheMisses)
 		}

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"golang.org/x/oauth2"
 )
 
@@ -204,18 +204,14 @@ func TestProvider_RepoPerms(t *testing.T) {
 						}
 
 						perms, err := p.RepoPerms(context.Background(), c.userAccount, c.repos)
-						if diff := cmp.Diff(c.wantErr, err); diff != "" {
-							t.Fatal(diff)
-						}
+						testutil.DeepCompare(t, c.wantErr, err)
 
 						for _, ps := range [][]authz.RepoPerms{perms, c.wantPerms} {
 							sort.Slice(ps, func(i, j int) bool {
 								return ps[i].Repo.Name <= ps[j].Repo.Name
 							})
 						}
-						if diff := cmp.Diff(c.wantPerms, perms); diff != "" {
-							t.Fatal(diff)
-						}
+						testutil.DeepCompare(t, c.wantPerms, perms)
 
 						if j == 1 && called > 0 {
 							t.Fatal("expected entries to be fully cached")
@@ -272,12 +268,8 @@ func Test_fetchUserRepos(t *testing.T) {
 		"u99/public": true,
 	}
 
-	if diff := cmp.Diff(wantCanAccess, canAccess); diff != "" {
-		t.Fatal(diff)
-	}
-	if diff := cmp.Diff(wantIsPublic, isPublic); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, wantCanAccess, canAccess)
+	testutil.DeepCompare(t, wantIsPublic, isPublic)
 }
 
 func mustURL(t *testing.T, u string) *url.URL {
@@ -405,9 +397,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 		"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 	}
-	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepoIDs, repoIDs)
 }
 
 func TestProvider_FetchRepoPerms(t *testing.T) {
@@ -477,7 +467,5 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 		"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 		"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 	}
-	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expAccountIDs, accountIDs)
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/oauth_test.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 type mockDoer struct {
@@ -105,9 +105,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	}
 
 	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepoIDs, repoIDs)
 }
 
 func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
@@ -197,7 +195,5 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 
 	// 1 should not be included because of "access_level" < 20
 	expAccountIDs := []extsvc.AccountID{"2", "3"}
-	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expAccountIDs, accountIDs)
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/sudo_test.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestSudoProvider_FetchUserPerms(t *testing.T) {
@@ -103,9 +103,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	}
 
 	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepoIDs, repoIDs)
 }
 
 func TestSudoProvider_FetchRepoPerms(t *testing.T) {
@@ -195,7 +193,5 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 
 	// 1 should not be included because of "access_level" < 20
 	expAccountIDs := []extsvc.AccountID{"2", "3"}
-	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expAccountIDs, accountIDs)
 }

--- a/enterprise/internal/campaigns/changeset_events_test.go
+++ b/enterprise/internal/campaigns/changeset_events_test.go
@@ -1,12 +1,13 @@
 package campaigns
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -96,9 +97,7 @@ func TestChangesetEventsLabels(t *testing.T) {
 			want := tc.want
 			sort.Slice(have, func(i, j int) bool { return have[i].Name < have[j].Name })
 			sort.Slice(want, func(i, j int) bool { return want[i].Name < want[j].Name })
-			if diff := cmp.Diff(have, want, cmpopts.EquateEmpty()); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want, cmpopts.EquateEmpty())
 		})
 	}
 }

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/pkg/errors"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -456,9 +457,7 @@ func TestCampaigns(t *testing.T) {
 			c.ID = ""
 			have = append(have, c)
 		}
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, have, want)
 	}
 
 	var addChangesetsResult struct{ Campaign apitest.Campaign }

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func init() {
@@ -1021,9 +1022,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 			sort.Slice(wantIDs, func(i, j int) bool { return wantIDs[i] < wantIDs[j] })
 			sort.Slice(haveIDs, func(i, j int) bool { return haveIDs[i] < haveIDs[j] })
 
-			if diff := cmp.Diff(wantIDs, haveIDs); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, wantIDs, haveIDs)
 		})
 	}
 }

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 type clock interface {
@@ -97,9 +98,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			campaigns = append(campaigns, c)
 		}
@@ -191,9 +190,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 					t.Fatalf("listed %d campaigns, want: %d", len(have), len(want))
 				}
 
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, have, want)
 			}
 		}
 
@@ -243,9 +240,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				if err != nil {
 					t.Fatal(err)
 				}
-				if diff := cmp.Diff(have, tc.want); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, have, tc.want)
 			})
 		}
 
@@ -255,9 +250,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(have, campaigns[1:]); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, campaigns[1:])
 		})
 
 		t.Run("ListCampaigns HasPatchSet false", func(t *testing.T) {
@@ -266,9 +259,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(have, campaigns[0:1]); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, campaigns[0:1])
 		})
 	})
 
@@ -297,9 +288,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			// Test that duplicates are not introduced.
 			have.ChangesetIDs = append(have.ChangesetIDs, have.ChangesetIDs...)
@@ -307,9 +296,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			// Test we can add to the set.
 			have.ChangesetIDs = append(have.ChangesetIDs, 42)
@@ -323,9 +310,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				return have.ChangesetIDs[a] < have.ChangesetIDs[b]
 			})
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			// Test we can remove from the set.
 			have.ChangesetIDs = have.ChangesetIDs[:0]
@@ -335,9 +320,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -351,9 +334,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByPatchSetID", func(t *testing.T) {
@@ -365,9 +346,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {
@@ -488,9 +467,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -500,9 +477,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 		want := []string{"foobar-0", "foobar-1", "foobar-2"}
-		if diff := cmp.Diff(want, have); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, have)
 	})
 
 	t.Run("GetChangesetExternalIDs no branch", func(t *testing.T) {
@@ -516,9 +491,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 		want := []string{}
-		if diff := cmp.Diff(want, have); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, have)
 	})
 
 	t.Run("GetChangesetExternalIDs invalid external-id", func(t *testing.T) {
@@ -532,9 +505,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 		want := []string{}
-		if diff := cmp.Diff(want, have); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, have)
 	})
 
 	t.Run("GetChangesetExternalIDs invalid external service id", func(t *testing.T) {
@@ -548,9 +519,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 		want := []string{}
-		if diff := cmp.Diff(want, have); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, have)
 	})
 
 	t.Run("CreateAlreadyExistingChangesets", func(t *testing.T) {
@@ -589,9 +558,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				t.Fatalf("%d changesets already exist, want: %d", len(have), len(want))
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 
 		{
@@ -601,9 +568,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				t.Fatalf("created %d changesets, want: %d", len(have), len(want))
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -673,9 +638,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 					t.Fatalf("listed %d changesets, want: %d", len(have), len(want))
 				}
 
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, have, want)
 			}
 		}
 
@@ -691,9 +654,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			}
 
 			want := changesets
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 
 		{
@@ -884,9 +845,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByExternalID", func(t *testing.T) {
@@ -901,9 +860,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByRepoID", func(t *testing.T) {
@@ -917,9 +874,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {
@@ -953,9 +908,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, have, want)
 
 		for i := range have {
 			// Test that duplicates are not introduced.
@@ -966,9 +919,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, have, want)
 
 		for i := range have {
 			// Test we can add to the set.
@@ -985,9 +936,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				return have[i].CampaignIDs[a] < have[i].CampaignIDs[b]
 			})
 
-			if diff := cmp.Diff(have[i], want[i]); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have[i], want[i])
 		}
 
 		for i := range have {
@@ -1000,9 +949,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, have, want)
 	})
 }
 
@@ -1057,9 +1004,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -1093,9 +1038,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByKey", func(t *testing.T) {
@@ -1111,9 +1054,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {
@@ -1199,9 +1140,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 						t.Fatalf("listed %d events, want: %d", len(have), len(want))
 					}
 
-					if diff := cmp.Diff(have, want); diff != "" {
-						t.Fatal(diff)
-					}
+					testutil.DeepCompare(t, have, want)
 				}
 			}
 		})
@@ -1372,9 +1311,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 				ExternalServiceIDs: []int64{extSvcID},
 			},
 		}
-		if diff := cmp.Diff(want, hs); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, hs)
 	})
 
 	t.Run("ignore closed campaign", func(t *testing.T) {
@@ -1409,9 +1346,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 				ExternalServiceIDs: []int64{extSvcID},
 			},
 		}
-		if diff := cmp.Diff(want, hs); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, hs)
 
 		// If a changeset has ANY open campaigns we should list it
 		// Attach cs1 to both an open and closed campaign
@@ -1459,9 +1394,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 				ExternalServiceIDs: []int64{extSvcID},
 			},
 		}
-		if diff := cmp.Diff(want, hs); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, hs)
 	})
 }
 
@@ -1488,9 +1421,7 @@ func testStorePatchSets(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			patchSets = append(patchSets, c)
 		}
@@ -1551,9 +1482,7 @@ func testStorePatchSets(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 					t.Fatalf("listed %d patchSets, want: %d", len(have), len(want))
 				}
 
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, have, want)
 			}
 		}
 
@@ -1590,9 +1519,7 @@ func testStorePatchSets(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -1609,9 +1536,7 @@ func testStorePatchSets(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {
@@ -1688,9 +1613,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, _ repos.Store
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			patches = append(patches, p)
 		}
@@ -1765,9 +1688,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, _ repos.Store
 						t.Fatalf("listed %d patches, want: %d", len(have), len(want))
 					}
 
-					if diff := cmp.Diff(have, want); diff != "" {
-						t.Fatal(diff)
-					}
+					testutil.DeepCompare(t, have, want)
 				}
 			}
 		})
@@ -1787,9 +1708,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, _ repos.Store
 				t.Fatalf("listed %d patches, want: %d", len(have), len(want))
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("EmptyResultListingAll", func(t *testing.T) {
@@ -2006,9 +1925,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, _ repos.Store
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -2025,9 +1942,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, _ repos.Store
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {
@@ -2238,9 +2153,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 			want.CreatedAt = clock.now()
 			want.UpdatedAt = clock.now()
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 
 			changesetJobs = append(changesetJobs, c)
 		}
@@ -2315,9 +2228,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 						t.Fatalf("listed %d changesetJobs, want: %d", len(have), len(want))
 					}
 
-					if diff := cmp.Diff(have, want); diff != "" {
-						t.Fatal(diff)
-					}
+					testutil.DeepCompare(t, have, want)
 				}
 			}
 		})
@@ -2337,9 +2248,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatalf("listed %d patches, want: %d", len(have), len(want))
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("EmptyResultListingAll", func(t *testing.T) {
@@ -2437,9 +2346,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		}
 	})
 
@@ -2456,9 +2363,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByPatchID", func(t *testing.T) {
@@ -2473,9 +2378,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByChangesetID", func(t *testing.T) {
@@ -2490,9 +2393,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("ByCampaignID", func(t *testing.T) {
@@ -2509,9 +2410,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 
 		t.Run("NoResults", func(t *testing.T) {

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -7,12 +7,11 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestNextSync(t *testing.T) {
@@ -81,9 +80,7 @@ func TestNextSync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NextSync(clock, tt.h)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, got, tt.want)
 		})
 	}
 }
@@ -95,9 +92,7 @@ func TestChangesetPriorityQueue(t *testing.T) {
 		for i := range ids {
 			ids[i] = q.items[i].changesetID
 		}
-		if diff := cmp.Diff(expected, ids); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, expected, ids)
 	}
 
 	now := time.Now()
@@ -342,9 +337,7 @@ func TestFilterSyncData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			data := filterSyncData(tc.serviceID, tc.data)
-			if diff := cmp.Diff(tc.want, data); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, tc.want, data)
 		})
 	}
 }

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestChangesetMetadata(t *testing.T) {
@@ -289,9 +289,7 @@ func TestChangesetEvents(t *testing.T) {
 			have := tc.changeset.Events()
 			want := tc.events
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, have, want)
 		})
 	}
 }

--- a/internal/codeintel/bundles/mocks/mock_bundle_client.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_client.go
@@ -4,8 +4,9 @@ package mocks
 
 import (
 	"context"
-	client "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"sync"
+
+	client "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 )
 
 // MockBundleClient is a mock impelementation of the BundleClient interface

--- a/internal/codeintel/bundles/mocks/mock_bundle_manager_client.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_manager_client.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
-	client "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"io"
 	"sync"
+
+	client "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 )
 
 // MockBundleManagerClient is a mock impelementation of the

--- a/internal/codeintel/bundles/mocks/mock_bundle_reader.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_reader.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	reader "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/reader"
 	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
-	"sync"
 )
 
 // MockReader is a mock impelementation of the Reader interface (from the

--- a/internal/codeintel/bundles/mocks/mock_bundle_serializer.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_serializer.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
+	"sync"
+
 	serializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
 	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
-	"sync"
 )
 
 // MockSerializer is a mock impelementation of the Serializer interface

--- a/internal/codeintel/bundles/mocks/mock_bundle_writer.go
+++ b/internal/codeintel/bundles/mocks/mock_bundle_writer.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	writer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/writer"
-	"sync"
 )
 
 // MockWriter is a mock impelementation of the Writer interface (from the

--- a/internal/codeintel/db/mocks/mock_db.go
+++ b/internal/codeintel/db/mocks/mock_db.go
@@ -4,10 +4,11 @@ package mocks
 
 import (
 	"context"
-	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
-	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	"sync"
 	"time"
+
+	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
+	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 )
 
 // MockDB is a mock impelementation of the DB interface (from the package

--- a/internal/codeintel/db/mocks/mock_reference_pager.go
+++ b/internal/codeintel/db/mocks/mock_reference_pager.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
-	"sync"
 )
 
 // MockReferencePager is a mock impelementation of the ReferencePager

--- a/internal/codeintel/gitserver/mocks/mock_client.go
+++ b/internal/codeintel/gitserver/mocks/mock_client.go
@@ -4,10 +4,11 @@ package mocks
 
 import (
 	"context"
-	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
-	gitserver "github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 	"io"
 	"sync"
+
+	db "github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+	gitserver "github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
 )
 
 // MockClient is a mock impelementation of the Client interface (from the

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -84,9 +84,7 @@ func Test_newRepoCache(t *testing.T) {
 		prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
 		got := newRepoCache(url, token)
 		want := rcache.NewWithTTL(prefix, 600)
-		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, got, cmpOpts)
 	})
 
 	t.Run("GitHub Enterprise", func(t *testing.T) {
@@ -100,9 +98,7 @@ func Test_newRepoCache(t *testing.T) {
 		prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
 		got := newRepoCache(url, token)
 		want := rcache.NewWithTTL(prefix, 30)
-		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
-			t.Fatal(diff)
-		}
+		testutil.DeepCompare(t, want, got, cmpOpts)
 	})
 }
 

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/google/go-cmp/cmp"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestSplitRepositoryNameWithOwner(t *testing.T) {
@@ -536,9 +536,7 @@ func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
 		t.Fatal(err)
 	}
 	expRepo := &Repository{ID: "id0-tok1"}
-	if diff := cmp.Diff(expRepo, got); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepo, got)
 
 	// Verify c1 gets the "id0" from cache in subsequent calls
 	c1.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "SHOULD NOT BE SEEN" } } }`, http.StatusOK)
@@ -547,9 +545,7 @@ func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
 		t.Fatal(err)
 	}
 	expRepo = &Repository{ID: "id0-tok1"}
-	if diff := cmp.Diff(expRepo, got); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepo, got)
 
 	// c2 should not get "id0" from cache
 	c2.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id0-tok2" } } }`, http.StatusOK)
@@ -558,9 +554,7 @@ func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
 		t.Fatal(err)
 	}
 	expRepo = &Repository{ID: "id0-tok2"}
-	if diff := cmp.Diff(expRepo, got); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepo, got)
 
 	// Let c1 cache "id1" as not found
 	c1.httpClient = newMockHTTPResponseBody(`{}`, http.StatusNotFound)
@@ -583,9 +577,7 @@ func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
 		t.Fatal(err)
 	}
 	expRepo = &Repository{ID: "id1-tok2"}
-	if diff := cmp.Diff(expRepo, got); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepo, got)
 
 	// For sanity, c0 (unauthenticated) should get "id1" as usual
 	c0.httpClient = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1" } } }`, http.StatusOK)
@@ -594,9 +586,7 @@ func TestClient_GetRepositoryByNodeID_security(t *testing.T) {
 		t.Fatal(err)
 	}
 	expRepo = &Repository{ID: "id1"}
-	if diff := cmp.Diff(expRepo, got); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, expRepo, got)
 }
 
 func TestClient_buildGetRepositoriesBatchQuery(t *testing.T) {

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -1,8 +1,9 @@
 package extsvc
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestExtractRateLimitConfig(t *testing.T) {
@@ -115,9 +116,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tc.want, rlc); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, tc.want, rlc)
 		})
 	}
 }

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func TestPreSpansToTable_Simple(t *testing.T) {
@@ -181,9 +182,7 @@ func TestSplitHighlightedLines(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(have, want); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, have, want)
 }
 
 func TestCodeAsLines(t *testing.T) {

--- a/internal/prometheusutil/prometheus_mock.go
+++ b/internal/prometheusutil/prometheus_mock.go
@@ -4,9 +4,10 @@ package prometheusutil
 
 import (
 	"context"
+	"sync"
+
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	model "github.com/prometheus/common/model"
-	"sync"
 )
 
 // MockPrometheusQuerier is a mock impelementation of the PrometheusQuerier

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func Test_ScanParameter(t *testing.T) {
@@ -641,9 +642,7 @@ func Test_Parse(t *testing.T) {
 			check := func(result []Node, err error, want string) {
 				var resultStr []string
 				if err != nil {
-					if diff := cmp.Diff(want, err.Error()); diff != "" {
-						t.Fatal(diff)
-					}
+					testutil.DeepCompare(t, want, err.Error())
 					return
 				}
 				for _, node := range result {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 func prettyPrint(nodes []Node) string {
@@ -20,9 +21,7 @@ func Test_SubstituteAliases(t *testing.T) {
 	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
 	query, _ := ParseAndOr(input)
 	got := prettyPrint(SubstituteAliases(query))
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, got, want)
 }
 
 func Test_LowercaseFieldNames(t *testing.T) {
@@ -30,9 +29,7 @@ func Test_LowercaseFieldNames(t *testing.T) {
 	want := `(and "repo:foo" "PATTERN")`
 	query, _ := ParseAndOr(input)
 	got := prettyPrint(LowercaseFieldNames(query))
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatal(diff)
-	}
+	testutil.DeepCompare(t, got, want)
 }
 
 func Test_Hoist(t *testing.T) {
@@ -176,9 +173,7 @@ func TestSearchUppercase(t *testing.T) {
 		t.Run("searchUppercase", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
 			got := prettyPrint(SearchUppercase(query))
-			if diff := cmp.Diff(got, c.want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, got, c.want)
 		})
 	}
 }
@@ -204,9 +199,7 @@ func TestMap(t *testing.T) {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
 			got := prettyPrint(Map(query, c.fns...))
-			if diff := cmp.Diff(got, c.want); diff != "" {
-				t.Fatal(diff)
-			}
+			testutil.DeepCompare(t, got, c.want)
 		})
 	}
 }

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
@@ -56,12 +58,8 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected test to fail")
 			}
-			if diff := cmp.Diff(c.want, err.Error()); diff != "" {
-				t.Fatal(diff)
-			}
-
+			testutil.DeepCompare(t, c.want, err.Error())
 		})
-
 	}
 }
 
@@ -225,9 +223,7 @@ func Test_PartitionSearchPattern(t *testing.T) {
 			q, _ := ParseAndOr(tt.input)
 			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
-				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {
-					t.Fatal(diff)
-				}
+				testutil.DeepCompare(t, tt.want, err.Error())
 				return
 			}
 			result := scopeParameters

--- a/internal/testutil/diff.go
+++ b/internal/testutil/diff.go
@@ -1,9 +1,11 @@
 package testutil
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"testing"
 )
 
 func Diff(b1, b2 string) (string, error) {
@@ -35,4 +37,13 @@ func Diff(b1, b2 string) (string, error) {
 		err = nil
 	}
 	return string(data), err
+}
+
+// DeepCompare compares x and y using cmp.Diff and raises a fatal error
+// on t if there are any differences.
+func DeepCompare(t *testing.T, x, y interface{}, opts ...cmp.Option) {
+	t.Helper()
+	if diff := cmp.Diff(x, y, opts...); diff != "" {
+		t.Fatal(diff)
+	}
 }

--- a/internal/testutil/diff.go
+++ b/internal/testutil/diff.go
@@ -1,11 +1,12 @@
 package testutil
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Diff(b1, b2 string) (string, error) {
@@ -44,6 +45,6 @@ func Diff(b1, b2 string) (string, error) {
 func DeepCompare(t *testing.T, x, y interface{}, opts ...cmp.Option) {
 	t.Helper()
 	if diff := cmp.Diff(x, y, opts...); diff != "" {
-		t.Fatal(diff)
+		t.Fatalf(diff)
 	}
 }


### PR DESCRIPTION
It's pretty common in our codebase to use `cmp.Diff':

```text
rg cmp.Diff | wc -l
473
```

Should we replace it with a helper function? 

I've made the change to the simple case where we check for a non empty diff and then call `t.Fatal`

To cover all cases we'd also need to handle uses of `t.Fatalf` and `t.Error/f`

We could add `testutil.DeepCompareFatal/f` that takes a format string.

WDYT?