### PR TITLE
Render blob panel even if the highlighting request failed

### DIFF
--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -240,6 +240,14 @@ export class BlobPage extends React.PureComponent<Props, State> {
                     }
                     repoHeaderContributionsLifecycleProps={this.props.repoHeaderContributionsLifecycleProps}
                 />
+                <BlobPanel
+                    {...this.props}
+                    position={
+                        lprToRange(parseHash(this.props.location.hash))
+                            ? lprToRange(parseHash(this.props.location.hash))!.start
+                            : undefined
+                    }
+                />
             </>
         )
 
@@ -317,14 +325,6 @@ export class BlobPage extends React.PureComponent<Props, State> {
                         renderMode={renderMode}
                     />
                 )}
-                <BlobPanel
-                    {...this.props}
-                    position={
-                        lprToRange(parseHash(this.props.location.hash))
-                            ? lprToRange(parseHash(this.props.location.hash))!.start
-                            : undefined
-                    }
-                />
             </>
         )
     }


### PR DESCRIPTION
This caused #10999 where no git history would show up, because the
request for the highlighted content fails, as the file is binary.

The Blob panel should be rendered independently of the blob content. That way
- it's possible to still show the history when the render failed
- the fetch for the history data can happen earlier, before the blob is done highlighting


Closes #10999