### PR TITLE
search: add remaining mapper helpers

### DIFF
--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -4,65 +4,132 @@ package query
 // query grammar. It is a visitor that will replace the visited node by the
 // returned value.
 type Mapper interface {
-	MapNodes(v Mapper, node []Node) []Node
-	MapOperator(v Mapper, kind operatorKind, operands []Node) []Node
-	MapParameter(v Mapper, field, value string, negated bool) Node
-	MapPattern(v Mapper, value string, negated, quoted bool) Node
+	MapNodes(m Mapper, node []Node) []Node
+	MapOperator(m Mapper, kind operatorKind, operands []Node) []Node
+	MapParameter(m Mapper, field, value string, negated bool) Node
+	MapPattern(m Mapper, value string, negated, quoted bool) Node
 }
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
-// maps it to itself. A BaseMapper's methods may be overrided by embedding it a
-// custom mapper's definitoin. See ParameterMapper for an example.
+// maps it to itself. A BaseMapper's methods may be overriden by embedding it a
+// custom mapper's definition. See ParameterMapper for an example.
 type BaseMapper struct{}
 
-func (*BaseMapper) MapNodes(visitor Mapper, nodes []Node) []Node {
+func (*BaseMapper) MapNodes(mapper Mapper, nodes []Node) []Node {
 	mapped := []Node{}
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Pattern:
-			mapped = append(mapped, visitor.MapPattern(visitor, v.Value, v.Negated, v.Quoted))
+			mapped = append(mapped, mapper.MapPattern(mapper, v.Value, v.Negated, v.Quoted))
 		case Parameter:
-			mapped = append(mapped, visitor.MapParameter(visitor, v.Field, v.Value, v.Negated))
+			mapped = append(mapped, mapper.MapParameter(mapper, v.Field, v.Value, v.Negated))
 		case Operator:
-			mapped = append(mapped, visitor.MapOperator(visitor, v.Kind, v.Operands)...)
+			mapped = append(mapped, mapper.MapOperator(mapper, v.Kind, v.Operands)...)
 		}
 	}
 	return mapped
 }
 
 // Base mapper for Operators. Reduces operands if changed.
