### PR TITLE
env: optimize performance

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"io"
@@ -16,9 +15,15 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
-var descriptions = make(map[string]string)
+type envflag struct {
+	name        string
+	description string
+	value       string
+}
+
+var env []envflag
+var environ map[string]string
 var locked = false
-var env = expvar.NewMap("env")
 
 var (
 	// MyName represents the name of the current process.
@@ -83,52 +88,60 @@ func Get(name, defaultValue, description string) string {
 		panic("env.Get has to be called on package initialization")
 	}
 
-	if _, ok := descriptions[name]; ok {
-		panic(fmt.Sprintf("%q already registered", name))
+	// os.LookupEnv is a syscall. We use Get a lot on startup in many
+	// packages. This leads to it being the main contributer to init being
+	// slow. So we avoid the constant syscalls by checking env once.
+	if environ == nil {
+		li := os.Environ()
+		environ = make(map[string]string, len(li))
+		for _, e := range environ {
+			i := strings.Index(e, "=")
+			environ[e[:i]] = e[i+1:]
+		}
 	}
-
-	if defaultValue != "" {
-		description = fmt.Sprintf("%s (default: %q)", description, defaultValue)
-	}
-	descriptions[name] = description
 
 	// Allow per-process override. For instance, SRC_LOG_LEVEL_repo_updater would
 	// apply to repo-updater, but not to anything else.
 	perProg := name + "_" + envVarName
-	value, ok := os.LookupEnv(perProg)
+	value, ok := environ[perProg]
 	if !ok {
-		value, ok = os.LookupEnv(name)
+		value, ok = environ[name]
 		if !ok {
 			value = defaultValue
 		}
 	}
-	env.Set(name, jsonStringer(value))
+
+	env = append(env, envflag{
+		name:        name,
+		description: description,
+		value:       value,
+	})
+
 	return value
-}
-
-type jsonStringer string
-
-func (s jsonStringer) String() string {
-	v, _ := json.Marshal(s)
-	return string(v)
 }
 
 // Lock makes later calls to Get fail with a panic. Call this at the beginning of the main function.
 func Lock() {
 	locked = true
+
+	sort.Slice(env, func(i, j int) bool { return env[i].name < env[j].name })
+
+	for i := 1; i < len(env); i++ {
+		if env[i-1].name == env[i].name {
+			panic(fmt.Sprintf("%q already registered", env[i].name))
+		}
+	}
+
+	expvar.Publish("env", expvar.Func(func() interface{} {
+		return env
+	}))
 }
 
 // PrintHelp prints a list of all registered environment variables and their descriptions.
 func PrintHelp() {
-	var names []string
-	for name := range descriptions {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
 	log.Print("Environment variables:")
-	for _, name := range names {
-		log.Printf("  %-40s %s", name, descriptions[name])
+	for _, e := range env {
+		log.Printf("  %-40s %s (value: %q)", e.name, e.description, e.value)
 	}
 }
 


### PR DESCRIPTION
I was noticing running tests, but specifying no tests to run would take
a second. I assumed this is due to us doing too much work in "func
init". I found https://github.com/mvdan/benchinit and applied it to
./cmd/searcher out of interest. It found in that case that env is the
main cause of init slowness.

This is unlikely the main cause, but it was fun to optimize
anyways. Will have to properly investigate init startup by targetting a
slow package. But this acheived a _much_ faster Get implementation by:

- removing call to fmt.Sprintf if we have a defaultValue
- removing map insertions, instead build a list and validate uniqueness
  in Lock.
- remove updating expvar.Map. This involves a bunch of nasty
  locks. Instead we change the format of our expvar and return the list
  we build up.

This ended in the following results:

```
  name    old time/op    new time/op    delta
  Init-8    1.15µs ± 0%    0.53µs ±28%  -53.72%  (p=0.016 n=4+5)

  name    old alloc/op   new alloc/op   delta
  Init-8      384B ± 0%      604B ±22%  +57.19%  (p=0.008 n=5+5)

  name    old allocs/op  new allocs/op  delta
  Init-8      14.0 ± 0%       1.0 ± 0%  -92.86%  (p=0.008 n=5+5)
```

Note the numbers are tiny already, but ./cmd/searcher isn't
representative of slowness experienced in ./cmd/frontend/...