### PR TITLE
codeintel: Add RepoUsageStatistics to db

### DIFF
--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -160,6 +160,11 @@ type DB interface {
 	// false valued flag. This method must not be called from within a transaction.
 	DequeueIndex(ctx context.Context) (Index, DB, bool, error)
 
+	// RepoUsageStatistics reads recent event log records and returns the number of search-based and precise
+	// code intelligence activity within the last week grouped by repository. The resulting slice is ordered
+	// by search then precise event counts.
+	RepoUsageStatistics(ctx context.Context) ([]RepoUsageStatistics, error)
+
 	// RepoName returns the name for the repo with the given identifier.
 	RepoName(ctx context.Context, repositoryID int) (string, error)
 }

--- a/internal/codeintel/db/repo_usage.go
+++ b/internal/codeintel/db/repo_usage.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"context"
+	"sort"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+// RepoUsageStatistics pairs a repository identifier with a count of code intelligence events.
+type RepoUsageStatistics struct {
+	RepositoryID int
+	SearchCount  int
+	PreciseCount int
+}
+
+// RepoUsageStatistics reads recent event log records and returns the number of search-based and precise
+// code intelligence activity within the last week grouped by repository. The resulting slice is ordered
+// by search then precise event counts.
+func (db *dbImpl) RepoUsageStatistics(ctx context.Context) ([]RepoUsageStatistics, error) {
+	stats, err := scanRepoUsageStatisticsSlice(db.query(ctx, sqlf.Sprintf(`
+		SELECT
+			r.id,
+			counts.search_count,
+			counts.precise_count
+		FROM (
+			SELECT
+				-- Cut out repo portion of event url
+				-- e.g. https://{github.com/owner/repo}/-/rest-of-path
+				substring(url from '//[^/]+/(.+)/-/') AS repo_name,
+				COUNT(*) FILTER (WHERE name LIKE 'codeintel.search%%%%') AS search_count,
+				COUNT(*) FILTER (WHERE name LIKE 'codeintel.lsif%%%%') AS precise_count
+			FROM event_logs
+			WHERE timestamp >= NOW() - INTERVAL '1 week'
+			GROUP BY repo_name
+		) counts
+		-- Cast allows use of the uri btree index
+		JOIN repo r ON r.uri = counts.repo_name::citext
+	`)))
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		comparisons := [2]int{
+			stats[j].SearchCount - stats[i].SearchCount,
+			stats[j].PreciseCount - stats[i].PreciseCount,
+		}
+
+		for _, cmp := range comparisons {
+			if cmp != 0 {
+				return cmp < 0
+			}
+		}
+
+		return false
+	})
+
+	return stats, nil
+}

--- a/internal/codeintel/db/repo_usage_test.go
+++ b/internal/codeintel/db/repo_usage_test.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestRepoUsageStatistics(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := testDB()
+
+	insertEvent := func(url, name string, count int) {
+		query := sqlf.Sprintf(`
+			INSERT INTO event_logs (user_id, anonymous_user_id, source, argument, version, timestamp, name, url)
+			VALUES (1, '', 'test', '{}', 'dev', NOW(), %s, %s)
+		`, name, url)
+
+		for i := 0; i < count; i++ {
+			if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+				t.Fatalf("unexpected error inserting event record: %s", err)
+			}
+		}
+	}
+
+	for _, data := range []struct {
+		URL              string
+		NumSearchEvents  int
+		NumPreciseEvents int
+	}{
+		{"http://localhost:3080/github.com/foo/baz/-/remainder_of_path", 10, 10},
+		{"https://sourcegraph.com/github.com/foo/bar/-/remainder_of_path", 25, 20},
+		{"http://localhost:3080/gitlab.com/bar/baz/-/remainder_of_path", 15, 30},
+		{"https://sourcegraph.com/github.com/bar/bonk/-/remainder_of_path", 5, 40},
+		{"http://srcgraph.org/github.com/bonk/quux/-/remainder_of_path", 4, 50},
+		{"https://sourcegraph.com/github.com/bonk/honk/-/remainder_of_path", 10, 60}, // no such repo
+	} {
+		insertEvent(data.URL, "codeintel.searchHover", data.NumSearchEvents)
+		insertEvent(data.URL, "codeintel.lsifHover", data.NumPreciseEvents)
+	}
+
+	for i, name := range []string{
+		"github.com/foo/baz",
+		"github.com/foo/bar",
+		"gitlab.com/bar/baz",
+		"github.com/bar/bonk",
+		"github.com/bonk/quux",
+	} {
+		query := sqlf.Sprintf(`INSERT INTO repo (id, name, uri) VALUES (%s, %s, %s)`, i+1, name, name)
+
+		if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error inserting repo: %s", err)
+		}
+	}
+
+	stats, err := db.RepoUsageStatistics(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error getting repo counts: %s", err)
+	}
+
+	expectedStatistics := []RepoUsageStatistics{
+		{RepositoryID: 2, SearchCount: 25, PreciseCount: 20},
+		{RepositoryID: 3, SearchCount: 15, PreciseCount: 30},
+		{RepositoryID: 1, SearchCount: 10, PreciseCount: 10},
+		{RepositoryID: 4, SearchCount: 5, PreciseCount: 40},
+		{RepositoryID: 5, SearchCount: 4, PreciseCount: 50},
+	}
+	if diff := cmp.Diff(expectedStatistics, stats); diff != "" {
+		t.Errorf("unexpected repo counts (-want +got):\n%s", diff)
+	}
+}

