### PR TITLE
codeintel: Reduce allocations in serializer

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/reader"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
+	jsonserializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer/json"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
@@ -245,7 +245,7 @@ func openTestDatabase(t *testing.T) Database {
 	filename := "../../../../internal/codeintel/bundles/testdata/lsif-go@ad3507cb.lsif.db"
 
 	// TODO(efritz) - rewrite test not to require actual reader
-	reader, err := reader.NewSQLiteReader(filename, serializer.NewDefaultSerializer())
+	reader, err := reader.NewSQLiteReader(filename, jsonserializer.New())
 	if err != nil {
 		t.Fatalf("unexpected error creating reader: %s", err)
 	}

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-bundle-manager/internal/database"
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-bundle-manager/internal/paths"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/reader"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
+	jsonserializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer/json"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -299,7 +299,7 @@ func (s *Server) dbQueryErr(w http.ResponseWriter, r *http.Request, handler dbQu
 			return nil, ErrUnknownDatabase
 		}
 
-		sqliteReader, err := reader.NewSQLiteReader(filename, serializer.NewDefaultSerializer())
+		sqliteReader, err := reader.NewSQLiteReader(filename, jsonserializer.New())
 		if err != nil {
 			return nil, pkgerrors.Wrap(err, "reader.NewSQLiteReader")
 		}

--- a/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/correlation"
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker/internal/existence"
 	bundles "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
