### PR TITLE
Jaeger reverse proxy working 

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -17,6 +17,7 @@ import (
 )
 
 var grafanaURLFromEnv = env.Get("GRAFANA_SERVER_URL", "", "URL at which Grafana can be reached")
+var jaegerURLFromEnv = env.Get("JAEGER_SERVER_URL", "", "URL at which Jaeger UI can be reached")
 
 func addNoK8sClientHandler(r *mux.Router) {
 	noHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -30,6 +31,7 @@ func addNoK8sClientHandler(r *mux.Router) {
 // endpoints.
 func addDebugHandlers(r *mux.Router) {
 	addGrafana(r)
+	addJaeger(r)
 
 	var rph debugproxies.ReverseProxyHandler
 
@@ -87,6 +89,40 @@ func addGrafana(r *mux.Router) {
 		}
 	} else {
 		addNoGrafanaHandler(r)
+	}
+}
+
+func addNoJaegerHandler(r *mux.Router) {
+	noJaeger := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `Jaeger endpoint proxying: Please set env var JAEGER_SERVER_URL`)
+	})
+	r.Handle("/jaeger", adminOnly(noJaeger))
+}
+
+func addJaeger(r *mux.Router) {
+	if len(jaegerURLFromEnv) > 0 {
+		fmt.Println("Jaeger URL from env ", jaegerURLFromEnv)
+		jaegerURL, err := url.Parse(jaegerURLFromEnv)
+		if err != nil {
+			log.Printf("failed to parse JAEGER_SERVER_URL=%s: %v", jaegerURLFromEnv, err)
+			addNoJaegerHandler(r)
+		} else {
+			prefix := "/jaeger"
+			// 🚨 SECURITY: Only admins have access to Jaeger dashboard
+			r.PathPrefix(prefix).Handler(adminOnly(&httputil.ReverseProxy{
+				Director: func(req *http.Request) {
+					req.URL.Scheme = "http"
+					req.URL.Host = jaegerURL.Host
+					//if i := strings.Index(req.URL.Path, prefix); i >= 0 {
+					//	req.URL.Path = req.URL.Path[i+len(prefix):]
+					//}
+				},
+				ErrorLog: log.New(env.DebugOut, fmt.Sprintf("%s debug proxy: ", "jaeger"), log.LstdFlags),
+			}))
+		}
+
+	} else {
+		addNoJaegerHandler(r)
 	}
 }
 

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -113,9 +113,6 @@ func addJaeger(r *mux.Router) {
 				Director: func(req *http.Request) {
 					req.URL.Scheme = "http"
 					req.URL.Host = jaegerURL.Host
-					//if i := strings.Index(req.URL.Path, prefix); i >= 0 {
-					//	req.URL.Path = req.URL.Path[i+len(prefix):]
-					//}
 				},
 				ErrorLog: log.New(env.DebugOut, fmt.Sprintf("%s debug proxy: ", "jaeger"), log.LstdFlags),
 			}))

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -39,6 +39,7 @@ var defaultEnv = map[string]string{
 	"GITHUB_BASE_URL":                       "http://127.0.0.1:3180", // points to github-proxy
 
 	"GRAFANA_SERVER_URL": "http://127.0.0.1:3370",
+	"JAEGER_SERVER_URL":  "http://127.0.0.0.1:16686",
 
 	// Limit our cache size to 100GB, same as prod. We should probably update
 	// searcher/symbols to ensure this value isn't larger than the volume for

--- a/dev/jaeger.sh
+++ b/dev/jaeger.sh
@@ -24,4 +24,6 @@ chmod +x "${target}"
 
 popd >/dev/null
 
+export QUERY_BASE_PATH="/-/debug/jaeger"
+
 exec "${target}" --log-level "${JAEGER_LOG_LEVEL:-info}" "$@" >>"${JAEGER_DISK}"/logs/jaeger.log 2>&1

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -66,6 +66,10 @@ export USE_ENHANCED_LANGUAGE_DETECTION=${USE_ENHANCED_LANGUAGE_DETECTION:-1}
 export GRAFANA_SERVER_URL=http://localhost:3370
 export PROMETHEUS_URL="${PROMETHEUS_URL:-"http://localhost:9090"}"
 
+# Jaeger config to get UI to work with reverse proxy, see https://www.jaegertracing.io/docs/1.11/deployment/#ui-base-path
+# export QUERY_BASE_PATH="http://localhost:3080/-/debug/jaeger/"
+export JAEGER_SERVER_URL=http://localhost:16686
+
 # Caddy / HTTPS configuration
 export SOURCEGRAPH_HTTPS_DOMAIN="${SOURCEGRAPH_HTTPS_DOMAIN:-"sourcegraph.test"}"
 export SOURCEGRAPH_HTTPS_PORT="${SOURCEGRAPH_HTTPS_PORT:-"3443"}"

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -67,7 +67,6 @@ export GRAFANA_SERVER_URL=http://localhost:3370
 export PROMETHEUS_URL="${PROMETHEUS_URL:-"http://localhost:9090"}"
 
 # Jaeger config to get UI to work with reverse proxy, see https://www.jaegertracing.io/docs/1.11/deployment/#ui-base-path
-# export QUERY_BASE_PATH="http://localhost:3080/-/debug/jaeger/"
 export JAEGER_SERVER_URL=http://localhost:16686
 
 # Caddy / HTTPS configuration

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -47,6 +47,9 @@ RUN chown -R jaeger /tmp
 USER jaeger
 VOLUME ["/tmp"]
 
+# Used in order to reverse proxy the Jaeger UI
+ENV QUERY_BASE_PATH="/-/debug/jaeger"
+
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
 CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]
 

--- a/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/web/src/site-admin/SiteAdminSidebar.tsx
@@ -53,8 +53,8 @@ export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = 
         <a href="/-/debug/grafana" className={SIDEBAR_BUTTON_CLASS}>
             Monitoring
         </a>
-        <a href="/-/debug/jaeger" className={SIDEBAR_BUTTON_CLASS} >
-           Tracing
+        <a href="/-/debug/jaeger" className={SIDEBAR_BUTTON_CLASS}>
+            Tracing
         </a>
     </div>
 )

--- a/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/web/src/site-admin/SiteAdminSidebar.tsx
@@ -53,5 +53,8 @@ export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = 
         <a href="/-/debug/grafana" className={SIDEBAR_BUTTON_CLASS}>
             Monitoring
         </a>
+        <a href="/-/debug/jaeger" className={SIDEBAR_BUTTON_CLASS} >
+           Tracing
+        </a>
     </div>
 )


### PR DESCRIPTION
The jaeger reverse proxy is working in dev builds at
example.com/-/debug/jaeger

Fixes https://github.com/sourcegraph/sourcegraph/issues/10491

Also added UI element under Monitoring
![Screen Shot 2020-05-27 at 10 30 46 AM](https://user-images.githubusercontent.com/31839142/83053326-68197180-a005-11ea-8d9d-b03a86455141.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->