### PR TITLE
Implement diff for merged and closed changesets, when available

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -411,26 +411,9 @@ func (r *changesetResolver) Base(ctx context.Context) (*graphqlbackend.GitRefRes
 		return nil, errors.New("changeset base ref could not be determined")
 	}
 
-	var oid string
-	if r.ExternalState == campaigns.ChangesetStateMerged {
-		// The PR was merged, find the merge commit
-		events, err := r.computeEvents(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "fetching changeset events")
-		}
-		oid = ee.ChangesetEvents(events).FindMergeCommitID()
-		// We actually want the parent of that commit, so base...head
-		// returns exactly the changes from the merged changeset.
-		if oid != "" {
-			oid += "^"
-		}
-	}
-	if oid == "" {
-		// Fall back to the base ref
-		oid, err = r.Changeset.BaseRefOid()
-		if err != nil {
-			return nil, err
-		}
+	oid, err := r.Changeset.BaseRefOid()
+	if err != nil {
+		return nil, err
 	}
 
 	resolver, err := r.gitRef(ctx, name, oid, false)

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -578,7 +578,7 @@ func (c *Changeset) HeadRefOid() (string, error) {
 	case *github.PullRequest:
 		return m.HeadRefOid, nil
 	case *bitbucketserver.PullRequest:
-		return "", nil
+		return m.Commits[len(m.Commits)-1].ID, nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -555,6 +555,21 @@ func (c *Changeset) Events() (events []*ChangesetEvent) {
 	return events
 }
 
+// HiddenHeadRef returns the hidden ref on the code host where the PR code is stored.
+// Note: GitHub persists these forever, but Bitbucket prunes them, so there is no
+// guarantee they exist.
+func (c *Changeset) HiddenHeadRef() (changesetRef string, err error) {
+	switch strings.ToLower(c.ExternalServiceType) {
+	case "github":
+		changesetRef = fmt.Sprintf("refs/pull/%s/head", c.ExternalID)
+	case "bitbucketserver":
+		changesetRef = fmt.Sprintf("refs/pull-requests/%s/from", c.ExternalID)
+	default:
+		err = errors.Errorf("invalid service type %q", c.ExternalServiceType)
+	}
+	return
+}
+
 // HeadRefOid returns the git ObjectID of the HEAD reference associated with
 // Changeset on the codehost. If the codehost doesn't include the ObjectID, an
 // empty string is returned.


### PR DESCRIPTION
Closes #10959

I implemented it using the hidden refs. Bitbucket, however removes the refs of closed PRs, so I didn't find a way to retrieve it for those.