### PR TITLE
Use same transaction in DeleteCampaign (and add some tests)

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -320,7 +320,7 @@ func (s *Service) DeleteCampaign(ctx context.Context, id int64, closeChangesets 
 
 		// First load the Changesets with the given campaignID, before deleting
 		// the campaign would remove the association.
-		cs, _, err = s.store.ListChangesets(ctx, ListChangesetsOpts{
+		cs, _, err = tx.ListChangesets(ctx, ListChangesetsOpts{
 			CampaignID: id,
 			Limit:      -1,
 		})
@@ -335,7 +335,7 @@ func (s *Service) DeleteCampaign(ctx context.Context, id int64, closeChangesets 
 			c.RemoveCampaignID(id)
 		}
 
-		return cs, s.store.DeleteCampaign(ctx, id)
+		return cs, tx.DeleteCampaign(ctx, id)
 	}
 
 	cs, err := transaction()

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -186,7 +186,7 @@ func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store
 // ErrCloseProcessingCampaign is returned by CloseCampaign if the Campaign has
 // been published at the time of closing but its ChangesetJobs have not
 // finished execution.
-var ErrCloseProcessingCampaign = errors.New("cannot delete a Campaign while changesets are being created on codehosts")
+var ErrCloseProcessingCampaign = errors.New("cannot close a Campaign while changesets are being created on codehosts")
 
 // CloseCampaign closes the Campaign with the given ID if it has not been closed yet.
 func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets bool) (campaign *campaigns.Campaign, err error) {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -209,7 +209,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 			return err
 		}
 		if processing {
-			err = ErrDeleteProcessingCampaign
+			err = ErrCloseProcessingCampaign
 			return err
 		}
 

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -171,8 +171,8 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := svc.DeleteCampaign(ctx, campaign.ID, true); err == nil {
-			t.Fatalf("deleting campaign should fail, since it's processing")
+		if err := svc.DeleteCampaign(ctx, campaign.ID, true); err != ErrDeleteProcessingCampaign {
+			t.Fatalf("DeleteCampaign returned unexpected error: %s", err)
 		}
 
 		jobs, _, err := store.ListChangesetJobs(ctx, ListChangesetJobsOpts{
@@ -221,8 +221,8 @@ func TestService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err = svc.CloseCampaign(ctx, campaign.ID, true); err == nil {
-			t.Fatalf("closing campaign should fail, since it's processing")
+		if _, err = svc.CloseCampaign(ctx, campaign.ID, true); err != ErrCloseProcessingCampaign {
+			t.Fatalf("CloseCampaign returned unexpected error: %s", err)
 		}
 
 		jobs, _, err := store.ListChangesetJobs(ctx, ListChangesetJobsOpts{

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -152,6 +152,110 @@ func TestService(t *testing.T) {
 		}
 	})
 
+	t.Run("DeleteCampaign", func(t *testing.T) {
+		patchSet := &campaigns.PatchSet{UserID: user.ID}
+		if err = store.CreatePatchSet(ctx, patchSet); err != nil {
+			t.Fatal(err)
+		}
+
+		patch := testPatch(patchSet.ID, rs[0].ID, now)
+		if err := store.CreatePatch(ctx, patch); err != nil {
+			t.Fatal(err)
+		}
+
+		campaign := testCampaign(user.ID, patchSet.ID)
+
+		svc := NewServiceWithClock(store, cf, clock)
+		// This creates processing ChangesetJobs.
+		if err = svc.CreateCampaign(ctx, campaign, false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.DeleteCampaign(ctx, campaign.ID, true); err == nil {
+			t.Fatalf("deleting campaign should fail, since it's processing")
+		}
+
+		jobs, _, err := store.ListChangesetJobs(ctx, ListChangesetJobsOpts{
+			CampaignID: campaign.ID,
+			Limit:      -1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(jobs) != 1 {
+			t.Fatalf("wrong number of changeset jobs: %d", len(jobs))
+		}
+
+		for _, j := range jobs {
+			j.Error = "failed"
+			j.FinishedAt = clock()
+			if err := store.UpdateChangesetJob(ctx, j); err != nil {
+				t.Fatalf("updating changeset job failed: %s\n", err)
+			}
+		}
+
+		// Now it should work, since the jobs failed to execute and campaign is
+		// no longer processing.
+		if err := svc.DeleteCampaign(ctx, campaign.ID, true); err != nil {
+			t.Fatalf("campaign not deleted: %s", err)
+		}
+	})
+
+	t.Run("CloseCampaign", func(t *testing.T) {
+		patchSet := &campaigns.PatchSet{UserID: user.ID}
+		if err = store.CreatePatchSet(ctx, patchSet); err != nil {
+			t.Fatal(err)
+		}
+
+		patch := testPatch(patchSet.ID, rs[0].ID, now)
+		if err := store.CreatePatch(ctx, patch); err != nil {
+			t.Fatal(err)
+		}
+
+		campaign := testCampaign(user.ID, patchSet.ID)
+
+		svc := NewServiceWithClock(store, cf, clock)
+		// This creates processing ChangesetJobs.
+		if err = svc.CreateCampaign(ctx, campaign, false); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err = svc.CloseCampaign(ctx, campaign.ID, true); err == nil {
+			t.Fatalf("closing campaign should fail, since it's processing")
+		}
+
+		jobs, _, err := store.ListChangesetJobs(ctx, ListChangesetJobsOpts{
+			CampaignID: campaign.ID,
+			Limit:      -1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(jobs) != 1 {
+			t.Fatalf("wrong number of changeset jobs: %d", len(jobs))
+		}
+
+		for _, j := range jobs {
+			j.Error = "failed"
+			j.FinishedAt = clock()
+			if err := store.UpdateChangesetJob(ctx, j); err != nil {
+				t.Fatalf("updating changeset job failed: %s\n", err)
+			}
+		}
+
+		// Now it should work, since the jobs failed to execute and campaign is
+		// no longer processing.
+		campaign, err = svc.CloseCampaign(ctx, campaign.ID, true)
+		if err != nil {
+			t.Fatalf("campaign not closed: %s", err)
+		}
+		if campaign.ClosedAt.IsZero() {
+			t.Fatalf("campaign ClosedAt is zero")
+		}
+	})
+
 	t.Run("CreateCampaignAsDraft", func(t *testing.T) {
 		patchSet := &campaigns.PatchSet{UserID: user.ID}
 		err = store.CreatePatchSet(ctx, patchSet)


### PR DESCRIPTION
I noticed this while working on #10808 so I decided to fix it separately and add a bunch of tests.