+	jsonserializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer/json"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/writer"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
@@ -295,7 +295,7 @@ func convert(
 
 // write commits the correlated data to disk.
 func write(ctx context.Context, filename string, groupedBundleData *correlation.GroupedBundleData) error {
-	writer, err := writer.NewSQLiteWriter(filename, serializer.NewDefaultSerializer())
+	writer, err := writer.NewSQLiteWriter(filename, jsonserializer.New())
 	if err != nil {
 		return err
 	}

--- a/internal/codeintel/bundles/reader/sqlite_reader_test.go
+++ b/internal/codeintel/bundles/reader/sqlite_reader_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
+	jsonserializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer/json"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
@@ -144,7 +144,7 @@ func TestReadReferences(t *testing.T) {
 }
 
 func testReader(t *testing.T) Reader {
-	reader, err := NewSQLiteReader("../testdata/lsif-go@ad3507cb.lsif.db", serializer.NewDefaultSerializer())
+	reader, err := NewSQLiteReader("../testdata/lsif-go@ad3507cb.lsif.db", jsonserializer.New())
 	if err != nil {
 		t.Fatalf("unexpected error opening database: %s", err)
 	}

--- a/internal/codeintel/bundles/serializer/json/gzip.go
+++ b/internal/codeintel/bundles/serializer/json/gzip.go
@@ -1,0 +1,34 @@
+package json
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+)
+
+// TODO(efritz) - document
+func compress(uncompressed []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+
+	if _, err := io.Copy(gzipWriter, bytes.NewReader(uncompressed)); err != nil {
+		return nil, err
+	}
+
+	if err := gzipWriter.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// unmarshalGzippedJSON unmarshals the gzip+json encoded data.
+func unmarshalGzippedJSON(data []byte, payload interface{}) error {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	return json.NewDecoder(gzipReader).Decode(&payload)
+}

--- a/internal/codeintel/bundles/serializer/json/id.go
+++ b/internal/codeintel/bundles/serializer/json/id.go
@@ -1,0 +1,28 @@
+package json
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+type ID string
+
+func (id *ID) UnmarshalJSON(raw []byte) error {
+	if raw[0] == '"' {
+		var v string
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return err
+		}
+
+		*id = ID(v)
+		return nil
+	}
+
+	var v int64
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	*id = ID(strconv.FormatInt(v, 10))
+	return nil
+}

--- a/internal/codeintel/bundles/serializer/json/serializer_test.go
+++ b/internal/codeintel/bundles/serializer/json/serializer_test.go
@@ -1,4 +1,4 @@
-package serializer
+package json
 
 import (
 	"fmt"
@@ -59,7 +59,7 @@ func TestDefaultSerializerDocumentData(t *testing.T) {
 		},
 	}
 
-	for _, file := range []string{"../testdata/documentdata-strings.json", "../testdata/documentdata-ints.json"} {
+	for _, file := range []string{"../../testdata/documentdata-strings.json", "../../testdata/documentdata-ints.json"} {
 		name := fmt.Sprintf("file=%s", file)
 
 		t.Run(name, func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestDefaultSerializerDocumentData(t *testing.T) {
 				t.Fatalf("unexpected error compressing file contents: %s", err)
 			}
 
-			serializer := &defaultSerializer{}
+			serializer := &jsonSerializer{}
 			actual, err := serializer.UnmarshalDocumentData(compressed)
 			if err != nil {
 				t.Fatalf("unexpected error unmarshalling document data: %s", err)
@@ -123,7 +123,7 @@ func TestDefaultSerializerResultChunkData(t *testing.T) {
 		},
 	}
 
-	for _, file := range []string{"../testdata/resultchunkdata-strings.json", "../testdata/resultchunkdata-ints.json"} {
+	for _, file := range []string{"../../testdata/resultchunkdata-strings.json", "../../testdata/resultchunkdata-ints.json"} {
 		name := fmt.Sprintf("file=%s", file)
 
 		t.Run(name, func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestDefaultSerializerResultChunkData(t *testing.T) {
 				t.Fatalf("unexpected error compressing file contents: %s", err)
 			}
 
-			serializer := &defaultSerializer{}
+			serializer := &jsonSerializer{}
 			actual, err := serializer.UnmarshalResultChunkData(compressed)
 			if err != nil {
 				t.Fatalf("unexpected error unmarshalling result chunk data: %s", err)

--- a/internal/codeintel/bundles/serializer/json/types.go
+++ b/internal/codeintel/bundles/serializer/json/types.go
@@ -1,0 +1,86 @@
+package json
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
+)
+
+//
+// The following types are used during marshalling
+
+type SerializingTaggedValue struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+type SerializingRange struct {
+	StartLine          int                    `json:"startLine"`
+	StartCharacter     int                    `json:"startCharacter"`
+	EndLine            int                    `json:"endLine"`
+	EndCharacter       int                    `json:"endCharacter"`
+	DefinitionResultID types.ID               `json:"definitionResultId"`
+	ReferenceResultID  types.ID               `json:"referenceResultId"`
+	HoverResultID      types.ID               `json:"hoverResultId"`
+	MonikerIDs         SerializingTaggedValue `json:"monikerIds"`
+}
+
+type SerializingDocument struct {
+	Ranges             SerializingTaggedValue `json:"ranges"`
+	HoverResults       SerializingTaggedValue `json:"hoverResults"`
+	Monikers           SerializingTaggedValue `json:"monikers"`
+	PackageInformation SerializingTaggedValue `json:"packageInformation"`
+}
+
+type SerializingResultChunk struct {
+	DocumentPaths      SerializingTaggedValue `json:"documentPaths"`
+	DocumentIDRangeIDs SerializingTaggedValue `json:"documentIdRangeIds"`
+}
+
+//
+// The following types are used during unmarshalling
+
+type SerializedTaggedValue struct {
+	Type  string            `json:"type"`
+	Value []json.RawMessage `json:"value"`
+}
+
+type SerializedRange struct {
+	StartLine          int                   `json:"startLine"`
+	StartCharacter     int                   `json:"startCharacter"`
+	EndLine            int                   `json:"endLine"`
+	EndCharacter       int                   `json:"endCharacter"`
+	DefinitionResultID ID                    `json:"definitionResultId"`
+	ReferenceResultID  ID                    `json:"referenceResultId"`
+	HoverResultID      ID                    `json:"hoverResultId"`
+	MonikerIDs         SerializedTaggedValue `json:"monikerIds"`
+}
+
+type SerializedDocument struct {
+	Ranges             SerializedTaggedValue `json:"ranges"`
+	HoverResults       SerializedTaggedValue `json:"hoverResults"`
+	Monikers           SerializedTaggedValue `json:"monikers"`
+	PackageInformation SerializedTaggedValue `json:"packageInformation"`
+}
+
+type SerializedResultChunk struct {
+	DocumentPaths      SerializedTaggedValue `json:"documentPaths"`
+	DocumentIDRangeIDs SerializedTaggedValue `json:"documentIdRangeIds"`
+}
+
+type SerializedMoniker struct {
+	Kind                 string `json:"kind"`
+	Scheme               string `json:"scheme"`
+	Identifier           string `json:"identifier"`
+	PackageInformationID ID     `json:"packageInformationId"`
+}
+
+type SerializedPackageInformation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type SerializedDocumentIDRangeID struct {
+	DocumentID ID `json:"documentId"`
+	RangeID    ID `json:"rangeId"`
+}

--- a/internal/codeintel/bundles/serializer/json/unmarshal.go
+++ b/internal/codeintel/bundles/serializer/json/unmarshal.go
@@ -1,0 +1,1 @@
+package json

--- a/internal/codeintel/bundles/serializer/json/unmarshal.go
+++ b/internal/codeintel/bundles/serializer/json/unmarshal.go
@@ -1,1 +1,0 @@
-package json

--- a/internal/codeintel/bundles/writer/sqlite_writer_test.go
+++ b/internal/codeintel/bundles/writer/sqlite_writer_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/reader"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer"
+	jsonserializer "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/serializer/json"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 )
@@ -28,7 +28,7 @@ func TestWrite(t *testing.T) {
 
 	ctx := context.Background()
 	filename := filepath.Join(tempDir, "test.db")
-	serializer := serializer.NewDefaultSerializer()
+	serializer := jsonserializer.New()
 
 	writer, err := NewSQLiteWriter(filename, serializer)
 	if err != nil {


### PR DESCRIPTION
This was an attempt to reduce the number of allocations in the worker, which it turns out are all situated inside of the serializer before writing to a SQLite file.

This refactors the defaultSerializer into a new JSON serializer package (we will probably be choosing another serialization format in the near future). The only differences is that instead of serializing `map[string]interface{}`, we create a named struct and serialize a value type. This allows us to stack allocate most of the stuff we pass to `json.Marshal`, where maps would need to be heap allocated regardless of their escape properties.

Running the precise-code-intel integration suite's upload phase on master:

```
3m37.597s
3m35.858s
3m42.591s
```

And after this change:

```
3m23.639s
3m13.413s
3m17.683s
```
