### PR TITLE
codeintel: LSIF line reader

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/reader.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/reader.go
@@ -8,6 +8,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif"
 )
 
+// Read reads the given content as line-separated JSON objects representing a single LSIF vertex or edge and
+// returns a channel of lsif.Pair values for each non-empty line.
+func Read(ctx context.Context, r io.Reader) <-chan lsif.Pair {
+	return ReadLines(ctx, r, unmarshalElement)
+}
+
 // LineBufferSize is the maximum size of the buffer used to read each line of a raw LSIF index. Lines in
 // LSIF can get very long as it include escaped hover text (package documentation), as well as large edges
 // such as the contains edge of large documents.
@@ -15,40 +21,94 @@ import (
 // This corresponds a 10MB buffer that can accommodate 10 million characters.
 const LineBufferSize = 1e7
 
-// Read reads the given content as line-separated JSON objects representing a single LSIF vertex or edge and
-// returns a channel of lsif.Pair values for each non-empty line.
-func Read(ctx context.Context, r io.Reader) <-chan lsif.Pair {
+// TODO - document
+const ChannelBufferSize = 500
+
+// TODO - document
+const NumUnmarshalRoutines = 100
+
+// TODO - document
+func ReadLines(ctx context.Context, r io.Reader, unmarshal func(line []byte) (_ lsif.Element, err error)) <-chan lsif.Pair {
 	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)
 	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)
 
-	ch := make(chan lsif.Pair)
-
+	// TODO - document
+	lineCh := make(chan []byte, ChannelBufferSize)
 	go func() {
-		defer close(ch)
+		defer close(lineCh)
 
 		for scanner.Scan() {
-			line := scanner.Bytes()
-			if len(line) == 0 {
-				continue
+			if line := scanner.Bytes(); len(line) != 0 {
+				lineCh <- line
+			}
+		}
+	}()
+
+	pairCh := make(chan lsif.Pair, ChannelBufferSize)
+	go func() {
+		defer close(pairCh)
+
+		// TODO - document
+		work := make(chan int, NumUnmarshalRoutines)
+		defer close(work)
+
+		// TODO - document
+		signal := make(chan struct{}, NumUnmarshalRoutines)
+		defer close(signal)
+
+		lines := make([][]byte, NumUnmarshalRoutines)
+		pairs := make([]lsif.Pair, NumUnmarshalRoutines)
+
+		// TODO - document
+		for i := 0; i < NumUnmarshalRoutines; i++ {
+			go func() {
+				for idx := range work {
+					element, err := unmarshal(lines[idx])
+					pairs[idx].Element = element
+					pairs[idx].Err = err
+					signal <- struct{}{}
+				}
+			}()
+		}
+
+		done := false
+		for !done {
+			i := 0
+
+			// TODO - document
+			for i < NumUnmarshalRoutines {
+				line, ok := <-lineCh
+				if !ok {
+					done = true
+					break
+				}
+
+				lines[i] = line
+				work <- i
+				i++
 			}
 
-			element, err := unmarshalElement(line)
-			if err != nil {
-				ch <- lsif.Pair{Err: err}
-			} else {
+			// TODO - document
+			for j := 0; j < i; j++ {
+				<-signal
+			}
+
+			// TODO - document
+			for j := 0; j < i; j++ {
 				select {
-				case ch <- lsif.Pair{Element: element}:
+				case pairCh <- pairs[j]:
 				case <-ctx.Done():
 					return
 				}
 			}
 		}
 
+		// TODO - document
 		if err := scanner.Err(); err != nil {
-			ch <- lsif.Pair{Err: err}
+			pairCh <- lsif.Pair{Err: err}
 		}
 	}()
 
-	return ch
+	return pairCh
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/reader.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/reader.go
@@ -1,114 +1,15 @@
 package jsonlines
 
 import (
-	"bufio"
 	"context"
 	"io"
 
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif"
+	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif/lines"
 )
 
-// Read reads the given content as line-separated JSON objects representing a single LSIF vertex or edge and
-// returns a channel of lsif.Pair values for each non-empty line.
+// Read reads the given content as line-separated JSON objects representing a single LSIF vertex or
+// edge and returns a channel of lsif.Pair values for each non-empty line.
 func Read(ctx context.Context, r io.Reader) <-chan lsif.Pair {
-	return ReadLines(ctx, r, unmarshalElement)
-}
-
-// LineBufferSize is the maximum size of the buffer used to read each line of a raw LSIF index. Lines in
-// LSIF can get very long as it include escaped hover text (package documentation), as well as large edges
-// such as the contains edge of large documents.
-//
-// This corresponds a 10MB buffer that can accommodate 10 million characters.
-const LineBufferSize = 1e7
-
-// TODO - document
-const ChannelBufferSize = 500
-
-// TODO - document
-const NumUnmarshalRoutines = 100
-
-// TODO - document
-func ReadLines(ctx context.Context, r io.Reader, unmarshal func(line []byte) (_ lsif.Element, err error)) <-chan lsif.Pair {
-	scanner := bufio.NewScanner(r)
-	scanner.Split(bufio.ScanLines)
-	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)
-
-	// TODO - document
-	lineCh := make(chan []byte, ChannelBufferSize)
-	go func() {
-		defer close(lineCh)
-
-		for scanner.Scan() {
-			if line := scanner.Bytes(); len(line) != 0 {
-				lineCh <- line
-			}
-		}
-	}()
-
-	pairCh := make(chan lsif.Pair, ChannelBufferSize)
-	go func() {
-		defer close(pairCh)
-
-		// TODO - document
-		work := make(chan int, NumUnmarshalRoutines)
-		defer close(work)
-
-		// TODO - document
-		signal := make(chan struct{}, NumUnmarshalRoutines)
-		defer close(signal)
-
-		lines := make([][]byte, NumUnmarshalRoutines)
-		pairs := make([]lsif.Pair, NumUnmarshalRoutines)
-
-		// TODO - document
-		for i := 0; i < NumUnmarshalRoutines; i++ {
-			go func() {
-				for idx := range work {
-					element, err := unmarshal(lines[idx])
-					pairs[idx].Element = element
-					pairs[idx].Err = err
-					signal <- struct{}{}
-				}
-			}()
-		}
-
-		done := false
-		for !done {
-			i := 0
-
-			// TODO - document
-			for i < NumUnmarshalRoutines {
-				line, ok := <-lineCh
-				if !ok {
-					done = true
-					break
-				}
-
-				lines[i] = line
-				work <- i
-				i++
-			}
-
-			// TODO - document
-			for j := 0; j < i; j++ {
-				<-signal
-			}
-
-			// TODO - document
-			for j := 0; j < i; j++ {
-				select {
-				case pairCh <- pairs[j]:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}
-
-		// TODO - document
-		if err := scanner.Err(); err != nil {
-			pairCh <- lsif.Pair{Err: err}
-		}
-	}()
-
-	return pairCh
+	return lines.Read(ctx, r, unmarshalElement)
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
@@ -24,7 +24,7 @@ var NumUnmarshalGoRoutines = runtime.NumCPU()
 
 // Read reads the given content as line-separated objects which are unmarshallable by the given function
 // and returns a channel of lsif.Pair values for each non-empty line.
-func Read(ctx context.Context, r io.Reader, unmarshal func(line []byte) (_ lsif.Element, err error)) <-chan lsif.Pair {
+func Read(ctx context.Context, r io.Reader, unmarshal func(line []byte) (lsif.Element, error)) <-chan lsif.Pair {
 	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)
 	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
@@ -1,0 +1,117 @@
+package lines
+
+import (
+	"bufio"
+	"context"
+	"io"
+
+	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif"
+)
+
+// LineBufferSize is the maximum size of the buffer used to read each line of a raw LSIF index. Lines in
+// LSIF can get very long as it include escaped hover text (package documentation), as well as large edges
+// such as the contains edge of large documents.
+//
+// This corresponds a 10MB buffer that can accommodate 10 million characters.
+const LineBufferSize = 1e7
+
+// ChannelBufferSize is the number sources lines that can be read ahead of the correlator.
+const ChannelBufferSize = 500
+
+// NumUnmarshalRoutines is the number of goroutines launched to unmarshal individual lines.
+const NumUnmarshalGoRoutines = 100
+
+// Read reads the given content as line-separated objects which are unmarshallable by the given function
+// and returns a channel of lsif.Pair values for each non-empty line.
+func Read(ctx context.Context, r io.Reader, unmarshal func(line []byte) (_ lsif.Element, err error)) <-chan lsif.Pair {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanLines)
+	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)
+
+	// Read the document in a separate go-routine.
+	lineCh := make(chan []byte, ChannelBufferSize)
+	go func() {
+		defer close(lineCh)
+
+		for scanner.Scan() {
+			if line := scanner.Bytes(); len(line) != 0 {
+				lineCh <- line
+			}
+		}
+	}()
+
+	pairCh := make(chan lsif.Pair, ChannelBufferSize)
+	go func() {
+		defer close(pairCh)
+
+		// Unmarshal workers receive work assignments as indices into a shared
+		// slice and put the result into the same index in a second shared slice.
+		work := make(chan int, NumUnmarshalGoRoutines)
+		defer close(work)
+
+		// Each unmarshal worker sends a zero-length value on this channel
+		// to signal completion of a unit of work.
+		signal := make(chan struct{}, NumUnmarshalGoRoutines)
+		defer close(signal)
+
+		// The input slice
+		lines := make([][]byte, NumUnmarshalGoRoutines)
+
+		// The result slice
+		pairs := make([]lsif.Pair, NumUnmarshalGoRoutines)
+
+		for i := 0; i < NumUnmarshalGoRoutines; i++ {
+			go func() {
+				for idx := range work {
+					element, err := unmarshal(lines[idx])
+					pairs[idx].Element = element
+					pairs[idx].Err = err
+					signal <- struct{}{}
+				}
+			}()
+		}
+
+		done := false
+		for !done {
+			i := 0
+
+			// Read a new "batch" of lines from the reader routine and fill the
+			// shared array. Each index that receives a new value is queued in
+			// the unmarshal worker channel and can be immediately processed.
+			for i < NumUnmarshalGoRoutines {
+				line, ok := <-lineCh
+				if !ok {
+					done = true
+					break
+				}
+
+				lines[i] = line
+				work <- i
+				i++
+			}
+
+			// Wait until the current batch has bee completely unmarshalled
+			for j := 0; j < i; j++ {
+				<-signal
+			}
+
+			// Read the result array in order. If the caller context has completed,
+			// we'll abandon any additional values we were going to send on this
+			// channel (as well as any additional errors from the scanner).
+			for j := 0; j < i; j++ {
+				select {
+				case pairCh <- pairs[j]:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+
+		// If there was an error reading from the source, output it here
+		if err := scanner.Err(); err != nil {
+			pairCh <- lsif.Pair{Err: err}
+		}
+	}()
+
+	return pairCh
+}

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"runtime"
 
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif"
 )
@@ -16,10 +17,10 @@ import (
 const LineBufferSize = 1e7
 
 // ChannelBufferSize is the number sources lines that can be read ahead of the correlator.
-const ChannelBufferSize = 500
+const ChannelBufferSize = 512
 
-// NumUnmarshalRoutines is the number of goroutines launched to unmarshal individual lines.
-const NumUnmarshalGoRoutines = 100
+// NumUnmarshalGoRoutines is the number of goroutines launched to unmarshal individual lines.
+var NumUnmarshalGoRoutines = runtime.NumCPU()
 
 // Read reads the given content as line-separated objects which are unmarshallable by the given function
 // and returns a channel of lsif.Pair values for each non-empty line.

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/lines/reader_test.go
@@ -1,0 +1,39 @@
+package lines
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation/lsif"
+)
+
+func TestRead(t *testing.T) {
+	var content []byte
+	var expectedIDs []string
+	for i := 0; i < 10000; i++ {
+		id := fmt.Sprintf("%d", i)
+		content = append(content, id...)
+		content = append(content, '\n')
+		expectedIDs = append(expectedIDs, id)
+	}
+
+	pairs := Read(context.Background(), bytes.NewReader(content), func(line []byte) (lsif.Element, error) {
+		return lsif.Element{ID: string(line)}, nil
+	})
+
+	var ids []string
+	for pair := range pairs {
+		if pair.Err != nil {
+			t.Fatalf("unexpected error: %s", pair.Err)
+		}
+
+		ids = append(ids, pair.Element.ID)
+	}
+
+	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
+		t.Errorf("unexpected ids (-want +got):\n%s", diff)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/jmespath/go-jmespath v0.3.0 // indirect
 	github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5
 	github.com/joho/godotenv v1.3.0
+	github.com/json-iterator/go v1.1.9
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/karlseguin/expect v1.0.6 // indirect
 	github.com/karlseguin/typed v1.1.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/jmespath/go-jmespath v0.3.0 // indirect
 	github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5
 	github.com/joho/godotenv v1.3.0
-	github.com/json-iterator/go v1.1.9
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/karlseguin/expect v1.0.6 // indirect
 	github.com/karlseguin/typed v1.1.7 // indirect


### PR DESCRIPTION
Refactor the function that reads and unmarshalls lines of LSIF data from a source. This is done in a generic (focus on reading, not unmarshalling) way so we can replace/supplment JSON as an encoding in the future.

There are three significant changes: 

- Add a buffered channel between the bufio Scanner and the consumer so that IO can be done ahead of the consumer
- Introduce a pool of unmarshal workers that can work on a batch of lines concurrently
- Buffer the output channel so that unmarshalling can be done ahead of the correlator process

Running the precise-code-intel integration suite's upload phase on master:

```
3m37.597s
3m35.858s
3m42.591s
```

And after this change:

```
2m29.395s
2m32.812s
2m30.429s
```