-func (*BaseMapper) MapOperator(visitor Mapper, kind operatorKind, operands []Node) []Node {
-	return newOperator(visitor.MapNodes(visitor, operands), kind)
+func (*BaseMapper) MapOperator(mapper Mapper, kind operatorKind, operands []Node) []Node {
+	return newOperator(mapper.MapNodes(mapper, operands), kind)
 }
 
 // Base mapper for Parameters. It is the identity function.
-func (*BaseMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
+func (*BaseMapper) MapParameter(mapper Mapper, field, value string, negated bool) Node {
 	return Parameter{Field: field, Value: value, Negated: negated}
 }
 
 // Base mapper for Patterns. It is the identity function.
-func (*BaseMapper) MapPattern(visitor Mapper, value string, negated, quoted bool) Node {
+func (*BaseMapper) MapPattern(mapper Mapper, value string, negated, quoted bool) Node {
 	return Pattern{Value: value, Negated: negated, Quoted: quoted}
+}
+
+// OperatorMapper is a helper mapper that maps operators in a query. It takes as
+// state a callback that will call and map each visited operator with the return
+// value.
+type OperatorMapper struct {
+	BaseMapper
+	callback func(kind operatorKind, operands []Node) []Node
+}
+
+// MapOperator implements OperatorMapper by overriding the BaseMapper's value to
+// substitute a node computed by the callback. It reduces any substituted node.
+func (s *OperatorMapper) MapOperator(mapper Mapper, kind operatorKind, operands []Node) []Node {
+	return newOperator(s.callback(kind, operands), And)
 }
 
 // ParameterMapper is a helper mapper that only maps parameters in a query. It
 // takes as state a callback that will call and map each visited parameter by
 // the return value.
 type ParameterMapper struct {
-	callback func(field, value string, negated bool) Node
 	BaseMapper
+	callback func(field, value string, negated bool) Node
 }
 
 // MapParameter implements ParameterMapper by overriding the BaseMapper's value
-// to substitute a node as determined by the callback.
-func (s *ParameterMapper) MapParameter(visitor Mapper, field, value string, negated bool) Node {
+// to substitute a node computed by the callback.
+func (s *ParameterMapper) MapParameter(mapper Mapper, field, value string, negated bool) Node {
 	return s.callback(field, value, negated)
 }
 
-// MapParameter calls callback on all parameter nodes, substituting them for
-// callback's return value. callback supplies the node's field, value, and
-// whether the value is negated.
+// PatternMapper is a helper mapper that only maps patterns in a query. It
+// takes as state a callback that will call and map each visited pattern by
+// the return value.
+type PatternMapper struct {
+	BaseMapper
+	callback func(value string, negated, quoted bool) Node
+}
+
+func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated, quoted bool) Node {
+	return s.callback(value, negated, quoted)
+}
+
+// FieldMapper is a helper mapper that only maps patterns in a query, for a
+// field specified in state. For each parameter with this field name it calls
+// the callback that maps the field's members.
+type FieldMapper struct {
+	BaseMapper
+	field    string
+	callback func(value string, negated bool) Node
+}
+
+func (s *FieldMapper) MapParameter(mapper Mapper, field, value string, negated bool) Node {
+	if s.field == field {
+		return s.callback(value, negated)
+	}
+	return Parameter{Field: field, Value: value, Negated: negated}
+}
+
+// MapOperator is a convenience function that calls callback on all operator
+// nodes, substituting them for callback's return value. callback supplies the
+// node's kind and operands.
+func MapOperator(nodes []Node, callback func(kind operatorKind, operands []Node) []Node) []Node {
+	mapper := &OperatorMapper{callback: callback}
+	return mapper.MapNodes(mapper, nodes)
+}
+
+// MapParameter is a convenience function that calls callback on all parameter
+// nodes, substituting them for callback's return value. callback supplies the
+// node's field, value, and whether the value is negated.
 func MapParameter(nodes []Node, callback func(field, value string, negated bool) Node) []Node {
-	visitor := &ParameterMapper{callback: callback}
-	return visitor.MapNodes(visitor, nodes)
+	mapper := &ParameterMapper{callback: callback}
+	return mapper.MapNodes(mapper, nodes)
+}
+
+// MapPattern is a convenience function that calls callback on all pattern
+// nodes, substituting them for callback's return value. callback supplies the
+// node's field, value, and whether the value is negated.
+func MapPattern(nodes []Node, callback func(value string, negated, quoted bool) Node) []Node {
+	mapper := &PatternMapper{callback: callback}
+	return mapper.MapNodes(mapper, nodes)
+}
+
+// MapField is a convenience function that calls callback on all parameter nodes
+// whose field matches the field argument, substituting them for callback's
+// return value. callback supplies the node's value, and whether the value is
+// negated.
+func MapField(nodes []Node, field string, callback func(value string, negated bool) Node) []Node {
+	mapper := &FieldMapper{callback: callback, field: field}
+	return mapper.MapNodes(mapper, nodes)
 }

--- a/internal/search/query/mapper_test.go
+++ b/internal/search/query/mapper_test.go
@@ -1,0 +1,43 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMapOperator(t *testing.T) {
+	input := []Node{
+		Operator{
+			Kind: And,
+			Operands: []Node{
+				Parameter{Field: "repo", Value: "github.com/saucegraph/saucegraph"},
+				Pattern{Value: "pasta_sauce"},
+			},
+		},
+	}
+	want := input
+	got := MapOperator(input, func(kind operatorKind, operands []Node) []Node {
+		return newOperator(newOperator(newOperator(operands, kind), And), Or)
+	})
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestMapField(t *testing.T) {
+	input := Parameter{Field: "before", Value: "today"}
+	want := Operator{
+		Kind: Or,
+		Operands: []Node{
+			Parameter{Field: "before", Value: "yesterday"},
+			Parameter{Field: "after", Value: "yesterday"},
+		},
+	}
+	got := MapField([]Node{input}, "before", func(_ string, _ bool) Node {
+		return want
+	})
+	if diff := cmp.Diff(want, got[0]); diff != "" {
+		t.Fatal(diff)
+	}
+}


### PR DESCRIPTION
This just adds a couple more helper functions to the `mapper` interface, analog to `visitor` (i.e., for changing operators, fields, patterns, etc.) I added tests for the main additions `MapOperators` and `MapFields`, the other important ones are covered by existing tests.