--- a/internal/codeintel/db/scan.go
+++ b/internal/codeintel/db/scan.go
@@ -409,3 +409,31 @@ func scanFirstIndex(rows *sql.Rows, err error) (Index, bool, error) {
 func scanFirstIndexDequeue(rows *sql.Rows, err error) (interface{}, bool, error) {
 	return scanFirstIndex(rows, err)
 }
+
+// scanRepoUsageStatistics populates a RepoUsageStatistics from the given scanner.
+func scanRepoUsageStatistics(scanner scanner) (stats RepoUsageStatistics, err error) {
+	err = scanner.Scan(&stats.RepositoryID, &stats.SearchCount, &stats.PreciseCount)
+	return stats, err
+}
+
+// scanRepoUsageStatisticsSlice reads the given set of repo usage stat rows and returns
+// a slice of RepoUsageStatistics values. This method should be called directly from the
+// return value of `*db.query`.
+func scanRepoUsageStatisticsSlice(rows *sql.Rows, err error) ([]RepoUsageStatistics, error) {
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var stats []RepoUsageStatistics
+	for rows.Next() {
+		s, err := scanRepoUsageStatistics(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		stats = append(stats, s)
+	}
+
+	return stats, nil
+}


### PR DESCRIPTION
Part of [RFC 153](https://docs.google.com/document/u/1/d/1LFwtfIqTgxzyNQDRvKsWbY9pZKiXVhwPyrNB04gnpDQ).

Add a method to the codeintel db layer to determine the search and lsif-based code intel event counts in the past week for each unique repo known to the instance.

This will be used by the auto indexer to determine which repos should be eligible for automatic LSIF indexing. The basic idea is that things with a code intel event count over a threshold and a high enough search/(precise+search) ratio would benefit greatly from precise indexes.

Query plan of new query:

```
                                                                              QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=428850.23..639314.06 rows=92757 width=20) (actual time=10122.697..11508.229 rows=4614 loops=1)
   ->  GroupAggregate  (cost=428849.67..443148.53 rows=92757 width=48) (actual time=10121.537..10874.261 rows=12988 loops=1)
         Group Key: ("substring"(event_logs.url, '//[^/]+/(.+)/-/'::text))
         ->  Sort  (cost=428849.67..431039.57 rows=875960 width=52) (actual time=10121.520..10670.309 rows=1014416 loops=1)
               Sort Key: ("substring"(event_logs.url, '//[^/]+/(.+)/-/'::text))
               Sort Method: external merge  Disk: 63240kB
               ->  Index Scan using event_logs_timestamp on event_logs  (cost=0.44..307314.71 rows=875960 width=52) (actual time=0.075..7587.788 rows=1014416 loops=1)
                     Index Cond: ("timestamp" >= (now() - '7 days'::interval))
   ->  Index Scan using repo_uri_idx on repo r  (cost=0.56..2.09 rows=1 width=39) (actual time=0.048..0.048 rows=0 loops=12988)
         Index Cond: (uri = (("substring"(event_logs.url, '//[^/]+/(.+)/-/'::text)))::citext)
 Planning Time: 0.447 ms
 Execution Time: 11536.736 ms
```

This query will only be called periodically (probably on the order of a handful of times an hour) from the auto indexer service (coming soon) so doesn't need to be terribly efficient (just not waste resources of other processes).