### PR TITLE
codecov: fix `after_n_builds` to 5

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -25,10 +25,10 @@ coverage:
 comment:
   require_changes: yes
   layout: 'diff, flags, files'
-  # We upload at least 5 times in CI (to confirm: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+codecov.io/bash&patternType=literal)
+  # We upload at least 5 times in CI (to confirm: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%22https://codecov.io/bash%22&patternType=regexp)
   # Exceptions:
   # - PRs that only update docs, we don't need Codecov there.
   # - e2e tests, which don't run on most PRs.
-  after_n_builds: 6
+  after_n_builds: 5
 ignore:
   - '**/bindata.go'


### PR DESCRIPTION
On almost all PRs, we only have 5 reports/uploads, e.g. https://codecov.io/gh/sourcegraph/sourcegraph/commit/ffe90713033a6483f8137ca3eab64f556ebed5ab/build

If we include e2e, then we have 6 but that doesn't run on most PRs (almost always only on `master`?). Therefore, if we set `after_n_builds` to 6, PRs are no longer receiving PR comments from Codecov.

